### PR TITLE
Add --amazonec2-block-duration-minutes flag

### DIFF
--- a/machine/drivers/aws.md
+++ b/machine/drivers/aws.md
@@ -66,6 +66,7 @@ You can use environment variables:
 -   `--amazonec2-ssh-user`: The SSH Login username, which must match the default SSH user set in the ami used.
 -   `--amazonec2-request-spot-instance`: Use spot instances.
 -   `--amazonec2-spot-price`: Spot instance bid price (in dollars). Require the `--amazonec2-request-spot-instance` flag.
+-   `--amazonec2-block-duration-minutes`: Spot instance duration in minutes (60, 120, 180, 240, 300, or 360)
 -   `--amazonec2-use-private-address`: Use the private IP address for docker-machine, but still create a public IP address.
 -   `--amazonec2-private-address-only`: Use the private IP address only.
 -   `--amazonec2-monitoring`: Enable CloudWatch Monitoring.
@@ -97,6 +98,7 @@ You can use environment variables:
 | `--amazonec2-ssh-user`                   | `AWS_SSH_USER`          | `ubuntu`         |
 | `--amazonec2-request-spot-instance`      | -                       | `false`          |
 | `--amazonec2-spot-price`                 | -                       | `0.50`           |
+| `--amazonec2-block-duration-minutes`     | -                       | -                |
 | `--amazonec2-use-private-address`        | -                       | `false`          |
 | `--amazonec2-private-address-only`       | -                       | `false`          |
 | `--amazonec2-monitoring`                 | -                       | `false`          |


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.txt.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

Add the --amazonec2-block-duration-minutes flag (docker/machine#3796)

### Project version

<!-- If this change only applies to a future version of a project (like
     Docker Engine 1.13), note that here and base your work on the `vnext-`
     branch for your project. -->

### Related issue

<!-- If this relates to an issue or PR in this repo, refer to it like
     #1234, or 'Fixes #1234' or 'Closes #1234'. -->

### Related issue or PR in another project

<!-- Links to issues or pull requests in other repositories if applicable. -->

Reflects docker/machine#3796

### Please take a look

<!-- At-mention specific individuals or groups who should take a
     look at this PR. For instance, @exampleuser123 -->

@nathanleclaire 


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->