### PR TITLE
Add manifest of files maintained elsewhere

### DIFF
--- a/.NOT_EDITED_HERE.txt
+++ b/.NOT_EDITED_HERE.txt
@@ -1,0 +1,29 @@
+# Files and directories here are not edited in the docker.github.io repo.
+# Instead, they are edited in the appropriate upstream repo and pulled
+# into this repo periodically. The intent is that if you submit a PR
+# with changes to these files or directories, a CI job will fail in the
+# PR, indicating that it should not be merged.
+
+# If you need to edit these files or directories, submit a PR in one of the
+# following repos. The file will probably be located within the docs/ subdirectory.
+
+# docker-trusted-registry:                 n/a, file an issue
+# engine:                                  https://github.com/docker/docker
+# compose:                                 https://github.com/docker/compose
+# notary:                                  https://github.com/docker/notary
+# registry:                                https://github.com/docker/distribution
+# swarm:                                   https://github.com/docker/swarm
+# ucp:                                     n/a, file an issue
+
+# Make sure directories have the trailing slash, keep the list alphabetical
+
+apidocs/
+compose/reference/
+docker-trusted-registry/reference/
+engine/reference/
+machine/reference/
+notary/reference/
+registry/configuration.md
+registry/spec/
+swarm/reference/
+ucp/reference/

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,13 @@
 guidelines to help us review it. You can remove these comments
 as you fill out this template. -->
 
+<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.txt
+as these are maintained in upstream repos and added to the central
+docs repo periodically. Your PR will fail automated checks if it
+includes changes to these files or directories.-->
+
 <!-- **Squash your commits**: Please use an
-[interactive rebase](https://help.github.com/articles/about-git-rebase/)
+interactive rebase (https://help.github.com/articles/about-git-rebase/)
 to squash (combine) multiple commits into a single commit, to keep the
 commit history clean. The exception is when commits from multiple
 contributors exist in the same pull request. In that case, one commit


### PR DESCRIPTION
### Describe the proposed changes

Adds a manifest of files which should not be edited in this repo because they are
maintained elsewhere. The intent is for this file to be used by a CI process to fail
a PR which changes one of these files.

### Project version

This change will need to go into all the vnext branches.


### Related issue

#208 

### Related issue or PR in another project

https://github.com/docker/distribution/pull/1985

### Please take a look

/cc @stevvooe @thaJeztah @johndmulhausen and please CC others who will know which files or directories should be excluded from the other projects.


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

The plan is for this file to be used by a CI process which
will fail a PR if it includes changes to any of these files.