### PR TITLE
fix type of keywords entry in frontmatter (in /registry/)

### DIFF
--- a/registry/compatibility.md
+++ b/registry/compatibility.md
@@ -1,7 +1,6 @@
 ---
 description: describes get by digest pitfall
-keywords:
-- registry, manifest, images, tags, repository, distribution, digest
+keywords: registry, manifest, images, tags, repository, distribution, digest
 title: Registry compatibility
 ---
 

--- a/registry/configuration.md
+++ b/registry/configuration.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to configure a registry
-keywords:
-- registry, on-prem, images, tags, repository, distribution, configuration
+keywords: registry, on-prem, images, tags, repository, distribution, configuration
 title: Registry configuration reference
 ---
 

--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to deploy a registry
-keywords:
-- registry, on-prem, images, tags, repository, distribution, deployment
+keywords: registry, on-prem, images, tags, repository, distribution, deployment
 title: Deploying a registry server
 ---
 

--- a/registry/deprecated.md
+++ b/registry/deprecated.md
@@ -1,7 +1,6 @@
 ---
 description: describes deprecated functionality
-keywords:
-- registry, manifest, images, signatures, repository, distribution, digest
+keywords: registry, manifest, images, signatures, repository, distribution, digest
 title: Docker Registry deprecation
 ---
 

--- a/registry/garbage-collection.md
+++ b/registry/garbage-collection.md
@@ -1,7 +1,6 @@
 ---
 description: High level discussion of garbage collection
-keywords:
-- registry, garbage, images, tags, repository, distribution
+keywords: registry, garbage, images, tags, repository, distribution
 title: Garbage collection
 ---
 

--- a/registry/help.md
+++ b/registry/help.md
@@ -1,7 +1,6 @@
 ---
 description: Getting help with the Registry
-keywords:
-- registry, on-prem, images, tags, repository, distribution, help, 101, TL;DR
+keywords: registry, on-prem, images, tags, repository, distribution, help, 101, TL;DR
 title: Get help
 ---
 

--- a/registry/index.md
+++ b/registry/index.md
@@ -1,9 +1,8 @@
 ---
+description: High-level overview of the Registry
+keywords: registry, on-prem, images, tags, repository, distribution
 redirect_from:
 - /registry/overview/
-description: High-level overview of the Registry
-keywords:
-- registry, on-prem, images, tags, repository, distribution
 title: Docker Registry
 ---
 

--- a/registry/insecure.md
+++ b/registry/insecure.md
@@ -1,7 +1,6 @@
 ---
 description: Deploying a Registry in an insecure fashion
-keywords:
-- registry, on-prem, images, tags, repository, distribution, insecure
+keywords: registry, on-prem, images, tags, repository, distribution, insecure
 title: Test an insecure registry
 ---
 

--- a/registry/introduction.md
+++ b/registry/introduction.md
@@ -1,7 +1,6 @@
 ---
 description: Explains what the Registry is, basic use cases and requirements
-keywords:
-- registry, on-prem, images, tags, repository, distribution, use cases, requirements
+keywords: registry, on-prem, images, tags, repository, distribution, use cases, requirements
 title: About Registry
 ---
 

--- a/registry/notifications.md
+++ b/registry/notifications.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to work with registry notifications
-keywords:
-- registry, on-prem, images, tags, repository, distribution, notifications, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, notifications, advanced
 title: Work with notifications
 ---
 

--- a/registry/recipes/apache.md
+++ b/registry/recipes/apache.md
@@ -1,7 +1,6 @@
 ---
 description: Restricting access to your registry using an apache proxy
-keywords:
-- registry, on-prem, images, tags, repository, distribution, authentication, proxy, apache, httpd, TLS, recipe, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, authentication, proxy, apache, httpd, TLS, recipe, advanced
 title: Authenticate proxy with apache
 ---
 

