### PR TITLE
make link a real link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docs @ Docker
 
 Welcome to the repo for our documentation. This is the source for the URL
-served at docs.docker.com.
+served at https://docs.docker.com/.
 
 Feel free to send us pull requests and file issues. Our docs are completely
 open source and we deeply appreciate contributions from our community!


### PR DESCRIPTION
Just fixed the docs.docker.com link in README to be a clickable link 👍 