### PR TITLE
absolute links to docs.docker.com are now relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You have three options:
     ```
 
     If you haven't got Docker Compose installed,
-    [follow these installation instructions](https://docs.docker.com/compose/install/).
+    [follow these installation instructions](/compose/install/).
 
     The container runs in the background and incrementally rebuilds the site each
     time a file changes. You can keep your browser open to http://localhost:4000/
@@ -150,7 +150,7 @@ directly on docs.docker.com.
 ## Style guide
 
 If you have questions about how to write for Docker's documentation, please see
-the [style guide](https://docs.docker.com/opensource/doc-style/). The style guide provides
+the [style guide](/opensource/doc-style/). The style guide provides
 guidance about grammar, syntax, formatting, styling, language, or tone. If
 something isn't clear in the guide, please submit an issue to let us know or
 submit a pull request to help us improve it.

--- a/compose/bundles.md
+++ b/compose/bundles.md
@@ -54,8 +54,8 @@ Wrote bundle to vossibility-stack.dab
 > you need to install an experimental build of Docker Engine to use it.
 >
 > If you're on Mac or Windows, download the “Beta channel” version of
-> [Docker for Mac](https://docs.docker.com/docker-for-mac/) or
-> [Docker for Windows](https://docs.docker.com/docker-for-windows/) to install
+> [Docker for Mac](/docker-for-mac/) or
+> [Docker for Windows](/docker-for-windows/) to install
 > it. If you're on Linux, follow the instructions in the
 > [experimental build README](https://github.com/docker/docker/blob/master/experimental/README.md).
 

--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -171,7 +171,7 @@ Override the default command.
 
     command: bundle exec thin -p 3000
 
-The command can also be a list, in a manner similar to [dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
+The command can also be a list, in a manner similar to [dockerfile](/engine/reference/builder/#cmd):
 
     command: [bundle, exec, thin, -p, 3000]
 
@@ -264,7 +264,7 @@ Override the default entrypoint.
 
     entrypoint: /code/entrypoint.sh
 
-The entrypoint can also be a list, in a manner similar to [dockerfile](https://docs.docker.com/engine/reference/builder/#entrypoint):
+The entrypoint can also be a list, in a manner similar to [dockerfile](/engine/reference/builder/#entrypoint):
 
     entrypoint:
         - php
@@ -413,7 +413,7 @@ options and tags it with the specified tag.
 
 ### labels
 
-Add metadata to containers using [Docker labels](https://docs.docker.com/engine/userguide/labels-custom-metadata/). You can use either an array or a dictionary.
+Add metadata to containers using [Docker labels](/engine/userguide/labels-custom-metadata/). You can use either an array or a dictionary.
 
 It's recommended that you use reverse-DNS notation to prevent your labels from conflicting with those used by other software.
 
@@ -462,7 +462,7 @@ Logging configuration for the service.
 
 The `driver`  name specifies a logging driver for the service's
 containers, as with the ``--log-driver`` option for docker run
-([documented here](https://docs.docker.com/engine/reference/logging/overview/)).
+([documented here](/engine/reference/logging/overview/)).
 
 The default value is json-file.
 
@@ -721,8 +721,8 @@ use the specified driver.
 > Note: No path expansion will be done if you have also specified a
 > `volume_driver`.
 
-See [Docker Volumes](https://docs.docker.com/engine/userguide/dockervolumes/) and
-[Volume Plugins](https://docs.docker.com/engine/extend/plugins_volume/) for more
+See [Docker Volumes](/engine/userguide/dockervolumes/) and
+[Volume Plugins](/engine/extend/plugins_volume/) for more
 information.
 
 ### volumes_from
@@ -749,7 +749,7 @@ then read-write will be used.
 ### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
 
 Each of these is a single value, analogous to its
-[docker run](https://docs.docker.com/engine/reference/run/) counterpart.
+[docker run](/engine/reference/run/) counterpart.
 
     cpu_shares: 73
     cpu_quota: 50000
@@ -781,7 +781,7 @@ While it is possible to declare volumes on the fly as part of the service
 declaration, this section allows you to create named volumes that can be
 reused across multiple services (without relying on `volumes_from`), and are
 easily retrieved and inspected using the docker command line or API.
-See the [docker volume](https://docs.docker.com/engine/reference/commandline/volume_create/)
+See the [docker volume](/engine/reference/commandline/volume_create/)
 subcommand documentation for more information.
 
 ### driver

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -14,7 +14,7 @@ title: Networking in Compose
 > **Note:** This document only applies if you're using [version 2 of the Compose file format](compose-file.md#versioning). Networking features are not supported for version 1 (legacy) Compose files.
 
 By default Compose sets up a single
-[network](https://docs.docker.com/engine/reference/commandline/network_create/) for your app. Each
+[network](/engine/reference/commandline/network_create/) for your app. Each
 container for a service joins the default network and is both *reachable* by
 other containers on that network, and *discoverable* by them at a hostname
 identical to the container name.
@@ -77,11 +77,11 @@ See the [links reference](compose-file.md#links) for more information.
 
 When [deploying a Compose application to a Swarm cluster](swarm.md), you can make use of the built-in `overlay` driver to enable multi-host communication between containers with no changes to your Compose file or application code.
 
-Consult the [Getting started with multi-host networking](https://docs.docker.com/engine/userguide/networking/get-started-overlay/) to see how to set up a Swarm cluster. The cluster will use the `overlay` driver by default, but you can specify it explicitly if you prefer - see below for how to do this.
+Consult the [Getting started with multi-host networking](/engine/userguide/networking/get-started-overlay/) to see how to set up a Swarm cluster. The cluster will use the `overlay` driver by default, but you can specify it explicitly if you prefer - see below for how to do this.
 
 ## Specifying custom networks
 
-Instead of just using the default app network, you can specify your own networks with the top-level `networks` key. This lets you create more complex topologies and specify [custom network drivers](https://docs.docker.com/engine/extend/plugins_network/) and options. You can also use it to connect services to externally-created networks which aren't managed by Compose.
+Instead of just using the default app network, you can specify your own networks with the top-level `networks` key. This lets you create more complex topologies and specify [custom network drivers](/engine/extend/plugins_network/) and options. You can also use it to connect services to externally-created networks which aren't managed by Compose.
 
 Each service can specify what networks to connect to with the *service-level* `networks` key, which is a list of names referencing entries under the *top-level* `networks` key.
 

--- a/compose/overview.md
+++ b/compose/overview.md
@@ -184,4 +184,4 @@ individuals, we have a number of open channels for communication.
 
 * To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/compose/pulls).
 
-For more information and resources, please visit the [Getting Help project page](https://docs.docker.com/opensource/get-help/).
+For more information and resources, please visit the [Getting Help project page](/opensource/get-help/).

--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -25,10 +25,10 @@ format](compose-file.md#versioning) you are using:
 
     - subject to the [limitations](swarm.md#limitations) described below,
 
-    - as long as the Swarm cluster is configured to use the [overlay driver](https://docs.docker.com/engine/userguide/networking/dockernetworks/#an-overlay-network),
+    - as long as the Swarm cluster is configured to use the [overlay driver](/engine/userguide/networking/dockernetworks/#an-overlay-network),
       or a custom driver which supports multi-host networking.
 
-Read [Get started with multi-host networking](https://docs.docker.com/engine/userguide/networking/get-started-overlay/) to see how to
+Read [Get started with multi-host networking](/engine/userguide/networking/get-started-overlay/) to see how to
 set up a Swarm cluster with [Docker Machine](/machine/overview.md) and the overlay driver. Once you've got it running, deploying your app to it should be as simple as:
 
     $ eval "$(docker-machine env --swarm <name of swarm master machine>)"

--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -94,7 +94,7 @@ This pulls the needed images, and starts the wordpress and database containers, 
 
 ### Bring up WordPress in a web browser
 
-If you're using [Docker Machine](https://docs.docker.com/machine/), then `docker-machine ip MACHINE_VM` gives you the machine address and you can open `http://MACHINE_VM_IP:8000` in a browser.
+If you're using [Docker Machine](/machine/), then `docker-machine ip MACHINE_VM` gives you the machine address and you can open `http://MACHINE_VM_IP:8000` in a browser.
 
 At this point, WordPress should be running on port `8000` of your Docker Host, and you can complete the "famous five-minute installation" as a WordPress administrator.
 

