### PR TITLE
fix type of keywords entry in frontmatter (in /engine/)

### DIFF
--- a/engine/admin/ambassador_pattern_linking.md
+++ b/engine/admin/ambassador_pattern_linking.md
@@ -1,9 +1,8 @@
 ---
+description: Using the Ambassador pattern to abstract (network) services
+keywords: Examples, Usage, links, docker, documentation, examples, names, name,  container naming
 redirect_from:
 - /engine/articles/ambassador_pattern_linking/
-description: Using the Ambassador pattern to abstract (network) services
-keywords:
-- Examples, Usage, links, docker, documentation, examples, names, name,  container naming
 title: Link via an ambassador container
 ---
 

--- a/engine/admin/ansible.md
+++ b/engine/admin/ansible.md
@@ -1,7 +1,6 @@
 ---
 description: Installation and using Docker via Ansible
-keywords:
-- ansible, installation, usage, docker,  documentation
+keywords: ansible, installation, usage, docker,  documentation
 title: Use Ansible
 ---
 

--- a/engine/admin/b2d_volume_resize.md
+++ b/engine/admin/b2d_volume_resize.md
@@ -1,8 +1,7 @@
 ---
 description: Resizing a Boot2Docker volume in VirtualBox with GParted
+keywords: boot2docker, volume,  virtualbox
 published: false
-keywords:
-- boot2docker, volume,  virtualbox
 title: Resize a Boot2Docker volume
 ---
 

--- a/engine/admin/chef.md
+++ b/engine/admin/chef.md
@@ -1,9 +1,8 @@
 ---
+description: Installation and using Docker via Chef
+keywords: chef, installation, usage, docker,  documentation
 redirect_from:
 - /engine/articles/chef/
-description: Installation and using Docker via Chef
-keywords:
-- chef, installation, usage, docker,  documentation
 title: Use Chef
 ---
 

--- a/engine/admin/dsc.md
+++ b/engine/admin/dsc.md
@@ -1,9 +1,8 @@
 ---
+description: Using DSC to configure a new Docker host
+keywords: powershell, dsc, installation, usage, docker,  documentation
 redirect_from:
 - /engine/articles/dsc/
-description: Using DSC to configure a new Docker host
-keywords:
-- powershell, dsc, installation, usage, docker,  documentation
 title: Use PowerShell DSC
 ---
 

--- a/engine/admin/formatting.md
+++ b/engine/admin/formatting.md
@@ -1,7 +1,6 @@
 ---
 description: CLI and log output formatting reference
-keywords:
-- format, formatting, output, templates, log
+keywords: format, formatting, output, templates, log
 title: Format command and log output
 ---
 

--- a/engine/admin/host_integration.md
+++ b/engine/admin/host_integration.md
@@ -1,9 +1,8 @@
 ---
+description: How to generate scripts for upstart, systemd, etc.
+keywords: systemd, upstart, supervisor, docker, documentation,  host integration
 redirect_from:
 - /engine/articles/host_integration/
-description: How to generate scripts for upstart, systemd, etc.
-keywords:
-- systemd, upstart, supervisor, docker, documentation,  host integration
 title: Start containers automatically
 ---
 

--- a/engine/admin/index.md
+++ b/engine/admin/index.md
@@ -1,10 +1,9 @@
 ---
+description: Configuring and running the Docker daemon on various distributions
+keywords: docker, daemon, configuration, running,  process managers
 redirect_from:
 - /engine/articles/configuring/
 - /engine/admin/configuring/
-description: Configuring and running the Docker daemon on various distributions
-keywords:
-- docker, daemon, configuration, running,  process managers
 title: Configure and run Docker on various distributions
 ---
 

--- a/engine/admin/live-restore.md
+++ b/engine/admin/live-restore.md
@@ -1,7 +1,6 @@
 ---
 description: How to keep containers running when the daemon isn't available.
-keywords:
-- docker, upgrade, daemon, dockerd, live-restore, daemonless container
+keywords: docker, upgrade, daemon, dockerd, live-restore, daemonless container
 title: Keep containers alive during daemon downtime
 ---
 

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -1,9 +1,8 @@
 ---
+description: Describes how to use the Amazon CloudWatch Logs logging driver.
+keywords: AWS, Amazon, CloudWatch, logging, driver
 redirect_from:
 - /engine/reference/logging/awslogs/
-description: Describes how to use the Amazon CloudWatch Logs logging driver.
-keywords:
-- AWS, Amazon, CloudWatch, logging, driver
 title: Amazon CloudWatch Logs logging driver
 ---
 

--- a/engine/admin/logging/etwlogs.md
+++ b/engine/admin/logging/etwlogs.md
@@ -1,7 +1,6 @@
 ---
 description: Describes how to use the etwlogs logging driver.
-keywords:
-- ETW, docker, logging, driver
+keywords: ETW, docker, logging, driver
 title: ETW logging driver
 ---
 

--- a/engine/admin/logging/fluentd.md
+++ b/engine/admin/logging/fluentd.md
@@ -1,10 +1,9 @@
 ---
+description: Describes how to use the fluentd logging driver.
+keywords: Fluentd, docker, logging, driver
 redirect_from:
 - /engine/reference/logging/fluentd/
 - /reference/logging/fluentd/
-description: Describes how to use the fluentd logging driver.
-keywords:
-- Fluentd, docker, logging, driver
 title: Fluentd logging driver
 ---
 

--- a/engine/admin/logging/gcplogs.md
+++ b/engine/admin/logging/gcplogs.md
@@ -1,7 +1,6 @@
 ---
 description: Describes how to use the Google Cloud Logging driver.
-keywords:
-- gcplogs, google, docker, logging, driver
+keywords: gcplogs, google, docker, logging, driver
 title: Google Cloud Logging driver
 ---
 

--- a/engine/admin/logging/index.md
+++ b/engine/admin/logging/index.md
@@ -1,9 +1,8 @@
 ---
+description: Logging and Logging Drivers
+keywords: ' docker, logging, driver'
 redirect_from:
 - /engine/reference/logging/
-description: Logging and Logging Drivers
-keywords:
-- ' docker, logging, driver'
 title: Logging drivers
 ---
 

--- a/engine/admin/logging/journald.md
+++ b/engine/admin/logging/journald.md
@@ -1,9 +1,8 @@
 ---
+description: Describes how to use the fluentd logging driver.
+keywords: Journald, docker, logging, driver
 redirect_from:
 - /engine/reference/logging/journald/
-description: Describes how to use the fluentd logging driver.
-keywords:
-- Journald, docker, logging, driver
 title: Journald logging driver
 ---
 

