### PR TITLE
fix type of keywords entry in frontmatter (in /docker-store/, /toolbox/, and /kitematic/ dirs)

### DIFF
--- a/docker-store/faq.md
+++ b/docker-store/faq.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Store frequently asked questions
-keywords:
-- Docker, docker, store, purchase images
+keywords: Docker, docker, store, purchase images
 title: Docker Store frequently asked questions (FAQ)
 ---
 

--- a/docker-store/index.md
+++ b/docker-store/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Store overview
-keywords:
-- Docker, docker, store, purchase images
+keywords: Docker, docker, store, purchase images
 title: Docker Store overview
 ---
 

--- a/docker-store/publish.md
+++ b/docker-store/publish.md
@@ -1,7 +1,6 @@
 ---
 description: Submit a product for the Docker Store
-keywords:
-- Docker, docker, store, purchase images
+keywords: Docker, docker, store, purchase images
 title: Submit a product to Docker Store
 ---
 

--- a/kitematic/faq.md
+++ b/kitematic/faq.md
@@ -1,8 +1,7 @@
 ---
 description: Documentation covering common questions users have about Kitematic
-keywords:
-- docker, documentation, about, technology, kitematic,  gui
-title: "Kitematic: Frequently asked questions (FAQ)"
+keywords: docker, documentation, about, technology, kitematic,  gui
+title: 'Kitematic: Frequently asked questions (FAQ)'
 ---
 
 ### Is Kitematic Open Source?

--- a/kitematic/index.md
+++ b/kitematic/index.md
@@ -1,7 +1,6 @@
 ---
 description: Documentation that provides an overview of Kitematic and installation instructions
-keywords:
-- docker, documentation, about, technology, kitematic,  gui
+keywords: docker, documentation, about, technology, kitematic, gui
 title: Kitematic
 ---
 

--- a/kitematic/known-issues.md
+++ b/kitematic/known-issues.md
@@ -1,8 +1,7 @@
 ---
 description: Information about known issues in Kitematic
-keywords:
-- docker, documentation, about, technology, kitematic,  gui
-title: "Kitematic: Known issues"
+keywords: docker, documentation, about, technology, kitematic,  gui
+title: 'Kitematic: Known issues'
 ---
 
 Kitematic is in beta, so we're still working out the kinks. The most common

--- a/kitematic/minecraft-server.md
+++ b/kitematic/minecraft-server.md
@@ -1,8 +1,7 @@
 ---
 description: Tutorial demonstrating the setup of a Minecraft server using Docker and Kitematic
-keywords:
-- docker, documentation, about, technology, kitematic, gui, minecraft,  tutorial
-title: "Kitematic tutorial: Set up a Minecraft server"
+keywords: docker, documentation, about, technology, kitematic, gui, minecraft, tutorial
+title: 'Kitematic tutorial: Set up a Minecraft server'
 ---
 
 This is a quick tutorial demonstrating how to set up a local Minecraft server

--- a/kitematic/nginx-web-server.md
+++ b/kitematic/nginx-web-server.md
@@ -1,8 +1,7 @@
 ---
 description: Tutorial demonstrating the setup of an Nginx web server using Docker and Kitematic
-keywords:
-- docker, documentation, about, technology, kitematic, gui, nginx,  tutorial
-title: "Kitematic tutorial: Serve a static website with NGINX"
+keywords: docker, documentation, about, technology, kitematic, gui, nginx, tutorial
+title: 'Kitematic tutorial: Serve a static website with NGINX'
 ---
 
 In this tutorial, you will:

--- a/kitematic/rethinkdb-dev-database.md
+++ b/kitematic/rethinkdb-dev-database.md
@@ -1,8 +1,7 @@
 ---
 description: Tutorial demonstrating the setup of an RethinkDB database for development
-keywords:
-- docker, documentation, about, technology, kitematic, gui, rethink,  tutorial
-title: "Kitematic tutorial: Create a local RethinkDB database for development"
+keywords: docker, documentation, about, technology, kitematic, gui, rethink, tutorial
+title: 'Kitematic tutorial: Create a local RethinkDB database for development'
 ---
 
 In this tutorial, you will:

--- a/kitematic/userguide.md
+++ b/kitematic/userguide.md
@@ -1,8 +1,7 @@
 ---
 description: Documentation that provides an overview of Kitematic and installation instructions
-keywords:
-- docker, documentation, about, technology, kitematic, gui
-title: "Kitematic user guide"
+keywords: docker, documentation, about, technology, kitematic, gui
+title: Kitematic user guide
 ---
 
 ## Overview

--- a/thank-you-subscribing-docker-weekly.md
+++ b/thank-you-subscribing-docker-weekly.md
@@ -1,7 +1,6 @@
 ---
 description: We've sent you a welcome email with links to previous newsletters.
-keywords:
-- Docker, documentation, manual, guide, reference, api
+keywords: Docker, documentation, manual, guide, reference, api
 title: Thank you for subscribing to Docker weekly
 ---
 
@@ -9,4 +8,3 @@ title: Thank you for subscribing to Docker weekly
 
 We've sent you a welcome email with links to previous newsletters.
 Please check your inbox to confirm you received it.
-

--- a/toolbox/faqs/index.md
+++ b/toolbox/faqs/index.md
@@ -1,8 +1,7 @@
 ---
 description: FAQs, troubleshooting, and tips index for Toolbox installs
 identifier: toolbox_overview_faqs
-keywords:
-- docker, documentation, about, technology, kitematic, gui, toolbox
+keywords: docker, documentation, about, technology, kitematic, gui, toolbox
 title: FAQs and troubleshooting
 ---
 

--- a/toolbox/faqs/troubleshoot.md
+++ b/toolbox/faqs/troubleshoot.md
@@ -1,7 +1,6 @@
 ---
 description: Troubleshooting connectivity and certificate issues
-keywords:
-- beginner, getting started, FAQs, troubleshooting, Docker
+keywords: beginner, getting started, FAQs, troubleshooting, Docker
 title: Troubleshooting
 ---
 

--- a/toolbox/index.md
+++ b/toolbox/index.md
@@ -1,7 +1,6 @@
 ---
 description: Documentation that provides an overview of Docker Toolbox and installation instructions
-keywords:
-- docker, documentation, about, technology, docker toolbox, gui
+keywords: docker, documentation, about, technology, docker toolbox, gui
 title: Docker Toolbox
 ---
 

--- a/toolbox/overview.md
+++ b/toolbox/overview.md
@@ -1,7 +1,6 @@
 ---
 description: Documentation that provides an overview of Toolbox
-keywords:
-- docker, documentation, about, technology, kitematic, gui, toolbox
+keywords: docker, documentation, about, technology, kitematic, gui, toolbox
 title: Docker Toolbox Overview
 ---
 

--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -1,7 +1,6 @@
 ---
 description: How to install Toolbox on Mac
-keywords:
-- docker, documentation, install, toolbox, mac
+keywords: docker, documentation, install, toolbox, mac
 title: Install Docker Toolbox on macOS
 ---
 

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -1,7 +1,6 @@
 ---
 description: How to install Toolbox on Mac
-keywords:
-- docker, documentation, install, toolbox, win
+keywords: docker, documentation, install, toolbox, win
 title: Install Docker Toolbox on Windows
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/docker-store/`, `/kitematic/` and `/toolbox/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>