### PR TITLE
fix type of keywords entry in frontmatter (in /machine/ and index.md)

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,9 +1,8 @@
 ---
 description: Home page for Docker's documentation
-keywords:
-- Docker, documentation, manual, guide, reference, api
-title: Welcome to the Docs
+keywords: Docker, documentation, manual, guide, reference, api
 layout: docs
+title: Welcome to the Docs
 ---
 
 {% include content/docker_elevator_pitch.md %}

--- a/machine/DRIVER_SPEC.md
+++ b/machine/DRIVER_SPEC.md
@@ -1,8 +1,7 @@
 ---
 description: machine
+keywords: machine, orchestration, install, installation, docker, documentation
 published: false
-keywords:
-- machine, orchestration, install, installation, docker, documentation
 title: Machine driver specification v1
 ---
 

--- a/machine/completion.md
+++ b/machine/completion.md
@@ -1,7 +1,6 @@
 ---
 description: Install Machine command-line completion
-keywords:
-- machine, docker, orchestration, cli,  reference
+keywords: machine, docker, orchestration, cli,  reference
 title: Command-line completion
 ---
 

--- a/machine/concepts.md
+++ b/machine/concepts.md
@@ -1,7 +1,6 @@
 ---
 description: Understand concepts for Docker Machine, including drivers, base OS, IP addresses, environment variables
-keywords:
-- docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
+keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
 title: Machine concepts and getting help
 ---
 

--- a/machine/drivers/aws.md
+++ b/machine/drivers/aws.md
@@ -1,7 +1,6 @@
 ---
 description: Amazon Web Services driver for machine
-keywords:
-- machine, Amazon Web Services, driver
+keywords: machine, Amazon Web Services, driver
 title: Amazon Web Services
 ---
 

--- a/machine/drivers/azure.md
+++ b/machine/drivers/azure.md
@@ -1,7 +1,6 @@
 ---
 description: Microsoft Azure driver for machine
-keywords:
-- machine, Microsoft Azure, driver
+keywords: machine, Microsoft Azure, driver
 title: Microsoft Azure
 ---
 

--- a/machine/drivers/digital-ocean.md
+++ b/machine/drivers/digital-ocean.md
@@ -1,7 +1,6 @@
 ---
 description: Digital Ocean driver for machine
-keywords:
-- machine, Digital Ocean, driver
+keywords: machine, Digital Ocean, driver
 title: Digital Ocean
 ---
 

--- a/machine/drivers/exoscale.md
+++ b/machine/drivers/exoscale.md
@@ -1,7 +1,6 @@
 ---
 description: Exoscale driver for machine
-keywords:
-- machine, exoscale, driver
+keywords: machine, exoscale, driver
 title: Exoscale
 ---
 

--- a/machine/drivers/gce.md
+++ b/machine/drivers/gce.md
@@ -1,7 +1,6 @@
 ---
 description: Google Compute Engine driver for machine
-keywords:
-- machine, Google Compute Engine, driver
+keywords: machine, Google Compute Engine, driver
 title: Google Compute Engine
 ---
 

--- a/machine/drivers/generic.md
+++ b/machine/drivers/generic.md
@@ -1,7 +1,6 @@
 ---
 description: Generic driver for machine
-keywords:
-- machine, Generic, driver
+keywords: machine, Generic, driver
 title: Generic
 ---
 

--- a/machine/drivers/hyper-v.md
+++ b/machine/drivers/hyper-v.md
@@ -1,7 +1,6 @@
 ---
 description: Microsoft Hyper-V driver for machine
-keywords:
-- machine, Microsoft Hyper-V, driver
+keywords: machine, Microsoft Hyper-V, driver
 title: Microsoft Hyper-V
 ---
 

--- a/machine/drivers/index.md
+++ b/machine/drivers/index.md
@@ -1,7 +1,6 @@
 ---
 description: Reference for drivers Docker Machine supports
