### PR TITLE
clarify syntax on swarm heartbeat for create machine command

### DIFF
--- a/machine/reference/create.md
+++ b/machine/reference/create.md
@@ -207,8 +207,7 @@ you can use Machine to specify how the created Swarm master should be
 configured. There is a `--swarm-strategy` flag, which you can use to specify
 the [scheduling strategy](/swarm/scheduler/strategy.md)
 which Docker Swarm should use (Machine defaults to the `spread` strategy).
-There is also a general purpose `--swarm-opt` option which works similar to how
-the aforementioned `--engine-opt` option does, except that it specifies options
+There is also a general purpose `--swarm-opt` option which works similar to the aforementioned `--engine-opt` option, except that it specifies options
 for the `swarm manage` command (used to boot a master node) instead of the base
 command. You can use this to configure features that power users might be
 interested in, such as configuring the heartbeat interval or Swarm's willingness
@@ -228,7 +227,7 @@ $ docker-machine create -d virtualbox \
     --swarm-master \
     --swarm-discovery token://<token> \
     --swarm-strategy binpack \
-    --swarm-opt heartbeat=5 \
+    --swarm-opt heartbeat=5s \
     upbeat
 ```
 


### PR DESCRIPTION
### Proposed changes

Corrected the example to set a Swarm heartbeat as part of `docker-machine create `. Units of measure need to be specified. 

 `--swarm-opt heartbeat=5 \ ` should be `  --swarm-opt heartbeat=5s \` to indicate "seconds" as the unit of measure.

### Related issue

[Docker Machine GitHub Issue 3851: swarm opt "heartbeat" Fails](https://github.com/docker/machine/issues/3851) 

### Please take a look

@nathanleclaire @viveky4d4v @joaofnfernandes @mstanleyjones 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>