### PR TITLE
fix type of keywords entry in frontmatter (in /datacenter/)

### DIFF
--- a/datacenter/dtr/2.0/architecture.md
+++ b/datacenter/dtr/2.0/architecture.md
@@ -1,9 +1,8 @@
 ---
+description: Learn about the architecture of Docker Trusted Registry.
+keywords: docker, registry, dtr, architecture
 redirect_from:
 - /docker-trusted-registry/architecture/
-description: Learn about the architecture of Docker Trusted Registry.
-keywords:
-- docker, registry, dtr, architecture
 title: DTR architecture
 ---
 

--- a/datacenter/dtr/2.0/configure/config-general.md
+++ b/datacenter/dtr/2.0/configure/config-general.md
@@ -1,9 +1,8 @@
 ---
+description: Configure general settings for Docker Trusted Registry
+keywords: docker, documentation, about, technology, understanding, enterprise, hub, general, domain name, HTTP, HTTPS ports, Notary, registry
 redirect_from:
 - /docker-trusted-registry/configure/config-general/
-description: Configure general settings for Docker Trusted Registry
-keywords:
-- docker, documentation, about, technology, understanding, enterprise, hub, general, domain name, HTTP, HTTPS ports, Notary, registry
 title: Configure general settings
 ---
 

--- a/datacenter/dtr/2.0/configure/config-security.md
+++ b/datacenter/dtr/2.0/configure/config-security.md
@@ -1,9 +1,8 @@
 ---
+description: Security configuration for Docker Trusted Registry
+keywords: docker, documentation, about, technology, understanding, configuration, security, enterprise, hub, registry
 redirect_from:
 - /docker-trusted-registry/configure/config-security/
-description: Security configuration for Docker Trusted Registry
-keywords:
-- docker, documentation, about, technology, understanding, configuration, security, enterprise, hub, registry
 title: Security configuration
 ---
 

--- a/datacenter/dtr/2.0/configure/config-storage.md
+++ b/datacenter/dtr/2.0/configure/config-storage.md
@@ -1,9 +1,8 @@
 ---
+description: Storage configuration for Docker Trusted Registry
+keywords: docker, documentation, about, technology, understanding, configuration, storage, storage drivers, Azure, S3, Swift,  enterprise, hub, registry
 redirect_from:
 - /docker-trusted-registry/configure/config-storage/
-description: Storage configuration for Docker Trusted Registry
-keywords:
-- docker, documentation, about, technology, understanding, configuration, storage, storage drivers, Azure, S3, Swift,  enterprise, hub, registry
 title: Storage configuration
 ---
 

--- a/datacenter/dtr/2.0/configure/configuration.md
+++ b/datacenter/dtr/2.0/configure/configuration.md
@@ -1,9 +1,8 @@
 ---
+description: Configuration overview for Docker Trusted Registry
+keywords: docker, documentation, about, technology, understanding, enterprise, hub, registry
 redirect_from:
 - /docker-trusted-registry/configure/configuration/
-description: Configuration overview for Docker Trusted Registry
-keywords:
-- docker, documentation, about, technology, understanding, enterprise, hub,  registry
 title: Configuration overview
 ---
 

--- a/datacenter/dtr/2.0/configure/index.md
+++ b/datacenter/dtr/2.0/configure/index.md
@@ -1,7 +1,6 @@
 ---
 description: Trusted Registry configuration options
-keywords:
-- docker, documentation, about, technology, install, enterprise, hub, CS engine, Docker Trusted Registry, configure, storage, backend, drivers
+keywords: docker, documentation, about, technology, install, enterprise, hub, CS engine, Docker Trusted Registry, configure, storage, backend, drivers
 title: Configuration of Docker Trusted Registry
 ---
 

--- a/datacenter/dtr/2.0/high-availability/backups-and-disaster-recovery.md
+++ b/datacenter/dtr/2.0/high-availability/backups-and-disaster-recovery.md
@@ -1,10 +1,8 @@
 ---
+description: Learn how to backup your Docker Trusted Registry cluster, and to recover your cluster from an existing backup.
+keywords: docker, registry, high-availability, backup, recovery
 redirect_from:
 - /docker-trusted-registry/high-availability/backups-and-disaster-recovery/
-description: Learn how to backup your Docker Trusted Registry cluster, and to recover
-  your cluster from an existing backup.
-keywords:
-- docker, registry, high-availability, backup, recovery
 title: Backups and disaster recovery
 ---
 

--- a/datacenter/dtr/2.0/high-availability/index.md
+++ b/datacenter/dtr/2.0/high-availability/index.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to set up Docker Trusted Registry for high availability.
+keywords: docker, registry, high-availability, backup, recovery
 redirect_from:
 - /docker-trusted-registry/high-availability/high-availability/
-description: Learn how to set up Docker Trusted Registry for high availability.
-keywords:
-- docker, registry, high-availability, backup, recovery
 title: Set up high availability
 ---
 

--- a/datacenter/dtr/2.0/index.md
+++ b/datacenter/dtr/2.0/index.md
@@ -1,11 +1,10 @@
 ---
+description: Learn how to install, configure, and use Docker Trusted Registry.
+keywords: docker, registry, repository, images
 redirect_from:
 - /docker-hub-enterprise/
 - /docker-trusted-registry/overview/
 - /docker-trusted-registry/
-description: Learn how to install, configure, and use Docker Trusted Registry.
-keywords:
-- docker, registry, repository, images
 title: Docker Trusted Registry overview
 ---
 

--- a/datacenter/dtr/2.0/install/index.md
+++ b/datacenter/dtr/2.0/install/index.md
@@ -1,12 +1,11 @@
 ---
