### PR TITLE
Remove line numbers from caps link

### DIFF
--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -197,7 +197,7 @@ to the host.
 This won't affect regular web apps; but malicious users will find that
 the arsenal at their disposal has shrunk considerably! By default Docker
 drops all capabilities except [those
-needed](https://github.com/docker/docker/blob/master/oci/defaults_linux.go),
+needed](https://github.com/docker/docker/blob/master/oci/defaults_linux.go#L62-L77),
 a whitelist instead of a blacklist approach. You can see a full list of
 available capabilities in [Linux
 manpages](http://man7.org/linux/man-pages/man7/capabilities.7.html).

--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -197,7 +197,7 @@ to the host.
 This won't affect regular web apps; but malicious users will find that
 the arsenal at their disposal has shrunk considerably! By default Docker
 drops all capabilities except [those
-needed](https://github.com/docker/docker/blob/master/oci/defaults_linux.go#L64-L79),
+needed](https://github.com/docker/docker/blob/master/oci/defaults_linux.go),
 a whitelist instead of a blacklist approach. You can see a full list of
 available capabilities in [Linux
 manpages](http://man7.org/linux/man-pages/man7/capabilities.7.html).


### PR DESCRIPTION

### Describe the proposed changes

Remove static line numbers from defaults_linux.go, since they will probably change in the future, and the source file IMHO is clear enough that `s.Process.Capabilities` is easy to find.

### Related issue

Closes #294 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>