### PR TITLE
Fix broken link in /opensource/index/ to /project/who-written-for/

### DIFF
--- a/opensource/index.md
+++ b/opensource/index.md
@@ -15,7 +15,7 @@ Contributing to the Docker project or to any open source project can be a
 rewarding experience. You help yourself and you help the projects you work on.
 You also help the countless number of other project participants.
 
-- [Configure the development environment](project/who-written-for.md) explains how to setup an environment to contribute to Docker engine.
+- [Configure the development environment](opensource/project/who-written-for.md) explains how to setup an environment to contribute to Docker engine.
 - [Understand the contribution workflow ](workflow/make-a-contribution.md) explains the workflow the team uses across most Docker projects.
 - [Other ways to contribute](ways/index.md) provides tips for contributing if you don't want to code.
 - [Governance](governance/index.md) describes the proper conduct and who defines it.


### PR DESCRIPTION
### Describe the proposed change
The link in
http://docs.docker.com/opensource/
to
http://docs.docker.com/project/who-written-for/
should be 
http://docs.docker.com/opensource/project/who-written-for/ 

### Related issue
Fixes #188 