### PR TITLE
Added GID to USER instruction

### DIFF
--- a/engine/reference/builder.md
+++ b/engine/reference/builder.md
@@ -1204,8 +1204,8 @@ into the newly created volume.
 
 The `USER` instruction sets the user name or UID to use when running the image
 and for any `RUN`, `CMD` and `ENTRYPOINT` instructions that follow it in the
-`Dockerfile`. Optionaly a group name can be set by adding a `:` and a GID, which will be used as the GID 
-for `RUN`, `CMD` and `ENTRYPOINT` instructions.
+`Dockerfile`. To specify the group ID (GID), add it as a suffix to the UID, 
+separated by a colon. For instance, `MYUSER:MYGROUP`.
 
 ## WORKDIR
 

--- a/engine/reference/builder.md
+++ b/engine/reference/builder.md
@@ -1200,11 +1200,12 @@ into the newly created volume.
 
 ## USER
 
-    USER daemon
+    USER daemon[:daemon]
 
 The `USER` instruction sets the user name or UID to use when running the image
 and for any `RUN`, `CMD` and `ENTRYPOINT` instructions that follow it in the
-`Dockerfile`.
+`Dockerfile`. Optionaly a group name can be set by adding a `:` and a GID, which will be used as the GID 
+for `RUN`, `CMD` and `ENTRYPOINT` instructions.
 
 ## WORKDIR
 


### PR DESCRIPTION
### Describe the proposed changes

I added a GID parameter to the USER instruction. The USER instruction does not only allow setting the UID of a container, but also the GID of this user. GID may be added by adding a colon and a GID after the user name (such as: `USER www-data:www-data`. This feature is already implemented, but not documented. 