--- a/engine/admin/logging/log_tags.md
+++ b/engine/admin/logging/log_tags.md
@@ -1,9 +1,8 @@
 ---
+description: Describes how to format tags for.
+keywords: docker, logging, driver, syslog, Fluentd, gelf, journald
 redirect_from:
 - /engine/reference/logging/log_tags/
-description: Describes how to format tags for.
-keywords:
-- docker, logging, driver, syslog, Fluentd, gelf, journald
 title: Log tags for logging driver
 ---
 

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -1,9 +1,8 @@
 ---
+description: Configure logging driver.
+keywords: docker, logging, driver, Fluentd
 redirect_from:
 - /engine/reference/logging/overview/
-description: Configure logging driver.
-keywords:
-- docker, logging, driver, Fluentd
 title: Configure logging drivers
 ---
 

--- a/engine/admin/logging/splunk.md
+++ b/engine/admin/logging/splunk.md
@@ -1,9 +1,8 @@
 ---
+description: Describes how to use the Splunk logging driver.
+keywords: splunk, docker, logging, driver
 redirect_from:
 - /engine/reference/logging/splunk/
-description: Describes how to use the Splunk logging driver.
-keywords:
-- splunk, docker, logging, driver
 title: Splunk logging driver
 ---
 

--- a/engine/admin/puppet.md
+++ b/engine/admin/puppet.md
@@ -1,9 +1,8 @@
 ---
+description: Installing and using Puppet
+keywords: puppet, installation, usage, docker,  documentation
 redirect_from:
 - /engine/articles/puppet/
-description: Installing and using Puppet
-keywords:
-- puppet, installation, usage, docker,  documentation
 title: Use Puppet
 ---
 

--- a/engine/admin/registry_mirror.md
+++ b/engine/admin/registry_mirror.md
@@ -1,9 +1,8 @@
 ---
+description: How to set up and run a local registry mirror
+keywords: docker, registry, mirror,  examples
 redirect_from:
 - /engine/articles/registry_mirror/
-description: How to set up and run a local registry mirror
-keywords:
-- docker, registry, mirror,  examples
 title: Run a local registry mirror
 ---
 

--- a/engine/admin/runmetrics.md
+++ b/engine/admin/runmetrics.md
@@ -1,10 +1,9 @@
 ---
+description: Measure the behavior of running containers
+keywords: docker, metrics, CPU, memory, disk, IO, run,  runtime, stats
 redirect_from:
 - /engine/articles/run_metrics
 - /engine/articles/runmetrics
-description: Measure the behavior of running containers
-keywords:
-- docker, metrics, CPU, memory, disk, IO, run,  runtime, stats
 title: Runtime metrics
 ---
 

--- a/engine/admin/systemd.md
+++ b/engine/admin/systemd.md
@@ -1,9 +1,8 @@
 ---
+description: Controlling and configuring Docker using systemd
+keywords: docker, daemon, systemd,  configuration
 redirect_from:
 - /engine/articles/systemd/
-description: Controlling and configuring Docker using systemd
-keywords:
-- docker, daemon, systemd,  configuration
 title: Control and configure Docker with systemd
 ---
 

--- a/engine/admin/using_supervisord.md
+++ b/engine/admin/using_supervisord.md
@@ -1,9 +1,8 @@
 ---
+description: How to use Supervisor process management with Docker
+keywords: docker, supervisor,  process management
 redirect_from:
 - /engine/articles/using_supervisord/
-description: How to use Supervisor process management with Docker
-keywords:
-- docker, supervisor,  process management
 title: Use Supervisor with Docker
 ---
 

--- a/engine/examples/apt-cacher-ng.md
+++ b/engine/examples/apt-cacher-ng.md
@@ -1,7 +1,6 @@
 ---
 description: Installing and running an apt-cacher-ng service
-keywords:
-- docker, example, package installation, networking, debian,  ubuntu
+keywords: docker, example, package installation, networking, debian,  ubuntu
 title: Dockerize an apt-cacher-ng service
 ---
 

--- a/engine/examples/couchbase.md
+++ b/engine/examples/couchbase.md
@@ -1,7 +1,6 @@
 ---
 description: Dockerizing a Couchbase service
-keywords:
-- docker, example, package installation, networking, couchbase
+keywords: docker, example, package installation, networking, couchbase
 title: Dockerize a Couchbase service
 ---
 

--- a/engine/examples/couchdb_data_volumes.md
+++ b/engine/examples/couchdb_data_volumes.md
@@ -1,7 +1,6 @@
 ---
 description: Sharing data between 2 couchdb databases
-keywords:
-- docker, example, package installation, networking, couchdb,  data volumes
+keywords: docker, example, package installation, networking, couchdb,  data volumes
 title: Dockerize a CouchDB service
 ---
 

--- a/engine/examples/index.md
+++ b/engine/examples/index.md
@@ -1,7 +1,6 @@
 ---
 description: Provides examples for using Docker
-keywords:
-- dockerize, dockerizing apps, dockerizing applications, container,  containers
+keywords: dockerize, dockerizing apps, dockerizing applications, container,  containers
 title: Dockerize an application
 ---
 

--- a/engine/examples/mongodb.md
+++ b/engine/examples/mongodb.md
@@ -1,7 +1,6 @@
 ---
 description: Creating a Docker image with MongoDB pre-installed using a Dockerfile and sharing the image on Docker Hub
-keywords:
-- docker, dockerize, dockerizing, article, example, docker.io, platform, package, installation, networking, mongodb, containers, images, image, sharing, dockerfile, build, auto-building,  framework
+keywords: docker, dockerize, dockerizing, article, example, docker.io, platform, package, installation, networking, mongodb, containers, images, image, sharing, dockerfile, build, auto-building,  framework
 title: Dockerize MongoDB
 ---
 

--- a/engine/examples/postgresql_service.md
+++ b/engine/examples/postgresql_service.md
@@ -1,7 +1,6 @@
 ---
 description: Running and installing a PostgreSQL service
-keywords:
-- docker, example, package installation,  postgresql
+keywords: docker, example, package installation,  postgresql
 title: Dockerize PostgreSQL
 ---
 

--- a/engine/examples/running_redis_service.md
+++ b/engine/examples/running_redis_service.md
@@ -1,7 +1,6 @@
 ---
 description: Installing and running a redis service
-keywords:
-- docker, example, package installation, networking,  redis
+keywords: docker, example, package installation, networking,  redis
 title: Dockerize a Redis service
 ---
 

--- a/engine/examples/running_riak_service.md
+++ b/engine/examples/running_riak_service.md
@@ -1,7 +1,6 @@
 ---
 description: Build a Docker image with Riak pre-installed
