### PR TITLE
PRs on shared drives and CAs, HTML fixes

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -97,18 +97,32 @@ If you are working with applications like [Apache Maven](https://maven.apache.or
 
 The Mac has a changing IP address (or none if you have no network access). Our current recommendation is to attach an unused IP to the `lo0` interface on the Mac so that containers can connect to this address.
 
-For a full explanation and examples, see [I want to connect from a container to a service on the host](networking.md#i-want-to-connect-from-a-container-to-a-service-on-the-host) under [Known Limitations, Use Cases, and Workarounds](networking.md#known-limitations-use-cases-and-workarounds) in the Networking topic.
+For a full explanation and examples, see [I want to connect from a container to
+a service on the
+host](networking.md#i-want-to-connect-from-a-container-to-a-service-on-the-host)
+under [Known Limitations, Use Cases, and
+Workarounds](networking.md#known-limitations-use-cases-and-workarounds) in the
+Networking topic.
 
 ### How do I to connect to a container from the Mac?
 
 Our current recommendation is to publish a port, or to connect from another container. Note that this is what you have to do even on Linux if the container is on an overlay network, not a bridge network, as these are not routed.
 
-For a full explanation and examples, see [I want to connect to a container from the Mac](networking.md#i-want-to-connect-to-a-container-from-the-mac) under [Known Limitations, Use Cases, and Workarounds](networking.md#known-limitations-use-cases-and-workarounds) in the Networking topic.
+For a full explanation and examples, see [I want to connect to a container from
+the Mac](networking.md#i-want-to-connect-to-a-container-from-the-mac) under
+[Known Limitations, Use Cases, and
+Workarounds](networking.md#known-limitations-use-cases-and-workarounds) in the
+Networking topic.
+
+### How do I add custom CA certificates?
+
+Starting with Docker for Mac 1.12.1, 2016-09-16 (stable) and Beta 27 Release Notes (2016-09-28 1.12.2-rc1-beta27), all trusted certificate authorities (CAs) (root or intermediate) are supported.
+
+Docker for Mac creates a certificate bundle of all user-trusted CAs based on the Mac Keychain, and appends it to Moby trusted certificates. So if an enterprise SSL certificate is trusted by the user on the host, it will be trusted by Docker for Mac.
 
 ### What are system requirements for Docker for Mac?
 
 Note that you need a Mac that supports hardware virtualization, which is most non ancient ones; i.e., use OS X `10.10.3+` or `10.11` (OS X Yosemite or OS X El Capitan). See also "What to know before you install" in [Getting Started](index.md).
-
 
 ### Do I need to uninstall Docker Toolbox to use Docker for Mac?
 

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -175,24 +175,22 @@ See also, [Hypervisor Framework Reference](https://developer.apple.com/library/m
 
 * IPv6 workaround to auto-filter DNS addresses - IPv6 is not yet supported on Docker for Mac, which typically manifests as a network timeout when running `docker` commands that need access to external network servers (e.g., `docker pull busybox`).
 
-        ```
         $ docker pull busybox
         Using default tag: latest
         Pulling repository docker.io/library/busybox
         Network timed out while trying to connect to https://index.docker.io/v1/repositories/library/busybox/images. You may want to check your internet connection or if you are behind a proxy.
-        ```
 
     Starting with v1.12.1, 2016-09016 on the stable channel, and Beta 24 on the beta channel, a workaround is provided that auto-filters out the IPv6 addresses in DNS server lists and enables successful network accesss. For example, `2001:4860:4860::8888` would become `8.8.8.8`. So, the only workaround action needed for users is to [upgrade to Docker for Mac stable v1.12.1 or newer, or Beta 24 or newer](index.md#download-docker-for-mac).
 
     On releases with the workaround included to filter out / truncate IPv6 addresses from the DNS list, the above command should run properly:
 
-        ```
+
         $ docker pull busybox
         Using default tag: latest
         latest: Pulling from library/busybox
         Digest: sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6
         Status: Image is up to date for busy box:latest
-        ```
+
 
     To learn more, see these issues on GitHub and Docker for Mac forums:
 
@@ -200,7 +198,10 @@ See also, [Hypervisor Framework Reference](https://developer.apple.com/library/m
 
   * [ERROR: Network timed out while trying to connect to index.docker.io](https://forums.docker.com/t/error-network-timed-out-while-trying-to-connect-to-index-docker-io/17206)
 
+  <p></p>
+
 * If Docker for Mac fails to install or start properly:
+
   * Make sure you quit Docker for Mac before installing a new version of the application ( <img src="../images/whale-x.png"> --> **Quit Docker**). Otherwise, you will get an "application in use" error when you try to copy the new app from the `.dmg` to `/Applications`.
 
   * Restart your Mac to stop / discard any vestige of the daemon running from the previously installed version.
@@ -211,14 +212,11 @@ See also, [Hypervisor Framework Reference](https://developer.apple.com/library/m
 
 * If `docker` commands aren't working properly or as expected:
 
-    Make sure you are not using the legacy Docker Machine environment in your shell
-or command window. You do not need `DOCKER_HOST` set, so unset it as it may be
-pointing at another Docker (e.g. VirtualBox). If you use bash, `unset
+  * Make sure you are not using the legacy Docker Machine environment in your shell or command window. You do not need `DOCKER_HOST` set, so unset it as it
+may be pointing at another Docker (e.g. VirtualBox). If you use bash, `unset
 ${!DOCKER_*}` will unset existing `DOCKER` environment variables you have set.
-For other shells, unset each environment variable individually as described in
-[Setting up to run Docker for
-Mac](docker-toolbox.md#setting-up-to-run-docker-for-mac) in [Docker for Mac vs.
-Docker Toolbox](docker-toolbox.md).
+
+  * For other shells, unset each environment variable individually as described in [Setting up to run Docker for Mac](docker-toolbox.md#setting-up-to-run-docker-for-mac) in [Docker for Mac vs. Docker Toolbox](docker-toolbox.md).
 
 <p></p>
 
@@ -255,6 +253,8 @@ timeout when you run `docker` commands that need access to external network
 servers. The aforementioned releases include a workaround for this because
 Docker for Mac does not yet support IPv6. See "IPv6 workaround to auto-filter DNS addresses" in
 [Workarounds for common problems](troubleshoot.md#workarounds-for-common-problems).
+
+<p></p>
 
 * You might encounter errors when using `docker-compose up` with Docker for Mac (`ValueError: Extra Data`). We've identified this is likely related to data and/or events being passed all at once rather than one by one, so sometimes the data comes back as 2+ objects concatenated and causes an error.
 
@@ -294,14 +294,16 @@ Alternatively you could create a plain-text TCP proxy on localhost:1234 using:
   repeated scans of large directory trees, may suffer from poor
   performance. Applications that behave in this way include:
 
-  	- `rake`
-  	- `ember build`
-  	- Symfony
-  	- Magento
-    - Zend Framework
-    - PHP applications that use [Composer](https://getcomposer.org) to install dependencies in a ```vendor``` folder 
+  - `rake`
+  - `ember build`
+  - Symfony
+  - Magento
+  - Zend Framework
+  - PHP applications that use [Composer](https://getcomposer.org) to install dependencies in a ```vendor``` folder
 
-    As a work-around for this behavior, you can put vendor or third-party library directories in Docker volumes, perform temporary file system
+<p></p>
+
+  As a work-around for this behavior, you can put vendor or third-party library directories in Docker volumes, perform temporary file system
     operations outside of `osxfs` mounts, and use third-party tools like
     Unison or `rsync` to synchronize between container directories and
     bind-mounted directories. We are actively working on `osxfs`
@@ -314,12 +316,12 @@ Alternatively you could create a plain-text TCP proxy on localhost:1234 using:
 
         docker run --rm --privileged alpine hwclock -s
 
-  	Or, to resolve both issues, you can add the local clock as a low-priority (high stratum) fallback NTP time source for the host. To do this, edit the host's `/etc/ntp-restrict.conf` to add:
+    Or, to resolve both issues, you can add the local clock as a low-priority (high stratum) fallback NTP time source for the host. To do this, edit the host's `/etc/ntp-restrict.conf` to add:
 
         server 127.127.1.1              # LCL, local clock
         fudge  127.127.1.1 stratum 12   # increase stratum
 
-  	Then restart the NTP service with:
+    Then restart the NTP service with:
 
         sudo launchctl unload /System/Library/LaunchDaemons/org.ntp.ntpd.plist
         sudo launchctl load /System/Library/LaunchDaemons/org.ntp.ntpd.plist

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -30,9 +30,15 @@ This topic also has more information about the two channels.
 
 A: Two different download channels are available for Docker for Windows:
 
-* The stable channel provides a general availability release-ready installer for a fully baked and tested, more reliable app. The stable version of Docker for Windows comes with the latest released version of Docker Engine.  The release schedule is synched with Docker Engine releases and hotfixes.
+* The stable channel provides a general availability release-ready installer for a fully baked and tested, more reliable app. The stable version of Docker
+for Windows comes with the latest released version of Docker Engine.  The
+release schedule is synched with Docker Engine releases and hotfixes.
 
-* The beta channel provides an installer with new features we are working on, but is not necessarily fully tested. It comes with the experimental version of Docker Engine. Bugs, crashes and issues are more likely to occur with the beta app, but you get a chance to preview new functionality, experiment, and provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month.
+* The beta channel provides an installer with new features we are working on, but is not necessarily fully tested. It comes with the experimental version of
+Docker Engine. Bugs, crashes and issues are more likely to occur with the beta
+app, but you get a chance to preview new functionality, experiment, and provide
+feedback as the apps evolve. Releases are typically more frequent than for
+stable, often one or more per month.
 
 **Q: Can I switch back and forth between stable and beta versions of Docker for Windows?**
 
@@ -83,13 +89,26 @@ in [Docker Swarm](/engine/swarm/index.md). A good place to start is the
 You can find the list of frequent issues in
 [Logs and Troubleshooting](troubleshoot.md).
 
-If you do not find a solution in Troubleshooting, browse issues on [Docker for Windows issues on GitHub](https://github.com/docker/for-win/issues) or create a new one. You can also create new issues based on diagnostics. To learn more about running diagnostics and about Docker for Windows GitHub issues, see [Diagnose and Feedback](index.md#diagnose-and-feedback).
+If you do not find a solution in Troubleshooting, browse issues on [Docker for
+Windows issues on GitHub](https://github.com/docker/for-win/issues) or create a
+new one. You can also create new issues based on diagnostics. To learn more
+about running diagnostics and about Docker for Windows GitHub issues, see
+[Diagnose and Feedback](index.md#diagnose-and-feedback).
 
-[Docker for Windows forum](https://forums.docker.com/c/docker-for-windows) provides discussion threads as well, and you can create discussion topics there, but we recommend using the GitHub issues over the forums for better tracking and response.
+[Docker for Windows forum](https://forums.docker.com/c/docker-for-windows)
+provides discussion threads as well, and you can create discussion topics there,
+but we recommend using the GitHub issues over the forums for better tracking and
+response.
 
 ### Can I use Docker for Windows with new swarm mode?
 
-Yes! You can use Docker for Windows to test single-node features of [swarm mode](/engine/swarm/index.md) introduced with Docker Engine 1.12, including initializing a swarm with a single node, creating services, and scaling services. Docker “Moby” on Hyper-V will serve as the single swarm node. You can also use Docker Machine, which comes with Docker for Windows, to create and experiment with a multi-node swarm. Check out the tutorial at [Get started with swarm mode](/engine/swarm/swarm-tutorial/index.md).
+Yes! You can use Docker for Windows to test single-node features of [swarm
+mode](/engine/swarm/index.md) introduced with Docker Engine 1.12, including
+initializing a swarm with a single node, creating services, and scaling
+services. Docker “Moby” on Hyper-V will serve as the single swarm node. You can
+also use Docker Machine, which comes with Docker for Windows, to create and
+experiment with a multi-node swarm. Check out the tutorial at [Get started with
+swarm mode](/engine/swarm/swarm-tutorial/index.md).
 
 ### How do I connect to the remote Docker Engine API?
 
@@ -117,6 +136,14 @@ Symlinks created outside of containers (e.g., on the host) will not work in  con
 
 To learn more about the reasons for this limitation, see this issue on GitHub: [Symlinks don't work as expected](https://github.com/docker/for-win/issues/109#issuecomment-251307391).
 
+### How do I add custom CA certificates?
+
+Starting with Docker for Windows 1.12.1, 2016-09-16 (stable) and Beta 26 (2016-09-14 1.12.1-beta26), all trusted CAs (root or intermediate) are supported. Docker recognizes certs stored under Trust Root Certification Authorities or Intermediate Certification Authorities.
+
+Docker for Windows creates a certificate bundle of all user-trusted CAs based on the Windows certificate store, and appends it to Moby trusted certificates. So if an enterprise SSL certificate is trusted by the user on the host, it will be trusted by Docker for Windows.
+
+To learn more, see the GitHub issue [Allow user to add custom Certificate Authorities ](https://github.com/docker/for-win/issues/48).
+
 ### Why does Docker for Windows sometimes lose network connectivity (e.g., `push`/`pull` doesn't work)?
 
 Networking is not yet fully stable across network changes and system sleep
@@ -140,8 +167,12 @@ Windows to work.
 
 ### Why does Docker for Windows fail to start when firewalls or anti-virus software is installed?
 
-Some firewalls and anti-virus software might be incompatible with Hyper-V and some Windows 10 builds  (possibly, the Anniversary Update), which impacts Docker for Windows. See details and workarounds in [Docker fails to start when firewall or anti-virus software is installed](troubleshoot.md#docker-fails-to-start-when-firewall-or-anti-virus-software-is-installed) in [Troubleshooting](troubleshoot.md).
-
+Some firewalls and anti-virus software might be incompatible with Hyper-V and
+some Windows 10 builds  (possibly, the Anniversary Update), which impacts Docker
+for Windows. See details and workarounds in [Docker fails to start when firewall
+or anti-virus software is
+installed](troubleshoot.md#docker-fails-to-start-when-firewall-or-anti-virus-software-is-installed)
+in [Troubleshooting](troubleshoot.md).
 
 ### How do I uninstall Docker Toolbox?
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -268,7 +268,7 @@ To get a popup menu with application options, right-click the whale:
 
 The **Settings** dialogs provide options to allow Docker auto-start, automatically check for updates, share local drives with Docker containers, enable VPN compatibility, manage CPUs and memory Docker uses, restart Docker, or perform a factory reset.
 
-**Beta 26** includes an option to switch between Windows and Linux conatiners. See [Switch between Windows and Linux containers (Beta 26)](index.md#switch-between-windows-and-linux-containers-beta-26). This is not yet available on stable builds.
+**Beta 26 and newer** include an option to switch between Windows and Linux conatiners. See [Switch between Windows and Linux containers (Beta feature)](index.md#switch-between-windows-and-linux-containers-beta-feature). This is not yet available on stable builds.
 
 ![Beta 26 popup with switch for Windows or Linux containers](images/config-popup-menu-win-switch-containers.png)
 
@@ -296,6 +296,8 @@ Share your local drives (volumes) with Docker for Windows, so that they are avai
 You will be asked to provide your Windows system username and password (domain user) to apply shared drives. You can select an option to have Docker store the credentials so that you don't have to re-enter them every time.
 
 Permissions to access shared drives are tied to the credentials you provide here. If you run `docker` commands and tasks under a different username than the one used here to set up sharing, your containers will not have permissions to access the mounted volumes.
+
+>**Tip:** Shared drives are only required for volume mounting [Linux containers](#switch-between-windows-and-linux-containers-beta-feature), not Windows containers.
 
 See also [Verify domain user has permissions for shared drives](troubleshoot.md#verify-domain-user-has-permissions-for-shared-drives-volumes) in Troubleshooting.
 
@@ -356,13 +358,15 @@ For a full list of options on the Docker daemon, see <a href="https://docs.docke
 
 Note that updating these settings requires a reconfiguration and reboot of the Linux VM.
 
-### Switch between Windows and Linux containers (Beta 26)
+### Switch between Windows and Linux containers (Beta feature)
 
 Starting with Beta 26, you can select which daemon (Linux or Windows) the Docker CLI talks to. Select **Switch to Windows containers** to toggle to Windows containers. Select **Switch to Linux containers**.
 
 Microsoft Developer Network has preliminary/draft information on Windows containers [here](https://msdn.microsoft.com/en-us/virtualization/windowscontainers/about/about_overview).
 
 This feature is not yet available on stable builds.
+
+See also [Shared Drives](#shared-drives)
 
 ### Diagnose and Feedback
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -32,7 +32,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 >
 > The auto-update function in Beta 21 will not be able to install this update. To install the latest beta manually if you are still on Beta 21, please download the installer here:
 
-> https://download.docker.com/win/beta/InstallDocker.msi
+> [https://download.docker.com/win/beta/InstallDocker.msi](https://download.docker.com/win/beta/InstallDocker.msi)
 
 > This problem is fixed as of Beta 23 for subsequent auto-updates.
 
@@ -138,7 +138,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 >
 > The auto-update function in Beta 21 will not be able to install this update. To install the latest beta manually if you are still on Beta 21, please download the installer here:
 
-> https://download.docker.com/win/beta/InstallDocker.msi
+> [https://download.docker.com/win/beta/InstallDocker.msi](https://download.docker.com/win/beta/InstallDocker.msi)
 
 > This problem is fixed as of Beta 23 for subsequent auto-updates.
 
@@ -176,7 +176,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 >
 > The auto-update function in Beta 21 will not be able to install this update. To install the latest beta manually if you are still on Beta 21, please download the installer here:
 
-> https://download.docker.com/win/beta/InstallDocker.msi
+> [https://download.docker.com/win/beta/InstallDocker.msi](https://download.docker.com/win/beta/InstallDocker.msi)
 
 > This problem is fixed as of Beta 23 for subsequent auto-updates.
 
@@ -209,7 +209,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 >
 > The auto-update function in Beta 21 will not be able to install this update. To install the latest beta manually if you are still on Beta 21, please download the installer here:
 
-> https://download.docker.com/win/beta/InstallDocker.msi
+> [https://download.docker.com/win/beta/InstallDocker.msi](https://download.docker.com/win/beta/InstallDocker.msi)
 
 > This problem is fixed as of Beta 23 for subsequent auto-updates.
 
@@ -235,7 +235,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 >
 > The auto-update function in Beta 21 will not be able to install this update. To install the latest beta manually if you are still on Beta 21, please download the installer here:
 
-> https://download.docker.com/win/beta/InstallDocker.msi
+> [https://download.docker.com/win/beta/InstallDocker.msi](https://download.docker.com/win/beta/InstallDocker.msi)
 
 > This problem is fixed as of Beta 23 for subsequent auto-updates.
 
@@ -262,7 +262,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 >
 > The auto-update function in Beta 21 will not be able to install this update. To install the latest beta manually if you are still on Beta 21, please download the installer here:
 
-> https://download.docker.com/win/beta/InstallDocker.msi
+> [https://download.docker.com/win/beta/InstallDocker.msi](https://download.docker.com/win/beta/InstallDocker.msi)
 
 > This problem is fixed as of Beta 23 for subsequent auto-updates.
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -49,6 +49,8 @@ Currently, `inotify` does not work on Docker for Windows. This will become evide
 
 ### Verify domain user has permissions for shared drives (volumes)
 
+>**Tip:** Shared drives are only required for volume mounting [Linux containers](index.md#switch-between-windows-and-linux-containers-beta-feature), not Windows containers.
+
 Permissions to access shared drives are tied to the username and password you use to set up shared drives. (See [Shared Drives](index.md#shared-drives).) If you run `docker` commands and tasks under a different username than the one used to set up shared drives, your containers will not have permissions to access the mounted volumes. The volumes will show as empty.
 
 The solution to this is to switch to the domain user account and reset credentials on shared drives.


### PR DESCRIPTION
@friism @dgageot @ebriney @simonferquel 

Submitting these docs updates to our new consolidated docs repo. This PR includes fixes for:

[Make it clear in UI and docs that sharing drives is only required for volume mounting Linux containers #5417](https://github.com/docker/pinata/issues/5417#event-809590718)

[Document custom Certificate Authorities #5384](https://github.com/docker/pinata/issues/5384#event-807196369)

After this PR is merged, updates will show up on https://docker.github.io/ (the new docs preview site), and as soon as we start serving docs this new repo (today or tomorrow), the changes will show up on docs.docker.com as well.  

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>