### PR TITLE
Fix the command and typo for trust_sandbox

### DIFF
--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -34,7 +34,7 @@ Finally, you'll need to have a text editor installed on your local system or VM.
 ## What is in the sandbox?
 
 If you are just using trust out-of-the-box you only need your Docker Engine
-client and access to the Docker hub. The sandbox mimics a
+client and access to the Docker Hub. The sandbox mimics a
 production trust environment, and sets up these additional components.
 
 | Container       | Description                                                                                                                                 |
@@ -70,8 +70,8 @@ the `trustsandbox` container, the Notary server, and the Registry server.
 
 1. Create a new `trustsandbox` directory and change into it.
 
-        $ mkdir `trustsandbox`
-        $ cd `trustsandbox`
+        $ mkdir trustsandbox
+        $ cd trustsandbox
 
 2. Create a filed called `docker-compose.yml` with your favorite editor.  For example, using vim:
 


### PR DESCRIPTION
1. Modify the description from "the Docker hub" to "the Docker Hub".
2. Remove the sign '' from "$ mkdir trustsandbox" to "$ mkdir trustsandbox" and from "$ cd trustsandbox" to "$ cd trustsandbox". Although two ways have the effect, it may be clear and simple after modifying.


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>