### PR TITLE
Init cap Exoscale in Machine driver docs side menu

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1076,7 +1076,7 @@ toc:
     - path: /machine/drivers/digital-ocean/
       title: Digital Ocean
     - path: /machine/drivers/exoscale/
-      title: exoscale
+      title: Exoscale
     - path: /machine/drivers/generic/
       title: Generic
     - path: /machine/drivers/gce/


### PR DESCRIPTION
### Proposed changes
updated Exoscale entry to initial caps, note this was done on `vnext-compose` branch (should have been on `vnext-machine` branch) and in `master`, but somehow was lost or reverted in follow-on PRs.

### Related issue

#450 

### Please take a look

@mstanleyjones 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>