### PR TITLE
Add aliases to engine/reference/ subdirs for backwards compatible links

### DIFF
--- a/engine/reference/api/docker-io_api.md
+++ b/engine/reference/api/docker-io_api.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker-io_api/
 description: API Documentation for the Docker Hub API
 published: false
 keywords:

--- a/engine/reference/api/docker_io_accounts_api.md
+++ b/engine/reference/api/docker_io_accounts_api.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_io_accounts_api/
 description: API Documentation for docker.io accounts.
 keywords:
 - API, Docker, accounts, REST,  documentation

--- a/engine/reference/api/docker_remote_api.md
+++ b/engine/reference/api/docker_remote_api.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.18.md
+++ b/engine/reference/api/docker_remote_api_v1.18.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.18/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.19.md
+++ b/engine/reference/api/docker_remote_api_v1.19.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.19/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.20.md
+++ b/engine/reference/api/docker_remote_api_v1.20.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.20/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.21.md
+++ b/engine/reference/api/docker_remote_api_v1.21.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.21/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.22.md
+++ b/engine/reference/api/docker_remote_api_v1.22.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.22/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.23.md
+++ b/engine/reference/api/docker_remote_api_v1.23.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.23/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.24.md
+++ b/engine/reference/api/docker_remote_api_v1.24.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.24/
 description: API Documentation for Docker
 keywords:
 - API, Docker, rcli, REST,  documentation

--- a/engine/reference/api/docker_remote_api_v1.25.md
+++ b/engine/reference/api/docker_remote_api_v1.25.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/docker_remote_api_v1.25/
 description: API Documentation for Docker
 published: false
 keywords:

--- a/engine/reference/api/hub_registry_spec.md
+++ b/engine/reference/api/hub_registry_spec.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/hub_registry_spec/
 description: Documentation for docker Registry and Registry API
 published: false
 keywords:

--- a/engine/reference/api/index.md
+++ b/engine/reference/api/index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/
 description: Reference
 keywords:
 - Engine

--- a/engine/reference/api/remote_api_client_libraries.md
+++ b/engine/reference/api/remote_api_client_libraries.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/api/remote_api_client_libraries/
 description: Various client libraries available to use with the Docker remote API
 keywords:
 - API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy,

--- a/engine/reference/commandline/attach.md
+++ b/engine/reference/commandline/attach.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/attach/
 description: The attach command description and usage
 keywords:
 - attach, running, container

--- a/engine/reference/commandline/build.md
+++ b/engine/reference/commandline/build.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/build/
 description: The build command description and usage
 keywords:
 - build, docker, image

--- a/engine/reference/commandline/cli.md
+++ b/engine/reference/commandline/cli.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/cli/
 description: Docker's CLI command description and usage
 keywords:
 - Docker, Docker documentation, CLI,  command line

--- a/engine/reference/commandline/commit.md
+++ b/engine/reference/commandline/commit.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/commit/
 description: The commit command description and usage
 keywords:
 - commit, file, changes

--- a/engine/reference/commandline/cp.md
+++ b/engine/reference/commandline/cp.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/cp/
 description: The cp command description and usage
 keywords:
 - copy, container, files, folders

--- a/engine/reference/commandline/create.md
+++ b/engine/reference/commandline/create.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/create/
 description: The create command description and usage
 keywords:
 - docker, create, container

--- a/engine/reference/commandline/deploy.md
+++ b/engine/reference/commandline/deploy.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/deploy/
 advisory: experimental
 description: The deploy command description and usage
 keywords:

--- a/engine/reference/commandline/diff.md
+++ b/engine/reference/commandline/diff.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/diff/
 description: The diff command description and usage
 keywords:
 - list, changed, files, container

--- a/engine/reference/commandline/dockerd.md
+++ b/engine/reference/commandline/dockerd.md
@@ -1,5 +1,7 @@
 ---
 aliases:
+  - /reference/commandline/dockerd/
+aliases:
 - /engine/reference/commandline/daemon/
 description: The daemon command description and usage
 keywords:

--- a/engine/reference/commandline/events.md
+++ b/engine/reference/commandline/events.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/events/
 description: The events command description and usage
 keywords:
 - events, container, report

--- a/engine/reference/commandline/exec.md
+++ b/engine/reference/commandline/exec.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/exec/
 description: The exec command description and usage
 keywords:
 - command, container, run, execute

--- a/engine/reference/commandline/export.md
+++ b/engine/reference/commandline/export.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/export/
 description: The export command description and usage
 keywords:
 - export, file, system, container

--- a/engine/reference/commandline/history.md
+++ b/engine/reference/commandline/history.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/history/
 description: The history command description and usage
 keywords:
 - docker, image, history

