### PR TITLE
correct typo in engine securitydoc

### DIFF
--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -128,7 +128,7 @@ virtual network setup, filesystem management, etc. That is, most likely,
 pieces of the Docker engine itself will run inside of containers.
 
 Finally, if you run Docker on a server, it is recommended to run
-exclusively Docker in the server, and move all other services within
+exclusively Docker on the server, and move all other services within
 containers controlled by Docker. Of course, it is fine to keep your
 favorite admin tools (probably at least an SSH server), as well as
 existing monitoring/supervision processes, such as NRPE and collectd.


### PR DESCRIPTION
corrected:

> run docker *in* the server

to:

> run docker *on* the server