### PR TITLE
Misleading steps in work with development container 

### DIFF
--- a/opensource/project/set-up-dev-env.md
+++ b/opensource/project/set-up-dev-env.md
@@ -125,7 +125,7 @@ can take over 15 minutes to complete.
 4. Use `make` to build a development environment image and run it in a container.
 
    ```none
-   $ make shell
+   $ make BIN_DIR=. shell
    ```
 
    The command returns informational messages as it runs. The first build may
@@ -162,11 +162,11 @@ can take over 15 minutes to complete.
    Copying nested executables into bundles/1.12.0-dev/binary
    ```
 
-7. Copy the binary to the container's `/usr/bin` directory.
+7. Copy the binary to the container's `**/usr/bin/**` directory.
 
    ```none
-   root@a8b2885ab900:/go/src/github.com/docker/docker# cp bundles/1.12.0-dev/binary-client/docker* /usr/bin
-   root@a8b2885ab900:/go/src/github.com/docker/docker# cp bundles/1.12.0-dev/binary-daemon/docker* /usr/bin
+   root@a8b2885ab900:/go/src/github.com/docker/docker# cp bundles/1.12.0-dev/binary-client/docker* /usr/bin/
+   root@a8b2885ab900:/go/src/github.com/docker/docker# cp bundles/1.12.0-dev/binary-daemon/docker* /usr/bin/
    ```
 
 8. Start the Engine daemon running in the background.
@@ -275,15 +275,19 @@ example, you'll edit the help for the `attach` subcommand.
 
 5. Save and close the `cli/command/container/attach.go` file.
 
-6. Go to your running development container.
+6. Go to your running docker development container shell.
 
-7. Remake the binary and copy it to `usr/bin`
+7. Rebuild the binary by using the command `hack/make.sh binary` in the docker development container shell.
 
-8. Restart the Docker daemon with the new binary.
+8. Copy the binaries to **/usr/bin** by entering the following commands in the docker development container shell.
+```
+cp bundles/1.12.0-dev/binary-client/docker* /usr/bin/
+cp bundles/1.12.0-dev/binary-daemon/docker* /usr/bin/
+```
 
-9. View your change by display the `attach` help.
+9. To view your change, run the `docker attach --help` command in the docker development container shell.
 
-   ```none
+   ```bash
    root@b0cb4f22715d:/go/src/github.com/docker/docker# docker attach --help
 
    Usage:	docker attach [OPTIONS] CONTAINER


### PR DESCRIPTION
## Open Source Documentation Change 

#### When trying to contribute to Docker, the steps listed in the docs were misleading.  I couldn't get my changes from my local editor in the container with the way the docs are set up now.  

#### In Task 3 it states 
```
Save and close the cli/command/container/attach.go file.
Go to your running development container.
Remake the binary and copy it to usr/bin
Restart the Docker daemon with the new binary.
```

With these steps it doesn't tell you that you have to `make shell` again to push your local changes to a newly created image so you can continue to follow the steps.  

These changes add the step to get a new shell with the changes you made locally and then `hack/make.sh binary` to build the binaries to copy them into the "containers" /usr/bin.

With this change, hopefully it'll give people who may be confused the direction they need to continue to contribute to docker.  

Also the version that is now current in the branch clone from the `docker/docker` repository is 1.13.0-dev, which is changed and reflected in this pull request.

#### Cute cat image because it doesn't hurt
![cute-cat](https://cloud.githubusercontent.com/assets/5985850/19487278/1a043af4-9530-11e6-8fc5-79c29531fcf0.jpeg)
