### PR TITLE
Fix thinpool name in storage opts flag

### DIFF
--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -322,7 +322,7 @@ assumes that the Docker daemon is in the `stopped` state.
     Now that your storage is configured, configure the Docker daemon to use it. There are two ways to do this. You can set options on the command line if you start the daemon there:
 
     ```bash
-    --storage-driver=devicemapper --storage-opt=dm.thinpooldev=/dev/mapper/docker-thinpool-tpool --storage-opt=dm.use_deferred_removal=true --storage-opt=dm.use_deferred_deletion=true
+    --storage-driver=devicemapper --storage-opt=dm.thinpooldev=/dev/mapper/docker-thinpool --storage-opt=dm.use_deferred_removal=true --storage-opt=dm.use_deferred_deletion=true
     ```
 
     You can also set them for startup in the `daemon.json` configuration, for example:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.txt.
    These are maintained in upstream repos and changes here will be lost.-->
### Describe the proposed changes

Fixing a small typo in a command option

<!-- Tell us what you did and why. You can leave this off if the PR title
     is descriptive. The commit message will be added to the end of this form.-->
### Project version

<!-- If this change only applies to a future version of a project (like
     Docker Engine 1.13), note that here and base your work on the `vnext-`
     branch for your project. -->
### Related issue

<!-- If this relates to an issue or PR in this repo, refer to it like
     #1234, or 'Fixes #1234' or 'Closes #1234'. -->
### Related issue or PR in another project

<!-- Links to issues or pull requests in other repositories if applicable. -->
### Please take a look

<!-- At-mention specific individuals or groups who should take a
     look at this PR. For instance, @exampleuser123 -->

<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

The thinpool created in the example didn't have -tpool in the name, so
if you copy these verbatim this fails.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
