### PR TITLE
remove some unneeded text with new Docker ID topic

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -846,7 +846,7 @@ toc:
   - path: /docker-cloud/overview/
     title: Docker Cloud Overview
   - path: /docker-cloud/dockerid/
-    title: Docker ID and Settings
+    title: Docker Cloud Settings and Docker ID
   - path: /docker-cloud/orgs/
     title: Organizations and Teams
   - sectiontitle: Getting Started
@@ -976,7 +976,7 @@ toc:
   - path: /docker-hub/
     title: Overview of Docker Hub
   - path: /docker-hub/accounts/
-    title: Your Docker ID
+    title: Use Docker Hub with Docker ID
   - path: /docker-hub/orgs/
     title: Teams &amp; Organizations
   - path: /docker-hub/repos/

--- a/docker-cloud/dockerid.md
+++ b/docker-cloud/dockerid.md
@@ -1,7 +1,7 @@
 ---
 description: Using your DockerID to log in to Docker Cloud
 keywords: one, two, three
-title: Docker ID and Docker Cloud settings
+title: Docker Cloud Settings and Docker ID
 ---
 
 Docker Cloud uses your Docker ID for access and access control, and this allows
@@ -10,9 +10,9 @@ you to link your Hub and Cloud accounts.
 If you already have an account on Docker Hub you can use the same credentials to
 log in to Docker Cloud.
 
-If you don't have an existing Docker ID, you can sign up for a new Docker ID
-from the Cloud website, or using the `docker login` command in the Docker CLI.
-The name you choose for your Docker ID becomes part of your account namespace.
+If you don't have a [Docker ID](../docker-id/) yet, you can sign up for one from
+the Cloud website, or using the `docker login` command in the Docker CLI. The
+name you choose for your Docker ID becomes part of your account namespace.
 
 ## Manage cloud services and source providers
 
@@ -25,7 +25,10 @@ Bitbucket from your Docker Cloud account settings.
 
 ## Email addresses
 
-You can associate multiple email addresses with your Docker ID, and one of these addresses becomes the primary address for the account. The primary address is used by Docker to send password reset notifications and other important information, so be sure to keep it updated.
+You can associate multiple email addresses with your Docker ID, and one of these
+becomes the primary address for the account. The primary address is used by
+Docker to send password reset notifications and other important information, so
+be sure to keep it updated.
 
 To add another email address to your Docker ID:
 

--- a/docker-hub/accounts.md
+++ b/docker-hub/accounts.md
@@ -1,56 +1,27 @@
 ---
-description: Your Docker ID
+description: Using Docker Hub with your Docker ID account
 keywords: Docker, docker, trusted, sign-up, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation
-title: Docker ID and Docker Hub accounts
+title: Use Docker Hub with Docker ID
 ---
 
