### PR TITLE
fix frontmatter keywords values in compose/reference/ files

### DIFF
--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -1,7 +1,6 @@
 ---
 description: build
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  build
+keywords: fig, composition, compose, docker, orchestration, cli,  build
 menu:
   main:
     identifier: build.compose

--- a/compose/reference/bundle.md
+++ b/compose/reference/bundle.md
@@ -1,7 +1,6 @@
 ---
 description: Create a distributed application bundle from the Compose file.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  bundle
+keywords: fig, composition, compose, docker, orchestration, cli,  bundle
 menu:
   main:
     identifier: bundle.compose

--- a/compose/reference/config.md
+++ b/compose/reference/config.md
@@ -1,7 +1,6 @@
 ---
 description: Config validates and view the compose file.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, config
+keywords: fig, composition, compose, docker, orchestration, cli, config
 menu:
   main:
     identifier: config.compose

--- a/compose/reference/create.md
+++ b/compose/reference/create.md
@@ -1,7 +1,6 @@
 ---
 description: Create creates containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, create
+keywords: fig, composition, compose, docker, orchestration, cli, create
 menu:
   main:
     identifier: create.compose

--- a/compose/reference/down.md
+++ b/compose/reference/down.md
@@ -1,7 +1,6 @@
 ---
 description: down
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  down
+keywords: fig, composition, compose, docker, orchestration, cli,  down
 menu:
   main:
     identifier: down.compose

--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -1,7 +1,6 @@
 ---
 description: CLI Environment Variables
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  reference
+keywords: fig, composition, compose, docker, orchestration, cli,  reference
 menu:
   main:
     parent: smn_compose_cli

--- a/compose/reference/events.md
+++ b/compose/reference/events.md
@@ -1,7 +1,6 @@
 ---
 description: Receive real time events from containers.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, events
+keywords: fig, composition, compose, docker, orchestration, cli, events
 menu:
   main:
     identifier: events.compose

--- a/compose/reference/exec.md
+++ b/compose/reference/exec.md
@@ -1,7 +1,6 @@
 ---
 description: exec
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  exec
+keywords: fig, composition, compose, docker, orchestration, cli,  exec
 menu:
   main:
     identifier: exec.compose

--- a/compose/reference/help.md
+++ b/compose/reference/help.md
@@ -1,7 +1,6 @@
 ---
 description: help
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  help
+keywords: fig, composition, compose, docker, orchestration, cli,  help
 menu:
   main:
     identifier: help.compose

--- a/compose/reference/index.md
+++ b/compose/reference/index.md
@@ -1,7 +1,6 @@
 ---
 description: Compose CLI reference
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  reference
+keywords: fig, composition, compose, docker, orchestration, cli,  reference
 menu:
   main:
     identifier: smn_compose_cli

--- a/compose/reference/kill.md
+++ b/compose/reference/kill.md
@@ -1,7 +1,6 @@
 ---
 description: Forces running containers to stop.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  kill
+keywords: fig, composition, compose, docker, orchestration, cli,  kill
 menu:
   main:
     identifier: kill.compose

--- a/compose/reference/logs.md
+++ b/compose/reference/logs.md
@@ -1,7 +1,6 @@
 ---
 description: Displays log output from services.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  logs
+keywords: fig, composition, compose, docker, orchestration, cli,  logs
 menu:
   main:
     identifier: logs.compose

--- a/compose/reference/overview.md
+++ b/compose/reference/overview.md
@@ -2,8 +2,7 @@
 aliases:
 - /compose/reference/docker-compose/
 description: Overview of docker-compose CLI
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  docker-compose
+keywords: fig, composition, compose, docker, orchestration, cli,  docker-compose
 menu:
   main:
     parent: smn_compose_cli

--- a/compose/reference/pause.md
+++ b/compose/reference/pause.md
@@ -1,7 +1,6 @@
 ---
 description: Pauses running containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, pause