--- a/registry/recipes/index.md
+++ b/registry/recipes/index.md
@@ -1,7 +1,6 @@
 ---
 description: Fun stuff to do with your registry
-keywords:
-- registry, on-prem, images, tags, repository, distribution, recipes, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, recipes, advanced
 title: Recipes Overview
 ---
 

--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -1,7 +1,6 @@
 ---
 description: Setting-up a local mirror for Docker Hub images
-keywords:
-- registry, on-prem, images, tags, repository, distribution, mirror, Hub, recipe, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, mirror, Hub, recipe, advanced
 title: Registry as a pull through cache
 ---
 

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -1,7 +1,6 @@
 ---
 description: Restricting access to your registry using a nginx proxy
-keywords:
-- registry, on-prem, images, tags, repository, distribution, nginx, proxy, authentication, TLS, recipe, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, nginx, proxy, authentication, TLS, recipe, advanced
 title: Authenticate proxy with nginx
 ---
 

--- a/registry/recipes/osx-setup-guide.md
+++ b/registry/recipes/osx-setup-guide.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to run a registry on macOS
-keywords:
-- registry, on-prem, images, tags, repository, distribution, macOS, recipe, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, macOS, recipe, advanced
 title: macOS Setup Guide
 ---
 

--- a/registry/spec/api.md
+++ b/registry/spec/api.md
@@ -1,7 +1,6 @@
 ---
 description: Specification for the Registry API.
-keywords:
-- registry, on-prem, images, tags, repository, distribution, api, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, api, advanced
 title: Docker Registry HTTP API V2
 ---
 

--- a/registry/spec/auth/index.md
+++ b/registry/spec/auth/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Registry v2 authentication schema
-keywords:
-- registry, on-prem, images, tags, repository, distribution, authentication, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, authentication, advanced
 title: Docker Registry v2 authentication
 ---
 

--- a/registry/spec/auth/jwt.md
+++ b/registry/spec/auth/jwt.md
@@ -1,7 +1,6 @@
 ---
 description: Describe the reference implementation of the Docker Registry v2 authentication schema
-keywords:
-- registry, on-prem, images, tags, repository, distribution, JWT authentication, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, JWT authentication, advanced
 title: Docker Registry v2 Bearer token specification
 ---
 

--- a/registry/spec/auth/oauth.md
+++ b/registry/spec/auth/oauth.md
@@ -1,7 +1,6 @@
 ---
 description: Specifies the Docker Registry v2 authentication
-keywords:
-- registry, on-prem, images, tags, repository, distribution, oauth2, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, oauth2, advanced
 title: Docker Registry v2 authentication using OAuth2
 ---
 

--- a/registry/spec/auth/scope.md
+++ b/registry/spec/auth/scope.md
@@ -1,7 +1,6 @@
 ---
 description: Describes the scope and access fields used for registry authorization tokens
-keywords:
-- registry, on-prem, images, tags, repository, distribution, advanced, access, scope
+keywords: registry, on-prem, images, tags, repository, distribution, advanced, access, scope
 title: Docker Registry token scope and access
 ---
 

--- a/registry/spec/auth/token.md
+++ b/registry/spec/auth/token.md
@@ -1,7 +1,6 @@
 ---
 description: Specifies the Docker Registry v2 authentication
-keywords:
-- registry, on-prem, images, tags, repository, distribution, Bearer authentication, advanced
+keywords: registry, on-prem, images, tags, repository, distribution, Bearer authentication, advanced
 title: Docker Registry v2 authentication via central service
 ---
 

--- a/registry/spec/index.md
+++ b/registry/spec/index.md
@@ -1,7 +1,6 @@
 ---
 description: Explains registry JSON objects
-keywords:
-- registry, service, images, repository,  json
+keywords: registry, service, images, repository,  json
 title: Docker Registry Reference
 ---
 

--- a/registry/spec/json.md
+++ b/registry/spec/json.md
@@ -1,8 +1,7 @@
 ---
 description: Explains registry JSON objects