-You can `search` for Docker images and `pull` them from [Docker
-Hub](https://hub.docker.com) without signing in or even having an account.
-However, to `push` images, leave comments, or to *star* a repository, you need a
-free [Docker ID](https://hub.docker.com) to log in to Docker Hub.
+Docker Hub uses your free [Docker ID](../docker-id/) to save your account
+settings, and as your account namespace. If you don't yet have a Docker ID, you
+can [register for one](../docker-id/#/register-for-a-docker-id).
+
+You can `search` Docker Hub and `pull` images without an account and
+without signing in. However, to `push` images, leave comments, or to *star* a
+repository, you need to log in using a Docker ID.
 
 Once you have a personal Docker ID, you can also create or join
 Docker Hub [Organizations and Teams](orgs.md).
 
-## Register for a Docker ID
+## Upgrading your account
 
-If you're not already logged in, go to [Docker Hub](https://hub.docker.com) to
-use the sign up page. A valid email address is required to register. A
-verification email is sent to this address to activate your account.
-
-You cannot log in to your Docker ID until you verify the email address.
-
-#### Confirm your email
-
-Once you've filled in the registration form, check your email for a welcome
-message asking for confirmation so we can activate your account.
-
-## Login
-
-After you complete the account creation process, you can log in any time using
-the web console with your Docker ID:
-
-![Login using the web console](images/login-web.png)
-
-Or via the command line with the `docker login` command:
-
-    $ docker login
-
-Your Docker ID is now active and ready to use.
-
-> **Note:**
-> Your authentication credentials will be stored in the `.dockercfg`
-> authentication file in your home directory.
-
-### Upgrading your account
-
-Free Hub accounts include one private registry. If you need more private
-registries, you can [upgrade your
-account](https://hub.docker.com/account/billing-plans/) to a paid plan directly
+Free Docker Hub accounts include one private registry. If you need more private
+registries, you can [upgrade your account](https://hub.docker.com/account/billing-plans/) to a paid plan directly
 from the Hub.
 
 ## Password reset process
 
-If you can't access your account for some reason, you can reset your password
-from the [*Password Reset*](https://hub.docker.com/reset-password/)
-page.
+If you forget your password, or can't access your account for some reason, you
+can reset your password from the [*Password Reset*](https://hub.docker.com/reset-password/) page.

--- a/engine/getstarted/step_five.md
+++ b/engine/getstarted/step_five.md
@@ -9,61 +9,50 @@ title: Create a Docker Hub account and repository
 ---
 
 You've built something really cool, you should share it. In this next section,
-you'll do just that. You'll need a Docker Hub account. Then, you'll push your
-image up to it so other people with Docker Engine can run it.
+you'll do just that. First, you'll create a Docker ID account. Then, you'll push
+your image to a repository on Docker Hub so other people with Docker Engine can
+run it.
 
 
 ## Step 1: Sign up for an account
 
-1. Use your browser to navigate to <a href="https://hub.docker.com/?utm_source=getting_started_guide&utm_medium=embedded_MacOSX&utm_campaign=create_docker_hub_account" target="_blank">the Docker Hub signup page</a>.
+1. In your web browser, go to <a href="https://hub.docker.com/register/?utm_source=getting_started_guide&utm_medium=embedded_MacOSX&utm_campaign=create_docker_hub_account" target="_blank">the Docker Hub signup page</a>.
 
 	Your browser displays the page.
 
 	![Docker Hub signup](tutimg/hub_signup.png)
 
-2. Fill out the form on the signup page.
+2. Enter a new Docker ID (username), and email address, and a password.
 
-	Docker Hub is free. Docker does need a name, password, and email address.
+3. Click **Sign Up**.
 
-3. Press **Signup**.
-
-	The browser displays the welcome to Docker Hub page.
+	The browser displays a "Welcome to Docker Hub" page.
 
 ## Step 2: Verify your email and add a repository
 
-Before you can share anything on the hub, you need to verify your email address.
+Before you can share anything on Docker Hub, you need to verify your email address.
 
-1. Open your email inbox.
-
-2. Look for the email titled `Please confirm email for your Docker Hub account`.
+1. Go to your email, and look for the email titled `Please confirm email for your Docker ID`.
 
 	  If you don't see the email, check your Spam folder or wait a moment for the email to arrive.
 
-2. Open the email and click the **Confirm Your Email** button.
+2. Open the email and click **Confirm Your Email**.
 
 	 The browser opens Docker Hub to your profile page.
 
-4. Choose **Create Repository**.
+4. From that page, choose **Create Repository**.
 
-	The browser opens the **Create Repository** page.
+5. Enter a Repository Name and Short Description.
 
-5. Provide a Repository Name and Short Description.
-
-6. Make sure Visibility is set to **Public**.
+6. Make sure the repo **Visibility** is set to **Public**.
 
     When you are done, your form should look similar to the following:
 
 	![Add repo](tutimg/add_repository.png)
 
-6. Press **Create** when you are done.
-
-	Docker Hub creates your new repository.
+6. Press **Create** to save your entries and create the new repository.
 
 ## Where to go next
 
-On this page, you opened an account on Docker Hub and created a new repository.
-In the next section, you populate the repository [by tagging and pushing the
-image you created earlier](step_six.md).
-
-
-&nbsp;
+On this page, you created a Docker ID, navigated to your Docker Hub account and created a new repository.
+In the next section, you populate the repository [by tagging and pushing the image you created earlier](step_six.md).


### PR DESCRIPTION
Follow-on to #634 , removes duplicate instructions from Hub, updates and tightens up some writing in a tutorial page, and adds links to the appropriate topic for Cloud.

Signed-off-by: LRubin <lrubin@docker.com>