### PR TITLE
Initial dump of CLI in yaml

### DIFF
--- a/_data/engine-cli/docker.yaml
+++ b/_data/engine-cli/docker.yaml
@@ -1,0 +1,3 @@
+command: docker
+cname: docker wait
+clink: docker_wait.yaml

--- a/_data/engine-cli/docker_attach.yaml
+++ b/_data/engine-cli/docker_attach.yaml
@@ -1,0 +1,15 @@
+command: docker attach
+short: Attach to a running container
+long: Attach to a running container
+usage: docker attach [OPTIONS] CONTAINER
+pname: docker
+plink: docker.yaml
+options:
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: no-stdin
+  default_value: "false"
+  description: Do not attach STDIN
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy all received signals to the process

--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -1,0 +1,77 @@
+command: docker build
+short: Build an image from a Dockerfile
+long: Build an image from a Dockerfile
+usage: docker build [OPTIONS] PATH | URL | -
+pname: docker
+plink: docker.yaml
+options:
+- option: build-arg
+  default_value: '[]'
+  description: Set build-time variables
+- option: cache-from
+  default_value: '[]'
+  description: Images to consider as cache sources
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: compress
+  default_value: "false"
+  description: Compress the build context using gzip
+- option: cpu-period
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: file
+  shorthand: f
+  description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
+- option: force-rm
+  default_value: "false"
+  description: Always remove intermediate containers
+- option: isolation
+  description: Container isolation technology
+- option: label
+  default_value: '[]'
+  description: Set metadata for an image
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: no-cache
+  default_value: "false"
+  description: Do not use cache when building the image
+- option: pull
+  default_value: "false"
+  description: Always attempt to pull a newer version of the image
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the build output and print image ID on success
+- option: rm
+  default_value: "true"
+  description: Remove intermediate containers after a successful build
+- option: security-opt
+  default_value: '[]'
+  description: Security options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: tag
+  shorthand: t
+  default_value: '[]'
+  description: Name and optionally a tag in the 'name:tag' format
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options

--- a/_data/engine-cli/docker_commit.yaml
+++ b/_data/engine-cli/docker_commit.yaml
@@ -1,0 +1,21 @@
+command: docker commit
+short: Create a new image from a container's changes
+long: Create a new image from a container's changes
+usage: docker commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]
+pname: docker
+plink: docker.yaml
+options:
+- option: author
+  shorthand: a
+  description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Commit message
+- option: pause
+  shorthand: p
+  default_value: "true"
+  description: Pause container during commit

--- a/_data/engine-cli/docker_container.yaml
+++ b/_data/engine-cli/docker_container.yaml
@@ -1,0 +1,8 @@
+command: docker container
+short: Manage containers
+long: Manage containers
+usage: docker container
+pname: docker
+plink: docker.yaml
+cname: docker container wait
+clink: docker_container_wait.yaml

--- a/_data/engine-cli/docker_container_attach.yaml
+++ b/_data/engine-cli/docker_container_attach.yaml
@@ -1,0 +1,15 @@
+command: docker container attach
+short: Attach to a running container
+long: Attach to a running container
+usage: docker container attach [OPTIONS] CONTAINER
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: no-stdin
+  default_value: "false"
+  description: Do not attach STDIN
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy all received signals to the process

--- a/_data/engine-cli/docker_container_commit.yaml
+++ b/_data/engine-cli/docker_container_commit.yaml
@@ -1,0 +1,21 @@
+command: docker container commit
+short: Create a new image from a container's changes
+long: Create a new image from a container's changes
+usage: docker container commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: author
+  shorthand: a
+  description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Commit message
+- option: pause
+  shorthand: p
+  default_value: "true"
+  description: Pause container during commit

