### PR TITLE
Add DNS SubjectAltName to certificate recipe

### DIFF
--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -78,7 +78,7 @@ Since TLS connections can be made via IP address as well as DNS name, they need
 to be specified when creating the certificate. For example, to allow connections
 using `10.10.10.20` and `127.0.0.1`:
 
-    $ echo subjectAltName = IP:10.10.10.20,IP:127.0.0.1 > extfile.cnf
+    $ echo subjectAltName = DNS:$HOST,IP:10.10.10.20,IP:127.0.0.1 > extfile.cnf
 
     $ openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem \
       -CAcreateserial -out server-cert.pem -extfile extfile.cnf


### PR DESCRIPTION
### Describe the proposed changes

If a SubjectAltName is present, the certificates CommonName should be
discarded by the clients. This ensure that people following the guide
generates valid certificates.

### Related issue

Fixes #607 

