### PR TITLE
Fix typo in Swarm scheduling doc

### DIFF
--- a/swarm/scheduler/rescheduling.md
+++ b/swarm/scheduler/rescheduling.md
@@ -2,16 +2,12 @@
 description: Swarm rescheduling
 keywords:
 - docker, swarm, clustering, rescheduling
-menu:
-  main:
-    parent: swarm_sched
-    weight: 6
 title: Rescheduling
 ---
 
 # Swarm Rescheduling
 
-You can set recheduling policies with Docker Swarm. A rescheduling policy
+You can set rescheduling policies with Docker Swarm. A rescheduling policy
 determines what the Swarm scheduler does for containers when the nodes they are
 running on fail.
 
@@ -26,7 +22,7 @@ container when a node fails.
 To set the `on-node-failure` policy with a `reschedule` environment variable:
 
 ```bash
-$ docker run -d -e reschedule:on-node-failure redis
+$ docker run -d -e "reschedule=on-node-failure" redis
 ```
 
 To set the same policy with a `com.docker.swarm.reschedule-policies` label:
@@ -40,14 +36,14 @@ $ docker run -d -l 'com.docker.swarm.reschedule-policies=["on-node-failure"]' re
 You can use the `docker logs` command to review the rescheduled container
 actions.  To do this, use the following command syntax:
 
-```
+```bash
 docker logs SWARM_MANAGER_CONTAINER_ID
 ```
 
 When a container is successfully rescheduled, it generates a message similar to
 the following:
 
-```
+```no-highlight
 Rescheduled container 2536adb23 from node-1 to node-2 as 2362901cb213da321
 Container 2536adb23 was running, starting container 2362901cb213da321
 ```
@@ -55,7 +51,7 @@ Container 2536adb23 was running, starting container 2362901cb213da321
 If for some reason, the new container fails to start on the new node, the log
 contains:
 
-```
+```no-highlight
 Failed to start rescheduled container 2362901cb213da321
 ```
 


### PR DESCRIPTION


### Describe the proposed changes

Fix a typo / incorrect command syntax. Original PR was https://github.com/docker/swarm/pull/2490.

### Project version

n/a

### Related issue

n/a

### Related issue or PR in another project

https://github.com/docker/swarm/pull/2490

### Please take a look

@thaJeztah @allencloud 