+description: Learn how to install Docker Trusted Registry for production.
+keywords: docker, dtr, registry, install
 redirect_from:
 - /docker-trusted-registry/install/dtr-ami-byol-launch/
 - /docker-trusted-registry/install/dtr-ami-bds-launch/
 - /docker-trusted-registry/install/dtr-vhd-azure/
 - /docker-trusted-registry/install/install-dtr/
-description: Learn how to install Docker Trusted Registry for production.
-keywords:
-- docker, dtr, registry, install
 title: Install Docker Trusted Registry
 ---
 

--- a/datacenter/dtr/2.0/install/install-dtr-offline.md
+++ b/datacenter/dtr/2.0/install/install-dtr-offline.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /docker-trusted-registry/install/install-dtr-offline/
 description: Learn how to install Docker Trusted Registry on a machine with no internet
   access.
-keywords:
-- docker, registry, install, offline
+keywords: docker, registry, install, offline
+redirect_from:
+- /docker-trusted-registry/install/install-dtr-offline/
 title: Install Docker Trusted Registry offline
 ---
 

--- a/datacenter/dtr/2.0/install/license.md
+++ b/datacenter/dtr/2.0/install/license.md
@@ -1,10 +1,9 @@
 ---
+description: Learn how to license your Docker Trusted Registry installation.
+keywords: docker, dtr, install, license
 redirect_from:
 - /docker-trusted-registry/license/
 - /docker-trusted-registry/install/license
-description: Learn how to license your Docker Trusted Registry installation.
-keywords:
-- docker, dtr, install, license
 title: License Docker Trusted Registry
 ---
 

--- a/datacenter/dtr/2.0/install/system-requirements.md
+++ b/datacenter/dtr/2.0/install/system-requirements.md
@@ -1,9 +1,8 @@
 ---
+description: Learn about the system requirements for installing Docker Trusted Registry.
+keywords: docker, DTR, architecture, requirements
 redirect_from:
 - /docker-trusted-registry/install/system-requirements/
-description: Learn about the system requirements for installing Docker Trusted Registry.
-keywords:
-- docker, DTR, architecture, requirements
 title: Docker Trusted Registry system requirements
 ---
 

--- a/datacenter/dtr/2.0/install/uninstall.md
+++ b/datacenter/dtr/2.0/install/uninstall.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to uninstall your Docker Trusted Registry installation.
+keywords: docker, dtr, install, uninstall
 redirect_from:
 - /docker-trusted-registry/install/uninstall/
-description: Learn how to uninstall your Docker Trusted Registry installation.
-keywords:
-- docker, dtr, install, uninstall
 title: Uninstall Docker Trusted Registry
 ---
 

--- a/datacenter/dtr/2.0/install/upgrade/index.md
+++ b/datacenter/dtr/2.0/install/upgrade/index.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to upgrade your Docker Trusted Registry to a new minor version or patch release.
+keywords: docker, dtr, upgrade, install
 redirect_from:
 - /docker-trusted-registry/install/upgrade/upgrade-minor/
-description: Learn how to upgrade your Docker Trusted Registry to a new minor version or patch release.
-keywords:
-- docker, dtr, upgrade, install
 title: Upgrade from 2.0.0
 ---
 

--- a/datacenter/dtr/2.0/install/upgrade/upgrade-major.md
+++ b/datacenter/dtr/2.0/install/upgrade/upgrade-major.md
@@ -1,11 +1,9 @@
 ---
+description: Learn how to upgrade your Docker Trusted Registry to the latest major release.
+keywords: docker, dtr, upgrade, install
 redirect_from:
 - /docker-trusted-registry/install/upgrade/
 - /docker-trusted-registry/upgrade/upgrade-major/
-description: Learn how to upgrade your Docker Trusted Registry to the latest major
-  release.
-keywords:
-- docker, dtr, upgrade, install
 title: Upgrade from 1.4.3
 ---
 

--- a/datacenter/dtr/2.0/monitor-troubleshoot/index.md
+++ b/datacenter/dtr/2.0/monitor-troubleshoot/index.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to monitor your DTR installation.
+keywords: docker, registry, monitor, troubleshoot
 redirect_from:
 - /docker-trusted-registry/monitor-troubleshoot/monitor/
-description: Learn how to monitor your DTR installation.
-keywords:
-- docker, registry, monitor, troubleshoot
 title: Monitor Docker Trusted Registry
 ---
 

--- a/datacenter/dtr/2.0/monitor-troubleshoot/troubleshoot.md
+++ b/datacenter/dtr/2.0/monitor-troubleshoot/troubleshoot.md
@@ -1,10 +1,9 @@
 ---
+description: Learn how to troubleshoot your DTR installation.
+keywords: docker, registry, monitor, troubleshoot
 redirect_from:
 - /docker-trusted-registry/adminguide/
 - /docker-trusted-registry/monitor/troubleshoot
-description: Learn how to troubleshoot your DTR installation.
-keywords:
-- docker, registry, monitor, troubleshoot
 title: Troubleshoot Docker Trusted Registry
 ---
 

--- a/datacenter/dtr/2.0/reference/backup.md
+++ b/datacenter/dtr/2.0/reference/backup.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry backup command reference.
-keywords:
-- docker, registry, reference, backup
+keywords: docker, registry, reference, backup
 title: docker/dtr backup
 ---
 

--- a/datacenter/dtr/2.0/reference/dumpcerts.md
+++ b/datacenter/dtr/2.0/reference/dumpcerts.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry dumpcerts command reference.
-keywords:
-- docker, registry, reference, dumpcerts
+keywords: docker, registry, reference, dumpcerts
 title: docker/dtr dumpcerts
 ---
 

