### PR TITLE
fix type of keywords entry in frontmatter (in /compose/ dir)

### DIFF
--- a/compose/bundles.md
+++ b/compose/bundles.md
@@ -1,8 +1,7 @@
 ---
 advisory: experimental
 description: Description of Docker and Compose's experimental support for application bundles
-keywords:
-- documentation, docs,  docker, compose, bundles, stacks
+keywords: documentation, docs,  docker, compose, bundles, stacks
 title: Docker stacks and distributed application bundles (experimental)
 ---
 

--- a/compose/completion.md
+++ b/compose/completion.md
@@ -1,7 +1,6 @@
 ---
 description: Compose CLI reference
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  reference
+keywords: fig, composition, compose, docker, orchestration, cli, reference
 title: Command-line completion
 ---
 

--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -1,9 +1,8 @@
 ---
+description: Compose file reference
+keywords: fig, composition, compose, docker
 redirect_from:
 - /compose/yml
-description: Compose file reference
-keywords:
-- fig, composition, compose, docker
 title: Compose file reference
 ---
 

--- a/compose/django.md
+++ b/compose/django.md
@@ -1,7 +1,6 @@
 ---
 description: Getting started with Docker Compose and Django
-keywords:
-- documentation, docs,  docker, compose, orchestration, containers
+keywords: documentation, docs,  docker, compose, orchestration, containers
 title: "Quickstart: Compose and Django"
 ---
 

--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -1,7 +1,6 @@
 ---
 description: Declare default environment variables in a file
-keywords:
-- fig, composition, compose, docker, orchestration, environment, env file
+keywords: fig, composition, compose, docker, orchestration, environment, env file
 title: Declare default environment variables in file
 ---
 

--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -1,7 +1,6 @@
 ---
 description: How to set, use and manage environment variables in Compose
-keywords:
-- fig, composition, compose, docker, orchestration, environment, variables, env file
+keywords: fig, composition, compose, docker, orchestration, environment, variables, env file
 title: Environment variables in Compose
 ---
 

--- a/compose/extends.md
+++ b/compose/extends.md
@@ -1,7 +1,6 @@
 ---
 description: How to use Docker Compose's extends keyword to share configuration between files and projects
-keywords:
-- fig, composition, compose, docker, orchestration, documentation, docs
+keywords: fig, composition, compose, docker, orchestration, documentation, docs
 title: Share Compose configurations between files and projects
 ---
 

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -1,7 +1,6 @@
 ---
 description: Get started with Docker Compose
-keywords:
-- documentation, docs,  docker, compose, orchestration, containers
+keywords: documentation, docs, docker, compose, orchestration, containers
 title: Get started with Docker Compose
 ---
 

--- a/compose/index.md
+++ b/compose/index.md
@@ -1,7 +1,6 @@
 ---
 description: Introduction and Overview of Compose
-keywords:
-- documentation, docs,  docker, compose, orchestration,  containers
+keywords: documentation, docs,  docker, compose, orchestration,  containers
 title: Docker Compose
 ---
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -1,7 +1,6 @@
 ---
 description: How to install Docker Compose
-keywords:
-- compose, orchestration, install, installation, docker, documentation
+keywords: compose, orchestration, install, installation, docker, documentation
 title: Install Docker Compose
 ---
 

--- a/compose/link-env-deprecated.md
+++ b/compose/link-env-deprecated.md
@@ -1,9 +1,8 @@
 ---
+description: Compose CLI reference
+keywords: fig, composition, compose, docker, orchestration, cli, reference
 redirect_from:
 - /compose/env
-description: Compose CLI reference
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  reference
 title: Link environment variables (superseded)
 ---
 

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -1,7 +1,6 @@
 ---
 description: How Compose sets up networking between containers
-keywords:
-- documentation, docs,  docker, compose, orchestration, containers, networking
+keywords: documentation, docs, docker, compose, orchestration, containers, networking
 title: Networking in Compose
 ---
 

--- a/compose/overview.md
+++ b/compose/overview.md
@@ -1,7 +1,6 @@
 ---
 description: Introduction and Overview of Compose
-keywords:
-- documentation, docs,  docker, compose, orchestration,  containers
+keywords: documentation, docs,  docker, compose, orchestration, containers
 title: Overview of Docker Compose
 ---
 

