### PR TITLE
fix type of keywords entry in frontmatter (in /opensource/)

### DIFF
--- a/opensource/FAQ.md
+++ b/opensource/FAQ.md
@@ -1,7 +1,6 @@
 ---
 description: Overview of contributing
-keywords:
-- open, source, contributing, overview
+keywords: open, source, contributing, overview
 title: FAQ for contributors
 ---
 

--- a/opensource/code.md
+++ b/opensource/code.md
@@ -1,9 +1,8 @@
 ---
+description: Contribute code
+keywords: governance, board, members, profiles
 redirect_from:
 - /contributing/contributing
-description: Contribute code
-keywords:
-- governance, board, members, profiles
 title: Quickstart code or doc contribution
 ---
 

--- a/opensource/doc-style.md
+++ b/opensource/doc-style.md
@@ -1,7 +1,6 @@
 ---
 description: Style guide for Docker documentation describing standards and conventions for contributors
-keywords:
-- style, guide, docker,  documentation
+keywords: style, guide, docker, documentation
 title: Documentation style and grammar conventions
 ---
 

--- a/opensource/get-help.md
+++ b/opensource/get-help.md
@@ -1,7 +1,6 @@
 ---
 description: Describes Docker's communication channels
-keywords:
-- IRC, Google group, Twitter, blog,  Stackoverflow
+keywords: IRC, Google group, Twitter, blog,  Stackoverflow
 title: Where to chat or get help
 ---
 

--- a/opensource/governance/board-profiles.md
+++ b/opensource/governance/board-profiles.md
@@ -1,7 +1,6 @@
 ---
 description: Board member profiles
-keywords:
-- governance, board, members, profiles
+keywords: governance, board, members, profiles
 title: Board member profiles
 ---
 

--- a/opensource/governance/conduct-code.md
+++ b/opensource/governance/conduct-code.md
@@ -1,7 +1,6 @@
 ---
 description: Explains Docker's code of conduct
-keywords:
-- Docker, conduct, code
+keywords: Docker, conduct, code
 title: Code of conduct
 ---
 

--- a/opensource/governance/dgab-info.md
+++ b/opensource/governance/dgab-info.md
@@ -1,8 +1,7 @@
 ---
 description: Docker Governance Advisory Board
-keywords:
-- governance, board, members, explained
-title: "Docker Governance Advisory Board: June 2015 version"
+keywords: governance, board, members, explained
+title: 'Docker Governance Advisory Board: June 2015 version'
 ---
 
 An initial version of this proposal was posted for comments on April 30th,

--- a/opensource/governance/index.md
+++ b/opensource/governance/index.md
@@ -1,7 +1,6 @@
 ---
 description: Describes Docker's communication channels
-keywords:
-- IRC, Google group, Twitter, blog,  Stackoverflow
+keywords: IRC, Google group, Twitter, blog,  Stackoverflow
 title: Governance
 ---
 

--- a/opensource/index.md
+++ b/opensource/index.md
@@ -1,7 +1,6 @@
 ---
 description: Overview of contributing
-keywords:
-- open, source, contributing, overview
+keywords: open, source, contributing, overview
 title: Open Source at Docker
 ---
 

--- a/opensource/kitematic/create_pr.md
+++ b/opensource/kitematic/create_pr.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to create a pull request for change or new feature
-keywords:
-- Kitematic, open source, contribute, contributor, tour, development, contribute, pull request, review, workflow, beginner, squash,  commit
+keywords: Kitematic, open source, contribute, contributor, tour, development, contribute, pull request, review, workflow, beginner, squash, commit
 title: Create a pull request (PR)
 ---
 

--- a/opensource/kitematic/find_issue.md
+++ b/opensource/kitematic/find_issue.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to find a Kitematic issue
-keywords:
-- Kitematic, open source, contribute, contributor, tour
+keywords: Kitematic, open source, contribute, contributor, tour
 title: Find an issue on GitHub
 ---
 

--- a/opensource/kitematic/get_started.md
+++ b/opensource/kitematic/get_started.md
@@ -1,7 +1,6 @@
 ---
 description: Overview of Kitematic development process
-keywords:
-- Kitematic, open source, contribute, contributor, tour, development
+keywords: Kitematic, open source, contribute, contributor, tour, development
 title: Get started with your Kitematic contributions
 ---
 

--- a/opensource/kitematic/index.md
+++ b/opensource/kitematic/index.md
@@ -1,7 +1,6 @@
 ---
 description: Introduces Kitematic contribute topics and tour