-keywords:
-- docker, example, package installation, networking,  riak
+keywords: docker, example, package installation, networking,  riak
 title: Dockerize a Riak service
 ---
 

--- a/engine/examples/running_ssh_service.md
+++ b/engine/examples/running_ssh_service.md
@@ -1,7 +1,6 @@
 ---
 description: Installing and running an SSHd service on Docker
-keywords:
-- docker, example, package installation,  networking
+keywords: docker, example, package installation,  networking
 title: Dockerize an SSH service
 ---
 

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -1,9 +1,8 @@
 ---
+description: Most frequently asked questions.
+keywords: faq, questions, documentation,  docker
 redirect_from:
 - /engine/misc/faq/
-description: Most frequently asked questions.
-keywords:
-- faq, questions, documentation,  docker
 title: Docker Engine frequently asked questions (FAQ)
 ---
 

--- a/engine/getstarted/index.md
+++ b/engine/getstarted/index.md
@@ -1,12 +1,11 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker
 redirect_from:
 - /mac/started/
 - /windows/started/
 - /linux/started/
 - /getting-started/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker
 title: Get started with Docker
 ---
 

--- a/engine/getstarted/last_page.md
+++ b/engine/getstarted/last_page.md
@@ -1,11 +1,10 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker
 redirect_from:
 - /mac/last_page/
 - /windows/last_page/
 - /linux/last_page/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker
 title: Learn more
 ---
 

--- a/engine/getstarted/linux_install_help.md
+++ b/engine/getstarted/linux_install_help.md
@@ -1,10 +1,9 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker, install
 redirect_from:
 - /mac/started/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker, install
-title: "Example: Install Docker on Ubuntu Linux"
+title: 'Example: Install Docker on Ubuntu Linux'
 ---
 
 This installation procedure for users who are unfamiliar with package

--- a/engine/getstarted/step_five.md
+++ b/engine/getstarted/step_five.md
@@ -1,11 +1,10 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker
 redirect_from:
 - /mac/step_five/
 - /windows/step_five/
 - /linux/step_five/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker
 title: Create a Docker Hub account and repository
 ---
 

--- a/engine/getstarted/step_one.md
+++ b/engine/getstarted/step_one.md
@@ -1,11 +1,10 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker, install
 redirect_from:
 - /mac/step_one/
 - /windows/step_one/
 - /linux/step_one/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker, install
 title: Install Docker and run hello-world
 ---
 

--- a/engine/getstarted/step_six.md
+++ b/engine/getstarted/step_six.md
@@ -1,11 +1,10 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker
 redirect_from:
 - /mac/step_six/
 - /windows/step_six/
 - /linux/step_six/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker
 title: Tag, push, and pull your image
 ---
 

--- a/engine/getstarted/step_three.md
+++ b/engine/getstarted/step_three.md
@@ -1,11 +1,10 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker
 redirect_from:
 - /mac/step_three/
 - /windows/step_three/
 - /linux/step_three/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker
 title: Find and run the whalesay image
 ---
 

--- a/engine/getstarted/step_two.md
+++ b/engine/getstarted/step_two.md
@@ -1,11 +1,10 @@
 ---
+description: Getting started with Docker
+keywords: beginner, getting started, Docker
 redirect_from:
 - /mac/step_two/
 - /windows/step_two/
 - /linux/step_two/
-description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker
 title: Learn about images and containers
 ---
 

--- a/engine/index.md
+++ b/engine/index.md
@@ -1,9 +1,8 @@
 ---
+description: Engine
+keywords: Engine
 redirect_from:
 - /engine/misc/
-description: Engine
-keywords:
-- Engine
 title: About Docker Engine
 ---
 

--- a/engine/installation/binaries.md
+++ b/engine/installation/binaries.md
@@ -1,7 +1,6 @@
 ---
 description: Instructions for installing Docker as a binary. Mostly meant for hackers who want to try out Docker on a variety of environments.
-keywords:
-- binaries, installation, docker, documentation, linux
+keywords: binaries, installation, docker, documentation, linux
 title: Install Docker from binaries
 ---
 

--- a/engine/installation/cloud/cloud-ex-aws.md
+++ b/engine/installation/cloud/cloud-ex-aws.md
@@ -1,8 +1,7 @@
 ---
 description: Example of a manual install of Docker Engine on a cloud provider, using Amazon Web Services (AWS) EC2. Shows how to create an EC2 instance, and install Docker Engine on it.
-keywords:
-- cloud, docker, machine, documentation,  installation, AWS, EC2
-title: "Example: Manual installation on a cloud provider"
+keywords: cloud, docker, machine, documentation, installation, AWS, EC2
+title: 'Example: Manual installation on a cloud provider'
 ---
 
 You can install Docker Engine directly to servers you have on cloud providers.  This example shows how to create an <a href="https://aws.amazon.com/" target="_blank"> Amazon Web Services (AWS)</a> EC2 instance, and install Docker Engine on it.

--- a/engine/installation/cloud/cloud-ex-machine-ocean.md
+++ b/engine/installation/cloud/cloud-ex-machine-ocean.md
@@ -1,8 +1,7 @@
 ---
 description: Example of using Docker Machine to install Docker Engine on a cloud provider, using Digital Ocean.
-keywords:
-- cloud, docker, machine, documentation,  installation, digitalocean
-title: "Example: Use Docker Machine to provision cloud hosts"
+keywords: cloud, docker, machine, documentation, installation, digitalocean
+title: 'Example: Use Docker Machine to provision cloud hosts'
 ---
 
 Docker Machine driver plugins are available for many cloud platforms, so you can use Machine to provision cloud hosts. When you use Docker Machine for provisioning, you create cloud hosts with Docker Engine installed on them.

--- a/engine/installation/cloud/index.md
+++ b/engine/installation/cloud/index.md
@@ -1,4 +1,6 @@
 ---
+description: Cloud Installations
+keywords: Docker install
 redirect_from:
 - /engine/installation/amazon/
 - /engine/installation/google/
@@ -6,9 +8,6 @@ redirect_from:
 - /engine/installation/azure/
 - /engine/installation/rackspace/
 - /engine/installation/joyent/
-description: Cloud Installations
-keywords:
-- Docker install
 title: Install Engine on cloud hosts
 ---
 

--- a/engine/installation/cloud/overview.md
+++ b/engine/installation/cloud/overview.md
@@ -1,9 +1,8 @@
 ---
+description: Installation instructions for Docker on cloud.
+keywords: cloud, docker, machine, documentation,  installation
 redirect_from:
 - /engine/installation/cloud/cloud/
-description: Installation instructions for Docker on cloud.
-keywords:
-- cloud, docker, machine, documentation,  installation
 title: Choose an installation method
 ---
 

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -1,11 +1,10 @@
 ---
