### PR TITLE
Update django.md

### DIFF
--- a/compose/django.md
+++ b/compose/django.md
@@ -146,7 +146,7 @@ In this section, you set up the database connection for Django.
 
         DATABASES = {
             'default': {
-                'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                'ENGINE': 'django.db.backends.postgresql',
                 'NAME': 'postgres',
                 'USER': 'postgres',
                 'HOST': 'db',


### PR DESCRIPTION
okay-to-publish

### Describe the proposed changes

As of Django 1.10 the database backend django.db.backends.postgresql_psycopg2 is called django.db.backends.postgresql .

See https://docs.djangoproject.com/en/1.10/ref/settings/#engine