+keywords: fig, composition, compose, docker, orchestration, cli, pause
 menu:
   main:
     identifier: pause.compose

--- a/compose/reference/port.md
+++ b/compose/reference/port.md
@@ -1,7 +1,6 @@
 ---
 description: Prints the public port for a port binding.s
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  port
+keywords: fig, composition, compose, docker, orchestration, cli,  port
 menu:
   main:
     identifier: port.compose

--- a/compose/reference/ps.md
+++ b/compose/reference/ps.md
@@ -1,7 +1,6 @@
 ---
 description: Lists containers.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  ps
+keywords: fig, composition, compose, docker, orchestration, cli,  ps
 menu:
   main:
     identifier: ps.compose

--- a/compose/reference/pull.md
+++ b/compose/reference/pull.md
@@ -1,7 +1,6 @@
 ---
 description: Pulls service images.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  pull
+keywords: fig, composition, compose, docker, orchestration, cli,  pull
 menu:
   main:
     identifier: pull.compose

--- a/compose/reference/push.md
+++ b/compose/reference/push.md
@@ -1,7 +1,6 @@
 ---
 description: Pushes service images.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  push
+keywords: fig, composition, compose, docker, orchestration, cli,  push
 menu:
   main:
     identifier: push.compose

--- a/compose/reference/restart.md
+++ b/compose/reference/restart.md
@@ -1,7 +1,6 @@
 ---
 description: Restarts Docker Compose services.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  restart
+keywords: fig, composition, compose, docker, orchestration, cli,  restart
 menu:
   main:
     identifier: restart.compose

--- a/compose/reference/rm.md
+++ b/compose/reference/rm.md
@@ -1,7 +1,6 @@
 ---
 description: Removes stopped service containers.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  rm
+keywords: fig, composition, compose, docker, orchestration, cli,  rm
 menu:
   main:
     identifier: rm.compose

--- a/compose/reference/run.md
+++ b/compose/reference/run.md
@@ -1,7 +1,6 @@
 ---
 description: Runs a one-off command on a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  run
+keywords: fig, composition, compose, docker, orchestration, cli,  run
 menu:
   main:
     identifier: run.compose

--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -1,7 +1,6 @@
 ---
 description: Sets the number of containers to run for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  scale
+keywords: fig, composition, compose, docker, orchestration, cli,  scale
 menu:
   main:
     parent: smn_compose_cli

--- a/compose/reference/start.md
+++ b/compose/reference/start.md
@@ -1,7 +1,6 @@
 ---
 description: Starts existing containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  start
+keywords: fig, composition, compose, docker, orchestration, cli,  start
 menu:
   main:
     identifier: start.compose

--- a/compose/reference/stop.md
+++ b/compose/reference/stop.md
@@ -1,7 +1,6 @@
 ---
 description: 'Stops running containers without removing them. '
-keywords:
-- fig, composition, compose, docker, orchestration, cli, stop
+keywords: fig, composition, compose, docker, orchestration, cli, stop
 menu:
   main:
     identifier: stop.compose

--- a/compose/reference/unpause.md
+++ b/compose/reference/unpause.md
@@ -1,7 +1,6 @@
 ---
 description: Unpauses paused containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, unpause
+keywords: fig, composition, compose, docker, orchestration, cli, unpause
 menu:
   main:
     identifier: unpause.compose

--- a/compose/reference/up.md
+++ b/compose/reference/up.md
@@ -1,7 +1,6 @@
 ---
 description: Builds, (re)creates, starts, and attaches to containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  up
+keywords: fig, composition, compose, docker, orchestration, cli,  up
 menu:
   main:
     identifier: up.compose


### PR DESCRIPTION
### Describe the proposed changes

fixes files in which the keywords value is of the wrong type.

### Project version

current stable

### Related issue

contributes to #435 

### Related issue or PR in another project

N/A

### Please take a look

N/A

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>