### PR TITLE
Optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+.git
+.gitignore
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,88 +1,28 @@
 FROM starefossen/github-pages
 
-# Basic Git set-up for throwaway commits
-RUN git config --global user.email "gordon@docker.com"
-RUN git config --global user.name "Gordon"
+ENV VERSIONS="v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 v1.10 v1.11"
 
-# Clone the docs repo
-RUN git clone https://www.github.com/docker/docker.github.io allv
+# Create archive; check out each version, create HTML, tweak links
+RUN git clone https://www.github.com/docker/docker.github.io temp; \
+ for VER in $VERSIONS; do \
+		git --git-dir=./temp/.git --work-tree=./temp checkout ${VER} \
+		&& mkdir -p allvbuild/${VER} \
+		&& jekyll build -s temp -d allvbuild/${VER} \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/'"$VER"'/#g'; \
+	done; \
+	rm -rf temp
+
+COPY . allv
 
 # Get docker/docker ref docs from 1.12.x branch to be used in master builds
 # Uses Github Subversion gateway to limit the checkout
-RUN svn co https://github.com/docker/docker/branches/1.12.x/docs/reference allv/engine/reference
-RUN svn co https://github.com/docker/docker/branches/1.12.x/docs/extend allv/engine/extend
-# Can't use the svn trick to get a single file, use wget instead
-RUN wget -O allv/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/1.12.x/docs/deprecated.md
-# Make a temporary commit for the files we added so we can check out other branches later
-RUN git --git-dir=./allv/.git --work-tree=./allv add engine
-RUN git --git-dir=./allv/.git --work-tree=./allv commit -m "Temporary commit"
-
-# Create HTML for master
-RUN jekyll build -s allv -d allvbuild
-
-# Check out 1.4 branch, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.4
-RUN mkdir allvbuild/v1.4
-RUN jekyll build -s allv -d allvbuild/v1.4
-RUN find allvbuild/v1.4 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.4/#g'
-RUN find allvbuild/v1.4 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.4/#g'
-RUN find allvbuild/v1.4 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.4/#g'
-
-# Check out 1.5 branch, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.5
-RUN mkdir allvbuild/v1.5
-RUN jekyll build -s allv -d allvbuild/v1.5
-RUN find allvbuild/v1.5 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.5/#g'
-RUN find allvbuild/v1.5 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.5/#g'
-RUN find allvbuild/v1.5 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.5/#g'
-
-# Check out 1.6, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.6
-RUN mkdir allvbuild/v1.6
-RUN jekyll build -s allv -d allvbuild/v1.6
-RUN find allvbuild/v1.6 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.6/#g'
-RUN find allvbuild/v1.6 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.6/#g'
-RUN find allvbuild/v1.6 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.6/#g'
-
-# Check out 1.7, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.7
-RUN mkdir allvbuild/v1.7
-RUN jekyll build -s allv -d allvbuild/v1.7
-RUN find allvbuild/v1.7 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.7/#g'
-RUN find allvbuild/v1.7 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.7/#g'
-RUN find allvbuild/v1.7 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.7/#g'
-
-# Check out 1.8, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.8
-RUN mkdir allvbuild/v1.8
-RUN jekyll build -s allv -d allvbuild/v1.8
-RUN find allvbuild/v1.8 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.8/#g'
-RUN find allvbuild/v1.8 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.8/#g'
-RUN find allvbuild/v1.8 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.8/#g'
-
-# Check out 1.9, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.9
-RUN mkdir allvbuild/v1.9
-RUN jekyll build -s allv -d allvbuild/v1.9
-RUN find allvbuild/v1.9 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.9/#g'
-RUN find allvbuild/v1.9 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.9/#g'
-RUN find allvbuild/v1.9 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.9/#g'
-
-# Check out 1.10, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.10
-RUN mkdir allvbuild/v1.10
-RUN jekyll build -s allv -d allvbuild/v1.10
-RUN find allvbuild/v1.10 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.10/#g'
-RUN find allvbuild/v1.10 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.10/#g'
-RUN find allvbuild/v1.10 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.10/#g'
-
-# Check out 1.11, create HTML, tweak links
-RUN git --git-dir=./allv/.git --work-tree=./allv checkout v1.11
-RUN mkdir allvbuild/v1.11
-RUN jekyll build -s allv -d allvbuild/v1.11
-RUN find allvbuild/v1.11 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/v1.11/#g'
-RUN find allvbuild/v1.11 -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/v1.11/#g'
-RUN find allvbuild/v1.11 -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/v1.11/#g'
+RUN svn co https://github.com/docker/docker/branches/1.12.x/docs/reference allv/engine/reference \
+ && svn co https://github.com/docker/docker/branches/1.12.x/docs/extend allv/engine/extend \
+ && wget -O allv/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/1.12.x/docs/deprecated.md \
+ && jekyll build -s allv -d allvbuild \
+ && rm -rf allv
 
 # Serve the site, which is now all static HTML
 CMD jekyll serve -s /usr/src/app/allvbuild -d /_site --no-watch -H 0.0.0.0 -P 4000

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ permalink: pretty
 safe: false
 lsi: false
 url: https://docs.docker.com
+keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11"]
 
 gems:
   - jekyll-redirect-from


### PR DESCRIPTION
This optimizes the Dockerfile a bit by;

- putting the docs archives at the top to optimize caching and to
  prevent having to clone the github repository on each build. Note
  that '--no-cache' is needed to forcefully break the cache, but the
  archives should not frequently change
- grouping RUN lines to reduce image size (adds/deletes in the same layer).
- using a loop for the archived versions to reduce the amount of
  duplicated code.
- using the local files for the *current* version of the docs instead
  of the git clone from GitHub. this makes it also use the right source
  instead of "master"
- adding a .dockerignore to prevent busting the cache if not needed,
  and to prevent uploading the '.git' repository, which is not used for
  the "current" docs

Difference in size before/after;

    REPOSITORY     TAG     IMAGE ID      CREATED         SIZE
    docs           latest  36f6ad029e6a  3 minutes ago   1.722 GB
    docs-orig      latest  4f1a3e3fda4f  16 minutes ago  3.344 GB

/cc @johndmulhausen PTAL, I built this and I think everything works as before, but let me know if there's issues in this change