--- a/compose/production.md
+++ b/compose/production.md
@@ -1,7 +1,6 @@
 ---
 description: Guide to using Docker Compose in production
-keywords:
-- documentation, docs,  docker, compose, orchestration, containers,  production
+keywords: documentation, docs,  docker, compose, orchestration, containers, production
 title: Using Compose in production
 ---
 

--- a/compose/rails.md
+++ b/compose/rails.md
@@ -1,7 +1,6 @@
 ---
 description: Getting started with Docker Compose and Rails
-keywords:
-- documentation, docs,  docker, compose, orchestration, containers
+keywords: documentation, docs, docker, compose, orchestration, containers
 title: "Quickstart: Compose and Rails"
 ---
 

--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -1,7 +1,6 @@
 ---
 description: docker-compose build
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  build
+keywords: fig, composition, compose, docker, orchestration, cli, build
 title: docker-compose build
 ---
 

--- a/compose/reference/bundle.md
+++ b/compose/reference/bundle.md
@@ -1,7 +1,6 @@
 ---
 description: Create a distributed application bundle from the Compose file.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  bundle
+keywords: fig, composition, compose, docker, orchestration, cli, bundle
 title: docker-compose bundle
 ---
 

--- a/compose/reference/config.md
+++ b/compose/reference/config.md
@@ -1,7 +1,6 @@
 ---
 description: Config validates and view the compose file.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, config
+keywords: fig, composition, compose, docker, orchestration, cli, config
 title: docker-compose config
 ---
 

--- a/compose/reference/create.md
+++ b/compose/reference/create.md
@@ -1,7 +1,6 @@
 ---
 description: Create creates containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, create
+keywords: fig, composition, compose, docker, orchestration, cli, create
 title: docker-compose create
 ---
 

--- a/compose/reference/down.md
+++ b/compose/reference/down.md
@@ -1,7 +1,6 @@
 ---
 description: docker-compose down
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  down
+keywords: fig, composition, compose, docker, orchestration, cli, down
 title: docker-compose down
 ---
 

--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -1,7 +1,6 @@
 ---
 description: Compose CLI environment variables
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  reference
+keywords: fig, composition, compose, docker, orchestration, cli, reference
 title: Compose CLI environment variables
 ---
 

--- a/compose/reference/events.md
+++ b/compose/reference/events.md
@@ -1,7 +1,6 @@
 ---
 description: Receive real time events from containers.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, events
+keywords: fig, composition, compose, docker, orchestration, cli, events
 title: docker-compose events
 ---
 

--- a/compose/reference/exec.md
+++ b/compose/reference/exec.md
@@ -1,7 +1,6 @@
 ---
 description: docker-compose exec
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  exec
+keywords: fig, composition, compose, docker, orchestration, cli, exec
 title: docker-compose exec
 ---
 

--- a/compose/reference/help.md
+++ b/compose/reference/help.md
@@ -1,7 +1,6 @@
 ---
 description: docker-compose help
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  help
+keywords: fig, composition, compose, docker, orchestration, cli, help
 title: docker-compose help
 ---
 

--- a/compose/reference/index.md
+++ b/compose/reference/index.md
@@ -1,7 +1,6 @@
 ---
 description: Compose CLI reference
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  reference
+keywords: fig, composition, compose, docker, orchestration, cli,  reference
 title: Compose command-line reference
 ---
 

--- a/compose/reference/kill.md
+++ b/compose/reference/kill.md
@@ -1,7 +1,6 @@
 ---
 description: Forces running containers to stop.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  kill
+keywords: fig, composition, compose, docker, orchestration, cli,  kill
 title: docker-compose kill
 ---
 

--- a/compose/reference/logs.md
+++ b/compose/reference/logs.md
@@ -1,7 +1,6 @@
 ---
 description: Displays log output from services.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  logs
+keywords: fig, composition, compose, docker, orchestration, cli,  logs
 title: docker-compose logs
 ---
 

--- a/compose/reference/overview.md
+++ b/compose/reference/overview.md
@@ -1,9 +1,8 @@
 ---
+description: Overview of docker-compose CLI
+keywords: fig, composition, compose, docker, orchestration, cli,  docker-compose
 redirect_from:
 - /compose/reference/docker-compose/
-description: Overview of docker-compose CLI
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  docker-compose
 title: Overview of docker-compose CLI
 ---
 

