### PR TITLE
Add dirty COW security event

### DIFF
--- a/engine/security/non-events.md
+++ b/engine/security/non-events.md
@@ -89,3 +89,10 @@ Bugs *not* mitigated:
 the kernel's non-maskable interrupt handling allowed privilege escalation.
 Can be exploited in Docker containers because the `modify_ldt()` system call is
 not currently blocked using seccomp.
+* [CVE-2016-5195](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5195):
+A race condition was found in the way the Linux kernel's memory subsystem
+handled the copy-on-write (COW) breakage of private read-only memory mappings,
+which allowed unprivileged local users to gain write access to read-only memory.
+Also known as "dirty COW."
+*Partial mitigations:* on some operating systems this vulnerability is mitigated
+by the combination of seccomp filtering of `ptrace` and the fact that `/proc/self/mem` is read-only.


### PR DESCRIPTION
Adds dirty COW as a security event to docker.

cc @NathanMcCauley @justincormack  @vikstrous 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>