### PR TITLE
Update document for Fluentd logging driver options

### DIFF
--- a/engine/admin/logging/fluentd.md
+++ b/engine/admin/logging/fluentd.md
@@ -29,7 +29,7 @@ The `docker logs` command is not available for this logging driver.
 
 Some options are supported by specifying `--log-opt` as many times as needed:
 
- - `fluentd-address`: specify `host:port` to connect `localhost:24224`
+ - `fluentd-address`: specify a socket address to connect to the Fluentd daemon, ex `fluentdhost:24224` or `unix:///path/to/fluentd.sock`
  - `tag`: specify tag for fluentd message, which interpret some markup, ex `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`
 
 
@@ -47,7 +47,7 @@ Before using this logging driver, launch a Fluentd daemon. The logging driver
 connects to this daemon through `localhost:24224` by default. Use the
 `fluentd-address` option to connect to a different address.
 
-    docker run --log-driver=fluentd --log-opt fluentd-address=myhost.local:24224
+    docker run --log-driver=fluentd --log-opt fluentd-address=fluentdhost:24224
 
 If container cannot connect to the Fluentd daemon, the container stops
 immediately unless the `fluentd-async-connect` option is used.
@@ -59,9 +59,13 @@ Users can use the `--log-opt NAME=VALUE` flag to specify additional Fluentd logg
 ### fluentd-address
 
 By default, the logging driver connects to `localhost:24224`. Supply the
-`fluentd-address` option to connect to a different address.
+`fluentd-address` option to connect to a different address. `tcp`(default) and `unix` sockets are supported.
 
-    docker run --log-driver=fluentd --log-opt fluentd-address=myhost.local:24224
+    docker run --log-driver=fluentd --log-opt fluentd-address=fluentdhost:24224
+    docker run --log-driver=fluentd --log-opt fluentd-address=tcp://fluentdhost:24224
+    docker run --log-driver=fluentd --log-opt fluentd-address=unix:///path/to/fluentd.sock
+
+Two of the above specify the same address, because `tcp` is default.
 
 ### tag
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

<!-- Tell us what you did and why.-->
Document a new feature; Fluentd logging driver supports unix-sockets.

### Unreleased project version

<!-- If this change only applies to an unreleased version of a project, note
     that here and base your work on the `vnext-` branch for your project. -->
Engine 1.13

### Related issue

<!-- Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'. -->

### Related issue or PR in another project

<!-- Full URLs to issues or pull requests in other Github projects -->
https://github.com/docker/docker/pull/26088

### Please take a look

<!-- At-mention specific individuals or groups, like @exampleuser123 -->
@thaJeztah 

<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->
