### PR TITLE
fix type of keywords entry in frontmatter (in /docker-for-mac/ dir)

### DIFF
--- a/docker-for-mac/docker-toolbox.md
+++ b/docker-for-mac/docker-toolbox.md
@@ -1,9 +1,8 @@
 ---
+description: Docker for Mac and Docker Toolbox
+keywords: mac, windows, alpha, beta, toolbox, docker-machine, tutorial
 redirect_from:
 - /mackit/docker-toolbox/
-description: Docker for Mac and Docker Toolbox
-keywords:
-- mac, windows, alpha, beta, toolbox, docker-machine, tutorial
 title: Docker for Mac vs. Docker Toolbox
 ---
 

--- a/docker-for-mac/examples.md
+++ b/docker-for-mac/examples.md
@@ -1,7 +1,6 @@
 ---
 description: Docker for Mac  and Docker for Windows Tutorials
-keywords:
-- mac, windows, examples, Compose
+keywords: mac, windows, examples, Compose
 title: Example applications
 ---
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -1,9 +1,8 @@
 ---
+description: Frequently asked questions
+keywords: mac faqs
 redirect_from:
 - /mackit/faqs/
-description: Frequently asked questions
-keywords:
-- mac faqs
 title: Frequently asked questions (FAQ)
 ---
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -1,4 +1,6 @@
 ---
+description: Getting Started
+keywords: mac, beta, alpha, tutorial
 redirect_from:
 - /mackit/
 - /mackit/getting-started/
@@ -6,9 +8,6 @@ redirect_from:
 - /mac/started/
 - /docker-for-mac/started/
 - /installation/mac/
-description: Getting Started
-keywords:
-- mac, beta, alpha, tutorial
 title: Get started with Docker for Mac
 ---
 

--- a/docker-for-mac/multi-arch.md
+++ b/docker-for-mac/multi-arch.md
@@ -1,9 +1,8 @@
 ---
+description: Multi-CPU Architecture Support
+keywords: mac, Multi-CPU architecture support
 redirect_from:
 - /mackit/multi-arch/
-description: Multi-CPU Architecture Support
-keywords:
-- mac, Multi-CPU architecture support
 title: Leveraging multi-CPU architecture support
 ---
 

--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -1,9 +1,8 @@
 ---
+description: Networking
+keywords: mac, networking
 redirect_from:
 - /mackit/networking/
-description: Networking
-keywords:
-- mac, networking
 title: Networking features in Docker for Mac
 ---
 

--- a/docker-for-mac/opensource.md
+++ b/docker-for-mac/opensource.md
@@ -1,7 +1,6 @@
 ---
 description: Docker's use of Open Source
-keywords:
-- docker, opensource
+keywords: docker, opensource
 title: Open source components and licensing
 ---
 

--- a/docker-for-mac/osxfs.md
+++ b/docker-for-mac/osxfs.md
@@ -1,9 +1,8 @@
 ---
+description: OSXFS
+keywords: mac, osxfs
 redirect_from:
 - /mackit/osxfs/
-description: OSXFS
-keywords:
-- mac, osxfs
 title: File system sharing (osxfs)
 ---
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -1,9 +1,8 @@
 ---
+description: Change log / release notes per release
+keywords: pinata, alpha, tutorial
 redirect_from:
 - /mackit/release-notes/
-description: Change log / release notes per release
-keywords:
-- pinata, alpha, tutorial
 title: Docker for Mac release notes
 ---
 

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -1,9 +1,8 @@
 ---
+description: Troubleshooting, logs, and known issues
+keywords: mac, troubleshooting, logs, issues
 redirect_from:
 - /mackit/troubleshoot/
-description: Troubleshooting, logs, and known issues
-keywords:
-- mac, troubleshooting, logs, issues
 title: Logs and troubleshooting
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/docker-for-mac/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>