--- a/datacenter/dtr/2.0/reference/images.md
+++ b/datacenter/dtr/2.0/reference/images.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry images command reference.
-keywords:
-- docker, registry, reference, images
+keywords: docker, registry, reference, images
 title: docker/dtr images
 ---
 

--- a/datacenter/dtr/2.0/reference/index.md
+++ b/datacenter/dtr/2.0/reference/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn about the options available on the docker/dtr image.
-keywords:
-- docker, dtr, install, uninstall, configure
+keywords: docker, dtr, install, uninstall, configure
 title: docker/dtr overview
 ---
 

--- a/datacenter/dtr/2.0/reference/install.md
+++ b/datacenter/dtr/2.0/reference/install.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry install command reference.
-keywords:
-- docker, registry, reference, install
+keywords: docker, registry, reference, install
 title: docker/dtr install
 ---
 

--- a/datacenter/dtr/2.0/reference/join.md
+++ b/datacenter/dtr/2.0/reference/join.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry join command reference.
-keywords:
-- docker, registry, reference, join
+keywords: docker, registry, reference, join
 title: docker/dtr join
 ---
 

--- a/datacenter/dtr/2.0/reference/migrate.md
+++ b/datacenter/dtr/2.0/reference/migrate.md
@@ -1,7 +1,6 @@
 ---
 description: Learn about the options available on the docker/dtr image.
-keywords:
-- docker, dtr, install, uninstall, configure
+keywords: docker, dtr, install, uninstall, configure
 title: docker/dtr migrate
 ---
 

--- a/datacenter/dtr/2.0/reference/reconfigure.md
+++ b/datacenter/dtr/2.0/reference/reconfigure.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry reconfigure command reference.
-keywords:
-- docker, registry, reference, reconfigure
+keywords: docker, registry, reference, reconfigure
 title: docker/dtr reconfigure
 ---
 

--- a/datacenter/dtr/2.0/reference/remove.md
+++ b/datacenter/dtr/2.0/reference/remove.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry remove command reference.
-keywords:
-- docker, registry, reference, remove
+keywords: docker, registry, reference, remove
 title: docker/dtr remove
 ---
 

--- a/datacenter/dtr/2.0/reference/restore.md
+++ b/datacenter/dtr/2.0/reference/restore.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry restore command reference.
-keywords:
-- docker, registry, restore, backup
+keywords: docker, registry, restore, backup
 title: docker/dtr restore
 ---
 

--- a/datacenter/dtr/2.0/reference/upgrade.md
+++ b/datacenter/dtr/2.0/reference/upgrade.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry upgrade command reference.
-keywords:
-- docker, registry, restore, upgrade
+keywords: docker, registry, restore, upgrade
 title: docker/dtr upgrade
 ---
 

--- a/datacenter/dtr/2.0/release-notes/index.md
+++ b/datacenter/dtr/2.0/release-notes/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Trusted Registry release notes
-keywords:
-- docker, documentation, about, technology, understanding, enterprise, hub, registry, release notes, Docker Trusted Registry
+keywords: docker, documentation, about, technology, understanding, enterprise, hub, registry, release notes, Docker Trusted Registry
 title: Docker Trusted Registry release notes
 ---
 

--- a/datacenter/dtr/2.0/release-notes/prior-release-notes.md
+++ b/datacenter/dtr/2.0/release-notes/prior-release-notes.md
@@ -1,10 +1,9 @@
 ---
+description: Archived release notes for Docker Trusted Registry
+keywords: docker, documentation, about, technology, understanding, enterprise, hub, registry, Docker Trusted Registry, release
 redirect_from:
 - /docker-trusted-registry/prior-release-notes/
 - /docker-trusted-registry/release-notes/prior-release-notes/
-description: Archived release notes for Docker Trusted Registry
-keywords:
-- docker, documentation, about, technology, understanding, enterprise, hub, registry, Docker Trusted Registry, release
 title: DTR release notes archive
 ---
 

--- a/datacenter/dtr/2.0/repos-and-images/delete-an-image.md
+++ b/datacenter/dtr/2.0/repos-and-images/delete-an-image.md
@@ -1,11 +1,10 @@
 ---
+description: Learn how to delete images from your repositories on Docker Trusted Registry.
+keywords: docker, registry, repository, delete, image
 redirect_from:
 - /docker-trusted-registry/soft-garbage/
 - /docker-trusted-registry/repos-and-images/delete-images/
 - /docker-trusted-registry/repos-and-images/delete-an-image/
-description: Learn how to delete images from your repositories on Docker Trusted Registry.
-keywords:
-- docker, registry, repository, delete, image
 title: Delete an image
 ---
 

--- a/datacenter/dtr/2.0/repos-and-images/index.md
+++ b/datacenter/dtr/2.0/repos-and-images/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to configure your Docker Engine to push and pull images from Docker Trusted Registry.
-keywords:
-- docker, registry, TLS, certificates
+keywords: docker, registry, TLS, certificates
 title: Configure your Docker Engine
 ---
 

--- a/datacenter/dtr/2.0/repos-and-images/pull-an-image.md
+++ b/datacenter/dtr/2.0/repos-and-images/pull-an-image.md
@@ -1,10 +1,9 @@
 ---
+description: Learn how to pull an image from Docker Trusted Registry.
+keywords: docker, registry, images, pull
 redirect_from:
 - /docker-trusted-registry/quick-start/
 - /docker-trusted-registry/repos-and-images/pull-an-image/
