### PR TITLE
Fix go get command

### DIFF
--- a/opensource/project/software-req-win.md
+++ b/opensource/project/software-req-win.md
@@ -211,9 +211,8 @@ from GitHub.
 
 4. Go get the `docker/docker` repository.
 
-		$ go.exe get github.com/docker/docker package github.com/docker/docker
-        imports github.com/docker/docker
-        imports github.com/docker/docker: no buildable Go source files in C:\gopath\src\github.com\docker\docker
+		$ go.exe get github.com/docker/docker
+		package github.com/docker/docker: no buildable Go source files in C:\gopath\src\github.com\docker\docker
 
 	In the next steps, you create environment variables for you Go paths.
 


### PR DESCRIPTION
This command was presumably pasted incorrectly, which lead to immense frustration for someone not familiar with the Go toolchian. The command to run is just `go.exe get github.com/docker/docker`, without any sort of `package` directive. And the output (on my machine) is close to what was previously recorded:

```
package github.com/docker/docker: no buildable Go source files in C:\gopath\src\github.com\docker\docker
```