### PR TITLE
Update Go API client to docker/docker/client

### DIFF
--- a/engine/reference/api/remote_api_client_libraries.md
+++ b/engine/reference/api/remote_api_client_libraries.md
@@ -53,8 +53,8 @@ with the library maintainers.
     </tr>
     <tr>
       <td>Go</td>
-      <td>engine-api</td>
-      <td><a class="reference external" href="https://github.com/docker/engine-api">https://github.com/docker/engine-api</a></td>
+      <td>Docker Go client</td>
+      <td><a class="reference external" href="https://godoc.org/github.com/docker/docker/client">https://godoc.org/github.com/docker/docker/client</a></td>
     </tr>
     <tr>
       <td>Gradle</td>


### PR DESCRIPTION
This has moved from docker/engine-api. See https://github.com/docker/docker/pull/27232

This page needs an overhaul at some point, but this is just fixing this particular bug.