-description: Learn how to pull an image from Docker Trusted Registry.
-keywords:
-- docker, registry, images, pull
 title: Pull an image from DTR
 ---
 

--- a/datacenter/dtr/2.0/repos-and-images/push-an-image.md
+++ b/datacenter/dtr/2.0/repos-and-images/push-an-image.md
@@ -1,12 +1,11 @@
 ---
+description: Learn how to push an image to Docker Trusted Registry.
+keywords: docker, registry, images, pull
 redirect_from:
 - /docker-trusted-registry/repos-and-images/create-repo/
 - /docker-trusted-registry/userguide/
 - /docker-trusted-registry/repos-and-images/push-and-pull-images/
 - /docker-trusted-registry/repos-and-images/push-an-image/
-description: Learn how to push an image to Docker Trusted Registry.
-keywords:
-- docker, registry, images, pull
 title: Push an image to DTR
 ---
 

--- a/datacenter/dtr/2.0/user-management/create-and-manage-orgs.md
+++ b/datacenter/dtr/2.0/user-management/create-and-manage-orgs.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /docker-trusted-registry/user-management/create-and-manage-orgs/
 description: Learn how to set up organizations to enforce security in Docker Trusted
   Registry.
-keywords:
-- docker, registry, security, permissions, organizations
+keywords: docker, registry, security, permissions, organizations
+redirect_from:
+- /docker-trusted-registry/user-management/create-and-manage-orgs/
 title: Create and manage organizations
 ---
 

--- a/datacenter/dtr/2.0/user-management/create-and-manage-teams.md
+++ b/datacenter/dtr/2.0/user-management/create-and-manage-teams.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /docker-trusted-registry/user-management/create-and-manage-teams/
 description: Learn how to manage teams to enforce fine-grain access control in Docker
   Trusted Registry.
-keywords:
-- docker, registry, security, permissions, teams
+keywords: docker, registry, security, permissions, teams
+redirect_from:
+- /docker-trusted-registry/user-management/create-and-manage-teams/
 title: Create and manage teams
 ---
 

--- a/datacenter/dtr/2.0/user-management/create-and-manage-users.md
+++ b/datacenter/dtr/2.0/user-management/create-and-manage-users.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to manage user permissions in Docker Trusted Registry.
+keywords: docker, registry, security, permissions, users
 redirect_from:
 - /docker-trusted-registry/user-management/create-and-manage-users/
-description: Learn how to manage user permissions in Docker Trusted Registry.
-keywords:
-- docker, registry, security, permissions, users
 title: Create and manage users
 ---
 

--- a/datacenter/dtr/2.0/user-management/index.md
+++ b/datacenter/dtr/2.0/user-management/index.md
@@ -1,9 +1,8 @@
 ---
+description: Learn about the permission levels available on Docker Trusted Registry.
+keywords: docker, registry, security, permissions, users
 redirect_from:
 - /docker-trusted-registry/accounts/
-description: Learn about the permission levels available on Docker Trusted Registry.
-keywords:
-- docker, registry, security, permissions, users
 title: Authentication and authorization
 ---
 

--- a/datacenter/dtr/2.0/user-management/permission-levels.md
+++ b/datacenter/dtr/2.0/user-management/permission-levels.md
@@ -1,9 +1,8 @@
 ---
+description: Learn about the permission levels available in Docker Trusted Registry.
+keywords: docker, registry, security, permissions
 redirect_from:
 - /docker-trusted-registry/user-management/permission-levels/
-description: Learn about the permission levels available in Docker Trusted Registry.
-keywords:
-- docker, registry, security, permissions
 title: Permission levels
 ---
 

--- a/datacenter/ucp/1.1/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/1.1/access-ucp/cli-based-access.md
@@ -1,10 +1,9 @@
 ---
 description: Learn how to access Docker Universal Control Plane from the CLI.
-keywords:
-- docker, ucp, cli, administration
-title: CLI-based access
+keywords: docker, ucp, cli, administration
 redirect_from:
 - /ucp/access-ucp/cli-based-access/
+title: CLI-based access
 ---
 
 Docker UCP secures your cluster with role-based access control, so that only

--- a/datacenter/ucp/1.1/access-ucp/index.md
+++ b/datacenter/ucp/1.1/access-ucp/index.md
@@ -1,8 +1,7 @@
 ---
 description: Learn how to access Docker Universal Control Plane from the web and the
   CLI.
-keywords:
-- docker, ucp, cli
+keywords: docker, ucp, cli
 title: Access UCP
 ---
 

--- a/datacenter/ucp/1.1/access-ucp/web-based-access.md
+++ b/datacenter/ucp/1.1/access-ucp/web-based-access.md
@@ -1,10 +1,9 @@
 ---
 description: Learn how to access Docker Universal Control Plane from the web browser.
-keywords:
-- docker, ucp, web, administration
-title: Web-based access
+keywords: docker, ucp, web, administration
 redirect_from:
 - /ucp/access-ucp/web-based-access/
+title: Web-based access
 ---
 
 Docker Universal Control Plane allows you to manage your cluster in a visual

--- a/datacenter/ucp/1.1/applications/deploy-app-cli.md
+++ b/datacenter/ucp/1.1/applications/deploy-app-cli.md
@@ -1,11 +1,9 @@
 ---
+description: Learn how to deploy containerized applications on a cluster, with Docker Universal Control Plane.
+keywords: deploy, application
 redirect_from:
 - /ucp/deploy-application/
 - /ucp/applications/deploy-app-cli/
-description: Learn how to deploy containerized applications on a cluster, with Docker
-  Universal Control Plane.
-keywords:
-- deploy, application
 title: Deploy an app from the CLI
 ---
 

