### PR TITLE
CI - added test for keywords in markdown frontmatters

### DIFF
--- a/datacenter/dtr/2.0/support.md
+++ b/datacenter/dtr/2.0/support.md
@@ -1,11 +1,9 @@
 ---
-redirect_from:
-- /docker-trusted-registry/support/
 description: Your Docker subscription gives you access to prioritized support. You
   can file tickets via email, your the support portal.
-keywords:
-- Docker, support
-- help
+keywords: Docker, support, help
+redirect_from:
+- /docker-trusted-registry/support/
 title: Get support for DTR
 ---
 

--- a/datacenter/dtr/2.1/guides/architecture.md
+++ b/datacenter/dtr/2.1/guides/architecture.md
@@ -1,8 +1,7 @@
 ---
-title: DTR architecture
 description: Learn about the architecture of Docker Trusted Registry.
-keywords:
-- docker, registry, dtr, architecture
+keywords: docker, registry, dtr, architecture
+title: DTR architecture
 ---
 
 Docker Trusted Registry (DTR) is a Dockerized application that runs on a Docker

--- a/datacenter/dtr/2.1/guides/configure/configure-storage.md
+++ b/datacenter/dtr/2.1/guides/configure/configure-storage.md
@@ -1,8 +1,8 @@
 ---
-title: Configure where images are stored
 description: Storage configuration for Docker Trusted Registry
-keywords:
-- docker, documentation, about, technology, understanding, configuration, storage, storage drivers, Azure, S3, Swift,  enterprise, hub, registry
+keywords: docker, documentation, about, technology, understanding, configuration,
+  storage, storage drivers, Azure, S3, Swift, enterprise, hub, registry
+title: Configure where images are stored
 ---
 
 After installing Docker Trusted Registry, one of your first tasks is to

--- a/datacenter/dtr/2.1/guides/configure/index.md
+++ b/datacenter/dtr/2.1/guides/configure/index.md
@@ -1,8 +1,8 @@
 ---
-title: Use your own certificates
 description: Trusted Registry configuration options
-keywords:
-- docker, documentation, about, technology, install, enterprise, hub, CS engine, Docker Trusted Registry, configure, storage, backend, drivers
+keywords: docker, documentation, about, technology, install, enterprise, hub, CS engine,
+  Docker Trusted Registry, configure, storage, backend, drivers
+title: Use your own certificates
 ---
 
 By default the DTR services are exposed using HTTPS, to ensure all

--- a/datacenter/dtr/2.1/guides/high-availability/backups-and-disaster-recovery.md
+++ b/datacenter/dtr/2.1/guides/high-availability/backups-and-disaster-recovery.md
@@ -1,9 +1,8 @@
 ---
-title: Backups and disaster recovery
 description: Learn how to backup your Docker Trusted Registry cluster, and to recover
   your cluster from an existing backup.
-keywords:
-- docker, registry, high-availability, backup, recovery
+keywords: docker, registry, high-availability, backup, recovery
+title: Backups and disaster recovery
 ---
 
 When you decide to start using Docker Trusted Registry on a production

--- a/datacenter/dtr/2.1/guides/high-availability/index.md
+++ b/datacenter/dtr/2.1/guides/high-availability/index.md
@@ -1,8 +1,7 @@
 ---
-title: Set up high availability
 description: Learn how to set up Docker Trusted Registry for high availability.
-keywords:
-- docker, registry, high-availability, backup, recovery
+keywords: docker, registry, high-availability, backup, recovery
+title: Set up high availability
 ---
 
 Docker Trusted Registry (DTR) is designed for high availability.

--- a/datacenter/dtr/2.1/guides/index.md
+++ b/datacenter/dtr/2.1/guides/index.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to install, configure, and use Docker Trusted Registry.
-keywords:
-- docker, registry, repository, images
+keywords: docker, registry, repository, images
 title: Docker Trusted Registry overview
 ---
 

--- a/datacenter/dtr/2.1/guides/install/index.md
+++ b/datacenter/dtr/2.1/guides/install/index.md
@@ -1,8 +1,7 @@
 ---
-title: Install Docker Trusted Registry
 description: Learn how to install Docker Trusted Registry for production.
-keywords:
-- docker, dtr, registry, install
+keywords: docker, dtr, registry, install
+title: Install Docker Trusted Registry
 ---
 
 Docker Trusted Registry (DTR) is a containerized application that runs on a

--- a/datacenter/dtr/2.1/guides/install/install-offline.md
+++ b/datacenter/dtr/2.1/guides/install/install-offline.md
@@ -1,9 +1,8 @@
 ---
-title: Install Docker Trusted Registry offline
 description: Learn how to install Docker Trusted Registry on a machine with no internet
   access.
-keywords:
-- docker, registry, install, offline
+keywords: docker, registry, install, offline
+title: Install Docker Trusted Registry offline
 ---
 
 The procedure to install Docker Trusted Registry on a node is the same,

--- a/datacenter/dtr/2.1/guides/install/license.md
+++ b/datacenter/dtr/2.1/guides/install/license.md
@@ -1,8 +1,7 @@
 ---
-title: License Docker Trusted Registry
 description: Learn how to license your Docker Trusted Registry installation.
-keywords:
-- docker, dtr, install, license
+keywords: docker, dtr, install, license
+title: License Docker Trusted Registry
 ---
 
 By default, you don't need to license your Docker Trusted Registry. When

--- a/datacenter/dtr/2.1/guides/install/system-requirements.md
+++ b/datacenter/dtr/2.1/guides/install/system-requirements.md
@@ -1,8 +1,7 @@
 ---
-title: Docker Trusted Registry system requirements
 description: Learn about the system requirements for installing Docker Trusted Registry.
-keywords:
-- docker, DTR, architecture, requirements
+keywords: docker, DTR, architecture, requirements
+title: Docker Trusted Registry system requirements
 ---
 
 Docker Trusted Registry can be installed on-premises or on the cloud.

--- a/datacenter/dtr/2.1/guides/install/uninstall.md
+++ b/datacenter/dtr/2.1/guides/install/uninstall.md
@@ -1,8 +1,7 @@
 ---
-title: Uninstall Docker Trusted Registry
 description: Learn how to uninstall your Docker Trusted Registry installation.
-keywords:
-- docker, dtr, install, uninstall
+keywords: docker, dtr, install, uninstall
+title: Uninstall Docker Trusted Registry
 ---
 
 Use the `remove` command, to remove a DTR replica from an existing deployment.

--- a/datacenter/dtr/2.1/guides/install/upgrade.md
+++ b/datacenter/dtr/2.1/guides/install/upgrade.md
@@ -1,8 +1,7 @@
 ---
-title: Upgrade DTR
 description: Learn how to upgrade your Docker Trusted Registry
-keywords:
-- docker, dtr, upgrade, install
+keywords: docker, dtr, upgrade, install
+title: Upgrade DTR
 ---
 
 The first step in upgrading to a new minor version or patch release of DTR 2.0,

