### PR TITLE
Fix buggy markdown

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -133,9 +133,7 @@ Run these commands to test if your versions of `docker`, `docker-compose`, and `
 
 2. For something more adventurous, start a Dockerized web server.
 
-	```shell
-	docker run -d -p 80:80 --name webserver nginx
-	```
+	`docker run -d -p 80:80 --name webserver nginx`
 
 	If the image is not found locally, Docker will pull it from Docker Hub.
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -131,18 +131,19 @@ Run these commands to test if your versions of `docker`, `docker-compose`, and `
 
 	Some good commands to try are `docker version` to check that you have the latest release installed, and `docker ps` and `docker run hello-world` to verify that Docker is running.
 
-2. For something more adventurous, start a Dockerized web server.
+2.  For something more adventurous, start a Dockerized web server.
 
-	`docker run -d -p 80:80 --name webserver nginx`
+    ```
+    docker run -d -p 80:80 --name webserver nginx
+    ```
 
-	If the image is not found locally, Docker will pull it from Docker Hub.
+    If the image is not found locally, Docker will pull it from Docker Hub.
 
-	In a web browser, go to `http://localhost/` to bring up the home page. (Since you specified the default HTTP port, it isn't necessary to append `:80` at the end of the URL.)
+    In a web browser, go to `http://localhost/` to bring up the home page. (Since you specified the default HTTP port, it isn't necessary to append `:80` at the end of the URL.)
 
-	![nginx home page](images/hello-world-nginx.png)
+    ![nginx home page](images/hello-world-nginx.png)
 
-	>**Note:** Early beta releases used `docker` as the hostname to build the URL.  Now, ports are exposed on the private IP addresses of the VM and   forwarded to `localhost` with no other host name set. See also, [Release Notes](release-notes.md) for Beta 9.
-  >
+    >**Note:** Early beta releases used `docker` as the hostname to build the URL.  Now, ports are exposed on the private IP addresses of the VM and   forwarded to `localhost` with no other host name set. See also, [Release Notes](release-notes.md) for Beta 9.
 
 3. Run `docker ps` while your web server is running to see details on the webserver container.
 


### PR DESCRIPTION
### Describe the proposed changes

Changes `shell docker run -d -p 80:80 --name webserver nginx`
to `docker run -d -p 80:80 --name webserver nginx`
in bullet number 2.

Before:
![screen shot 2016-10-19 at 00 17 58](https://cloud.githubusercontent.com/assets/7613067/19506614/93257828-9592-11e6-8771-121d3eea451e.png)


After:
![screen shot 2016-10-19 at 00 18 26](https://cloud.githubusercontent.com/assets/7613067/19506617/96a4e07e-9592-11e6-96a1-e487657a9200.png)

FYI modifying the TRIPLE-BACKTICK block to render correctly would misalign the rest of the content under bullet 2, so I opted to just change it to a SINGLE-BACKTICK snippet.

### Related issue

#227 

Signed-off-by: Robin Kim <therobinkim@gmail.com>