### PR TITLE
modify docs feedback to route support questions properly and encourag…

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -200,9 +200,9 @@ ng\:form {
 							{% if page.noratings != true %}
 							<div style="text-align: center; margin-top: 50px">
 								<img src="/images/chat.png" alt="chat icon" style="margin-right: 10px">
-								<b>Feedback?</b> Questions? Suggestions?<br/>
-							  <a href="https://github.com/docker/docker.github.io/edit/master/{{ page.path }}" class="nomunge">Edit this page</a>,
-								<a href="https://github.com/docker/docker.github.io/issues/new?title=Feedback for: {{ page.path }}&assignee={% if page.assignee %}{{ page.assignee }}{% else %}{{ page.defaultassignee }}{% endif %}&body=File: [{{ page.path }}](https://docs.docker.com{{ page.url }})" class="nomunge">file a ticket</a>, or rate this page:
+								<b>Feedback?</b> Suggestions? Can't find something in the docs?<br/>
+							  <a href="https://github.com/docker/docker.github.io/edit/master/{{ page.path }}" class="nomunge">Edit this page</a> <span style="color:#D8E0E0">&#9679;</span>
+								<a href="https://github.com/docker/docker.github.io/issues/new?title=Feedback for: {{ page.path }}&assignee={% if page.assignee %}{{ page.assignee }}{% else %}{{ page.defaultassignee }}{% endif %}&body=File: [{{ page.path }}](https://docs.docker.com{{ page.url }})" class="nomunge">Request docs changes</a> <span style="color:#D8E0E0">&#9679;</span>  <a href="https://www.docker.com/docker-support-services">Get support</a> <br />Rate this page:
 								<div id="pd_rating_holder_8453675"></div>
 								<script type="text/javascript">
 								PDRTJS_settings_8453675 = {


### PR DESCRIPTION
### Proposed changes

Strawman update to docs feedback footer. Goal is to re-route issues and questions that are better sent to Support, Forums, and Knowledge Hub and keep this feedback link for docs issues.

### Please take a look

@johndmulhausen @sanscontext @mstanleyjones @joaofnfernandes 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>