### PR TITLE
update 'environment' to 'labels'

### DIFF
--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -89,15 +89,15 @@ all three services end up on the same node:
         image: foo
         volumes_from: ["bar"]
         network_mode: "service:baz"
-        environment:
+        labels:
           - "constraint:node==node-1"
       bar:
         image: bar
-        environment:
+        labels:
           - "constraint:node==node-1"
       baz:
         image: baz
-        environment:
+        labels:
           - "constraint:node==node-1"
 
 ### Host ports and recreating containers
@@ -165,15 +165,15 @@ environment variables, so you can use Compose's `environment` option to set
 them.
 
     # Schedule containers on a specific node
-    environment:
+    labels:
       - "constraint:node==node-1"
 
     # Schedule containers on a node that has the 'storage' label set to 'ssd'
-    environment:
+    labels:
       - "constraint:storage==ssd"
 
     # Schedule containers where the 'redis' image is already pulled
-    environment:
+    labels:
       - "affinity:image==redis"
 
 For the full set of available filters and expressions, see the [Swarm


### PR DESCRIPTION
according to @aanandPrasad
constraining containers in swarm with compose is now done with 'labels' as of Swarm 0.3 and Compose 1.3

https://groups.google.com/forum/#!topic/docker-dev/Uzcies21qPo