### PR TITLE
fix duplicated page titles

### DIFF
--- a/allpagelinks.md
+++ b/allpagelinks.md
@@ -1,7 +1,6 @@
 ---
 title: All Page Links
 ---
-# All Page Links
 
 {% assign sorted_pages = site.pages | sort:"path" %}
 {% for thispage in sorted_pages %}

--- a/datacenter/dtr/2.0/configure/config-security.md
+++ b/datacenter/dtr/2.0/configure/config-security.md
@@ -7,8 +7,6 @@ keywords:
 title: Security configuration
 ---
 
-# Security configuration
-
 This document describes the security settings you need to configure.
 
 * *SSL Certificate*: Used to enter the hash (string) from the SSL Certificate.

--- a/engine/reference/index.md
+++ b/engine/reference/index.md
@@ -7,8 +7,6 @@ keywords:
 title: Engine reference
 ---
 
-# Engine reference
-
 * [Dockerfile reference](builder.md)
 * [Docker run reference](run.md)
 * [Command line reference](commandline/index.md)

--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -8,8 +8,6 @@ keywords:
 title: Docker security
 ---
 
-# Docker security
-
 There are four major areas to consider when reviewing Docker security:
 
  - the intrinsic security of the kernel and its support for

--- a/engine/tutorials/usingdocker.md
+++ b/engine/tutorials/usingdocker.md
@@ -12,8 +12,6 @@ menu:
 title: Run a simple application
 ---
 
-# Run a simple application
-
 In the ["*Hello world in a container*"](dockerizing.md) you launched your first
 containers using the `docker run` command. You ran an *interactive container*
 that ran in the foreground. You also ran a *detached container* that ran in the

--- a/engine/understanding-docker.md
+++ b/engine/understanding-docker.md
@@ -10,8 +10,6 @@ keywords:
 title: Docker Overview
 ---
 
-# Docker Overview
-
 Docker is an open platform for developing, shipping, and running applications.
 Docker enables you to separate your applications from your infrastructure so
 you can deliver software quickly. With Docker, you can manage your infrastructure

--- a/opensource/get-help.md
+++ b/opensource/get-help.md
@@ -13,8 +13,6 @@ title: Where to chat or get help
 }
 </style>
 
-# Where to chat or get help
-
 There are several communications channels you can use to chat with Docker
 community members and developers.
 

--- a/opensource/workflow/find-an-issue.md
+++ b/opensource/workflow/find-an-issue.md
@@ -35,9 +35,6 @@ hugo converts them to paragraphs, causing the styles to be ignored
 .gh-label.kinddocs { background-color: #B5E9D5; color: #333333; }
 </style>
 
-
-# Find and claim an issue
-
 As a contributor, you can work on any open issue you want. You can view
 issues in the Issues tab in every repository. If you are new to
 contributing, use the filter option to find suitable issues. You can

--- a/thank-you-subscribing-docker-weekly.md
+++ b/thank-you-subscribing-docker-weekly.md
@@ -5,8 +5,6 @@ keywords:
 title: Thank you for subscribing to Docker weekly
 ---
 
-# Thank you for subscribing to Docker weekly
-
 We've sent you a welcome email with links to previous newsletters.
 Please check your inbox to confirm you received it.
 


### PR DESCRIPTION
### Describe the proposed changes

fix duplicated titles in those pages:
https://docs.docker.com/allpagelinks/
https://docs.docker.com/datacenter/dtr/2.0/configure/config-security/
https://docs.docker.com/engine/reference/index/
https://docs.docker.com/engine/security/security/
https://docs.docker.com/engine/tutorials/usingdocker/
https://docs.docker.com/engine/understanding-docker/
https://docs.docker.com/opensource/get-help/
https://docs.docker.com/opensource/workflow/find-an-issue/
https://docs.docker.com/thank-you-subscribing-docker-weekly/

⚠️ This breaks page consistency, regarding anchor links (see #510)

### Related issue

could be considered related to #510 

### Please take a look

N/A

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>