### PR TITLE
fix type of keywords entry in frontmatter (in /docker-cloud/ dir)

### DIFF
--- a/docker-cloud/apps/api-roles.md
+++ b/docker-cloud/apps/api-roles.md
@@ -1,9 +1,8 @@
 ---
+description: API Roles
+keywords: API, Services, roles
 redirect_from:
 - /docker-cloud/feature-reference/api-roles/
-description: API Roles
-keywords:
-- API, Services, roles
 title: Service API roles
 ---
 

--- a/docker-cloud/apps/auto-destroy.md
+++ b/docker-cloud/apps/auto-destroy.md
@@ -1,9 +1,8 @@
 ---
+description: Autodestroy
+keywords: Autodestroy, service, terminate, container
 redirect_from:
 - /docker-cloud/feature-reference/auto-destroy/
-description: Autodestroy
-keywords:
-- Autodestroy, service, terminate, container
 title: Destroy containers automatically
 ---
 

--- a/docker-cloud/apps/auto-redeploy.md
+++ b/docker-cloud/apps/auto-redeploy.md
@@ -1,9 +1,8 @@
 ---
+description: Autoredeploy
+keywords: Autoredeploy, image, store, service
 redirect_from:
 - /docker-cloud/feature-reference/auto-redeploy/
-description: Autoredeploy
-keywords:
-- Autoredeploy, image, store, service
 title: Redeploy services automatically
 ---
 

--- a/docker-cloud/apps/autorestart.md
+++ b/docker-cloud/apps/autorestart.md
@@ -1,9 +1,8 @@
 ---
+description: Automatically restart a container in Docker Cloud
+keywords: container, restart, automated
 redirect_from:
 - /docker-cloud/feature-reference/autorestart/
-description: Automatically restart a container in Docker Cloud
-keywords:
-- container, restart, automated
 title: Restart a container automatically
 ---
 

--- a/docker-cloud/apps/deploy-tags.md
+++ b/docker-cloud/apps/deploy-tags.md
@@ -1,9 +1,8 @@
 ---
+description: Deployment tags
+keywords: Deployment, tags, services
 redirect_from:
 - /docker-cloud/feature-reference/deploy-tags/
-description: Deployment tags
-keywords:
-- Deployment, tags, services
 title: Deployment tags
 ---
 

--- a/docker-cloud/apps/deploy-to-cloud-btn.md
+++ b/docker-cloud/apps/deploy-to-cloud-btn.md
@@ -1,10 +1,9 @@
 ---
+description: Deploy to Docker Cloud
+keywords: deploy, docker, cloud
 redirect_from:
 - /docker-cloud/feature-reference/deploy-to-cloud/
 - /docker-cloud/tutorials/deploy-to-cloud/
-description: Deploy to Docker Cloud
-keywords:
-- deploy, docker, cloud
 title: Add a "Deploy to Docker Cloud" button
 ---
 

--- a/docker-cloud/apps/index.md
+++ b/docker-cloud/apps/index.md
@@ -1,7 +1,6 @@
 ---
 description: Manage your Docker Cloud Applications
-keywords:
-- applications, reference, Cloud
+keywords: applications, reference, Cloud
 title: Applications in Docker Cloud
 ---
 

--- a/docker-cloud/apps/load-balance-hello-world.md
+++ b/docker-cloud/apps/load-balance-hello-world.md
@@ -1,10 +1,9 @@
 ---
+description: Create a proxy or load balancer
+keywords: proxy, load, balancer
 redirect_from:
 - /docker-cloud/getting-started/intermediate/load-balance-hello-world/
 - /docker-cloud/tutorials/load-balance-hello-world/
-description: Create a proxy or load balancer
-keywords:
-- proxy, load, balancer
 title: Create a proxy or load balancer
 ---
 

--- a/docker-cloud/apps/ports.md
+++ b/docker-cloud/apps/ports.md
@@ -1,9 +1,8 @@
 ---
+description: Publish and expose service or container ports
+keywords: publish, expose, ports, containers, services
 redirect_from:
 - /docker-cloud/feature-reference/ports/
-description: Publish and expose service or container ports
-keywords:
-- publish, expose, ports, containers, services
 title: Publish and expose service or container ports
 ---
 

