### PR TITLE
CLOUD-3695 remove deprecated section from api docs

### DIFF
--- a/apidocs/cloud-api-source/source/includes/container.md
+++ b/apidocs/cloud-api-source/source/includes/container.md
@@ -364,15 +364,6 @@ bridge | Creates a new network stack for the container on the docker bridge.
 host | Uses the host network stack inside the container.
 
 
-### Container Last Metric attributes
-
-Attribute | Description
---------- | -----------
-cpu       | CPU percentage usage
-memory    | Memory usage in bytes
-disk      | Disk storage usage in bytes
-
-
 ### Container Link attributes
 
 Attribute | Description

--- a/apidocs/cloud-api-source/source/includes/node.md
+++ b/apidocs/cloud-api-source/source/includes/node.md
@@ -77,14 +77,6 @@ Upgrading | The node docker daemon is being upgraded. No actions allowed in this
 Terminating | The node is being terminated in the cloud provider. No actions allowed in this state.
 Terminated | The node has been terminated and is no longer present in the cloud provider. No actions allowed in this state.
 
-### Node Last Metric attributes
-
-Attribute | Description
---------- | -----------
-cpu       | CPU percentage usage
-memory    | Memory usage in bytes
-disk      | Disk storage usage in bytes
-
 
 ## List all nodes
 

--- a/apidocs/docker-cloud/includes/container.html
+++ b/apidocs/docker-cloud/includes/container.html
@@ -630,28 +630,6 @@
 </tr>
 </tbody></table>
 
-<h3 id="container-last-metric-attributes">Container Last Metric attributes</h3>
-
-<table><thead>
-<tr>
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead><tbody>
-<tr>
-<td>cpu</td>
-<td>CPU percentage usage</td>
-</tr>
-<tr>
-<td>memory</td>
-<td>Memory usage in bytes</td>
-</tr>
-<tr>
-<td>disk</td>
-<td>Disk storage usage in bytes</td>
-</tr>
-</tbody></table>
-
 <h3 id="container-link-attributes">Container Link attributes</h3>
 
 <table><thead>

--- a/apidocs/docker-cloud/includes/node.html
+++ b/apidocs/docker-cloud/includes/node.html
@@ -200,28 +200,6 @@
 </tr>
 </tbody></table>
 
-<h3 id="node-last-metric-attributes">Node Last Metric attributes</h3>
-
-<table><thead>
-<tr>
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead><tbody>
-<tr>
-<td>cpu</td>
-<td>CPU percentage usage</td>
-</tr>
-<tr>
-<td>memory</td>
-<td>Memory usage in bytes</td>
-</tr>
-<tr>
-<td>disk</td>
-<td>Disk storage usage in bytes</td>
-</tr>
-</tbody></table>
-
 <h2 id="list-all-nodes">List all nodes</h2>
 <pre class="highlight python"><code><span class="kn">import</span> <span class="nn">dockercloud</span>
 

--- a/apidocs/docker-cloud/index.html
+++ b/apidocs/docker-cloud/index.html
@@ -1983,28 +1983,6 @@ docker-cloud tag <span class="nb">set</span> -t tag-2 7eaf7fff
 </tr>
 </tbody></table>
 
-<h3 id="node-last-metric-attributes">Node Last Metric attributes</h3>
-
-<table><thead>
-<tr>
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead><tbody>
-<tr>
-<td>cpu</td>
-<td>CPU percentage usage</td>
-</tr>
-<tr>
-<td>memory</td>
-<td>Memory usage in bytes</td>
-</tr>
-<tr>
-<td>disk</td>
-<td>Disk storage usage in bytes</td>
-</tr>
-</tbody></table>
-
 <h2 id="list-all-nodes">List all nodes</h2>
 <pre class="highlight python"><code><span class="kn">import</span> <span class="nn">dockercloud</span>
 
@@ -5435,28 +5413,6 @@ docker-cloud tag <span class="nb">set</span> -t tag-2 7eaf7fff
 <tr>
 <td>host</td>
 <td>Uses the host network stack inside the container.</td>
-</tr>
-</tbody></table>
-
-<h3 id="container-last-metric-attributes">Container Last Metric attributes</h3>
-
-<table><thead>
-<tr>
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead><tbody>
-<tr>
-<td>cpu</td>
-<td>CPU percentage usage</td>
-</tr>
-<tr>
-<td>memory</td>
-<td>Memory usage in bytes</td>
-</tr>
-<tr>
-<td>disk</td>
-<td>Disk storage usage in bytes</td>
 </tr>
 </tbody></table>
 

--- a/apidocs/layouts/single.html
+++ b/apidocs/layouts/single.html
@@ -1983,28 +1983,6 @@ docker-cloud tag <span class="nb">set</span> -t tag-2 7eaf7fff
 </tr>
 </tbody></table>
 
-<h3 id="node-last-metric-attributes">Node Last Metric attributes</h3>
-
-<table><thead>
-<tr>
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead><tbody>
-<tr>
-<td>cpu</td>
-<td>CPU percentage usage</td>
-</tr>
-<tr>
-<td>memory</td>
-<td>Memory usage in bytes</td>
-</tr>
-<tr>
-<td>disk</td>
-<td>Disk storage usage in bytes</td>
-</tr>
-</tbody></table>
-
 <h2 id="list-all-nodes">List all nodes</h2>
 <pre class="highlight python"><code><span class="kn">import</span> <span class="nn">dockercloud</span>
 
@@ -5435,28 +5413,6 @@ docker-cloud tag <span class="nb">set</span> -t tag-2 7eaf7fff
 <tr>
 <td>host</td>
 <td>Uses the host network stack inside the container.</td>
-</tr>
-</tbody></table>
-
-<h3 id="container-last-metric-attributes">Container Last Metric attributes</h3>
-
-<table><thead>
-<tr>
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead><tbody>
-<tr>
-<td>cpu</td>
-<td>CPU percentage usage</td>
-</tr>
-<tr>
-<td>memory</td>
-<td>Memory usage in bytes</td>
-</tr>
-<tr>
-<td>disk</td>
-<td>Disk storage usage in bytes</td>
 </tr>
 </tbody></table>
 


### PR DESCRIPTION
Removes two section that refer to a deprecated feature, per https://github.com/docker/dockercloud-cli/issues/40

cc @tifayuki PTAL

Signed-off-by: LRubin <lrubin@docker.com>