### PR TITLE
Add `docker ps -a`

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -157,7 +157,7 @@ Run these commands to test if your versions of `docker`, `docker-compose`, and `
 
 4. Stop or remove containers and images.
 
-    The `nginx` webserver will continue to run in the container on that port until you stop and/or remove the container. If you want to stop the webserver, type: `docker stop webserver` and start it again with `docker start webserver`.
+    The `nginx` webserver will continue to run in the container on that port until you stop and/or remove the container. If you want to stop the webserver, type: `docker stop webserver` and start it again with `docker start webserver`. A stopped container will not show up with `docker ps`; for that, you need to run `docker ps -a`.
 
     To stop and remove the running container with a single command, type: `docker rm -f webserver`. This will remove the container, but not the `nginx` image. You can list local images with `docker images`. You might want to keep some images around so that you don't have to pull them again from Docker Hub. To remove an image you no longer need, use `docker rmi <imageID>|<imageName>`. For example, `docker rmi nginx`.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

<!-- Tell us what you did and why.-->

### Unreleased project version

<!-- If this change only applies to an unreleased version of a project, note
     that here and base your work on the `vnext-` branch for your project. -->

### Related issue

<!-- Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'. -->

### Related issue or PR in another project

<!-- Full URLs to issues or pull requests in other Github projects -->

### Please take a look

<!-- At-mention specific individuals or groups, like @exampleuser123 -->


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

When one wants to remove an image no longer needed (as in the subsequent example w.r.t. nginx), but still used by a stopped container, one would not find that container using only `docker ps`. Introduction of `docker ps -a` seems warranted to me here.