### PR TITLE
Remove Ubuntu 15.10 Wily Werewolf

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -17,7 +17,6 @@ title: 'Installation on Ubuntu '
 Docker is supported on these Ubuntu operating systems:
 
 - Ubuntu Xenial 16.04 (LTS)
-- Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 - Ubuntu Precise 12.04 (LTS)
 
@@ -26,8 +25,8 @@ installation mechanisms. Using these packages ensures you get the latest officia
 release of Docker. If you are required to install using Ubuntu-managed packages,
 consult the Ubuntu documentation.
 
->**Note**: Ubuntu Utopic 14.10 and 15.04 exist in Docker's `APT` repository but
-are no longer officially supported.
+>**Note**: Ubuntu Utopic 14.10, 15.10, and 15.04 exist in Docker's `APT`
+repository but are no longer officially supported.
 
 ## Prerequisites
 
@@ -132,10 +131,9 @@ From now on when you run `apt-get upgrade`, `APT` pulls from the new repository.
 ### Prerequisites by Ubuntu Version
 
 - Ubuntu Xenial 16.04 (LTS)
-- Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 
-For Ubuntu Trusty, Wily, and Xenial, it's recommended to install the
+For Ubuntu Trusty and Xenial, it's recommended to install the
 `linux-image-extra-*` kernel packages. The `linux-image-extra-*` packages
 allows you use the `aufs` storage driver.
 

--- a/engine/security/seccomp.md
+++ b/engine/security/seccomp.md
@@ -26,7 +26,7 @@ CONFIG_SECCOMP=y
 ```
 
 > **Note**: seccomp profiles require seccomp 2.2.1 and are only
-> available starting with Debian 9 "Stretch", Ubuntu 15.10 "Wily",
+> available starting with Debian 9 "Stretch", Ubuntu 16.04 "Xenial",
 > Fedora 22, CentOS 7 and Oracle Linux 7. To use this feature on Ubuntu 14.04, Debian Wheezy, or
 > Debian Jessie, you must download the [latest static Docker Linux binary](../installation/binaries.md).
 > This feature is currently *not* available on other distributions.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

As of July 28, 2016, Ubuntu 15.10 is officially EOL
(https://lists.ubuntu.com/archives/ubuntu-announce/2016-July/000210.html),
and will receive no further updates.

Support for 15.10 was removed in Docker 1.13 through
https://github.com/docker/docker/pull/27042

(https://github.com/docker/docker/pull/27042/commits/e9a81057086cf9834cce4c49c6f8ef035938fc64)

### Unreleased project version

This is for Docker 1.13

### Related issue or PR in another project

https://github.com/docker/docker.github.io/pull/35, https://github.com/docker/docker/pull/27042

### Please take a look

@londoncalling @mlaventure 