### PR TITLE
Update debian.md

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -74,7 +74,7 @@ from the new repository:
  4. Update package information, ensure that APT works with the `https` method, and that CA certificates are installed.
 
          $ apt-get update
-         $ apt-get install apt-transport-https ca-certificates
+         $ apt-get install apt-transport-https ca-certificates gnupg2
 
  5. Add the new `GPG` key.
 


### PR DESCRIPTION
### Update debian.md

Add dirmngr , required for gnupg, setting up publickey entries in apt

Otherwise, the `apt-key` command fails:

```
# apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
Executing: /tmp/tmp.3nIvpf0TjG/gpg.1.sh --keyserver
hkp://p80.pool.sks-keyservers.net:80
--recv-keys
58118E89F3A912897C070ADBF76221572C52609D
gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory
gpg: connecting dirmngr at '/tmp/tmp.3nIvpf0TjG/S.dirmngr' failed: No such file or directory
gpg: keyserver receive failed: No dirmngr
```