--- a/docker-cloud/apps/service-links.md
+++ b/docker-cloud/apps/service-links.md
@@ -1,9 +1,8 @@
 ---
+description: Service discovery
+keywords: service, discover, links
 redirect_from:
 - /docker-cloud/feature-reference/service-links/
-description: Service discovery
-keywords:
-- service, discover, links
 title: Service discovery and links
 ---
 

--- a/docker-cloud/apps/service-redeploy.md
+++ b/docker-cloud/apps/service-redeploy.md
@@ -1,9 +1,8 @@
 ---
+description: Redeploy running services
+keywords: redeploy, running, services
 redirect_from:
 - /docker-cloud/feature-reference/service-redeploy/
-description: Redeploy running services
-keywords:
-- redeploy, running, services
 title: Redeploy a running service
 ---
 

--- a/docker-cloud/apps/service-scaling.md
+++ b/docker-cloud/apps/service-scaling.md
@@ -1,9 +1,8 @@
 ---
+description: Scale your service, spawn new containers
+keywords: spawn, container, service, deploy
 redirect_from:
 - /docker-cloud/feature-reference/service-scaling/
-description: Scale your service, spawn new containers
-keywords:
-- spawn, container, service, deploy
 title: Scale your service
 ---
 

--- a/docker-cloud/apps/stack-yaml-reference.md
+++ b/docker-cloud/apps/stack-yaml-reference.md
@@ -1,9 +1,8 @@
 ---
+description: Stack YAML reference
+keywords: YAML, stack, reference
 redirect_from:
 - /docker-cloud/feature-reference/stack-yaml-reference/
-description: Stack YAML reference
-keywords:
-- YAML, stack, reference
 title: Stack file YAML reference
 ---
 

--- a/docker-cloud/apps/stacks.md
+++ b/docker-cloud/apps/stacks.md
@@ -1,9 +1,8 @@
 ---
+description: Manage service stacks
+keywords: service, stack, yaml
 redirect_from:
 - /docker-cloud/feature-reference/stacks/
-description: Manage service stacks
-keywords:
-- service, stack, yaml
 title: Manage service stacks
 ---
 

--- a/docker-cloud/apps/triggers.md
+++ b/docker-cloud/apps/triggers.md
@@ -1,9 +1,8 @@
 ---
+description: Use triggers
+keywords: API, triggers, endpoints
 redirect_from:
 - /docker-cloud/feature-reference/triggers/
-description: Use triggers
-keywords:
-- API, triggers, endpoints
 title: Use triggers
 ---
 

--- a/docker-cloud/apps/volumes.md
+++ b/docker-cloud/apps/volumes.md
@@ -1,10 +1,9 @@
 ---
+description: Work with data volumes
+keywords: data, volumes, create, reuse
 redirect_from:
 - /docker-cloud/tutorials/download-volume-data/
 - /docker-cloud/feature-reference/volumes/
-description: Work with data volumes
-keywords:
-- data, volumes, create, reuse
 title: Work with data volumes
 ---
 

--- a/docker-cloud/builds/advanced.md
+++ b/docker-cloud/builds/advanced.md
@@ -1,7 +1,6 @@
 ---
 description: Automated builds
-keywords:
-- automated, build, images
+keywords: automated, build, images
 title: Advanced options for Autobuild and Autotest
 ---
 

--- a/docker-cloud/builds/automated-build.md
+++ b/docker-cloud/builds/automated-build.md
@@ -1,9 +1,8 @@
 ---
+description: Automated builds
+keywords: automated, build, images
 redirect_from:
 - /docker-cloud/feature-reference/automated-build/
-description: Automated builds
-keywords:
-- automated, build, images
 title: Automated builds
 ---
 

--- a/docker-cloud/builds/automated-testing.md
+++ b/docker-cloud/builds/automated-testing.md
@@ -1,9 +1,8 @@
 ---
+description: Automated tests
+keywords: Automated, testing, repository
 redirect_from:
 - /docker-cloud/feature-reference/automated-testing/
-description: Automated tests
-keywords:
-- Automated, testing, repository
 title: Automated repository tests
 ---
 

--- a/docker-cloud/builds/image-scan.md
+++ b/docker-cloud/builds/image-scan.md
@@ -1,7 +1,6 @@
 ---
