### PR TITLE
Update branding for macOS

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -11,13 +11,13 @@ title: Install Compose
 
 # Install Docker Compose
 
-You can run Compose on OS X, Windows and 64-bit Linux. To install it, you'll need to install Docker first.
+You can run Compose on macOS, Windows and 64-bit Linux. To install it, you'll need to install Docker first.
 
 To install Compose, do the following:
 
 1. Install Docker Engine:
 
-     * <a href="/engine/installation/mac/" target="_blank">Mac OS X installation</a>
+     * <a href="/engine/installation/mac/" target="_blank">macOS installation</a>
 
      * <a href="/engine/installation/windows/" target="_blank">Windows installation</a>
 

--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -34,7 +34,7 @@ Specify the path to a Compose file. If not provided, Compose looks for a file na
 succession until a file by that name is found.
 
 This variable supports multiple compose files separate by a path separator (on
-Linux and OSX the path separator is `:`, on Windows it is `;`). For example:
+Linux and macOS the path separator is `:`, on Windows it is `;`). For example:
 `COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml`
 
 See also the `-f` [command-line option](overview.md).

--- a/docker-cloud/getting-started/deploy-app/1_introduction.md
+++ b/docker-cloud/getting-started/deploy-app/1_introduction.md
@@ -23,7 +23,7 @@ This tutorial assumes that you have:
 
 - a free <a href="https://hub.docker.com/" target="_blank">Docker ID account</a>.
 - at least one node running. If you don't have any nodes set up in Docker Cloud yet, [start here](../../getting-started/your_first_node.md) to set these up.
-- (optional) Docker Engine installed - see the installation guides for <a href="https://docs.docker.com/installation/#installation" target="_blank">OS X, Windows and Linux</a>.
+- (optional) Docker Engine installed - see the installation guides for <a href="https://docs.docker.com/installation/#installation" target="_blank">macOS, Windows and Linux</a>.
 
 Let's get started!
 

--- a/docker-cloud/getting-started/deploy-app/2_set_up.md
+++ b/docker-cloud/getting-started/deploy-app/2_set_up.md
@@ -38,9 +38,9 @@ Open your shell or terminal application and execute the following command:
 $ pip install docker-cloud
 ```
 
-#### Install on Mac OS X
+#### Install on macOS
 
-We recommend installing Docker CLI for OS X using Homebrew. If you don't have `brew` installed, follow the instructions here: <a href="http://brew.sh" target="_blank">http://brew.sh</a>
+We recommend installing Docker CLI for macOS using Homebrew. If you don't have `brew` installed, follow the instructions here: <a href="http://brew.sh" target="_blank">http://brew.sh</a>
 
 Once Homebrew is installed, open Terminal and run the following command:
 

--- a/docker-cloud/installing-cli.md
+++ b/docker-cloud/installing-cli.md
@@ -3,7 +3,7 @@ aliases:
 - /docker-cloud/getting-started/intermediate/installing-cli/
 - /docker-cloud/getting-started/installing-cli/
 - /docker-cloud/tutorials/installing-cli/
-description: Using the Docker Cloud CLI on Linux, Windows, and Mac OS X, installing,
+description: Using the Docker Cloud CLI on Linux, Windows, and macOS, installing,
   updating, uninstall
 keywords:
 - cloud, command-line, CLI
@@ -43,9 +43,9 @@ Open your terminal or command shell and execute the following command:
 $ pip install docker-cloud
 ```
 
-#### Install on Mac OS X
+#### Install on macOS
 
-We recommend installing Docker CLI for OS X using Homebrew. If you don't have `brew` installed, follow the instructions here: <a href="http://brew.sh" target="_blank">http://brew.sh</a>
+We recommend installing Docker CLI for macOS using Homebrew. If you don't have `brew` installed, follow the instructions here: <a href="http://brew.sh" target="_blank">http://brew.sh</a>
 
 Once Homebrew is installed, open Terminal and run the following command:
 
@@ -90,7 +90,7 @@ Periodically, Docker will add new features and fix bugs in the existing CLI. To 
 $ pip install -U docker-cloud
 ```
 
-#### Upgrade the docker-cloud CLI on Mac OS X
+#### Upgrade the docker-cloud CLI on macOS
 
 ```
 $ brew update && brew upgrade docker-cloud
