### PR TITLE
fix type of keywords entry in frontmatter (in /docker-hub/ dir)

### DIFF
--- a/docker-hub/accounts.md
+++ b/docker-hub/accounts.md
@@ -1,7 +1,6 @@
 ---
 description: Your Docker ID
-keywords:
-- Docker, docker, trusted, sign-up, registry, accounts, plans, Dockerfile, Docker Hub, docs,  documentation
+keywords: Docker, docker, trusted, sign-up, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation
 title: Docker ID and Docker Hub accounts
 ---
 

--- a/docker-hub/bitbucket.md
+++ b/docker-hub/bitbucket.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Hub Automated Builds using Bitbucket
-keywords:
-- Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation, trusted, builds, trusted builds,  automated builds, bitbucket
+keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation, trusted, builds, trusted builds,  automated builds, bitbucket
 title: Configure automated builds with Bitbucket
 ---
 

--- a/docker-hub/builds.md
+++ b/docker-hub/builds.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Hub Automated Builds
-keywords:
-- Dockerfile, Hub, builds, trusted builds, automated builds
+keywords: Dockerfile, Hub, builds, trusted builds, automated builds
 title: Configure automated builds on Docker Hub
 ---
 

--- a/docker-hub/github.md
+++ b/docker-hub/github.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Hub Automated Builds with GitHub
-keywords:
-- Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation, trusted, builds, trusted builds,  automated builds, GitHub
+keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation, trusted, builds, trusted builds,  automated builds, GitHub
 title: Configure automated builds from GitHub
 ---
 

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -1,9 +1,8 @@
 ---
+description: Docker Hub overview
+keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation, accounts, organizations, repositories, groups, teams
 redirect_from:
 - /docker-hub/overview/
-description: Docker Hub overview
-keywords:
-- Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation, accounts, organizations, repositories, groups,  teams
 title: Overview of Docker Hub
 ---
 

--- a/docker-hub/official_repos.md
+++ b/docker-hub/official_repos.md
@@ -1,7 +1,6 @@
 ---
 description: Guidelines for Official Repositories on Docker Hub
-keywords:
-- Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, official,image, documentation
+keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, official,image, documentation
 title: Official repositories on Docker Hub
 ---
 

--- a/docker-hub/orgs.md
+++ b/docker-hub/orgs.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Hub Teams and Organizations
-keywords:
-- Docker, docker, registry, teams, organizations, plans, Dockerfile, Docker Hub, docs,  documentation
+keywords: Docker, docker, registry, teams, organizations, plans, Dockerfile, Docker Hub, docs, documentation
 title: Organizations and teams in Docker Hub
 ---
 

--- a/docker-hub/repos.md
+++ b/docker-hub/repos.md
@@ -1,7 +1,6 @@
 ---
 description: Your Repositories on Docker Hub
-keywords:
-- Docker, docker, trusted, registry, accounts, plans, Dockerfile, Docker Hub, webhooks, docs,  documentation
+keywords: Docker, docker, trusted, registry, accounts, plans, Dockerfile, Docker Hub, webhooks, docs, documentation
 title: Repositories on Docker Hub
 ---
 

--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Hub Automated Builds
-keywords:
-- Docker, webhookds, hub, builds
+keywords: Docker, webhookds, hub, builds
 title: Webhooks for automated builds
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/docker-hub/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>