-description: "Docker Security Scanning: automatic image scanning"
-keywords:
-- Docker, docker, scan, scanning, security, registry, plans, Docker Cloud, docs, documentation, trusted, builds, trusted builds, automated builds
+description: 'Docker Security Scanning: automatic image scanning'
+keywords: Docker, docker, scan, scanning, security, registry, plans, Docker Cloud, docs, documentation, trusted, builds, trusted builds, automated builds
 title: Docker Security Scanning
 ---
 

--- a/docker-cloud/builds/index.md
+++ b/docker-cloud/builds/index.md
@@ -1,7 +1,6 @@
 ---
 description: Manage Builds and Images in Docker Cloud
-keywords:
-- builds, images, Cloud
+keywords: builds, images, Cloud
 notoc: true
 title: Builds and images overview
 ---

--- a/docker-cloud/builds/link-source.md
+++ b/docker-cloud/builds/link-source.md
@@ -1,9 +1,8 @@
 ---
+description: Link to your source code repository
+keywords: sourcecode, github, bitbucket, Cloud
 redirect_from:
 - /docker-cloud/tutorials/link-source/
-description: Link to your source code repository
-keywords:
-- sourcecode, github, bitbucket, Cloud
 title: Link Docker Cloud to a source code provider
 ---
 

--- a/docker-cloud/builds/push-images.md
+++ b/docker-cloud/builds/push-images.md
@@ -1,10 +1,9 @@
 ---
+description: Push images to Docker Cloud
+keywords: images, private, registry
 redirect_from:
 - /docker-cloud/getting-started/intermediate/pushing-images-to-dockercloud/
 - /docker-cloud/tutorials/pushing-images-to-dockercloud/
-description: Push images to Docker Cloud
-keywords:
-- images, private, registry
 title: Push images to Docker Cloud
 ---
 

--- a/docker-cloud/builds/repos.md
+++ b/docker-cloud/builds/repos.md
@@ -1,7 +1,6 @@
 ---
 description: Create and edit Docker Cloud repositories
-keywords:
-- Docker Cloud repositories, automated, build, images
+keywords: Docker Cloud repositories, automated, build, images
 title: Docker Cloud repositories
 ---
 

--- a/docker-cloud/docker-errors-faq.md
+++ b/docker-cloud/docker-errors-faq.md
@@ -1,9 +1,8 @@
 ---
+description: Known Docker Engine issues in Docker Cloud
+keywords: Engine, issues, troubleshoot
 redirect_from:
 - /docker-cloud/faq/docker-errors-faq/
-description: Known Docker Engine issues in Docker Cloud
-keywords:
-- Engine, issues, troubleshoot
 title: Known issues in Docker Cloud
 ---
 

--- a/docker-cloud/dockerid.md
+++ b/docker-cloud/dockerid.md
@@ -1,7 +1,6 @@
 ---
 description: Using your DockerID to log in to Docker Cloud
-keywords:
-- one, two, three
+keywords: one, two, three
 title: Docker ID and Docker Cloud settings
 ---
 

--- a/docker-cloud/getting-started/connect-infra.md
+++ b/docker-cloud/getting-started/connect-infra.md
@@ -1,9 +1,8 @@
 ---
+description: How to link Docker Cloud to a hosted cloud services provider or your own hosts
+keywords: node, create, understand
 redirect_from:
 - /docker-cloud/getting-started/use-hosted/
-description: How to link Docker Cloud to a hosted cloud services provider or your own hosts
-keywords:
-- node, create, understand
 title: Link to your infrastructure
 ---
 

--- a/docker-cloud/getting-started/deploy-app/10_provision_a_data_backend_for_your_service.md
+++ b/docker-cloud/getting-started/deploy-app/10_provision_a_data_backend_for_your_service.md
@@ -1,10 +1,9 @@
 ---
+description: Provision a data backend for the service
+keywords: provision, Python, service
 redirect_from:
 - /docker-cloud/getting-started/python/10_provision_a_data_backend_for_your_service/
 - /docker-cloud/getting-started/golang/10_provision_a_data_backend_for_your_service/
-description: Provision a data backend for the service
-keywords:
-- provision, Python, service
 title: Provision a data backend for your service
 ---
 

--- a/docker-cloud/getting-started/deploy-app/11_service_stacks.md
+++ b/docker-cloud/getting-started/deploy-app/11_service_stacks.md
@@ -1,9 +1,8 @@
 ---
