### PR TITLE
Fix wrong links in "Testing contributions" Documentation page

### DIFF
--- a/opensource/ways/test.md
+++ b/opensource/ways/test.md
@@ -47,6 +47,6 @@ What to look for:
 
 # Test code in the Docker
 
-If you are interested in writing or fixing test code for the Docker project, learn  about  <a href="http://docs.docker.com/project/test-and-docs/" target="_blank">our test infrastructure</a>.
+If you are interested in writing or fixing test code for the Docker project, learn  about  <a href="https://docs.docker.com/opensource/project/test-and-docs/" target="_blank">our test infrastructure</a>.
 
-View <a href="http://goo.gl/EkyABb" target="_blank"> our open test issues</a> in Docker for something to work on. Or, create one of your own.
+View <a href="https://goo.gl/JWuQPJ" target="_blank"> our open test issues</a> in Docker for something to work on. Or, create one of your own.


### PR DESCRIPTION
- What I did

While reading ["Testing contributions"](https://docs.docker.com/opensource/project/test-and-docs/) documentation I saw two wrong links and proposed fix.

- How I did it

First wrong link: I've change the filter from: is:open is:issue label:kind/test -label:status/claimed -label:status/assigned no:assignee  to: is:issue is:open 

Second wrong link: http://docs.docker.com/project/test-and-docs/ points to "Sorry, we can't find that page", I've change it to: