### PR TITLE
removed ubuntu wily 15.10 references in install docs

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -16,7 +16,6 @@ title: 'Installation on Ubuntu '
 Docker is supported on these Ubuntu operating systems:
 
 - Ubuntu Xenial 16.04 (LTS)
-- Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 - Ubuntu Precise 12.04 (LTS)
 
@@ -83,10 +82,6 @@ packages from the new repository:
 
             deb https://apt.dockerproject.org/repo ubuntu-trusty main
 
-    - Ubuntu Wily 15.10
-
-            deb https://apt.dockerproject.org/repo ubuntu-wily main
-
     - Ubuntu Xenial 16.04 (LTS)
 
             deb https://apt.dockerproject.org/repo ubuntu-xenial main
@@ -116,10 +111,9 @@ packages from the new repository:
 ### Prerequisites by Ubuntu Version
 
 - Ubuntu Xenial 16.04 (LTS)
-- Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 
-For Ubuntu Trusty, Wily, and Xenial, it's recommended to install the
+For Ubuntu Trusty, and Xenial, it's recommended to install the
 `linux-image-extra-*` kernel packages. The `linux-image-extra-*` packages
 allows you use the `aufs` storage driver.
 


### PR DESCRIPTION
@thaJeztah @mlaventure @tianon @justincormack 

Submitting PR for docs changes related to https://github.com/docker/docker/pull/27042/files (Remove Ubuntu 15.10 (Wily Werewolf) from build-deb targets)

Docs source has moved to new consolidated repository, and docs.docker.com will begin serving out of this repo today. You all can file docs PR's on this repo. When you have code changes that require docs changes, please x-ref/link the PR's across the two repos.

(For now you can view the generated / updated docs at https://docker.github.io/ preview site, once this PR is merged.)

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>