### PR TITLE
Fix label used in social media previews 

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -36,7 +36,7 @@ ng\:form {
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@docker_docs">
 <meta name="twitter:url" content="https://twitter.com/docker_docs">
-<meta name="twitter:title" content="Docs team">
+<meta name="twitter:title" content="Docker docs">
 <meta name="twitter:image:src" content="https://www.docker.com/sites/default/files/social/docker-twitter-share.png">
 <meta property="article:published_time" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -36,7 +36,7 @@ ng\:form {
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@docker_docs">
 <meta name="twitter:url" content="https://twitter.com/docker_docs">
-<meta name="twitter:title" content="Docker docs">
+<meta name="twitter:title" content="{{ page.title }}">
 <meta name="twitter:image:src" content="https://www.docker.com/sites/default/files/social/docker-twitter-share.png">
 <meta property="article:published_time" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Currently when you send a link to the docs in slack, the snippet view is created from this "twitter:title" element, which was confusingly set to "Docs team"

![image](https://cloud.githubusercontent.com/assets/17016388/19490710/0cb82992-9525-11e6-8fec-1cc0cc75d814.png)
  
This changes that to say "Docker docs" instead. We can probably do something better using the pagetitle variable, but this at least fixes it for now.

### Please take a look
 
@mstanleyjones @johndmulhausen 

Signed-off-by: LRubin <lrubin@docker.com>