+description: Stackfiles for your service
+keywords: Python, service, stack
 redirect_from:
 - /docker-cloud/getting-started/python/11_service_stacks/
-description: Stackfiles for your service
-keywords:
-- Python, service, stack
 title: Stackfiles for your service
 ---
 

--- a/docker-cloud/getting-started/deploy-app/12_data_management_with_volumes.md
+++ b/docker-cloud/getting-started/deploy-app/12_data_management_with_volumes.md
@@ -1,9 +1,8 @@
 ---
+description: Data management with Volumes
+keywords: Python, data, management
 redirect_from:
 - /docker-cloud/getting-started/python/12_data_management_with_volumes/
-description: Data management with Volumes
-keywords:
-- Python, data, management
 title: Data management with volumes
 ---
 

--- a/docker-cloud/getting-started/deploy-app/1_introduction.md
+++ b/docker-cloud/getting-started/deploy-app/1_introduction.md
@@ -1,10 +1,9 @@
 ---
+description: Deploy an app to Docker Cloud
+keywords: deploy, Python, application
 redirect_from:
 - /docker-cloud/getting-started/python/1_introduction/
 - /docker-cloud/getting-started/golang/1_introduction/
-description: Deploy an app to Docker Cloud
-keywords:
-- deploy, Python, application
 title: Introduction to deploying an app in Docker Cloud
 ---
 

--- a/docker-cloud/getting-started/deploy-app/2_set_up.md
+++ b/docker-cloud/getting-started/deploy-app/2_set_up.md
@@ -1,10 +1,9 @@
 ---
+description: Set up the application
+keywords: Python, application, setup
 redirect_from:
 - /docker-cloud/getting-started/python/2_set_up/
 - /docker-cloud/getting-started/golang/2_set_up/
-description: Set up the application
-keywords:
-- Python, application, setup
 title: Set up your environment
 ---
 

--- a/docker-cloud/getting-started/deploy-app/3_prepare_the_app.md
+++ b/docker-cloud/getting-started/deploy-app/3_prepare_the_app.md
@@ -1,10 +1,9 @@
 ---
+description: Prepare the application
+keywords: Python, prepare, application
 redirect_from:
 - /docker-cloud/getting-started/python/3_prepare_the_app/
 - /docker-cloud/getting-started/golang/3_prepare_the_app/
-description: Prepare the application
-keywords:
-- Python, prepare, application
 title: Prepare the application
 ---
 

--- a/docker-cloud/getting-started/deploy-app/4_push_to_cloud_registry.md
+++ b/docker-cloud/getting-started/deploy-app/4_push_to_cloud_registry.md
@@ -1,10 +1,9 @@
 ---
+description: Push the Docker image to Docker Cloud's Registry
+keywords: image, Docker, cloud
 redirect_from:
 - /docker-cloud/getting-started/python/4_push_to_cloud_registry/
 - /docker-cloud/getting-started/golang/4_push_to_cloud_registry/
-description: Push the Docker image to Docker Cloud's Registry
-keywords:
-- image, Docker, cloud
 title: Push the image to Docker Cloud's registry
 ---
 

--- a/docker-cloud/getting-started/deploy-app/5_deploy_the_app_as_a_service.md
+++ b/docker-cloud/getting-started/deploy-app/5_deploy_the_app_as_a_service.md
@@ -1,10 +1,9 @@
 ---
+description: Deploy the app as a Docker Cloud service
+keywords: Python, deploy, Cloud
 redirect_from:
 - /docker-cloud/getting-started/python/5_deploy_the_app_as_a_service/
 - /docker-cloud/getting-started/golang/5_deploy_the_app_as_a_service/
-description: Deploy the app as a Docker Cloud service
-keywords:
-- Python, deploy, Cloud
 title: Deploy the app as a Docker Cloud service
 ---
 

--- a/docker-cloud/getting-started/deploy-app/6_define_environment_variables.md
+++ b/docker-cloud/getting-started/deploy-app/6_define_environment_variables.md
@@ -1,10 +1,9 @@
 ---
+description: Define environment variables
+keywords: Python, service, environment, service
 redirect_from:
 - /docker-cloud/getting-started/python/6_define_environment_variables/
 - /docker-cloud/getting-started/golang/6_define_environment_variables/