-keywords:
-- Kitematic, open source, contribute, contributor, tour, issue, review
+keywords: Kitematic, open source, contribute, contributor, tour, issue, review
 title: Contribute to Kitematic
 ---
 

--- a/opensource/kitematic/next_steps.md
+++ b/opensource/kitematic/next_steps.md
@@ -1,8 +1,6 @@
 ---
 description: Explains next steps after the tour
-keywords:
-- Kitematic, open source, contribute, contributor, tour, development, contribute
-
+keywords: Kitematic, open source, contribute, contributor, tour, development, contribute
 title: Where to learn more
 ---
 

--- a/opensource/kitematic/set_up_dev.md
+++ b/opensource/kitematic/set_up_dev.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to find a Kitematic issue
-keywords:
-- Kitematic, open source, contribute, contributor, tour, development
+keywords: Kitematic, open source, contribute, contributor, tour, development
 title: Set up for Kitematic development
 ---
 

--- a/opensource/kitematic/work_issue.md
+++ b/opensource/kitematic/work_issue.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to find a Kitematic issue
-keywords:
-- Kitematic, open source, contribute, contributor, tour, development
+keywords: Kitematic, open source, contribute, contributor, tour, development
 title: Develop in Kitematic (work on an issue)
 ---
 

--- a/opensource/project/index.md
+++ b/opensource/project/index.md
@@ -1,7 +1,6 @@
 ---
 description: Describes Docker's communication channels
-keywords:
-- IRC, Google group, Twitter, blog, Stackoverflow
+keywords: IRC, Google group, Twitter, blog, Stackoverflow
 title: Set up for Engine development
 ---
 

--- a/opensource/project/set-up-dev-env.md
+++ b/opensource/project/set-up-dev-env.md
@@ -1,7 +1,6 @@
 ---
 description: How to use Docker's development environment
-keywords:
-- development, inception, container, image Dockerfile, dependencies, Go,  artifacts
+keywords: development, inception, container, image Dockerfile, dependencies, Go,  artifacts
 title: Work with a development container
 ---
 

--- a/opensource/project/set-up-git.md
+++ b/opensource/project/set-up-git.md
@@ -1,7 +1,6 @@
 ---
 description: Describes how to set up your local machine and repository
-keywords:
-- GitHub account, repository, clone, fork, branch, upstream, Git, Go, make
+keywords: GitHub account, repository, clone, fork, branch, upstream, Git, Go, make
 title: Configure Git for contributing
 ---
 

--- a/opensource/project/software-req-win.md
+++ b/opensource/project/software-req-win.md
@@ -1,7 +1,6 @@
 ---
 description: How to set up a server to test Docker Windows client
-keywords:
-- development, inception, container, image Dockerfile, dependencies, Go, artifacts,  windows
+keywords: development, inception, container, image Dockerfile, dependencies, Go, artifacts,  windows
 title: Get the required software for Windows
 ---
 

--- a/opensource/project/software-required.md
+++ b/opensource/project/software-required.md
@@ -1,7 +1,6 @@
 ---
 description: Describes the software required to contribute to Docker
-keywords:
-- 'GitHub account, repository, Docker, Git, Go, make,  '
+keywords: 'GitHub account, repository, Docker, Git, Go, make,  '
 title: Get the required software for Linux or macOS
 ---
 

--- a/opensource/project/test-and-docs.md
+++ b/opensource/project/test-and-docs.md
@@ -1,7 +1,6 @@
 ---
 description: Describes Docker's testing infrastructure
-keywords:
-- make test, make docs, Go tests, gofmt, contributing,  running tests
+keywords: make test, make docs, Go tests, gofmt, contributing,  running tests
 title: Run tests and test documentation
 ---
 

--- a/opensource/project/who-written-for.md
+++ b/opensource/project/who-written-for.md
@@ -1,9 +1,8 @@
 ---
+description: Introduction to project contribution at Docker
+keywords: Gordon, introduction, turtle, machine, libcontainer,  how to
 redirect_from:
 - /project/who-written-for/
-description: Introduction to project contribution at Docker
-keywords:
-- Gordon, introduction, turtle, machine, libcontainer,  how to
 title: README first
 ---
 

--- a/opensource/ways/community.md
+++ b/opensource/ways/community.md
@@ -1,7 +1,6 @@
 ---
 description: Support the community
