### PR TITLE
registry/azure.md: fix broken syntax/links

### DIFF
--- a/registry/storage-drivers/azure.md
+++ b/registry/storage-drivers/azure.md
@@ -8,59 +8,12 @@ An implementation of the `storagedriver.StorageDriver` interface which uses [Mic
 
 ## Parameters
 
-<table>
-  <tr>
-    <th>Parameter</th>
-    <th>Required</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>
-      <code>accountname</code>
-    </td>
-    <td>
-      yes
-    </td>
-    <td>
-      Name of the Azure Storage Account.
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>accountkey</code>
-    </td>
-    <td>
-      yes
-    </td>
-    <td>
-      Primary or Secondary Key for the Storage Account.
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>container</code>
-    </td>
-    <td>
-      yes
-    </td>
-    <td>
-      Name of the Azure root storage container in which all registry data will be stored. Must comply the storage container name <a href='https://docs.microsoft.com/rest/api/storageservices/fileservices/naming-and-referencing-containers--blobs--and-metadata'>requirements</a>.
-    </td>
-  </tr>
-   <tr>
-    <td>
-      <code>realm</code>
-    </td>
-    <td>
-      no
-    </td>
-    <td>
-      Domain name suffix for the Storage Service API endpoint. For example realm for "Azure in China" would be <code>core.chinacloudapi.cn</code> and realm for "Azure Government" would be <code>core.usgovcloudapi.net</code>. By default, this
-      is <code>core.windows.net</code>.
-    </td>
-  </tr>
-
-</table>
+| Parameter     | Required | Description                                                                                                                                                                                                                                                         |
+|:--------------|:---------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `accountname` | yes      | Name of the Azure Storage Account.                                                                                                                                                                                                                                  |
+| `accountkey`  | yes      | Primary or Secondary Key for the Storage Account.                                                                                                                                                                                                                   |
+| `container`   | yes      | Name of the Azure root storage container in which all registry data will be stored. Must comply the storage container name [requirements](https://docs.microsoft.com/rest/api/storageservices/fileservices/naming-and-referencing-containers--blobs--and-metadata). |
+| `realm`       | no       | Domain name suffix for the Storage Service API endpoint. For example realm for "Azure in China" would be `core.chinacloudapi.cn` and realm for "Azure Government" would be `core.usgovcloudapi.net`. By default, this is `core.windows.net`.                        |
 
 
 ## Related Information

--- a/registry/storage-drivers/azure.md
+++ b/registry/storage-drivers/azure.md
@@ -44,7 +44,7 @@ An implementation of the `storagedriver.StorageDriver` interface which uses [Mic
       yes
     </td>
     <td>
-      Name of the Azure root storage container in which all registry data will be stored. Must comply the storage container name [requirements][create-container-api].
+      Name of the Azure root storage container in which all registry data will be stored. Must comply the storage container name <a href='https://docs.microsoft.com/rest/api/storageservices/fileservices/naming-and-referencing-containers--blobs--and-metadata'>requirements</a>.
     </td>
   </tr>
    <tr>
@@ -55,7 +55,7 @@ An implementation of the `storagedriver.StorageDriver` interface which uses [Mic
       no
     </td>
     <td>
-      Domain name suffix for the Storage Service API endpoint. For example realm for "Azure in China" would be `core.chinacloudapi.cn` and realm for "Azure Government" would be `core.usgovcloudapi.net`. By default, this
+      Domain name suffix for the Storage Service API endpoint. For example realm for "Azure in China" would be <code>core.chinacloudapi.cn</code> and realm for "Azure Government" would be <code>core.usgovcloudapi.net</code>. By default, this
       is <code>core.windows.net</code>.
     </td>
   </tr>
@@ -68,4 +68,4 @@ An implementation of the `storagedriver.StorageDriver` interface which uses [Mic
 * To get information about
 [azure-blob-storage](http://azure.microsoft.com/en-us/services/storage/) visit
 the Microsoft website.
-* You can use Microsoft's [Blob Service REST API](https://msdn.microsoft.com/en-us/library/azure/dd135733.aspx) to [create a container] (https://msdn.microsoft.com/en-us/library/azure/dd179468.aspx).
+* You can use Microsoft's [Blob Service REST API](https://msdn.microsoft.com/en-us/library/azure/dd135733.aspx) to [create a storage container](https://msdn.microsoft.com/en-us/library/azure/dd179468.aspx).


### PR DESCRIPTION
It looks like this doc, which was in docker/distribution repository before, is converted to HTML tables from Markdown tables. And in the table we used to have Markdown usage for

1. links
2. backtick-escaped sections

Since the table is HTML now, those Markdown usages won't work inside HTML.

I am just noticing this and adding them back. I wish the transition was more smooth.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>