### PR TITLE
Docker Cloud: clarify use case for different types of env vars

### DIFF
--- a/docker-cloud/builds/advanced.md
+++ b/docker-cloud/builds/advanced.md
@@ -29,9 +29,9 @@ processes and do not affect your service's run environment.
 * `DOCKER_TAG`: the Docker repository tag being built.
 * `IMAGE_NAME`: the name and tag of the Docker repository being built. (This variable is a combination of `DOCKER_REPO`/`DOCKER_TAG`.)
 
-If you are using these environment variables in a `docker-compose.test.yml` file
-for automated testing, declare them in your `sut` service's environment as shows
-below.
+If you are using these build environment variables in a
+`docker-compose.test.yml` file for automated testing, declare them in your `sut`
+service's environment as shown below.
 
 ```yml
 sut:
@@ -81,7 +81,7 @@ The following hooks are available:
 
 #### Override the "build" phase to set variables
 
-Docker Cloud allows you to define build environment variables in the UI which you can then reference in hooks.
+Docker Cloud allows you to define build environment variables either in the hook files, or from the automated build UI (which you can then reference in hooks).
 
 In the following example, we define a build hook that uses `docker build` arguments to set the variable `CUSTOM` based on the value of variable we defined using the Docker Cloud build settings. `$IMAGE_NAME` is a variable that we provide with the name of the image being built.
 

--- a/docker-cloud/builds/automated-build.md
+++ b/docker-cloud/builds/automated-build.md
@@ -105,6 +105,24 @@ run an initial test.
     Docker Cloud on every push. Only pushes to branches that are listed as the
     source for one or more tags will trigger a build.
 
+### Environment variables for builds
+
+You can set the values for environment variables used in your build processes
+when you configure an automated build. Add your build environment variables by
+clicking the plus sign next to the **Build environment variables** section, and
+then entering a variable name and the value.
+
+When you set variable values from the Docker Cloud UI, they can be used by the
+commands you set in `hooks` files, but they are stored so that only users who
+have `admin` access to the Docker Cloud repository can see their values. This
+means you can use them to safely store access tokens or other information that
+should remain secret.
+
+> **Note**: The variables set on the build configuration screen are used during
+the build processes _only_ and should not be confused with the environment
+values used by your service (for example to create service links).
+
+
 ## Check your active builds
 
 1. To view active builds, go to the repository view and click **Timeline**.
@@ -188,7 +206,7 @@ To work around this, you can set up your automated build using the `SSH_PRIVATE`
     This step is optional, but allows you to revoke the build-only keypair without removing other access. <!-- (TODO: Link to instructions for GH & BB ) -->
 2. Copy the private half of the keypair to your clipboard.
 3. In Docker Cloud, navigate to the build page for the repository that has linked private submodules. (If necessary, follow the steps [here](automated-build.md#configure-automated-build-settings) to configure the automated build.)
-4. At the bottom of the screen, click the plus sign ( **+** ) next to **Environment Variables**.
+4. At the bottom of the screen, click the plus sign ( **+** ) next to **Build Environment variables**.
 5. Enter `SSH_PRIVATE` as the name for the new environment variable.
 6. Paste the private half of the keypair into the **Value** field.
 7. Click **Save**, or **Save and Build** to validate that the build now completes.

--- a/docker-cloud/orgs.md
+++ b/docker-cloud/orgs.md
@@ -174,9 +174,9 @@ Optionally, override the default access level for specific repositories. -->
 | Read/Write | Pull, push |
 | Admin | All of the above, plus update description, create and delete |
 | **Build** | |
-| Read | View build and build settings |
-| Read/write | View, cancel build, retry or trigger build |
-| Admin | All of the above, plus change a build source, create and delete |
+| Read | View basic build settings and Timeline |
+| Read/write | All of the above plus start, retry, or cancel build |
+| Admin | All of the above, plus view and change build configuration, change build source, create and delete |
 | **Nodes** | |
 | Read | View |
 | Read/write  | View, scale, check node health |


### PR DESCRIPTION
Clarify why you'd use env vars in the Cloud build settings vs when you'd declare them directly in hooks.

cc @pchico83 and @pkennedyr for review

Signed-off-by: LRubin lrubin@docker.com
