### PR TITLE
fix type of keywords entry in frontmatter (swarm)

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,7 +1,6 @@
 ---
 description: Release notes for Docker
-keywords:
-- docker, documentation, about, technology, understanding,  release
+keywords: docker, documentation, about, technology, understanding,  release
 title: Docker Release Notes
 ---
 

--- a/search.md
+++ b/search.md
@@ -1,10 +1,9 @@
 ---
 description: Docker documentation search results
-keywords:
-- Search, Docker, documentation, manual, guide, reference, api
+keywords: Search, Docker, documentation, manual, guide, reference, api
+noratings: true
 notoc: true
 title: Search results
-noratings: true
 ---
 
 <style type='text/css'>

--- a/swarm/configure-tls.md
+++ b/swarm/configure-tls.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm and transport layer security
-keywords:
-- docker, swarm, TLS, discovery, security,  certificates
+keywords: docker, swarm, TLS, discovery, security,  certificates
 title: Configure Docker Swarm for TLS
 ---
 

--- a/swarm/discovery.md
+++ b/swarm/discovery.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm discovery
-keywords:
-- docker, swarm, clustering,  discovery
+keywords: docker, swarm, clustering,  discovery
 title: Docker Swarm discovery
 ---
 

--- a/swarm/get-swarm.md
+++ b/swarm/get-swarm.md
@@ -1,7 +1,6 @@
 ---
 description: Running a Swarm container on Docker Engine. Run a Swarm binary on the host OS without Docker Engine.
-keywords:
-- docker, Swarm, container, binary, clustering, install, installation
+keywords: docker, Swarm, container, binary, clustering, install, installation
 title: Get Docker Swarm
 ---
 

--- a/swarm/index.md
+++ b/swarm/index.md
@@ -1,7 +1,6 @@
 ---
 description: 'Swarm: a Docker-native clustering system'
-keywords:
-- docker, swarm,  clustering
+keywords: docker, swarm,  clustering
 title: Docker Swarm
 ---
 

--- a/swarm/install-manual.md
+++ b/swarm/install-manual.md
@@ -1,7 +1,6 @@
 ---
 description: Deploying Swarm on AWS EC2 AMI's in a VPC
-keywords:
-- docker, swarm, clustering, examples, Amazon, AWS EC2
+keywords: docker, swarm, clustering, examples, Amazon, AWS EC2
 title: Build a Swarm cluster for production
 ---
 

--- a/swarm/install-w-machine.md
+++ b/swarm/install-w-machine.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm release notes
-keywords:
-- docker, swarm, clustering, discovery, release,  notes
+keywords: docker, swarm, clustering, discovery, release,  notes
 menu:
   main:
     parent: workw_swarm

--- a/swarm/multi-manager-setup.md
+++ b/swarm/multi-manager-setup.md
@@ -1,7 +1,6 @@
 ---
 description: High availability in Swarm
-keywords:
-- docker, swarm,  clustering
+keywords: docker, swarm,  clustering
 title: High availability in Docker Swarm
 ---
 

--- a/swarm/networking.md
+++ b/swarm/networking.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm and container networks
-keywords:
-- docker, swarm, clustering,  networking
+keywords: docker, swarm, clustering,  networking
 title: Swarm and container networks
 ---
 

--- a/swarm/overview.md
+++ b/swarm/overview.md
@@ -1,7 +1,6 @@
 ---
 description: 'Swarm: a Docker-native clustering system'
-keywords:
-- docker, swarm,  clustering
+keywords: docker, swarm, clustering
 title: Docker Swarm overview
 ---
 

--- a/swarm/plan-for-production.md
+++ b/swarm/plan-for-production.md
@@ -1,7 +1,6 @@
 ---
 description: Plan for Swarm in production
-keywords:
-- docker, swarm, scale, voting, application,  plan
+keywords: docker, swarm, scale, voting, application, plan
 title: Plan for Swarm in production
 ---
 

--- a/swarm/provision-with-machine.md
+++ b/swarm/provision-with-machine.md
@@ -1,7 +1,6 @@
 ---
 description: Provision with Machine
-keywords:
-- docker, Swarm, clustering, provision, Machine
+keywords: docker, Swarm, clustering, provision, Machine
 title: Provision a Swarm cluster with Docker Machine
 ---
 

--- a/swarm/reference/create.md
+++ b/swarm/reference/create.md
@@ -1,7 +1,6 @@
 ---
 description: Create a Swarm manager.
-keywords:
-- swarm, create
+keywords: swarm, create
 title: create — Create a discovery token
 ---
 

--- a/swarm/reference/help.md
+++ b/swarm/reference/help.md
@@ -1,7 +1,6 @@
 ---
 description: Get help for Swarm commands.
-keywords:
-- swarm, help
+keywords: swarm, help
 title: help - Display information about a command
 ---
 

--- a/swarm/reference/index.md
+++ b/swarm/reference/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Swarm Commands Overview
-keywords:
-- Swarm, cluster, commands
+keywords: Swarm, cluster, commands
 title: Swarm command-line reference
 ---
 

--- a/swarm/reference/join.md
+++ b/swarm/reference/join.md
@@ -1,7 +1,6 @@
 ---
 description: Create a Swarm node.
-keywords:
-- swarm, create, join
+keywords: swarm, create, join
 title: join — Create a Swarm node
 ---
 

--- a/swarm/reference/list.md
+++ b/swarm/reference/list.md
@@ -1,7 +1,6 @@
 ---
 description: List the nodes in a cluster.
-keywords:
-- swarm, list
+keywords: swarm, list
 title: list — List the nodes in a cluster
 ---
 