--- a/compose/reference/pause.md
+++ b/compose/reference/pause.md
@@ -1,7 +1,6 @@
 ---
 description: Pauses running containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, pause
+keywords: fig, composition, compose, docker, orchestration, cli, pause
 title: docker-compose pause
 ---
 

--- a/compose/reference/port.md
+++ b/compose/reference/port.md
@@ -1,7 +1,6 @@
 ---
 description: Prints the public port for a port binding.s
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  port
+keywords: fig, composition, compose, docker, orchestration, cli,  port
 title: docker-compose port
 ---
 

--- a/compose/reference/ps.md
+++ b/compose/reference/ps.md
@@ -1,7 +1,6 @@
 ---
 description: Lists containers.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  ps
+keywords: fig, composition, compose, docker, orchestration, cli,  ps
 title: docker-compose ps
 ---
 

--- a/compose/reference/pull.md
+++ b/compose/reference/pull.md
@@ -1,7 +1,6 @@
 ---
 description: Pulls service images.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  pull
+keywords: fig, composition, compose, docker, orchestration, cli,  pull
 title: docker-compose pull
 ---
 

--- a/compose/reference/push.md
+++ b/compose/reference/push.md
@@ -1,7 +1,6 @@
 ---
 description: Pushes service images.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  push
+keywords: fig, composition, compose, docker, orchestration, cli,  push
 title: docker-compose push
 ---
 

--- a/compose/reference/restart.md
+++ b/compose/reference/restart.md
@@ -1,7 +1,6 @@
 ---
 description: Restarts Docker Compose services.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  restart
+keywords: fig, composition, compose, docker, orchestration, cli,  restart
 title: docker-compose restart
 ---
 

--- a/compose/reference/rm.md
+++ b/compose/reference/rm.md
@@ -1,7 +1,6 @@
 ---
 description: Removes stopped service containers.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  rm
+keywords: fig, composition, compose, docker, orchestration, cli,  rm
 title: docker-compose rm
 ---
 

--- a/compose/reference/run.md
+++ b/compose/reference/run.md
@@ -1,7 +1,6 @@
 ---
 description: Runs a one-off command on a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  run
+keywords: fig, composition, compose, docker, orchestration, cli,  run
 title: docker-compose run
 ---
 

--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -1,7 +1,6 @@
 ---
 description: Sets the number of containers to run for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  scale
+keywords: fig, composition, compose, docker, orchestration, cli,  scale
 title: docker-compose scale
 ---
 

--- a/compose/reference/start.md
+++ b/compose/reference/start.md
@@ -1,7 +1,6 @@
 ---
 description: Starts existing containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  start
+keywords: fig, composition, compose, docker, orchestration, cli,  start
 title: docker-compose start
 ---
 

--- a/compose/reference/stop.md
+++ b/compose/reference/stop.md
@@ -1,7 +1,6 @@
 ---
 description: 'Stops running containers without removing them. '
-keywords:
-- fig, composition, compose, docker, orchestration, cli, stop
+keywords: fig, composition, compose, docker, orchestration, cli, stop
 title: docker-compose stop
 ---
 

--- a/compose/reference/unpause.md
+++ b/compose/reference/unpause.md
@@ -1,7 +1,6 @@
 ---
 description: Unpauses paused containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli, unpause
+keywords: fig, composition, compose, docker, orchestration, cli, unpause
 title: docker-compose unpause
 ---
 

--- a/compose/reference/up.md
+++ b/compose/reference/up.md
@@ -1,7 +1,6 @@
 ---
 description: Builds, (re)creates, starts, and attaches to containers for a service.
-keywords:
-- fig, composition, compose, docker, orchestration, cli,  up
+keywords: fig, composition, compose, docker, orchestration, cli,  up
 title: docker-compose up
 ---
 

--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -1,7 +1,6 @@
 ---
 description: How to use Compose and Swarm together to deploy apps to multi-host clusters
-keywords:
-- documentation, docs,  docker, compose, orchestration, containers, swarm
+keywords: documentation, docs,  docker, compose, orchestration, containers, swarm
 title: Use Compose with Swarm
 ---
 

--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -1,7 +1,6 @@
 ---
 description: Getting started with Compose and WordPress
-keywords:
-- documentation, docs,  docker, compose, orchestration, containers
+keywords: documentation, docs,  docker, compose, orchestration, containers
 title: "Quickstart: Compose and WordPress"
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/compose/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>