### PR TITLE
Add jekyll-seo-tag to Jekyll template

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,8 @@ gems:
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-gist
+  - jekyll-seo-tag
+
 
 defaults:
   -

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -81,6 +81,7 @@ ng\:form {
 <meta class="foundation-mq-topbar">
 <link id="mktoForms2BaseStyle" rel="stylesheet" type="text/css" href="/css/forms2.css">
 <link id="mktoForms2ThemeStyle" rel="stylesheet" type="text/css" href="/css/forms2-theme-simple.css">
+{% seo %}
 </head>
 <body class="html front not-logged-in no-sidebars page-node page-node- page-node-1 node-type-front-page path-docker ng-scope short retina-display all_loaded" ng-app="Docker" ng-controller="DockerController" style="">
 <div class="off-canvas-wrap" data-offcanvas="" style="min-height: 548px;">


### PR DESCRIPTION
Makes title and  description  populate the right tags
See https://github.com/jekyll/jekyll-seo-tag

An example of this in action:
```
<!-- Begin Jekyll SEO tag v2.0.0 -->
<title>Docker Engine - Docker</title>
<meta property="og:title" content="Docker Engine" />
<meta name="description" content="Engine" />
<meta property="og:description" content="Engine" />
<meta property="og:site_name" content="Docker" />
<script type="application/ld+json">
  {
    "@context": "http://schema.org",
    "@type": "WebPage",
    "headline": "Docker Engine",
    "description": "Engine",
    "url": "/engine/"
  }
</script>
<!-- End Jekyll SEO tag -->
```