### PR TITLE
Fix incorrect information about swarm port assignment

### DIFF
--- a/engine/swarm/key-concepts.md
+++ b/engine/swarm/key-concepts.md
@@ -74,7 +74,9 @@ run on the assigned node or fail.
 The swarm manager uses **ingress load balancing** to expose the services you
 want to make available externally to the swarm. The swarm manager can
 automatically assign the service a **PublishedPort** or you can configure a
-PublishedPort for the service in the 30000-32767 range.
+PublishedPort for the service. You can specify any unused port. If you do not
+specify a port, the swarm manager assigns the service a port in the 30000-32767
+range.
 
 External components, such as cloud load balancers, can access the service on the
 PublishedPort of any node in the cluster whether or not the node is currently


### PR DESCRIPTION
The docs imply that services can only use ports in the 30000-32767. In fact, you can specify any port, but if you don't specify one, a port in that range is assigned.