+description: Lists the installation methods
+keywords: Docker install
 redirect_from:
 - /installation/
 - /engine/installation/linux/frugalware/
 - /engine/installation/frugalware/
-description: Lists the installation methods
-keywords:
-- Docker install
 title: Install Docker Engine
 ---
 

--- a/engine/installation/linux/SUSE.md
+++ b/engine/installation/linux/SUSE.md
@@ -1,9 +1,8 @@
 ---
+description: Installation instructions for Docker on openSUSE and on SUSE Linux Enterprise.
+keywords: openSUSE, SUSE Linux Enterprise, SUSE, SLE, docker, documentation,  installation
 redirect_from:
 - /engine/installation/SUSE/
-description: Installation instructions for Docker on openSUSE and on SUSE Linux Enterprise.
-keywords:
-- openSUSE, SUSE Linux Enterprise, SUSE, SLE, docker, documentation,  installation
 title: Install Docker on openSUSE and SUSE Linux Enterprise
 ---
 

--- a/engine/installation/linux/archlinux.md
+++ b/engine/installation/linux/archlinux.md
@@ -1,9 +1,8 @@
 ---
+description: Installation instructions for Docker on ArchLinux.
+keywords: arch linux, docker, documentation,  installation
 redirect_from:
 - /engine/installation/archlinux/
-description: Installation instructions for Docker on ArchLinux.
-keywords:
-- arch linux, docker, documentation,  installation
 title: Install Docker on Arch Linux
 ---
 

--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -1,9 +1,8 @@
 ---
+description: Instructions for installing Docker on CentOS
+keywords: Docker, Docker documentation, requirements, linux, centos, epel, docker.io,  docker-io
 redirect_from:
 - /engine/installation/centos/
-description: Instructions for installing Docker on CentOS
-keywords:
-- Docker, Docker documentation, requirements, linux, centos, epel, docker.io,  docker-io
 title: Install Docker on CentOS
 ---
 

--- a/engine/installation/linux/cruxlinux.md
+++ b/engine/installation/linux/cruxlinux.md
@@ -1,9 +1,8 @@
 ---
+description: Docker installation on CRUX Linux.
+keywords: crux linux, Docker, documentation,  installation
 redirect_from:
 - /engine/installation/cruxlinux/
-description: Docker installation on CRUX Linux.
-keywords:
-- crux linux, Docker, documentation,  installation
 title: Install Docker on CRUX Linux
 ---
 

--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -1,9 +1,8 @@
 ---
+description: Instructions for installing Docker on Debian.
+keywords: Docker, Docker documentation, installation,  debian
 redirect_from:
 - /engine/installation/debian/
-description: Instructions for installing Docker on Debian.
-keywords:
-- Docker, Docker documentation, installation,  debian
 title: Install Docker on Debian
 ---
 

--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -1,9 +1,8 @@
 ---
+description: Instructions for installing Docker on Fedora.
+keywords: Docker, Docker documentation, Fedora, requirements,  linux
 redirect_from:
 - /engine/installation/fedora/
-description: Instructions for installing Docker on Fedora.
-keywords:
-- Docker, Docker documentation, Fedora, requirements,  linux
 title: Install Docker on Fedora
 ---
 

--- a/engine/installation/linux/gentoolinux.md
+++ b/engine/installation/linux/gentoolinux.md
@@ -1,9 +1,8 @@
 ---
+description: Installation instructions for Docker on Gentoo.
+keywords: gentoo linux, docker, documentation,  installation
 redirect_from:
 - /engine/installation/gentoolinux/
-description: Installation instructions for Docker on Gentoo.
-keywords:
-- gentoo linux, docker, documentation,  installation
 title: Install Docker on Gentoo
 ---
 

--- a/engine/installation/linux/oracle.md
+++ b/engine/installation/linux/oracle.md
@@ -1,9 +1,8 @@
 ---
+description: Installation instructions for Docker on Oracle Linux.
+keywords: Docker, Docker documentation, requirements, linux, rhel, centos, oracle,  ol
 redirect_from:
 - /engine/installation/oracle/
-description: Installation instructions for Docker on Oracle Linux.
-keywords:
-- Docker, Docker documentation, requirements, linux, rhel, centos, oracle,  ol
 title: Install Docker on Oracle Linux
 ---
 

--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -1,10 +1,9 @@
 ---
+description: Instructions for installing Docker on Red Hat Enterprise Linux.
+keywords: Docker, Docker documentation, requirements, linux,  rhel
 redirect_from:
 - /engine/installation/rhel/
 - /installation/rhel/
-description: Instructions for installing Docker on Red Hat Enterprise Linux.
-keywords:
-- Docker, Docker documentation, requirements, linux,  rhel
 title: Install Docker on Red Hat Enterprise Linux
 ---
 

--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -1,10 +1,9 @@
 ---
+description: 'Instructions for installing Docker on Ubuntu. '
+keywords: Docker, Docker documentation, requirements, apt, installation,  ubuntu
 redirect_from:
 - /engine/installation/ubuntulinux/
 - /installation/ubuntulinux/
-description: 'Instructions for installing Docker on Ubuntu. '
-keywords:
-- Docker, Docker documentation, requirements, apt, installation,  ubuntu
 title: Install Docker on Ubuntu
 ---
 

--- a/engine/installation/mac.md
+++ b/engine/installation/mac.md
@@ -1,7 +1,6 @@
 ---
 description: Docker installation on macOS
-keywords:
-- Docker, Docker documentation, requirements, boot2docker, VirtualBox, SSH, Linux, osx, os x, macOS,  Mac
+keywords: Docker, Docker documentation, requirements, boot2docker, VirtualBox, SSH, Linux, osx, os x, macOS, Mac
 title: Install Docker on macOS
 ---
 

--- a/engine/installation/windows.md
+++ b/engine/installation/windows.md
@@ -1,7 +1,6 @@
 ---
 description: Docker installation on Microsoft Windows
-keywords:
-- Docker, Docker documentation, Windows, requirements, virtualbox,  boot2docker
+keywords: Docker, Docker documentation, Windows, requirements, virtualbox,  boot2docker
 title: Install Docker on Windows
 ---
 

--- a/engine/migration.md
+++ b/engine/migration.md
@@ -1,7 +1,6 @@
 ---
 description: Migrate to Engine 1.10
-keywords:
-- docker, documentation, engine, upgrade, migration
+keywords: docker, documentation, engine, upgrade, migration
 title: Migrate to Engine 1.10
 ---
 

--- a/engine/security/apparmor.md
+++ b/engine/security/apparmor.md
@@ -1,7 +1,6 @@
 ---
 description: Enabling AppArmor in Docker