-description: Define environment variables
-keywords:
-- Python, service, environment, service
 title: Define environment variables
 ---
 

--- a/docker-cloud/getting-started/deploy-app/7_scale_the_service.md
+++ b/docker-cloud/getting-started/deploy-app/7_scale_the_service.md
@@ -1,10 +1,9 @@
 ---
+description: Scale the service
+keywords: scale, Python, service
 redirect_from:
 - /docker-cloud/getting-started/python/7_scale_the_service/
 - /docker-cloud/getting-started/golang/7_scale_the_service/
-description: Scale the service
-keywords:
-- scale, Python, service
 title: Scale the service
 ---
 

--- a/docker-cloud/getting-started/deploy-app/8_view_logs.md
+++ b/docker-cloud/getting-started/deploy-app/8_view_logs.md
@@ -1,10 +1,9 @@
 ---
+description: View service logs
+keywords: View, logs, Python
 redirect_from:
 - /docker-cloud/getting-started/python/8_view_logs/
 - /docker-cloud/getting-started/golang/8_view_logs/
-description: View service logs
-keywords:
-- View, logs, Python
 title: View service logs
 ---
 

--- a/docker-cloud/getting-started/deploy-app/9_load-balance_the_service.md
+++ b/docker-cloud/getting-started/deploy-app/9_load-balance_the_service.md
@@ -1,10 +1,9 @@
 ---
+description: Load-balance the service
+keywords: load, balance, Python
 redirect_from:
 - /docker-cloud/getting-started/python/9_load-balance_the_service/
 - /docker-cloud/getting-started/golang/9_load-balance_the_service/
-description: Load-balance the service
-keywords:
-- load, balance, Python
 title: Load-balance the service
 ---
 

--- a/docker-cloud/getting-started/deploy-app/index.md
+++ b/docker-cloud/getting-started/deploy-app/index.md
@@ -1,10 +1,9 @@
 ---
+description: Go or Python and Docker Cloud
+keywords: Python, Go, Docker, Cloud, application
 redirect_from:
 - /docker-cloud/getting-started/python/
 - /docker-cloud/getting-started/golang/
-description: Go or Python and Docker Cloud
-keywords:
-- Python, Go, Docker, Cloud, application
 title: Deploy an application
 ---
 

--- a/docker-cloud/getting-started/index.md
+++ b/docker-cloud/getting-started/index.md
@@ -1,8 +1,7 @@
 ---
 description: 'Getting Started with Docker Cloud: Setting up a node using a hosted
   cloud provider or your own nodes, deploying a service and clustering.'
-keywords:
-- one, two, three
+keywords: one, two, three
 title: Getting started with Docker Cloud
 ---
 

--- a/docker-cloud/getting-started/intro_cloud.md
+++ b/docker-cloud/getting-started/intro_cloud.md
@@ -1,9 +1,8 @@
 ---
+description: Introducing Docker Cloud concepts and terminology
+keywords: node, create, understand
 redirect_from:
 - /docker-cloud/getting-started/beginner/intro_cloud/
-description: Introducing Docker Cloud concepts and terminology
-keywords:
-- node, create, understand
 title: Introducing Docker Cloud
 ---
 

--- a/docker-cloud/getting-started/your_first_node.md
+++ b/docker-cloud/getting-started/your_first_node.md
@@ -1,10 +1,9 @@
 ---
+description: Deploy your first node on Docker Cloud
+keywords: node, create, understand
 redirect_from:
 - /docker-cloud/getting-started/beginner/your_first_node/
 - /docker-cloud/getting-started/beginner/deploy_first_node/
-description: Deploy your first node on Docker Cloud
-keywords:
-- node, create, understand
 title: Deploy your first node
 ---
 

--- a/docker-cloud/getting-started/your_first_service.md
+++ b/docker-cloud/getting-started/your_first_service.md
@@ -1,10 +1,9 @@
 ---
+description: Deploy your first service on Docker Cloud
+keywords: service, Cloud, three
 redirect_from:
 - /docker-cloud/getting-started/beginner/your_first_service/
 - /docker-cloud/getting-started/beginner/deploy_first_service/
-description: Deploy your first service on Docker Cloud
-keywords:
-- service, Cloud, three
 title: Create your first service
 ---
 

