### PR TITLE
Add swarm routing mesh topic to TOC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -205,6 +205,8 @@ toc:
         title: Apply rolling updates
       - path: /engine/swarm/swarm-tutorial/drain-node/
         title: Drain a node
+      - path: /engine/swarm/ingress/
+        title: Use swarm mode routing mesh
     - sectiontitle: How swarm mode works
       section:
       - path: /engine/swarm/how-swarm-mode-works/nodes/


### PR DESCRIPTION
### Describe the proposed changes

Topic was no longer in TOC after migration to Jekyll

### Related issue

Fixes #197 
