### PR TITLE
fix type of keywords entry in frontmatter (in /notary/)

### DIFF
--- a/notary/advanced_usage.md
+++ b/notary/advanced_usage.md
@@ -1,7 +1,6 @@
 ---
 description: Becoming a power user of the notary client.
-keywords:
-- docker, notary, notary-client, docker content trust, content trust, power user, advanced
+keywords: docker, notary, notary-client, docker content trust, content trust, power user, advanced
 title: Use the Notary client for advanced users
 ---
 

--- a/notary/changelog.md
+++ b/notary/changelog.md
@@ -1,7 +1,6 @@
 ---
 description: Notary release changelog
-keywords:
-- docker, notary, changelog, notary changelog, notary releases, releases, notary versions, versions
+keywords: docker, notary, changelog, notary changelog, notary releases, releases, notary versions, versions
 title: Notary Changelog
 ---
 

--- a/notary/getting_started.md
+++ b/notary/getting_started.md
@@ -1,7 +1,6 @@
 ---
 description: Performing basic operation to use Notary in tandem with Docker Content Trust.
-keywords:
-- docker, Notary, notary-client, docker content trust, content trust
+keywords: docker, Notary, notary-client, docker content trust, content trust
 title: Getting started with Docker Notary
 ---
 

--- a/notary/index.md
+++ b/notary/index.md
@@ -1,7 +1,6 @@
 ---
 description: List of Notary Documentation
-keywords:
-- docker, notary, trust, image, signing, repository, tuf
+keywords: docker, notary, trust, image, signing, repository, tuf
 title: Docker Notary
 ---
 

--- a/notary/running_a_service.md
+++ b/notary/running_a_service.md
@@ -1,7 +1,6 @@
 ---
 description: Run your own notary service to host arbitrary content signing.
-keywords:
-- docker, notary, notary-server, notary server, notary-signer, notary signer
+keywords: docker, notary, notary-server, notary server, notary-signer, notary signer
 title: Run a Notary service
 ---
 

--- a/notary/service_architecture.md
+++ b/notary/service_architecture.md
@@ -1,7 +1,6 @@
 ---
 description: How the three requisite notary components interact
-keywords:
-- docker, notary, notary-client, docker content trust, content trust, notary-server, notary server, notary-signer, notary signer, notary architecture
+keywords: docker, notary, notary-client, docker content trust, content trust, notary-server, notary server, notary-signer, notary signer, notary architecture
 title: Understand the Notary service architecture
 ---
 


### PR DESCRIPTION
### Proposed changes

in `/notary/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>