### PR TITLE
Add apt source with sudo tee

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -90,7 +90,7 @@ packages from the Docker repository:
     for the placeholder `<REPO>`.
 
     ```bash
-    $ sudo echo "<REPO>" > /etc/apt/sources.list.d/docker.list
+    $ echo "<REPO>" | sudo tee /etc/apt/sources.list.d/docker.list
     ```
 
 7.  Update the `APT` package index.


### PR DESCRIPTION
### Describe the proposed changes

@JonJagger is correct when pointing out that `sudo echo "<REPO>" > /etc/apt/sources.list.d/docker.list` will fail, and that the docs should mention `sudo tee` instead.

### Related issue

Closes #272 


Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>