--- a/engine/reference/commandline/images.md
+++ b/engine/reference/commandline/images.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/images/
 description: The images command description and usage
 keywords:
 - list, docker, images

--- a/engine/reference/commandline/import.md
+++ b/engine/reference/commandline/import.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/import/
 description: The import command description and usage
 keywords:
 - import, file, system, container

--- a/engine/reference/commandline/index.md
+++ b/engine/reference/commandline/index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/
 description: Docker's CLI command description and usage
 keywords:
 - Docker, Docker documentation, CLI,  command line

--- a/engine/reference/commandline/info.md
+++ b/engine/reference/commandline/info.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/info/
 description: The info command description and usage
 keywords:
 - display, docker, information

--- a/engine/reference/commandline/inspect.md
+++ b/engine/reference/commandline/inspect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/inspect/
 description: The inspect command description and usage
 keywords:
 - inspect, container, json

--- a/engine/reference/commandline/kill.md
+++ b/engine/reference/commandline/kill.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/kill/
 description: The kill command description and usage
 keywords:
 - container, kill, signal

--- a/engine/reference/commandline/load.md
+++ b/engine/reference/commandline/load.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/load/
 description: The load command description and usage
 keywords:
 - stdin, tarred, repository

--- a/engine/reference/commandline/login.md
+++ b/engine/reference/commandline/login.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/login/
 description: The login command description and usage
 keywords:
 - registry, login, image

--- a/engine/reference/commandline/logout.md
+++ b/engine/reference/commandline/logout.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/logout/
 description: The logout command description and usage
 keywords:
 - logout, docker, registry

--- a/engine/reference/commandline/logs.md
+++ b/engine/reference/commandline/logs.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/logs/
 description: The logs command description and usage
 keywords:
 - logs, retrieve, docker

--- a/engine/reference/commandline/menu.md
+++ b/engine/reference/commandline/menu.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/menu/
 description: Docker's CLI command description and usage
 keywords:
 - Docker, Docker documentation, CLI,  command line

--- a/engine/reference/commandline/network_connect.md
+++ b/engine/reference/commandline/network_connect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/network_connect/
 description: The network connect command description and usage
 keywords:
 - network, connect, user-defined

--- a/engine/reference/commandline/network_create.md
+++ b/engine/reference/commandline/network_create.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/network_create/
 description: The network create command description and usage
 keywords:
 - network, create

--- a/engine/reference/commandline/network_disconnect.md
+++ b/engine/reference/commandline/network_disconnect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/network_disconnect/
 description: The network disconnect command description and usage
 keywords:
 - network, disconnect, user-defined

--- a/engine/reference/commandline/network_inspect.md
+++ b/engine/reference/commandline/network_inspect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/network_inspect/
 description: The network inspect command description and usage
 keywords:
 - network, inspect, user-defined

--- a/engine/reference/commandline/network_ls.md
+++ b/engine/reference/commandline/network_ls.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/network_ls/
 description: The network ls command description and usage
 keywords:
 - network, list, user-defined

--- a/engine/reference/commandline/network_rm.md
+++ b/engine/reference/commandline/network_rm.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/network_rm/
 description: the network rm command description and usage
 keywords:
 - network, rm, user-defined

--- a/engine/reference/commandline/node_demote.md
+++ b/engine/reference/commandline/node_demote.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/node_demote/
 description: The node demote command description and usage
 keywords:
 - node, demote

--- a/engine/reference/commandline/node_inspect.md
+++ b/engine/reference/commandline/node_inspect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/node_inspect/
 description: The node inspect command description and usage
 keywords:
 - node, inspect

--- a/engine/reference/commandline/node_ls.md
+++ b/engine/reference/commandline/node_ls.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/node_ls/
 description: The node ls command description and usage
 keywords:
 - node, list

--- a/engine/reference/commandline/node_promote.md
+++ b/engine/reference/commandline/node_promote.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/node_promote/
 description: The node promote command description and usage
 keywords:
 - node, promote

--- a/engine/reference/commandline/node_ps.md
+++ b/engine/reference/commandline/node_ps.md
@@ -1,5 +1,7 @@
 ---
 aliases:
+  - /reference/commandline/node_ps/
+aliases:
 - /engine/reference/commandline/node_tasks/
 description: The node ps command description and usage
 keywords:

--- a/engine/reference/commandline/node_rm.md
+++ b/engine/reference/commandline/node_rm.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/node_rm/
 description: The node rm command description and usage
 keywords:
 - node, remove

--- a/engine/reference/commandline/node_update.md
+++ b/engine/reference/commandline/node_update.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/node_update/
 description: The node update command description and usage
 keywords:
 - resources, update, dynamically

--- a/engine/reference/commandline/pause.md
+++ b/engine/reference/commandline/pause.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/pause/
 description: The pause command description and usage
 keywords:
 - cgroups, container, suspend, SIGSTOP