-keywords:
-- AppArmor, security, docker, documentation
+keywords: AppArmor, security, docker, documentation
 title: AppArmor security profiles for Docker
 ---
 

--- a/engine/security/certificates.md
+++ b/engine/security/certificates.md
@@ -1,9 +1,8 @@
 ---
+description: How to set up and use certificates with a registry to verify access
+keywords: Usage, registry, repository, client, root, certificate, docker, apache, ssl, tls, documentation, examples, articles, tutorials
 redirect_from:
 - /engine/articles/certificates/
-description: How to set up and use certificates with a registry to verify access
-keywords:
-- Usage, registry, repository, client, root, certificate, docker, apache, ssl, tls, documentation, examples, articles,  tutorials
 title: Verify repository client with certificates
 ---
 

--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -1,10 +1,9 @@
 ---
+description: How to setup and run Docker with HTTPS
+keywords: docker, docs, article, example, https, daemon, tls, ca,  certificate
 redirect_from:
 - /engine/articles/https/
 - /articles/https/
-description: How to setup and run Docker with HTTPS
-keywords:
-- docker, docs, article, example, https, daemon, tls, ca,  certificate
 title: Protect the Docker daemon socket
 ---
 

--- a/engine/security/index.md
+++ b/engine/security/index.md
@@ -1,7 +1,6 @@
 ---
 description: Sec
-keywords:
-- seccomp, security, docker, documentation
+keywords: seccomp, security, docker, documentation
 title: Secure Engine
 ---
 

--- a/engine/security/non-events.md
+++ b/engine/security/non-events.md
@@ -1,7 +1,6 @@
 ---
 description: Review of security vulnerabilities Docker mitigated
-keywords:
-- Docker, Docker documentation,  security, security non-events
+keywords: Docker, Docker documentation,  security, security non-events
 title: Docker security non-events
 ---
 

--- a/engine/security/seccomp.md
+++ b/engine/security/seccomp.md
@@ -1,7 +1,6 @@
 ---
 description: Enabling seccomp in Docker
-keywords:
-- seccomp, security, docker, documentation
+keywords: seccomp, security, docker, documentation
 title: Seccomp security profiles for Docker
 ---
 

--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -1,10 +1,9 @@
 ---
+description: Review of the Docker Daemon attack surface
+keywords: Docker, Docker documentation,  security
 redirect_from:
 - /engine/articles/security/
 - /security/security/
-description: Review of the Docker Daemon attack surface
-keywords:
-- Docker, Docker documentation,  security
 title: Docker security
 ---
 

--- a/engine/security/trust/content_trust.md
+++ b/engine/security/trust/content_trust.md
@@ -1,7 +1,6 @@
 ---
 description: Enabling content trust in Docker
-keywords:
-- content, trust, security, docker,  documentation
+keywords: content, trust, security, docker,  documentation
 title: Content trust in Docker
 ---
 

--- a/engine/security/trust/deploying_notary.md
+++ b/engine/security/trust/deploying_notary.md
@@ -1,7 +1,6 @@
 ---
 description: Deploying Notary
-keywords:
-- trust, security, notary, deployment
+keywords: trust, security, notary, deployment
 title: Deploying Notary Server with Compose
 ---
 

--- a/engine/security/trust/index.md
+++ b/engine/security/trust/index.md
@@ -1,7 +1,6 @@
 ---
 description: Use trusted images
-keywords:
-- trust, security, docker,  index
+keywords: trust, security, docker,  index
 title: Use trusted images
 ---
 

--- a/engine/security/trust/trust_automation.md
+++ b/engine/security/trust/trust_automation.md
@@ -1,7 +1,6 @@
 ---
 description: Automating content push pulls with trust
-keywords:
-- trust, security, docker,  documentation, automation
+keywords: trust, security, docker,  documentation, automation
 title: Automation with content trust
 ---
 

--- a/engine/security/trust/trust_delegation.md
+++ b/engine/security/trust/trust_delegation.md
@@ -1,7 +1,6 @@
 ---
 description: Delegations for content trust
-keywords:
-- trust, security, delegations, keys, repository
+keywords: trust, security, delegations, keys, repository
 title: Delegations for content trust
 ---
 

--- a/engine/security/trust/trust_key_mng.md
+++ b/engine/security/trust/trust_key_mng.md
@@ -1,7 +1,6 @@
 ---
 description: Manage keys for content trust
-keywords:
-- trust, security, root,  keys, repository
+keywords: trust, security, root,  keys, repository
 title: Manage keys for content trust
 ---
 

--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -1,7 +1,6 @@
 ---
 description: Play in a trust sandbox
-keywords:
-- trust, security, root,  keys, repository, sandbox
+keywords: trust, security, root,  keys, repository, sandbox
 title: Play in a content trust sandbox
 ---
 

--- a/engine/swarm/admin_guide.md
+++ b/engine/swarm/admin_guide.md
@@ -1,9 +1,8 @@
 ---
+description: Manager administration guide
+keywords: docker, container, swarm, manager, raft
 redirect_from:
 - /engine/swarm/manager-administration-guide/
-description: Manager administration guide
-keywords:
-- docker, container, swarm, manager, raft
 title: Administer and maintain a swarm of Docker Engines
 ---
 

--- a/engine/swarm/how-swarm-mode-works/nodes.md
+++ b/engine/swarm/how-swarm-mode-works/nodes.md
@@ -1,9 +1,8 @@
 ---
+description: How swarm nodes work
+keywords: docker, container, cluster, swarm mode, node
 redirect_from:
 - /engine/swarm/how-swarm-mode-works/
-description: How swarm nodes work
-keywords:
-- docker, container, cluster, swarm mode, node
 title: How nodes work
 ---
 

--- a/engine/swarm/how-swarm-mode-works/services.md
+++ b/engine/swarm/how-swarm-mode-works/services.md
@@ -1,7 +1,6 @@
 ---
 description: How swarm mode services work
-keywords:
-- docker, container, cluster, swarm mode, node
+keywords: docker, container, cluster, swarm mode, node
 title: How services work
 ---
 

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Engine swarm mode overview
-keywords:
-- docker, container, cluster, swarm
+keywords: docker, container, cluster, swarm
 title: Swarm mode overview
 ---
 

--- a/engine/swarm/join-nodes.md
+++ b/engine/swarm/join-nodes.md
@@ -1,7 +1,6 @@
 ---
 description: Add worker and manager nodes to a swarm
-keywords:
-- guide, swarm mode, node
+keywords: guide, swarm mode, node
 title: Join nodes to a swarm
 ---
 

