### PR TITLE
Fix link to link_local_ips in docs

### DIFF
--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -1167,7 +1167,7 @@ available with Docker Engine version **1.12.0+**
 
 Introduces the following additional parameters:
 
-- [`link_local_ips`](compose-file.md#link_local_ips)
+- [`link_local_ips`](compose-file.md#linklocalips)
 - [`isolation`](compose-file.md#isolation)
 - `labels` for [volumes](compose-file.md#volume-configuration-reference) and
   [networks](compose-file.md#network-configuration-reference)


### PR DESCRIPTION
### Describe the proposed changes

In *Compose file reference* documentation, in the *Version 2.1* section the link to `link_local_ips` is broken. This patch fixes that. 