### PR TITLE
Manual scheduling in compose file is set with "environment" instead o…

### DIFF
--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -165,15 +165,15 @@ environment variables, so you can use Compose's `environment` option to set
 them.
 
     # Schedule containers on a specific node
-    labels:
+    environment:
       - "constraint:node==node-1"
 
     # Schedule containers on a node that has the 'storage' label set to 'ssd'
-    labels:
+    environment:
       - "constraint:storage==ssd"
 
     # Schedule containers where the 'redis' image is already pulled
-    labels:
+    environment:
       - "affinity:image==redis"
 
 For the full set of available filters and expressions, see the [Swarm


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.txt.
    These are maintained in upstream repos and changes here will be lost.-->
### Describe the proposed changes

Manual scheduling in compose file is set with "environment" instead of "labels"

<!-- Tell us what you did and why. You can leave this off if the PR title
     is descriptive. The commit message will be added to the end of this form.-->
### Project version

<!-- If this change only applies to a future version of a project (like
     Docker Engine 1.13), note that here and base your work on the `vnext-`
     branch for your project. -->

Docker Engine 1.12

<!-- If this relates to an issue or PR in this repo, refer to it like
     #1234, or 'Fixes #1234' or 'Closes #1234'. -->

<!-- Links to issues or pull requests in other repositories if applicable. -->

<!-- At-mention specific individuals or groups who should take a
     look at this PR. For instance, @exampleuser123 -->

<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->
