### PR TITLE
fix error on swarm constraint exemple

### DIFF
--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -82,15 +82,15 @@ all three services end up on the same node:
         image: foo
         volumes_from: ["bar"]
         network_mode: "service:baz"
-        labels:
+        environment:
           - "constraint:node==node-1"
       bar:
         image: bar
-        labels:
+        environment:
           - "constraint:node==node-1"
       baz:
         image: baz
-        labels:
+        environment:
           - "constraint:node==node-1"
 
 ### Host ports and recreating containers


### PR DESCRIPTION
Constraints for Swarm scheduling are defined as an **environment** option, according to the example in the section *Manual scheduling* at the end of this doc, and not as a **label** option