### PR TITLE
Update machine drivers docs

### DIFF
--- a/machine/drivers/aws.md
+++ b/machine/drivers/aws.md
@@ -26,7 +26,7 @@ to authenticate with AWS:
 1.  EC2 Instance Role
 
 For more information, see the [AWS SDK for Go Developer's Guide](http://docs.aws.amazon.com/sdk-for-go/v1/developerguide/configuring-sdk.html).
- 
+
 ### Command line flags
 
 The first way to specify credentials is with the flags `--amazonec2-access-key` and `--amazonec2-secret-key` on the command line:
@@ -90,39 +90,45 @@ assigned to the instance if they are configured.
 -   `--amazonec2-use-ebs-optimized-instance`: Create an EBS Optimized Instance, instance type must support it.
 -   `--amazonec2-ssh-keypath`: Path to Private Key file to use for instance. Matching public key with .pub extension should exist
 -   `--amazonec2-retries`:  Set retry count for recoverable failures (use -1 to disable)
+-   `--amazonec2-endpoint`:  Optional endpoint URL (hostname only or fully qualified URI)
+-   `--amazonec2-insecure-transport`:  Disable SSL when sending requests
+-   `--amazonec2-userdata`:  path to file with cloud-init user data
 
 
 #### Environment variables and default values:
 
-| CLI option                               | Environment variable    | Default          |
-| ---------------------------------------- | ----------------------- | ---------------- |
-| `--amazonec2-access-key`                 | `AWS_ACCESS_KEY_ID`     | -                |
-| `--amazonec2-secret-key`                 | `AWS_SECRET_ACCESS_KEY` | -                |
-| `--amazonec2-session-token`              | `AWS_SESSION_TOKEN`     | -                |
-| `--amazonec2-ami`                        | `AWS_AMI`               | `ami-c60b90d1`   |
-| `--amazonec2-region`                     | `AWS_DEFAULT_REGION`    | `us-east-1`      |
-| `--amazonec2-vpc-id`                     | `AWS_VPC_ID`            | -                |
-| `--amazonec2-zone`                       | `AWS_ZONE`              | `a`              |
-| `--amazonec2-subnet-id`                  | `AWS_SUBNET_ID`         | -                |
-| `--amazonec2-security-group`             | `AWS_SECURITY_GROUP`    | `docker-machine` |
-| `--amazonec2-open-port`                  | -                       | -                |
-| `--amazonec2-tags`                       | `AWS_TAGS`              | -                |
-| `--amazonec2-instance-type`              | `AWS_INSTANCE_TYPE`     | `t2.micro`       |
-| `--amazonec2-keypair-name`               | `AWS_KEYPAIR_NAME`      | -                |
-| `--amazonec2-device-name`                | `AWS_DEVICE_NAME`       | `/dev/sda1`      |
-| `--amazonec2-root-size`                  | `AWS_ROOT_SIZE`         | `16`             |
-| `--amazonec2-volume-type`                | `AWS_VOLUME_TYPE`       | `gp2`            |
-| `--amazonec2-iam-instance-profile`       | `AWS_INSTANCE_PROFILE`  | -                |
-| `--amazonec2-ssh-user`                   | `AWS_SSH_USER`          | `ubuntu`         |
-| `--amazonec2-request-spot-instance`      | -                       | `false`          |
-| `--amazonec2-spot-price`                 | -                       | `0.50`           |
-| `--amazonec2-block-duration-minutes`     | -                       | -                |
-| `--amazonec2-use-private-address`        | -                       | `false`          |
-| `--amazonec2-private-address-only`       | -                       | `false`          |
-| `--amazonec2-monitoring`                 | -                       | `false`          |
-| `--amazonec2-use-ebs-optimized-instance` | -                       | `false`          |
-| `--amazonec2-ssh-keypath`                | `AWS_SSH_KEYPATH`       | -                |
-| `--amazonec2-retries`                    | -                       | `5`              |
+| CLI option                               | Environment variable     | Default          |
+| ---------------------------------------- | ------------------------ | ---------------- |
+| `--amazonec2-access-key`                 | `AWS_ACCESS_KEY_ID`      | -                |
+| `--amazonec2-secret-key`                 | `AWS_SECRET_ACCESS_KEY`  | -                |
+| `--amazonec2-session-token`              | `AWS_SESSION_TOKEN`      | -                |
+| `--amazonec2-ami`                        | `AWS_AMI`                | `ami-c60b90d1`   |
+| `--amazonec2-region`                     | `AWS_DEFAULT_REGION`     | `us-east-1`      |
+| `--amazonec2-vpc-id`                     | `AWS_VPC_ID`             | -                |
+| `--amazonec2-zone`                       | `AWS_ZONE`               | `a`              |
+| `--amazonec2-subnet-id`                  | `AWS_SUBNET_ID`          | -                |
+| `--amazonec2-security-group`             | `AWS_SECURITY_GROUP`     | `docker-machine` |
+| `--amazonec2-open-port`                  | -                        | -                |
+| `--amazonec2-tags`                       | `AWS_TAGS`               | -                |
+| `--amazonec2-instance-type`              | `AWS_INSTANCE_TYPE`      | `t2.micro`       |
+| `--amazonec2-keypair-name`               | `AWS_KEYPAIR_NAME`       | -                |
+| `--amazonec2-device-name`                | `AWS_DEVICE_NAME`        | `/dev/sda1`      |
+| `--amazonec2-root-size`                  | `AWS_ROOT_SIZE`          | `16`             |
+| `--amazonec2-volume-type`                | `AWS_VOLUME_TYPE`        | `gp2`            |
+| `--amazonec2-iam-instance-profile`       | `AWS_INSTANCE_PROFILE`   | -                |
+| `--amazonec2-ssh-user`                   | `AWS_SSH_USER`           | `ubuntu`         |
+| `--amazonec2-request-spot-instance`      | -                        | `false`          |
+| `--amazonec2-spot-price`                 | -                        | `0.50`           |
+| `--amazonec2-block-duration-minutes`     | -                        | -                |
+| `--amazonec2-use-private-address`        | -                        | `false`          |
+| `--amazonec2-private-address-only`       | -                        | `false`          |
+| `--amazonec2-monitoring`                 | -                        | `false`          |
+| `--amazonec2-use-ebs-optimized-instance` | -                        | `false`          |
+| `--amazonec2-ssh-keypath`                | `AWS_SSH_KEYPATH`        | -                |
+| `--amazonec2-retries`                    | -                        | `5`              |
+| `--amazonec2-endpoint`                   | `AWS_ENDPOINT`           | -                |
+| `--amazonec2-insecure-transport`         | `AWS_INSECURE_TRANSPORT` | -                |
+| `--amazonec2-userdata`                   | `AWS_USERDATA`           | -                |
 
 ## Default AMIs
 
@@ -177,7 +183,7 @@ To create a machine with a non-default vpc-id:
 This example assumes the VPC ID was found in the `a` availability zone. Use the`--amazonec2-zone` flag to specify a zone other than the `a` zone. For example, `--amazonec2-zone c` signifies `us-east1-c`.
 
 ## VPC Connectivity
-Machine uses SSH to complete the set up of instances in EC2 and requires the ability to access the instance directly.  
+Machine uses SSH to complete the set up of instances in EC2 and requires the ability to access the instance directly.
 
 If you use the flag `--amazonec2-private-address-only`, you will need to ensure that you have some method of accessing the new instance from within the internal network of the VPC (e.g. a corporate VPN to the VPC, a VPN instance inside the VPC or using Docker-machine from an instance within your VPC).
 

--- a/machine/drivers/gce.md
+++ b/machine/drivers/gce.md
@@ -24,6 +24,10 @@ via the built-in service account.
 Otherwise, [install gcloud](https://cloud.google.com/sdk/) and get
 through the oauth2 process with `gcloud auth login`.
 
+Or, manually download the credentials.json file to the local, and set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable point to its location, such as:
+
+    export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gce-credentials.json
+
 ### Example
 
 To create a machine instance, specify `--driver google`, the project id and the machine name.
@@ -53,25 +57,27 @@ To create a machine instance, specify `--driver google`, the project id and the 
     -   `--google-use-internal-ip-only`: When this option is used during create, the new VM will not be assigned a public IP address. This is useful only when the host running `docker-machine` is located inside the Google Cloud infrastructure; otherwise, `docker-machine` can't reach the VM to provision the Docker daemon. The presence of this flag implies `--google-use-internal-ip`.
     -   `--google-use-existing`: Don't create a new VM, use an existing one. This is useful when you'd like to provision Docker on a VM you created yourself, maybe because it uses create options not supported by this driver.
 
-The GCE driver will use the `ubuntu-1510-wily-v20151114` instance image unless otherwise specified. To obtain a
+The GCE driver will use the `ubuntu-1604-xenial-v20161130` instance image unless otherwise specified. To obtain a
 list of image URLs run:
 
     gcloud compute images list --uri
 
 #### Environment variables and default values
 
-| CLI option                 | Environment variable     | Default                              |
-| -------------------------- | ------------------------ | ------------------------------------ |
-| **`--google-project`**     | `GOOGLE_PROJECT`         | -                                    |
-| `--google-zone`            | `GOOGLE_ZONE`            | `us-central1-a`                      |
-| `--google-machine-type`    | `GOOGLE_MACHINE_TYPE`    | `f1-standard-1`                      |
-| `--google-machine-image`   | `GOOGLE_MACHINE_IMAGE`   | `ubuntu-1510-wily-v20151114`         |
-| `--google-username`        | `GOOGLE_USERNAME`        | `docker-user`                        |
-| `--google-scopes`          | `GOOGLE_SCOPES`          | `devstorage.read_only,logging.write` |
-| `--google-disk-size`       | `GOOGLE_DISK_SIZE`       | `10`                                 |
-| `--google-disk-type`       | `GOOGLE_DISK_TYPE`       | `pd-standard`                        |
-| `--google-address`         | `GOOGLE_ADDRESS`         | -                                    |
-| `--google-preemptible`     | `GOOGLE_PREEMPTIBLE`     | -                                    |
-| `--google-tags`            | `GOOGLE_TAGS`            | -                                    |
-| `--google-use-internal-ip` | `GOOGLE_USE_INTERNAL_IP` | -                                    |
-| `--google-use-existing`    | `GOOGLE_USE_EXISTING`    | -                                    |
+| CLI option                      | Environment variable          | Default                              |
+| ------------------------------- | ----------------------------- | ------------------------------------ |
+| **`--google-project`**          | `GOOGLE_PROJECT`              | -                                    |
+| `--google-zone`                 | `GOOGLE_ZONE`                 | `us-central1-a`                      |
+| `--google-machine-type`         | `GOOGLE_MACHINE_TYPE`         | `f1-standard-1`                      |
+| `--google-machine-image`        | `GOOGLE_MACHINE_IMAGE`        | `ubuntu-1604-xenial-v20161130`       |
+| `--google-username`             | `GOOGLE_USERNAME`             | `docker-user`                        |
+| `--google-scopes`               | `GOOGLE_SCOPES`               | `devstorage.read_only,logging.write` |
+| `--google-disk-size`            | `GOOGLE_DISK_SIZE`            | `10`                                 |
+| `--google-disk-type`            | `GOOGLE_DISK_TYPE`            | `pd-standard`                        |
+| `--google-address`              | `GOOGLE_ADDRESS`              | -                                    |
+| `--google-network`              | `GOOGLE_NETWORK`              | `default`                            |
+| `--google-preemptible`          | `GOOGLE_PREEMPTIBLE`          | -                                    |
+| `--google-tags`                 | `GOOGLE_TAGS`                 | -                                    |
+| `--google-use-internal-ip`      | `GOOGLE_USE_INTERNAL_IP`      | -                                    |
+| `--google-use-internal-ip-only` | `GOOGLE_USE_INTERNAL_IP_ONLY` | -                                    |
+| `--google-use-existing`         | `GOOGLE_USE_EXISTING`         | -                                    |

--- a/machine/drivers/rackspace.md
+++ b/machine/drivers/rackspace.md
@@ -22,13 +22,14 @@ Create machines on [Rackspace cloud](http://www.rackspace.com/cloud)
 -   `--rackspace-api-key`: **required** Rackspace API key.
 -   `--rackspace-region`: **required** Rackspace region name.
 -   `--rackspace-endpoint-type`: Rackspace endpoint type (`adminURL`, `internalURL` or the default `publicURL`).
--   `--rackspace-image-id`: Rackspace image ID. Default: Ubuntu 15.10 (Wily Werewolf) (PVHVM).
+-   `--rackspace-image-id`: Rackspace image ID. Default: Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM).
 -   `--rackspace-flavor-id`: Rackspace flavor ID. Default: General Purpose 1GB.
 -   `--rackspace-ssh-user`: SSH user for the newly booted machine.
 -   `--rackspace-ssh-port`: SSH port for the newly booted machine.
 -   `--rackspace-docker-install`: Set if Docker has to be installed on the machine.
+-   `--rackspace-active-timeout`: Rackspace active timeout
 
-The Rackspace driver will use `59a3fadd-93e7-4674-886a-64883e17115f` (Ubuntu 15.10) by default.
+The Rackspace driver will use `821ba5f4-712d-4ec8-9c65-a3fa4bc500f9` (Ubuntu 16.04 LTS) by default.
 
 #### Environment variables and default values
 
@@ -36,10 +37,11 @@ The Rackspace driver will use `59a3fadd-93e7-4674-886a-64883e17115f` (Ubuntu 15.
 | ---------------------------- | -------------------- | -------------------------------------- |
 | **`--rackspace-username`**   | `OS_USERNAME`        | -                                      |
 | **`--rackspace-api-key`**    | `OS_API_KEY`         | -                                      |
-| **`--rackspace-region`**     | `OS_REGION_NAME`     | -                                      |
+| **`--rackspace-region`**     | `OS_REGION_NAME`     | `IAD` (Northern Virginia)              |
 | `--rackspace-endpoint-type`  | `OS_ENDPOINT_TYPE`   | `publicURL`                            |
-| `--rackspace-image-id`       | -                    | `59a3fadd-93e7-4674-886a-64883e17115f` |
+| `--rackspace-image-id`       | `OS_IMAGE_ID`        | `821ba5f4-712d-4ec8-9c65-a3fa4bc500f9` |
 | `--rackspace-flavor-id`      | `OS_FLAVOR_ID`       | `general1-1`                           |
-| `--rackspace-ssh-user`       | -                    | `root`                                 |
-| `--rackspace-ssh-port`       | -                    | `22`                                   |
+| `--rackspace-ssh-user`       | `OS_SSH_USER`        | `root`                                 |
+| `--rackspace-ssh-port`       | `OS_SSH_PORT`        | `22`                                   |
 | `--rackspace-docker-install` | -                    | `true`                                 |
+| `--rackspace-active-timeout` | `OS_ACTIVE_TIMEOUT`  | `300`                                  |

--- a/machine/drivers/virtualbox.md
+++ b/machine/drivers/virtualbox.md
@@ -41,9 +41,12 @@ The size of the VM's disk can be configured this way:
 -   `--virtualbox-hostonly-nictype`: Host Only Network Adapter Type. Possible values are are '82540EM' (Intel PRO/1000), 'Am79C973' (PCnet-FAST III) and 'virtio' Paravirtualized network adapter.
 -   `--virtualbox-hostonly-nicpromisc`: Host Only Network Adapter Promiscuous Mode. Possible options are deny , allow-vms, allow-all
 -   `--virtualbox-hostonly-no-dhcp`: Disable the Host Only DHCP Server
+-   `--virtualbox-nat-nictype`: Specify the NAT Network Adapter Type. Possible values are are '82540EM' (Intel PRO/1000), 'Am79C973' (PCnet-FAST III) and 'virtio' Paravirtualized network adapter.
 -   `--virtualbox-no-share`: Disable the mount of your home directory
 -   `--virtualbox-no-dns-proxy`: Disable proxying all DNS requests to the host (Boolean value, default to false)
 -   `--virtualbox-no-vtx-check`: Disable checking for the availability of hardware virtualization before the vm is started
+-   `--virtualbox-ui-type`: Specify the UI Type: (gui|sdl|headless|separate)
+-   `--virtualbox-share-folder`: Mount the specified directory instead of the default home location. Format: dir:name
 
 The `--virtualbox-boot2docker-url` flag takes a few different forms. By
 default, if no value is specified for this flag, Machine will check locally for
@@ -85,9 +88,12 @@ upper bound of `192.168.24.254`.
 | `--virtualbox-hostonly-nictype`      | `VIRTUALBOX_HOSTONLY_NIC_TYPE`     | `82540EM`                |
 | `--virtualbox-hostonly-nicpromisc`   | `VIRTUALBOX_HOSTONLY_NIC_PROMISC`  | `deny`                   |
 | `--virtualbox-hostonly-no-dhcp`      | `VIRTUALBOX_HOSTONLY_NO_DHCP`      | `false`                  |
+| `--virtualbox-nat-nictype`           | `VIRTUALBOX_NAT_NICTYPE`           | `82540EM`                |
 | `--virtualbox-no-share`              | `VIRTUALBOX_NO_SHARE`              | `false`                  |
 | `--virtualbox-no-dns-proxy`          | `VIRTUALBOX_NO_DNS_PROXY`          | `false`                  |
 | `--virtualbox-no-vtx-check`          | `VIRTUALBOX_NO_VTX_CHECK`          | `false`                  |
+| `--virtualbox-ui-type`               | `VIRTUALBOX_UI_TYPE`               | `headless`               |
+| `--virtualbox-share-folder`          | `VIRTUALBOX_SHARE_FOLDER`          | -                        |
 
 ## Known Issues
 


### PR DESCRIPTION
### Describe the proposed changes

* Update Google and Rackspace default image to Ubuntu 16.04, as docker/machine#3888 has been merged.
* Update docs for new options of aws, gce, rackspace and virtualbox drivers.

### Related issue or PR in another project

<https://github.com/docker/machine/pull/3888>
<https://github.com/docker/machine/pull/3890>
<https://github.com/docker/machine/pull/3799>
<https://github.com/docker/machine/pull/3671>
<https://github.com/docker/machine/commit/6789c51b83af67231bfa0f6acb87757c0b3e5206>
<https://github.com/docker/machine/commit/bd5ea7c335099900a96368f25899306042635a02>
<https://github.com/docker/machine/commit/6408bf7f05aa71eefbd635a42d9a5dd7f9dd9287>
<https://github.com/docker/machine/commit/6a2221fd97eb7108d6cf625168da17621720e0e5>
<https://github.com/docker/machine/commit/f0ac1c00eab8261a07dec27372847daebe3176a7>

Signed-off-by: Tao Wang <twang2218@gmail.com>