### PR TITLE
Docker Cloud: refix labels

### DIFF
--- a/docker-cloud/builds/automated-testing.md
+++ b/docker-cloud/builds/automated-testing.md
@@ -74,8 +74,8 @@ Docker repository, regardless of the Autotest settings.
     The following options are available:
 
     * `Off`: No additional test builds. Tests only run if they're configured as part of an automated build.
-    * `Source repository`: Run a test build for any pull requests to branches that match a build rule, but only when the pull request comes from the same source repository.
-    * `Source repository & external pull requests`: Run a test build for any pull requests to branches that match a build rule, including when the pull request originated in an external source repository.
+    * `Internal pull requests`: Run a test build for any pull requests to branches that match a build rule, but only when the pull request comes from the same source repository.
+    * `Internal and external pull requests`: Run a test build for any pull requests to branches that match a build rule, including when the pull request originated in an external source repository.
 
     > **Note**: For security purposes, autotest on _external pull requests_ is
     disabled on public repositories. If you select this option on a public


### PR DESCRIPTION
Reimplements emergency fix of labels ( https://github.com/docker/docker.github.io/commit/ebecc8b16c6883c94a4c8eb5192281f0945ca094#diff-550878e4b3722bb4537b684978b513a5 ) that somehow got squashed over the weekend.

@pchico83 I'm not sure how this got reverted, sorry.