### PR TITLE
add leading url to feedback link email template

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -197,7 +197,7 @@ ng\:form {
 								<img src="/images/chat.png" alt="chat icon" style="margin-right: 10px">
 								<b>Feedback?</b> Questions? Suggestions?<br/>
 							  <a href="https://github.com/docker/docker.github.io/edit/master/{{ page.path }}" class="nomunge">Edit this page</a>,
-								<a href="https://github.com/docker/docker.github.io/issues/new?title=Feedback for: {{ page.path }}&body=URL: {{ page.path }}" class="nomunge">file a ticket</a>, or rate this page:
+								<a href="https://github.com/docker/docker.github.io/issues/new?title=Feedback for: {{ page.path }}&body=URL: [https://docs.docker.com/{{ page.path }}](https://docs.docker.com{{ page.url }})" class="nomunge">file a ticket</a>, or rate this page:
 								<div id="pd_rating_holder_8453675"></div>
 								<script type="text/javascript">
 								PDRTJS_settings_8453675 = {


### PR DESCRIPTION
For @johndmulhausen  - this just adds the domain name, because I can't figure out how to rewrite the `page.path` to replace `.md` with `/` to make it an actual correct url. What I was going for is to make the "URL" part of any ticket filed a live link to the page, rather than a flat file path.

Feel free to carry or close, or point me at something I could reverse-engineer.

Signed-off-by: LRubin <lrubin@docker.com>