### PR TITLE
Completed metadata of the journald log driver

### DIFF
--- a/engine/admin/logging/journald.md
+++ b/engine/admin/logging/journald.md
@@ -14,12 +14,13 @@ journal API, or using the `docker logs` command.
 In addition to the text of the log message itself, the `journald` log driver
 stores the following metadata in the journal with each message:
 
-| Field               | Description |
-----------------------|-------------|
-| `CONTAINER_ID`      | The container ID truncated to 12 characters. |
-| `CONTAINER_ID_FULL` | The full 64-character container ID. |
-| `CONTAINER_NAME`    | The container name at the time it was started. If you use `docker rename` to rename a container, the new name is not reflected in the journal entries. |
-| `CONTAINER_TAG`     | The container tag ([log tag option documentation](log_tags.md)). |
+| Field                       | Description |
+------------------------------|-------------|
+| `CONTAINER_ID`              | The container ID truncated to 12 characters. |
+| `CONTAINER_ID_FULL`         | The full 64-character container ID. |
+| `CONTAINER_NAME`            | The container name at the time it was started. If you use `docker rename` to rename a container, the new name is not reflected in the journal entries. |
+| `CONTAINER_TAG`             | The container tag ([log tag option documentation](log_tags.md)). |
+| `CONTAINER_PARTIAL_MESSAGE` | A field that flags log integrity. Improve logging of long log lines. |
 
 ## Usage
 
@@ -88,3 +89,4 @@ logs:
 
     for msg in reader:
       print '{CONTAINER_ID_FULL}: {MESSAGE}'.format(**msg)
+


### PR DESCRIPTION
`CONTAINER_PARTIAL_MESSAGE` field is also a metadata of the journald log driver. So we should add a description for it.

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>