### PR TITLE
Engine reference BUILD tarball contexts mangled

### DIFF
--- a/engine/reference/commandline/build.md
+++ b/engine/reference/commandline/build.md
@@ -94,11 +94,9 @@ Build Syntax Suffix             | Commit Used           | Build Context Used
 
 If you pass an URL to a remote tarball, the URL itself is sent to the daemon:
 
-Instead of specifying a context, you can pass a single Dockerfile in the `URL`
-or pipe the file in via `STDIN`. To pipe a Dockerfile from `STDIN`:
-
 ```bash
 $ docker build http://server/context.tar.gz
+```
 
 The download operation will be performed on the host the Docker daemon is
 running on, which is not necessarily the same host from which the build command


### PR DESCRIPTION
Closed code fence, removed duplicate text. Perhaps caused by bad merge?