+keywords: registry, service, images, repository,  json
 published: false
-keywords:
-- registry, service, images, repository,  json
 title: Docker Distribution JSON canonicalization
 ---
 

--- a/registry/spec/manifest-v2-1.md
+++ b/registry/spec/manifest-v2-1.md
@@ -1,7 +1,6 @@
 ---
 description: image manifest for the Registry.
-keywords:
-- registry, on-prem, images, tags, repository, distribution, api, advanced, manifest
+keywords: registry, on-prem, images, tags, repository, distribution, api, advanced, manifest
 title: Image manifest V2, schema 1
 ---
 

--- a/registry/spec/manifest-v2-2.md
+++ b/registry/spec/manifest-v2-2.md
@@ -1,7 +1,6 @@
 ---
 description: image manifest for the Registry.
-keywords:
-- registry, on-prem, images, tags, repository, distribution, api, advanced, manifest
+keywords: registry, on-prem, images, tags, repository, distribution, api, advanced, manifest
 title: Image manifest V2, schema 2
 ---
 

--- a/registry/storage-drivers/azure.md
+++ b/registry/storage-drivers/azure.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to use the Azure storage drivers
-keywords:
-- registry, service, driver, images, storage,  azure
+keywords: registry, service, driver, images, storage,  azure
 title: Microsoft Azure storage driver
 ---
 

--- a/registry/storage-drivers/filesystem.md
+++ b/registry/storage-drivers/filesystem.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to use the filesystem storage drivers
-keywords:
-- registry, service, driver, images, storage,  filesystem
+keywords: registry, service, driver, images, storage,  filesystem
 title: Filesystem storage driver
 ---
 

--- a/registry/storage-drivers/gcs.md
+++ b/registry/storage-drivers/gcs.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to use the Google Cloud Storage drivers
-keywords:
-- registry, service, driver, images, storage,  gcs, google, cloud
+keywords: registry, service, driver, images, storage,  gcs, google, cloud
 title: Google Cloud Storage driver
 ---
 

--- a/registry/storage-drivers/index.md
+++ b/registry/storage-drivers/index.md
@@ -1,9 +1,8 @@
 ---
+description: Explains how to use storage drivers
+keywords: registry, on-prem, images, tags, repository, distribution, storage drivers, advanced
 redirect_from:
 - /registry/storagedrivers/
-description: Explains how to use storage drivers
-keywords:
-- registry, on-prem, images, tags, repository, distribution, storage drivers, advanced
 title: Docker Registry storage driver
 ---
 

--- a/registry/storage-drivers/inmemory.md
+++ b/registry/storage-drivers/inmemory.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to use the in-memory storage drivers
-keywords:
-- registry, service, driver, images, storage,  in-memory
+keywords: registry, service, driver, images, storage,  in-memory
 title: In-memory storage driver (testing only)
 ---
 

--- a/registry/storage-drivers/oss.md
+++ b/registry/storage-drivers/oss.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to use the Aliyun OSS storage driver
-keywords:
-- registry, service, driver, images, storage, OSS, aliyun
+keywords: registry, service, driver, images, storage, OSS, aliyun
 title: Aliyun OSS storage driver
 ---
 

--- a/registry/storage-drivers/s3.md
+++ b/registry/storage-drivers/s3.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to use the S3 storage drivers
-keywords:
-- registry, service, driver, images, storage,  S3
+keywords: registry, service, driver, images, storage,  S3
 title: S3 storage driver
 ---
 

--- a/registry/storage-drivers/swift.md
+++ b/registry/storage-drivers/swift.md
@@ -1,7 +1,6 @@
 ---
 description: Explains how to use the OpenStack swift storage driver
-keywords:
-- registry, service, driver, images, storage,  swift
+keywords: registry, service, driver, images, storage,  swift
 title: OpenStack Swift storage driver
 ---
 


### PR DESCRIPTION
### Describe the proposed changes

in `/registry/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>