### PR TITLE
Add engine/extend to the not-edited-here manifest

### DIFF
--- a/.NOT_EDITED_HERE.txt
+++ b/.NOT_EDITED_HERE.txt
@@ -20,6 +20,7 @@
 apidocs/
 compose/reference/
 docker-trusted-registry/reference/
+engine/extend/
 engine/reference/
 machine/reference/
 notary/reference/


### PR DESCRIPTION
### Describe the proposed changes

The `engine/extend/` directory's contents should be edited in the upstream repo.

### Project version


### Related issue

#209 

### Related issue or PR in another project

https://github.com/docker/docker/pull/27332

### Please take a look

@thaJeztah 