--- a/datacenter/ucp/1.1/applications/deploy-app-ui.md
+++ b/datacenter/ucp/1.1/applications/deploy-app-ui.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/applications/deploy-app-ui/
 description: Learn how to deploy containerized applications on a cluster, with Docker
   Universal Control Plane.
-keywords:
-- ucp, deploy, application
+keywords: ucp, deploy, application
+redirect_from:
+- /ucp/applications/deploy-app-ui/
 title: Deploy an app from the UI
 ---
 

--- a/datacenter/ucp/1.1/applications/index.md
+++ b/datacenter/ucp/1.1/applications/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to manage applications on  Docker Universal Control Plane.
-keywords:
-- docker, ucp, apps, management
+keywords: docker, ucp, apps, management
 title: UCP applications
 ---
 

--- a/datacenter/ucp/1.1/architecture.md
+++ b/datacenter/ucp/1.1/architecture.md
@@ -1,9 +1,8 @@
 ---
+description: Learn about the architecture of Docker Universal Control Plane.
+keywords: docker, ucp, architecture
 redirect_from:
 - /ucp/architecture/
-description: Learn about the architecture of Docker Universal Control Plane.
-keywords:
-- docker, ucp, architecture
 title: UCP architecture
 ---
 

--- a/datacenter/ucp/1.1/configuration/configure-logs.md
+++ b/datacenter/ucp/1.1/configuration/configure-logs.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/configuration/configure-logs/
 description: Learn how to configure Docker Universal Control Plane to store your logs
   on an external log system.
-keywords:
-- docker, ucp, integrate, logs
+keywords: docker, ucp, integrate, logs
+redirect_from:
+- /ucp/configuration/configure-logs/
 title: Configure UCP logging
 ---
 

--- a/datacenter/ucp/1.1/configuration/dtr-integration.md
+++ b/datacenter/ucp/1.1/configuration/dtr-integration.md
@@ -1,10 +1,9 @@
 ---
+description: Integrate UCP with Docker Trusted Registry
+keywords: trusted, registry, integrate, UCP, DTR
 redirect_from:
 - /ucp/dtr-integration/
 - /ucp/configuration/dtr-integration/
-description: Integrate UCP with Docker Trusted Registry
-keywords:
-- trusted, registry, integrate, UCP, DTR
 title: Integrate with Docker Trusted Registry
 ---
 

--- a/datacenter/ucp/1.1/configuration/index.md
+++ b/datacenter/ucp/1.1/configuration/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to configure Docker Universal Control Plane on production.
-keywords:
-- docker, ucp, install, configuration
+keywords: docker, ucp, install, configuration
 title: UCP configuration
 ---
 

--- a/datacenter/ucp/1.1/configuration/ldap-integration.md
+++ b/datacenter/ucp/1.1/configuration/ldap-integration.md
@@ -1,11 +1,9 @@
 ---
+description: Learn how to integrate UCP with an LDAP service, so that you can manage users from a single place.
+keywords: LDAP, authentication, user management
 redirect_from:
 - /docker-trusted-registry/configure/config-auth/
 - /ucp/configuration/ldap-integration/
-description: Learn how to integrate UCP with an LDAP service, so that you can manage
-  users from a single place.
-keywords:
-- LDAP, authentication, user management
 title: Integrate with LDAP
 ---
 

--- a/datacenter/ucp/1.1/configuration/multi-host-networking.md
+++ b/datacenter/ucp/1.1/configuration/multi-host-networking.md
@@ -1,10 +1,9 @@
 ---
+description: Docker Universal Control Plane
+keywords: networking, kv, engine-discovery, ucp
 redirect_from:
 - /ucp/networking/
 - /ucp/configuration/multi-host-networking/
-description: Docker Universal Control Plane
-keywords:
-- networking, kv, engine-discovery, ucp
 title: Enable container networking with UCP
 ---
 

--- a/datacenter/ucp/1.1/configuration/use-externally-signed-certs.md
+++ b/datacenter/ucp/1.1/configuration/use-externally-signed-certs.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/configuration/use-externally-signed-certs/
 description: Learn how to configure Docker Universal Control Plane to use your own
   certificates.
-keywords:
-- Universal Control Plane, UCP, certificate, authentiation, tls
+keywords: Universal Control Plane, UCP, certificate, authentiation, tls
+redirect_from:
+- /ucp/configuration/use-externally-signed-certs/
 title: Use externally-signed certificates
 ---
 

--- a/datacenter/ucp/1.1/high-availability/backups-and-disaster-recovery.md
+++ b/datacenter/ucp/1.1/high-availability/backups-and-disaster-recovery.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/high-availability/backups-and-disaster-recovery/
 description: Learn how to backup your Docker Universal Control Plane cluster, and
   to recover your cluster from an existing backup.
-keywords:
-- docker, ucp, backup, restore, recovery
+keywords: docker, ucp, backup, restore, recovery
+redirect_from:
+- /ucp/high-availability/backups-and-disaster-recovery/
 title: Backups and disaster recovery
 ---
 

--- a/datacenter/ucp/1.1/high-availability/index.md
+++ b/datacenter/ucp/1.1/high-availability/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to set up Docker Universal Control Plane for high availability.
-keywords:
-- docker, ucp, high-availability, backup, recovery
+keywords: docker, ucp, high-availability, backup, recovery
 title: Configure UCP for high availability
 ---
 

