### PR TITLE
live-restore unsupported on Windows

### DIFF
--- a/engine/admin/live-restore.md
+++ b/engine/admin/live-restore.md
@@ -72,3 +72,6 @@ You can modify the kernel's buffer size by changing `/proc/sys/fs/pipe-max-size`
 The live restore option is not compatible with Docker Engine swarm mode. When
 the Docker Engine runs in swarm mode, the orchestration feature manages tasks
 and keeps containers running according to a service specification.
+
+> **Note**: The live restore option is only supported on Linux.
+

--- a/engine/admin/live-restore.md
+++ b/engine/admin/live-restore.md
@@ -10,6 +10,9 @@ containers remain running if the daemon becomes unavailable. The live restore
 option helps reduce container downtime due to daemon crashes, planned outages,
 or upgrades.
 
+> **Note**: Live restore is not supported on Windows containers, but it does work
+for Linux containers running on Windows.
+
 ## Enable the live restore option
 
 There are two ways to enable the live restore setting to keep containers alive
@@ -72,6 +75,4 @@ You can modify the kernel's buffer size by changing `/proc/sys/fs/pipe-max-size`
 The live restore option is not compatible with Docker Engine swarm mode. When
 the Docker Engine runs in swarm mode, the orchestration feature manages tasks
 and keeps containers running according to a service specification.
-
-> **Note**: The live restore option is only supported on Linux.
 


### PR DESCRIPTION
### Describe the proposed changes
Updated the page with a section that clearly states live-restore is unsupported on windows. 


### Related issue
Fixes https://github.com/docker/docker/issues/28295

### Related issue or PR in another project
https://github.com/docker/docker/pull/28384