### PR TITLE
Implement per-page reading-time stats

### DIFF
--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,0 +1,9 @@
+<span class="reading-time" title="Estimated reading time">
+  <span class="reading-time-label">Estimated reading time: </span>
+  {% assign words = content | number_of_words %}
+  {% if words < 360 %}
+    1 minute
+  {% else %}
+    {{ words | divided_by:180 }} minutes
+  {% endif %}
+</span>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -187,6 +187,7 @@ ng\:form {
               <section class="section" id="DocumentationText">
 								{% if page.title %}<h1>{{ page.title }}</h1>{% endif %}
 								{% if page.advisory %}<blockquote><p><strong style="color:black">{{ site.data.advisories.texts[page.advisory] }}</strong></p></blockquote>{% endif %}
+              {% include read_time.html %}
               {{ content }}
 							{% if page.noratings != true %}
 							<div style="text-align: center; margin-top: 50px">

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -346,3 +346,17 @@ color: #F04124;
 }
 
 /* end search */
+
+/* begin reading_time */
+
+span.reading-time {
+  font-style: italic;
+  font-size: 80%;
+  display: block;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  color: #999;
+}
+
+span.reading-time-label {
+}


### PR DESCRIPTION
### Describe the proposed changes

Implemented a simple reading-time metric which displays just below the page title on every page

Includes some basic styling, but I leave feedback on styling and positioning to others

Uses the metric of 180 wpm, as that is what this [Wikipedia article](http://en.wikipedia.org/wiki/Words_per_minute) thinks you can read on a screen.

Credit to https://carlosbecker.com/posts/jekyll-reading-time-without-plugins/ for the implementation

### Unreleased project version

n/a

### Related issue

n/a

### Related issue or PR in another project

n/a

### Please take a look

@johndmulhausen @sanscontext @londoncalling @joaofnfernandes 

@hansfrederickbrown can you please ping the right person on the Design team to PTAL?

See the Netlify staged site when it completes.


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->