--- a/datacenter/dtr/2.1/guides/monitor-troubleshoot/index.md
+++ b/datacenter/dtr/2.1/guides/monitor-troubleshoot/index.md
@@ -1,8 +1,7 @@
 ---
-title: Monitor Docker Trusted Registry
 description: Learn how to monitor your DTR installation.
-keywords:
-- docker, registry, monitor, troubleshoot
+keywords: docker, registry, monitor, troubleshoot
+title: Monitor Docker Trusted Registry
 ---
 
 Docker Trusted Registry is a Dockerized application. To monitor it, you can

--- a/datacenter/dtr/2.1/guides/monitor-troubleshoot/troubleshoot.md
+++ b/datacenter/dtr/2.1/guides/monitor-troubleshoot/troubleshoot.md
@@ -1,8 +1,7 @@
 ---
-title: Troubleshoot Docker Trusted Registry
 description: Learn how to troubleshoot your DTR installation.
-keywords:
-- docker, registry, monitor, troubleshoot
+keywords: docker, registry, monitor, troubleshoot
+title: Troubleshoot Docker Trusted Registry
 ---
 
 High availability in DTR depends on having overlay networking working in UCP.

--- a/datacenter/dtr/2.1/guides/release-notes.md
+++ b/datacenter/dtr/2.1/guides/release-notes.md
@@ -1,11 +1,10 @@
 ---
-title: Docker Trusted Registry release notes
 description: Docker Trusted Registry release notes
-keywords:
-- docker trusted registry, whats new, release notes
+keywords: docker trusted registry, whats new, release notes
 redirect_from:
 - /docker-trusted-registry/release-notes/release-notes/
 - /docker-trusted-registry/release-notes/
+title: Docker Trusted Registry release notes
 ---
 
 Here you can learn about new features, bug fixes, breaking changes and

--- a/datacenter/dtr/2.1/guides/repos-and-images/delete-an-image.md
+++ b/datacenter/dtr/2.1/guides/repos-and-images/delete-an-image.md
@@ -1,8 +1,7 @@
 ---
-title: Delete an image
 description: Learn how to delete images from your repositories on Docker Trusted Registry.
-keywords:
-- docker, registry, repository, delete, image
+keywords: docker, registry, repository, delete, image
+title: Delete an image
 ---
 
 To delete an image, go to the **DTR web UI**, and navigate to the image

--- a/datacenter/dtr/2.1/guides/repos-and-images/index.md
+++ b/datacenter/dtr/2.1/guides/repos-and-images/index.md
@@ -1,7 +1,7 @@
 ---
-description: Learn how to configure your Docker Engine to push and pull images from Docker Trusted Registry.
-keywords:
-- docker, registry, TLS, certificates
+description: Learn how to configure your Docker Engine to push and pull images from
+  Docker Trusted Registry.
+keywords: docker, registry, TLS, certificates
 title: Configure your Docker Engine
 ---
 

--- a/datacenter/dtr/2.1/guides/repos-and-images/pull-an-image.md
+++ b/datacenter/dtr/2.1/guides/repos-and-images/pull-an-image.md
@@ -1,8 +1,7 @@
 ---
-title: Pull an image from DTR
 description: Learn how to pull an image from Docker Trusted Registry.
-keywords:
-- docker, registry, images, pull
+keywords: docker, registry, images, pull
+title: Pull an image from DTR
 ---
 
 Pulling an image from Docker Trusted Registry is the same as pulling an image

--- a/datacenter/dtr/2.1/guides/repos-and-images/push-an-image.md
+++ b/datacenter/dtr/2.1/guides/repos-and-images/push-an-image.md
@@ -1,7 +1,6 @@
 ---
 description: Learn how to push an image to Docker Trusted Registry.
-keywords:
-- docker, registry, images, pull
+keywords: docker, registry, images, pull
 title: Push an image to DTR
 ---
 

--- a/datacenter/dtr/2.1/guides/support.md
+++ b/datacenter/dtr/2.1/guides/support.md
@@ -1,10 +1,8 @@
 ---
-title: Get support for DTR
 description: Your Docker subscription gives you access to prioritized support. You
   can file tickets via email, your the support portal.
-keywords:
-- Docker, support
-- help
+keywords: Docker, support, help
+title: Get support for DTR
 ---
 
 Your Docker Data Center, or Docker Trusted Registry subscription gives you

--- a/datacenter/dtr/2.1/guides/user-management/create-and-manage-orgs.md
+++ b/datacenter/dtr/2.1/guides/user-management/create-and-manage-orgs.md
@@ -1,9 +1,8 @@
 ---
-title: Create and manage organizations
 description: Learn how to set up organizations to enforce security in Docker Trusted
   Registry.
-keywords:
-- docker, registry, security, permissions, organizations
+keywords: docker, registry, security, permissions, organizations
+title: Create and manage organizations
 ---
 
 When a user creates a repository, only that user has permissions to make changes

--- a/datacenter/dtr/2.1/guides/user-management/create-and-manage-teams.md
+++ b/datacenter/dtr/2.1/guides/user-management/create-and-manage-teams.md
@@ -1,9 +1,8 @@
 ---
-title: Create and manage teams
 description: Learn how to manage teams to enforce fine-grain access control in Docker
   Trusted Registry.
-keywords:
-- docker, registry, security, permissions, teams
+keywords: docker, registry, security, permissions, teams
+title: Create and manage teams
 ---
 
 You can extend the user's default permissions by granting them fine-grain

--- a/datacenter/dtr/2.1/guides/user-management/create-and-manage-users.md
+++ b/datacenter/dtr/2.1/guides/user-management/create-and-manage-users.md
@@ -1,8 +1,7 @@
 ---
-title: Create and manage users
 description: Learn how to manage user permissions in Docker Trusted Registry.
-keywords:
-- docker, registry, security, permissions, users
+keywords: docker, registry, security, permissions, users
+title: Create and manage users
 ---
 
 When using the Docker Datacenter built-in authentication, you can create users

--- a/datacenter/dtr/2.1/guides/user-management/index.md
+++ b/datacenter/dtr/2.1/guides/user-management/index.md
@@ -1,8 +1,7 @@
 ---
-title: Authentication and authorization
 description: Learn about the permission levels available on Docker Trusted Registry.
-keywords:
-- docker, registry, security, permissions, users
+keywords: docker, registry, security, permissions, users
+title: Authentication and authorization
 ---
 
 With DTR you get to control which users have access to your image repositories.

--- a/datacenter/dtr/2.1/guides/user-management/permission-levels.md
+++ b/datacenter/dtr/2.1/guides/user-management/permission-levels.md
@@ -1,8 +1,7 @@
 ---
-title: Permission levels
 description: Learn about the permission levels available in Docker Trusted Registry.
