### PR TITLE
Docked for Mac: Custom host CA certs in stable

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -117,7 +117,7 @@ Networking topic.
 
 ### How do I add custom CA certificates?
 
-Starting with Docker for Mac Beta 27 Release Notes (2016-09-28 1.12.2-rc1-beta27) and follow-on Beta releases, all trusted certificate authorities (CAs) (root or intermediate) are supported. (**Note:** Custom CA certificates are not yet supported on stable releases.)
+Starting with Docker for Mac Beta 27 and Stable 1.12.3, all trusted certificate authorities (CAs) (root or intermediate) are supported.
 
 Docker for Mac creates a certificate bundle of all user-trusted CAs based on the Mac Keychain, and appends it to Moby trusted certificates. So if an enterprise SSL certificate is trusted by the user on the host, it will be trusted by Docker for Mac.
 


### PR DESCRIPTION
### Describe the proposed changes

Update TLS CA cert FAQ for 1.12.3 stable.

### Unreleased project version

Current.

### Related issue

N/A

### Related issue or PR in another project

N/A

### Please take a look

/cc @djs55

Since 1.12.3, custom CA certificates are sourced from the OS X keychain.