### PR TITLE
hide beta 29 release notes until completed

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -144,7 +144,7 @@ events or unexpected unmounts.
 * Docker Compose 1.8.0
 
 ## Beta Release Notes
-
+<!--
 ### Beta 29 Release Notes (2016-10-22 1.12.2-rc3-beta29)
 
 **New**
@@ -158,6 +158,7 @@ TBD
 **Bug fixes and minor changes**
 
 TBD
+-->
 
 ### Beta 28 Release Notes (2016-10-13 1.12.2-rc3-beta28)
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -132,6 +132,8 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 
 ## Beta Release Notes
 
+<!--
+
 ### Beta 29 Release Notes (2016-10-22 1.12.2-rc3-beta29)
 
 >**Important Note**:
@@ -158,6 +160,8 @@ TBD
 **Bug fixes and minor changes**
 
 TBD
+
+-->
 
 ### Beta 28 Release Notes (2016-10-13 1.12.2-rc3-beta28)
 


### PR DESCRIPTION
@mstanleyjones hiding Beta 29 release notes in HTML until you have full change log in place, and the Piñata binaries are released.