--- a/docker-cloud/index.md
+++ b/docker-cloud/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Cloud
-keywords:
-- Docker, cloud
+keywords: Docker, cloud
 notoc: true
 title: Welcome to the Docker Cloud docs!
 ---

--- a/docker-cloud/infrastructure/byoh.md
+++ b/docker-cloud/infrastructure/byoh.md
@@ -1,11 +1,10 @@
 ---
+description: Use the Docker Cloud Agent
+keywords: agent, Cloud, install
 redirect_from:
 - /docker-cloud/feature-reference/byoh/
 - /docker-cloud/tutorials/byoh/
 - /docker-cloud/getting-started/use-byon/
-description: Use the Docker Cloud Agent
-keywords:
-- agent, Cloud, install
 title: Use the Docker Cloud Agent
 ---
 

--- a/docker-cloud/infrastructure/cloud-on-aws-faq.md
+++ b/docker-cloud/infrastructure/cloud-on-aws-faq.md
@@ -1,9 +1,8 @@
 ---
+description: Docker Cloud on AWS
+keywords: Cloud, AWS, faq
 redirect_from:
 - /docker-cloud/faq/cloud-on-aws-faq/
-description: Docker Cloud on AWS
-keywords:
-- Cloud, AWS, faq
 title: Use Docker Cloud on AWS
 ---
 

--- a/docker-cloud/infrastructure/cloud-on-packet.net-faq.md
+++ b/docker-cloud/infrastructure/cloud-on-packet.net-faq.md
@@ -1,9 +1,8 @@
 ---
+description: Docker Cloud and Packet.net
+keywords: Packet.net, Cloud, drives
 redirect_from:
 - /docker-cloud/faq/cloud-on-packet.net-faq/
-description: Docker Cloud and Packet.net
-keywords:
-- Packet.net, Cloud, drives
 title: Use Docker Cloud and Packet.net
 ---
 

--- a/docker-cloud/infrastructure/deployment-strategies.md
+++ b/docker-cloud/infrastructure/deployment-strategies.md
@@ -1,9 +1,8 @@
 ---
+description: Schedule a deployment
+keywords: schedule, deployment, container
 redirect_from:
 - /docker-cloud/feature-reference/deployment-strategies/
-description: Schedule a deployment
-keywords:
-- schedule, deployment, container
 title: Container distribution strategies
 ---
 

--- a/docker-cloud/infrastructure/docker-upgrade.md
+++ b/docker-cloud/infrastructure/docker-upgrade.md
@@ -1,10 +1,9 @@
 ---
+description: Upgrade Docker Engine on a node
+keywords: upgrade, engine, node
 redirect_from:
 - /docker-cloud/feature-reference/docker-upgrade/
 - /docker-cloud/tutorials/docker-upgrade/
-description: Upgrade Docker Engine on a node
-keywords:
-- upgrade, engine, node
 title: Upgrade Docker Engine on a node
 ---
 

--- a/docker-cloud/infrastructure/index.md
+++ b/docker-cloud/infrastructure/index.md
@@ -1,7 +1,6 @@
 ---
 description: Manage network in Docker Cloud
-keywords:
-- nodes, hosts, infrastructure, Cloud
+keywords: nodes, hosts, infrastructure, Cloud
 title: Docker Cloud infrastructure overview
 ---
 

--- a/docker-cloud/infrastructure/link-aws.md
+++ b/docker-cloud/infrastructure/link-aws.md
@@ -1,10 +1,9 @@
 ---
+description: Link your Amazon Web Services account
+keywords: AWS, Cloud, link
 redirect_from:
 - /docker-cloud/getting-started/beginner/link-aws/
 - /docker-cloud/getting-started/link-aws/
-description: Link your Amazon Web Services account
-keywords:
-- AWS, Cloud, link
 title: Link an Amazon Web Services account
 ---
 

--- a/docker-cloud/infrastructure/link-azure.md
+++ b/docker-cloud/infrastructure/link-azure.md
@@ -1,10 +1,9 @@
 ---
+description: Link your Microsoft Azure account
+keywords: Microsoft, Azure, account
 redirect_from:
 - /docker-cloud/getting-started/beginner/link-azure/
 - /docker-cloud/getting-started/link-azure/
-description: Link your Microsoft Azure account
-keywords:
-- Microsoft, Azure, account
 title: Link a Microsoft Azure account
 ---
 

