### PR TITLE
Update installing-cli.md to mention python-dev for pip install

### DIFF
--- a/docker-cloud/installing-cli.md
+++ b/docker-cloud/installing-cli.md
@@ -42,6 +42,7 @@ Open your terminal or command shell and execute the following command:
 ```bash
 $ pip install docker-cloud
 ```
+(On Linux machines, ensure that python-dev is installed.)
 
 #### Install on macOS
 

--- a/docker-cloud/installing-cli.md
+++ b/docker-cloud/installing-cli.md
@@ -42,7 +42,8 @@ Open your terminal or command shell and execute the following command:
 ```bash
 $ pip install docker-cloud
 ```
-(On Linux machines, ensure that python-dev is installed.)
+If you encounter errors on Linux machines, make sure that `python-dev` is installed.
+For example, on Ubuntu, run the following command: `apt-get install python-dev`
 
 #### Install on macOS
 


### PR DESCRIPTION
Ran into the same problem described here:
http://stackoverflow.com/questions/36067018/install-docker-cloud-client-using-pip

It wasn't immediately obvious how to proceed -- mentioning python-dev should make it much easier.