### PR TITLE
Fix OSX entries to MacOS in TOC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -6,7 +6,7 @@ toc:
   - sectiontitle: Install
     section:
     - path: /engine/installation/mac/
-      title: Installation on Mac OS X
+      title: Installation on macOS
     - path: /engine/installation/windows/
       title: Installation on Windows
     - sectiontitle: On Linux distributions
@@ -1218,7 +1218,7 @@ toc:
         - path: /registry/recipes/mirror/
           title: Mirroring Docker Hub
         - path: /registry/recipes/osx-setup-guide/
-          title: Running on OS X
+          title: Running on macOS
       - sectiontitle: Reference
         section:
         - path: /registry/spec/


### PR DESCRIPTION
### Describe the proposed changes

Fixes #404 
We changed instances of 'OS X' to 'macOS' and this makes the TOC consistent.

### Project version


### Related issue

#404 

### Related issue or PR in another project

n/a

### Please take a look

n/a


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

