### PR TITLE
remove jekyll-gist from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,6 @@ url: https://docs.docker.com
 
 gems:
   - jekyll-redirect-from
-  - jekyll-gist
   - jekyll-seo-tag
 
 webrick:


### PR DESCRIPTION
### Proposed changes

I removed the jekyll-gist gem from  from _config.yml.
It's not being used anymore, and in my opinion we shouldn't use it in the future either. All content should come from that repository. 

Signed-off-by: Adrien Duermael <adrien@duermael.com>