### PR TITLE
fix 404 at linked path /installation/windows

### DIFF
--- a/kitematic/index.md
+++ b/kitematic/index.md
@@ -11,8 +11,8 @@ menu:
 title: Kitematic
 ---
 
-# Kitematic 
+# Kitematic
 
-Kitematic, the Docker GUI, runs on macOS and Windows operating systems. Beginning with the 1.8 Docker release, you use the Docker Toolbox to install Kitematic.  See the [macOS installation guide](https://docs.docker.com/installation/mac) or the [Windows installation guide](https://docs.docker.com/installation/windows) for details on installing with Docker Toolbox.
+Kitematic, the Docker GUI, runs on macOS and Windows operating systems. Beginning with the 1.8 Docker release, you use the Docker Toolbox to install Kitematic.  See the [macOS installation guide](https://docs.docker.com/installation/mac) or the [Windows installation guide](https://docs.docker.com/docker-for-windows) for details on installing with Docker Toolbox.
 
 For information about using Kitematic, take a look at the [User Guide](userguide.md).

--- a/kitematic/index.md
+++ b/kitematic/index.md
@@ -13,6 +13,6 @@ title: Kitematic
 
 # Kitematic
 
-Kitematic, the Docker GUI, runs on macOS and Windows operating systems. Beginning with the 1.8 Docker release, you use the Docker Toolbox to install Kitematic.  See the [macOS installation guide](https://docs.docker.com/installation/mac) or the [Windows installation guide](https://docs.docker.com/docker-for-windows) for details on installing with Docker Toolbox.
+Kitematic, the Docker GUI, runs on macOS and Windows operating systems. Beginning with the 1.8 Docker release, you use the Docker Toolbox to install Kitematic.  See the [macOS installation guide](/docker-for-mac/) or the [Windows installation guide](/docker-for-windows/) for details on installing with Docker Toolbox.
 
 For information about using Kitematic, take a look at the [User Guide](userguide.md).

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -15,7 +15,7 @@ On macOS and Windows, Machine is installed along with other Docker products when
 you install the Docker Toolbox. For details on installing Docker Toolbox, see
 the <a href="https://docs.docker.com/installation/mac/" target="_blank">macOS
 installation</a> instructions or <a
-href="https://docs.docker.com/installation/windows" target="_blank">Windows
+href="https://docs.docker.com/docker-for-windows/" target="_blank">Windows
 installation</a> instructions.
 
 If you want only Docker Machine, you can install the Machine binaries directly by following the instructions in the next section. You can find the latest versions of the binaries are on the <a href="https://github.com/docker/machine/releases/" target="_blank"> docker/machine release page</a> on GitHub.


### PR DESCRIPTION
<!--Thanks for your contribution. Please use the following
guidelines to help us review it. You can remove these comments
as you fill out this template. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.txt
as these are maintained in upstream repos and added to the central
docs repo periodically. Your PR will fail automated checks if it
includes changes to these files or directories.-->

<!-- **Squash your commits**: Please use an
interactive rebase (https://help.github.com/articles/about-git-rebase/)
to squash (combine) multiple commits into a single commit, to keep the
commit history clean. The exception is when commits from multiple
contributors exist in the same pull request. In that case, one commit
per contributor is preferred, to keep the history clean but also give
credit for the work to all contributors. -->

### Describe the proposed changes
<!-- Tell us what you did and why. You can leave this off if
the PR title is descriptive. -->
updates links heading to `https://docs.docker.com/installation/windows/` (404) to `https://docs.docker.com/docker-for-windows/`

### Related issue

<!-- If this relates to an issue or PR in this repo, refer to it
like #1234 -->
Closes #255 

Signed-off-by: Alicia Lauerman <allydevour@me.com>