### PR TITLE
Add missing dollar-sign / consistent shell style

### DIFF
--- a/compose/django.md
+++ b/compose/django.md
@@ -89,7 +89,7 @@ In this step, you create a Django started project by building the image from the
 
 2. Create the Django project using the `docker-compose` command.
 
-        $ docker-compose run web django-admin.py startproject composeexample .
+        docker-compose run web django-admin.py startproject composeexample .
 
     This instructs Compose to run `django-admin.py startproject composeeexample`
     in a container, using the `web` service's image and configuration. Because

--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -50,11 +50,11 @@ You can pass multiple environment variables from an external file through to a s
 
 Just like with `docker run -e`, you can set environment variables on a one-off container with `docker-compose run -e`:
 
-    $ docker-compose run -e DEBUG=1 web python console.py
+    docker-compose run -e DEBUG=1 web python console.py
 
 You can also pass a variable through from the shell by not giving it a value:
 
-    $ docker-compose run -e DEBUG web python console.py
+    docker-compose run -e DEBUG web python console.py
 
 The value of the `DEBUG` variable in the container will be taken from the value for the same variable in the shell in which Compose is run.
 
@@ -83,7 +83,6 @@ When you run `docker-compose up`, the `web` service defined above uses the image
 Values in the shell take precedence over those specified in the `.env` file. If you set `TAG` to a different value in your shell, the substitution in `image` uses that instead:
 
     $ export TAG=v2.0
-
     $ docker-compose config
     version: '2.0'
     services:
@@ -93,7 +92,6 @@ Values in the shell take precedence over those specified in the `.env` file. If 
 ## Configuring Compose using environment variables
 
 Several environment variables are available for you to configure the Docker Compose command-line behaviour. They begin with `COMPOSE_` or `DOCKER_`, and are documented in [CLI Environment Variables](reference/envvars.md).
-
 
 ## Environment variables created by links
 

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -163,14 +163,14 @@ The `docker-compose run` command allows you to run one-off commands for your
 services. For example, to see what environment variables are available to the
 `web` service:
 
-    $ docker-compose run web env
+    docker-compose run web env
 
 See `docker-compose --help` to see other available commands. You can also install [command completion](completion.md) for the bash and zsh shell, which will also show you available commands.
 
 If you started Compose with `docker-compose up -d`, you'll probably want to stop
 your services once you've finished with them:
 
-    $ docker-compose stop
+    docker-compose stop
 
 At this point, you have seen the basics of how Compose works.
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -38,7 +38,7 @@ which the release page specifies, in your terminal.
 
 5. Apply executable permissions to the binary:
 
-        $ chmod +x /usr/local/bin/docker-compose
+        chmod +x /usr/local/bin/docker-compose
 
 6.  Optionally, install [command completion](completion.md) for the
 `bash` and `zsh` shell.
