### PR TITLE
[Registry Docs] Fix invalid YAML

### DIFF
--- a/registry/configuration.md
+++ b/registry/configuration.md
@@ -78,7 +78,7 @@ information about each option that appears later in this page.
     storage:
       filesystem:
         rootdirectory: /var/lib/registry
-		maxthreads: 100
+        maxthreads: 100
       azure:
         accountname: accountname
         accountkey: base64encodedaccountkey


### PR DESCRIPTION
I have no idea what `maxthread` is, or if that's where it goes. But as it was, it was invalid YAML and confusing. This PR is more to get someone who _does_ know where `maxthread` goes to take a look and either direct a fix, or, if this _is_ correct, then to merge this.