### PR TITLE
Fix syntax for passing options to `volume create`

### DIFF
--- a/engine/tutorials/dockervolumes.md
+++ b/engine/tutorials/dockervolumes.md
@@ -187,10 +187,11 @@ You may also use the `docker volume create` command, to create a volume before
 using it in a container.
 
 The following example also creates the `my-named-volume` volume, this time
-using the `docker volume create` command.
+using the `docker volume create` command. Options are specified as key-value
+pairs in the format `o=<key>=<value>`.
 
 ```bash
-$ docker volume create -d flocker -o size=20GB my-named-volume
+$ docker volume create -d flocker --opt o=size=20GB my-named-volume
 
 $ docker run -d -P \
   -v my-named-volume:/webapp \


### PR DESCRIPTION
### Describe the proposed changes

Fix syntax mistake when passing options to `volume create`.

### Related issue

Fixes #325


### Please take a look

@dusek @lybrus

<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