--- a/engine/reference/commandline/plugin_disable.md
+++ b/engine/reference/commandline/plugin_disable.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/plugin_disable/
 advisory: experimental
 description: the plugin disable command description and usage
 keywords:

--- a/engine/reference/commandline/plugin_enable.md
+++ b/engine/reference/commandline/plugin_enable.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/plugin_enable/
 advisory: experimental
 description: the plugin enable command description and usage
 keywords:

--- a/engine/reference/commandline/plugin_inspect.md
+++ b/engine/reference/commandline/plugin_inspect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/plugin_inspect/
 advisory: experimental
 description: The plugin inspect command description and usage
 keywords:

--- a/engine/reference/commandline/plugin_install.md
+++ b/engine/reference/commandline/plugin_install.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/plugin_install/
 advisory: experimental
 description: the plugin install command description and usage
 keywords:

--- a/engine/reference/commandline/plugin_ls.md
+++ b/engine/reference/commandline/plugin_ls.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/plugin_ls/
 advisory: experimental
 description: The plugin ls command description and usage
 keywords:

--- a/engine/reference/commandline/plugin_rm.md
+++ b/engine/reference/commandline/plugin_rm.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/plugin_rm/
 advisory: experimental
 description: the plugin rm command description and usage
 keywords:

--- a/engine/reference/commandline/port.md
+++ b/engine/reference/commandline/port.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/port/
 description: The port command description and usage
 keywords:
 - port, mapping, container

--- a/engine/reference/commandline/ps.md
+++ b/engine/reference/commandline/ps.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/ps/
 description: The ps command description and usage
 keywords:
 - container, running, list

--- a/engine/reference/commandline/pull.md
+++ b/engine/reference/commandline/pull.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/pull/
 description: The pull command description and usage
 keywords:
 - pull, image, hub, docker

--- a/engine/reference/commandline/push.md
+++ b/engine/reference/commandline/push.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/push/
 description: The push command description and usage
 keywords:
 - share, push, image

--- a/engine/reference/commandline/rename.md
+++ b/engine/reference/commandline/rename.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/rename/
 description: The rename command description and usage
 keywords:
 - rename, docker, container

--- a/engine/reference/commandline/restart.md
+++ b/engine/reference/commandline/restart.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/restart/
 description: The restart command description and usage
 keywords:
 - restart, container, Docker

--- a/engine/reference/commandline/rm.md
+++ b/engine/reference/commandline/rm.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/rm/
 description: The rm command description and usage
 keywords:
 - remove, Docker, container

--- a/engine/reference/commandline/rmi.md
+++ b/engine/reference/commandline/rmi.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/rmi/
 description: The rmi command description and usage
 keywords:
 - remove, image, Docker

--- a/engine/reference/commandline/run.md
+++ b/engine/reference/commandline/run.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/run/
 description: The run command description and usage
 keywords:
 - run, command, container

--- a/engine/reference/commandline/save.md
+++ b/engine/reference/commandline/save.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/save/
 description: The save command description and usage
 keywords:
 - tarred, repository, backup

--- a/engine/reference/commandline/search.md
+++ b/engine/reference/commandline/search.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/search/
 description: The search command description and usage
 keywords:
 - search, hub, images

--- a/engine/reference/commandline/service_create.md
+++ b/engine/reference/commandline/service_create.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/service_create/
 description: The service create command description and usage
 keywords:
 - service, create

--- a/engine/reference/commandline/service_inspect.md
+++ b/engine/reference/commandline/service_inspect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/service_inspect/
 description: The service inspect command description and usage
 keywords:
 - service, inspect

--- a/engine/reference/commandline/service_ls.md
+++ b/engine/reference/commandline/service_ls.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/service_ls/
 description: The service ls command description and usage
 keywords:
 - service, ls

--- a/engine/reference/commandline/service_ps.md
+++ b/engine/reference/commandline/service_ps.md
@@ -1,5 +1,7 @@
 ---
 aliases:
+  - /reference/commandline/service_ps/
+aliases:
 - /engine/reference/commandline/service_tasks/
 description: The service ps command description and usage
 keywords:

--- a/engine/reference/commandline/service_rm.md
+++ b/engine/reference/commandline/service_rm.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/service_rm/
 description: The service rm command description and usage
 keywords:
 - service, rm

--- a/engine/reference/commandline/service_scale.md
+++ b/engine/reference/commandline/service_scale.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/service_scale/
 description: The service scale command description and usage
 keywords:
 - service, scale

--- a/engine/reference/commandline/service_update.md
+++ b/engine/reference/commandline/service_update.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/service_update/
 description: The service update command description and usage
 keywords:
 - service, update

