### PR TITLE
added Beta 29.1, 29.2, 29.3 release notes for mac and windows

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -145,6 +145,25 @@ events or unexpected unmounts.
 
 ## Beta Release Notes
 
+### Beta 29.3 Release Notes (2016-11-02 1.12.3-beta29.3)
+
+**Upgrades**
+
+- Docker Compose 1.9.0-rc2
+- `osxfs`: Fixed a simultaneous volume mount race which can result in a crash
+
+### Beta 29.2 Release Notes (2016-10-27 1.12.2-beta29.2)
+
+**Hotfixes**
+
+- Upgrade to Docker 1.12.3
+
+### Beta 29.1 Release Notes (2016-10-26 1.12.1-beta29.1)
+
+**Hotfixes**
+
+- Fixed missing `/dev/pty/ptmx`
+
 ### Beta 29 Release Notes (2016-10-25 1.12.3-rc1-beta29)
 
 **New**

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -164,7 +164,7 @@ See [About Windows containers and Windows Server
 
 A full tutorial is available in [docker/labs](https://github.com/docker/labs) at
 [Getting Started with Windows
-Containers](https://github.com/docker/labs/tree/master/windows/windows-containers).
+Containers](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md).
 
 ### Why is Windows 10 Home not supported?
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -94,7 +94,7 @@ enabled](troubleshoot.md#virtualization-must-be-enabled) in Troubleshooting.
 
 Looking for information on using Windows containers?
 
-* [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/tree/master/windows/windows-containers)
+* [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md)
 provides a tutorial on how to set up and run Windows containers on Windows 10 or
 with Windows Server 2016. It shows you how to use a MusicStore application with
 Windows containers.
@@ -425,7 +425,7 @@ If you are interested in working with Windows containers, here are some guides t
 
 * [Build and Run Your First Windows Server Container (Blog Post)](https://blog.docker.com/2016/09/build-your-first-docker-windows-server-container/) gives a quick tour of how to build and run native Docker Windows containers on Windows 10 and Windows Server 2016 evaluation releases.
 
-* [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/tree/master/windows/windows-containers) shows you how to use the [MusicStore](https://github.com/aspnet/MusicStore/blob/dev/README.md) application with Windows containers. The MusicStore is a standard .NET application and, [forked here to use containers](https://github.com/friism/MusicStore), is a good example of a multi-container application.
+* [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md) shows you how to use the [MusicStore](https://github.com/aspnet/MusicStore/blob/dev/README.md) application with Windows containers. The MusicStore is a standard .NET application and, [forked here to use containers](https://github.com/friism/MusicStore), is a good example of a multi-container application.
 
   >**Disclaimer:** This lab is still in work, and is based off of the blog, but you can test and leverage the example walkthroughs now, if you want to start experimenting. Please checking back as the lab evolves.
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -132,6 +132,24 @@ Release notes for _stable_ and _beta_ releases are listed below. You can learn a
 
 ## Beta Release Notes
 
+### Beta 29.3 Release Notes (2016-11-02 1.12.3-beta29.3)
+
+**Upgrades**
+
+- Docker Compose 1.9.0-rc2
+
+### Beta 29.2 Release Notes (2016-10-27 1.12.2-beta29.2)
+
+**Hotfixes**
+
+- Upgrade to Docker 1.12.3
+
+### Beta 29.1 Release Notes (2016-10-26 1.12.1-beta29.1)
+
+**Hotfixes**
+
+- Fixed missing `/dev/pty/ptmx`
+
 ### Beta 29 Release Notes (2016-10-25 1.12.3-rc1-beta29)
 
 >**Important Note**:

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -194,7 +194,7 @@ Server 2016 or Windows 10, see [About Windows containers and Windows Server
 
 A full tutorial is available in [docker/labs](https://github.com/docker/labs) at
 [Getting Started with Windows
-Containers](https://github.com/docker/labs/tree/master/windows/windows-containers).
+Containers](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md).
 
 You can install a native Windows binary which allows you to develop and run
 Windows containers without Docker for Windows. However, if you install Docker


### PR DESCRIPTION
### Proposed changes

* Added release notes for Betas 29.1, 29.2, 29.3 for Mac and Windows
* Updated some links to `docker/labs` tutorials to go directly to README's for better usability

### Project version

* should go directly into master

### Related issues

* change logs and test plans in private repo


### Please take a look

@joaofnfernandes @johndmulhausen @sanscontext @mstanleyjones @friism @MagnusS @dave-tucker 

These docs changes are for already released hot fix betas, so I'd like to publish tonight. Thanks!

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>