--- a/datacenter/ucp/1.1/high-availability/replicate-cas.md
+++ b/datacenter/ucp/1.1/high-availability/replicate-cas.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/high-availability/replicate-cas/
 description: Docker Universal Control plane has support for high availability. Learn
   how to set up your installation to ensure it tolerates failures.
-keywords:
-- replica, controller, availability, high, ucp
+keywords: replica, controller, availability, high, ucp
+redirect_from:
+- /ucp/high-availability/replicate-cas/
 title: Replicate CAs for high availability
 ---
 

--- a/datacenter/ucp/1.1/high-availability/set-up-high-availability.md
+++ b/datacenter/ucp/1.1/high-availability/set-up-high-availability.md
@@ -1,11 +1,9 @@
 ---
+description: Docker Universal Control plane has support for high availability. Learn how to set up your installation to ensure it tolerates failures.
+keywords: docker, ucp, high-availability, replica
 redirect_from:
 - /ucp/understand_ha/
 - /ucp/high-availability/set-up-high-availability/
-description: Docker Universal Control plane has support for high availability. Learn
-  how to set up your installation to ensure it tolerates failures.
-keywords:
-- docker, ucp, high-availability, replica
 title: Set up high availability
 ---
 

--- a/datacenter/ucp/1.1/index.md
+++ b/datacenter/ucp/1.1/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Universal Control Plane
-keywords:
-- universal, control, plane, ucp
+keywords: universal, control, plane, ucp
 title: Docker Universal Control Plane
 ---
 

--- a/datacenter/ucp/1.1/installation/index.md
+++ b/datacenter/ucp/1.1/installation/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn the requirements and procedure to install Docker Universal Control Plane on production.
-keywords:
-- docker, ucp, install, requirements
+keywords: docker, ucp, install, requirements
 title: Install UCP
 ---
 

--- a/datacenter/ucp/1.1/installation/install-offline.md
+++ b/datacenter/ucp/1.1/installation/install-offline.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/installation/install-offline/
 description: Learn how to install Docker Universal Control Plane. on a machine with
   no internet access.
-keywords:
-- docker, ucp, install, offline
+keywords: docker, ucp, install, offline
+redirect_from:
+- /ucp/installation/install-offline/
 title: Install UCP offline
 ---
 

--- a/datacenter/ucp/1.1/installation/install-production.md
+++ b/datacenter/ucp/1.1/installation/install-production.md
@@ -1,10 +1,9 @@
 ---
+description: Learn how to install Docker Universal Control Plane on production
+keywords: Universal Control Plane, UCP, install
 redirect_from:
 - /ucp/production-install/
 - /ucp/installation/install-production/
-description: Learn how to install Docker Universal Control Plane on production
-keywords:
-- Universal Control Plane, UCP, install
 title: Install UCP for production
 ---
 

--- a/datacenter/ucp/1.1/installation/license.md
+++ b/datacenter/ucp/1.1/installation/license.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to license your Docker Universal Control Plane installation.
+keywords: Universal Control Plane, UCP, install, license
 redirect_from:
 - /ucp/installation/license/
-description: Learn how to license your Docker Universal Control Plane installation.
-keywords:
-- Universal Control Plane, UCP, install, license
 title: License UCP
 ---
 

--- a/datacenter/ucp/1.1/installation/plan-production-install.md
+++ b/datacenter/ucp/1.1/installation/plan-production-install.md
@@ -1,11 +1,9 @@
 ---
+description: Learn about the Docker Universal Control Plane architecture, and the requirements to install it on production.
+keywords: docker, ucp, install, checklist
 redirect_from:
 - /ucp/plan-production-install/
 - /ucp/installation/plan-production-install/
-description: Learn about the Docker Universal Control Plane architecture, and the
-  requirements to install it on production.
-keywords:
-- docker, ucp, install, checklist
 title: Plan a production installation
 ---
 

--- a/datacenter/ucp/1.1/installation/system-requirements.md
+++ b/datacenter/ucp/1.1/installation/system-requirements.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/installation/system-requirements/
 description: Learn about the system requirements for installing Docker Universal Control
   Plane.
-keywords:
-- docker, ucp, architecture, requirements
+keywords: docker, ucp, architecture, requirements
+redirect_from:
+- /ucp/installation/system-requirements/
 title: UCP System requirements
 ---
 

--- a/datacenter/ucp/1.1/installation/uninstall.md
+++ b/datacenter/ucp/1.1/installation/uninstall.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to uninstall a Docker Universal Control Plane cluster.
+keywords: docker, ucp, uninstall
 redirect_from:
 - /ucp/installation/uninstall/
-description: Learn how to uninstall a Docker Universal Control Plane cluster.
-keywords:
-- docker, ucp, uninstall
 title: Uninstall UCP
 ---
 

--- a/datacenter/ucp/1.1/installation/upgrade.md
+++ b/datacenter/ucp/1.1/installation/upgrade.md
@@ -1,8 +1,7 @@
 ---
 description: Learn how to upgrade Docker Universal Control Plane with minimal impact
   to your users.
-keywords:
-- Docker, UCP, upgrade, update
+keywords: Docker, UCP, upgrade, update
 title: Upgrade UCP
 ---
 

--- a/datacenter/ucp/1.1/monitor/index.md
+++ b/datacenter/ucp/1.1/monitor/index.md
@@ -1,9 +1,8 @@
 ---
+description: Manage, monitor, troubleshoot
+keywords: manage, monitor, troubleshoot
 redirect_from:
 - /ucp/manage/
-description: Manage, monitor, troubleshoot
-keywords:
-- manage, monitor, troubleshoot
 title: Monitor and troubleshoot UCP
 ---
 