--- a/_data/engine-cli/docker_container_cp.yaml
+++ b/_data/engine-cli/docker_container_cp.yaml
@@ -1,0 +1,18 @@
+command: docker container cp
+short: Copy files/folders between a container and the local filesystem
+long: |-
+  Copy files/folders between a container and the local filesystem
+
+  Use '-' as the source to read a tar archive from stdin
+  and extract it to a directory destination in a container.
+  Use '-' as the destination to stream a tar archive of a
+  container source to stdout.
+usage: "docker container cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp
+  [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH"
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: follow-link
+  shorthand: L
+  default_value: "false"
+  description: Always follow symbol link in SRC_PATH

--- a/_data/engine-cli/docker_container_create.yaml
+++ b/_data/engine-cli/docker_container_create.yaml
@@ -1,0 +1,258 @@
+command: docker container create
+short: Create a new container
+long: Create a new container
+usage: docker container create [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: Block IO (relative weight), between 10 and 1000
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: "0"
+  description: Time between running the check
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: "0"
+  description: Maximum time to allow one check to run
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container

--- a/_data/engine-cli/docker_container_diff.yaml
+++ b/_data/engine-cli/docker_container_diff.yaml
@@ -1,0 +1,6 @@
+command: docker container diff
+short: Inspect changes on a container's filesystem
+long: Inspect changes on a container's filesystem
+usage: docker container diff CONTAINER
+pname: docker container
+plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_exec.yaml
+++ b/_data/engine-cli/docker_container_exec.yaml
@@ -1,0 +1,27 @@
+command: docker container exec
+short: Run a command in a running container
+long: Run a command in a running container
+usage: docker container exec [OPTIONS] CONTAINER COMMAND [ARG...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: 'Detached mode: run command in the background'
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to the command
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'

--- a/_data/engine-cli/docker_container_export.yaml
+++ b/_data/engine-cli/docker_container_export.yaml
@@ -1,0 +1,10 @@
+command: docker container export
+short: Export a container's filesystem as a tar archive
+long: Export a container's filesystem as a tar archive
+usage: docker container export [OPTIONS] CONTAINER
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT

--- a/_data/engine-cli/docker_container_inspect.yaml
+++ b/_data/engine-cli/docker_container_inspect.yaml
@@ -1,0 +1,14 @@
+command: docker container inspect
+short: Display detailed information on one or more containers
+long: Display detailed information on one or more containers
+usage: docker container inspect [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes

--- a/_data/engine-cli/docker_container_kill.yaml
+++ b/_data/engine-cli/docker_container_kill.yaml
@@ -1,0 +1,11 @@
+command: docker container kill
+short: Kill one or more running containers
+long: Kill one or more running containers
+usage: docker container kill [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: signal
+  shorthand: s
+  default_value: KILL
+  description: Signal to send to the container

--- a/_data/engine-cli/docker_container_logs.yaml
+++ b/_data/engine-cli/docker_container_logs.yaml
@@ -1,0 +1,23 @@
+command: docker container logs
+short: Fetch the logs of a container
+long: Fetch the logs of a container
+usage: docker container logs [OPTIONS] CONTAINER
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: details
+  default_value: "false"
+  description: Show extra details provided to logs
+- option: follow
+  shorthand: f
+  default_value: "false"
+  description: Follow log output
+- option: since
+  description: Show logs since timestamp
+- option: tail
+  default_value: all
+  description: Number of lines to show from the end of the logs
+- option: timestamps
+  shorthand: t
+  default_value: "false"
+  description: Show timestamps

--- a/_data/engine-cli/docker_container_ls.yaml
+++ b/_data/engine-cli/docker_container_ls.yaml
@@ -1,0 +1,35 @@
+command: docker container ls
+short: List containers
+long: List containers
+usage: docker container ls [OPTIONS]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print containers using a Go template
+- option: last
+  shorthand: "n"
+  default_value: "-1"
+  description: Show n last created containers (includes all states)
+- option: latest
+  shorthand: l
+  default_value: "false"
+  description: Show the latest created container (includes all states)
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display numeric IDs
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes

--- a/_data/engine-cli/docker_container_pause.yaml
+++ b/_data/engine-cli/docker_container_pause.yaml
@@ -1,0 +1,6 @@
+command: docker container pause
+short: Pause all processes within one or more containers
+long: Pause all processes within one or more containers
+usage: docker container pause CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_port.yaml
+++ b/_data/engine-cli/docker_container_port.yaml
@@ -1,0 +1,6 @@
+command: docker container port
+short: List port mappings or a specific mapping for the container
+long: List port mappings or a specific mapping for the container
+usage: docker container port CONTAINER [PRIVATE_PORT[/PROTO]]
+pname: docker container
+plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_prune.yaml
+++ b/_data/engine-cli/docker_container_prune.yaml
@@ -1,0 +1,11 @@
+command: docker container prune
+short: Remove all stopped containers
+long: Remove all stopped containers
+usage: docker container prune [OPTIONS]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation

--- a/_data/engine-cli/docker_container_rename.yaml
+++ b/_data/engine-cli/docker_container_rename.yaml
@@ -1,0 +1,6 @@
+command: docker container rename
+short: Rename a container
+long: Rename a container
+usage: docker container rename CONTAINER NEW_NAME
+pname: docker container
+plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_restart.yaml
+++ b/_data/engine-cli/docker_container_restart.yaml
@@ -1,0 +1,11 @@
+command: docker container restart
+short: Restart one or more containers
+long: Restart one or more containers
+usage: docker container restart [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing the container

--- a/_data/engine-cli/docker_container_rm.yaml
+++ b/_data/engine-cli/docker_container_rm.yaml
@@ -1,0 +1,19 @@
+command: docker container rm
+short: Remove one or more containers
+long: Remove one or more containers
+usage: docker container rm [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the removal of a running container (uses SIGKILL)
+- option: link
+  shorthand: l
+  default_value: "false"
+  description: Remove the specified link
+- option: volumes
+  shorthand: v
+  default_value: "false"
+  description: Remove the volumes associated with the container

--- a/_data/engine-cli/docker_container_run.yaml
+++ b/_data/engine-cli/docker_container_run.yaml
@@ -1,0 +1,267 @@
+command: docker container run
+short: Run a command in a new container
+long: Run a command in a new container
+usage: docker container run [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: Block IO (relative weight), between 10 and 1000
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: Run container in background and print container ID
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: "0"
+  description: Time between running the check
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: "0"
+  description: Maximum time to allow one check to run
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy received signals to the process
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container

--- a/_data/engine-cli/docker_container_start.yaml
+++ b/_data/engine-cli/docker_container_start.yaml
@@ -1,0 +1,17 @@
+command: docker container start
+short: Start one or more stopped containers
+long: Start one or more stopped containers
+usage: docker container start [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: attach
+  shorthand: a
+  default_value: "false"
+  description: Attach STDOUT/STDERR and forward signals
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Attach container's STDIN

--- a/_data/engine-cli/docker_container_stats.yaml
+++ b/_data/engine-cli/docker_container_stats.yaml
@@ -1,0 +1,16 @@
+command: docker container stats
+short: Display a live stream of container(s) resource usage statistics
+long: Display a live stream of container(s) resource usage statistics
+usage: docker container stats [OPTIONS] [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-stream
+  default_value: "false"
+  description: Disable streaming stats and only pull the first result

--- a/_data/engine-cli/docker_container_stop.yaml
+++ b/_data/engine-cli/docker_container_stop.yaml
@@ -1,0 +1,11 @@
+command: docker container stop
+short: Stop one or more running containers
+long: Stop one or more running containers
+usage: docker container stop [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing it

--- a/_data/engine-cli/docker_container_top.yaml
+++ b/_data/engine-cli/docker_container_top.yaml
@@ -1,0 +1,6 @@
+command: docker container top
+short: Display the running processes of a container
+long: Display the running processes of a container
+usage: docker container top CONTAINER [ps OPTIONS]
+pname: docker container
+plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_unpause.yaml
+++ b/_data/engine-cli/docker_container_unpause.yaml
@@ -1,0 +1,6 @@
+command: docker container unpause
+short: Unpause all processes within one or more containers
+long: Unpause all processes within one or more containers
+usage: docker container unpause CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_update.yaml
+++ b/_data/engine-cli/docker_container_update.yaml
@@ -1,0 +1,36 @@
+command: docker container update
+short: Update configuration of one or more containers
+long: Update configuration of one or more containers
+usage: docker container update [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: blkio-weight
+  default_value: "0"
+  description: Block IO (relative weight), between 10 and 1000
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: kernel-memory
+  description: Kernel memory limit
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: restart
+  description: Restart policy to apply when a container exits

--- a/_data/engine-cli/docker_container_wait.yaml
+++ b/_data/engine-cli/docker_container_wait.yaml
@@ -1,0 +1,6 @@
+command: docker container wait
+short: Block until one or more containers stop, then print their exit codes
+long: Block until one or more containers stop, then print their exit codes
+usage: docker container wait CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml

--- a/_data/engine-cli/docker_cp.yaml
+++ b/_data/engine-cli/docker_cp.yaml
@@ -1,0 +1,18 @@
+command: docker cp
+short: Copy files/folders between a container and the local filesystem
+long: |-
+  Copy files/folders between a container and the local filesystem
+
+  Use '-' as the source to read a tar archive from stdin
+  and extract it to a directory destination in a container.
+  Use '-' as the destination to stream a tar archive of a
+  container source to stdout.
+usage: "docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp [OPTIONS]
+  SRC_PATH|- CONTAINER:DEST_PATH"
+pname: docker
+plink: docker.yaml
+options:
+- option: follow-link
+  shorthand: L
+  default_value: "false"
+  description: Always follow symbol link in SRC_PATH

--- a/_data/engine-cli/docker_create.yaml
+++ b/_data/engine-cli/docker_create.yaml
@@ -1,0 +1,258 @@
+command: docker create
+short: Create a new container
+long: Create a new container
+usage: docker create [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker
+plink: docker.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: Block IO (relative weight), between 10 and 1000
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: "0"
+  description: Time between running the check
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: "0"
+  description: Maximum time to allow one check to run
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container

--- a/_data/engine-cli/docker_diff.yaml
+++ b/_data/engine-cli/docker_diff.yaml
@@ -1,0 +1,6 @@
+command: docker diff
+short: Inspect changes on a container's filesystem
+long: Inspect changes on a container's filesystem
+usage: docker diff CONTAINER
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_events.yaml
+++ b/_data/engine-cli/docker_events.yaml
@@ -1,0 +1,16 @@
+command: docker events
+short: Get real time events from the server
+long: Get real time events from the server
+usage: docker events [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Format the output using the given go template
+- option: since
+  description: Show all events created since timestamp
+- option: until
+  description: Stream events until this timestamp

--- a/_data/engine-cli/docker_exec.yaml
+++ b/_data/engine-cli/docker_exec.yaml
@@ -1,0 +1,27 @@
+command: docker exec
+short: Run a command in a running container
+long: Run a command in a running container
+usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
+pname: docker
+plink: docker.yaml
+options:
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: 'Detached mode: run command in the background'
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to the command
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'

--- a/_data/engine-cli/docker_export.yaml
+++ b/_data/engine-cli/docker_export.yaml
@@ -1,0 +1,10 @@
+command: docker export
+short: Export a container's filesystem as a tar archive
+long: Export a container's filesystem as a tar archive
+usage: docker export [OPTIONS] CONTAINER
+pname: docker
+plink: docker.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT

--- a/_data/engine-cli/docker_history.yaml
+++ b/_data/engine-cli/docker_history.yaml
@@ -1,0 +1,18 @@
+command: docker history
+short: Show the history of an image
+long: Show the history of an image
+usage: docker history [OPTIONS] IMAGE
+pname: docker
+plink: docker.yaml
+options:
+- option: human
+  shorthand: H
+  default_value: "true"
+  description: Print sizes and dates in human readable format
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs

--- a/_data/engine-cli/docker_image.yaml
+++ b/_data/engine-cli/docker_image.yaml
@@ -1,0 +1,8 @@
+command: docker image
+short: Manage images
+long: Manage images
+usage: docker image
+pname: docker
+plink: docker.yaml
+cname: docker image tag
+clink: docker_image_tag.yaml

--- a/_data/engine-cli/docker_image_build.yaml
+++ b/_data/engine-cli/docker_image_build.yaml
@@ -1,0 +1,77 @@
+command: docker image build
+short: Build an image from a Dockerfile
+long: Build an image from a Dockerfile
+usage: docker image build [OPTIONS] PATH | URL | -
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: build-arg
+  default_value: '[]'
+  description: Set build-time variables
+- option: cache-from
+  default_value: '[]'
+  description: Images to consider as cache sources
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: compress
+  default_value: "false"
+  description: Compress the build context using gzip
+- option: cpu-period
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: file
+  shorthand: f
+  description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
+- option: force-rm
+  default_value: "false"
+  description: Always remove intermediate containers
+- option: isolation
+  description: Container isolation technology
+- option: label
+  default_value: '[]'
+  description: Set metadata for an image
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: no-cache
+  default_value: "false"
+  description: Do not use cache when building the image
+- option: pull
+  default_value: "false"
+  description: Always attempt to pull a newer version of the image
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the build output and print image ID on success
+- option: rm
+  default_value: "true"
+  description: Remove intermediate containers after a successful build
+- option: security-opt
+  default_value: '[]'
+  description: Security options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: tag
+  shorthand: t
+  default_value: '[]'
+  description: Name and optionally a tag in the 'name:tag' format
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options

--- a/_data/engine-cli/docker_image_history.yaml
+++ b/_data/engine-cli/docker_image_history.yaml
@@ -1,0 +1,18 @@
+command: docker image history
+short: Show the history of an image
+long: Show the history of an image
+usage: docker image history [OPTIONS] IMAGE
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: human
+  shorthand: H
+  default_value: "true"
+  description: Print sizes and dates in human readable format
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs

--- a/_data/engine-cli/docker_image_import.yaml
+++ b/_data/engine-cli/docker_image_import.yaml
@@ -1,0 +1,14 @@
+command: docker image import
+short: Import the contents from a tarball to create a filesystem image
+long: Import the contents from a tarball to create a filesystem image
+usage: docker image import [OPTIONS] file|URL|- [REPOSITORY[:TAG]]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Set commit message for imported image

--- a/_data/engine-cli/docker_image_inspect.yaml
+++ b/_data/engine-cli/docker_image_inspect.yaml
@@ -1,0 +1,10 @@
+command: docker image inspect
+short: Display detailed information on one or more images
+long: Display detailed information on one or more images
+usage: docker image inspect [OPTIONS] IMAGE [IMAGE...]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template

--- a/_data/engine-cli/docker_image_load.yaml
+++ b/_data/engine-cli/docker_image_load.yaml
@@ -1,0 +1,14 @@
+command: docker image load
+short: Load an image from a tar archive or STDIN
+long: Load an image from a tar archive or STDIN
+usage: docker image load [OPTIONS]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: input
+  shorthand: i
+  description: Read from tar archive file, instead of STDIN
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the load output

--- a/_data/engine-cli/docker_image_ls.yaml
+++ b/_data/engine-cli/docker_image_ls.yaml
@@ -1,0 +1,26 @@
+command: docker image ls
+short: List images
+long: List images
+usage: docker image ls [OPTIONS] [REPOSITORY[:TAG]]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all images (default hides intermediate images)
+- option: digests
+  default_value: "false"
+  description: Show digests
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs

--- a/_data/engine-cli/docker_image_prune.yaml
+++ b/_data/engine-cli/docker_image_prune.yaml
@@ -1,0 +1,15 @@
+command: docker image prune
+short: Remove unused images
+long: Remove unused images
+usage: docker image prune [OPTIONS]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Remove all unused images, not just dangling ones
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation

--- a/_data/engine-cli/docker_image_pull.yaml
+++ b/_data/engine-cli/docker_image_pull.yaml
@@ -1,0 +1,14 @@
+command: docker image pull
+short: Pull an image or a repository from a registry
+long: Pull an image or a repository from a registry
+usage: docker image pull [OPTIONS] NAME[:TAG|@DIGEST]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: all-tags
+  shorthand: a
+  default_value: "false"
+  description: Download all tagged images in the repository
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification

--- a/_data/engine-cli/docker_image_push.yaml
+++ b/_data/engine-cli/docker_image_push.yaml
@@ -1,0 +1,10 @@
+command: docker image push
+short: Push an image or a repository to a registry
+long: Push an image or a repository to a registry
+usage: docker image push [OPTIONS] NAME[:TAG]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification

--- a/_data/engine-cli/docker_image_rm.yaml
+++ b/_data/engine-cli/docker_image_rm.yaml
@@ -1,0 +1,14 @@
+command: docker image rm
+short: Remove one or more images
+long: Remove one or more images
+usage: docker image rm [OPTIONS] IMAGE [IMAGE...]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force removal of the image
+- option: no-prune
+  default_value: "false"
+  description: Do not delete untagged parents

--- a/_data/engine-cli/docker_image_save.yaml
+++ b/_data/engine-cli/docker_image_save.yaml
@@ -1,0 +1,10 @@
+command: docker image save
+short: Save one or more images to a tar archive (streamed to STDOUT by default)
+long: Save one or more images to a tar archive (streamed to STDOUT by default)
+usage: docker image save [OPTIONS] IMAGE [IMAGE...]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT

--- a/_data/engine-cli/docker_image_tag.yaml
+++ b/_data/engine-cli/docker_image_tag.yaml
@@ -1,0 +1,6 @@
+command: docker image tag
+short: Tag an image into a repository
+long: Tag an image into a repository
+usage: docker image tag IMAGE[:TAG] IMAGE[:TAG]
+pname: docker image
+plink: docker_image.yaml

--- a/_data/engine-cli/docker_images.yaml
+++ b/_data/engine-cli/docker_images.yaml
@@ -1,0 +1,26 @@
+command: docker images
+short: List images
+long: List images
+usage: docker images [OPTIONS] [REPOSITORY[:TAG]]
+pname: docker
+plink: docker.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all images (default hides intermediate images)
+- option: digests
+  default_value: "false"
+  description: Show digests
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs

--- a/_data/engine-cli/docker_import.yaml
+++ b/_data/engine-cli/docker_import.yaml
@@ -1,0 +1,14 @@
+command: docker import
+short: Import the contents from a tarball to create a filesystem image
+long: Import the contents from a tarball to create a filesystem image
+usage: docker import [OPTIONS] file|URL|- [REPOSITORY[:TAG]]
+pname: docker
+plink: docker.yaml
+options:
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Set commit message for imported image

--- a/_data/engine-cli/docker_info.yaml
+++ b/_data/engine-cli/docker_info.yaml
@@ -1,0 +1,10 @@
+command: docker info
+short: Display system-wide information
+long: Display system-wide information
+usage: docker info [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template

--- a/_data/engine-cli/docker_inspect.yaml
+++ b/_data/engine-cli/docker_inspect.yaml
@@ -1,0 +1,16 @@
+command: docker inspect
+short: Return low-level information on a container, image or task
+long: Return low-level information on a container, image or task
+usage: docker inspect [OPTIONS] CONTAINER|IMAGE|TASK [CONTAINER|IMAGE|TASK...]
+pname: docker
+plink: docker.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes if the type is container
+- option: type
+  description: Return JSON for specified type

--- a/_data/engine-cli/docker_kill.yaml
+++ b/_data/engine-cli/docker_kill.yaml
@@ -1,0 +1,11 @@
+command: docker kill
+short: Kill one or more running containers
+long: Kill one or more running containers
+usage: docker kill [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: signal
+  shorthand: s
+  default_value: KILL
+  description: Signal to send to the container

--- a/_data/engine-cli/docker_load.yaml
+++ b/_data/engine-cli/docker_load.yaml
@@ -1,0 +1,14 @@
+command: docker load
+short: Load an image from a tar archive or STDIN
+long: Load an image from a tar archive or STDIN
+usage: docker load [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: input
+  shorthand: i
+  description: Read from tar archive file, instead of STDIN
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the load output

--- a/_data/engine-cli/docker_login.yaml
+++ b/_data/engine-cli/docker_login.yaml
@@ -1,0 +1,18 @@
+command: docker login
+short: Log in to a Docker registry.
+long: |-
+  Log in to a Docker registry.
+  If no server is specified, the default is defined by the daemon.
+usage: docker login [OPTIONS] [SERVER]
+pname: docker
+plink: docker.yaml
+options:
+- option: email
+  shorthand: e
+  description: Email
+- option: password
+  shorthand: p
+  description: Password
+- option: username
+  shorthand: u
+  description: Username

--- a/_data/engine-cli/docker_logout.yaml
+++ b/_data/engine-cli/docker_logout.yaml
@@ -1,0 +1,8 @@
+command: docker logout
+short: Log out from a Docker registry.
+long: |-
+  Log out from a Docker registry.
+  If no server is specified, the default is defined by the daemon.
+usage: docker logout [SERVER]
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_logs.yaml
+++ b/_data/engine-cli/docker_logs.yaml
@@ -1,0 +1,23 @@
+command: docker logs
+short: Fetch the logs of a container
+long: Fetch the logs of a container
+usage: docker logs [OPTIONS] CONTAINER
+pname: docker
+plink: docker.yaml
+options:
+- option: details
+  default_value: "false"
+  description: Show extra details provided to logs
+- option: follow
+  shorthand: f
+  default_value: "false"
+  description: Follow log output
+- option: since
+  description: Show logs since timestamp
+- option: tail
+  default_value: all
+  description: Number of lines to show from the end of the logs
+- option: timestamps
+  shorthand: t
+  default_value: "false"
+  description: Show timestamps

--- a/_data/engine-cli/docker_network.yaml
+++ b/_data/engine-cli/docker_network.yaml
@@ -1,0 +1,8 @@
+command: docker network
+short: Manage networks
+long: Manage networks
+usage: docker network
+pname: docker
+plink: docker.yaml
+cname: docker network rm
+clink: docker_network_rm.yaml

--- a/_data/engine-cli/docker_network_connect.yaml
+++ b/_data/engine-cli/docker_network_connect.yaml
@@ -1,0 +1,62 @@
+command: docker network connect
+short: Connect a container to a network
+long: |
+  Connects a container to a network. You can connect a container by name
+  or by ID. Once connected, the container can communicate with other containers in
+  the same network.
+
+  ```bash
+  $ docker network connect multi-host-network container1
+  ```
+
+  You can also use the `docker run --net=<network-name>` option to start a container and immediately connect it to a network.
+
+  ```bash
+  $ docker run -itd --net=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::8822 busybox
+  ```
+
+  You can pause, restart, and stop containers that are connected to a network.
+  Paused containers remain connected and can be revealed by a `network inspect`.
+  When the container is stopped, it does not appear on the network until you restart
+  it.
+
+  If specified, the container's IP address(es) is reapplied when a stopped
+  container is restarted. If the IP address is no longer available, the container
+  fails to start. One way to guarantee that the IP address is available is
+  to specify an `--ip-range` when creating the network, and choose the static IP
+  address(es) from outside that range. This ensures that the IP address is not
+  given to another container while this container is not on the network.
+
+  ```bash
+  $ docker network create --subnet 172.20.0.0/16 --ip-range 172.20.240.0/20 multi-host-network
+  ```
+
+  ```bash
+  $ docker network connect --ip 172.20.128.2 multi-host-network container2
+  ```
+
+  To verify the container is connected, use the `docker network inspect` command. Use `docker network disconnect` to remove a container from the network.
+
+  Once connected in network, containers can communicate using only another
+  container's IP address or name. For `overlay` networks or custom plugins that
+  support multi-host connectivity, containers connected to the same multi-host
+  network but launched from different Engines can also communicate in this way.
+
+  You can connect a container to one or more networks. The networks need not be the same type. For example, you can connect a single container bridge and overlay networks.
+usage: docker network connect [OPTIONS] NETWORK CONTAINER
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: ip
+  description: IP Address
+- option: ip6
+  description: IPv6 Address
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Add a link-local address for the container

--- a/_data/engine-cli/docker_network_create.yaml
+++ b/_data/engine-cli/docker_network_create.yaml
@@ -1,0 +1,102 @@
+command: docker network create
+short: Create a network
+long: "Creates a new network. The `DRIVER` accepts `bridge` or `overlay` which are
+  the\nbuilt-in network drivers. If you have installed a third party or your own custom\nnetwork
+  driver you can specify that `DRIVER` here also. If you don't specify the\n`--driver`
+  option, the command automatically creates a `bridge` network for you.\nWhen you
+  install Docker Engine it creates a `bridge` network automatically. This\nnetwork
+  corresponds to the `docker0` bridge that Engine has traditionally relied\non. When
+  launch a new container with  `docker run` it automatically connects to\nthis bridge
+  network. You cannot remove this default bridge network but you can\ncreate new ones
+  using the `network create` command.\n\n```bash\n$ docker network create -d bridge
+  my-bridge-network\n```\n\nBridge networks are isolated networks on a single Engine
+  installation. If you\nwant to create a network that spans multiple Docker hosts
+  each running an\nEngine, you must create an `overlay` network. Unlike `bridge` networks
+  overlay\nnetworks require some pre-existing conditions before you can create one.
+  These\nconditions are:\n\n* Access to a key-value store. Engine supports Consul,
+  Etcd, and Zookeeper (Distributed store) key-value stores.\n* A cluster of hosts
+  with connectivity to the key-value store.\n* A properly configured Engine `daemon`
+  on each host in the cluster.\n\nThe `dockerd` options that support the `overlay`
+  network are:\n\n* `--cluster-store`\n* `--cluster-store-opt`\n* `--cluster-advertise`\n\nTo
+  read more about these options and how to configure them, see [\"*Get started\nwith
+  multi-host\nnetwork*\"](https://docs.docker.com/engine/userguide/networking/get-started-overlay/).\n\nIt
+  is also a good idea, though not required, that you install Docker Swarm on to\nmanage
+  the cluster that makes up your network. Swarm provides sophisticated\ndiscovery
+  and server management that can assist your implementation.\n\nOnce you have prepared
+  the `overlay` network prerequisites you simply choose a\nDocker host in the cluster
+  and issue the following to create the network:\n\n```bash\n$ docker network create
+  -d overlay my-multihost-network\n```\n\nNetwork names must be unique. The Docker
+  daemon attempts to identify naming\nconflicts but this is not guaranteed. It is
+  the user's responsibility to avoid\nname conflicts.\n\n## Connect containers\n\nWhen
+  you start a container use the `--net` flag to connect it to a network.\nThis adds
+  the `busybox` container to the `mynet` network.\n\n```bash\n$ docker run -itd --net=mynet
+  busybox\n```\n\nIf you want to add a container to a network after the container
+  is already\nrunning use the `docker network connect` subcommand.\n\nYou can connect
+  multiple containers to the same network. Once connected, the\ncontainers can communicate
+  using only another container's IP address or name.\nFor `overlay` networks or custom
+  plugins that support multi-host connectivity,\ncontainers connected to the same
+  multi-host network but launched from different\nEngines can also communicate in
+  this way.\n\nYou can disconnect a container from a network using the `docker network\ndisconnect`
+  command.\n\n## Specifying advanced options\n\nWhen you create a network, Engine
+  creates a non-overlapping subnetwork for the\nnetwork by default. This subnetwork
+  is not a subdivision of an existing network.\nIt is purely for ip-addressing purposes.
+  You can override this default and\nspecify subnetwork values directly using the
+  `--subnet` option. On a\n`bridge` network you can only create a single subnet:\n\n```bash\n$
+  docker network create -d bridge --subnet=192.168.0.0/16 br0\n```\n\nAdditionally,
+  you also specify the `--gateway` `--ip-range` and `--aux-address`\noptions.\n\n```bash\n$
+  docker network create \\\n  --driver=bridge \\\n  --subnet=172.28.0.0/16 \\\n  --ip-range=172.28.5.0/24
+  \\\n  --gateway=172.28.5.254 \\\n  br0\n```\n\nIf you omit the `--gateway` flag
+  the Engine selects one for you from inside a\npreferred pool. For `overlay` networks
+  and for network driver plugins that\nsupport it you can create multiple subnetworks.\n\n```bash\n$
+  docker network create -d overlay \\\n  --subnet=192.168.0.0/16 \\\n  --subnet=192.170.0.0/16
+  \\\n  --gateway=192.168.0.100 \\ \n  --gateway=192.170.0.100 \\\n  --ip-range=192.168.1.0/24
+  \\\n  --aux-address=\"my-router=192.168.1.5\" --aux-address=\"my-switch=192.168.1.6\"
+  \\\n  --aux-address=\"my-printer=192.170.1.5\" --aux-address=\"my-nas=192.170.1.6\"
+  \\\n  my-multihost-network\n```\n\nBe sure that your subnetworks do not overlap.
+  If they do, the network create\nfails and Engine returns an error.\n\n### Network
+  internal mode\n\nBy default, when you connect a container to an `overlay` network,
+  Docker also\nconnects a bridge network to it to provide external connectivity. If
+  you want\nto create an externally isolated `overlay` network, you can specify the\n`--internal`
+  option.\n"
+usage: docker network create [OPTIONS] NETWORK
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: attachable
+  default_value: "false"
+  description: Enable manual container attachment
+- option: aux-address
+  default_value: map[]
+  description: Auxiliary IPv4 or IPv6 addresses used by Network driver
+- option: driver
+  shorthand: d
+  default_value: bridge
+  description: Driver to manage the Network
+- option: gateway
+  default_value: '[]'
+  description: IPv4 or IPv6 Gateway for the master subnet
+- option: internal
+  default_value: "false"
+  description: Restrict external access to the network
+- option: ip-range
+  default_value: '[]'
+  description: Allocate container ip from a sub-range
+- option: ipam-driver
+  default_value: default
+  description: IP Address Management Driver
+- option: ipam-opt
+  default_value: map[]
+  description: Set IPAM driver specific options
+- option: ipv6
+  default_value: "false"
+  description: Enable IPv6 networking
+- option: label
+  default_value: '[]'
+  description: Set metadata on a network
+- option: opt
+  shorthand: o
+  default_value: map[]
+  description: Set driver specific options
+- option: subnet
+  default_value: '[]'
+  description: Subnet in CIDR format that represents a network segment

--- a/_data/engine-cli/docker_network_disconnect.yaml
+++ b/_data/engine-cli/docker_network_disconnect.yaml
@@ -1,0 +1,16 @@
+command: docker network disconnect
+short: Disconnect a container from a network
+long: |
+  Disconnects a container from a network.
+
+  ```bash
+  $ docker network disconnect multi-host-network container1
+  ```
+usage: docker network disconnect [OPTIONS] NETWORK CONTAINER
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the container to disconnect from a network

--- a/_data/engine-cli/docker_network_inspect.yaml
+++ b/_data/engine-cli/docker_network_inspect.yaml
@@ -1,0 +1,98 @@
+command: docker network inspect
+short: Display detailed information on one or more networks
+long: |
+  Returns information about one or more networks. By default, this command renders all results in a JSON object. For example, if you connect two containers to the default `bridge` network:
+
+  ```bash
+  $ sudo docker run -itd --name=container1 busybox
+  f2870c98fd504370fb86e59f32cd0753b1ac9b69b7d80566ffc7192a82b3ed27
+
+  $ sudo docker run -itd --name=container2 busybox
+  bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727
+  ```
+
+  The `network inspect` command shows the containers, by id, in its
+  results. You can specify an alternate format to execute a given
+  template for each result. Go's
+  [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+
+  ```bash
+  $ sudo docker network inspect bridge
+  [
+      {
+          "Name": "bridge",
+          "Id": "b2b1a2cba717161d984383fd68218cf70bbbd17d328496885f7c921333228b0f",
+          "Scope": "local",
+          "Driver": "bridge",
+          "IPAM": {
+              "Driver": "default",
+              "Config": [
+                  {
+                      "Subnet": "172.17.42.1/16",
+                      "Gateway": "172.17.42.1"
+                  }
+              ]
+          },
+          "Internal": false,
+          "Containers": {
+              "bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727": {
+                  "Name": "container2",
+                  "EndpointID": "0aebb8fcd2b282abe1365979536f21ee4ceaf3ed56177c628eae9f706e00e019",
+                  "MacAddress": "02:42:ac:11:00:02",
+                  "IPv4Address": "172.17.0.2/16",
+                  "IPv6Address": ""
+              },
+              "f2870c98fd504370fb86e59f32cd0753b1ac9b69b7d80566ffc7192a82b3ed27": {
+                  "Name": "container1",
+                  "EndpointID": "a00676d9c91a96bbe5bcfb34f705387a33d7cc365bac1a29e4e9728df92d10ad",
+                  "MacAddress": "02:42:ac:11:00:01",
+                  "IPv4Address": "172.17.0.1/16",
+                  "IPv6Address": ""
+              }
+          },
+          "Options": {
+              "com.docker.network.bridge.default_bridge": "true",
+              "com.docker.network.bridge.enable_icc": "true",
+              "com.docker.network.bridge.enable_ip_masquerade": "true",
+              "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
+              "com.docker.network.bridge.name": "docker0",
+              "com.docker.network.driver.mtu": "1500"
+          }
+      }
+  ]
+  ```
+
+  Returns the information about the user-defined network:
+
+  ```bash
+  $ docker network create simple-network
+  69568e6336d8c96bbf57869030919f7c69524f71183b44d80948bd3927c87f6a
+  $ docker network inspect simple-network
+  [
+      {
+          "Name": "simple-network",
+          "Id": "69568e6336d8c96bbf57869030919f7c69524f71183b44d80948bd3927c87f6a",
+          "Scope": "local",
+          "Driver": "bridge",
+          "IPAM": {
+              "Driver": "default",
+              "Config": [
+                  {
+                      "Subnet": "172.22.0.0/16",
+                      "Gateway": "172.22.0.1"
+                  }
+              ]
+          },
+          "Containers": {},
+          "Options": {}
+      }
+  ]
+  ```
+usage: docker network inspect [OPTIONS] NETWORK [NETWORK...]
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template

--- a/_data/engine-cli/docker_network_ls.yaml
+++ b/_data/engine-cli/docker_network_ls.yaml
@@ -1,0 +1,78 @@
+command: docker network ls
+short: List networks
+long: "Lists all the networks the Engine `daemon` knows about. This includes the\nnetworks
+  that span across multiple hosts in a cluster, for example:\n\n```bash\n    $ docker
+  network ls\n    NETWORK ID          NAME                DRIVER\n    7fca4eb8c647
+  \       bridge              bridge\n    9f904ee27bf5        none                null\n
+  \   cf03ee007fb4        host                host\n    78b03ee04fc4        multi-host
+  \         overlay\n```\n\nUse the `--no-trunc` option to display the full network
+  id:\n\n```bash\n$ docker network ls --no-trunc\nNETWORK ID                                                         NAME
+  \               DRIVER\n18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3
+  \  none                null                \nc288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47
+  \  host                host                \n7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185
+  \  bridge              bridge              \n95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd
+  \  foo                 bridge    \n63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161
+  \  dev                 bridge\n```\n\n## Filtering\n\nThe filtering flag (`-f` or
+  `--filter`) format is a `key=value` pair. If there\nis more than one filter, then
+  pass multiple flags (e.g. `--filter \"foo=bar\" --filter \"bif=baz\"`).\nMultiple
+  filter flags are combined as an `OR` filter. For example, \n`-f type=custom -f type=builtin`
+  returns both `custom` and `builtin` networks.\n\nThe currently supported filters
+  are:\n\n* driver\n* id (network's id)\n* label (`label=<key>` or `label=<key>=<value>`)\n*
+  name (network's name)\n* type (custom|builtin)\n\n#### Driver\n\nThe `driver` filter
+  matches networks based on their driver.\n\nThe following example matches networks
+  with the `bridge` driver:\n\n```bash\n$ docker network ls --filter driver=bridge\nNETWORK
+  ID          NAME                DRIVER\ndb9db329f835        test1               bridge\nf6e212da9dfd
+  \       test2               bridge\n```\n\n#### ID\n\nThe `id` filter matches on
+  all or part of a network's ID.\n\nThe following filter matches all networks with
+  an ID containing the\n`63d1ff1f77b0...` string.\n\n```bash\n$ docker network ls
+  --filter id=63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161\nNETWORK
+  ID          NAME                DRIVER\n63d1ff1f77b0        dev                 bridge\n```\n\nYou
+  can also filter for a substring in an ID as this shows:\n\n```bash\n$ docker network
+  ls --filter id=95e74588f40d\nNETWORK ID          NAME                DRIVER\n95e74588f40d
+  \       foo                 bridge\n\n$ docker network ls --filter id=95e\nNETWORK
+  ID          NAME                DRIVER\n95e74588f40d        foo                 bridge\n```\n\n####
+  Label\n\nThe `label` filter matches networks based on the presence of a `label`
+  alone or a `label` and a\nvalue.\n\nThe following filter matches networks with the
+  `usage` label regardless of its value.\n\n```bash\n$ docker network ls -f \"label=usage\"\nNETWORK
+  ID          NAME                DRIVER\ndb9db329f835        test1               bridge
+  \             \nf6e212da9dfd        test2               bridge\n```\n\nThe following
+  filter matches networks with the `usage` label with the `prod` value.\n\n```bash\n$
+  docker network ls -f \"label=usage=prod\"\nNETWORK ID          NAME                DRIVER\nf6e212da9dfd
+  \       test2               bridge\n```\n\n#### Name\n\nThe `name` filter matches
+  on all or part of a network's name.\n\nThe following filter matches all networks
+  with a name containing the `foobar` string.\n\n```bash\n$ docker network ls --filter
+  name=foobar\nNETWORK ID          NAME                DRIVER\n06e7eef0a170        foobar
+  \             bridge\n```\n\nYou can also filter for a substring in a name as this
+  shows:\n\n```bash\n$ docker network ls --filter name=foo\nNETWORK ID          NAME
+  \               DRIVER\n95e74588f40d        foo                 bridge\n06e7eef0a170
+  \       foobar              bridge\n```\n\n#### Type\n\nThe `type` filter supports
+  two values; `builtin` displays predefined networks\n(`bridge`, `none`, `host`),
+  whereas `custom` displays user defined networks.\n\nThe following filter matches
+  all user defined networks:\n\n```bash\n$ docker network ls --filter type=custom\nNETWORK
+  ID          NAME                DRIVER\n95e74588f40d        foo                 bridge\n63d1ff1f77b0
+  \       dev                 bridge\n```\n\nBy having this flag it allows for batch
+  cleanup. For example, use this filter\nto delete all user defined networks:\n\n```bash\n$
+  docker network rm `docker network ls --filter type=custom -q`\n```\n\nA warning
+  will be issued when trying to remove a network that has containers\nattached.\n\n##
+  Format\n\nFormat uses a Go template to print the output. The following variables
+  are \nsupported: \n\n* .ID - Network ID\n* .Name - Network name\n* .Driver - Network
+  driver\n* .Scope - Network scope (local, global)\n* .IPv6 - Whether IPv6 is enabled
+  on the network or not\n* .Internal - Whether the network is internal or not\n* .Labels
+  - All labels assigned to the network\n* .Label - Value of a specific label for this
+  network. For example `{{.Label \"project.version\"}}`\n"
+usage: docker network ls [OPTIONS]
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Provide filter values (i.e. 'dangling=true')
+- option: format
+  description: Pretty-print networks using a Go template
+- option: no-trunc
+  default_value: "false"
+  description: Do not truncate the output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display network IDs

--- a/_data/engine-cli/docker_network_rm.yaml
+++ b/_data/engine-cli/docker_network_rm.yaml
@@ -1,0 +1,26 @@
+command: docker network rm
+short: Remove one or more networks
+long: |
+  Removes one or more networks by name or identifier. To remove a network,
+  you must first disconnect any containers connected to it.
+  To remove the network named 'my-network':
+
+  ```bash
+    $ docker network rm my-network
+  ```
+
+  To delete multiple networks in a single `docker network rm` command, provide
+  multiple network names or ids. The following example deletes a network with id
+  `3695c422697f` and a network named `my-network`:
+
+  ```bash
+    $ docker network rm 3695c422697f my-network
+  ```
+
+  When you specify multiple networks, the command attempts to delete each in turn.
+  If the deletion of one network fails, the command continues to the next on the
+  list and tries to delete that. The command reports success or failure for each
+  deletion.
+usage: docker network rm NETWORK [NETWORK...]
+pname: docker network
+plink: docker_network.yaml

--- a/_data/engine-cli/docker_node.yaml
+++ b/_data/engine-cli/docker_node.yaml
@@ -1,0 +1,8 @@
+command: docker node
+short: Manage Swarm nodes
+long: Manage Swarm nodes
+usage: docker node
+pname: docker
+plink: docker.yaml
+cname: docker node update
+clink: docker_node_update.yaml

--- a/_data/engine-cli/docker_node_demote.yaml
+++ b/_data/engine-cli/docker_node_demote.yaml
@@ -1,0 +1,6 @@
+command: docker node demote
+short: Demote one or more nodes from manager in the swarm
+long: Demote one or more nodes from manager in the swarm
+usage: docker node demote NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml

--- a/_data/engine-cli/docker_node_inspect.yaml
+++ b/_data/engine-cli/docker_node_inspect.yaml
@@ -1,0 +1,13 @@
+command: docker node inspect
+short: Display detailed information on one or more nodes
+long: Display detailed information on one or more nodes
+usage: docker node inspect [OPTIONS] self|NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template
+- option: pretty
+  default_value: "false"
+  description: Print the information in a human friendly format.

--- a/_data/engine-cli/docker_node_ls.yaml
+++ b/_data/engine-cli/docker_node_ls.yaml
@@ -1,0 +1,14 @@
+command: docker node ls
+short: List nodes in the swarm
+long: List nodes in the swarm
+usage: docker node ls [OPTIONS]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display IDs

--- a/_data/engine-cli/docker_node_promote.yaml
+++ b/_data/engine-cli/docker_node_promote.yaml
@@ -1,0 +1,6 @@
+command: docker node promote
+short: Promote one or more nodes to manager in the swarm
+long: Promote one or more nodes to manager in the swarm
+usage: docker node promote NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml

--- a/_data/engine-cli/docker_node_ps.yaml
+++ b/_data/engine-cli/docker_node_ps.yaml
@@ -1,0 +1,16 @@
+command: docker node ps
+short: List tasks running on one or more nodes, defaults to current node
+long: List tasks running on one or more nodes, defaults to current node
+usage: docker node ps [OPTIONS] [NODE...]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: no-resolve
+  default_value: "false"
+  description: Do not map IDs to Names
+- option: no-trunc
+  default_value: "false"
+  description: Do not truncate output

--- a/_data/engine-cli/docker_node_rm.yaml
+++ b/_data/engine-cli/docker_node_rm.yaml
@@ -1,0 +1,10 @@
+command: docker node rm
+short: Remove one or more nodes from the swarm
+long: Remove one or more nodes from the swarm
+usage: docker node rm [OPTIONS] NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: force
+  default_value: "false"
+  description: Force remove an active node

--- a/_data/engine-cli/docker_node_update.yaml
+++ b/_data/engine-cli/docker_node_update.yaml
@@ -1,0 +1,17 @@
+command: docker node update
+short: Update a node
+long: Update a node
+usage: docker node update [OPTIONS] NODE
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: availability
+  description: Availability of the node (active/pause/drain)
+- option: label-add
+  default_value: '[]'
+  description: Add or update a node label (key=value)
+- option: label-rm
+  default_value: '[]'
+  description: Remove a node label if exists
+- option: role
+  description: Role of the node (worker/manager)

--- a/_data/engine-cli/docker_pause.yaml
+++ b/_data/engine-cli/docker_pause.yaml
@@ -1,0 +1,6 @@
+command: docker pause
+short: Pause all processes within one or more containers
+long: Pause all processes within one or more containers
+usage: docker pause CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_port.yaml
+++ b/_data/engine-cli/docker_port.yaml
@@ -1,0 +1,6 @@
+command: docker port
+short: List port mappings or a specific mapping for the container
+long: List port mappings or a specific mapping for the container
+usage: docker port CONTAINER [PRIVATE_PORT[/PROTO]]
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -1,0 +1,35 @@
+command: docker ps
+short: List containers
+long: List containers
+usage: docker ps [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print containers using a Go template
+- option: last
+  shorthand: "n"
+  default_value: "-1"
+  description: Show n last created containers (includes all states)
+- option: latest
+  shorthand: l
+  default_value: "false"
+  description: Show the latest created container (includes all states)
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display numeric IDs
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes

--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -1,0 +1,14 @@
+command: docker pull
+short: Pull an image or a repository from a registry
+long: Pull an image or a repository from a registry
+usage: docker pull [OPTIONS] NAME[:TAG|@DIGEST]
+pname: docker
+plink: docker.yaml
+options:
+- option: all-tags
+  shorthand: a
+  default_value: "false"
+  description: Download all tagged images in the repository
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification

--- a/_data/engine-cli/docker_push.yaml
+++ b/_data/engine-cli/docker_push.yaml
@@ -1,0 +1,10 @@
+command: docker push
+short: Push an image or a repository to a registry
+long: Push an image or a repository to a registry
+usage: docker push [OPTIONS] NAME[:TAG]
+pname: docker
+plink: docker.yaml
+options:
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification

--- a/_data/engine-cli/docker_rename.yaml
+++ b/_data/engine-cli/docker_rename.yaml
@@ -1,0 +1,6 @@
+command: docker rename
+short: Rename a container
+long: Rename a container
+usage: docker rename CONTAINER NEW_NAME
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_restart.yaml
+++ b/_data/engine-cli/docker_restart.yaml
@@ -1,0 +1,11 @@
+command: docker restart
+short: Restart one or more containers
+long: Restart one or more containers
+usage: docker restart [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing the container

--- a/_data/engine-cli/docker_rm.yaml
+++ b/_data/engine-cli/docker_rm.yaml
@@ -1,0 +1,19 @@
+command: docker rm
+short: Remove one or more containers
+long: Remove one or more containers
+usage: docker rm [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the removal of a running container (uses SIGKILL)
+- option: link
+  shorthand: l
+  default_value: "false"
+  description: Remove the specified link
+- option: volumes
+  shorthand: v
+  default_value: "false"
+  description: Remove the volumes associated with the container

--- a/_data/engine-cli/docker_rmi.yaml
+++ b/_data/engine-cli/docker_rmi.yaml
@@ -1,0 +1,14 @@
+command: docker rmi
+short: Remove one or more images
+long: Remove one or more images
+usage: docker rmi [OPTIONS] IMAGE [IMAGE...]
+pname: docker
+plink: docker.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force removal of the image
+- option: no-prune
+  default_value: "false"
+  description: Do not delete untagged parents

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -1,0 +1,267 @@
+command: docker run
+short: Run a command in a new container
+long: Run a command in a new container
+usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker
+plink: docker.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: Block IO (relative weight), between 10 and 1000
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: Run container in background and print container ID
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: "0"
+  description: Time between running the check
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: "0"
+  description: Maximum time to allow one check to run
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy received signals to the process
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container

--- a/_data/engine-cli/docker_save.yaml
+++ b/_data/engine-cli/docker_save.yaml
@@ -1,0 +1,10 @@
+command: docker save
+short: Save one or more images to a tar archive (streamed to STDOUT by default)
+long: Save one or more images to a tar archive (streamed to STDOUT by default)
+usage: docker save [OPTIONS] IMAGE [IMAGE...]
+pname: docker
+plink: docker.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT

--- a/_data/engine-cli/docker_search.yaml
+++ b/_data/engine-cli/docker_search.yaml
@@ -1,0 +1,23 @@
+command: docker search
+short: Search the Docker Hub for images
+long: Search the Docker Hub for images
+usage: docker search [OPTIONS] TERM
+pname: docker
+plink: docker.yaml
+options:
+- option: automated
+  default_value: "false"
+  description: Only show automated builds
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: limit
+  default_value: "25"
+  description: Max number of search results
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: stars
+  shorthand: s
+  default_value: "0"
+  description: Only displays with at least x stars

--- a/_data/engine-cli/docker_service.yaml
+++ b/_data/engine-cli/docker_service.yaml
@@ -1,0 +1,8 @@
+command: docker service
+short: Manage services
+long: Manage services
+usage: docker service
+pname: docker
+plink: docker.yaml
+cname: docker service update
+clink: docker_service_update.yaml

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -1,0 +1,93 @@
+command: docker service create
+short: Create a new service
+long: Create a new service
+usage: docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: constraint
+  default_value: '[]'
+  description: Placement constraints
+- option: container-label
+  default_value: '[]'
+  description: Container labels
+- option: endpoint-mode
+  description: Endpoint mode (vip or dnsrr)
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: group-add
+  default_value: '[]'
+  description: Add additional user groups to the container
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Service labels
+- option: limit-cpu
+  default_value: "0.000"
+  description: Limit CPUs
+- option: limit-memory
+  default_value: 0 B
+  description: Limit Memory
+- option: log-driver
+  description: Logging driver for service
+- option: log-opt
+  default_value: '[]'
+  description: Logging driver options
+- option: mode
+  default_value: replicated
+  description: Service mode (replicated or global)
+- option: mount
+  description: Attach a mount to the service
+- option: name
+  description: Service name
+- option: network
+  default_value: '[]'
+  description: Network attachments
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a port as a node port
+- option: replicas
+  default_value: none
+  description: Number of tasks
+- option: reserve-cpu
+  default_value: "0.000"
+  description: Reserve CPUs
+- option: reserve-memory
+  default_value: 0 B
+  description: Reserve Memory
+- option: restart-condition
+  description: Restart when condition is met (none, on-failure, or any)
+- option: restart-delay
+  default_value: none
+  description: Delay between restart attempts
+- option: restart-max-attempts
+  default_value: none
+  description: Maximum number of restarts before giving up
+- option: restart-window
+  default_value: none
+  description: Window used to evaluate the restart policy
+- option: stop-grace-period
+  default_value: none
+  description: Time to wait before force killing a container
+- option: update-delay
+  default_value: "0"
+  description: Delay between updates
+- option: update-failure-action
+  default_value: pause
+  description: Action on update failure (pause|continue)
+- option: update-parallelism
+  default_value: "1"
+  description: |
+    Maximum number of tasks updated simultaneously (0 to update all at once)
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: with-registry-auth
+  default_value: "false"
+  description: Send registry authentication details to swarm agents
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container

--- a/_data/engine-cli/docker_service_inspect.yaml
+++ b/_data/engine-cli/docker_service_inspect.yaml
@@ -1,0 +1,13 @@
+command: docker service inspect
+short: Display detailed information on one or more services
+long: Display detailed information on one or more services
+usage: docker service inspect [OPTIONS] SERVICE [SERVICE...]
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template
+- option: pretty
+  default_value: "false"
+  description: Print the information in a human friendly format.

--- a/_data/engine-cli/docker_service_ls.yaml
+++ b/_data/engine-cli/docker_service_ls.yaml
@@ -1,0 +1,14 @@
+command: docker service ls
+short: List services
+long: List services
+usage: docker service ls [OPTIONS]
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display IDs

--- a/_data/engine-cli/docker_service_ps.yaml
+++ b/_data/engine-cli/docker_service_ps.yaml
@@ -1,0 +1,16 @@
+command: docker service ps
+short: List the tasks of a service
+long: List the tasks of a service
+usage: docker service ps [OPTIONS] SERVICE
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: no-resolve
+  default_value: "false"
+  description: Do not map IDs to Names
+- option: no-trunc
+  default_value: "false"
+  description: Do not truncate output

--- a/_data/engine-cli/docker_service_rm.yaml
+++ b/_data/engine-cli/docker_service_rm.yaml
@@ -1,0 +1,6 @@
+command: docker service rm
+short: Remove one or more services
+long: Remove one or more services
+usage: docker service rm SERVICE [SERVICE...]
+pname: docker service
+plink: docker_service.yaml

--- a/_data/engine-cli/docker_service_scale.yaml
+++ b/_data/engine-cli/docker_service_scale.yaml
@@ -1,0 +1,6 @@
+command: docker service scale
+short: Scale one or multiple services
+long: Scale one or multiple services
+usage: docker service scale SERVICE=REPLICAS [SERVICE=REPLICAS...]
+pname: docker service
+plink: docker_service.yaml

--- a/_data/engine-cli/docker_service_update.yaml
+++ b/_data/engine-cli/docker_service_update.yaml
@@ -1,0 +1,109 @@
+command: docker service update
+short: Update a service
+long: Update a service
+usage: docker service update [OPTIONS] SERVICE
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: args
+  description: Service command args
+- option: constraint-add
+  default_value: '[]'
+  description: Add or update placement constraints
+- option: constraint-rm
+  default_value: '[]'
+  description: Remove a constraint
+- option: container-label-add
+  default_value: '[]'
+  description: Add or update container labels
+- option: container-label-rm
+  default_value: '[]'
+  description: Remove a container label by its key
+- option: endpoint-mode
+  description: Endpoint mode (vip or dnsrr)
+- option: env-add
+  default_value: '[]'
+  description: Add or update environment variables
+- option: env-rm
+  default_value: '[]'
+  description: Remove an environment variable
+- option: group-add
+  default_value: '[]'
+  description: Add additional user groups to the container
+- option: group-rm
+  default_value: '[]'
+  description: Remove previously added user groups from the container
+- option: image
+  description: Service image tag
+- option: label-add
+  default_value: '[]'
+  description: Add or update service labels
+- option: label-rm
+  default_value: '[]'
+  description: Remove a label by its key
+- option: limit-cpu
+  default_value: "0.000"
+  description: Limit CPUs
+- option: limit-memory
+  default_value: 0 B
+  description: Limit Memory
+- option: log-driver
+  description: Logging driver for service
+- option: log-opt
+  default_value: '[]'
+  description: Logging driver options
+- option: mount-add
+  description: Add or update a mount on a service
+- option: mount-rm
+  default_value: '[]'
+  description: Remove a mount by its target path
+- option: name
+  description: Service name
+- option: publish-add
+  default_value: '[]'
+  description: Add or update a published port
+- option: publish-rm
+  default_value: '[]'
+  description: Remove a published port by its target port
+- option: replicas
+  default_value: none
+  description: Number of tasks
+- option: reserve-cpu
+  default_value: "0.000"
+  description: Reserve CPUs
+- option: reserve-memory
+  default_value: 0 B
+  description: Reserve Memory
+- option: restart-condition
+  description: Restart when condition is met (none, on-failure, or any)
+- option: restart-delay
+  default_value: none
+  description: Delay between restart attempts
+- option: restart-max-attempts
+  default_value: none
+  description: Maximum number of restarts before giving up
+- option: restart-window
+  default_value: none
+  description: Window used to evaluate the restart policy
+- option: stop-grace-period
+  default_value: none
+  description: Time to wait before force killing a container
+- option: update-delay
+  default_value: "0"
+  description: Delay between updates
+- option: update-failure-action
+  default_value: pause
+  description: Action on update failure (pause|continue)
+- option: update-parallelism
+  default_value: "1"
+  description: |
+    Maximum number of tasks updated simultaneously (0 to update all at once)
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: with-registry-auth
+  default_value: "false"
+  description: Send registry authentication details to swarm agents
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container

--- a/_data/engine-cli/docker_start.yaml
+++ b/_data/engine-cli/docker_start.yaml
@@ -1,0 +1,17 @@
+command: docker start
+short: Start one or more stopped containers
+long: Start one or more stopped containers
+usage: docker start [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: attach
+  shorthand: a
+  default_value: "false"
+  description: Attach STDOUT/STDERR and forward signals
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Attach container's STDIN

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -1,0 +1,16 @@
+command: docker stats
+short: Display a live stream of container(s) resource usage statistics
+long: Display a live stream of container(s) resource usage statistics
+usage: docker stats [OPTIONS] [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-stream
+  default_value: "false"
+  description: Disable streaming stats and only pull the first result

--- a/_data/engine-cli/docker_stop.yaml
+++ b/_data/engine-cli/docker_stop.yaml
@@ -1,0 +1,11 @@
+command: docker stop
+short: Stop one or more running containers
+long: Stop one or more running containers
+usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing it

--- a/_data/engine-cli/docker_swarm.yaml
+++ b/_data/engine-cli/docker_swarm.yaml
@@ -1,0 +1,8 @@
+command: docker swarm
+short: Manage Swarm
+long: Manage Swarm
+usage: docker swarm
+pname: docker
+plink: docker.yaml
+cname: docker swarm update
+clink: docker_swarm_update.yaml

--- a/_data/engine-cli/docker_swarm_init.yaml
+++ b/_data/engine-cli/docker_swarm_init.yaml
@@ -1,0 +1,26 @@
+command: docker swarm init
+short: Initialize a swarm
+long: Initialize a swarm
+usage: docker swarm init [OPTIONS]
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: advertise-addr
+  description: 'Advertised address (format: <ip|interface>[:port])'
+- option: cert-expiry
+  default_value: 2160h0m0s
+  description: Validity period for node certificates
+- option: dispatcher-heartbeat
+  default_value: 5s
+  description: Dispatcher heartbeat period
+- option: external-ca
+  description: Specifications of one or more certificate signing endpoints
+- option: force-new-cluster
+  default_value: "false"
+  description: Force create a new cluster from current state.
+- option: listen-addr
+  default_value: 0.0.0.0:2377
+  description: 'Listen address (format: <ip|interface>[:port])'
+- option: task-history-limit
+  default_value: "5"
+  description: Task history retention limit

--- a/_data/engine-cli/docker_swarm_join-token.yaml
+++ b/_data/engine-cli/docker_swarm_join-token.yaml
@@ -1,0 +1,14 @@
+command: docker swarm join-token
+short: Manage join tokens
+long: Manage join tokens
+usage: docker swarm join-token [OPTIONS] (worker|manager)
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display token
+- option: rotate
+  default_value: "false"
+  description: Rotate join token

--- a/_data/engine-cli/docker_swarm_join.yaml
+++ b/_data/engine-cli/docker_swarm_join.yaml
@@ -1,0 +1,14 @@
+command: docker swarm join
+short: Join a swarm as a node and/or manager
+long: Join a swarm as a node and/or manager
+usage: docker swarm join [OPTIONS] HOST:PORT
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: advertise-addr
+  description: 'Advertised address (format: <ip|interface>[:port])'
+- option: listen-addr
+  default_value: 0.0.0.0:2377
+  description: 'Listen address (format: <ip|interface>[:port])'
+- option: token
+  description: Token for entry into the swarm

--- a/_data/engine-cli/docker_swarm_leave.yaml
+++ b/_data/engine-cli/docker_swarm_leave.yaml
@@ -1,0 +1,10 @@
+command: docker swarm leave
+short: Leave the swarm (workers only)
+long: Leave the swarm (workers only)
+usage: docker swarm leave [OPTIONS]
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: force
+  default_value: "false"
+  description: Force this node to leave the swarm, ignoring warnings

--- a/_data/engine-cli/docker_swarm_update.yaml
+++ b/_data/engine-cli/docker_swarm_update.yaml
@@ -1,0 +1,18 @@
+command: docker swarm update
+short: Update the swarm
+long: Update the swarm
+usage: docker swarm update [OPTIONS]
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: cert-expiry
+  default_value: 2160h0m0s
+  description: Validity period for node certificates
+- option: dispatcher-heartbeat
+  default_value: 5s
+  description: Dispatcher heartbeat period
+- option: external-ca
+  description: Specifications of one or more certificate signing endpoints
+- option: task-history-limit
+  default_value: "5"
+  description: Task history retention limit

--- a/_data/engine-cli/docker_system.yaml
+++ b/_data/engine-cli/docker_system.yaml
@@ -1,0 +1,8 @@
+command: docker system
+short: Manage Docker
+long: Manage Docker
+usage: docker system
+pname: docker
+plink: docker.yaml
+cname: docker system prune
+clink: docker_system_prune.yaml

--- a/_data/engine-cli/docker_system_df.yaml
+++ b/_data/engine-cli/docker_system_df.yaml
@@ -1,0 +1,11 @@
+command: docker system df
+short: Show docker disk usage
+long: Show docker disk usage
+usage: docker system df [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: verbose
+  shorthand: v
+  default_value: "false"
+  description: Show detailed information on space usage

--- a/_data/engine-cli/docker_system_events.yaml
+++ b/_data/engine-cli/docker_system_events.yaml
@@ -1,0 +1,16 @@
+command: docker system events
+short: Get real time events from the server
+long: Get real time events from the server
+usage: docker system events [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Format the output using the given go template
+- option: since
+  description: Show all events created since timestamp
+- option: until
+  description: Stream events until this timestamp

--- a/_data/engine-cli/docker_system_info.yaml
+++ b/_data/engine-cli/docker_system_info.yaml
@@ -1,0 +1,10 @@
+command: docker system info
+short: Display system-wide information
+long: Display system-wide information
+usage: docker system info [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template

--- a/_data/engine-cli/docker_system_prune.yaml
+++ b/_data/engine-cli/docker_system_prune.yaml
@@ -1,0 +1,15 @@
+command: docker system prune
+short: Remove unused data
+long: Remove unused data
+usage: docker system prune [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Remove all unused images not just dangling ones
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation

--- a/_data/engine-cli/docker_tag.yaml
+++ b/_data/engine-cli/docker_tag.yaml
@@ -1,0 +1,6 @@
+command: docker tag
+short: Tag an image into a repository
+long: Tag an image into a repository
+usage: docker tag IMAGE[:TAG] IMAGE[:TAG]
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_top.yaml
+++ b/_data/engine-cli/docker_top.yaml
@@ -1,0 +1,17 @@
+command: docker top
+short: Display the running processes of a container
+long: |
+  Display the running process of the container. ps-OPTION can be any of the options you would pass to a Linux ps command.
+
+  All displayed information is from host's point of view.
+
+  # EXAMPLES
+
+  Run **docker top** with the ps option of -x:
+
+      $ docker top 8601afda2b -x
+      PID      TTY       STAT       TIME         COMMAND
+      16623    ?         Ss         0:00         sleep 99999
+usage: docker top CONTAINER [ps OPTIONS]
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_unpause.yaml
+++ b/_data/engine-cli/docker_unpause.yaml
@@ -1,0 +1,6 @@
+command: docker unpause
+short: Unpause all processes within one or more containers
+long: Unpause all processes within one or more containers
+usage: docker unpause CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml

--- a/_data/engine-cli/docker_update.yaml
+++ b/_data/engine-cli/docker_update.yaml
@@ -1,0 +1,36 @@
+command: docker update
+short: Update configuration of one or more containers
+long: Update configuration of one or more containers
+usage: docker update [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: blkio-weight
+  default_value: "0"
+  description: Block IO (relative weight), between 10 and 1000
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: kernel-memory
+  description: Kernel memory limit
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: restart
+  description: Restart policy to apply when a container exits

--- a/_data/engine-cli/docker_version.yaml
+++ b/_data/engine-cli/docker_version.yaml
@@ -1,0 +1,21 @@
+command: docker version
+short: Show the Docker version information
+long: "This command displays version information for both the Docker client and \ndaemon.
+  \n\n# EXAMPLES\n\n## Display Docker version information\n\nThe default output:\n\n
+  \   $ docker version\n\tClient:\n\t Version:      1.8.0\n\t API version:  1.20\n\t
+  Go version:   go1.4.2\n\t Git commit:   f5bae0a\n\t Built:        Tue Jun 23 17:56:00
+  UTC 2015\n\t OS/Arch:      linux/amd64\n\n\tServer:\n\t Version:      1.8.0\n\t
+  API version:  1.20\n\t Go version:   go1.4.2\n\t Git commit:   f5bae0a\n\t Built:
+  \       Tue Jun 23 17:56:00 UTC 2015\n\t OS/Arch:      linux/amd64\n\nGet server
+  version:\n\n    $ docker version --format '{{.Server.Version}}'\n\t1.8.0\n\nDump
+  raw data:\n\nTo view all available fields, you can use the format `{{json .}}`.\n\n
+  \   $ docker version --format '{{json .}}'\n    {\"Client\":{\"Version\":\"1.8.0\",\"ApiVersion\":\"1.20\",\"GitCommit\":\"f5bae0a\",\"GoVersion\":\"go1.4.2\",\"Os\":\"linux\",\"Arch\":\"amd64\",\"BuildTime\":\"Tue
+  Jun 23 17:56:00 UTC 2015\"},\"ServerOK\":true,\"Server\":{\"Version\":\"1.8.0\",\"ApiVersion\":\"1.20\",\"GitCommit\":\"f5bae0a\",\"GoVersion\":\"go1.4.2\",\"Os\":\"linux\",\"Arch\":\"amd64\",\"KernelVersion\":\"3.13.2-gentoo\",\"BuildTime\":\"Tue
+  Jun 23 17:56:00 UTC 2015\"}}\n"
+usage: docker version [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template

--- a/_data/engine-cli/docker_volume.yaml
+++ b/_data/engine-cli/docker_volume.yaml
@@ -1,0 +1,22 @@
+command: docker volume
+short: Manage volumes
+long: |
+  The `docker volume` command has subcommands for managing data volumes. A data
+  volume is a specially-designated directory that by-passes storage driver
+  management.
+
+  Data volumes persist data independent of a container's life cycle. When you
+  delete a container, the Engine daemon does not delete any data volumes. You can
+  share volumes across multiple containers. Moreover, you can share data volumes
+  with other computing resources in your system.
+
+  To see help for a subcommand, use:
+
+      docker volume CMD help
+
+  For full details on using docker volume visit Docker's online documentation.
+usage: docker volume COMMAND
+pname: docker
+plink: docker.yaml
+cname: docker volume rm
+clink: docker_volume_rm.yaml

--- a/_data/engine-cli/docker_volume_create.yaml
+++ b/_data/engine-cli/docker_volume_create.yaml
@@ -1,0 +1,55 @@
+command: docker volume create
+short: Create a volume
+long: |
+  Creates a new volume that containers can consume and store data in. If a name
+  is not specified, Docker generates a random name. You create a volume and then
+  configure the container to use it, for example:
+
+      $ docker volume create hello
+      hello
+      $ docker run -d -v hello:/world busybox ls /world
+
+  The mount is created inside the container's `/src` directory. Docker doesn't
+  not support relative paths for mount points inside the container.
+
+  Multiple containers can use the same volume in the same time period. This is
+  useful if two containers need access to shared data. For example, if one
+  container writes and the other reads the data.
+
+  ## Driver specific options
+
+  Some volume drivers may take options to customize the volume creation. Use the
+  `-o` or `--opt` flags to pass driver options:
+
+      $ docker volume create --driver fake --opt tardis=blue --opt timey=wimey
+
+  These options are passed directly to the volume driver. Options for different
+  volume drivers may do different things (or nothing at all).
+
+  The built-in `local` driver on Windows does not support any options.
+
+  The built-in `local` driver on Linux accepts options similar to the linux
+  `mount` command:
+
+      $ docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=size=100m,uid=1000
+
+  Another example:
+
+      $ docker volume create --driver local --opt type=btrfs --opt device=/dev/sda2
+usage: docker volume create [OPTIONS] [VOLUME]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: driver
+  shorthand: d
+  default_value: local
+  description: Specify volume driver name
+- option: label
+  default_value: '[]'
+  description: Set metadata for a volume
+- option: name
+  description: Specify volume name
+- option: opt
+  shorthand: o
+  default_value: map[]
+  description: Set driver specific options

--- a/_data/engine-cli/docker_volume_inspect.yaml
+++ b/_data/engine-cli/docker_volume_inspect.yaml
@@ -1,0 +1,14 @@
+command: docker volume inspect
+short: Display detailed information on one or more volumes
+long: |
+  Returns information about one or more volumes. By default, this command renders
+  all results in a JSON array. You can specify an alternate format to execute a
+  given template is executed for each result. Go's https://golang.org/pkg/text/template/
+  package describes all the details of the format.
+usage: docker volume inspect [OPTIONS] VOLUME [VOLUME...]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given go template

--- a/_data/engine-cli/docker_volume_ls.yaml
+++ b/_data/engine-cli/docker_volume_ls.yaml
@@ -1,0 +1,27 @@
+command: docker volume ls
+short: List volumes
+long: |
+  Lists all the volumes Docker knows about. You can filter using the `-f` or
+  `--filter` flag. The filtering format is a `key=value` pair. To specify
+  more than one filter,  pass multiple flags (for example,
+  `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * `dangling` (boolean - `true` or `false`, `1` or `0`)
+  * `driver` (a volume driver's name)
+  * `label` (`label=<key>` or `label=<key>=<value>`)
+  * `name` (a volume's name)
+usage: docker volume ls [OPTIONS]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Provide filter values (e.g. 'dangling=true')
+- option: format
+  description: Pretty-print volumes using a Go template
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display volume names

--- a/_data/engine-cli/docker_volume_prune.yaml
+++ b/_data/engine-cli/docker_volume_prune.yaml
@@ -1,0 +1,11 @@
+command: docker volume prune
+short: Remove all unused volumes
+long: Remove all unused volumes
+usage: docker volume prune [OPTIONS]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation

--- a/_data/engine-cli/docker_volume_rm.yaml
+++ b/_data/engine-cli/docker_volume_rm.yaml
@@ -1,0 +1,17 @@
+command: docker volume rm
+short: Remove one or more volumes
+long: |2
+
+  Remove one or more volumes. You cannot remove a volume that is in use by a container.
+usage: docker volume rm [OPTIONS] VOLUME [VOLUME...]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the removal of one or more volumes
+example: |2
+
+  $ docker volume rm hello
+  hello

--- a/_data/engine-cli/docker_wait.yaml
+++ b/_data/engine-cli/docker_wait.yaml
@@ -1,0 +1,6 @@
+command: docker wait
+short: Block until one or more containers stop, then print their exit codes
+long: Block until one or more containers stop, then print their exit codes
+usage: docker wait CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml


### PR DESCRIPTION
### Describe the proposed changes

Initial dump of CLI commands in YAML format. Keep in mind that multiple iterations may be needed in order to get the final desired output

### Unreleased project version

1.13 branch of docker/docker

### Related issue or PR in another project

https://github.com/docker/docker/pull/26830

### Please take a look

@johndmulhausen @mstanleyjones 


Couple of notes:
`pname` parent command name
`plink` parent file link
`cname` child command name
`clink` child file link

Most of the parent command had child commands - I didn't loop through all of them, but can do so if we think that the dependency should be bi-directional.