### PR TITLE
Add sysctls option documentation

### DIFF
--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -888,6 +888,21 @@ SIGTERM. Setting an alternative signal using `stop_signal` will cause
 
     stop_signal: SIGUSR1
 
+### sysctls
+
+> [Added in version 2.1 file format](compose-file.md#version-21).
+
+Kernel parameters to set in the container. You can use either an array or a
+dictionary.
+
+    sysctls:
+      net.core.somaxconn: 1024
+      net.ipv4.tcp_syncookies: 0
+
+    sysctls:
+      - net.core.somaxconn=1024
+      - net.ipv4.tcp_syncookies=0
+
 ### ulimits
 
 Override the default ulimits for a container. You can either specify a single
@@ -909,6 +924,7 @@ limit as an integer or soft/hard limits as a mapping.
 Disables the user namespace for this service, if Docker daemon is configured with user namespaces.
 See [dockerd](/engine/reference/commandline/dockerd.md#disable-user-namespace-for-a-container) for
 more information.
+
 
 ### volumes, volume\_driver
 
@@ -1438,6 +1454,7 @@ several more.
 - Added: [deploy](compose-file.md#deploy),
   [healthcheck](compose-file.md#healthcheck),
   [stop_grace_period](compose-file.md#stop-grace-period).
+- [`sysctls`](compose-file.md#sysctls)
 
 ### Upgrading
 


### PR DESCRIPTION
### Describe the proposed changes

Documents the sysctls compose-file option introduced in docker/compose#3798.

### Unreleased project version

Pending on docker/compose#3798 acceptance. This is branched off vnext-compose.

### Related issue

N/A

### Related issue or PR in another project

docker/compose#3798

### Please take a look

@aanand 

Signed-off-by: Jari Takkala jtakkala@gmail.com