### PR TITLE
fixing TOC entry for Docker Store publish topic

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1105,7 +1105,7 @@ toc:
   section:
   - path: /docker-store/
     title: Docker Store Overview
-  - path: /docker-store/
+  - path: /docker-store/publish/
     title: Submit a product to Docker Store
   - path: /docker-store/faq/
     title: Docker Store FAQs


### PR DESCRIPTION
### Proposed changes

Fixed entry in `toc.yaml` for (corrected path for "Submit a product to the Docker Store" to be `/docker-store/publish/`)

Previous to this change, this Docker Store topic showed up in the left-side TOC based on the heading in the`publish.md` file, but since the path to it was incorrect in `toc.yaml` the page wasn't available when you clicked the TOC entry. 

Clicking either this or the previous topic in the menu made both highlighted, but the `publish.md` file was inaccessible.

### Please take a look

@sanscontext @mstanleyjones 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>