-keywords:
-- machine, drivers, supports
+keywords: machine, drivers, supports
 title: Drivers
 ---
 

--- a/machine/drivers/openstack.md
+++ b/machine/drivers/openstack.md
@@ -1,7 +1,6 @@
 ---
 description: OpenStack driver for machine
-keywords:
-- machine, OpenStack, driver
+keywords: machine, OpenStack, driver
 title: OpenStack
 ---
 

--- a/machine/drivers/os-base.md
+++ b/machine/drivers/os-base.md
@@ -1,7 +1,6 @@
 ---
 description: Identify active machines
-keywords:
-- machine, driver, base, operating system
+keywords: machine, driver, base, operating system
 title: Driver options and operating system defaults
 ---
 

--- a/machine/drivers/rackspace.md
+++ b/machine/drivers/rackspace.md
@@ -1,7 +1,6 @@
 ---
 description: Rackspace driver for machine
-keywords:
-- machine, Rackspace, driver
+keywords: machine, Rackspace, driver
 title: Rackspace
 ---
 

--- a/machine/drivers/soft-layer.md
+++ b/machine/drivers/soft-layer.md
@@ -1,7 +1,6 @@
 ---
 description: IBM Softlayer driver for machine
-keywords:
-- machine, IBM Softlayer, driver
+keywords: machine, IBM Softlayer, driver
 title: IBM Softlayer
 ---
 

--- a/machine/drivers/virtualbox.md
+++ b/machine/drivers/virtualbox.md
@@ -1,7 +1,6 @@
 ---
 description: Oracle VirtualBox driver for machine
-keywords:
-- machine, Oracle VirtualBox, driver
+keywords: machine, Oracle VirtualBox, driver
 title: Oracle VirtualBox
 ---
 

--- a/machine/drivers/vm-cloud.md
+++ b/machine/drivers/vm-cloud.md
@@ -1,7 +1,6 @@
 ---
 description: VMware vCloud Air driver for machine
-keywords:
-- machine, VMware vCloud Air, driver
+keywords: machine, VMware vCloud Air, driver
 title: VMware vCloud Air
 ---
 

--- a/machine/drivers/vm-fusion.md
+++ b/machine/drivers/vm-fusion.md
@@ -1,7 +1,6 @@
 ---
 description: VMware Fusion driver for machine
-keywords:
-- machine, VMware Fusion, driver
+keywords: machine, VMware Fusion, driver
 title: VMware Fusion
 ---
 

--- a/machine/drivers/vsphere.md
+++ b/machine/drivers/vsphere.md
@@ -1,7 +1,6 @@
 ---
 description: VMware vSphere driver for machine
-keywords:
-- machine, VMware vSphere, driver
+keywords: machine, VMware vSphere, driver
 title: VMware vSphere
 ---
 

--- a/machine/examples/aws.md
+++ b/machine/examples/aws.md
@@ -1,7 +1,6 @@
 ---
 description: Using Docker Machine to provision hosts on AWS
-keywords:
-- docker, machine, cloud, aws
+keywords: docker, machine, cloud, aws
 title: Amazon Web Services (AWS) EC2 example
 ---
 

--- a/machine/examples/index.md
+++ b/machine/examples/index.md
@@ -1,7 +1,6 @@
 ---
 description: Examples of cloud installs
-keywords:
-- docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
+keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
 title: Learn by example
 ---
 

--- a/machine/examples/ocean.md
+++ b/machine/examples/ocean.md
@@ -1,7 +1,6 @@
 ---
 description: Using Docker Machine to provision hosts on Digital Ocean
-keywords:
-- docker, machine, cloud, digital ocean
+keywords: docker, machine, cloud, digital ocean
 title: Digital Ocean example
 ---
 

--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -1,7 +1,6 @@
 ---
 description: Using Docker Machine to provision hosts on cloud providers
-keywords:
-- docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
+keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
 title: Use Docker Machine to provision hosts on cloud providers
 ---
 

