### PR TITLE
don't split verbatim text over few lines

### DIFF
--- a/engine/reference/builder.md
+++ b/engine/reference/builder.md
@@ -1248,9 +1248,9 @@ The output of the final `pwd` command in this `Dockerfile` would be
     ARG <name>[=<default value>]
 
 The `ARG` instruction defines a variable that users can pass at build-time to
-the builder with the `docker build` command using the `--build-arg
-<varname>=<value>` flag. If a user specifies a build argument that was not
-defined in the Dockerfile, the build outputs an error.
+the builder with the `docker build` command using the
+`--build-arg <varname>=<value>` flag. If a user specifies a build argument
+that was not defined in the Dockerfile, the build outputs an error.
 
 ```
 One or more build-args were not consumed, failing build.


### PR DESCRIPTION
Should fix improperly formatted documentation page.

This page https://docs.docker.com/engine/reference/builder/#/arg looks currently like this:

![2016-10-05_19 38 42_1](https://cloud.githubusercontent.com/assets/46573/19122507/d3592a72-8b3b-11e6-8dc3-a24d0394979d.png)
