### PR TITLE
updated link to Docker Cloud and surrounding text

### DIFF
--- a/docker-cloud/getting-started/connect-infra.md
+++ b/docker-cloud/getting-started/connect-infra.md
@@ -11,7 +11,7 @@ To deploy Docker Cloud nodes, you first need to grant Docker Cloud access to you
 This could mean granting access to a cloud services provider such as AWS or Azure, or installing the Docker Cloud Agent on your own hosts. Once this is done, you can provision nodes directly from within Docker Cloud using the Web UI, CLI or API.
 
 ## Link to a cloud service provider
-To link your cloud provider accounts, first go to your [Docker Cloud account dashboard](https://cloud.docker.com/account/). (You can also click your username in the top right corner and choose **Account info**.)
+To link your cloud provider accounts, first go to your [Docker Cloud dashboard](https://cloud.docker.com/).
 
 Then, use the one of the detailed tutorials below to link your account. You should open the detailed linking tutorial in a new tab or window so you can continue the tutorial when you're finished.
 


### PR DESCRIPTION
### Proposed changes

Updated the link the Docker Cloud dashboard because the one on the docs site was giving me a 404 (see https://docs.docker.com/docker-cloud/getting-started/connect-infra/#/link-to-a-cloud-service-provider). 

I also re-worded the text in that paragraph to better match what I'm seeing on the Cloud login page and my dashboard.  (If you don't like any of this feel free to reject it :-) I've been going through the Cloud docs to learn about Cloud and follow along with the tutorials, so these copyedits are incidental to that. The docs look great really .. quite beautiful.)

### Please take a look

@sanscontext 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>