### PR TITLE
Revert "Engine reference BUILD tarball contexts mangled"

### DIFF
--- a/engine/reference/commandline/build.md
+++ b/engine/reference/commandline/build.md
@@ -96,9 +96,11 @@ Build Syntax Suffix             | Commit Used           | Build Context Used
 
 If you pass an URL to a remote tarball, the URL itself is sent to the daemon:
 
+Instead of specifying a context, you can pass a single Dockerfile in the `URL`
+or pipe the file in via `STDIN`. To pipe a Dockerfile from `STDIN`:
+
 ```bash
 $ docker build http://server/context.tar.gz
-```
 
 The download operation will be performed on the host the Docker daemon is
 running on, which is not necessarily the same host from which the build command


### PR DESCRIPTION
Reverts docker/docker.github.io#175

This removed actual content, and also we don't maintain these docs here, but in `docker/docker`.