--- a/cs-engine/release-notes/prior-release-notes.md
+++ b/cs-engine/release-notes/prior-release-notes.md
@@ -340,5 +340,5 @@ Because this addition is preventative, no CVE-ID is requested.
 ## CS Engine 1.6.0-cs2
 (23 Apr 2015)
 
-First release, see the [Docker Engine 1.6.0 Release notes](https://docs.docker.com/v1.6/release-notes/)
+First release, see the [Docker Engine 1.6.0 Release notes](/v1.6/release-notes/)
   for more details.

--- a/docker-cloud/apps/ports.md
+++ b/docker-cloud/apps/ports.md
@@ -12,7 +12,7 @@ title: Publish and expose service or container ports
 
 # Publish and expose service or container ports
 
-In Docker Cloud you can **publish** or **expose** ports in services and containers, just like you can in Docker Engine (as documented [here](https://docs.docker.com/reference/run/#expose-incoming-ports) ).
+In Docker Cloud you can **publish** or **expose** ports in services and containers, just like you can in Docker Engine (as documented [here](/reference/run/#expose-incoming-ports) ).
 
 * **Exposed ports** are ports that a container or service is using either to
 provide a service, or listen on. By default, exposed ports in Docker Cloud are

--- a/docker-cloud/apps/service-links.md
+++ b/docker-cloud/apps/service-links.md
@@ -17,7 +17,7 @@ Docker Cloud creates a per-user overlay network which connects all containers ac
 Docker Cloud gives your containers two ways find other services:
 
 * Using service and container names directly as **hostnames**
-* Using **service links**, which are based on [Docker Compose links](https://docs.docker.com/compose/compose-file/#links)
+* Using **service links**, which are based on [Docker Compose links](/compose/compose-file/#links)
 
 **Service and Container Hostnames** update automatically when a service scales up or down or redeploys. As a user, you can configure service names, and Docker Cloud uses these names to find the IP of the services and containers for you. You can use hostnames in your code to provide abstraction that allows you to easily swap service containers or components.
 
@@ -55,7 +55,7 @@ If the container making the query is part of a stack, and there is a local match
 
 ## Using service links for service discovery
 
-Docker Cloud's service linking is modeled on [Docker Compose links](https://docs.docker.com/compose/compose-file/#links) to provide a basic service discovery functionality using directional links recorded in environment variables.
+Docker Cloud's service linking is modeled on [Docker Compose links](/compose/compose-file/#links) to provide a basic service discovery functionality using directional links recorded in environment variables.
 
 When you link a "client" service to a "server" service, Docker Cloud performs the following actions on the "client" service:
 

--- a/docker-cloud/apps/volumes.md
+++ b/docker-cloud/apps/volumes.md
@@ -22,7 +22,7 @@ redeployment, or shared with other services.
 ## Add a data volume to a service
 
 Data volumes can be either specified in the image's `Dockerfile` using the
-[VOLUME instruction](https://docs.docker.com/reference/builder/#volume), or when
+[VOLUME instruction](/reference/builder/#volume), or when
 creating a service.
 
 To define a data volume in a service, specify the **container path** where it

--- a/docker-cloud/builds/image-scan.md
+++ b/docker-cloud/builds/image-scan.md
@@ -188,4 +188,4 @@ components.
 ## Related information
 
 * [Learn about CVE and how it compiles data](https://cve.mitre.org/about/index.html).
-* [How to create a Docker Official image](https://docs.docker.com/docker-hub/official_repos/)
+* [How to create a Docker Official image](/docker-hub/official_repos/)

--- a/docker-cloud/getting-started/deploy-app/12_data_management_with_volumes.md
+++ b/docker-cloud/getting-started/deploy-app/12_data_management_with_volumes.md
@@ -139,6 +139,6 @@ Docker Cloud, deploy an app to your Cloud nodes, set environment variables,
 scale the service, view logs, set up a load balancer and a data back end, and
 set up a volume to save the data.
 
-There's lots more to learn about Docker Cloud, so check out [the rest of our documentation](https://docs.docker.com/docker-cloud/), the [API and CLI Documentation](../../../apidocs/docker-cloud.md), and our [Knowledge Hub](https://success.docker.com/Cloud) and [Docker Cloud Forums](https://forums.docker.com/c/docker-cloud).
+There's lots more to learn about Docker Cloud, so check out [the rest of our documentation](/docker-cloud/), the [API and CLI Documentation](../../../apidocs/docker-cloud.md), and our [Knowledge Hub](https://success.docker.com/Cloud) and [Docker Cloud Forums](https://forums.docker.com/c/docker-cloud).
 
 Happy Docking!

--- a/docker-cloud/release-notes.md
+++ b/docker-cloud/release-notes.md
@@ -55,7 +55,7 @@ The following release notes document changes since [Tutum v0.19.5](https://suppo
 - **Docker Cloud is Generally Available**: all features of Docker Cloud are Generally Available with the exception of the build features which remain in beta.
 - **Docker Hub Registry Integration**: All of your Docker Hub image repositories are available and accessible when you login to Docker Cloud. Changes you make to your repositories are reflected in both Docker Hub and Docker Cloud.
 - **Autoredeploy from Docker Hub**: services that use a repository stored in the Docker Hub now have the [**autoredeploy** option](apps/auto-redeploy.md) available, which allows automatic redeployments on push without setting up webhooks.
-- **Environment variable substitution on CLI**: the `docker-cloud` CLI now substitutes environment variables in stack files, [the same way Docker Compose does it](https://docs.docker.com/compose/compose-file/#variable-substitution:91de898b5f5cdb090642a917d3dedf68).
+- **Environment variable substitution on CLI**: the `docker-cloud` CLI now substitutes environment variables in stack files, [the same way Docker Compose does it](/compose/compose-file/#variable-substitution:91de898b5f5cdb090642a917d3dedf68).
 
 
 ### Changed

--- a/docker-for-mac/docker-toolbox.md
+++ b/docker-for-mac/docker-toolbox.md
@@ -18,7 +18,7 @@ If you already have an installation of Docker Toolbox, please read these topics 
 
 ## The Docker Toolbox environment
 
-Docker Toolbox installs `docker`, `docker-compose` and `docker-machine` in `/usr/local/bin` on your Mac. It also installs VirtualBox. At installation time, Toolbox uses `docker-machine` to provision a VirtualBox VM called `default`, running the `boot2docker` Linux distribution, with  [Docker Engine](https://docs.docker.com/engine/) with certificates located on your Mac at `$HOME/.docker/machine/machines/default`.
+Docker Toolbox installs `docker`, `docker-compose` and `docker-machine` in `/usr/local/bin` on your Mac. It also installs VirtualBox. At installation time, Toolbox uses `docker-machine` to provision a VirtualBox VM called `default`, running the `boot2docker` Linux distribution, with  [Docker Engine](/engine/) with certificates located on your Mac at `$HOME/.docker/machine/machines/default`.
 
 Before you use `docker` or `docker-compose` on your Mac, you typically use the command `eval $(docker-machine env default)` to set environment variables so that `docker` or `docker-compose` know how to talk to Docker Engine running on VirtualBox.
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -85,7 +85,7 @@ For more about stable and beta channels, see the [FAQs](faqs.md#stable-and-beta-
   >**Note**: If your system does not satisfy these requirements, you can install [Docker Toolbox](/toolbox/overview.md), which uses Oracle Virtual Box instead of HyperKit.
 
 <p />
-* **What the install includes**: The installation provides [Docker Engine](https://docs.docker.com/engine/userguide/intro/), Docker CLI client, [Docker Compose](https://docs.docker.com/compose/overview/), and [Docker Machine](https://docs.docker.com/machine/overview/).
+* **What the install includes**: The installation provides [Docker Engine](/engine/userguide/intro/), Docker CLI client, [Docker Compose](/compose/overview/), and [Docker Machine](/machine/overview/).
 
 ## Step 1. Install and Run Docker for Mac
 
@@ -188,9 +188,9 @@ Choose <img src="images/whale-x.png"> --> **Preferences** from the menu bar. You
 ![Advanced Preference settings-advanced](images/settings-advanced.png)
 
 * **Adding registries** - As an alternative to using [Docker Hub](https://hub.docker.com/) to store your public or private images or [Docker
-Trusted Registry](https://docs.docker.com/docker-trusted-registry/overview/),
+Trusted Registry](/docker-trusted-registry/overview/),
 you can use Docker to set up your own insecure
-[registry](https://docs.docker.com/registry/introduction/). Add URLs for
+[registry](/registry/introduction/). Add URLs for
 insecure registries and registry mirrors on which to host your images. (See
 also, [How do I add custom CA
 certificates?](faqs.md#how-do-i-add-custom-ca-certificates) in the FAQs.)

--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -53,7 +53,7 @@ no_proxy=*.local, 169.254/16
 
 You can see from the above output that the `HTTP_PROXY`, `http_proxy` and `no_proxy` environment variables are set.
 When your proxy configuration changes, Docker restarts automatically to pick up the new settings.
-If you have containers that you wish to keep running across restarts, you should consider using [restart policies](https://docs.docker.com/engine/reference/run/#restart-policies-restart)
+If you have containers that you wish to keep running across restarts, you should consider using [restart policies](/engine/reference/run/#restart-policies-restart)
 
 ## Known Limitations, Use Cases, and Workarounds
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -504,7 +504,7 @@ events or unexpected unmounts.
 
 **Bug fixes and minor changes**
 
-* Documentation moved to [https://docs.docker.com/docker-for-mac/](https://docs.docker.com/docker-for-mac/)
+* Documentation moved to [https://docs.docker.com/docker-for-mac/](/docker-for-mac/)
 * Allow non-admin users to launch the app for the first time (using admin creds)
 * Prompt non-admin users for admin password when needed in Preferences
 * Fixed download links, documentation links

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -76,7 +76,7 @@ If you have not already done so, please install Docker for Windows. You can down
 <p />
 * Virtualization must be enabled. Typically, virtualization is enabled by default. (Note that this is different from having Hyper-V enabled.) For more detail see [Virtualization must be enabled](troubleshoot.md#virtualization-must-be-enabled) in Troubleshooting.
 <br><br>
-* **What the Docker for Windows install includes**: The installation provides [Docker Engine](https://docs.docker.com/engine/userguide/intro/), Docker CLI client, [Docker Compose](https://docs.docker.com/compose/overview/), and [Docker Machine](https://docs.docker.com/machine/overview/).
+* **What the Docker for Windows install includes**: The installation provides [Docker Engine](/engine/userguide/intro/), Docker CLI client, [Docker Compose](/compose/overview/), and [Docker Machine](/machine/overview/).
 <p />
 * You can run **Docker on Windows Server 16 and Windows 10** in two different ways:
 
@@ -385,7 +385,7 @@ no_proxy=*.local, 169.254/16
 
 You can see from the above output that the `HTTP_PROXY`, `http_proxy` and `no_proxy` environment variables are set.
 When your proxy configuration changes, Docker restarts automatically to pick up the new settings.
-If you have containers that you wish to keep running across restarts, you should consider using [restart policies](https://docs.docker.com/engine/reference/run/#restart-policies-restart)
+If you have containers that you wish to keep running across restarts, you should consider using [restart policies](/engine/reference/run/#restart-policies-restart)
 
 ### Docker daemon
 You can configure options on the Docker daemon in the given JSON configuration file, and determine how your containers will run.

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -15,7 +15,7 @@ title: Overview of Docker Hub
 
 [Docker Hub](https://hub.docker.com) is a cloud-based registry service which
 allows you to link to code repositories, build your images and test them, stores
-manually pushed images, and links to [Docker Cloud](https://docs.docker.com/docker-cloud/) so you can deploy images to your
+manually pushed images, and links to [Docker Cloud](/docker-cloud/) so you can deploy images to your
 hosts. It provides a centralized resource for container image discovery,
 distribution and change management, [user and team collaboration](orgs.md), and
 workflow automation throughout the development pipeline.
@@ -61,7 +61,7 @@ the repositories you can access and their status, view your "Dashboard" page on
 [Docker Hub](https://hub.docker.com).
 
 
-You can find more information on working with Docker images in the [Docker userguide](https://docs.docker.com/userguide/dockerimages/).
+You can find more information on working with Docker images in the [Docker userguide](/userguide/dockerimages/).
 
 ### Use Official Repositories
 
@@ -90,5 +90,5 @@ You can create public repositories which can be accessed by any other Hub user, 
 
 ### Docker commands and Docker Hub
 
-Docker itself provides access to Docker Hub services via the [`docker search`](http://docs.docker.com/reference/commandline/search),
-[`pull`](http://docs.docker.com/reference/commandline/pull), [`login`](http://docs.docker.com/reference/commandline/login), and [`push`](http://docs.docker.com/reference/commandline/push) commands.
+Docker itself provides access to Docker Hub services via the [`docker search`](/reference/commandline/search),
+[`pull`](/reference/commandline/pull), [`login`](/reference/commandline/login), and [`push`](/reference/commandline/push) commands.

--- a/docker-hub/official_repos.md
+++ b/docker-hub/official_repos.md
@@ -24,7 +24,7 @@ curated set of Docker repositories that are promoted on Docker Hub. They are des
   stores, and other services, similar to what a Platform-as-a-Service (PAAS)
   would offer.
 
-* Exemplify [`Dockerfile` best practices](https://docs.docker.com/articles/dockerfile_best-practices)
+* Exemplify [`Dockerfile` best practices](/articles/dockerfile_best-practices)
   and provide clear documentation to serve as a reference for other `Dockerfile`
   authors.
 
@@ -72,7 +72,7 @@ these efforts.
 
 ## How do I know the Official Repositories are secure?
 
-Docker provides a preview version of Docker Cloud's [Security Scanning service](http://docs.docker.com/docker-cloud/builds/image-scan/) for all of the
+Docker provides a preview version of Docker Cloud's [Security Scanning service](/docker-cloud/builds/image-scan/) for all of the
 Official Repositories located on Docker Hub. These security scan results provide
 valuable information about which images contain security vulnerabilities, which
 you should use to help you choose secure components for your own projects.

--- a/docker-hub/repos.md
+++ b/docker-hub/repos.md
@@ -102,7 +102,7 @@ You can name your local images either when you build it, using
 by re-tagging an existing local image `docker tag <existing-image> <hub-user>/<repo-name>[:<tag>]`,
 or by using `docker commit <exiting-container> <hub-user>/<repo-name>[:<tag>]` to commit
 changes.
-See [Working with Docker images](https://docs.docker.com/userguide/dockerimages) for a detailed description.
+See [Working with Docker images](/userguide/dockerimages) for a detailed description.
 
 Now you can push this repository to the registry designated by its name or tag.
 

--- a/docker-trusted-registry/install/index.md
+++ b/docker-trusted-registry/install/index.md
@@ -32,7 +32,7 @@ infrastructure has all the [requirements DTR needs to run](system-requirements.m
 
 Since DTR requires a Docker Universal Control Plane (UCP) cluster
 to run, you need to install UCP first.
-[Learn how to install UCP](https://docs.docker.com/ucp/installation/install-production/). Make sure that the node you install DTR on is already joined to the UCP cluster.
+[Learn how to install UCP](/ucp/installation/install-production/). Make sure that the node you install DTR on is already joined to the UCP cluster.
 
 
 ## Step 3. Install DTR
@@ -46,7 +46,7 @@ To install DTR:
 
     Having a UCP client bundle allows you to run Docker commands on a UCP
     cluster.
-    [Download a UCP client bundle](https://docs.docker.com/ucp/access-ucp/cli-based-access/)
+    [Download a UCP client bundle](/ucp/access-ucp/cli-based-access/)
     and set up your CLI client to use it.
 
 2.  Run the following command to install DTR.

--- a/docker-trusted-registry/release-notes/prior-release-notes.md
+++ b/docker-trusted-registry/release-notes/prior-release-notes.md
@@ -262,7 +262,7 @@ This release addresses a few bugs and issues in Docker Trusted Registry 1.2.0 an
 
 * A completely new user-interface for the Admin application brings Docker Trusted Registry in line with other Docker products and provides greater ease-of-use.
 
-* A new Accounts & Repos API provides new fine-grained role-based access control down to the per-repo level. See the [API's documentation](https://docs.docker.com/apidocs/v1.3.3/) for more information.
+* A new Accounts & Repos API provides new fine-grained role-based access control down to the per-repo level. See the [API's documentation](/apidocs/v1.3.3/) for more information.
 
 * Improvements to the handling of configuration changes so that fewer restarts are required.
 

--- a/engine/admin/registry_mirror.md
+++ b/engine/admin/registry_mirror.md
@@ -14,7 +14,7 @@ title: Run a local registry mirror
 # Run a local registry mirror
 
 The original content was deprecated. [An archived
-version](https://docs.docker.com/v1.6/articles/registry_mirror) is available in
+version](/v1.6/articles/registry_mirror) is available in
 the 1.7 documentation. For information about configuring mirrors with the latest
 Docker Registry version, please file a support request with [the Distribution
 project](https://github.com/docker/distribution/issues).

--- a/engine/examples/mongodb.md
+++ b/engine/examples/mongodb.md
@@ -198,4 +198,4 @@ $ mongo --port 28002
 
  - [Linking containers](../userguide/networking/default_network/dockerlinks.md)
  - [Cross-host linking containers](../admin/ambassador_pattern_linking.md)
- - [Creating an Automated Build](https://docs.docker.com/docker-hub/builds/)
+ - [Creating an Automated Build](/docker-hub/builds/)

--- a/engine/extend/plugins_network.md
+++ b/engine/extend/plugins_network.md
@@ -57,7 +57,7 @@ referring to that network will be sent to the plugin,
 ## Write a network plugin
 
 Network plugins implement the [Docker plugin
-API](https://docs.docker.com/extend/plugin_api/) and the network plugin protocol
+API](/extend/plugin_api/) and the network plugin protocol
 
 ## Network plugin protocol
 

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -107,7 +107,7 @@ offers a high-level tool with several powerful functionalities:
  where thousands of people have uploaded useful images: anything from Redis,
  CouchDB, PostgreSQL to IRC bouncers to Rails app servers to Hadoop to base
  images for various Linux distros. The
- [*registry*](https://docs.docker.com/registry/) also
+ [*registry*](/registry/) also
  includes an official "standard library" of useful containers maintained by the
  Docker team. The registry itself is open-source, so anyone can deploy their own
  registry to store and transfer private containers, for internal server

--- a/engine/getstarted/step_one.md
+++ b/engine/getstarted/step_one.md
@@ -69,9 +69,9 @@ For full instructions on getting Docker for various Linux distributions, see [In
 
 ## Step 2: Install Docker
 
-- **Docker for Mac** - Install instructions are at [Getting Started with Docker for Mac](https://docs.docker.com/docker-for-mac/).
+- **Docker for Mac** - Install instructions are at [Getting Started with Docker for Mac](/docker-for-mac/).
 
-- **Docker for Windows** - Install instructions are at [Getting Started with Docker for Windows](https://docs.docker.com/docker-for-windows/).
+- **Docker for Windows** - Install instructions are at [Getting Started with Docker for Windows](/docker-for-windows/).
 
 - **Docker Toolbox** - Install instructions are at [Docker Toolbox Overview](/toolbox/overview.md).
 

--- a/engine/index.md
+++ b/engine/index.md
@@ -98,7 +98,7 @@ implementation, check out the [Docker User Guide](userguide/index.md).
 ## Release notes
 
 A summary of the changes in each release in the current series can now be found
-on the separate [Release Notes page](https://docs.docker.com/release-notes)
+on the separate [Release Notes page](/release-notes)
 
 ## Feature Deprecation Policy
 

--- a/engine/installation/cloud/cloud-ex-aws.md
+++ b/engine/installation/cloud/cloud-ex-aws.md
@@ -199,11 +199,11 @@ For Ubuntu Trusty (and some other versions), it’s recommended to install the `
 
 ## Where to go next
 
-_Looking for a quicker way to do Docker cloud installs and provision multiple hosts?_ You can use [Docker Machine](https://docs.docker.com/machine/overview/) to provision hosts.
+_Looking for a quicker way to do Docker cloud installs and provision multiple hosts?_ You can use [Docker Machine](/machine/overview/) to provision hosts.
 
-  * [Use Docker Machine to provision hosts on cloud providers](https://docs.docker.com/machine/get-started-cloud/)
+  * [Use Docker Machine to provision hosts on cloud providers](/machine/get-started-cloud/)
 
-  * [Docker Machine driver reference](https://docs.docker.com/machine/drivers/)
+  * [Docker Machine driver reference](/machine/drivers/)
 
 *  [Install Docker Engine](../index.md)
 

--- a/engine/installation/cloud/cloud-ex-machine-ocean.md
+++ b/engine/installation/cloud/cloud-ex-machine-ocean.md
@@ -207,11 +207,11 @@ If you create a host with Docker Machine, but remove it through the cloud provid
 
 ## Where to go next
 
-* [Docker Machine driver reference](https://docs.docker.com/machine/drivers/)
+* [Docker Machine driver reference](/machine/drivers/)
 
-* [Docker Machine Overview](https://docs.docker.com/machine/overview/)
+* [Docker Machine Overview](/machine/overview/)
 
-* [Use Docker Machine to provision hosts on cloud providers](https://docs.docker.com/machine/get-started-cloud/)
+* [Use Docker Machine to provision hosts on cloud providers](/machine/get-started-cloud/)
 
 * [Install Docker Engine](../../installation/index.md)
 

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -43,7 +43,7 @@ If your linux distribution is not listed above, don't give up yet. To try out Do
 
 ## The Docker Archives
 Instructions for installing prior releases of Docker can be found in the following docker archives:
-[Docker v1.7](http://docs.docker.com/v1.7/), [Docker v1.6](http://docs.docker.com/v1.6/), [Docker v1.5](http://docs.docker.com/v1.5/), and [Docker v1.4](http://docs.docker.com/v1.4/).
+[Docker v1.7](/v1.7/), [Docker v1.6](/v1.6/), [Docker v1.5](/v1.5/), and [Docker v1.4](/v1.4/).
 
 ## Where to go after installing
 * [About Docker Engine](../index.md)

--- a/engine/installation/mac.md
+++ b/engine/installation/mac.md
@@ -21,7 +21,7 @@ You have two options for installing Docker on Mac:
 
 Docker for Mac is our newest offering for the Mac. It runs as a native Mac application and uses <a href="https://github.com/mist64/xhyve/" target="_blank">xhyve</a> to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-Go to [Getting Started with Docker for Mac](https://docs.docker.com/docker-for-mac/) for download and install instructions, and to learn all about Docker for Mac.
+Go to [Getting Started with Docker for Mac](/docker-for-mac/) for download and install instructions, and to learn all about Docker for Mac.
 
 **Requirements**
 
@@ -52,6 +52,6 @@ Your Mac must be running macOS 10.8 "Mountain Lion" or newer to install the Dock
 
 * You can find more extensive examples in [Learn by example](../tutorials/index.md) and in the [Docker Engine User Guide](../userguide/index.md).
 
-* If you are interested in using the Kitematic GUI, see the [Kitematic user guide](https://docs.docker.com/kitematic/userguide/).
+* If you are interested in using the Kitematic GUI, see the [Kitematic user guide](/kitematic/userguide/).
 
 > **Note**: The Boot2Docker command line was deprecated several releases back in favor of Docker Machine, and now Docker for Mac.

--- a/engine/installation/windows.md
+++ b/engine/installation/windows.md
@@ -20,7 +20,7 @@ You have two options for installing Docker on Windows:
 
 Docker for Windows is our newest offering for PCs. It runs as a native Windows application and uses Hyper-V to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-Go to [Getting Started with Docker for Windows](https://docs.docker.com/docker-for-windows/) for download and install instructions, and to learn all about Docker for Windows.
+Go to [Getting Started with Docker for Windows](/docker-for-windows/) for download and install instructions, and to learn all about Docker for Windows.
 
 **Requirements**
 
@@ -46,6 +46,6 @@ To run Docker, your machine must have a 64-bit operating system running Windows 
 
 * You can find more extensive examples in [Learn by example](../tutorials/index.md) and in the [Docker Engine User Guide](../userguide/index.md).
 
-* If you are interested in using the Kitematic GUI, see the [Kitematic user guide](https://docs.docker.com/kitematic/userguide/).
+* If you are interested in using the Kitematic GUI, see the [Kitematic user guide](/kitematic/userguide/).
 
 > **Note**: The Boot2Docker command line was deprecated several releases > back in favor of Docker Machine, and now Docker for Windows.

--- a/engine/reference/api/docker-io_api.md
+++ b/engine/reference/api/docker-io_api.md
@@ -15,4 +15,4 @@ title: Docker Hub API
 # Docker Hub API
 
 This API is deprecated as of 1.7. To view the old version, see the [Docker Hub
-API](https://docs.docker.com/v1.7/docker/reference/api/docker-io_api/) in the 1.7 documentation.
+API](/v1.7/docker/reference/api/docker-io_api/) in the 1.7 documentation.

--- a/engine/reference/api/hub_registry_spec.md
+++ b/engine/reference/api/hub_registry_spec.md
@@ -14,7 +14,7 @@ title: The Docker Hub and the Registry v1
 # The Docker Hub and the Registry v1
 
 This API is deprecated as of 1.7. To view the old version, see the [go
-here](https://docs.docker.com/v1.7/docker/reference/api/hub_registry_spec/) in
+here](/v1.7/docker/reference/api/hub_registry_spec/) in
 the 1.7 documentation. If you want an overview of the current features in
 Docker Hub or other image management features see the [image management
 overview](../../userguide/eng-image/image_management.md) in the current documentation set.

--- a/engine/reference/commandline/login.md
+++ b/engine/reference/commandline/login.md
@@ -34,7 +34,7 @@ adding the server name.
 `docker login` requires user to use `sudo` or be `root`, except when:
 
 1.  connecting to a remote daemon, such as a `docker-machine` provisioned `docker engine`.
-2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](https://docs.docker.com/security/security/#docker-daemon-attack-surface) for details.
+2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](/security/security/#docker-daemon-attack-surface) for details.
 
 You can log into any public or private repository for which you have
 credentials.  When you log in, the command stores encoded credentials in

--- a/engine/reference/commandline/service_create.md
+++ b/engine/reference/commandline/service_create.md
@@ -172,7 +172,7 @@ your web server containers when they start. To update the website, you just
 update the named volume.
 
 For more information about named volumes, see
-[Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).
+[Data Volumes](/engine/tutorials/dockervolumes/).
 
 The following table describes options which apply to both bind-mounts and named
 volumes in a service:

--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -27,7 +27,7 @@ This sandbox requires you to install two Docker tools: Docker Engine >= 1.10.0
 and Docker Compose >= 1.6.0. To install the Docker Engine, choose from the
 [list of supported platforms](../../installation/index.md). To install
 Docker Compose, see the
-[detailed instructions here](https://docs.docker.com/compose/install/).
+[detailed instructions here](/compose/install/).
 
 Finally, you'll need to have a text editor installed on your local system or VM.
 

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -23,7 +23,7 @@ application services to a swarm, and manage swarm behavior.
 
 
 If you’re using a Docker version prior to `v1.12.0`, see [Docker
-Swarm](https://docs.docker.com/swarm).
+Swarm](/swarm).
 
 ## Feature highlights
 

--- a/engine/tutorials/dockerimages.md
+++ b/engine/tutorials/dockerimages.md
@@ -136,7 +136,7 @@ You can see the command returns a lot of images that use the term `sinatra`.
 You've received a list of image names, descriptions, Stars (which measure the
 social popularity of images - if a user likes an image then they can "star" it),
 and the Official and Automated build statuses. [Official
-Repositories](https://docs.docker.com/docker-hub/official_repos) are a carefully
+Repositories](/docker-hub/official_repos) are a carefully
 curated set of Docker repositories supported by Docker, Inc.  Automated
 repositories are [Automated Builds](dockerrepos.md#automated-builds) that allow
 you to validate the source and content of an image.

--- a/engine/tutorials/dockerrepos.md
+++ b/engine/tutorials/dockerrepos.md
@@ -67,7 +67,7 @@ There you can see two example results: `centos` and `tianon/centos`. The second
 result shows that it comes from the public repository of a user, named
 `tianon/`, while the first result, `centos`, doesn't explicitly list a
 repository which means that it comes from the trusted top-level namespace for
-[Official Repositories](https://docs.docker.com/docker-hub/official_repos/). The `/` character separates
+[Official Repositories](/docker-hub/official_repos/). The `/` character separates
 a user's repository from the image name.
 
 Once you've found the image you want, you can download it with `docker pull <imagename>`:
@@ -100,7 +100,7 @@ see the [Docker Hub](https://hub.docker.com) registry.
 
 Anyone can pull public images from the [Docker Hub](https://hub.docker.com)
 registry, but if you would like to share your own images, then you must
-[register first](https://docs.docker.com/docker-hub/accounts).
+[register first](/docker-hub/accounts).
 
 ## Pushing a repository to Docker Hub
 
@@ -118,7 +118,7 @@ community.
 ## Features of Docker Hub
 
 Let's take a closer look at some of the features of Docker Hub. You can find more
-information [here](https://docs.docker.com/docker-hub/).
+information [here](/docker-hub/).
 
 * Private repositories
 * Organizations and teams
@@ -185,7 +185,7 @@ a webhook you can specify a target URL and a JSON payload that will be
 delivered when the image is pushed.
 
 See the Docker Hub documentation for [more information on
-webhooks](https://docs.docker.com/docker-hub/repos/#webhooks)
+webhooks](/docker-hub/repos/#webhooks)
 
 ## Next steps
 

--- a/engine/understanding-docker.md
+++ b/engine/understanding-docker.md
@@ -208,8 +208,8 @@ existing images and pull them from the registry to a host.
 [Docker Hub](http://hub.docker.com) is a public Docker
 registry which serves a huge collection of existing images and allows you to
 contribute your own. For more information, go to
-[Docker Registry](https://docs.docker.com/registry/overview/) and
-[Docker Trusted Registry](https://docs.docker.com/docker-trusted-registry/overview/).
+[Docker Registry](/registry/overview/) and
+[Docker Trusted Registry](/docker-trusted-registry/overview/).
 
 [Docker store](http://store.docker.com) allows you to buy and sell Docker images.
 For image, you can buy a Docker image containing an application or service from

--- a/engine/userguide/eng-image/baseimages.md
+++ b/engine/userguide/eng-image/baseimages.md
@@ -72,4 +72,4 @@ There are lots more resources available to help you write your 'Dockerfile`.
 * There's a [complete guide to all the instructions](../../reference/builder.md) available for use in a `Dockerfile` in the reference section.
 * To help you write a clear, readable, maintainable `Dockerfile`, we've also
 written a [`Dockerfile` Best Practices guide](dockerfile_best-practices.md).
-* If your goal is to create a new Official Repository, be sure to read up on Docker's [Official Repositories](https://docs.docker.com/docker-hub/official_repos/).
+* If your goal is to create a new Official Repository, be sure to read up on Docker's [Official Repositories](/docker-hub/official_repos/).

--- a/engine/userguide/eng-image/dockerfile_best-practices.md
+++ b/engine/userguide/eng-image/dockerfile_best-practices.md
@@ -531,6 +531,6 @@ These Official Repositories have exemplary `Dockerfile`s:
 
 * [Dockerfile Reference](../../reference/builder.md)
 * [More about Base Images](baseimages.md)
-* [More about Automated Builds](https://docs.docker.com/docker-hub/builds/)
+* [More about Automated Builds](/docker-hub/builds/)
 * [Guidelines for Creating Official
-Repositories](https://docs.docker.com/docker-hub/official_repos/)
+Repositories](/docker-hub/official_repos/)

--- a/engine/userguide/eng-image/image_management.md
+++ b/engine/userguide/eng-image/image_management.md
@@ -21,7 +21,7 @@ This section provides an overview of the major features and products Docker prov
 
 ## Docker Hub
 
-The [Docker Hub](https://docs.docker.com/docker-hub/) is responsible for centralizing information about user accounts, images, and public name spaces. It has different components:
+The [Docker Hub](/docker-hub/) is responsible for centralizing information about user accounts, images, and public name spaces. It has different components:
 
  - Web UI
  - Meta-data store (comments, stars, list public repositories)
@@ -38,7 +38,7 @@ different tagged versions. For example, the image `distribution/registry`, with
 tags `2.0` and `latest`. Users interact with a registry by using docker push and
 pull commands such as, `docker pull myregistry.com/stevvooe/batman:voice`.
 
-The Docker Hub has its own registry which, like the Hub itself, is run and managed by Docker. However, there are other ways to obtain a registry. You can purchase the [Docker Trusted Registry](https://docs.docker.com/docker-trusted-registry) product to run on your company's network. Alternatively, you can use the Docker Registry component to build a private registry. For information about using a registry, see overview for the [Docker Registry](https://docs.docker.com/registry).
+The Docker Hub has its own registry which, like the Hub itself, is run and managed by Docker. However, there are other ways to obtain a registry. You can purchase the [Docker Trusted Registry](/docker-trusted-registry) product to run on your company's network. Alternatively, you can use the Docker Registry component to build a private registry. For information about using a registry, see overview for the [Docker Registry](/registry).
 
 
 ## Content Trust

--- a/engine/userguide/intro.md
+++ b/engine/userguide/intro.md
@@ -97,7 +97,7 @@ Docker Hub is the central hub for Docker. It hosts public Docker images
 and provides services to help you build and manage your Docker
 environment. To learn more:
 
-Go to [Using Docker Hub](https://docs.docker.com/docker-hub/).
+Go to [Using Docker Hub](/docker-hub/).
 
 ### Docker Machine
 
@@ -106,7 +106,7 @@ can set up hosts for Docker Engines on your computer, on cloud providers,
 and/or in your data center, and then configure your Docker client to securely
 talk to them.
 
-Go to [Docker Machine user guide](https://docs.docker.com/machine/).
+Go to [Docker Machine user guide](/machine/).
 
 ### Docker Compose
 
@@ -114,7 +114,7 @@ Docker Compose allows you to define an application's components -- their contain
 configuration, links and volumes -- in a single file. Then a single command
 will set everything up and start your application running.
 
-Go to [Docker Compose user guide](https://docs.docker.com/compose/).
+Go to [Docker Compose user guide](/compose/).
 
 
 ### Docker Swarm
@@ -123,14 +123,14 @@ Docker Swarm pools several Docker Engines together and exposes them as a single
 virtual Docker Engine. It serves the standard Docker API, so any tool that already
 works with Docker can now transparently scale up to multiple hosts.
 
-Go to [Docker Swarm user guide](https://docs.docker.com/swarm/).
+Go to [Docker Swarm user guide](/swarm/).
 
 ## Getting help
 
 * [Docker homepage](https://www.docker.com/)
 * [Docker Hub](https://hub.docker.com)
 * [Docker blog](https://blog.docker.com/)
-* [Docker documentation](https://docs.docker.com/)
+* [Docker documentation](/)
 * [Docker Getting Started Guide](../getstarted/index.md)
 * [Docker code on GitHub](https://github.com/docker/docker)
 * [Docker mailing

--- a/engine/userguide/networking/get-started-macvlan.md
+++ b/engine/userguide/networking/get-started-macvlan.md
@@ -9,7 +9,7 @@ title: Get started with macvlan network driver
 
 ### Getting Started
 
-The Macvlan driver is in order to make Docker users use cases and vet the implementation to ensure a hardened, production ready driver. Libnetwork now gives users total control over both IPv4 and IPv6 addressing. The VLAN drivers build on top of that in giving operators complete control of layer 2 VLAN tagging for users interested in underlay network integration. For overlay deployments that abstract away physical constraints see the [multi-host overlay ](https://docs.docker.com/engine/userguide/networking/get-started-overlay/) driver.
+The Macvlan driver is in order to make Docker users use cases and vet the implementation to ensure a hardened, production ready driver. Libnetwork now gives users total control over both IPv4 and IPv6 addressing. The VLAN drivers build on top of that in giving operators complete control of layer 2 VLAN tagging for users interested in underlay network integration. For overlay deployments that abstract away physical constraints see the [multi-host overlay ](/engine/userguide/networking/get-started-overlay/) driver.
 
 Macvlan is a new twist on the tried and true network virtualization technique. The Linux implementations are extremely lightweight because rather than using the traditional Linux bridge for isolation, they are simply associated to a Linux Ethernet interface or sub-interface to enforce separation between networks and connectivity to the physical network.
 
@@ -129,7 +129,7 @@ docker network rm <network_name or id>
 
 - **Note:** In Macvlan you are not able to ping or communicate with the default namespace IP address. For example, if you create a container and try to ping the Docker host's `eth0` it will **not** work. That traffic is explicitly filtered by the kernel modules themselves to offer additional provider isolation and security.
 
-For more on Docker networking commands see [Working with Docker network commands](https://docs.docker.com/engine/userguide/networking/work-with-networks/)
+For more on Docker networking commands see [Working with Docker network commands](/engine/userguide/networking/work-with-networks/)
 
 ### Macvlan 802.1q Trunk Bridge Mode Example Usage
 

--- a/engine/userguide/networking/get-started-overlay.md
+++ b/engine/userguide/networking/get-started-overlay.md
@@ -387,5 +387,5 @@ multi-host networking scenario in the swarm cluster used above.
 
 * [Understand Docker container networks](index.md)
 * [Work with network commands](work-with-networks.md)
-* [Docker Swarm overview](https://docs.docker.com/swarm)
-* [Docker Machine overview](https://docs.docker.com/machine)
+* [Docker Swarm overview](/swarm)
+* [Docker Machine overview](/machine)

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -567,6 +567,6 @@ functionality in user-defined networks.
 - [Work with network commands](work-with-networks.md)
 - [Get started with multi-host networking](get-started-overlay.md)
 - [Managing Data in Containers](../../tutorials/dockervolumes.md)
-- [Docker Machine overview](https://docs.docker.com/machine)
-- [Docker Swarm overview](https://docs.docker.com/swarm)
+- [Docker Machine overview](/machine)
+- [Docker Swarm overview](/swarm)
 - [Investigate the LibNetwork project](https://github.com/docker/libnetwork)

--- a/engine/userguide/storagedriver/imagesandcontainers.md
+++ b/engine/userguide/storagedriver/imagesandcontainers.md
@@ -501,7 +501,7 @@ a container is deleted, any data stored in data volumes persists on the Docker
 host.
 
 For detailed information about data volumes 
-[Managing data in containers](https://docs.docker.com/engine/tutorials/dockervolumes/).
+[Managing data in containers](/engine/tutorials/dockervolumes/).
 
 ## Related information
 

--- a/kitematic/userguide.md
+++ b/kitematic/userguide.md
@@ -17,7 +17,7 @@ Kitematic is an open source project built to simplify and streamline using
 Docker on a Mac or Windows (coming soon) PC. Kitematic automates the Docker
 installation and setup process and provides an intuitive graphical user
 interface (GUI) for running Docker containers.  Kitematic integrates with
-[Docker Machine](https://docs.docker.com/machine/) to provision a VirtualBox VM
+[Docker Machine](/machine/) to provision a VirtualBox VM
 and install the Docker Engine locally on your machine.
 
 Once installed, the Kitematic GUI launches and from the home screen you will be

--- a/notary/running_a_service.md
+++ b/notary/running_a_service.md
@@ -14,8 +14,8 @@ title: Running a Notary service
 This document is for anyone who wants to run their own Notary
 service (such as those who want to use Notary with a
 private Docker registry). Running a Notary service requires that you are already
-familiar with using [Docker Engine](https://docs.docker.com/engine/userguide/)
-and [Docker Compose](https://docs.docker.com/compose/overview/).
+familiar with using [Docker Engine](/engine/userguide/)
+and [Docker Compose](/compose/overview/).
 
 ## Run a service for testing or development
 
@@ -185,7 +185,7 @@ One way to do this would be:
 		{"level":"info","msg":"Starting on :4443","time":"2016-02-25T00:53:59Z"}
 
 You can do the same using [Docker
-Compose](https://docs.docker.com/compose/overview/) by setting volumes,
+Compose](/compose/overview/) by setting volumes,
 environment variables, and overriding the default command for the Notary server
 containers in the Compose file.
 

--- a/opensource/project/test-and-docs.md
+++ b/opensource/project/test-and-docs.md
@@ -276,7 +276,7 @@ directly requires you to install some prerequisites, but is faster on each build
 
 The easiest way to build the docs locally on macOS, Windows, or Linux is to use
 `docker-compose`. If you have not yet installed `docker-compose`,
-[follow these installation instructions](https://docs.docker.com/compose/install/).
+[follow these installation instructions](/compose/install/).
 
 In the root of the repository, issue the following command:
 

--- a/registry/index.md
+++ b/registry/index.md
@@ -30,7 +30,7 @@ You should use the Registry if you want to:
 
 Users looking for a zero maintenance, ready-to-go solution are encouraged to head-over to the [Docker Hub](https://hub.docker.com), which provides a free-to-use, hosted Registry, plus additional features (organization accounts, automated builds, and more).
 
-Users looking for a commercially supported version of the Registry should look into [Docker Trusted Registry](https://docs.docker.com/docker-trusted-registry/overview/).
+Users looking for a commercially supported version of the Registry should look into [Docker Trusted Registry](/docker-trusted-registry/overview/).
 
 ## Requirements
 

--- a/swarm/install-manual.md
+++ b/swarm/install-manual.md
@@ -302,7 +302,7 @@ They will display corresponding entries for the change in leadership.
 
 ## Additional Resources
 
-- [Installing Docker Engine on a cloud provider](http://docs.docker.com/engine/installation/cloud/cloud-ex-aws/)
+- [Installing Docker Engine on a cloud provider](/engine/installation/cloud/cloud-ex-aws/)
 - [High availability in Docker Swarm](multi-manager-setup.md)
 - [Discovery](discovery.md)
 - [High-availability cluster using a trio of consul nodes](https://hub.docker.com/r/progrium/consul/)

--- a/swarm/install-w-machine.md
+++ b/swarm/install-w-machine.md
@@ -20,7 +20,7 @@ or Windows and have installed Docker, you should have VirtualBox already
 installed.
 
 Using the instructions appropriate to your system architecture, [install Docker
-Machine](http://docs.docker.com/machine/install-machine).
+Machine](/machine/install-machine).
 
 ## Create a Docker Swarm
 
@@ -240,7 +240,7 @@ your swarm, and start an image on your swarm.
     $ docker run -it ubuntu bash
     ```
 
-    For more examples and ideas, visit the [User Guide](http://docs.docker.com/userguide/).
+    For more examples and ideas, visit the [User Guide](/userguide/).
 
 5.  Use the `docker ps` command to find out which node the container ran on.
 

--- a/swarm/networking.md
+++ b/swarm/networking.md
@@ -17,9 +17,9 @@ container networks that span multiple Docker hosts.
 
 Before using Swarm with a custom network, read through the conceptual
 information in [Docker container
-networking](https://docs.docker.com/engine/userguide/networking/dockernetworks/).
+networking](/engine/userguide/networking/dockernetworks/).
 You should also have walked through the [Get started with multi-host
-networking](https://docs.docker.com/engine/userguide/networking/get-started-overlay/)
+networking](/engine/userguide/networking/get-started-overlay/)
 example.
 
 ## Create a custom network in a Swarm cluster

--- a/swarm/overview.md
+++ b/swarm/overview.md
@@ -80,4 +80,4 @@ like-minded individuals, we have a number of open channels for communication.
 
 * To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/swarm/pulls).
 
-For more information and resources, please visit the [Getting Help project page](https://docs.docker.com/project/get-help/).
+For more information and resources, please visit the [Getting Help project page](/project/get-help/).

--- a/swarm/provision-with-machine.md
+++ b/swarm/provision-with-machine.md
@@ -27,15 +27,15 @@ learn about Swarm and its requirements by [installing a Swarm for
 evaluation](install-w-machine.md) or [installing a Swarm for
 production](install-manual.md). If this is the first time you have used Machine,
 you should take some time to [understand Machine before
-continuing](https://docs.docker.com/machine).
+continuing](/machine).
 
 
 ## What you need
 
 If you are using macOS or Windows and have installed with Docker Toolbox, you
 should already have Machine installed. If you need to install, see the
-instructions for [macOS](https://docs.docker.com/engine/installation/mac/) or
-[Windows](https://docs.docker.com/engine/installation/mac/).
+instructions for [macOS](/engine/installation/mac/) or
+[Windows](/engine/installation/mac/).
 
 Machine supports installing on AWS, Digital Ocean, Google Cloud Platform, IBM
 Softlayer, Microsoft Azure and Hyper-V, OpenStack, Rackspace, VirtualBox, VMware
@@ -48,7 +48,7 @@ you need. It also gives you the ability provision on all the systems Machine
 supports.
 
 **Note**:These examples assume you are using macOS or Windows, if you like you can also [install Docker Machine directly on a Linux
-system](http://docs.docker.com/machine/install-machine).
+system](/machine/install-machine).
 
 ## Provision a host to generate a Swarm token
 
@@ -186,4 +186,4 @@ Name: swarm-manager
 * [Evaluate Swarm in a sandbox](install-w-machine.md)
 * [Build a Swarm cluster for production](install-manual.md)
 * [Swarm Discovery](discovery.md)
-* [Docker Machine](https://docs.docker.com/machine) documentation
+* [Docker Machine](/machine) documentation

--- a/swarm/scheduler/rescheduling.md
+++ b/swarm/scheduler/rescheduling.md
@@ -57,5 +57,5 @@ Failed to start rescheduled container 2362901cb213da321
 
 ## Related information
 
-* [Apply custom metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/)
-* [Environment variables with run](https://docs.docker.com/engine/reference/run/#env-environment-variables)
+* [Apply custom metadata](/engine/userguide/labels-custom-metadata/)
+* [Environment variables with run](/engine/reference/run/#env-environment-variables)

--- a/swarm/secure-swarm-tls.md
+++ b/swarm/secure-swarm-tls.md
@@ -164,4 +164,4 @@ facing production workloads exposed to untrusted networks.
 ## Related information
 
 * [Configure Docker Swarm for TLS](configure-tls.md)
-* [Docker security](https://docs.docker.com/engine/security/security/)
+* [Docker security](/engine/security/security/)

--- a/swarm/swarm-api.md
+++ b/swarm/swarm-api.md
@@ -15,7 +15,7 @@ title: Docker Swarm API
 # Docker Swarm API
 
 The Docker Swarm API is mostly compatible with the [Docker Remote
-API](https://docs.docker.com/engine/reference/api/docker_remote_api/). This
+API](/engine/reference/api/docker_remote_api/). This
 document is an overview of the differences between the Swarm API and the Docker
 Remote API.
 
@@ -182,7 +182,7 @@ $ docker run --rm -it yourprivateimage:latest
 
 ## Docker Swarm documentation index
 
-- [Docker Swarm overview](https://docs.docker.com/swarm/)
-- [Discovery options](https://docs.docker.com/swarm/discovery/)
-- [Scheduler strategies](https://docs.docker.com/swarm/scheduler/strategy/)
-- [Scheduler filters](https://docs.docker.com/swarm/scheduler/filter/)
+- [Docker Swarm overview](/swarm/)
+- [Discovery options](/swarm/discovery/)
+- [Scheduler strategies](/swarm/scheduler/strategy/)
+- [Scheduler filters](/swarm/scheduler/filter/)

--- a/toolbox/faqs/troubleshoot.md
+++ b/toolbox/faqs/troubleshoot.md
@@ -156,6 +156,6 @@ Here is an example of creating a `default` machine with proxies set to `http://e
     default
 
 
-To learn more about using `docker-machine create`, see the [create](https://docs.docker.com/machine/reference/create/) command in the [Docker Machine](https://docs.docker.com/machine/overview/) reference.
+To learn more about using `docker-machine create`, see the [create](/machine/reference/create/) command in the [Docker Machine](/machine/overview/) reference.
 
 &nbsp;

--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -39,7 +39,7 @@ software. To find out what version of the OS you have:
     If you aren't using a supported version, you could consider upgrading your
     operating system.
 
-    If you have macOS 10.10.3 Yosemite or newer, consider using [Docker for Mac](https://docs.docker.com/docker-for-mac/) instead. It runs natively on the Mac, so there is no need for a pre-configured Docker QuickStart shell. It uses xhyve for virtualization, instead of VirutalBox. Full install prerequisites are provided in the Docker for Mac topic in [Docker for Mac](https://docs.docker.com/docker-for-mac/#what-to-know-before-you-install).
+    If you have macOS 10.10.3 Yosemite or newer, consider using [Docker for Mac](/docker-for-mac/) instead. It runs natively on the Mac, so there is no need for a pre-configured Docker QuickStart shell. It uses xhyve for virtualization, instead of VirutalBox. Full install prerequisites are provided in the Docker for Mac topic in [Docker for Mac](/docker-for-mac/#what-to-know-before-you-install).
 
 ## Step 2: Install Docker Toolbox
 

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -35,7 +35,7 @@ To verify your machine meets these requirements, do the following:
     If you aren't using a supported version, you could consider upgrading your
     operating system.
 
-    If you have a newer system, specifically 64bit Windows 10 Pro, with Enterprise and Education (1511 November update, Build 10586 or later), consider using [Docker for Windows](https://docs.docker.com/docker-for-windows) instead. It runs natively on the Windows, so there is no need for a pre-configured Docker QuickStart shell. It also uses Hyper-V for virtualization, so the instructions below for checking virtualization will be out of date for newer Windows systems. Full install prerequisites are provided in the Docker for Windows topic in [What to know before you install](https://docs.docker.com/docker-for-windows/#what-to-know-before-you-install).
+    If you have a newer system, specifically 64bit Windows 10 Pro, with Enterprise and Education (1511 November update, Build 10586 or later), consider using [Docker for Windows](/docker-for-windows) instead. It runs natively on the Windows, so there is no need for a pre-configured Docker QuickStart shell. It also uses Hyper-V for virtualization, so the instructions below for checking virtualization will be out of date for newer Windows systems. Full install prerequisites are provided in the Docker for Windows topic in [What to know before you install](/docker-for-windows/#what-to-know-before-you-install).
 
 2.  Make sure your Windows system supports Hardware Virtualization Technology and that virtualization is enabled.
 

--- a/ucp/install-sandbox-2.md
+++ b/ucp/install-sandbox-2.md
@@ -31,9 +31,9 @@ First, we'll set up a security exception that allows a the Docker-machine hosts
 used in your UCP cluster to push images to and pull images from DTR even though
 the DTR instance has a self-signed certificate. For a production deployment,
 you would
-[set up certificate trust](https://docs.docker.com/ucp/configuration/dtr-integration/)
+[set up certificate trust](/ucp/configuration/dtr-integration/)
 between UCP and DTR, and
-[between DTR and your Docker Engine](https://docs.docker.com/docker-trusted-registry/repos-and-images/),
+[between DTR and your Docker Engine](/docker-trusted-registry/repos-and-images/),
 but for our sandbox deployment we can skip this.
 
 > **Warning**: These steps produce an insecure DTR connection. Do not use these

--- a/ucp/install-sandbox.md
+++ b/ucp/install-sandbox.md
@@ -58,7 +58,7 @@ If you are in another, you may need to adjust to use analogous commands for your
 
 This example requires that you have:
 
-* [Docker Toolbox installed](https://docs.docker.com/toolbox/overview/)
+* [Docker Toolbox installed](/toolbox/overview/)
 (contains Docker Machine and Docker Engine)
 * A free Docker ID account
 

--- a/ucp/installation/install-production.md
+++ b/ucp/installation/install-production.md
@@ -32,7 +32,7 @@ above to run. It is recommended to install the exact same version of the
 CS Docker Engine on all nodes.
 
 So on each host that you want to be part of the UCP cluster,
-[install CS Docker Engine 1.10.0 or above](https://docs.docker.com/docker-trusted-registry/cs-engine/install/).
+[install CS Docker Engine 1.10.0 or above](/docker-trusted-registry/cs-engine/install/).
 In the case where you are creating a VM template with CS Engine already
 installed, make sure that `/etc/docker/key.json` is not included in the image.
 You can do this by simply removing `/etc/docker/key.json`. You can then restart

--- a/ucp/installation/system-requirements.md
+++ b/ucp/installation/system-requirements.md
@@ -23,7 +23,7 @@ all nodes must have:
 
 * Linux kernel version 3.10 or higher
 * CS Docker Engine version 1.10 or higher. Learn about the
-[operating systems supported by CS Docker Engine](https://docs.docker.com/cs-engine/install/).
+[operating systems supported by CS Docker Engine](/cs-engine/install/).
 * 2.00 GB of RAM
 * 3.00 GB of available disk space
 * A static IP address


### PR DESCRIPTION
### Describe the proposed changes

Absolute links to `docs.docker.com` are now relative links. 

I used that command: 

```bash
$ ag -l "]\(https://docs.docker.com" . | xargs sed -i "" -e 's/\](https:\/\/docs.docker.com/\](/g'
$ ag -l "]\(http://docs.docker.com" . | xargs sed -i "" -e 's/\](http:\/\/docs.docker.com/\](/g'
```

Signed-off-by: Adrien Duermael <adrien@duermael.com>