@@ -60,7 +60,7 @@ have python system packages that conflict with docker-compose dependencies. See
 the [virtualenv tutorial](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
 to get started.
 
-    $ pip install docker-compose
+    pip install docker-compose
 
 > **Note:** pip version 6.0 or greater is required
 
@@ -92,24 +92,22 @@ to run so that you don't end up with two sets of them. If you want to keep using
 your existing containers (for example, because they have data volumes you want
 to preserve) you can use compose 1.5.x to migrate them with the following command:
 
-    $ docker-compose migrate-to-labels
+    docker-compose migrate-to-labels
 
 Alternatively, if you're not worried about keeping them, you can remove them.
 Compose will just create new ones.
 
-    $ docker rm -f -v myapp_web_1 myapp_db_1 ...
-
+    docker rm -f -v myapp_web_1 myapp_db_1 ...
 
 ## Uninstallation
 
 To uninstall Docker Compose if you installed using `curl`:
 
-    $ rm /usr/local/bin/docker-compose
-
+    rm /usr/local/bin/docker-compose
 
 To uninstall Docker Compose if you installed using `pip`:
 
-    $ pip uninstall docker-compose
+    pip uninstall docker-compose
 
 >**Note**: If you get a "Permission denied" error using either of the above
 >methods, you probably do not have the proper permissions to remove

--- a/compose/install.md
+++ b/compose/install.md
@@ -31,7 +31,7 @@ which the release page specifies, in your terminal.
 
      The following is an example command illustrating the format:
 
-        curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
+        $ curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
 
      If you have problems installing with `curl`, see
      [Alternative Install Options](install.md#alternative-install-options).

--- a/compose/production.md
+++ b/compose/production.md
@@ -34,7 +34,7 @@ can be applied over the original `docker-compose.yml` to create a new configurat
 Once you've got a second configuration file, tell Compose to use it with the
 `-f` option:
 
-    $ docker-compose -f docker-compose.yml -f production.yml up -d
+    docker-compose -f docker-compose.yml -f production.yml up -d
 
 See [Using multiple compose files](extends.md#different-environments) for a more
 complete example.

--- a/compose/rails.md
+++ b/compose/rails.md
@@ -34,7 +34,7 @@ Next, create a bootstrap `Gemfile` which just loads Rails. It'll be overwritten 
 
 You'll need an empty `Gemfile.lock` in order to build our `Dockerfile`.
 
-    $ touch Gemfile.lock
+    touch Gemfile.lock
 
 Finally, `docker-compose.yml` is where the magic happens. This file describes
 the services that comprise your app (a database and a web app), how to get each
@@ -61,7 +61,7 @@ to link them together and expose the web app's port.
 With those three files in place, you can now generate the Rails skeleton app
 using `docker-compose run`:
 
-    $ docker-compose run web rails new . --force --database=postgresql --skip-bundle
+    docker-compose run web rails new . --force --database=postgresql --skip-bundle
 
 First, Compose will build the image for the `web` service using the `Dockerfile`. Then it'll run `rails new` inside a new container, using that image. Once it's done, you should have generated a fresh app:
 
@@ -105,8 +105,7 @@ Now that you've got a new `Gemfile`, you need to build the image again. (This,
 and changes to the Dockerfile itself, should be the only times you'll need to
 rebuild.)
 
-    $ docker-compose build
-
+    docker-compose build
 
 ### Connect the database
 
@@ -132,7 +131,7 @@ Replace the contents of `config/database.yml` with the following:
 
 You can now boot the app with:
 
-    $ docker-compose up
+    docker-compose up
 
 If all's well, you should see some PostgreSQL output, and then—after a few
 seconds—the familiar refrain:
@@ -143,7 +142,7 @@ seconds—the familiar refrain:
 
 Finally, you need to create the database. In another terminal, run:
 
-    $ docker-compose run web rake db:create
+    docker-compose run web rake db:create
 
 That's it. Your app should now be running on port 3000 on your Docker daemon. If you're using [Docker Machine](/machine/overview.md), then `docker-machine ip MACHINE_VM` returns the Docker host IP address.
 

--- a/compose/reference/kill.md
+++ b/compose/reference/kill.md
@@ -14,4 +14,4 @@ Options:
 Forces running containers to stop by sending a `SIGKILL` signal. Optionally the
 signal can be passed, for example:
 
-    $ docker-compose kill -s SIGINT
+    docker-compose kill -s SIGINT

--- a/compose/reference/run.md
+++ b/compose/reference/run.md
@@ -24,7 +24,7 @@ Options:
 
 Runs a one-time command against a service. For example, the following command starts the `web` service and runs `bash` as its command.
 
-    $ docker-compose run web bash
+    docker-compose run web bash
 
 Commands you use with `run` start in new containers with the same configuration as defined by the service' configuration. This means the container has the same volumes, links, as defined in the configuration file. There two differences though.
 
@@ -32,18 +32,18 @@ First, the command passed by `run` overrides the command defined in the service 
 
 The second difference is the `docker-compose run` command does not create any of the ports specified in the service configuration. This prevents the port collisions with already open ports. If you *do want* the service's ports created and mapped to the host, specify the `--service-ports` flag:
 
-    $ docker-compose run --service-ports web python manage.py shell
+    docker-compose run --service-ports web python manage.py shell
 
 Alternatively manual port mapping can be specified. Same as when running Docker's `run` command - using `--publish` or `-p` options:
 
-    $ docker-compose run --publish 8080:80 -p 2022:22 -p 127.0.0.1:2021:21 web python manage.py shell
+    docker-compose run --publish 8080:80 -p 2022:22 -p 127.0.0.1:2021:21 web python manage.py shell
 
 If you start a service configured with links, the `run` command first checks to see if the linked service is running and starts the service if it is stopped.  Once all the linked services are running, the `run` executes the command you passed it.  So, for example, you could run:
 
-    $ docker-compose run db psql -h db -U docker
+    docker-compose run db psql -h db -U docker
 
 This would open up an interactive PostgreSQL shell for the linked `db` container.
 
 If you do not want the `run` command to start linked containers, specify the `--no-deps` flag:
 
-    $ docker-compose run --no-deps web python manage.py shell
+    docker-compose run --no-deps web python manage.py shell

--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -12,4 +12,4 @@ Sets the number of containers to run for a service.
 
 Numbers are specified as arguments in the form `service=num`. For example:
 
-    $ docker-compose scale web=2 worker=3
+    docker-compose scale web=2 worker=3

--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -28,7 +28,6 @@ set up a Swarm cluster with [Docker Machine](/machine/overview.md) and the overl
     $ eval "$(docker-machine env --swarm <name of swarm master machine>)"
     $ docker-compose up
 
-
 ## Limitations
 
 ### Building images
@@ -135,7 +134,6 @@ There are two viable workarounds for this problem:
         $ docker-compose stop web
         $ docker-compose rm -f web
         $ docker-compose up web
-
 
 ## Scheduling containers
 

--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -20,7 +20,7 @@ with Docker containers. This quick-start guide demonstrates how to use Compose t
 
     For example, if you named your directory `my_wordpress`:
 
-        $ cd my_wordpress/
+        cd my_wordpress/
 
 3.  Create a `docker-compose.yml` file that will start your
     `Wordpress` blog and a separate `MySQL` instance with a volume
@@ -96,7 +96,6 @@ At this point, WordPress should be running on port `8000` of your Docker Host, a
 ![Choose language for WordPress install](images/wordpress-lang.png)
 
 ![WordPress Welcome](images/wordpress-welcome.png)
-
 
 ## More Compose documentation
 


### PR DESCRIPTION
This PR adds a missing `$` in front of one of the installation instructions