### PR TITLE
Pin notary-server to v0.4.2

### DIFF
--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -77,7 +77,7 @@ the `trustsandbox` container, the Notary server, and the Registry server.
         version: "2"
         services:
           notaryserver:
-            image: dockersecurity/notary_autobuilds:server-latest
+            image: dockersecurity/notary_autobuilds:server-v0.4.2
             volumes:
               - notarycerts:/go/src/github.com/docker/notary/fixtures
             networks:


### PR DESCRIPTION
Pins a notary server version because our build process has changed the file directory format of the server.  We could bump to `v0.5.0` but since we haven't released that client yet I chose to stick with `v0.4.2`.  Closes https://github.com/docker/docker.github.io/issues/185

cc @cyli @endophage @mstanleyjones 