--- a/engine/swarm/key-concepts.md
+++ b/engine/swarm/key-concepts.md
@@ -1,7 +1,6 @@
 ---
 description: Introducing key concepts for Docker Engine swarm mode
-keywords:
-- docker, container, cluster, swarm mode
+keywords: docker, container, cluster, swarm mode
 title: Swarm mode key concepts
 ---
 

--- a/engine/swarm/manage-nodes.md
+++ b/engine/swarm/manage-nodes.md
@@ -1,7 +1,6 @@
 ---
 description: Manage existing nodes in a swarm
-keywords:
-- guide, swarm mode, node
+keywords: guide, swarm mode, node
 title: Manage nodes in a swarm
 ---
 

--- a/engine/swarm/raft.md
+++ b/engine/swarm/raft.md
@@ -1,7 +1,6 @@
 ---
 description: Raft consensus algorithm in swarm mode
-keywords:
-- docker, container, cluster, swarm, raft
+keywords: docker, container, cluster, swarm, raft
 title: Raft consensus in swarm mode
 ---
 

--- a/engine/swarm/swarm-mode.md
+++ b/engine/swarm/swarm-mode.md
@@ -1,7 +1,6 @@
 ---
 description: Run Docker Engine in swarm mode
-keywords:
-- guide, swarm mode, node
+keywords: guide, swarm mode, node
 title: Run Docker Engine in swarm mode
 ---
 

--- a/engine/swarm/swarm-tutorial/add-nodes.md
+++ b/engine/swarm/swarm-tutorial/add-nodes.md
@@ -1,7 +1,6 @@
 ---
 description: Add nodes to the swarm
-keywords:
-- tutorial, cluster management, swarm
+keywords: tutorial, cluster management, swarm
 title: Add nodes to the swarm
 ---
 

--- a/engine/swarm/swarm-tutorial/create-swarm.md
+++ b/engine/swarm/swarm-tutorial/create-swarm.md
@@ -1,7 +1,6 @@
 ---
 description: Initialize the swarm
-keywords:
-- tutorial, cluster management, swarm mode
+keywords: tutorial, cluster management, swarm mode
 title: Create a swarm
 ---
 

--- a/engine/swarm/swarm-tutorial/delete-service.md
+++ b/engine/swarm/swarm-tutorial/delete-service.md
@@ -1,7 +1,6 @@
 ---
 description: Remove the service from the swarm
-keywords:
-- tutorial, cluster management, swarm, service
+keywords: tutorial, cluster management, swarm, service
 title: Delete the service running on the swarm
 ---
 

--- a/engine/swarm/swarm-tutorial/deploy-service.md
+++ b/engine/swarm/swarm-tutorial/deploy-service.md
@@ -1,7 +1,6 @@
 ---
 description: Deploy a service to the swarm
-keywords:
-- tutorial, cluster management, swarm mode
+keywords: tutorial, cluster management, swarm mode
 title: Deploy a service to the swarm
 ---
 

--- a/engine/swarm/swarm-tutorial/drain-node.md
+++ b/engine/swarm/swarm-tutorial/drain-node.md
@@ -1,7 +1,6 @@
 ---
 description: Drain nodes on the swarm
-keywords:
-- tutorial, cluster management, swarm, service, drain
+keywords: tutorial, cluster management, swarm, service, drain
 title: Drain a node on the swarm
 ---
 

--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -1,7 +1,6 @@
 ---
 description: Getting Started tutorial for Docker Engine swarm mode
-keywords:
-- tutorial, cluster management, swarm mode
+keywords: tutorial, cluster management, swarm mode
 title: Getting started with swarm mode
 ---
 

--- a/engine/swarm/swarm-tutorial/inspect-service.md
+++ b/engine/swarm/swarm-tutorial/inspect-service.md
@@ -1,7 +1,6 @@
 ---
 description: Inspect the application
-keywords:
-- tutorial, cluster management, swarm mode
+keywords: tutorial, cluster management, swarm mode
 title: Inspect a service on the swarm
 ---
 

--- a/engine/swarm/swarm-tutorial/rolling-update.md
+++ b/engine/swarm/swarm-tutorial/rolling-update.md
@@ -1,7 +1,6 @@
 ---
 description: Apply rolling updates to a service on the swarm
-keywords:
-- tutorial, cluster management, swarm, service, rolling-update
+keywords: tutorial, cluster management, swarm, service, rolling-update
 title: Apply rolling updates to a service
 ---
 

--- a/engine/swarm/swarm-tutorial/scale-service.md
+++ b/engine/swarm/swarm-tutorial/scale-service.md
@@ -1,7 +1,6 @@
 ---
 description: Scale the service running in the swarm
-keywords:
-- tutorial, cluster management, swarm mode, scale
+keywords: tutorial, cluster management, swarm mode, scale
 title: Scale the service in the swarm
 ---
 

--- a/engine/tutorials/dockerimages.md
+++ b/engine/tutorials/dockerimages.md
@@ -1,10 +1,9 @@
 ---
+description: How to work with Docker images.
+keywords: documentation, docs, the docker guide, docker guide, docker, docker platform, docker.io, Docker images, Docker image, image management, Docker repos, Docker repositories, docker, docker tag, docker tags, Docker Hub, collaboration
 redirect_from:
 - /engine/userguide/containers/dockerimages/
 - /engine/userguide/dockerimages/
-description: How to work with Docker images.
-keywords:
-- documentation, docs, the docker guide, docker guide, docker, docker platform, docker.io, Docker images, Docker image, image management, Docker repos, Docker repositories, docker, docker tag, docker tags, Docker Hub,  collaboration
 title: Build your own images
 ---
 

--- a/engine/tutorials/dockerizing.md
+++ b/engine/tutorials/dockerizing.md
@@ -1,10 +1,9 @@
 ---
+description: A simple 'Hello world' exercise that introduced you to Docker.
+keywords: docker guide, docker, docker platform, how to, dockerize, dockerizing apps, dockerizing applications, container, containers
 redirect_from:
 - /engine/userguide/containers/dockerizing/
 - /engine/userguide/dockerizing/
-description: A simple 'Hello world' exercise that introduced you to Docker.
-keywords:
-- docker guide, docker, docker platform, how to, dockerize, dockerizing apps, dockerizing applications, container,  containers
 title: Hello world in a container
 ---
 

--- a/engine/tutorials/dockerrepos.md
+++ b/engine/tutorials/dockerrepos.md
@@ -1,10 +1,9 @@
 ---
+description: Learn how to use the Docker Hub to manage Docker images and work flow
+keywords: repo, Docker Hub, Docker Hub, registry, index, repositories, usage, pull image, push image, image, documentation
 redirect_from:
 - /engine/userguide/containers/dockerrepos/
 - /engine/userguide/dockerrepos/
