### PR TITLE
Info about IP 50 needing to be open

### DIFF
--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -121,6 +121,9 @@ The following ports must be available. On some systems, these ports are open by 
 * **TCP** and **UDP port 7946** for communication among nodes
 * **TCP** and **UDP port 4789** for overlay network traffic
 
+If you are planning on creating an overlay network with encryption (`--opt encyrpted`),
+you will also need to ensure protocol 50 (ESP) is open.
+
 ## What's next?
 
 After you have set up your environment, you are ready to [create a swarm](create-swarm.md).

--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -121,7 +121,7 @@ The following ports must be available. On some systems, these ports are open by 
 * **TCP** and **UDP port 7946** for communication among nodes
 * **TCP** and **UDP port 4789** for overlay network traffic
 
-If you are planning on creating an overlay network with encryption (`--opt encyrpted`),
+If you are planning on creating an overlay network with encryption (`--opt encrypted`),
 you will also need to ensure protocol 50 (ESP) is open.
 
 ## What's next?

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -465,6 +465,9 @@ You should open the following ports between each of your hosts.
 Your key-value store service may require additional ports.
 Check your vendor's documentation and open any required ports.
 
+If you are planning on creating an overlay network with encryption (`--opt encyrpted`),
+you will also need to ensure protocol 50 (ESP) is open.
+
 Once you have several machines provisioned, you can use Docker Swarm to quickly
 form them into a swarm which includes a discovery service as well.
 

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -465,7 +465,7 @@ You should open the following ports between each of your hosts.
 Your key-value store service may require additional ports.
 Check your vendor's documentation and open any required ports.
 
-If you are planning on creating an overlay network with encryption (`--opt encyrpted`),
+If you are planning on creating an overlay network with encryption (`--opt encrypted`),
 you will also need to ensure protocol 50 (ESP) is open.
 
 Once you have several machines provisioned, you can use Docker Swarm to quickly


### PR DESCRIPTION
### Describe the proposed changes

Added information about needing IP 50 open for overlay networks with the `--opt encrypted` flag to the docs.

### Project version

1.12 and up (anything with Docker Swarm mode).

### Please take a look

@thaJeztah