--- a/datacenter/ucp/1.1/monitor/monitor-ucp.md
+++ b/datacenter/ucp/1.1/monitor/monitor-ucp.md
@@ -1,11 +1,9 @@
 ---
+description: Monitor your Docker Universal Control Plane installation, and learn how to troubleshoot it.
+keywords: Docker, UCP, troubleshoot
 redirect_from:
 - /ucp/manage/monitor-ucp/
 - /ucp/monitor/monitor-ucp/
-description: Monitor your Docker Universal Control Plane installation, and learn how
-  to troubleshoot it.
-keywords:
-- Docker, UCP, troubleshoot
 title: Monitor your cluster
 ---
 

--- a/datacenter/ucp/1.1/monitor/troubleshoot-configurations.md
+++ b/datacenter/ucp/1.1/monitor/troubleshoot-configurations.md
@@ -1,10 +1,9 @@
 ---
+description: Learn how to troubleshoot your Docker Universal Control Plane cluster.
+keywords: ectd, key, value, store, ucp
 redirect_from:
 - /ucp/kv_store/
 - /ucp/monitor/troubleshoot-configurations/
-description: Learn how to troubleshoot your Docker Universal Control Plane cluster.
-keywords:
-- ectd, key, value, store, ucp
 title: Troubleshoot cluster configurations
 ---
 

--- a/datacenter/ucp/1.1/monitor/troubleshoot-ucp.md
+++ b/datacenter/ucp/1.1/monitor/troubleshoot-ucp.md
@@ -1,9 +1,8 @@
 ---
+description: Learn how to troubleshoot your Docker Universal Control Plane cluster.
+keywords: docker, ucp, troubleshoot
 redirect_from:
 - /ucp/monitor/troubleshoot-ucp/
-description: Learn how to troubleshoot your Docker Universal Control Plane cluster.
-keywords:
-- docker, ucp, troubleshoot
 title: Troubleshoot your cluster
 ---
 

--- a/datacenter/ucp/1.1/overview.md
+++ b/datacenter/ucp/1.1/overview.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/overview/
 description: Learn about Docker Universal Control Plane, the enterprise-grade cluster
   management solution from Docker.
-keywords:
-- docker, ucp, overview, orchestration, clustering
+keywords: docker, ucp, overview, orchestration, clustering
+redirect_from:
+- /ucp/overview/
 title: Universal Control Plane overview
 ---
 

--- a/datacenter/ucp/1.1/reference/backup.md
+++ b/datacenter/ucp/1.1/reference/backup.md
@@ -1,7 +1,6 @@
 ---
 description: Stream a tar file to stdout containing all UCP data volumes.
-keywords:
-- docker, ucp, backup, restore
+keywords: docker, ucp, backup, restore
 title: docker/ucp backup
 ---
 

--- a/datacenter/ucp/1.1/reference/dump-certs.md
+++ b/datacenter/ucp/1.1/reference/dump-certs.md
@@ -1,7 +1,6 @@
 ---
 description: Dump out public certificates
-keywords:
-- dump-certs, ucp
+keywords: dump-certs, ucp
 title: docker/ucp dump-certs
 ---
 

--- a/datacenter/ucp/1.1/reference/engine-discovery.md
+++ b/datacenter/ucp/1.1/reference/engine-discovery.md
@@ -1,7 +1,6 @@
 ---
 description: Manage the engine discovery configuration on a node.
-keywords:
-- docker, ucp, discovery
+keywords: docker, ucp, discovery
 title: docker/ucp engine-discovery
 ---
 

--- a/datacenter/ucp/1.1/reference/fingerprint.md
+++ b/datacenter/ucp/1.1/reference/fingerprint.md
@@ -1,7 +1,6 @@
 ---
 description: Dump out TLS certificates.
-keywords:
-- fingerprint, ucp, tool, reference, ucp
+keywords: fingerprint, ucp, tool, reference, ucp
 title: docker/ucp fingerprint
 ---
 

--- a/datacenter/ucp/1.1/reference/help.md
+++ b/datacenter/ucp/1.1/reference/help.md
@@ -1,7 +1,6 @@
 ---
 description: Shows a list of available commands for Docker Universal Control Plane.
-keywords:
-- help, ucp
+keywords: help, ucp
 title: docker/ucp help
 ---
 

--- a/datacenter/ucp/1.1/reference/id.md
+++ b/datacenter/ucp/1.1/reference/id.md
@@ -1,7 +1,6 @@
 ---
 description: Dump out the ID of the UCP components running on this engine.
-keywords:
-- docker, ucp, id
+keywords: docker, ucp, id
 title: docker/ucp id
 ---
 

--- a/datacenter/ucp/1.1/reference/images.md
+++ b/datacenter/ucp/1.1/reference/images.md
@@ -1,7 +1,6 @@
 ---
 description: Verify the UCP images on this Docker Engine.
-keywords:
-- images, ucp, images
+keywords: images, ucp, images
 title: docker/ucp images
 ---
 

--- a/datacenter/ucp/1.1/reference/index.md
+++ b/datacenter/ucp/1.1/reference/index.md
@@ -1,7 +1,6 @@
 ---
 description: Installs Docker Universal Control Plane.
-keywords:
-- docker, ucp, install
+keywords: docker, ucp, install
 title: UCP tool reference
 ---
 

--- a/datacenter/ucp/1.1/reference/install.md
+++ b/datacenter/ucp/1.1/reference/install.md
@@ -1,7 +1,6 @@
 ---
 description: Install Docker Universal Control Plane.
-keywords:
-- install, ucp
+keywords: install, ucp
 title: docker/ucp install
 ---
 

