### PR TITLE
Collapse left-nav so there's not so much whitespace

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -137,7 +137,8 @@ div.docsidebarnav_section.affix ul {
     line-height: 15px;
     border-radius: 0;
     background-color: #fff;
-		color: rgba(0, 0, 0, 0.7);
+    color: rgba(0, 0, 0, 0.7);
+    font-weight: bold;
 }
 .docsidebarnav_section ul li a:hover {
 		background: rgba(0, 0, 0, 0.05);

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -134,7 +134,6 @@ div.docsidebarnav_section.affix ul {
     font-weight: 400;
     display: block;
     width: 100%;
-		padding: 16px 5px 16px 20px;
     line-height: 15px;
     border-radius: 0;
     background-color: #fff;


### PR DESCRIPTION
@docker/design @sanscontext @joaofnfernandes @mstanleyjones @londoncalling 

This got on my last nerve today and it's an easy fix. WDYT? See the deploy preview link below for the demo.