### PR TITLE
Adding fix for builder reference markdown

### DIFF
--- a/engine/reference/builder.md
+++ b/engine/reference/builder.md
@@ -1363,8 +1363,11 @@ corresponding `ARG` instruction in the Dockerfile.
 * `NO_PROXY`
 * `no_proxy`
 
-To use these, simply pass them on the command line using the `--build-arg
-<varname>=<value>` flag.
+To use these, simply pass them on the command line using the flag:
+
+```
+--build-arg <varname>=<value>
+```
 
 ### Impact on build caching
 


### PR DESCRIPTION
Currently the https://docs.docker.com/engine/reference/builder/ page is broken near the end of the ARG section. This appears to be due to the inline code highlighting parsing HTML tags incorrectly - to fix this, the code has been moved to a full code block.