### PR TITLE
Cloud: corrects to autotest descriptions

### DIFF
--- a/docker-cloud/builds/advanced.md
+++ b/docker-cloud/builds/advanced.md
@@ -26,7 +26,7 @@ If you are using these build environment variables in a
 `docker-compose.test.yml` file for automated testing, declare them in your `sut`
 service's environment as shown below.
 
-```yml
+```none
 sut:
   build: .
   command: run_tests.sh

--- a/docker-cloud/builds/automated-build.md
+++ b/docker-cloud/builds/automated-build.md
@@ -13,16 +13,16 @@ repository and automatically push the built image to your Docker
 repositories.
 
 When you set up automated builds (also called autobuilds), you create a list of
-branches and tags of the images that you want to build. When you push code to a
-source code branch (for example in Github) for one of those listed image tags,
-the push uses a webhook to trigger a new build, which produces a Docker image.
-The built image is then pushed to the Docker Cloud registry or to an external
-registry.
+branches and tags that you want to build into Docker images. When you push code
+to a source code branch (for example in Github) for one of those listed image
+tags, the push uses a webhook to trigger a new build, which produces a Docker
+image. The built image is then pushed to the Docker Cloud registry or to an
+external registry.
 
 If you have automated tests configured, these run after building but before
 pushing to the registry. You can use these tests to create a continuous
-integration workflow. Automated tests do not push images to the registry on
-their own. [Learn more about automated image testing here.](automated-testing.md)
+integration workflow where a build that fails its tests does not push the built
+image. Automated tests do not push images to the registry on their own. [Learn more about automated image testing here.](automated-testing.md)
 
 You can also just use `docker push` to push pre-built images to these
 repositories, even if you have automatic builds set up.
@@ -31,7 +31,7 @@ repositories, even if you have automatic builds set up.
 
 ## Configure automated build settings
 
-You can configure your repositories in Docker Cloud so that they automatically
+You can configure repositories in Docker Cloud so that they automatically
 build an image each time you push new code to your source provider. If you have
 [automated tests](automated-testing.md) configured, the new image is only pushed
 when the tests succeed.
@@ -94,7 +94,8 @@ the code repository service where the image's source code is stored.
 
     Only branches or tags with autobuild enabled are built, tested, *and* have
     the resulting image pushed to the repository. Branches with autobuild
-    disabled will be built for test purposes (if enabled at the repository level), but not pushed.
+    disabled will be built for test purposes (if enabled at the repository
+    level), but the built Docker image is not pushed to the repository.
 
 10. For each branch or tag, enable or disable the **Build Caching** toggle.
 

--- a/docker-cloud/builds/automated-testing.md
+++ b/docker-cloud/builds/automated-testing.md
@@ -6,9 +6,9 @@ redirect_from:
 title: Automated repository tests
 ---
 
-Docker Cloud can automatically test changes pushed to your source code
-repositories using containers. You can enable `Autotest` on [any Docker Cloud repository](repos.md) to run tests at each push to the source code repository,
-similar to a continuous integration testing service.
+Docker Cloud can automatically test changes to your source code repositories
+using containers. You can enable `Autotest` on [any Docker Cloud repository](repos.md) to run tests on each pull request to the source code
+repository to create a continuous integration testing service.
 
 Enabling `Autotest` builds an image for testing purposes, but does **not**
 automatically push the built image to the Docker repository. If you want to push
@@ -22,7 +22,7 @@ tests to be run.
 
 For example:
 
-```yml
+```none
 sut:
   build: .
   command: run_tests.sh
@@ -78,8 +78,9 @@ Docker repository, regardless of the Autotest settings.
 
     > **Note**: For security purposes, autotest on _external pull requests_ is
     disabled on public repositories. If you select this option on a public
-    repository, tests will still run on pushes to the source code repository,
-    but not on pull requests.
+    repository, tests will still run on _internal_ pull requests (for example
+    from one branch into another inside the code repository) but not on for
+    external pull requests.
 
 9. Click **Save** to save the settings, or click **Save and build** to save and
 run an initial test.


### PR DESCRIPTION
Corrects autotest functionality description to the PR-based testing model.
Also removes `yml` syntax queues which seem to be broken currently.

@pchico83, I had asked you a question offline - it was for this doc.
 
Signed-off-by: LRubin <lrubin@docker.com>