### PR TITLE
Typo in cd command

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -27,7 +27,7 @@ with Docker containers. This quick-start guide demonstrates how to use Compose t
 
     For example, if you named your directory `my_wordpress`:
 
-        $ cd my-wordpress/
+        $ cd my_wordpress/
 
 3. Create a `docker-compose.yml` file that will start your `Wordpress` blog and a separate `MySQL` instance with a volume mount for data persistence:
 


### PR DESCRIPTION
The guide to create a wordpress docker container using docker-compose states:

> if you named your directory `my_wordpress`:
> ```
>  $ cd my-wordpress/
> ```

Obviously, you should cd into `my_wordpress` (with underscore).

The guide refers to `my_wordpress` later on (but never to `my-wordpress`).

This commit fixes just that.