-description: Learn how to use the Docker Hub to manage Docker images and work flow
-keywords:
-- repo, Docker Hub, Docker Hub, registry, index, repositories, usage, pull image, push image, image,  documentation
 title: Store images on Docker Hub
 ---
 

--- a/engine/tutorials/dockervolumes.md
+++ b/engine/tutorials/dockervolumes.md
@@ -1,10 +1,9 @@
 ---
+description: How to manage data inside your Docker containers.
+keywords: Examples, Usage, volume, docker, documentation, user guide, data,  volumes
 redirect_from:
 - /engine/userguide/containers/dockervolumes/
 - /engine/userguide/dockervolumes/
-description: How to manage data inside your Docker containers.
-keywords:
-- Examples, Usage, volume, docker, documentation, user guide, data,  volumes
 title: Manage data in containers
 ---
 

--- a/engine/tutorials/index.md
+++ b/engine/tutorials/index.md
@@ -1,9 +1,8 @@
 ---
+description: Explains how to work with containers
+keywords: docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, home, intro
 redirect_from:
 - /engine/userguide/containers/
-description: Explains how to work with containers
-keywords:
-- docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, home,  intro
 ---
 
 # Learn by example

--- a/engine/tutorials/networkingcontainers.md
+++ b/engine/tutorials/networkingcontainers.md
@@ -1,10 +1,9 @@
 ---
+description: How to network Docker containers.
+keywords: Examples, Usage, volume, docker, documentation, user guide, data,  volumes
 redirect_from:
 - /engine/userguide/containers/networkigncontainers/
 - /engine/userguide/networkigncontainers/
-description: How to network Docker containers.
-keywords:
-- Examples, Usage, volume, docker, documentation, user guide, data,  volumes
 title: Network containers
 ---
 

--- a/engine/understanding-docker.md
+++ b/engine/understanding-docker.md
@@ -1,12 +1,11 @@
 ---
+description: Docker explained in depth
+keywords: docker, introduction, documentation, about, technology,  understanding
 redirect_from:
 - /introduction/understanding-docker/
 - /engine/userguide/basics/
 - /engine/quickstart.md
 - /engine/introduction/understanding-docker/
-description: Docker explained in depth
-keywords:
-- docker, introduction, documentation, about, technology,  understanding
 title: Docker Overview
 ---
 

--- a/engine/userguide/eng-image/baseimages.md
+++ b/engine/userguide/eng-image/baseimages.md
@@ -1,9 +1,8 @@
 ---
+description: How to create base images
+keywords: Examples, Usage, base image, docker, documentation,  examples
 redirect_from:
 - /engine/articles/baseimages/
-description: How to create base images
-keywords:
-- Examples, Usage, base image, docker, documentation,  examples
 title: Create a base image
 ---
 

--- a/engine/userguide/eng-image/dockerfile_best-practices.md
+++ b/engine/userguide/eng-image/dockerfile_best-practices.md
@@ -1,12 +1,11 @@
 ---
+description: Hints, tips and guidelines for writing clean, reliable Dockerfiles
+keywords: Examples, Usage, base image, docker, documentation, dockerfile, best practices, hub, official repo
 redirect_from:
 - /articles/dockerfile_best-practices/
 - /engine/articles/dockerfile_best-practices/
 - /docker-cloud/getting-started/intermediate/optimize-dockerfiles/
 - /docker-cloud/tutorials/optimize-dockerfiles/
-description: Hints, tips and guidelines for writing clean, reliable Dockerfiles
-keywords:
-- Examples, Usage, base image, docker, documentation, dockerfile, best practices, hub,  official repo
 title: Best practices for writing Dockerfiles
 ---
 

--- a/engine/userguide/eng-image/image_management.md
+++ b/engine/userguide/eng-image/image_management.md
@@ -3,8 +3,7 @@ alias:
 - /reference/api/hub_registry_spec/
 - /userguide/image_management/
 description: Documentation for docker Registry and Registry API
-keywords:
-- docker, registry, api,  hub
+keywords: docker, registry, api,  hub
 title: Image management
 ---
 

--- a/engine/userguide/eng-image/index.md
+++ b/engine/userguide/eng-image/index.md
@@ -1,7 +1,6 @@
 ---
 description: The Docker user guide home page
-keywords:
-- docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, home,  intro
+keywords: docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, home, intro
 title: Work with images
 ---
 

--- a/engine/userguide/index.md
+++ b/engine/userguide/index.md
@@ -1,7 +1,6 @@
 ---
 description: How to use the Docker Engine user guide
-keywords:
-- engine, introduction, documentation, about, technology, docker, user, guide, framework, home, intro
+keywords: engine, introduction, documentation, about, technology, docker, user, guide, framework, home, intro
 title: Docker Engine user guide
 ---
 

--- a/engine/userguide/intro.md
+++ b/engine/userguide/intro.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-  - /userguide/
 description: Introduction to user guide
 identifier: engine_guide_intro
-keywords:
-- docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, home,  intro
+keywords: docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, home, intro
+redirect_from:
+- /userguide/
 title: Engine user guide
 ---
 

--- a/engine/userguide/labels-custom-metadata.md
+++ b/engine/userguide/labels-custom-metadata.md
@@ -1,7 +1,6 @@
 ---
 description: Description of labels, which are used to manage metadata on Docker objects.
-keywords:
-- Usage, user guide, labels, metadata, docker, documentation, examples, annotating
+keywords: Usage, user guide, labels, metadata, docker, documentation, examples, annotating
 title: Docker object labels
 ---
 

--- a/engine/userguide/networking/configure-dns.md
+++ b/engine/userguide/networking/configure-dns.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to configure DNS in user-defined networks
-keywords:
-- docker, DNS, network
+keywords: docker, DNS, network
 title: Embedded DNS server in user-defined networks
 ---
 

--- a/engine/userguide/networking/default_network/binding.md
+++ b/engine/userguide/networking/default_network/binding.md
@@ -1,7 +1,6 @@
 ---
 description: expose, port, docker, bind publish
-keywords:
-- Examples, Usage, network, docker, documentation, user guide, multihost, cluster
+keywords: Examples, Usage, network, docker, documentation, user guide, multihost, cluster
 title: Bind container ports to the host
 ---
 

--- a/engine/userguide/networking/default_network/build-bridges.md
+++ b/engine/userguide/networking/default_network/build-bridges.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to build your own bridge interface
-keywords:
-- docker, bridge, docker0, network
+keywords: docker, bridge, docker0, network
 title: Build your own bridge
 ---
 

