### PR TITLE
Update swarm.md

### DIFF
--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -165,15 +165,15 @@ environment variables, so you can use Compose's `environment` option to set
 them.
 
     # Schedule containers on a specific node
-    labels:
+    environment:
       - "constraint:node==node-1"
 
     # Schedule containers on a node that has the 'storage' label set to 'ssd'
-    labels:
+    environment:
       - "constraint:storage==ssd"
 
     # Schedule containers where the 'redis' image is already pulled
-    labels:
+    environment:
       - "affinity:image==redis"
 
 For the full set of available filters and expressions, see the [Swarm


### PR DESCRIPTION
I have changed the example for compose affinity filters to use the environment option rather than labels.
Scheduling filters should be configured in the environment section of compose files - not labels.
