### PR TITLE
d4mac, added warning re:plan to drop support for OS X 10.10.x

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -70,15 +70,17 @@ For more about stable and beta channels, see the
 <p />
 *  **Relationship to Docker Machine**: Installing Docker for Mac does not affect machines you created with Docker Machine. You'll get the option to copy containers and images from your local `default` machine (if one exists) to the new Docker for Mac <a href="https://github.com/docker/HyperKit/" target="_blank">HyperKit</a> VM. When you are running Docker for Mac, you do not need Docker Machine nodes running at all locally (or anywhere else). With Docker for Mac, you have a new, native virtualization system running (HyperKit) which takes the place of the VirtualBox system. To learn more, see [Docker for Mac vs. Docker Toolbox](docker-toolbox.md).
 <p />
-* **System Requirements**: Docker for Mac will launch only if all these requirements are met.
+* **System Requirements**: Docker for Mac will launch only if all of these requirements are met.
 
 	- Mac must be a 2010 or newer model, with Intel's hardware support for memory management unit (MMU) virtualization; i.e., Extended Page Tables (EPT)
 
-	- macOS 10.10.3 Yosemite or newer
+  - OS X El Capitan 10.11 and newer macOS releases are supported. At a minimum, Docker for Mac requires macOS Yosemite 10.10.3 or newer, with the caveat that going forward 10.10.x is a use-at-your-own risk proposition.
 
-	- At least 4GB of RAM
+  - Starting with Docker for Mac stable release 1.13 (upcoming), and concurrent Beta releases, we will no longer address issues specific to OS X Yosemite 10.10. In future releases, Docker for Mac could stop working on OS X Yosemite 10.10 due to the deprecated status of this OS X version. We recommend upgrading to the latest version of macOS.
 
-	- VirtualBox prior to version 4.3.30 must NOT be installed (it is incompatible with Docker for Mac)
+  - At least 4GB of RAM
+
+  - VirtualBox prior to version 4.3.30 must NOT be installed (it is incompatible with Docker for Mac)
 
   >**Note**: If your system does not satisfy these requirements, you can install [Docker Toolbox](/toolbox/overview.md), which uses Oracle Virtual Box instead of HyperKit.
 


### PR DESCRIPTION
### Proposed changes

Added warning of plan to drop support on Docker for Mac for OS X 10.10.x Yosemite, and clarified system requirements for upcoming Beta and Stable releases.

### Related issue

Docker for Mac team issue.

### Please take a look

@dmp42 @ijc25 @MagnusS @FrenchBen 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>