### PR TITLE
fix type of keywords entry in frontmatter (in /docker-for-windows/ dir)

### DIFF
--- a/docker-for-windows/examples.md
+++ b/docker-for-windows/examples.md
@@ -1,7 +1,6 @@
 ---
 description: Docker for Mac and Docker for Windows Tutorials
-keywords:
-- mac, windows, examples, Compose
+keywords: mac, windows, examples, Compose
 title: Example applications
 ---
 

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -1,7 +1,6 @@
 ---
 description: Frequently asked questions
-keywords:
-- windows faqs
+keywords: windows faqs
 title: Frequently asked questions (FAQ)
 ---
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -1,4 +1,6 @@
 ---
+description: Getting Started
+keywords: windows, beta, alpha, tutorial
 redirect_from:
 - /winkit/getting-started/
 - /winkit/
@@ -6,9 +8,6 @@ redirect_from:
 - /windows/started/
 - /docker-for-windows/started/
 - /installation/windows/
-description: Getting Started
-keywords:
-- windows, beta, alpha, tutorial
 title: Get started with Docker for Windows
 ---
 

--- a/docker-for-windows/opensource.md
+++ b/docker-for-windows/opensource.md
@@ -1,7 +1,6 @@
 ---
 description: Docker's use of Open Source
-keywords:
-- docker, opensource
+keywords: docker, opensource
 title: Open source components and licensing
 ---
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -1,9 +1,8 @@
 ---
+description: Change log / release notes per release
+keywords: pinata, alpha, tutorial
 redirect_from:
 - /winkit/release-notes/
-description: Change log / release notes per release
-keywords:
-- pinata, alpha, tutorial
 title: Docker for Windows Release notes
 ---
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -1,9 +1,8 @@
 ---
+description: Troubleshooting, logs, and known issues
+keywords: windows, troubleshooting, logs, issues
 redirect_from:
 - /windows/troubleshoot/
-description: Troubleshooting, logs, and known issues
-keywords:
-- windows, troubleshooting, logs, issues
 title: Logs and troubleshooting
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/docker-for-windows/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>