--- a/engine/reference/commandline/stack_config.md
+++ b/engine/reference/commandline/stack_config.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/stack_config/
 advisory: experimental
 description: The stack config command description and usage
 keywords:

--- a/engine/reference/commandline/stack_deploy.md
+++ b/engine/reference/commandline/stack_deploy.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/stack_deploy/
 advisory: experimental
 description: The stack deploy command description and usage
 keywords:

--- a/engine/reference/commandline/stack_rm.md
+++ b/engine/reference/commandline/stack_rm.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/stack_rm/
 advisory: experimental
 description: The stack rm command description and usage
 keywords:

--- a/engine/reference/commandline/stack_services.md
+++ b/engine/reference/commandline/stack_services.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/stack_services/
 advisory: experimental
 description: The stack services command description and usage
 keywords:

--- a/engine/reference/commandline/stack_tasks.md
+++ b/engine/reference/commandline/stack_tasks.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/stack_tasks/
 advisory: experimental
 description: The stack tasks command description and usage
 keywords:

--- a/engine/reference/commandline/start.md
+++ b/engine/reference/commandline/start.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/start/
 description: The start command description and usage
 keywords:
 - Start, container, stopped

--- a/engine/reference/commandline/stats.md
+++ b/engine/reference/commandline/stats.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/stats/
 description: The stats command description and usage
 keywords:
 - container, resource, statistics

--- a/engine/reference/commandline/stop.md
+++ b/engine/reference/commandline/stop.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/stop/
 description: The stop command description and usage
 keywords:
 - stop, SIGKILL, SIGTERM

--- a/engine/reference/commandline/swarm_init.md
+++ b/engine/reference/commandline/swarm_init.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/swarm_init/
 description: The swarm init command description and usage
 keywords:
 - swarm, init

--- a/engine/reference/commandline/swarm_join.md
+++ b/engine/reference/commandline/swarm_join.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/swarm_join/
 description: The swarm join command description and usage
 keywords:
 - swarm, join

--- a/engine/reference/commandline/swarm_join_token.md
+++ b/engine/reference/commandline/swarm_join_token.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/swarm_join_token/
 description: The swarm join-token command description and usage
 keywords:
 - swarm, join-token

--- a/engine/reference/commandline/swarm_leave.md
+++ b/engine/reference/commandline/swarm_leave.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/swarm_leave/
 description: The swarm leave command description and usage
 keywords:
 - swarm, leave

--- a/engine/reference/commandline/swarm_update.md
+++ b/engine/reference/commandline/swarm_update.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/swarm_update/
 description: The swarm update command description and usage
 keywords:
 - swarm, update

--- a/engine/reference/commandline/tag.md
+++ b/engine/reference/commandline/tag.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/tag/
 description: The tag command description and usage
 keywords:
 - tag, name, image

--- a/engine/reference/commandline/top.md
+++ b/engine/reference/commandline/top.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/top/
 description: The top command description and usage
 keywords:
 - container, running, processes

--- a/engine/reference/commandline/unpause.md
+++ b/engine/reference/commandline/unpause.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/unpause/
 description: The unpause command description and usage
 keywords:
 - cgroups, suspend, container

--- a/engine/reference/commandline/update.md
+++ b/engine/reference/commandline/update.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/update/
 description: The update command description and usage
 keywords:
 - resources, update, dynamically

--- a/engine/reference/commandline/version.md
+++ b/engine/reference/commandline/version.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/version/
 description: The version command description and usage
 keywords:
 - version, architecture, api

--- a/engine/reference/commandline/volume_create.md
+++ b/engine/reference/commandline/volume_create.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/volume_create/
 description: The volume create command description and usage
 keywords:
 - volume, create

--- a/engine/reference/commandline/volume_inspect.md
+++ b/engine/reference/commandline/volume_inspect.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/volume_inspect/
 description: The volume inspect command description and usage
 keywords:
 - volume, inspect

--- a/engine/reference/commandline/volume_ls.md
+++ b/engine/reference/commandline/volume_ls.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/volume_ls/
 description: The volume ls command description and usage
 keywords:
 - volume, list

--- a/engine/reference/commandline/volume_rm.md
+++ b/engine/reference/commandline/volume_rm.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/volume_rm/
 description: the volume rm command description and usage
 keywords:
 - volume, rm

--- a/engine/reference/commandline/wait.md
+++ b/engine/reference/commandline/wait.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /reference/commandline/wait/
 description: The wait command description and usage
 keywords:
 - container, stop, wait


### PR DESCRIPTION
### Describe the proposed changes
Added aliases to old locations of docs in /engine/reference/commandline/ and api/ so that old incoming links (from, say, StackOverflow) will redirect properly.

Parent directory already had similar aliases, propagated them into subdirectory contents.

### Related issue
Issue #79