### PR TITLE
rails.md: change the database.yml default database

### DIFF
--- a/compose/rails.md
+++ b/compose/rails.md
@@ -122,7 +122,7 @@ Replace the contents of `config/database.yml` with the following:
     development: &default
       adapter: postgresql
       encoding: unicode
-      database: postgres
+      database: myapp_development
       pool: 5
       username: postgres
       password:


### PR DESCRIPTION
In this example,  database.yml uses the default value of `postgres` for the `database` key.  
The database postgres is normally not used for user data, but for administrative purposes.  This means people following this example will not be able to drop the database, and in general it's just not a great idea.