### PR TITLE
Updated link in step_four.md

### DIFF
--- a/engine/getstarted/step_four.md
+++ b/engine/getstarted/step_four.md
@@ -46,7 +46,7 @@ commands to run. Your recipe is going to be very short.
         $ ls
         Dockerfile
 
-5. Open the `Dockerfile` in a visual text editor like <a href="https://atom.io/" target="_blank">Atom</a> or <a href="https://www.sublimetext.com/" target="_blank">Sublime</a>, or a text based editor like `vi`, or `nano` (https://www.nano-editor.org/).
+5. Open the `Dockerfile` in a visual text editor like <a href="https://atom.io/" target="_blank">Atom</a> or <a href="https://www.sublimetext.com/" target="_blank">Sublime</a>, or a text based editor like `vi`, or <a href="https://www.nano-editor.org/" target="_blank">nano-editor</a>.
 
 6. Add a line to the file like this:
 

--- a/engine/getstarted/step_four.md
+++ b/engine/getstarted/step_four.md
@@ -46,7 +46,7 @@ commands to run. Your recipe is going to be very short.
         $ ls
         Dockerfile
 
-5. Open the `Dockerfile` in a visual text editor like <a href="https://atom.io/" target="_blank">Atom</a> or <a href="https://www.sublimetext.com/" target="_blank">Sublime</a>, or a text based editor like `vi`, or <a href="https://www.nano-editor.org/" target="_blank">nano-editor</a>.
+5. Open the `Dockerfile` in a visual text editor like <a href="https://atom.io/" target="_blank">Atom</a> or <a href="https://www.sublimetext.com/" target="_blank">Sublime</a>, or a text based editor like `vi`, or <a href="https://www.nano-editor.org/" target="_blank">nano</a>.
 
 6. Add a line to the file like this:
 
@@ -210,5 +210,3 @@ You ran your image in a container. You also just used Linux from your Mac yet
 again. In the next section, you take the first step in sharing your image by
 [creating a Docker Hub account](step_five.md).
 
-
-&nbsp;


### PR DESCRIPTION
Noticed that the link to nano-editor in step four of the getting started guide is inconsistent with other links.