### PR TITLE
Extend Logging documentation

### DIFF
--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -6,11 +6,17 @@ redirect_from:
 title: Configure logging drivers
 ---
 
+Docker comes with support of multiple logging mechanisms. Use the
+`--log-driver=VALUE` when starting the `dockerd` daemon to set default logging
+driver. You can use the `--log-opt NAME=VALUE` flag to specify extra options for
+selected driver.
+
 The container can have a different logging driver than the Docker daemon. Use
 the `--log-driver=VALUE` with the `docker run` command to configure the
 container's logging driver. If the `--log-driver` option is not set, docker
-uses the default (`json-file`) logging driver. The following options are
-supported:
+uses the daemon's default logging driver (`json-file` unless otherwise set).
+
+The following options are supported:
 
 | Driver      | Description                                                                                                                   |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------|

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -13,8 +13,16 @@ selected driver.
 
 The container can have a different logging driver than the Docker daemon. Use
 the `--log-driver=VALUE` with the `docker run` command to configure the
-container's logging driver. If the `--log-driver` option is not set, docker
-uses the daemon's default logging driver (`json-file` unless otherwise set).
+container's logging driver. If the `--log-driver` option is not set, containers
+use the daemon's default logging driver, which defaults to `json-file`. To check
+the default logging driver for your Docker daemon, search for `Logging Driver` in the
+output of the `docker info` command:
+
+```bash
+$ docker info |grep Logging
+
+Logging Driver: json-file
+```
 
 The following options are supported:
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

Current documentation about logging in Docker seems confusing. It even causes wrong PR being merged into Ansible's `docker_container` module: https://github.com/ansible/ansible-modules-core/pull/5482

[Documentation](https://docs.docker.com/engine/admin/logging/overview/) says:

> Use the --log-driver=VALUE with the docker run command to configure the container’s logging driver. If the --log-driver option is not set, docker uses the default (json-file) logging driver.

However, it's not completely true. If my daemon is running with different `log_driver` option, all containers without explicit `log_driver` option will fall back to daemon's log_driver, which is not always `json-file`.

With this PR I make documentation more explicit, and fix the confusion

### Related issue

### Related issue or PR in another project

https://github.com/docker/docker/issues/28860
https://github.com/ansible/ansible-modules-core/pull/5482