@@ -109,7 +109,7 @@ Open your terminal or command shell and execute the following command:
 $ pip uninstall docker-cloud
 ```
 
-#### Uninstall on Mac OS X
+#### Uninstall on macOS
 
 Open your Terminal application and execute the following command:
 

--- a/docker-for-mac/docker-toolbox.md
+++ b/docker-for-mac/docker-toolbox.md
@@ -33,7 +33,7 @@ Docker for Mac is a Mac native application, that you install in `/Applications`.
 
 Here are some key points to know about Docker for Mac before you get started:
 
-* Docker for Mac does not use VirtualBox, but rather <a href="https://github.com/docker/HyperKit/" target="_blank">HyperKit</a>, a lightweight OS X virtualization solution built on top of Hypervisor.framework in OS X 10.10 Yosemite and higher.
+* Docker for Mac does not use VirtualBox, but rather <a href="https://github.com/docker/HyperKit/" target="_blank">HyperKit</a>, a lightweight macOS virtualization solution built on top of Hypervisor.framework in macOS 10.10 Yosemite and higher.
 
 * Installing Docker for Mac does not affect machines you created with Docker Machine. The install offers to copy containers and images from your local `default` machine (if one exists) to the new Docker for Mac HyperKit VM. If chosen, content from `default` is copied to the new Docker for Mac HyperKit VM, and your original `default` machine is kept as is.
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -53,8 +53,8 @@ Do the following each time:
 ### What is Docker.app?
 
 `Docker.app` is Docker for Mac, a bundle of Docker client, and Docker
-Engine. `Docker.app` uses the OS X
-Hypervisor.framework (part of MacOS X 10.10 Yosemite and higher)
+Engine. `Docker.app` uses the macOS
+Hypervisor.framework (part of macOS 10.10 Yosemite and higher)
 to run containers, meaning that _**no separate VirtualBox is required**_.
 
 ### What kind of feedback are we looking for?
@@ -122,7 +122,7 @@ Docker for Mac creates a certificate bundle of all user-trusted CAs based on the
 
 ### What are system requirements for Docker for Mac?
 
-Note that you need a Mac that supports hardware virtualization, which is most non ancient ones; i.e., use OS X `10.10.3+` or `10.11` (OS X Yosemite or OS X El Capitan). See also "What to know before you install" in [Getting Started](index.md).
+Note that you need a Mac that supports hardware virtualization, which is most non ancient ones; i.e., use macOS `10.10.3+` or `10.11` (macOS Yosemite or macOS El Capitan). See also "What to know before you install" in [Getting Started](index.md).
 
 ### Do I need to uninstall Docker Toolbox to use Docker for Mac?
 
@@ -140,7 +140,7 @@ Toolbox Mac topics.
 
 ### What is HyperKit?
 
-HyperKit is a hypervisor built on top of the Hypervisor.framework in OS X 10.10 Yosemite and higher. It runs entirely in userspace and has no other dependencies.
+HyperKit is a hypervisor built on top of the Hypervisor.framework in macOS 10.10 Yosemite and higher. It runs entirely in userspace and has no other dependencies.
 
 We use HyperKit to eliminate the need for other VM products, such as Oracle Virtualbox or VMWare Fusion.
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -55,7 +55,7 @@ For more about stable and beta channels, see the [FAQs](faqs.md#stable-and-beta-
 
 >**Important Notes**:
 >
->* Docker for Mac requires OS X 10.10.3 Yosemite or newer running on a 2010 or newer Mac, with Intel's hardware support for MMU virtualization. Please see [What to know before you install](index.md#what-to-know-before-you-install) for a full list of prerequisites.
+>* Docker for Mac requires macOS 10.10.3 Yosemite or newer running on a 2010 or newer Mac, with Intel's hardware support for MMU virtualization. Please see [What to know before you install](index.md#what-to-know-before-you-install) for a full list of prerequisites.
 >
 >* <font color="#CC3366">You can switch between beta and stable versions, but _you must have only one app installed at a time_.</font> Also, you will need to save images and export containers you want to keep before uninstalling the current version before installing another. For more about this, see the [FAQs about beta and stable channels](faqs.md#stable-and-beta-channels).
 
@@ -70,7 +70,7 @@ For more about stable and beta channels, see the [FAQs](faqs.md#stable-and-beta-
 
 	- Mac must be a 2010 or newer model, with Intel's hardware support for memory management unit (MMU) virtualization; i.e., Extended Page Tables (EPT)
 
-	- OS X 10.10.3 Yosemite or newer
+	- macOS 10.10.3 Yosemite or newer
 
 	- At least 4GB of RAM
 

--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -21,7 +21,7 @@ Docker for Mac provides several networking features to make it easier to use.
 ### VPN Passthrough
 
 Docker for Mac's networking can work when attached to a VPN.
-To do this, Docker for Mac intercepts traffic from the `HyperKit` and injects it into OSX as if it originated from the Docker application.
+To do this, Docker for Mac intercepts traffic from the `HyperKit` and injects it into macOS as if it originated from the Docker application.
 
 ### Port Mapping
 
@@ -33,10 +33,10 @@ Docker for Mac will make the container port available at `localhost`.
 
 ### HTTP/HTTPS Proxy Support
 
-Docker for Mac will detect HTTP/HTTPS Proxy Settings from OSX and automatically propagate these to Docker and to your containers.
-For example, if you set your proxy settings to `http://proxy.example.com` in OSX, Docker will use this proxy when pulling containers.
+Docker for Mac will detect HTTP/HTTPS Proxy Settings from macOS and automatically propagate these to Docker and to your containers.
+For example, if you set your proxy settings to `http://proxy.example.com` in macOS, Docker will use this proxy when pulling containers.
 
-![OSX Proxy Settings](images/proxy-settings.png)
+![macOS Proxy Settings](images/proxy-settings.png)
 
 When you start a container, you will see that your proxy settings propagate into the containers. For example:
 
@@ -59,18 +59,18 @@ If you have containers that you wish to keep running across restarts, you should
 
 Following is a summary of current limitations on the Docker for Mac networking stack, along with some ideas for workarounds.
 
-### There is no docker0 bridge on OSX
+### There is no docker0 bridge on macOS
 
-Because of the way networking is implemented in Docker for Mac, you cannot see a `docker0` interface in OSX.
+Because of the way networking is implemented in Docker for Mac, you cannot see a `docker0` interface in macOS.
 This interface is actually within `HyperKit`.
 
 ### I cannot ping my containers
 
-Unfortunately, due to limitations in OSX, we're unable to route traffic to containers, and from containers back to the host.
+Unfortunately, due to limitations in macOS, we're unable to route traffic to containers, and from containers back to the host.
 
 ### Per-container IP addressing is not possible
 
-The docker (Linux) bridge network is not reachable from the OSX host.
+The docker (Linux) bridge network is not reachable from the macOS host.
 
 ### Use cases and workarounds
 
@@ -105,6 +105,6 @@ See the [run commmand](/engine/reference/commandline/run.md) for more details on
 
 #### A view into implementation
 
-We understand that these workarounds are not ideal, but there are several problems. In particular, there is a bug in OSX that is only fixed in 10.12 and is not being backported as far as we can tell, which means that we could not support this in all supported OSX versions. In addition, this network setup would require root access which we are trying to avoid entirely in Docker for Mac (we currently have a very small root helper that we are trying to remove).
+We understand that these workarounds are not ideal, but there are several problems. In particular, there is a bug in macOS that is only fixed in 10.12 and is not being backported as far as we can tell, which means that we could not support this in all supported macOS versions. In addition, this network setup would require root access which we are trying to avoid entirely in Docker for Mac (we currently have a very small root helper that we are trying to remove).
 
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -29,7 +29,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 
 **New**
 
-* Support for OSX 10.12 Sierra
+* Support for macOS 10.12 Sierra
 
 **Upgrades**
 
@@ -73,7 +73,7 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 
 * Use Mac System Configuration database to detect DNS
 
-**Filesharing (OSXFS)**
+**Filesharing (osxfs)**
 
 * Fixed thread leak
 
@@ -229,7 +229,7 @@ TBD
 
 **Known Issues**
 
-* `Docker.app` sometimes uses 200% CPU after OS X wakes up from sleep mode. The
+* `Docker.app` sometimes uses 200% CPU after macOS wakes up from sleep mode. The
 issue is being investigated. The workaround is to restart Docker.app.
 
 * There are a number of issues with the performance of directories bind-mounted with `osxfs`. In particular, writes of small blocks and
