### PR TITLE
Fixed Issue #128 - Syntax Error in: opensource/workflow/find-an-issue…

### DIFF
--- a/opensource/workflow/find-an-issue.md
+++ b/opensource/workflow/find-an-issue.md
@@ -110,7 +110,6 @@ The following table describes the kind labels.
 The following table describes the experience level guidelines.
 
 <table>
-<thead>
   <thead>
     <tr>
       <th>Exp Label</th>


### PR DESCRIPTION
In file: opensource/workflow/find-an-issue.md
I removed the extra table heading tag found on line 113
The associated table should now be displayed properly.

Signed-off-by: Jared Carlson <jaredrcarlson@gmail.com>