### PR TITLE
Use curl's -o to specify the output

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -31,7 +31,7 @@ which the release page specifies, in your terminal.
 
      The following is an example command illustrating the format:
 
-        $ curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
+        $ curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
      If you have problems installing with `curl`, see
      [Alternative Install Options](install.md#alternative-install-options).


### PR DESCRIPTION
### Describe the proposed changes

Suggest to use `curl -o ...` instead of `curl > ....`.

This makes it easier to fix up the command by just prepending a `sudo` if something goes wrong.