### PR TITLE
Change 'draft: true' to 'published: false' for Jekyll

### DIFF
--- a/engine/admin/b2d_volume_resize.md
+++ b/engine/admin/b2d_volume_resize.md
@@ -1,6 +1,6 @@
 ---
 description: Resizing a Boot2Docker volume in VirtualBox with GParted
-draft: "true"
+published: false
 keywords:
 - boot2docker, volume,  virtualbox
 menu:

--- a/engine/reference/api/README.md
+++ b/engine/reference/api/README.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 This directory holds the authoritative specifications of APIs defined and implemented by Docker. Currently this includes:

--- a/engine/reference/api/docker-io_api.md
+++ b/engine/reference/api/docker-io_api.md
@@ -1,6 +1,6 @@
 ---
 description: API Documentation for the Docker Hub API
-draft: true
+published: false
 keywords:
 - API, Docker, index, REST, documentation, Docker Hub,  registry
 menu:

--- a/engine/reference/api/docker_remote_api_v1.25.md
+++ b/engine/reference/api/docker_remote_api_v1.25.md
@@ -1,6 +1,6 @@
 ---
 description: API Documentation for Docker
-draft: true
+published: false
 keywords:
 - API, Docker, rcli, REST,  documentation
 menu:

--- a/engine/reference/api/hub_registry_spec.md
+++ b/engine/reference/api/hub_registry_spec.md
@@ -1,6 +1,6 @@
 ---
 description: Documentation for docker Registry and Registry API
-draft: true
+published: false
 keywords:
 - docker, registry, api,  hub
 menu:

--- a/engine/security/https/README.md
+++ b/engine/security/https/README.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 This is an initial attempt to make it easier to test the examples in the https.md

--- a/engine/static_files/README.md
+++ b/engine/static_files/README.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 Static files dir

--- a/machine/DRIVER_SPEC.md
+++ b/machine/DRIVER_SPEC.md
@@ -1,6 +1,6 @@
 ---
 description: machine
-draft: true
+published: false
 keywords:
 - machine, orchestration, install, installation, docker, documentation
 menu:

--- a/machine/RELEASE.md
+++ b/machine/RELEASE.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 # Docker Machine Release Process

--- a/registry/architecture.md
+++ b/registry/architecture.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 # Architecture

--- a/registry/glossary.md
+++ b/registry/glossary.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 # Glossary

--- a/registry/migration.md
+++ b/registry/migration.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 # Migrating a 1.0 registry to 2.0

--- a/registry/spec/implementations.md
+++ b/registry/spec/implementations.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+published: false
 ---
 
 # Distribution API Implementations

--- a/registry/spec/json.md
+++ b/registry/spec/json.md
@@ -1,6 +1,6 @@
 ---
 description: Explains registry JSON objects
-draft: true
+published: false
 keywords:
 - registry, service, images, repository,  json
 menu:


### PR DESCRIPTION
Hugo uses "draft=true|false" but Jekyll uses "published: true|false" (the opposite Boolean), so some things that should have been drafts were published. This fixes that. The files were all already public, they were just not ready to be on the website yet.