### PR TITLE
Update 3_prepare_the_app.md

### DIFF
--- a/docker-cloud/getting-started/deploy-app/3_prepare_the_app.md
+++ b/docker-cloud/getting-started/deploy-app/3_prepare_the_app.md
@@ -30,7 +30,7 @@ $ cd quickstart-python
 
 ```bash
 $ git clone https://github.com/docker/dockercloud-quickstart-go.git
-$ cd quickstart-go
+$ cd dockercloud-quickstart-go
 ```
 
 ## Build the application


### PR DESCRIPTION
The directory name for the dockercloud-quickstart-go repository is wrong.
The change directory command wouldn't work if copy pasted.