### PR TITLE
Added details about tag support for AWS log driver

### DIFF
--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -63,6 +63,17 @@ specified, the container ID is used as the log stream.
 > at a time.  Using the same log stream for multiple containers concurrently
 > can cause reduced logging performance.
 
+### tag
+
+Specify tag as an alternative to the AWS logstream name, which interpret some markup, ex `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`
+
+By default, Docker uses the first 12 characters of the container ID to tag log messages.
+Refer to the [log tag option documentation](log_tags.md) for customizing
+the log tag format.
+
+> **Note:**
+> `awslogs-stream` will **always** overwrite the `tag` specified.
+
 ## Credentials
 
 You must provide AWS credentials to the Docker daemon to use the `awslogs`

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -65,7 +65,7 @@ specified, the container ID is used as the log stream.
 
 ### tag
 
-Specify `tag` as an alternative to the `awslogs-stream` option. `tag` interprets template markup (e.g., `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`). 
+Specify `tag` as an alternative to the `awslogs-stream` option. `tag` interprets template markup (e.g., `{% raw %}{{.ID}}{% endraw %}`, `{% raw %}{{.FullID}}{% endraw %}` or `{% raw %}{{.Name}}{% endraw %}` `{% raw %}docker.{{.ID}}{% endraw %}`). 
 See the [tag option documentation](log_tags.md) for details on all supported template substitutions.
 
 When both `awslogs-stream` and `tag` are specified, the value supplied for `awslogs-stream` will override the template specified with `tag`.

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -70,7 +70,7 @@ See the [tag option documentation](log_tags.md) for details on all supported tem
 
 When both `awslogs-stream` and `tag` are specified, the value supplied for `awslogs-stream` will override the template specified with `tag`.
 
-By default, the `{{.FullID}}` template will be used to tag log messages.
+If not specified, the container ID is used as the log stream.
 
 
 ## Credentials

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -65,14 +65,15 @@ specified, the container ID is used as the log stream.
 
 ### tag
 
-Specify tag as an alternative to the AWS logstream name, which interpret some markup, ex `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`
+Specify `tag` as an alternative to the `awslogs-stream` option. `tag` interprets template markup (e.g., `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`). 
+See the [tag option documentation](log_tags.md) for details on all supported template substitutions.
+
+When both `awslogs-stream` and `tag` are specified, the value supplied for `awslogs-stream` will override the template specified with `tag`.
 
 By default, Docker uses the first 12 characters of the container ID to tag log messages.
 Refer to the [log tag option documentation](log_tags.md) for customizing
 the log tag format.
 
-> **Note:**
-> `awslogs-stream` will **always** overwrite the `tag` specified.
 
 ## Credentials
 

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -70,9 +70,7 @@ See the [tag option documentation](log_tags.md) for details on all supported tem
 
 When both `awslogs-stream` and `tag` are specified, the value supplied for `awslogs-stream` will override the template specified with `tag`.
 
-By default, Docker uses the first 12 characters of the container ID to tag log messages.
-Refer to the [log tag option documentation](log_tags.md) for customizing
-the log tag format.
+By default, the `{{.FullID}}` template will be used to tag log messages.
 
 
 ## Credentials

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -243,13 +243,15 @@ logging driver options.
 
 For example, to specify both additional options:
 
-```bash{% raw %}
+```bash
+{% raw %}
 $ docker run -dit \
     --log-driver=fluentd \
     --log-opt fluentd-address=localhost:24224 \
     --log-opt tag="docker.{{.Name}}" \
     alpine sh
-```{% endraw %}
+{% endraw %}
+```
 
 If container cannot connect to the Fluentd daemon on the specified address and
 `fluentd-async-connect` is not enabled, the container stops immediately.
@@ -261,12 +263,14 @@ see [the fluentd logging driver](fluentd.md)
 
 The Amazon CloudWatch Logs logging driver supports the following options:
 
-```bash{% raw %}
+```bash
+{% raw %}
 --log-opt awslogs-region=<aws_region>
 --log-opt awslogs-group=<log_group_name>
 --log-opt awslogs-stream=<log_stream_name>
 --log-opt tag="docker.{{.Name}}" \
-```{% endraw %}
+{% endraw %}
+```
 
 For detailed information on working with this logging driver, see [the awslogs
 logging driver](awslogs.md) reference documentation.

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -243,13 +243,13 @@ logging driver options.
 
 For example, to specify both additional options:
 
-```bash
+```bash{% raw %}
 $ docker run -dit \
     --log-driver=fluentd \
     --log-opt fluentd-address=localhost:24224 \
     --log-opt tag="docker.{{.Name}}" \
     alpine sh
-```
+```{% endraw %}
 
 If container cannot connect to the Fluentd daemon on the specified address and
 `fluentd-async-connect` is not enabled, the container stops immediately.
@@ -261,11 +261,12 @@ see [the fluentd logging driver](fluentd.md)
 
 The Amazon CloudWatch Logs logging driver supports the following options:
 
-```bash
+```bash{% raw %}
 --log-opt awslogs-region=<aws_region>
 --log-opt awslogs-group=<log_group_name>
 --log-opt awslogs-stream=<log_stream_name>
-```
+--log-opt tag="docker.{{.Name}}" \
+```{% endraw %}
 
 For detailed information on working with this logging driver, see [the awslogs
 logging driver](awslogs.md) reference documentation.


### PR DESCRIPTION
### Describe the proposed changes

Added details about the new flag for AWS logging. Pending https://github.com/docker/docker/pull/27707 is merged.
### Project version

1.13 milestone hopefully
### Related issue or PR in another project

No issue, but `docker/docker` PR: https://github.com/docker/docker/pull/27707
### Please take a look

cc @johndmulhausen @mstanleyjones @londoncalling @samuelkarp

_ps: Previous PR was deleted since it used the wrong branch_
