### PR TITLE
Revert "remove ubuntu wily 15.10"

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -11,6 +11,7 @@ title: Install Docker on Ubuntu
 Docker is supported on these Ubuntu operating systems:
 
 - Ubuntu Xenial 16.04 (LTS)
+- Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 - Ubuntu Precise 12.04 (LTS)
 
@@ -71,6 +72,7 @@ packages from the Docker repository:
     | ------------------- | ----------------------------------------------------------- |
     | Precise 12.04 (LTS) | `deb https://apt.dockerproject.org/repo ubuntu-precise main`|
     | Trusty 14.04 (LTS)  | `deb https://apt.dockerproject.org/repo ubuntu-trusty main` |
+    | Wily 15.10          | `deb https://apt.dockerproject.org/repo ubuntu-wily main`   |
     | Xenial 16.04 (LTS)  | `deb https://apt.dockerproject.org/repo ubuntu-xenial main` |
 
 
@@ -125,9 +127,10 @@ From now on when you run `apt-get upgrade`, `APT` pulls from the new repository.
 ### Prerequisites by Ubuntu Version
 
 - Ubuntu Xenial 16.04 (LTS)
+- Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 
-For Ubuntu Trusty, and Xenial, it's recommended to install the
+For Ubuntu Trusty, Wily, and Xenial, it's recommended to install the
 `linux-image-extra-*` kernel packages. The `linux-image-extra-*` packages
 allows you use the `aufs` storage driver.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

This reverts the changes made in
https://github.com/docker/docker.github.io/pull/35 (300486bd77b3c0e88bb5da3ccf2794f0d87ce6d9)

Support for unbuntu 15.10 is removed in
Docker 1.13, but still available in Docker 1.12

### Please take a look

@londoncalling 
