### PR TITLE
Replace 'ls Dockerfile' with 'ls'

### DIFF
--- a/engine/getstarted/step_four.md
+++ b/engine/getstarted/step_four.md
@@ -41,7 +41,7 @@ commands to run. Your recipe is going to be very short.
 
         $ touch Dockerfile
 
-    The command appears to do nothing but it actually creates the Dockerfile in the current directory.  Just type `ls Dockerfile` to see it.
+    The command appears to do nothing but it actually creates the Dockerfile in the current directory.  Just type `ls` to see it.
 
         $ ls
         Dockerfile


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

Replaced `ls Dockerfile` with `ls`.

### Unreleased project version

<!-- If this change only applies to an unreleased version of a project, note
     that here and base your work on the `vnext-` branch for your project. -->

### Related issue

<!-- Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'. -->

### Related issue or PR in another project

<!-- Full URLs to issues or pull requests in other Github projects -->

### Please take a look

<!-- At-mention specific individuals or groups, like @exampleuser123 -->


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

Running `ls Dockerfile`, if following the guide, would give you nothing. Dockerfile is not a directory.
Running `ls` would *return* `Dockerfile`.