### PR TITLE
Option --network not valid at least with the latest docker

### DIFF
--- a/engine/tutorials/networkingcontainers.md
+++ b/engine/tutorials/networkingcontainers.md
@@ -131,9 +131,9 @@ To build web applications that act in concert but do so securely, create a
 network. Networks, by definition, provide complete isolation for containers. You
 can add containers to a network when you first run a container.
 
-Launch a container running a PostgreSQL database and pass it the `--network=my-bridge-network` flag to connect it to your new network:
+Launch a container running a PostgreSQL database and pass it the `--net=my-bridge-network` flag to connect it to your new network:
 
-    $ docker run -d --network=my-bridge-network --name db training/postgres
+    $ docker run -d --net=my-bridge-network --name db training/postgres
 
 If you inspect your `my-bridge-network` you'll see it has a container attached.
 You can also inspect your container to see where it is connected:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

<!-- Tell us what you did and why.-->

### Unreleased project version

<!-- If this change only applies to an unreleased version of a project, note
     that here and base your work on the `vnext-` branch for your project. -->

### Related issue

<!-- Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'. -->

### Related issue or PR in another project

<!-- Full URLs to issues or pull requests in other Github projects -->

### Please take a look

<!-- At-mention specific individuals or groups, like @exampleuser123 -->


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

--network option not valid with docker version 1.11.2. So, proposing to change --network to --net
--network=my-bridge-network