### PR TITLE
adding high availability deployment link to bottom

### DIFF
--- a/datacenter/try.md
+++ b/datacenter/try.md
@@ -111,3 +111,4 @@ by UCP.
 * [Create and manage users](ucp/2.0/guides/user-management/create-and-manage-users.md)
 * [Deploy an application](ucp/2.0/guides/applications/index.md)
 * [Push an image to DTR](dtr/2.1/guides/repos-and-images/push-an-image.md)
+* [Considerations for a High Availability Deployment](datacenter/ucp/2.0/guides/high-availability/index.md)

--- a/datacenter/try.md
+++ b/datacenter/try.md
@@ -111,4 +111,4 @@ by UCP.
 * [Create and manage users](ucp/2.0/guides/user-management/create-and-manage-users.md)
 * [Deploy an application](ucp/2.0/guides/applications/index.md)
 * [Push an image to DTR](dtr/2.1/guides/repos-and-images/push-an-image.md)
-* [Considerations for a High Availability Deployment](datacenter/ucp/2.0/guides/high-availability/index.md)
+* [Considerations for a High Availability Deployment](ucp/2.0/guides/high-availability/index.md)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

<!-- Tell us what you did and why.-->

### Unreleased project version

<!-- If this change only applies to an unreleased version of a project, note
     that here and base your work on the `vnext-` branch for your project. -->

### Related issue

<!-- Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'. -->

### Related issue or PR in another project

<!-- Full URLs to issues or pull requests in other Github projects -->

### Please take a look

<!-- At-mention specific individuals or groups, like @exampleuser123 -->


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

Added a link to high availability since this is also a link used typically after a POC or trial install. Also matches Store and Email Nurture program emails which reference this.