--- a/engine/userguide/networking/default_network/configure-dns.md
+++ b/engine/userguide/networking/default_network/configure-dns.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to configure DNS in Docker
-keywords:
-- docker, bridge, docker0, network
+keywords: docker, bridge, docker0, network
 title: Configure container DNS
 ---
 

--- a/engine/userguide/networking/default_network/container-communication.md
+++ b/engine/userguide/networking/default_network/container-communication.md
@@ -1,7 +1,6 @@
 ---
 description: Understand container communication
-keywords:
-- docker, container, communication, network
+keywords: docker, container, communication, network
 title: Understand container communication
 ---
 

--- a/engine/userguide/networking/default_network/custom-docker0.md
+++ b/engine/userguide/networking/default_network/custom-docker0.md
@@ -1,7 +1,6 @@
 ---
 description: Customizing docker0
-keywords:
-- docker, bridge, docker0, network
+keywords: docker, bridge, docker0, network
 title: Customize the docker0 bridge
 ---
 

--- a/engine/userguide/networking/default_network/dockerlinks.md
+++ b/engine/userguide/networking/default_network/dockerlinks.md
@@ -1,9 +1,8 @@
 ---
 description: Learn how to connect Docker containers together.
+keywords: Examples, Usage, user guide, links, linking, docker, documentation, examples, names, name, container naming, port, map, network port, network
 redirect_from:
-  - /userguide/dockerlinks/
-keywords:
-- Examples, Usage, user guide, links, linking, docker, documentation, examples, names, name, container naming, port, map, network port,  network
+- /userguide/dockerlinks/
 title: Legacy container links
 ---
 

--- a/engine/userguide/networking/default_network/index.md
+++ b/engine/userguide/networking/default_network/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker networking
-keywords:
-- network, networking, bridge, docker,  documentation
+keywords: network, networking, bridge, docker,  documentation
 title: Default bridge network
 ---
 

--- a/engine/userguide/networking/default_network/ipv6.md
+++ b/engine/userguide/networking/default_network/ipv6.md
@@ -1,7 +1,6 @@
 ---
 description: How do we connect docker containers within and across hosts ?
-keywords:
-- docker, network, IPv6
+keywords: docker, network, IPv6
 title: IPv6 with Docker
 ---
 

--- a/engine/userguide/networking/get-started-macvlan.md
+++ b/engine/userguide/networking/get-started-macvlan.md
@@ -1,7 +1,6 @@
 ---
 description: Use macvlan for container networking
-keywords:
-- Examples, Usage, network, docker, documentation, user guide, macvlan, cluster
+keywords: Examples, Usage, network, docker, documentation, user guide, macvlan, cluster
 title: Get started with Macvlan network driver
 ---
 

--- a/engine/userguide/networking/get-started-overlay.md
+++ b/engine/userguide/networking/get-started-overlay.md
@@ -1,7 +1,6 @@
 ---
 description: Use overlay for multi-host networking
-keywords:
-- Examples, Usage, network, docker, documentation, user guide, multihost, cluster
+keywords: Examples, Usage, network, docker, documentation, user guide, multihost, cluster
 title: Get started with multi-host networking
 ---
 

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -1,9 +1,8 @@
 ---
+description: How do we connect docker containers within and across hosts ?
+keywords: Examples, Usage, network, docker, documentation, user guide, multihost, cluster
 redirect_from:
 - /engine/userguide/networking/dockernetworks/
-description: How do we connect docker containers within and across hosts ?
-keywords:
-- Examples, Usage, network, docker, documentation, user guide, multihost, cluster
 title: Docker container networking
 ---
 

--- a/engine/userguide/networking/work-with-networks.md
+++ b/engine/userguide/networking/work-with-networks.md
@@ -1,7 +1,6 @@
 ---
 description: How to work with docker networks
-keywords:
-- commands, Usage, network, docker, cluster
+keywords: commands, Usage, network, docker, cluster
 title: Work with network commands
 ---
 

--- a/engine/userguide/storagedriver/aufs-driver.md
+++ b/engine/userguide/storagedriver/aufs-driver.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to optimize your use of AUFS driver.
-keywords:
-- 'container, storage, driver, AUFS '
+keywords: 'container, storage, driver, AUFS '
 title: Docker and AUFS in practice
 ---
 

--- a/engine/userguide/storagedriver/btrfs-driver.md
+++ b/engine/userguide/storagedriver/btrfs-driver.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to optimize your use of Btrfs driver.
-keywords:
-- 'container, storage, driver, Btrfs '
+keywords: 'container, storage, driver, Btrfs '
 title: Docker and Btrfs in practice
 ---
 

--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to optimize your use of device mapper driver.
-keywords:
-- container, storage, driver, device mapper
+keywords: container, storage, driver, device mapper
 title: Docker and the Device Mapper storage driver
 ---
 

--- a/engine/userguide/storagedriver/imagesandcontainers.md
+++ b/engine/userguide/storagedriver/imagesandcontainers.md
@@ -1,7 +1,6 @@
 ---
 description: Learn the technologies that support storage drivers.
-keywords:
-- container, storage, driver, AUFS, btfs, devicemapper,zvfs
+keywords: container, storage, driver, AUFS, btfs, devicemapper,zvfs
 title: Understand images, containers, and storage drivers
 ---
 

--- a/engine/userguide/storagedriver/index.md
+++ b/engine/userguide/storagedriver/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how select the proper storage driver for your container.
-keywords:
-- container, storage, driver, AUFS, btfs, devicemapper,zvfs
+keywords: container, storage, driver, AUFS, btfs, devicemapper,zvfs
 title: Docker storage drivers
 ---
 

--- a/engine/userguide/storagedriver/overlayfs-driver.md
+++ b/engine/userguide/storagedriver/overlayfs-driver.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to optimize your use of OverlayFS driver.
-keywords:
-- container, storage, driver, OverlayFS
+keywords: container, storage, driver, OverlayFS
 title: Docker and OverlayFS in practice
 ---
 

--- a/engine/userguide/storagedriver/selectadriver.md
+++ b/engine/userguide/storagedriver/selectadriver.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how select the proper storage driver for your container.
-keywords:
-- container, storage, driver, AUFS, btfs, devicemapper,zvfs
+keywords: container, storage, driver, AUFS, btfs, devicemapper,zvfs
 title: Select a storage driver
 ---
 

--- a/engine/userguide/storagedriver/zfs-driver.md
+++ b/engine/userguide/storagedriver/zfs-driver.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to optimize your use of ZFS driver.
-keywords:
-- 'container, storage, driver, ZFS '
+keywords: 'container, storage, driver, ZFS '
 title: Docker and ZFS in practice
 ---
 


### PR DESCRIPTION
### Proposed changes

in `/engine/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>