--- a/datacenter/ucp/1.1/reference/join.md
+++ b/datacenter/ucp/1.1/reference/join.md
@@ -1,7 +1,6 @@
 ---
 description: Joins a node to an existing Docker Universal Control Plane cluster.
-keywords:
-- join, ucp
+keywords: join, ucp
 title: docker/ucp join
 ---
 

--- a/datacenter/ucp/1.1/reference/regen-certs.md
+++ b/datacenter/ucp/1.1/reference/regen-certs.md
@@ -1,7 +1,6 @@
 ---
 description: Regenerate certificates for Docker Universal Control Plane.
-keywords:
-- install, ucp
+keywords: install, ucp
 title: docker/ucp regen-certs
 ---
 

--- a/datacenter/ucp/1.1/reference/restart.md
+++ b/datacenter/ucp/1.1/reference/restart.md
@@ -1,7 +1,6 @@
 ---
 description: Restart Docker Universal Control Plane containers.
-keywords:
-- install, ucp, restart
+keywords: install, ucp, restart
 title: docker/ucp restart
 ---
 

--- a/datacenter/ucp/1.1/reference/restore.md
+++ b/datacenter/ucp/1.1/reference/restore.md
@@ -1,7 +1,6 @@
 ---
 description: Stream a tar file on stdin containing all local UCP data volumes.
-keywords:
-- docker, ucp, backup, restore
+keywords: docker, ucp, backup, restore
 title: docker/ucp restore
 ---
 

--- a/datacenter/ucp/1.1/reference/stop.md
+++ b/datacenter/ucp/1.1/reference/stop.md
@@ -1,7 +1,6 @@
 ---
 description: Stop Docker Universal Control Plane containers.
-keywords:
-- install, ucp, stop
+keywords: install, ucp, stop
 title: docker/ucp stop
 ---
 

--- a/datacenter/ucp/1.1/reference/support.md
+++ b/datacenter/ucp/1.1/reference/support.md
@@ -1,7 +1,6 @@
 ---
 description: Generate a support dump for this engine.
-keywords:
-- docker, ucp, support, logs
+keywords: docker, ucp, support, logs
 title: docker/ucp support
 ---
 

--- a/datacenter/ucp/1.1/reference/uninstall.md
+++ b/datacenter/ucp/1.1/reference/uninstall.md
@@ -1,7 +1,6 @@
 ---
 description: Uninstall a UCP controller and nodes
-keywords:
-- uninstall, ucp
+keywords: uninstall, ucp
 title: docker/ucp uninstall
 ---
 

--- a/datacenter/ucp/1.1/reference/upgrade.md
+++ b/datacenter/ucp/1.1/reference/upgrade.md
@@ -1,7 +1,6 @@
 ---
 description: Upgrade Docker Universal Control Plane.
-keywords:
-- docker, ucp, upgrade
+keywords: docker, ucp, upgrade
 title: docker/ucp upgrade
 ---
 

--- a/datacenter/ucp/1.1/user-management/authentication-and-authorization.md
+++ b/datacenter/ucp/1.1/user-management/authentication-and-authorization.md
@@ -1,11 +1,10 @@
 ---
+description: Learn how to manage permissions in Docker Universal Control Plane.
+keywords: authorization, authentication, users, teams, UCP
 redirect_from:
 - /ucp/manage/monitor-manage-users/
 - /ucp/user-management/manage-users/
 - /ucp/user-management/authentication-and-authorization/
-description: Learn how to manage permissions in Docker Universal Control Plane.
-keywords:
-- authorization, authentication, users, teams, UCP
 title: Authentication and authorization
 ---
 

--- a/datacenter/ucp/1.1/user-management/create-and-manage-teams.md
+++ b/datacenter/ucp/1.1/user-management/create-and-manage-teams.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/user-management/create-and-manage-teams/
 description: Learn how to create and manage user permissions, using teams in your
   Docker Universal Control Plane cluster.
-keywords:
-- authorize, authentication, users, teams, UCP, Docker
+keywords: authorize, authentication, users, teams, UCP, Docker
+redirect_from:
+- /ucp/user-management/create-and-manage-teams/
 title: Create and manage teams
 ---
 

--- a/datacenter/ucp/1.1/user-management/create-and-manage-users.md
+++ b/datacenter/ucp/1.1/user-management/create-and-manage-users.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/user-management/create-and-manage-users/
 description: Learn how to create and manage users in your Docker Universal Control
   Plane cluster.
-keywords:
-- authorize, authentication, users, teams, UCP, Docker
+keywords: authorize, authentication, users, teams, UCP, Docker
+redirect_from:
+- /ucp/user-management/create-and-manage-users/
 title: Create and manage users
 ---
 

--- a/datacenter/ucp/1.1/user-management/index.md
+++ b/datacenter/ucp/1.1/user-management/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to manage user permissions on  Docker Universal Control Plane.
-keywords:
-- docker, ucp, management, security, users
+keywords: docker, ucp, management, security, users
 title: Manage users in UCP
 ---
 

--- a/datacenter/ucp/1.1/user-management/permission-levels.md
+++ b/datacenter/ucp/1.1/user-management/permission-levels.md
@@ -1,10 +1,9 @@
 ---
-redirect_from:
-- /ucp/user-management/permission-levels/
 description: Learn about the permission levels available in Docker Universal Control
   Plane.
-keywords:
-- authorization, authentication, users, teams, UCP
+keywords: authorization, authentication, users, teams, UCP
+redirect_from:
+- /ucp/user-management/permission-levels/
 title: Permission levels
 ---
 


### PR DESCRIPTION
### Proposed changes

in `/datacenter/` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>