### PR TITLE
Better fix for inline monospace font

### DIFF
--- a/css/allcss.css
+++ b/css/allcss.css
@@ -7027,14 +7027,8 @@ small {
     line-height: inherit
 }
 code {
-    background-color: eee;
-    border-color: #aaa;
-    border-style: solid;
-    border-width: 1px;
-    color: #333;
     font-family: Consolas, "Liberation Mono", Courier, monospace;
     font-weight: normal;
-    padding: 0.125rem 0.3125rem 0.0625rem
 }
 ul,
 ol,


### PR DESCRIPTION
Remove the border, background, and padding.

Note, this is not how code blocks are styled -- they use highlight.js, apparently
the 'rouge' style.

(re)-fixes #6 (and #7 -- how did I end up with both??)