@@ -244,7 +244,7 @@ available in [Known Issues](troubleshoot.md#known-issues) in Troubleshooting.
 
 **Upgrades**
 
-* Experimental support for OSX 10.12 Sierra (beta)
+* Experimental support for macOS 10.12 Sierra (beta)
 
 **Bug fixes and minor changes**
 
@@ -258,7 +258,7 @@ available in [Known Issues](troubleshoot.md#known-issues) in Troubleshooting.
 investigated. This includes failure to launch the app and being unable to
 upgrade to a new version.
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The
 issue is being investigated. The workaround is to restart Docker.app
 
 * There are a number of issues with the performance of directories bind-mounted
@@ -296,7 +296,7 @@ Issues](troubleshoot.md#known-issues) in Troubleshooting.
 * Several problems have been reported on macOS 10.12 Sierra and are being investigated. This includes failure to launch the app and being unable to
 upgrade to a new version.
 
-* `Docker.app` sometimes uses 200% CPU after OS X wakes up from sleep mode.  The issue is being investigated. The workaround is to restart `Docker.app`.
+* `Docker.app` sometimes uses 200% CPU after macOS wakes up from sleep mode.  The issue is being investigated. The workaround is to restart `Docker.app`.
 
 * There are a number of issues with the performance of directories bind-mounted with `osxfs`. In particular, writes of small blocks and traversals of large
 directories are currently slow. Additionally, containers that perform large
@@ -323,9 +323,9 @@ trees, may suffer from poor performance. For more information and workarounds, s
 
 **Known issues**
 
-*  Docker for Mac is not supported on OSX 10.12 Sierra
+*  Docker for Mac is not supported on macOS 10.12 Sierra
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
 
 * There are a number of issues with the performance of directories bind-mounted with `osxfs`. In particular, writes of small blocks and traversals of large directories are currently slow. Additionally, containers that perform large numbers of directory operations, such as repeated scans of large directory trees, may suffer from poor performance. For more information and workarounds, see the bullet on [performance of bind-mounted directories](troubleshoot.md#bind-mounted-dirs) in [Known Issues](troubleshoot.md#known-issues) in Troubleshooting.
 
@@ -348,7 +348,7 @@ trees, may suffer from poor performance. For more information and workarounds, s
 
 **Known issues**
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
 
 * There are a number of issues with the performance of directories bind-mounted with `osxfs`. In particular, writes of small blocks and traversals of large directories are currently slow. Additionally, containers that perform large numbers of directory operations, such as repeated scans of large directory trees, may suffer from poor performance. More information is available in [Known Issues](troubleshoot.md#known-issues) in [Troubleshooting](troubleshoot.md)
 
@@ -395,7 +395,7 @@ events or unexpected unmounts.
 
 **Known issues**
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
 
 * There are a number of issues with the performance of directories bind-mounted with `osxfs`.  In particular, writes of small blocks, and traversals of large directories are currently slow.  Additionally, containers that perform large numbers of directory operations, such as repeated scans of large directory trees, may suffer from poor performance. For more information and workarounds, see [Known Issues](troubleshoot.md#known-issues) in [Logs and Troubleshooting](troubleshoot.md).
 
@@ -414,7 +414,7 @@ events or unexpected unmounts.
 
 **Known issues**
 
-*  `Docker.app` sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker for Mac (`Docker.app`).
+*  `Docker.app` sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker for Mac (`Docker.app`).
 
 ### Beta 19 Release Notes (2016-07-14 1.12.0-rc4-beta19)
 
@@ -563,7 +563,7 @@ events or unexpected unmounts.
 
 **Known issues**
 
-* `Docker.app` sometimes uses 200% CPU after OS X wakes up from sleep mode with OSX 10.10. The issue is being investigated. The workaround is to restart `Docker.app`.
+* `Docker.app` sometimes uses 200% CPU after macOS wakes up from sleep mode with macOS 10.10. The issue is being investigated. The workaround is to restart `Docker.app`.
 
 **Bug fixes and minor changes**
 
@@ -594,7 +594,7 @@ events or unexpected unmounts.
 
 **Known issues**
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
 
 **Bug fixes and minor changes**
 
@@ -613,7 +613,7 @@ events or unexpected unmounts.
 
 **Known issues**
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
 
 **Bug fixes and minor changes**
 
@@ -624,7 +624,7 @@ events or unexpected unmounts.
 
 **New**
 
-The `osxfs` file system now persists ownership changes in an extended attribute. (See the topic on [ownership](osxfs.md#ownership) in [Sharing the OS X file system with Docker containers](osxfs.md).)
+The `osxfs` file system now persists ownership changes in an extended attribute. (See the topic on [ownership](osxfs.md#ownership) in [Sharing the macOS file system with Docker containers](osxfs.md).)
 
 **Upgrades**
 
@@ -674,7 +674,7 @@ The `osxfs` file system now persists ownership changes in an extended attribute.
 
 **Known issues**
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
 
 **Bug fixes and minor changes**
 
@@ -709,7 +709,7 @@ The `osxfs` file system now persists ownership changes in an extended attribute.
 
 **Known issues**
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart `Docker.app`
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart `Docker.app`
 
 **Bug fixes and minor changes**
 
@@ -738,7 +738,7 @@ The `osxfs` file system now persists ownership changes in an extended attribute.
 
 **Known issues**
 
-* Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
+* Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app
 
 * If VPN mode is enabled and then disabled and then re-enabled again, `docker ps` will block for 90s
 
@@ -762,7 +762,7 @@ The `osxfs` file system now persists ownership changes in an extended attribute.
 
 **Known issues**
 
-* `Docker.app` sometimes uses 200% CPU after OS X wakes up from sleep mode.
+* `Docker.app` sometimes uses 200% CPU after macOS wakes up from sleep mode.
 The issue is being investigated. The workaround is to restart
 `Docker.app`.
 
@@ -798,7 +798,7 @@ lead to `Docker.app` not starting on reboot
 
 - There is a race on startup between docker and networking which can lead to Docker.app not starting on reboot. The workaround is to restart the application manually.
 
-- Docker.app sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
+- Docker.app sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart Docker.app.
 
 - In VPN mode, the `-p` option needs to be explicitly of the form `-p <host port>:<container port>`. `-p <port>` and `-P` will not work yet.
 
@@ -828,7 +828,7 @@ lead to `Docker.app` not starting on reboot
 
 - There is a race on startup between Docker and networking that can lead to `Docker.app` not starting on reboot. The workaround is to restart the application manually.
 
-- `Docker.app` sometimes uses 200% CPU after OS X wakes up from sleep mode. The issue is being investigated. The workaround is to restart `Docker.app`.
+- `Docker.app` sometimes uses 200% CPU after macOS wakes up from sleep mode. The issue is being investigated. The workaround is to restart `Docker.app`.
 
 - VPN/Hostnet: In VPN mode, the `-p` option needs to be explicitly of the form
 `-p <host port>:<container port>`. `-p <port>` and `-P` will not
@@ -840,7 +840,7 @@ work yet.
 
 - `docker ps` shows IP address rather than `docker.local`
 
-- Re-enabled support for OS X Yosemite version 10.10
+- Re-enabled support for macOS Yosemite version 10.10
 
 - Ensured binaries are built for 10.10 rather than 10.11
 
@@ -853,7 +853,7 @@ work yet.
 
 **New Features and Upgrades**
 
-- Improved file sharing write speed in OSXFS
+- Improved file sharing write speed in osxfs
 
 - User space networking: Renamed `bridged` mode to `nat` mode
 
@@ -866,8 +866,8 @@ work yet.
 - GUI: Auto update automatically checks for new versions again
 
 - File System
-  - Fixed OSXFS chmod on sockets
-  - FixED OSXFS EINVAL from `open` using O_NOFOLLOW
+  - Fixed osxfs chmod on sockets
+  - FixED osxfs EINVAL from `open` using O_NOFOLLOW
 
 
 - Hypervisor stability fixes, resynced with upstream repository

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -220,7 +220,7 @@ ${!DOCKER_*}` will unset existing `DOCKER` environment variables you have set.
 
 <p></p>
 
-* Note that network connections will fail if the OS X Firewall is set to
+* Note that network connections will fail if the macOS Firewall is set to
 "Block all incoming connections". You can enable the firewall, but `bootpd` must be allowed incoming connections so that the VM can get an IP address.
 
 <p></p>
@@ -268,7 +268,7 @@ Docker for Mac does not yet support IPv6. See "IPv6 workaround to auto-filter DN
 
 <p></p>
 
-* Docker for Mac uses the `HyperKit` hypervisor (https://github.com/docker/hyperkit) in Mac OS X 10.10 Yosemite and higher. If you are developing with tools that have conflicts with `HyperKit`, such as [Intel Hardware Accelerated Execution Manager (HAXM)](https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager/), the current workaround is not to run them at the same time. You can pause `HyperKit` by quitting Docker for Mac temporarily while you work with HAXM. This will allow you to continue work with the other tools and prevent `HyperKit` from interfering.
+* Docker for Mac uses the `HyperKit` hypervisor (https://github.com/docker/hyperkit) in macOS 10.10 Yosemite and higher. If you are developing with tools that have conflicts with `HyperKit`, such as [Intel Hardware Accelerated Execution Manager (HAXM)](https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager/), the current workaround is not to run them at the same time. You can pause `HyperKit` by quitting Docker for Mac temporarily while you work with HAXM. This will allow you to continue work with the other tools and prevent `HyperKit` from interfering.
 
 <p></p>
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -884,8 +884,8 @@ are working on a solution.
 - Rename `console` to `debug console`
 - Remove `machine` from notification
 - Open the feedback forum
-- Use same MixPanel project for Windows and OSX
-- Align MixPanel events with OSX
+- Use same MixPanel project for Windows and macOS
+- Align MixPanel events with macOS
 - Added a script to diagnose problems
 - Submit diagnostic with bugsnag reports
 - MixPanel heartbeat every hour

--- a/engine/examples/apt-cacher-ng.md
+++ b/engine/examples/apt-cacher-ng.md
@@ -13,7 +13,7 @@ title: Dockerizing an apt-cacher-ng service
 > **Note**:
 > - **If you don't like sudo** then see [*Giving non-root
 >   access*](../installation/binaries.md#giving-non-root-access).
-> - **If you're using OS X or docker via TCP** then you shouldn't use
+> - **If you're using macOS or docker via TCP** then you shouldn't use
 >   sudo.
 
 When you have multiple Docker servers, or build unrelated Docker

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -30,11 +30,11 @@ We are using the Apache License Version 2.0, see it here:
 [https://github.com/docker/docker/blob/master/LICENSE](
 https://github.com/docker/docker/blob/master/LICENSE)
 
-### Does Docker run on Mac OS X or Windows?
+### Does Docker run on macOS or Windows?
 
 Docker Engine currently runs only on Linux, but you can use VirtualBox to run
 Engine in a virtual machine on your box, and get the best of both worlds. Check
-out the [*Mac OS X*](installation/mac.md) and [*Microsoft
+out the [*macOS*](installation/mac.md) and [*Microsoft
 Windows*](installation/windows.md) installation guides. The small Linux
 distribution boot2docker can be set up using the Docker Machine tool to be run
 inside virtual machines on these two operating systems.

--- a/engine/getstarted/step_one.md
+++ b/engine/getstarted/step_one.md
@@ -32,7 +32,7 @@ Docker for Mac is our newest offering for the Mac. It runs as a native Mac appli
 
 - Mac must be a 2010 or newer model, with Intel's hardware support for memory management unit (MMU) virtualization; i.e., Extended Page Tables (EPT)
 
-- OS X 10.10.3 Yosemite or newer
+- macOS 10.10.3 Yosemite or newer
 
 - At least 4GB of RAM
 

--- a/engine/installation/binaries.md
+++ b/engine/installation/binaries.md
@@ -61,7 +61,7 @@ minor version will ensure critical kernel bugs get fixed.
 > newer kernels.
 
 Note that Docker also has a client mode, which can run on virtually any
-Linux kernel (it even builds on OS X!).
+Linux kernel (it even builds on macOS!).
 
 ## Enable AppArmor and SELinux when possible
 
@@ -169,14 +169,14 @@ For additional information about running the Engine in daemon mode, refer to
 the [daemon command](../reference/commandline/dockerd.md) in the Engine command
 line reference.
 
-### Get the Mac OS X binary
+### Get the macOS binary
 
-The Mac OS X binary is only a client. You cannot use it to run the `docker`
-daemon. To download the latest version for Mac OS X, use the following URLs:
+The macOS binary is only a client. You cannot use it to run the `docker`
+daemon. To download the latest version for macOS, use the following URLs:
 
     https://get.docker.com/builds/Darwin/x86_64/docker-latest.tgz
 
-To download a specific version for Mac OS X, use the
+To download a specific version for macOS, use the
 following URL pattern:
 
     https://get.docker.com/builds/Darwin/x86_64/docker-<version>.tgz

--- a/engine/installation/cloud/cloud-ex-machine-ocean.md
+++ b/engine/installation/cloud/cloud-ex-machine-ocean.md
@@ -49,7 +49,7 @@ To generate your access token:
 
 1. If you have not done so already, install Docker Machine on your local host.
 
-  * <a href="https://docs.docker.com/engine/installation/mac/" target="_blank"> How to install Docker Machine on Mac OS X</a>
+  * <a href="https://docs.docker.com/engine/installation/mac/" target="_blank"> How to install Docker Machine on macOS</a>
 
   * <a href="https://docs.docker.com/engine/installation/windows/" target="_blank">How to install Docker Machine on Windows</a>
 

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -16,7 +16,7 @@ title: Install
 
 # Install Docker Engine
 
-Docker Engine is supported on Linux, Cloud, Windows, and OS X. Installation instructions are available for the following:
+Docker Engine is supported on Linux, Cloud, Windows, and macOS. Installation instructions are available for the following:
 
 ## On Linux
 * [Arch Linux](linux/archlinux.md)
@@ -37,8 +37,8 @@ If your linux distribution is not listed above, don't give up yet. To try out Do
 * [Example: Manual install on a cloud provider](cloud/cloud-ex-aws.md)
 * [Example: Use Docker Machine to provision cloud hosts](cloud/cloud-ex-machine-ocean.md)
 
-## On OSX and Windows
-* [Mac OS X](mac.md)
+## On macOS and Windows
+* [macOS](mac.md)
 * [Windows](windows.md)
 
 ## The Docker Archives

--- a/engine/installation/mac.md
+++ b/engine/installation/mac.md
@@ -1,16 +1,16 @@
 ---
-description: Instructions for installing Docker on OS X using boot2docker.
+description: Instructions for installing Docker on macOS using boot2docker.
 keywords:
 - Docker, Docker documentation, requirements, boot2docker, VirtualBox, SSH, Linux,
-  OSX, OS X,  Mac
+  osx, os x, macOS,  Mac
 menu:
   main:
     parent: engine_install
     weight: "-90"
-title: Installation on Mac OS X
+title: Installation on macOS
 ---
 
-# Mac OS X
+# macOS
 
 You have two options for installing Docker on Mac:
 
@@ -27,7 +27,7 @@ Go to [Getting Started with Docker for Mac](https://docs.docker.com/docker-for-m
 
 - Mac must be a 2010 or newer model, with Intel's hardware support for memory management unit (MMU) virtualization; i.e., Extended Page Tables (EPT)
 
-- OS X 10.10.3 Yosemite or newer
+- macOS 10.10.3 Yosemite or newer
 
 - At least 4GB of RAM
 
@@ -39,11 +39,11 @@ If you have an earlier Mac that doesn't meet the Docker for Mac requirements, <a
 
 See [Docker Toolbox Overview](/toolbox/overview.md) for help on installing Docker with Toolbox.
 
-The Docker Toolbox setup does not run Docker natively in OS X. Instead, it uses `docker-machine` to create and attach to a virtual machine (VM). This machine is a Linux VM that hosts Docker for you on your Mac.
+The Docker Toolbox setup does not run Docker natively in macOS. Instead, it uses `docker-machine` to create and attach to a virtual machine (VM). This machine is a Linux VM that hosts Docker for you on your Mac.
 
 **Requirements**
 
-Your Mac must be running OS X 10.8 "Mountain Lion" or newer to install the Docker Toolbox. Full install instructions are at [Toolbox install instructions for Mac](/toolbox/toolbox_install_mac.md).
+Your Mac must be running macOS 10.8 "Mountain Lion" or newer to install the Docker Toolbox. Full install instructions are at [Toolbox install instructions for Mac](/toolbox/toolbox_install_mac.md).
 
 
 ## Learning more

--- a/engine/reference/commandline/login.md
+++ b/engine/reference/commandline/login.md
@@ -52,7 +52,7 @@ This is the list of currently available credentials helpers and where
 you can download them from:
 
 - D-Bus Secret Service: https://github.com/docker/docker-credential-helpers/releases
-- Apple OS X keychain: https://github.com/docker/docker-credential-helpers/releases
+- Apple macOS keychain: https://github.com/docker/docker-credential-helpers/releases
 - Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases
 
 ### Usage

--- a/engine/reference/glossary.md
+++ b/engine/reference/glossary.md
@@ -117,7 +117,7 @@ Examples :
 
 - Linux : ext4, aufs, btrfs, zfs
 - Windows : NTFS
-- OS X : HFS+
+- macOS : HFS+
 
 ## image
 

--- a/engine/security/certificates.md
+++ b/engine/security/certificates.md
@@ -67,7 +67,7 @@ key and then use the key to create the certificate.
 
 > **Note:**
 > These TLS commands will only generate a working set of certificates on Linux.
-> The version of OpenSSL in Mac OS X is incompatible with the type of
+> The version of OpenSSL in macOS is incompatible with the type of
 > certificate Docker requires.
 
 ## Troubleshooting tips

--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -30,7 +30,7 @@ it will only connect to servers with a certificate signed by that CA.
 
 > **Warning**:
 > These TLS commands will only generate a working set of certificates on Linux.
-> Mac OS X comes with a version of OpenSSL that is incompatible with the
+> macOS comes with a version of OpenSSL that is incompatible with the
 > certificates that Docker requires.
 
 ## Create a CA, server and client keys with OpenSSL

--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -19,7 +19,7 @@ overview](content_trust.md).
 
 ### Prerequisites
 
-These instructions assume you are running in Linux or Mac OS X. You can run
+These instructions assume you are running in Linux or macOS. You can run
 this sandbox on a local machine or on a virtual machine. You will need to
 have privileges to run docker commands on your local machine or in the VM.
 

--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -104,7 +104,7 @@ the IP address.
 Because other nodes contact the manager node on its IP address, you should use a
 fixed IP address.
 
-You can run `ifconfig` on Linux or Mac OS X to see a list of the
+You can run `ifconfig` on Linux or macOS to see a list of the
 available network interfaces.
 
 If you are using Docker Machine, you can get the manager IP with either

--- a/engine/tutorials/dockervolumes.md
+++ b/engine/tutorials/dockervolumes.md
@@ -122,9 +122,9 @@ If you supply the `/foo` value, the Docker Engine creates a bind-mount. If you s
 the `foo` specification, the Docker Engine creates a named volume.
 
 If you are using Docker Machine on Mac or Windows, your Docker Engine daemon has only
-limited access to your OS X or Windows filesystem. Docker Machine tries to
-auto-share your `/Users` (OS X) or `C:\Users` (Windows) directory.  So, you can
-mount files or directories on OS X using.
+limited access to your macOS or Windows filesystem. Docker Machine tries to
+auto-share your `/Users` (macOS) or `C:\Users` (Windows) directory.  So, you can
+mount files or directories on macOS using.
 
 ```bash
 docker run -v /Users/<path>:/<container path> ...

--- a/engine/tutorials/usingdocker.md
+++ b/engine/tutorials/usingdocker.md
@@ -172,7 +172,7 @@ see the application.
 Our Python application is live!
 
 > **Note:**
-> If you have been using a virtual machine on OS X, Windows or Linux,
+> If you have been using a virtual machine on macOS, Windows or Linux,
 > you'll need to get the IP of the virtual host instead of using localhost.
 > You can do this by running the `docker-machine ip your_vm_name` from your  command line or terminal application, for example:
 >

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ layout: docs
 	<div class="media_content">
 	<div data-mh="mh_docker_projects">
 	<h3><a href="/docker-for-mac/">Docker for Mac</a></h3>
-		<p>A native application using the OS X sandbox security model which delivers all Docker tools to your Mac.</p>
+		<p>A native application using the macOS sandbox security model which delivers all Docker tools to your Mac.</p>
 	</div>
 	</div>
 </li>
@@ -125,7 +125,7 @@ layout: docs
 	<h3><a href="/machine/install-machine/">Docker Machine</a></h3>
 		<p>
     Automate container provisioning on your network or in
-    the cloud. Available for Windows, Mac OS X, or Linux.</p>
+    the cloud. Available for Windows, macOS, or Linux.</p>
 	</div>
 	</div>
 </li>

--- a/kitematic/faq.md
+++ b/kitematic/faq.md
@@ -29,7 +29,7 @@ the Docker Remote API.
 
 ### Which platforms does Kitematic support?
 
-Right now Kitematic works on Mac OS X and Windows. Linux is planned in the
+Right now Kitematic works on macOS and Windows. Linux is planned in the
 future.  Review our product <a
 href="https://github.com/kitematic/kitematic/blob/master/ROADMAP.md">roadmap</a>.
 

--- a/kitematic/index.md
+++ b/kitematic/index.md
@@ -13,6 +13,6 @@ title: Kitematic
 
 # Kitematic 
 
-Kitematic, the Docker GUI, runs on Mac OS X and Windows operating systems. Beginning with the 1.8 Docker release, you use the Docker Toolbox to install Kitematic.  See the [Mac OS X installation guide](https://docs.docker.com/installation/mac) or the [Windows installation guide](https://docs.docker.com/installation/windows) for details on installing with Docker Toolbox.
+Kitematic, the Docker GUI, runs on macOS and Windows operating systems. Beginning with the 1.8 Docker release, you use the Docker Toolbox to install Kitematic.  See the [macOS installation guide](https://docs.docker.com/installation/mac) or the [Windows installation guide](https://docs.docker.com/installation/windows) for details on installing with Docker Toolbox.
 
 For information about using Kitematic, take a look at the [User Guide](userguide.md).

--- a/kitematic/rethinkdb-dev-database.md
+++ b/kitematic/rethinkdb-dev-database.md
@@ -44,7 +44,7 @@ for you). This means you can now reach RethinkDB via a client driver at
 ### (Advanced) Saving Data into RethinkDB with a local Node.js App
 
 Now, you'll create the RethinkDB example chat application running on your local
-OS X system to test drive your new containerized database.
+macOS system to test drive your new containerized database.
 
 First, if you don't have it yet, [download and install
 Node.js](http://nodejs.org/).

--- a/kitematic/userguide.md
+++ b/kitematic/userguide.md
@@ -162,7 +162,7 @@ Kitematic will prompt you to confirm that you want to delete.
 
 To see the complete list of exposed ports, go to "Settings" then "Ports". This
 page lists all the container ports exposed, and the IP address and host-only
-network port that you can access use to access that container from your OS X
+network port that you can access use to access that container from your macOS
 system.
 
 ## Docker Command-line Access

--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -49,8 +49,8 @@ Hyper-V](drivers/hyper-v.md).)
 #### If you are using Docker for Mac
 
 Docker for Mac uses [HyperKit](https://github.com/docker/HyperKit/), a
-lightweight OS X virtualization solution built on top of the
-[Hypervisor.framework](https://developer.apple.com/reference/hypervisor) in OS X
+lightweight macOS virtualization solution built on top of the
+[Hypervisor.framework](https://developer.apple.com/reference/hypervisor) in macOS
 10.10 Yosemite and higher.
 
 Currently, there is no `docker-machine create` driver for HyperKit, so you will
@@ -291,7 +291,7 @@ default)` in their shell profiles (e.g., the `~/.bash_profile` file). However,
 this fails if the `default` machine is not running. If desired, you can
 configure your system to start the `default` machine automatically.
 
-Here is an example of how to configure this on OS X.
+Here is an example of how to configure this on macOS.
 
 Create a file called `com.docker.machine.default.plist` under `~/Library/LaunchAgents` with the following content:
 

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -11,9 +11,9 @@ title: Install Machine
 
 # Install Docker Machine
 
-On OS X and Windows, Machine is installed along with other Docker products when
+On macOS and Windows, Machine is installed along with other Docker products when
 you install the Docker Toolbox. For details on installing Docker Toolbox, see
-the <a href="https://docs.docker.com/installation/mac/" target="_blank">Mac OS X
+the <a href="https://docs.docker.com/installation/mac/" target="_blank">macOS
 installation</a> instructions or <a
 href="https://docs.docker.com/installation/windows" target="_blank">Windows
 installation</a> instructions.
@@ -27,7 +27,7 @@ If you want only Docker Machine, you can install the Machine binaries directly b
 
 2.  Download the Docker Machine binary and extract it to your PATH.
 
-    If you are running OS X or Linux:
+    If you are running macOS or Linux:
 
         $ curl -L https://github.com/docker/machine/releases/download/v0.8.2/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine && \
         chmod +x /usr/local/bin/docker-machine

--- a/notary/getting_started.md
+++ b/notary/getting_started.md
@@ -32,7 +32,7 @@ freshness of your content.
 
 ## Install Notary
 
-You can download precompiled notary binary for 64 bit Linux or Mac OS X from the
+You can download precompiled notary binary for 64 bit Linux or macOS from the
 Notary repository's
 <a href="https://github.com/docker/notary/releases" target="_blank">releases page on
 GitHub</a>. Windows is not officially

--- a/opensource/kitematic/set_up_dev.md
+++ b/opensource/kitematic/set_up_dev.md
@@ -33,7 +33,7 @@ the above installer link will have an uninstaller available.
 
   ![windows installer](images/nvm_install.jpeg)
 
-### Mac OSX/Linux:
+### macOS/Linux:
 
 1. Open a terminal window
 
@@ -45,7 +45,7 @@ the above installer link will have an uninstaller available.
 
     (Alternatively, you can source nvm from your current shell with the command `. ~/.nvm/nvm.sh` )
 
-(To learn more about working with NVM, see <a href="https://github.com/creationix/nvm" target="_blank">Mac OSX/Linux official nvm repo</a>, <a href="https://github.com/coreybutler/nvm-windows" target="_blank">Windows official nvm repo</a>, and <a href="https://www.digitalocean.com/community/tutorials/how-to-install-node-js-with-nvm-node-version-manager-on-a-vps" target="_blank">How To Install Node.js with NVM ON A VPS</a>)
+(To learn more about working with NVM, see <a href="https://github.com/creationix/nvm" target="_blank">macOS/Linux official nvm repo</a>, <a href="https://github.com/coreybutler/nvm-windows" target="_blank">Windows official nvm repo</a>, and <a href="https://www.digitalocean.com/community/tutorials/how-to-install-node-js-with-nvm-node-version-manager-on-a-vps" target="_blank">How To Install Node.js with NVM ON A VPS</a>)
 
 ## Install Node.js
 

--- a/opensource/project/set-up-dev-env.md
+++ b/opensource/project/set-up-dev-env.md
@@ -30,7 +30,7 @@ you continue working with your fork on this branch.
 ##  Task 1. Remove images and containers
 
 Docker developers run the latest stable release of the Docker software (with
-Docker Machine if their machine is Mac OS X). They clean their local hosts of
+Docker Machine if their machine is macOS). They clean their local hosts of
 unnecessary Docker artifacts such as stopped containers or unused images.
 Cleaning unnecessary artifacts isn't strictly necessary, but it is good
 practice, so it is included here.

--- a/opensource/project/software-required.md
+++ b/opensource/project/software-required.md
@@ -9,9 +9,9 @@ menu:
 title: Get the required software
 ---
 
-# Get the required software for Linux or OS X
+# Get the required software for Linux or macOS
 
-This page explains how to get the software you need to use a Linux or OS X
+This page explains how to get the software you need to use a Linux or macOS
 machine for Docker development. Before you begin contributing you must have:
 
 *  a GitHub account
@@ -70,9 +70,9 @@ docker --version
 Docker version 1.11.0, build 4dc5990
 ```
 
-On Mac OS X or Windows, you should have installed Docker Toolbox which includes
+On macOS or Windows, you should have installed Docker Toolbox which includes
 Docker. You'll need to verify both Docker Machine and Docker. This
-documentation was written on OS X using the following versions.
+documentation was written on macOS using the following versions.
 
 ```bash
 $ docker-machine --version

--- a/opensource/project/test-and-docs.md
+++ b/opensource/project/test-and-docs.md
@@ -271,7 +271,7 @@ directly requires you to install some prerequisites, but is faster on each build
 
 #### Using Docker Compose
 
-The easiest way to build the docs locally on OS X, Windows, or Linux is to use
+The easiest way to build the docs locally on macOS, Windows, or Linux is to use
 `docker-compose`. If you have not yet installed `docker-compose`,
 [follow these installation instructions](https://docs.docker.com/compose/install/).
 
@@ -303,7 +303,7 @@ If for some reason you are unable to use Docker Compose, you can use Jekyll dire
 
 **Prerequisites:**
 
--  You need a recent version of Ruby installed. If you are on OS X, install Ruby
+-  You need a recent version of Ruby installed. If you are on macOS, install Ruby
   and Bundle using homebrew.
     ```bash
     brew install ruby

--- a/opensource/project/who-written-for.md
+++ b/opensource/project/who-written-for.md
@@ -61,5 +61,5 @@ Please feel free to skim past information you find obvious or boring.
 ## How to get started
 
 Start by getting the software you require. If you are on Mac or Linux, go to
-[get the required software for Linux or OS X](software-required.md). If you are
+[get the required software for Linux or macOS](software-required.md). If you are
 on Windows, see [get the required software for Windows](software-req-win.md).

--- a/opensource/ways/issues.md
+++ b/opensource/ways/issues.md
@@ -51,7 +51,7 @@ notification go to your GitHub or email inbox. Some of repositories you can watc
     </tr>
     <tr>
         <td class="tg-031e"><a href="https://github.com/kitematic/kitematic" target="_blank">kitematic/kitematic</a></td>
-        <td class="tg-031e">Kitematic is a simple application for managing Docker containers on Mac OS X and Windows.</td>
+        <td class="tg-031e">Kitematic is a simple application for managing Docker containers on macOS and Windows.</td>
     </tr>
     <tr>
         <td class="tg-031e"><a href="https://github.com/docker/swarm" target="_blank">docker/swarm</a></td>

--- a/registry/recipes/index.md
+++ b/registry/recipes/index.md
@@ -33,5 +33,5 @@ At this point, it's assumed that:
 
  * [using Apache as an authenticating proxy](apache.md)
  * [using Nginx as an authenticating proxy](nginx.md)
- * [running a Registry on OS X](osx-setup-guide.md)
+ * [running a Registry on macOS](osx-setup-guide.md)
  * [mirror the Docker Hub](mirror.md)

--- a/registry/recipes/menu.md
+++ b/registry/recipes/menu.md
@@ -17,5 +17,5 @@ type: menu
 
  * [using Apache as an authenticating proxy](apache.md)
  * [using Nginx as an authenticating proxy](nginx.md)
- * [running a Registry on OS X](osx-setup-guide.md)
+ * [running a Registry on macOS](osx-setup-guide.md)
  * [mirror the Docker Hub](mirror.md)

--- a/registry/recipes/osx-setup-guide.md
+++ b/registry/recipes/osx-setup-guide.md
@@ -1,32 +1,32 @@
 ---
-description: Explains how to run a registry on OS X
+description: Explains how to run a registry on macOS
 keywords:
-- registry, on-prem, images, tags, repository, distribution, OS X, recipe, advanced
+- registry, on-prem, images, tags, repository, distribution, macOS, recipe, advanced
 menu:
   main:
     parent: smn_recipes
-title: Running on OS X
+title: Running on macOS
 ---
 
-# OS X Setup Guide
+# macOS Setup Guide
 
 ## Use-case
 
-This is useful if you intend to run a registry server natively on OS X.
+This is useful if you intend to run a registry server natively on macOS.
 
 ### Alternatives
 
-You can start a VM on OS X, and deploy your registry normally as a container using Docker inside that VM.
+You can start a VM on macOS, and deploy your registry normally as a container using Docker inside that VM.
 
 The simplest road to get there is traditionally to use the [docker Toolbox](https://www.docker.com/toolbox), or [docker-machine](/machine/index.md), which usually relies on the [boot2docker](http://boot2docker.io/) iso inside a VirtualBox VM.
 
 ### Solution
 
-Using the method described here, you install and compile your own from the git repository and run it as an OS X agent.
+Using the method described here, you install and compile your own from the git repository and run it as an macOS agent.
 
 ### Gotchas
 
-Production services operation on OS X is out of scope of this document. Be sure you understand well these aspects before considering going to production with this.
+Production services operation on macOS is out of scope of this document. Be sure you understand well these aspects before considering going to production with this.
 
 ## Setup golang on your machine
 

--- a/swarm/install-w-machine.md
+++ b/swarm/install-w-machine.md
@@ -15,7 +15,7 @@ on your local machine using Docker Machine and VirtualBox.
 
 ## Prerequisites
 
-Make sure your local system has VirtualBox installed. If you are using Mac OS X
+Make sure your local system has VirtualBox installed. If you are using macOS
 or Windows and have installed Docker, you should have VirtualBox already
 installed.
 
@@ -41,7 +41,7 @@ Daemon running on each node. Other discovery service backends such as
 		NAME         ACTIVE   DRIVER       STATE     URL                         SWARM
 		docker-vm    *        virtualbox   Running   tcp://192.168.99.100:2376   
 
-	This example was run a Mac OSX system with Docker Toolbox installed. So, the
+	This example was run a macOS system with Docker Toolbox installed. So, the
 		`docker-vm` virtual machine is in the list.
 
 2. Create a VirtualBox machine called `local` on your system.  

--- a/swarm/provision-with-machine.md
+++ b/swarm/provision-with-machine.md
@@ -32,9 +32,9 @@ continuing](https://docs.docker.com/machine).
 
 ## What you need
 
-If you are using Mac OS X or Windows and have installed with Docker Toolbox, you
+If you are using macOS or Windows and have installed with Docker Toolbox, you
 should already have Machine installed. If you need to install, see the
-instructions for [Mac OS X](https://docs.docker.com/engine/installation/mac/) or
+instructions for [macOS](https://docs.docker.com/engine/installation/mac/) or
 [Windows](https://docs.docker.com/engine/installation/mac/).
 
 Machine supports installing on AWS, Digital Ocean, Google Cloud Platform, IBM
@@ -47,7 +47,7 @@ The Toolbox installation gives you VirtualBox and the `boot2docker.iso` image
 you need. It also gives you the ability provision on all the systems Machine
 supports.
 
-**Note**:These examples assume you are using Mac OS X or Windows, if you like you can also [install Docker Machine directly on a Linux
+**Note**:These examples assume you are using macOS or Windows, if you like you can also [install Docker Machine directly on a Linux
 system](http://docs.docker.com/machine/install-machine).
 
 ## Provision a host to generate a Swarm token

--- a/toolbox/overview.md
+++ b/toolbox/overview.md
@@ -37,7 +37,7 @@ Go to the <a href="https://www.docker.com/products/docker-toolbox" target="_blan
 
 Choose the install instructions for your platform, and follow the steps:
 
-* [Install Docker Toolbox on Mac OS X](toolbox_install_mac.md)
+* [Install Docker Toolbox on macOS](toolbox_install_mac.md)
 
 * [Install Docker Toolbox for Windows](toolbox_install_windows.md)
 

--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -9,37 +9,37 @@ menu:
 title: Install Toolbox on Mac
 ---
 
-# Install Docker Toolbox on Mac OS X
+# Install Docker Toolbox on macOS
 
-Mac OS X users use Docker Toolbox to install Docker software. Docker Toolbox includes the following Docker tools:
+macOS users use Docker Toolbox to install Docker software. Docker Toolbox includes the following Docker tools:
 
 * Docker CLI client for running Docker Engine to create images and containers
-* Docker Machine so you can run Docker Engine commands from Mac OS X terminals
+* Docker Machine so you can run Docker Engine commands from macOS terminals
 * Docker Compose for running the `docker-compose` command
 * Kitematic, the Docker GUI
 * the Docker QuickStart shell preconfigured for a Docker command-line environment
 * Oracle VM VirtualBox
 
 Because the Docker Engine daemon uses Linux-specific kernel features, you can't
-run Docker Engine natively in OS X. Instead, you must use the Docker Machine
+run Docker Engine natively in macOS. Instead, you must use the Docker Machine
 command,  `docker-machine`,  to create and attach to a small Linux VM on your
 machine. This VM hosts Docker Engine for you on your Mac.
 
 ## Step 1: Check your version
 
-Your Mac must be running OS X 10.8 "Mountain Lion" or newer to run Docker
+Your Mac must be running macOS 10.8 "Mountain Lion" or newer to run Docker
 software. To find out what version of the OS you have:
 
 1. Choose **About this Mac** from the Apple menu.
 
-    The version number appears directly below the words `OS X`.
+    The version number appears directly below the words `macOS`.
 
 2. If you have the correct version, go to the next step.
 
     If you aren't using a supported version, you could consider upgrading your
     operating system.
 
-    If you have Mac OS X 10.10.3 Yosemite or newer, consider using [Docker for Mac](https://docs.docker.com/docker-for-mac/) instead. It runs natively on the Mac, so there is no need for a pre-configured Docker QuickStart shell. It uses xhyve for virtualization, instead of VirutalBox. Full install prerequisites are provided in the Docker for Mac topic in [Docker for Mac](https://docs.docker.com/docker-for-mac/#what-to-know-before-you-install).
+    If you have macOS 10.10.3 Yosemite or newer, consider using [Docker for Mac](https://docs.docker.com/docker-for-mac/) instead. It runs natively on the Mac, so there is no need for a pre-configured Docker QuickStart shell. It uses xhyve for virtualization, instead of VirutalBox. Full install prerequisites are provided in the Docker for Mac topic in [Docker for Mac](https://docs.docker.com/docker-for-mac/#what-to-know-before-you-install).
 
 ## Step 2: Install Docker Toolbox
 

--- a/ucp/install-sandbox.md
+++ b/ucp/install-sandbox.md
@@ -51,7 +51,10 @@ container through UCP, and explore the user interface.
 environment. If you are in another, you may need to change the commands to use
 the correct ones for you environment.
 
-## Prerequisites
+>**Note**: The command examples in this page were tested for a macOS environment.
+If you are in another, you may need to adjust to use analogous commands for your environment.
+
+## Step 2. Verify the prerequisites
 
 This example requires that you have:
 


### PR DESCRIPTION
### Describe the proposed changes

Updated instances of 'OS X' and 'OSX' to 'macOS' to adhere to current Apple branding.

### Project version

n/a


### Related issue

n/a

### Related issue or PR in another project

n/a

### Please take a look

@londoncalling @johndmulhausen @joaofnfernandes @sanscontext


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

Apple has changed their branding guidelines from 'OS X' to 'macOS'
so we should update ours to be within trademark / branding
guidelines. See http://www.apple.com/macos/sierra/

Signed-off-by: Misty Stanley-Jones <misty@docker.com>