### PR TITLE
Fix 'Permission denied' when creating docker.list file

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -90,7 +90,7 @@ packages from the Docker repository:
     for the placeholder `<REPO>`.
 
     ```bash
-    $ sudo echo "<REPO>" > /etc/apt/sources.list.d/docker.list
+    $ echo "<REPO>" | sudo tee -a /etc/apt/sources.list.d/docker.list
     ```
 
 7.  Update the `APT` package index.


### PR DESCRIPTION
### Describe the proposed changes

Change to the documentation, in https://docs.docker.com/engine/installation/linux/ubuntulinux/

### Project version

Docker docs.

### Related issue

### Related issue or PR in another project

### Please take a look

Command was returning 'Permission Denied': "This is a known issue, when you use sudo in this fashion, it won't work right. That is because while the echo command is run as sudo, the >> for append tries to open the file target as a non-sudo user. That is where the permission issue is." See http://askubuntu.com/questions/185268/permission-denied-etc-apt-sources-list