--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -1,7 +1,6 @@
 ---
 description: Get started with Docker Machine and a local VM
-keywords:
-- docker, machine, virtualbox, local
+keywords: docker, machine, virtualbox, local
 title: Get started with Docker Machine and a local VM
 ---
 

--- a/machine/index.md
+++ b/machine/index.md
@@ -1,7 +1,6 @@
 ---
 description: Introduction and Overview of Machine
-keywords:
-- docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
+keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
 title: Docker Machine
 ---
 

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -1,7 +1,6 @@
 ---
 description: How to install Docker Machine
-keywords:
-- machine, orchestration, install, installation, docker, documentation
+keywords: machine, orchestration, install, installation, docker, documentation
 title: Install Docker Machine
 ---
 

--- a/machine/migrate-to-machine.md
+++ b/machine/migrate-to-machine.md
@@ -1,7 +1,6 @@
 ---
 description: Migrate from Boot2Docker to Docker Machine
-keywords:
-- machine, commands, boot2docker, migrate, docker
+keywords: machine, commands, boot2docker, migrate, docker
 title: Migrate from Boot2Docker to Machine
 ---
 

--- a/machine/overview.md
+++ b/machine/overview.md
@@ -1,7 +1,6 @@
 ---
 description: Introduction and Overview of Machine
-keywords:
-- docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
+keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, rackspace, softlayer, virtualbox, vmwarefusion, vmwarevcloudair, vmwarevsphere, exoscale
 title: Docker Machine Overview
 ---
 

--- a/machine/reference/active.md
+++ b/machine/reference/active.md
@@ -1,7 +1,6 @@
 ---
 description: Identify active machines
-keywords:
-- machine, active, subcommand
+keywords: machine, active, subcommand
 title: docker-machine active
 ---
 

--- a/machine/reference/config.md
+++ b/machine/reference/config.md
@@ -1,7 +1,6 @@
 ---
 description: Show client configuration
-keywords:
-- machine, config, subcommand
+keywords: machine, config, subcommand
 title: docker-machine config
 ---
 

--- a/machine/reference/create.md
+++ b/machine/reference/create.md
@@ -1,7 +1,6 @@
 ---
 description: Create a machine.
-keywords:
-- machine, create, subcommand
+keywords: machine, create, subcommand
 title: docker-machine create
 ---
 

--- a/machine/reference/env.md
+++ b/machine/reference/env.md
@@ -1,7 +1,6 @@
 ---
 description: Set environment variables on a machine
-keywords:
-- machine, env, subcommand
+keywords: machine, env, subcommand
 title: docker-machine env
 ---
 

--- a/machine/reference/help.md
+++ b/machine/reference/help.md
@@ -1,7 +1,6 @@
 ---
 description: Show command help
-keywords:
-- machine, help, subcommand
+keywords: machine, help, subcommand
 title: docker-machine help
 ---
 

--- a/machine/reference/index.md
+++ b/machine/reference/index.md
@@ -1,7 +1,6 @@
 ---
 description: Docker Machine Commands Overview
-keywords:
-- machine, commands
+keywords: machine, commands
 title: Docker Machine command-line reference
 ---
 

--- a/machine/reference/inspect.md
+++ b/machine/reference/inspect.md
@@ -1,7 +1,6 @@
 ---
 description: Inspect information about a machine
-keywords:
-- machine, inspect, subcommand
+keywords: machine, inspect, subcommand
 title: docker-machine inspect
 ---
 

--- a/machine/reference/ip.md
+++ b/machine/reference/ip.md
@@ -1,7 +1,6 @@
 ---
 description: Show client configuration
-keywords:
-- machine, ip, subcommand
+keywords: machine, ip, subcommand
 title: docker-machine ip
 ---
 

--- a/machine/reference/kill.md
+++ b/machine/reference/kill.md
@@ -1,7 +1,6 @@
 ---
 description: Kill (abruptly force stop) a machine.