--- a/swarm/reference/manage.md
+++ b/swarm/reference/manage.md
@@ -1,7 +1,6 @@
 ---
 description: Create a Swarm manager.
-keywords:
-- swarm, create, manage
+keywords: swarm, create, manage
 title: manage  — Create a Swarm manager
 ---
 

--- a/swarm/reference/swarm.md
+++ b/swarm/reference/swarm.md
@@ -1,8 +1,7 @@
 ---
 description: swarm command overview
-keywords:
-- Swarm, cluster, commands
-title: "Swarm: A Docker-native clustering system"
+keywords: Swarm, cluster, commands
+title: 'Swarm: A Docker-native clustering system'
 ---
 
 The `swarm` command runs a Swarm container on a Docker Engine host and performs the task specified by the required subcommand, `COMMAND`.

--- a/swarm/scheduler/filter.md
+++ b/swarm/scheduler/filter.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm filters
-keywords:
-- docker, swarm, clustering,  filters
+keywords: docker, swarm, clustering, filters
 title: Swarm filters
 ---
 

--- a/swarm/scheduler/index.md
+++ b/swarm/scheduler/index.md
@@ -1,7 +1,6 @@
 ---
 description: 'Swarm: a Docker-native clustering system'
-keywords:
-- docker, swarm, clustering, scheduling
+keywords: docker, swarm, clustering, scheduling
 title: Advanced Scheduling
 ---
 

--- a/swarm/scheduler/rescheduling.md
+++ b/swarm/scheduler/rescheduling.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm rescheduling
-keywords:
-- docker, swarm, clustering, rescheduling
+keywords: docker, swarm, clustering, rescheduling
 title: Swarm rescheduling
 ---
 

--- a/swarm/scheduler/strategy.md
+++ b/swarm/scheduler/strategy.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm strategies
-keywords:
-- docker, swarm, clustering,  strategies
+keywords: docker, swarm, clustering,  strategies
 title: Docker Swarm strategies
 ---
 

--- a/swarm/secure-swarm-tls.md
+++ b/swarm/secure-swarm-tls.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm and transport layer security
-keywords:
-- docker, swarm, TLS, discovery, security,  certificates
+keywords: docker, swarm, TLS, discovery, security, certificates
 title: Use Docker Swarm with TLS
 ---
 

--- a/swarm/status-code-comparison-to-docker.md
+++ b/swarm/status-code-comparison-to-docker.md
@@ -1,7 +1,6 @@
 ---
 description: Swarm API response codes
-keywords:
-- docker, swarm, response, code,  api
+keywords: docker, swarm, response, code, api
 title: Swarm vs. Engine response codes
 ---
 

--- a/swarm/swarm-api.md
+++ b/swarm/swarm-api.md
@@ -1,10 +1,9 @@
 ---
+description: Swarm API
+keywords: docker, swarm, clustering,  api
 redirect_from:
 - /api/swarm-api/
 - /swarm/api/
-description: Swarm API
-keywords:
-- docker, swarm, clustering,  api
 title: Docker Swarm API
 ---
 

--- a/swarm/swarm_at_scale/about.md
+++ b/swarm/swarm_at_scale/about.md
@@ -1,9 +1,8 @@
 ---
+description: Try Swarm at scale
+keywords: docker, swarm, scale, voting, application, architecture
 redirect_from:
 - /swarm/swarm_at_scale/about/
-description: Try Swarm at scale
-keywords:
-- docker, swarm, scale, voting, application, architecture
 title: Learn the application architecture
 ---
 

--- a/swarm/swarm_at_scale/deploy-app.md
+++ b/swarm/swarm_at_scale/deploy-app.md
@@ -1,9 +1,8 @@
 ---
+description: Try Swarm at scale
+keywords: docker, swarm, scale, voting, application, certificates
 redirect_from:
 - /swarm/swarm_at_scale/04-deploy-app/
-description: Try Swarm at scale
-keywords:
-- docker, swarm, scale, voting, application,  certificates
 title: Deploy the application
 ---
 

--- a/swarm/swarm_at_scale/deploy-infra.md
+++ b/swarm/swarm_at_scale/deploy-infra.md
@@ -1,10 +1,9 @@
 ---
+description: Try Swarm at scale
+keywords: docker, swarm, scale, voting, application, certificates
 redirect_from:
 - /swarm/swarm_at_scale/03-create-cluster/
 - /swarm/swarm_at_scale/02-deploy-infra/
-description: Try Swarm at scale
-keywords:
-- docker, swarm, scale, voting, application,  certificates
 title: Deploy application infrastructure
 ---
 

--- a/swarm/swarm_at_scale/index.md
+++ b/swarm/swarm_at_scale/index.md
@@ -1,7 +1,6 @@
 ---
 description: Try Swarm at scale
-keywords:
-- docker, swarm, scale, voting, application,  certificates
+keywords: docker, swarm, scale, voting, application,  certificates
 title: Try Swarm at scale
 ---
 

--- a/swarm/swarm_at_scale/troubleshoot.md
+++ b/swarm/swarm_at_scale/troubleshoot.md
@@ -1,9 +1,8 @@
 ---
+description: Try Swarm at scale
+keywords: docker, swarm, scale, voting, application,  certificates
 redirect_from:
 - /swarm/swarm_at_scale/05-troubleshoot/
-description: Try Swarm at scale
-keywords:
-- docker, swarm, scale, voting, application,  certificates
 title: Troubleshoot the application
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/swarm/` and `search.md` and `release-notes.md` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>