-keywords:
-- support, community, users, irc
+keywords: support, community, users, irc
 title: Support the community
 ---
 

--- a/opensource/ways/index.md
+++ b/opensource/ways/index.md
@@ -1,7 +1,6 @@
 ---
 description: Contribute code
-keywords:
-- governance, board, members, profiles
+keywords: governance, board, members, profiles
 title: Other ways to contribute
 ---
 

--- a/opensource/ways/issues.md
+++ b/opensource/ways/issues.md
@@ -1,7 +1,6 @@
 ---
 description: Organize our issues
-keywords:
-- governance, board, members, profiles
+keywords: governance, board, members, profiles
 title: Organize our issues
 ---
 

--- a/opensource/ways/meetups.md
+++ b/opensource/ways/meetups.md
@@ -1,7 +1,6 @@
 ---
 description: Organize a Docker Meetup
-keywords:
-- Docker, meetup, hosting, organizing
+keywords: Docker, meetup, hosting, organizing
 title: Organize a Docker meetup
 ---
 

--- a/opensource/ways/test.md
+++ b/opensource/ways/test.md
@@ -1,7 +1,6 @@
 ---
 description: Testing contributions
-keywords:
-- test, source, contributions, Docker
+keywords: test, source, contributions, Docker
 title: Testing contributions
 ---
 

--- a/opensource/workflow/advanced-contributing.md
+++ b/opensource/workflow/advanced-contributing.md
@@ -1,7 +1,6 @@
 ---
 description: Explains workflows for refactor and design proposals
-keywords:
-- contribute, project, design, refactor,  proposal
+keywords: contribute, project, design, refactor,  proposal
 title: Advanced contributing
 ---
 

--- a/opensource/workflow/coding-style.md
+++ b/opensource/workflow/coding-style.md
@@ -1,7 +1,6 @@
 ---
 description: List of guidelines for coding Docker contributions
-keywords:
-- change, commit, squash, request, pull request, test, unit test, integration tests, Go, gofmt,  LGTM
+keywords: change, commit, squash, request, pull request, test, unit test, integration tests, Go, gofmt, LGTM
 title: Coding style checklist
 ---
 

--- a/opensource/workflow/create-pr.md
+++ b/opensource/workflow/create-pr.md
@@ -1,7 +1,6 @@
 ---
 description: Basic workflow for Docker contributions
-keywords:
-- contribute, pull request, review, workflow, beginner, squash,  commit
+keywords: contribute, pull request, review, workflow, beginner, squash,  commit
 title: Create a pull request (PR)
 ---
 

--- a/opensource/workflow/find-an-issue.md
+++ b/opensource/workflow/find-an-issue.md
@@ -1,7 +1,6 @@
 ---
 description: Basic workflow for Docker contributions
-keywords:
-- contribute, issue, review, workflow, beginner, expert, squash, commit
+keywords: contribute, issue, review, workflow, beginner, expert, squash, commit
 title: Find and claim an issue
 ---
 

--- a/opensource/workflow/index.md
+++ b/opensource/workflow/index.md
@@ -1,7 +1,6 @@
 ---
 description: Describes Docker's communication channels
-keywords:
-- IRC, Google group, Twitter, blog,  Stackoverflow
+keywords: IRC, Google group, Twitter, blog,  Stackoverflow
 title: Contribution workflow
 ---
 

--- a/opensource/workflow/make-a-contribution.md
+++ b/opensource/workflow/make-a-contribution.md
@@ -1,7 +1,6 @@
 ---
 description: Explains basic workflow for Docker contributions
-keywords:
-- contribute, maintainers, review, workflow,  process
+keywords: contribute, maintainers, review, workflow,  process
 title: Understand how to contribute
 ---
 

--- a/opensource/workflow/review-pr.md
+++ b/opensource/workflow/review-pr.md
@@ -1,7 +1,6 @@
 ---
 description: Basic workflow for Docker contributions
-keywords:
-- contribute, pull request, review, workflow, beginner, squash,  commit
+keywords: contribute, pull request, review, workflow, beginner, squash,  commit
 title: Participate in the PR review
 ---
 

--- a/opensource/workflow/work-issue.md
+++ b/opensource/workflow/work-issue.md
@@ -1,7 +1,6 @@
 ---
 description: Basic workflow for Docker contributions
-keywords:
-- contribute, pull request, review, workflow, beginner, squash,  commit
+keywords: contribute, pull request, review, workflow, beginner, squash,  commit
 title: Work on your issue
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/opensource/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>