### PR TITLE
Fix some Liquid warnings

### DIFF
--- a/machine/reference/inspect.md
+++ b/machine/reference/inspect.md
@@ -61,8 +61,10 @@ For the most part, you can pick out any field from the JSON in a fairly
 straightforward manner.
 
 ```none
+{% raw %}
 $ docker-machine inspect --format='{{.Driver.IPAddress}}' dev
 192.168.5.99
+{% endraw %}
 ```
 
 **Formatting details:**
@@ -78,7 +80,8 @@ $ docker-machine inspect --format='{{json .Driver}}' dev-fusion
 While this is usable, it's not very human-readable. For this reason, there is
 `prettyjson`:
 
-```
+```none
+{% raw %}
 $ docker-machine inspect --format='{{prettyjson .Driver}}' dev-fusion
 {
   "Boot2DockerURL": "",
@@ -97,4 +100,5 @@ $ docker-machine inspect --format='{{prettyjson .Driver}}' dev-fusion
   "SwarmHost": "tcp://0.0.0.0:3376",
   "SwarmMaster": false
 }
+{% endraw %}
 ```

--- a/machine/reference/ls.md
+++ b/machine/reference/ls.md
@@ -103,16 +103,20 @@ The following example uses a template without headers and outputs the `Name` and
 for all running machines:
 
 ```none
+{% raw %}
 $ docker-machine ls --format "{{.Name}}: {{.DriverName}}"
 default: virtualbox
 ec2: amazonec2
+{% endraw %}
 ```
 
 To list all machine names with their driver in a table format you can use:
 
 ```none
+{% raw %}
 $ docker-machine ls --format "table {{.Name}} {{.DriverName}}"
 NAME     DRIVER
 default  virtualbox
 ec2      amazonec2
+{% endraw %}
 ```


### PR DESCRIPTION
### Describe the proposed changes

Wrap some Docker log template directives in `{% raw %}` because when Liquid sees `{{ }}` it gets really excited and treats them as mix-ins.

### Project version

n/a

### Related issue

n/a

### Related issue or PR in another project

n/a

### Please take a look

@johndmulhausen @joaofnfernandes @londoncalling 


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

