### PR TITLE
note to verify ssh sockets files are not stored

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -292,7 +292,9 @@ To create the `docker` group and add your user:
 		Cannot connect to the Docker daemon. Is 'docker daemon' running on this host?
 
 	Check that the `DOCKER_HOST` environment variable is not set for your shell.
-	If it is, unset it.
+	If it is, unset it. Also make sure that you aren't keeping ssh socket files with a timeout. 
+	You can wait for the sockets files to be removed as per specified timeout or manually delete
+	them before login again into the remote machine.
 
 ### Adjust memory and swap accounting
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.txt.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

<!-- Tell us what you did and why. You can leave this off if the PR title
     is descriptive. The commit message will be added to the end of this form.-->

Added a note to verify ssh sockets are not stored from remote machine while logging out and logging in to make add user into group effective.

### Project version

<!-- If this change only applies to a future version of a project (like
     Docker Engine 1.13), note that here and base your work on the `vnext-`
     branch for your project. -->
Docker Engine 1.13
### Related issue

<!-- If this relates to an issue or PR in this repo, refer to it like
     #1234, or 'Fixes #1234' or 'Closes #1234'. -->
None
### Related issue or PR in another project

<!-- Links to issues or pull requests in other repositories if applicable. -->
None
### Please take a look

<!-- At-mention specific individuals or groups who should take a
     look at this PR. For instance, @exampleuser123 -->


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->
