### PR TITLE
Removing leave off the `-P` flag and also

### DIFF
--- a/engine/tutorials/networkingcontainers.md
+++ b/engine/tutorials/networkingcontainers.md
@@ -145,7 +145,7 @@ You can also inspect your container to see where it is connected:
     {"my-bridge-network":{"NetworkID":"7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99",
     "EndpointID":"508b170d56b2ac9e4ef86694b0a76a22dd3df1983404f7321da5649645bf7043","Gateway":"172.18.0.1","IPAddress":"172.18.0.2","IPPrefixLen":16,"IPv6Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"MacAddress":"02:42:ac:11:00:02"}}
 
-Now, go ahead and start your by now familiar web application. This time leave off the `-P` flag and also don't specify a network.
+Now, go ahead and start your by now familiar web application. This time don't specify a network.
 
     $ docker run -d --name web training/webapp python app.py
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

<!-- Tell us what you did and why.-->

### Unreleased project version

<!-- If this change only applies to an unreleased version of a project, note
     that here and base your work on the `vnext-` branch for your project. -->

### Related issue

<!-- Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'. -->

### Related issue or PR in another project

<!-- Full URLs to issues or pull requests in other Github projects -->

### Please take a look

<!-- At-mention specific individuals or groups, like @exampleuser123 -->


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

I feel this sentence 'leave off the `-P` flag and also ' not necessary as that is not used that flag in the previous. User gets confused about this flag.
I am not sure any significance of that flag. If it is necessary to mention , we should better document it.

Thanks,
Srinivasarao Gurubelli