--- a/docker-cloud/infrastructure/link-do.md
+++ b/docker-cloud/infrastructure/link-do.md
@@ -1,10 +1,9 @@
 ---
+description: Link your DigitalOcean account
+keywords: link, DigitalOcean, account
 redirect_from:
 - /docker-cloud/getting-started/beginner/link-do/
 - /docker-cloud/getting-started/link-do/
-description: Link your DigitalOcean account
-keywords:
-- link, DigitalOcean, account
 title: Link a DigitalOcean account
 ---
 

--- a/docker-cloud/infrastructure/link-packet.md
+++ b/docker-cloud/infrastructure/link-packet.md
@@ -1,10 +1,9 @@
 ---
+description: Link your Packet account
+keywords: Packet, link, Cloud
 redirect_from:
 - /docker-cloud/getting-started/beginner/link-packet/
 - /docker-cloud/getting-started/link-packet/
-description: Link your Packet account
-keywords:
-- Packet, link, Cloud
 title: Link a Packet account
 ---
 

--- a/docker-cloud/infrastructure/link-softlayer.md
+++ b/docker-cloud/infrastructure/link-softlayer.md
@@ -1,10 +1,9 @@
 ---
+description: Link your SoftLayer account
+keywords: SoftLayer, link, cloud
 redirect_from:
 - /docker-cloud/getting-started/beginner/link-softlayer/
 - /docker-cloud/getting-started/link-softlayer/
-description: Link your SoftLayer account
-keywords:
-- SoftLayer, link, cloud
 title: Link a SoftLayer account
 ---
 

--- a/docker-cloud/infrastructure/ssh-into-a-node.md
+++ b/docker-cloud/infrastructure/ssh-into-a-node.md
@@ -1,11 +1,10 @@
 ---
+description: SSHing into a Docker Cloud-managed node
+keywords: ssh, Cloud, node
 redirect_from:
 - /docker-cloud/getting-started/intermediate/ssh-into-a-node/
 - /docker-cloud/tutorials/ssh-into-a-node/
 - /docker-cloud/faq/how-ssh-nodes/
-description: SSHing into a Docker Cloud-managed node
-keywords:
-- ssh, Cloud, node
 title: SSH into a Docker Cloud-managed node
 ---
 

--- a/docker-cloud/installing-cli.md
+++ b/docker-cloud/installing-cli.md
@@ -1,11 +1,10 @@
 ---
+description: Using the Docker Cloud CLI on Linux, Windows, and macOS, installing, updating, uninstall
+keywords: cloud, command-line, CLI
 redirect_from:
 - /docker-cloud/getting-started/intermediate/installing-cli/
 - /docker-cloud/getting-started/installing-cli/
 - /docker-cloud/tutorials/installing-cli/
-description: Using the Docker Cloud CLI on Linux, Windows, and macOS, installing, updating, uninstall
-keywords:
-- cloud, command-line, CLI
 title: The Docker Cloud CLI
 ---
 

--- a/docker-cloud/orgs.md
+++ b/docker-cloud/orgs.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Cloud for Organizations and Teams
-keywords:
-- organizations, teams, Docker Cloud, resources, permissions
+keywords: organizations, teams, Docker Cloud, resources, permissions
 title: Organizations and Teams in Docker Cloud
 ---
 

--- a/docker-cloud/overview.md
+++ b/docker-cloud/overview.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Cloud Overview
-keywords:
-- Docker, cloud, three
+keywords: Docker, cloud, three
 title: Docker Cloud overview
 ---
 

--- a/docker-cloud/release-notes.md
+++ b/docker-cloud/release-notes.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Cloud
-keywords:
-- Docker, cloud, release, notes
+keywords: Docker, cloud, release, notes
 title: Docker Cloud release notes
 ---
 

--- a/docker-cloud/slack-integration.md
+++ b/docker-cloud/slack-integration.md
@@ -1,9 +1,8 @@
 ---
+description: Integrate with Slack
+keywords: Slack, integrate, notifications
 redirect_from:
 - /docker-cloud/tutorials/slack-integration/
-description: Integrate with Slack
-keywords:
-- Slack, integrate, notifications
 title: Set up Docker Cloud notifications in Slack
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in /docker-cloud/ :
change keywords's type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>