### PR TITLE
Fix broken link to swarm/docker-compose.yml

### DIFF
--- a/swarm/swarm_at_scale/deploy-app.md
+++ b/swarm/swarm_at_scale/deploy-app.md
@@ -306,7 +306,7 @@ the containers at once. This extra credit
     service in the file file.  This application relies on a volume and a network,
     declare those at the bottom of the file.
 
-3. Check your work against <a href="../docker-compose.yml" target="_blank">this
+3. Check your work against <a href="docker-compose.yml" target="_blank">this
 result file</a>
 
 4. When you are satisfied, save the `docker-compose.yml` file to your system.


### PR DESCRIPTION
404 at: `/swarm/docker-compose.yml/`
URL: `/swarm/docker-compose.yml/`