-keywords:
-- machine, kill, subcommand
+keywords: machine, kill, subcommand
 title: docker-machine kill
 ---
 

--- a/machine/reference/ls.md
+++ b/machine/reference/ls.md
@@ -1,7 +1,6 @@
 ---
 description: List machines
-keywords:
-- machine, ls, subcommand
+keywords: machine, ls, subcommand
 title: docker-machine ls
 ---
 

--- a/machine/reference/provision.md
+++ b/machine/reference/provision.md
@@ -1,7 +1,6 @@
 ---
 description: Re-run provisioning on a created machine.
-keywords:
-- machine, provision, subcommand
+keywords: machine, provision, subcommand
 title: docker-machine provision
 ---
 

--- a/machine/reference/regenerate-certs.md
+++ b/machine/reference/regenerate-certs.md
@@ -1,7 +1,6 @@
 ---
 description: Regenerate and update TLS certificates
-keywords:
-- machine, regenerate-certs, subcommand
+keywords: machine, regenerate-certs, subcommand
 title: docker-machine regenerate-certs
 ---
 

--- a/machine/reference/restart.md
+++ b/machine/reference/restart.md
@@ -1,7 +1,6 @@
 ---
 description: Restart a machine
-keywords:
-- machine, restart, subcommand
+keywords: machine, restart, subcommand
 title: docker-machine restart
 ---
 

--- a/machine/reference/rm.md
+++ b/machine/reference/rm.md
@@ -1,7 +1,6 @@
 ---
 description: Remove a machine.
-keywords:
-- machine, rm, subcommand
+keywords: machine, rm, subcommand
 title: docker-machine rm
 ---
 

--- a/machine/reference/scp.md
+++ b/machine/reference/scp.md
@@ -1,7 +1,6 @@
 ---
 description: Copy files among machines
-keywords:
-- machine, scp, subcommand
+keywords: machine, scp, subcommand
 title: docker-machine scp
 ---
 

--- a/machine/reference/ssh.md
+++ b/machine/reference/ssh.md
@@ -1,7 +1,6 @@
 ---
 description: Log into or run a command on a machine using SSH.
-keywords:
-- machine, ssh, subcommand
+keywords: machine, ssh, subcommand
 title: docker-machine ssh
 ---
 

--- a/machine/reference/start.md
+++ b/machine/reference/start.md
@@ -1,7 +1,6 @@
 ---
 description: Start a machine
-keywords:
-- machine, start, subcommand
+keywords: machine, start, subcommand
 title: docker-machine start
 ---
 

--- a/machine/reference/status.md
+++ b/machine/reference/status.md
@@ -1,7 +1,6 @@
 ---
 description: Get the status of a machine
-keywords:
-- machine, status, subcommand
+keywords: machine, status, subcommand
 title: docker-machine status
 ---
 

--- a/machine/reference/stop.md
+++ b/machine/reference/stop.md
@@ -1,7 +1,6 @@
 ---
 description: Gracefully stop a machine
-keywords:
-- machine, stop, subcommand
+keywords: machine, stop, subcommand
 title: docker-machine stop
 ---
 

--- a/machine/reference/upgrade.md
+++ b/machine/reference/upgrade.md
@@ -1,7 +1,6 @@
 ---
 description: Upgrade Docker on a machine
-keywords:
-- machine, upgrade, subcommand
+keywords: machine, upgrade, subcommand
 title: docker-machine upgrade
 ---
 

--- a/machine/reference/url.md
+++ b/machine/reference/url.md
@@ -1,7 +1,6 @@
 ---
 description: Get the URL of a host
-keywords:
-- machine, url, subcommand
+keywords: machine, url, subcommand
 title: docker-machine url
 ---
 


### PR DESCRIPTION
### Proposed changes

in `/machine/` and `index.md` :
change `keywords`'s type from array to string.

### Project version

current stable

### Related issue

contributes to #435 

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>