-keywords:
-- docker, registry, security, permissions
+keywords: docker, registry, security, permissions
+title: Permission levels
 ---
 
 Docker Trusted Registry allows you to define fine-grain permissions over image

--- a/datacenter/dtr/2.1/reference/api/index.md
+++ b/datacenter/dtr/2.1/reference/api/index.md
@@ -1,8 +1,7 @@
 ---
-title: Docker Trusted Registry 2.1 API
 description: Learn how to use the Docker Trusted Registry REST API
-keywords:
-- dtr, api, reference
+keywords: dtr, api, reference
+title: Docker Trusted Registry 2.1 API
 ---
 
 <div class="swagger-section">

--- a/datacenter/dtr/2.1/reference/cli/backup.md
+++ b/datacenter/dtr/2.1/reference/cli/backup.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr backup
-keywords:
-- docker, dtr, cli, backup
 description: Backup a DTR cluster to a tar file and stream it to stdout
+keywords: docker, dtr, cli, backup
+title: docker/dtr backup
 ---
 
 Backup a DTR cluster to a tar file and stream it to stdout
@@ -45,4 +44,3 @@ stored securely.
 |`--ucp-ca`|Use a PEM-encoded TLS CA certificate for UCP|
 |`--existing-replica-id`|ID of an existing replica in a cluster|
 |`--config-only`|Backup/restore only the configurations of DTR and not the database|
-

--- a/datacenter/dtr/2.1/reference/cli/dumpcerts.md
+++ b/datacenter/dtr/2.1/reference/cli/dumpcerts.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr dumpcerts
-keywords:
-- docker, dtr, cli, dumpcerts
 description: Dump out the TLS certificates used by this DTR instance
+keywords: docker, dtr, cli, dumpcerts
+title: docker/dtr dumpcerts
 ---
 
 Dump out the TLS certificates used by this DTR instance
@@ -34,4 +33,3 @@ communicating across replicas with TLS.
 |`--ucp-insecure-tls`|Disable TLS verification for UCP|
 |`--ucp-ca`|Use a PEM-encoded TLS CA certificate for UCP|
 |`--existing-replica-id`|ID of an existing replica in a cluster|
-

--- a/datacenter/dtr/2.1/reference/cli/images.md
+++ b/datacenter/dtr/2.1/reference/cli/images.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr images
-keywords:
-- docker, dtr, cli, images
 description: Lists all the images necessary to install DTR
+keywords: docker, dtr, cli, images
+title: docker/dtr images
 ---
 
 Lists all the images necessary to install DTR
@@ -18,6 +17,3 @@ docker run -it --rm docker/dtr \
 
 
 This command lists all the images necessary to install DTR.
-
-
-

--- a/datacenter/dtr/2.1/reference/cli/index.md
+++ b/datacenter/dtr/2.1/reference/cli/index.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr overview
-keywords:
-- docker, dtr, install, uninstall, configure
 description: Learn about the commands available in the docker/dtr image.
+keywords: docker, dtr, install, uninstall, configure
+title: docker/dtr overview
 ---
 
 This tool has commands to install, configure, and backup Docker
@@ -34,4 +33,3 @@ docker run -it --rm docker/dtr \
 |`upgrade`| Upgrade a v2.0.0 or later cluster to this version of DTR|
 |`dumpcerts`| Dump out the TLS certificates used by this DTR instance|
 |`images`| Lists all the images necessary to install DTR|
-

--- a/datacenter/dtr/2.1/reference/cli/install.md
+++ b/datacenter/dtr/2.1/reference/cli/install.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr install
-keywords:
-- docker, dtr, cli, install
 description: Install Docker Trusted Registry on this Docker Engine
+keywords: docker, dtr, cli, install
+title: docker/dtr install
 ---
 
 Install Docker Trusted Registry on this Docker Engine
@@ -56,4 +55,3 @@ the 'join' command.
 |`--replica-id`|Specify the replica ID. Must be unique per replica, leave blank for random|
 |`--unsafe`|Enable this flag to skip safety checks when installing or joining|
 |`--extra-envs`|List of extra environment variables to use for deploying the DTR containers for the replica. This can be used to specify swarm constraints. Separate the environment variables with ampersands (&). You can escape actual ampersands with backslashes (\). Can't be used in combination with --ucp-node|
-

--- a/datacenter/dtr/2.1/reference/cli/join.md
+++ b/datacenter/dtr/2.1/reference/cli/join.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr join
-keywords:
-- docker, dtr, cli, join
 description: Add a new replica to an existing DTR cluster
+keywords: docker, dtr, cli, join
+title: docker/dtr join
 ---
 
 Add a new replica to an existing DTR cluster
@@ -39,4 +38,3 @@ the cluster.
 |`--replica-https-port`|Specify the public HTTPS port for the DTR replica; 0 means unchanged/default|
 |`--skip-network-test`|Enable this flag to skip the overlay networking test|
 |`--extra-envs`|List of extra environment variables to use for deploying the DTR containers for the replica. This can be used to specify swarm constraints. Separate the environment variables with ampersands (&). You can escape actual ampersands with backslashes (\). Can't be used in combination with --ucp-node|
-

--- a/datacenter/dtr/2.1/reference/cli/reconfigure.md
+++ b/datacenter/dtr/2.1/reference/cli/reconfigure.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr reconfigure
-keywords:
-- docker, dtr, cli, reconfigure
 description: Change DTR configurations
+keywords: docker, dtr, cli, reconfigure
+title: docker/dtr reconfigure
 ---
 
 Change DTR configurations
