### PR TITLE
Moving sudo command after echo pipe for Ubuntu install

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -90,7 +90,7 @@ packages from the Docker repository:
     for the placeholder `<REPO>`.
 
     ```bash
-    $ sudo echo "<REPO>" > /etc/apt/sources.list.d/docker.list
+    $ echo "<REPO>" | sudo tee /etc/apt/sources.list.d/docker.list
     ```
 
 7.  Update the `APT` package index.


### PR DESCRIPTION
The current command fails and requires the sudo to move after the pipe. This follows the same usage as other Linux installation instructions.