### PR TITLE
Updated apt-key keyserver URL

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -59,7 +59,7 @@ packages from the Docker repository:
 4.  Add the new `GPG` key.
 
     ```bash
-    $ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+    $ sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
     ```
 
 5.  Find the entry for your Ubuntu operating system.


### PR DESCRIPTION
### Describe the proposed changes

Updated keyserver URL for apt-key to "hkp://ha.pool.sks-keyservers.net:80" as it is when you install with the http://get.docker.com/ script. I.e. "ha." instead of "p80."

The old URL "hkp://p80.pool.sks-keyservers.net:80" caused an error about "gnutls_handshake() failed" when you did apt-get update.

### Unreleased project version

-

### Related issue

-

### Related issue or PR in another project

-

### Please take a look

-