@@ -56,4 +55,3 @@ effect. To have no down time, configure your DTR for high-availability.
 |`--ucp-ca`|Use a PEM-encoded TLS CA certificate for UCP|
 |`--nfs-storage-url`|URL (with IP address or hostname) of the NFS mount if using NFS (e.g. nfs://<ip address>/<mount point>)|
 |`--existing-replica-id`|ID of an existing replica in a cluster|
-

--- a/datacenter/dtr/2.1/reference/cli/remove.md
+++ b/datacenter/dtr/2.1/reference/cli/remove.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr remove
-keywords:
-- docker, dtr, cli, remove
 description: Remove a replica from a DTR cluster
+keywords: docker, dtr, cli, remove
+title: docker/dtr remove
 ---
 
 Remove a replica from a DTR cluster
@@ -36,4 +35,3 @@ DTR containers, and deletes all DTR volumes.
 |`--force-remove`|Force removal of replica even if it can break your cluster's state. Necessary only when --existing-replica-id == --replica-id.|
 |`--replica-id`|Specify the replica ID. Must be unique per replica, leave blank for random|
 |`--existing-replica-id`|ID of an existing replica in a cluster|
-

--- a/datacenter/dtr/2.1/reference/cli/restore.md
+++ b/datacenter/dtr/2.1/reference/cli/restore.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr restore
-keywords:
-- docker, dtr, cli, restore
 description: Create a new DTR cluster from an existing backup
+keywords: docker, dtr, cli, restore
+title: docker/dtr restore
 ---
 
 Create a new DTR cluster from an existing backup
@@ -65,4 +64,3 @@ the 'join' command.
 |`--ucp-node`|Specify the host to install Docker Trusted Registry|
 |`--replica-id`|Specify the replica ID. Must be unique per replica, leave blank for random|
 |`--config-only`|Backup/restore only the configurations of DTR and not the database|
-

--- a/datacenter/dtr/2.1/reference/cli/upgrade.md
+++ b/datacenter/dtr/2.1/reference/cli/upgrade.md
@@ -1,8 +1,7 @@
 ---
-title: docker/dtr upgrade
-keywords:
-- docker, dtr, cli, upgrade
 description: Upgrade a v2.0.0 or later cluster to this version of DTR
+keywords: docker, dtr, cli, upgrade
+title: docker/dtr upgrade
 ---
 
 Upgrade a v2.0.0 or later cluster to this version of DTR
@@ -51,4 +50,3 @@ this bootstrapper.
 |`--ucp-insecure-tls`|Disable TLS verification for UCP|
 |`--ucp-ca`|Use a PEM-encoded TLS CA certificate for UCP|
 |`--existing-replica-id`|ID of an existing replica in a cluster|
-

--- a/datacenter/ucp/1.1/release_notes.md
+++ b/datacenter/ucp/1.1/release_notes.md
@@ -1,12 +1,9 @@
 ---
-redirect_from:
-- /ucp/release_notes/
 description: Release notes for Docker Universal Control Plane. Learn more about the
   changes introduced in the latest versions.
-keywords:
-- Docker, UCP
-- Release notes
-- Versions
+keywords: Docker, UCP, Release notes, Versions
+redirect_from:
+- /ucp/release_notes/
 title: UCP release notes
 ---
 

--- a/datacenter/ucp/1.1/support.md
+++ b/datacenter/ucp/1.1/support.md
@@ -1,11 +1,9 @@
 ---
-redirect_from:
-- /ucp/support/
 description: Your Docker subscription gives you access to prioritized support. You
   can file tickets via email, your the support portal.
-keywords:
-- Docker, support
-- help
+keywords: Docker, support, help
+redirect_from:
+- /ucp/support/
 title: Get support
 ---
 

--- a/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
@@ -1,8 +1,7 @@
 ---
-title: CLI-based access
 description: Learn how to access Docker Universal Control Plane from the CLI.
-keywords:
-- docker, ucp, cli, administration
+keywords: docker, ucp, cli, administration
+title: CLI-based access
 ---
 
 Docker UCP secures your cluster with role-based access control, so that only

--- a/datacenter/ucp/2.0/guides/access-ucp/index.md
+++ b/datacenter/ucp/2.0/guides/access-ucp/index.md
@@ -1,8 +1,7 @@
 ---
-title: Web-based access
 description: Learn how to access Docker Universal Control Plane from the web browser.
-keywords:
-- docker, ucp, web, administration
+keywords: docker, ucp, web, administration
+title: Web-based access
 ---
 
 Docker Universal Control Plane allows you to manage your cluster in a visual

--- a/datacenter/ucp/2.0/guides/applications/deploy-app-cli.md
+++ b/datacenter/ucp/2.0/guides/applications/deploy-app-cli.md
@@ -1,9 +1,8 @@
 ---
-title: Deploy an app from the CLI
 description: Learn how to deploy containerized applications on a swarm, with Docker
   Universal Control Plane.
-keywords:
-- deploy, application
+keywords: deploy, application
+title: Deploy an app from the CLI
 ---
 
 With Docker Universal Control Plane you can deploy your apps from the CLI,

--- a/datacenter/ucp/2.0/guides/applications/index.md
+++ b/datacenter/ucp/2.0/guides/applications/index.md
@@ -1,9 +1,8 @@
 ---
-title: Deploy an app from the UI
 description: Learn how to deploy containerized applications on a cluster, with Docker
   Universal Control Plane.
-keywords:
-- ucp, deploy, application
+keywords: ucp, deploy, application
+title: Deploy an app from the UI
 ---
 
 With Docker Universal Control Plane you can deploy applications from the

--- a/datacenter/ucp/2.0/guides/architecture.md
+++ b/datacenter/ucp/2.0/guides/architecture.md
@@ -1,8 +1,7 @@
 ---
-title: UCP architecture
 description: Learn about the architecture of Docker Universal Control Plane.
-keywords:
-- docker, ucp, architecture
+keywords: docker, ucp, architecture
+title: UCP architecture
 ---
 
 Universal Control Plane is a containerized application that runs on the

--- a/datacenter/ucp/2.0/guides/configuration/configure-logs.md
+++ b/datacenter/ucp/2.0/guides/configuration/configure-logs.md
@@ -1,9 +1,8 @@
 ---
-title: Configure UCP logging
 description: Learn how to configure Docker Universal Control Plane to store your logs
   on an external log system.
-keywords:
-- docker, ucp, integrate, logs
+keywords: docker, ucp, integrate, logs
+title: Configure UCP logging
 ---
 
 ## Configure UCP logging

--- a/datacenter/ucp/2.0/guides/configuration/index.md
+++ b/datacenter/ucp/2.0/guides/configuration/index.md
@@ -1,9 +1,8 @@
 ---
-title: Use externally-signed certificates
 description: Learn how to configure Docker Universal Control Plane to use your own
   certificates.
-keywords:
-- Universal Control Plane, UCP, certificate, authentiation, tls
+keywords: Universal Control Plane, UCP, certificate, authentiation, tls
+title: Use externally-signed certificates
 ---
 
 By default the UCP web UI is exposed using HTTPS, to ensure all

--- a/datacenter/ucp/2.0/guides/configuration/integrate-with-dtr.md
+++ b/datacenter/ucp/2.0/guides/configuration/integrate-with-dtr.md
@@ -1,8 +1,7 @@
 ---
-title: Integrate with Docker Trusted Registry
 description: Integrate UCP with Docker Trusted Registry
-keywords:
-- trusted, registry, integrate, UCP, DTR
+keywords: trusted, registry, integrate, UCP, DTR
+title: Integrate with Docker Trusted Registry
 ---
 
 Docker UCP integrates out of the box with Docker Trusted Registry (DTR). This

--- a/datacenter/ucp/2.0/guides/configuration/integrate-with-ldap.md
+++ b/datacenter/ucp/2.0/guides/configuration/integrate-with-ldap.md
@@ -1,9 +1,8 @@
 ---
-title: Integrate with LDAP
 description: Learn how to integrate UCP with an LDAP service, so that you can manage
   users from a single place.
-keywords:
-- LDAP, authentication, user management
+keywords: LDAP, authentication, user management
+title: Integrate with LDAP
 ---
 
 Docker UCP integrates with LDAP services, so that you can manage users from a

--- a/datacenter/ucp/2.0/guides/configuration/route-hostnames.md
+++ b/datacenter/ucp/2.0/guides/configuration/route-hostnames.md
@@ -1,8 +1,7 @@
 ---
-title: Enable container networking with UCP
 description: Docker Universal Control Plane
-keywords:
-- networking, kv, engine-discovery, ucp
+keywords: networking, kv, engine-discovery, ucp
+title: Enable container networking with UCP
 ---
 
 UCP provides an HTTP routing mesh, that extends the networking capabilities

--- a/datacenter/ucp/2.0/guides/content-trust/index.md
+++ b/datacenter/ucp/2.0/guides/content-trust/index.md
@@ -1,8 +1,8 @@
 ---
+description: Configure a Docker Universal Plane cluster to only allow running applications
+  that use images you trust.
+keywords: docker, ucp, backup, restore, recovery
 title: Run only the images you trust
-description: Configure a Docker Universal Plane cluster to only allow running applications that use images you trust.
-keywords:
-- docker, ucp, backup, restore, recovery
 ---
 
 With Docker Universal Control Plane you can enforce applications to only use

--- a/datacenter/ucp/2.0/guides/content-trust/manage-trusted-repositories.md
+++ b/datacenter/ucp/2.0/guides/content-trust/manage-trusted-repositories.md
@@ -1,8 +1,7 @@
 ---
-title: Manage trusted repositories
 description: Learn how to use the Notary CLI client to manage trusted repositories
-keywords:
-- UCP, trust, notary, registry, security
+keywords: UCP, trust, notary, registry, security
+title: Manage trusted repositories
 ---
 
 Once you install the Notary CLI client, you can use it to manage your signing

--- a/datacenter/ucp/2.0/guides/high-availability/backups-and-disaster-recovery.md
+++ b/datacenter/ucp/2.0/guides/high-availability/backups-and-disaster-recovery.md
@@ -1,8 +1,8 @@
 ---
+description: Learn how to backup your Docker Universal Control Plane cluster, and
+  to recover your cluster from an existing backup.
+keywords: docker, ucp, backup, restore, recovery
 title: Backups and disaster recovery
-description: Learn how to backup your Docker Universal Control Plane cluster, and to recover your cluster from an existing backup.
-keywords:
-- docker, ucp, backup, restore, recovery
 ---
 
 When you decide to start using Docker Universal Control Plane on a production

--- a/datacenter/ucp/2.0/guides/high-availability/index.md
+++ b/datacenter/ucp/2.0/guides/high-availability/index.md
@@ -1,9 +1,8 @@
 ---
-title: Set up high availability
 description: Docker Universal Control plane has support for high availability. Learn
   how to set up your installation to ensure it tolerates failures.
-keywords:
-- docker, ucp, high-availability, replica
+keywords: docker, ucp, high-availability, replica
+title: Set up high availability
 ---
 
 Docker Universal Control Plane is designed for high availability (HA). You can

--- a/datacenter/ucp/2.0/guides/index.md
+++ b/datacenter/ucp/2.0/guides/index.md
@@ -1,9 +1,8 @@
 ---
-title: Universal Control Plane overview
 description: Learn about Docker Universal Control Plane, the enterprise-grade cluster
   management solution from Docker.
-keywords:
-- docker, ucp, overview, orchestration, clustering
+keywords: docker, ucp, overview, orchestration, clustering
+title: Universal Control Plane overview
 ---
 
 Docker Universal Control Plane (UCP) is the enterprise-grade cluster management

--- a/datacenter/ucp/2.0/guides/installation/index.md
+++ b/datacenter/ucp/2.0/guides/installation/index.md
@@ -1,8 +1,7 @@
 ---
-title: Install UCP for production
 description: Learn how to install Docker Universal Control Plane on production
-keywords:
-- Universal Control Plane, UCP, install
+keywords: Universal Control Plane, UCP, install
+title: Install UCP for production
 ---
 
 Docker Universal Control Plane (UCP) is a containerized application that can be

--- a/datacenter/ucp/2.0/guides/installation/install-offline.md
+++ b/datacenter/ucp/2.0/guides/installation/install-offline.md
@@ -1,9 +1,8 @@
 ---
-title: Install UCP offline
 description: Learn how to install Docker Universal Control Plane. on a machine with
   no internet access.
-keywords:
-- docker, ucp, install, offline
+keywords: docker, ucp, install, offline
+title: Install UCP offline
 ---
 
 The procedure to install Docker Universal Control Plane on a host is the same,

--- a/datacenter/ucp/2.0/guides/installation/license.md
+++ b/datacenter/ucp/2.0/guides/installation/license.md
@@ -1,8 +1,7 @@
 ---
-title: License UCP
 description: Learn how to license your Docker Universal Control Plane installation.
-keywords:
-- Universal Control Plane, UCP, install, license
+keywords: Universal Control Plane, UCP, install, license
+title: License UCP
 ---
 
 After installing Docker Universal Control Plane, you need to license your

--- a/datacenter/ucp/2.0/guides/installation/plan-production-install.md
+++ b/datacenter/ucp/2.0/guides/installation/plan-production-install.md
@@ -1,9 +1,8 @@
 ---
-title: Plan a production installation
 description: Learn about the Docker Universal Control Plane architecture, and the
   requirements to install it on production.
-keywords:
-- docker, ucp, install, checklist
+keywords: docker, ucp, install, checklist
+title: Plan a production installation
 ---
 
 Docker Universal Control Plane can be installed on-premises, or

--- a/datacenter/ucp/2.0/guides/installation/scale-your-cluster.md
+++ b/datacenter/ucp/2.0/guides/installation/scale-your-cluster.md
@@ -1,8 +1,8 @@
 ---
+description: Learn how to scale Docker Universal Control Plane cluster, by adding
+  and removing nodes.
+keywords: UCP, cluster, scale
 title: Scale your cluster
-description: Learn how to scale Docker Universal Control Plane cluster, by adding and removing nodes.
-keywords:
-- UCP, cluster, scale
 ---
 
 Docker UCP is designed for scaling horizontally as your applications grow in

--- a/datacenter/ucp/2.0/guides/installation/system-requirements.md
+++ b/datacenter/ucp/2.0/guides/installation/system-requirements.md
@@ -1,9 +1,8 @@
 ---
-title: UCP System requirements
 description: Learn about the system requirements for installing Docker Universal Control
   Plane.
-keywords:
-- docker, ucp, architecture, requirements
+keywords: docker, ucp, architecture, requirements
+title: UCP System requirements
 ---
 
 Docker Universal Control Plane can be installed on-premises or on the cloud.

--- a/datacenter/ucp/2.0/guides/installation/uninstall.md
+++ b/datacenter/ucp/2.0/guides/installation/uninstall.md
@@ -1,8 +1,7 @@
 ---
-title: Uninstall UCP
 description: Learn how to uninstall a Docker Universal Control Plane cluster.
-keywords:
-- docker, ucp, uninstall
+keywords: docker, ucp, uninstall
+title: Uninstall UCP
 ---
 
 Docker UCP is designed to scale as your applications grow in size and usage.

--- a/datacenter/ucp/2.0/guides/installation/upgrade.md
+++ b/datacenter/ucp/2.0/guides/installation/upgrade.md
@@ -1,12 +1,11 @@
 ---
-title: Upgrade to UCP 2.0
 description: Learn how to upgrade Docker Universal Control Plane with minimal impact
   to your users.
-keywords:
-- Docker, UCP, upgrade, update
+keywords: Docker, UCP, upgrade, update
 redirect_from:
 - /ucp/upgrade-ucp/
 - /ucp/installation/upgrade/
+title: Upgrade to UCP 2.0
 ---
 
 This page guides you in upgrading Docker Universal Control Plane (UCP) to

--- a/datacenter/ucp/2.0/guides/monitor/index.md
+++ b/datacenter/ucp/2.0/guides/monitor/index.md
@@ -1,9 +1,8 @@
 ---
-title: Monitor your cluster
 description: Monitor your Docker Universal Control Plane installation, and learn how
   to troubleshoot it.
-keywords:
-- Docker, UCP, troubleshoot
+keywords: Docker, UCP, troubleshoot
+title: Monitor your cluster
 ---
 
 This article gives you an overview of how to monitor your Docker UCP

--- a/datacenter/ucp/2.0/guides/monitor/troubleshoot-configurations.md
+++ b/datacenter/ucp/2.0/guides/monitor/troubleshoot-configurations.md
@@ -1,8 +1,7 @@
 ---
-title: Troubleshoot cluster configurations
 description: Learn how to troubleshoot your Docker Universal Control Plane cluster.
-keywords:
-- ectd, key, value, store, ucp
+keywords: ectd, key, value, store, ucp
+title: Troubleshoot cluster configurations
 ---
 
 Docker UCP persists configuration data on an [etcd](https://coreos.com/etcd/)

--- a/datacenter/ucp/2.0/guides/monitor/troubleshoot.md
+++ b/datacenter/ucp/2.0/guides/monitor/troubleshoot.md
@@ -1,8 +1,7 @@
 ---
-title: Troubleshoot your cluster
 description: Learn how to troubleshoot your Docker Universal Control Plane cluster.
-keywords:
-- docker, ucp, troubleshoot
+keywords: docker, ucp, troubleshoot
+title: Troubleshoot your cluster
 ---
 
 If you detect problems in your UCP cluster, you can start your troubleshooting

--- a/datacenter/ucp/2.0/guides/release-notes.md
+++ b/datacenter/ucp/2.0/guides/release-notes.md
@@ -1,11 +1,8 @@
 ---
-title: UCP release notes
 description: Release notes for Docker Universal Control Plane. Learn more about the
   changes introduced in the latest versions.
-keywords:
-- Docker, UCP
-- Release notes
-- Versions
+keywords: Docker, UCP, Release notes, Versions
+title: UCP release notes
 ---
 
 Here you can learn about new features, bug fixes, breaking changes and

--- a/datacenter/ucp/2.0/guides/support.md
+++ b/datacenter/ucp/2.0/guides/support.md
@@ -1,10 +1,8 @@
 ---
-title: Get support
 description: Your Docker subscription gives you access to prioritized support. You
   can file tickets via email, your the support portal.
-keywords:
-- Docker, support
-- help
+keywords: Docker, support, help
+title: Get support
 ---
 
 Your Docker Data Center, or Universal Control Plane subscription gives you

--- a/datacenter/ucp/2.0/guides/user-management/create-and-manage-teams.md
+++ b/datacenter/ucp/2.0/guides/user-management/create-and-manage-teams.md
@@ -1,9 +1,8 @@
 ---
-title: Create and manage teams
 description: Learn how to create and manage user permissions, using teams in your
   Docker Universal Control Plane cluster.
-keywords:
-- authorize, authentication, users, teams, UCP, Docker
+keywords: authorize, authentication, users, teams, UCP, Docker
+title: Create and manage teams
 ---
 
 You can extend the user's default permissions by granting them fine-grain

--- a/datacenter/ucp/2.0/guides/user-management/create-and-manage-users.md
+++ b/datacenter/ucp/2.0/guides/user-management/create-and-manage-users.md
@@ -1,9 +1,8 @@
 ---
-title: Create and manage users
 description: Learn how to create and manage users in your Docker Universal Control
   Plane cluster.
-keywords:
-- authorize, authentication, users, teams, UCP, Docker
+keywords: authorize, authentication, users, teams, UCP, Docker
+title: Create and manage users
 ---
 
 When using the UCP built-in authentication, you need to create users and

--- a/datacenter/ucp/2.0/guides/user-management/index.md
+++ b/datacenter/ucp/2.0/guides/user-management/index.md
@@ -1,8 +1,7 @@
 ---
-title: Authentication and authorization
 description: Learn how to manage permissions in Docker Universal Control Plane.
-keywords:
-- authorization, authentication, users, teams, UCP
+keywords: authorization, authentication, users, teams, UCP
+title: Authentication and authorization
 ---
 
 With Docker Universal Control Plane you get to control who can create and edit

--- a/datacenter/ucp/2.0/guides/user-management/permission-levels.md
+++ b/datacenter/ucp/2.0/guides/user-management/permission-levels.md
@@ -1,9 +1,8 @@
 ---
-title: Permission levels
 description: Learn about the permission levels available in Docker Universal Control
   Plane.
-keywords:
-- authorization, authentication, users, teams, UCP
+keywords: authorization, authentication, users, teams, UCP
+title: Permission levels
 ---
 
 Docker Universal Control Plane has two types of users: administrators and

--- a/datacenter/ucp/2.0/reference/cli/backup.md
+++ b/datacenter/ucp/2.0/reference/cli/backup.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp backup
 description: Create a backup of a UCP manager node
-keywords:
-- docker, dtr, cli, backup
+keywords: docker, dtr, cli, backup
+title: docker/ucp backup
 ---
 
 Create a backup of a UCP manager node

--- a/datacenter/ucp/2.0/reference/cli/dump-certs.md
+++ b/datacenter/ucp/2.0/reference/cli/dump-certs.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp dump-certs
 description: Print the public certificates used by this UCP web server
-keywords:
-- docker, dtr, cli, dump-certs
+keywords: docker, dtr, cli, dump-certs
+title: docker/ucp dump-certs
 ---
 
 Print the public certificates used by this UCP web server

--- a/datacenter/ucp/2.0/reference/cli/fingerprint.md
+++ b/datacenter/ucp/2.0/reference/cli/fingerprint.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp fingerprint
 description: Print the TLS fingerprint for this UCP web server
-keywords:
-- docker, dtr, cli, fingerprint
+keywords: docker, dtr, cli, fingerprint
+title: docker/ucp fingerprint
 ---
 
 Print the TLS fingerprint for this UCP web server
@@ -23,4 +22,3 @@ docker run --rm \
 
 This command displays the fingerprint of the certificate used in the UCP web
 server running on this node.
-

--- a/datacenter/ucp/2.0/reference/cli/id.md
+++ b/datacenter/ucp/2.0/reference/cli/id.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp id
 description: Print the ID of UCP running on this node
-keywords:
-- docker, dtr, cli, id
+keywords: docker, dtr, cli, id
+title: docker/ucp id
 ---
 
 Print the ID of UCP running on this node
@@ -26,4 +25,3 @@ matches what you see when running the 'docker info' command while using
 a client bundle.
 
 This ID is used by other commands as confirmation.
-

--- a/datacenter/ucp/2.0/reference/cli/images.md
+++ b/datacenter/ucp/2.0/reference/cli/images.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp images
 description: Verify the UCP images on this node
-keywords:
-- docker, dtr, cli, images
+keywords: docker, dtr, cli, images
+title: docker/ucp images
 ---
 
 Verify the UCP images on this node

--- a/datacenter/ucp/2.0/reference/cli/index.md
+++ b/datacenter/ucp/2.0/reference/cli/index.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp overview
 description: Learn about the commands available in the docker/ucp image.
-keywords:
-- docker, ucp, cli, ucp
+keywords: docker, ucp, cli, ucp
+title: docker/ucp overview
 ---
 
 This image has commands to install and manage

--- a/datacenter/ucp/2.0/reference/cli/install.md
+++ b/datacenter/ucp/2.0/reference/cli/install.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp install
 description: Install UCP on this node
-keywords:
-- docker, dtr, cli, install
+keywords: docker, dtr, cli, install
+title: docker/ucp install
 ---
 
 Install UCP on this node

--- a/datacenter/ucp/2.0/reference/cli/restart.md
+++ b/datacenter/ucp/2.0/reference/cli/restart.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp restart
 description: Start or restart UCP components running on this node
-keywords:
-- docker, dtr, cli, restart
+keywords: docker, dtr, cli, restart
+title: docker/ucp restart
 ---
 
 Start or restart UCP components running on this node

--- a/datacenter/ucp/2.0/reference/cli/restore.md
+++ b/datacenter/ucp/2.0/reference/cli/restore.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp restore
 description: Restore a UCP manager node from a backup
-keywords:
-- docker, dtr, cli, restore
+keywords: docker, dtr, cli, restore
+title: docker/ucp restore
 ---
 
 Restore a UCP manager node from a backup

--- a/datacenter/ucp/2.0/reference/cli/stop.md
+++ b/datacenter/ucp/2.0/reference/cli/stop.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp stop
 description: Stop UCP components running on this node
-keywords:
-- docker, dtr, cli, stop
+keywords: docker, dtr, cli, stop
+title: docker/ucp stop
 ---
 
 Stop UCP components running on this node

--- a/datacenter/ucp/2.0/reference/cli/support.md
+++ b/datacenter/ucp/2.0/reference/cli/support.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp support
 description: Create a support dump for this UCP node
-keywords:
-- docker, dtr, cli, support
+keywords: docker, dtr, cli, support
+title: docker/ucp support
 ---
 
 Create a support dump for this UCP node
@@ -22,4 +21,3 @@ docker run --rm \
 ## Description
 
 This command creates a support dump file for this node, and prints it to stdout.
-

--- a/datacenter/ucp/2.0/reference/cli/uninstall-ucp.md
+++ b/datacenter/ucp/2.0/reference/cli/uninstall-ucp.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp uninstall-ucp
 description: Uninstall UCP from this swarm
-keywords:
-- docker, dtr, cli, uninstall-ucp
+keywords: docker, dtr, cli, uninstall-ucp
+title: docker/ucp uninstall-ucp
 ---
 
 Uninstall UCP from this swarm

--- a/datacenter/ucp/2.0/reference/cli/upgrade.md
+++ b/datacenter/ucp/2.0/reference/cli/upgrade.md
@@ -1,8 +1,7 @@
 ---
-title: docker/ucp upgrade
 description: Upgrade the UCP components on this node
-keywords:
-- docker, dtr, cli, upgrade
+keywords: docker, dtr, cli, upgrade
+title: docker/ucp upgrade
 ---
 
 Upgrade the UCP components on this node

--- a/engine/admin/troubleshooting_volume_errors.md
+++ b/engine/admin/troubleshooting_volume_errors.md
@@ -1,7 +1,6 @@
 ---
 description: Troubleshooting volume errors
-keywords:
-- cadvisor, troubleshooting, volumes, bind-mounts
+keywords: cadvisor, troubleshooting, volumes, bind-mounts
 title: Troubleshoot volume errors
 ---
 

--- a/engine/breaking_changes.md
+++ b/engine/breaking_changes.md
@@ -2,9 +2,7 @@
 redirect_from:
 - /engine/misc/breaking/
 description: Breaking changes
-keywords:
-- docker, documentation, about, technology, breaking
-- incompatibilities
+keywords: docker, documentation, about, technology, breaking, incompatibilities
 title: Breaking changes and incompatibilities
 ---
 

--- a/engine/getstarted/step_four.md
+++ b/engine/getstarted/step_four.md
@@ -4,8 +4,7 @@ redirect_from:
 - /windows/step_four/
 - /linux/step_four/
 description: Getting started with Docker
-keywords:
-- beginner, getting started, Docker
+keywords: beginner, getting started, Docker
 title: Build your own image
 ---
 

--- a/engine/installation/linux/index.md
+++ b/engine/installation/linux/index.md
@@ -1,10 +1,6 @@
 ---
 description: Lists the installation methods
-keywords:
-- docker
-- engine
-- install
-- linux
+keywords: docker, engine, install, linux
 title: Install Docker on Linux distributions
 ---
 

--- a/engine/swarm/how-swarm-mode-works/pki.md
+++ b/engine/swarm/how-swarm-mode-works/pki.md
@@ -1,13 +1,6 @@
 ---
 description: How PKI works in swarm mode
-keywords:
-- docker
-- container
-- cluster
-- swarm mode
-- node
-- tls
-- pki
+keywords: docker, container, cluster, swarm mode, node, tls, pki
 title: How PKI works in swarm mode
 ---
 

--- a/engine/swarm/ingress.md
+++ b/engine/swarm/ingress.md
@@ -1,12 +1,6 @@
 ---
 description: Use the routing mesh to publish services externally to a swarm
-keywords:
-- guide
-- swarm mode
-- swarm
-- network
-- ingress
-- routing mesh
+keywords: guide, swarm mode, swarm, network, ingress, routing mesh
 title: Use swarm mode routing mesh
 ---
 

--- a/engine/swarm/networking.md
+++ b/engine/swarm/networking.md
@@ -1,10 +1,6 @@
 ---
 description: Use swarm mode networking features
-keywords:
-- guide
-- swarm mode
-- swarm
-- network
+keywords: guide, swarm mode, swarm, network
 title: Attach services to an overlay network
 ---
 

--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -1,10 +1,6 @@
 ---
 description: Deploy services to a swarm
-keywords:
-- guide
-- swarm mode
-- swarm
-- service
+keywords: guide, swarm mode, swarm, service
 title: Deploy services to a swarm
 ---
 

--- a/engine/tutorials/usingdocker.md
+++ b/engine/tutorials/usingdocker.md
@@ -2,9 +2,7 @@
 redirect_from:
 - /engine/userguide/containers/usingdocker/
 description: Learn how to manage and operate Docker containers.
-keywords:
-- docker, the docker guide, documentation, docker.io, monitoring containers,
-  docker top, docker inspect, docker port, ports, docker logs, log, logs
+keywords: docker, the docker guide, documentation, docker.io, monitoring containers, docker top, docker inspect, docker port, ports, docker logs, log, logs
 menu:
   main:
     parent: engine_learn_menu

--- a/engine/userguide/networking/overlay-security-model.md
+++ b/engine/userguide/networking/overlay-security-model.md
@@ -1,8 +1,6 @@
 ---
 description: Docker swarm mode overlay network security model
-keywords:
-- network, docker, documentation, user guide, multihost, swarm mode
-- overlay
+keywords: network, docker, documentation, user guide, multihost, swarm mode, overlay
 title: Docker swarm mode overlay network security model
 ---
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.7.3-alpine
-MAINTAINER Gaetan de Villele <gaetan@docker.com>
+MAINTAINER Adrien Duermael <adrien@docker.com>
 
 COPY src /go/src
 WORKDIR /go/src/validator

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,12 +1,8 @@
 FROM golang:1.7.3-alpine
 MAINTAINER Gaetan de Villele <gaetan@docker.com>
 
-RUN apk update
-RUN apk add git
-
 COPY src /go/src
 WORKDIR /go/src/validator
 
 # when running the container, MOUNT docs repo in /docs
-
 CMD ["go", "test"]

--- a/tests/src/validator/markdown_test.go
+++ b/tests/src/validator/markdown_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"github.com/gdevillele/frontparser"
 	"io/ioutil"
 	"os"
@@ -12,50 +11,114 @@ import (
 )
 
 // TestFrontmatterTitle tests if there's a title present in all
-// markdown frontmatters.
+// published markdown frontmatters.
 func TestFrontmatterTitle(t *testing.T) {
 	filepath.Walk("/docs", func(path string, info os.FileInfo, err error) error {
-		err = testFrontmatterTitle(path)
 		if err != nil {
-			fmt.Println(err.Error(), "-", path)
-			t.Fail()
+			t.Error(err.Error(), "-", path)
+		}
+		published, mdBytes, err := isPublishedMarkdown(path)
+		if err != nil {
+			t.Error(err.Error(), "-", path)
+		}
+		if published == false {
+			return nil
+		}
+		err = testFrontmatterTitle(mdBytes)
+		if err != nil {
+			t.Error(err.Error(), "-", path)
 		}
 		return nil
 	})
 }
 
 // testFrontmatterTitle tests if there's a title present in
-// markdown file at given path
-func testFrontmatterTitle(path string) error {
+// given markdown file bytes
+func testFrontmatterTitle(mdBytes []byte) error {
+	fm, _, err := frontparser.ParseFrontmatterAndContent(mdBytes)
+	if err != nil {
+		return err
+	}
+	if _, exists := fm["title"]; exists == false {
+		return errors.New("can't find title in frontmatter")
+	}
+	return nil
+}
+
+// TestFrontMatterKeywords tests if keywords are present and correctly
+// formatted in all published markdown frontmatters.
+func TestFrontMatterKeywords(t *testing.T) {
+	filepath.Walk("/docs", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Error(err.Error(), "-", path)
+		}
+		published, mdBytes, err := isPublishedMarkdown(path)
+		if err != nil {
+			t.Error(err.Error(), "-", path)
+		}
+		if published == false {
+			return nil
+		}
+		err = testFrontMatterKeywords(mdBytes)
+		if err != nil {
+			t.Error(err.Error(), "-", path)
+		}
+		return nil
+	})
+}
+
+// testFrontMatterKeywords tests if if keywords are present and correctly
+// formatted in given markdown file bytes
+func testFrontMatterKeywords(mdBytes []byte) error {
+	fm, _, err := frontparser.ParseFrontmatterAndContent(mdBytes)
+	if err != nil {
+		return err
+	}
+
+	keywords, exists := fm["keywords"]
+
+	// it's ok to have a page without keywords
+	if exists == false {
+		return nil
+	}
+
+	if _, ok := keywords.(string); !ok {
+		return errors.New("keywords should be a comma separated string")
+	}
+
+	return nil
+}
+
+//-----------------
+// utils
+//-----------------
+
+// isPublishedMarkdown returns wether a file is a published markdown or not
+// as a convenience it also returns the markdown bytes to avoid reading files twice
+func isPublishedMarkdown(path string) (bool, []byte, error) {
 	if strings.HasSuffix(path, ".md") {
 		fileBytes, err := ioutil.ReadFile(path)
 		if err != nil {
-			return err
+			return false, nil, err
 		}
-		// if file has frontmatter
 		if frontparser.HasFrontmatterHeader(fileBytes) {
 			fm, _, err := frontparser.ParseFrontmatterAndContent(fileBytes)
 			if err != nil {
-				return err
+				return false, nil, err
 			}
-
 			// skip markdowns that are not published
 			if published, exists := fm["published"]; exists {
 				if publishedBool, ok := published.(bool); ok {
-					if publishedBool == false {
-						return nil
+					if publishedBool {
+						// file is markdown, has frontmatter and is published
+						return true, fileBytes, nil
 					}
 				}
+			} else {
+				// if "published" field is missing, it means published == true
+				return true, fileBytes, nil
 			}
-
-			if _, exists := fm["title"]; exists == false {
-				return errors.New("can't find title in frontmatter")
-			}
-		} else {
-			// no frontmatter is not an error
-			// markdown files without frontmatter won't be considered
-			return nil
 		}
 	}
-	return nil
+	return false, nil, nil
 }


### PR DESCRIPTION
### Describe the proposed changes

I added tests to make sure keywords are correctly formatted in markdown frontmatters. 
The `keywords` field should always contain a comma separated string (and not an array).

Otherwise the meta tag for keywords in html is not generated correctly. Example from current https://docs.docker.com/engine/breaking_changes/:

```html
<meta name="keywords" content="docker, documentation, about, technology, breakingincompatibilities">
```

My fix for this file: https://github.com/docker/docker.github.io/pull/805/files#diff-19905fe91a80cf99357f4c7a0d4326dd
