### PR TITLE
fix markdown syntax issue

### DIFF
--- a/engine/reference/commandline/swarm_leave.md
+++ b/engine/reference/commandline/swarm_leave.md
@@ -32,6 +32,7 @@ without using `--force`. Only use `--force` in situations where the swarm will
 no longer be used after the manager leaves, such as in a single-node swarm.
 
 Consider the following swarm, as seen from the manager:
+
 ```bash
 $ docker node ls
 ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
@@ -41,10 +42,12 @@ dvfxp4zseq4s0rih1selh0d20 *  manager1  Ready   Active        Leader
 ```
 
 To remove `worker2`, issue the following command from `worker2` itself:
+
 ```bash
 $ docker swarm leave
 Node left the default swarm.
 ```
+
 To remove an inactive node, use the [`node rm`](node_rm.md) command instead.
 
 ## Related information


### PR DESCRIPTION
Add new lines.

The markdown issue generated a strange html page at 
https://docs.docker.com/engine/reference/commandline/swarm_leave/


<img width="823" alt="screen shot 2016-10-19 at 11 11 06" src="https://cloud.githubusercontent.com/assets/1212008/19504432/c5e78a80-95ec-11e6-8c0d-2cc37ff43064.png">
