### PR TITLE
Beta 32 docs updates to d4mac, d4win

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -120,14 +120,14 @@ For more about stable and beta channels, see the
 Run these commands to test if your versions of `docker`, `docker-compose`, and `docker-machine` are up-to-date and compatible with `Docker.app`.
 
 ```shell
-	$ docker --version
-	Docker version 1.12.3, build 6b644ec
+$ docker --version
+Docker version 1.13.0-rc3, build 4d92237
 
-	$ docker-compose --version
-	docker-compose version 1.8.1, build 878cff1
+$ docker-compose --version
+docker-compose version 1.9.0, build 2585387
 
-	$ docker-machine --version
-	docker-machine version 0.8.2, build e18a919
+$ docker-machine --version
+docker-machine version 0.9.0-rc2, build 7b19591
 ```
 
 >**Note**: The above is an example. Your output will differ if you are running different (e.g., newer) versions.
@@ -178,11 +178,11 @@ Run these commands to test if your versions of `docker`, `docker-compose`, and `
 Choose <img src="images/whale-x.png"> --> **Preferences** from the menu bar. You
 can set the following runtime options.
 
-#### General
+### General
 
 ![Preferences](images/settings.png)
 
-##### Auto-start, update, and backups
+#### Auto-start, update, and backups
 
 * Docker for Mac is set to **automatically start** when you log in. Uncheck the login autostart option if you don't want Docker to start when you open your
 session.
@@ -199,13 +199,13 @@ src="images/whale-x.png"> -> **Check for Updates**
   still on the Privacy tab. For now, both Stable and Beta users can read more
   about usage data settings in the [Privacy](#Privacy) topic.
 
-##### CPUs
+#### CPUs
 
 By default, Docker for Mac is set to use 2 processors. You can increase
 processing power for the app by setting this to a higher number, or lower it to
 have Docker for Mac use fewer computing resources.
 
-##### Memory
+#### Memory
 
 By default, Docker for Mac is set to use `2` GB runtime memory, allocated from
 the total available memory on your Mac. You can increase the RAM on the app to
@@ -218,11 +218,11 @@ are on the Advanced dialog, as shown here.
 >![CPUs and Memory settings UI
 starting at Beta 31](images/settings-advanced-beta.png)
 
-#### Advanced
+### Advanced
 
 ![Advanced Preference settings-advanced](images/settings-advanced.png)
 
-##### Custom Registries
+#### Custom Registries
 
 As an alternative to using [Docker Hub](https://hub.docker.com/) to store your
 public or private images or [Docker Trusted
@@ -236,7 +236,7 @@ the FAQs.)
 own registries are available as part of a new daemon tab. See [Docker
 daemon](#docker-daemon-beta-feature)).
 
-##### HTTP proxy settings
+#### HTTP proxy settings
 
 Docker for Mac will detect HTTP/HTTPS Proxy Settings and automatically propagate
 these to Docker and to your containers. For example, if you set your proxy
@@ -247,12 +247,12 @@ containers.
 >
 >![Proxies settings](images/settings-proxies-beta.png)
 
-#### Docker Daemon (Beta feature)
+### Docker Daemon (Beta feature)
 
 Starting with Beta 31, configuration options on the Docker daemon move to their
 own **Daemon** tab, including basic and advanced options.
 
-##### Daemon Basic (experimental mode and registries)
+#### Daemon Basic (experimental mode and registries)
 
 By default, Docker for Mac Beta releases use the experimental version of Docker
 Engine, described in the <a
@@ -262,13 +262,38 @@ Beta 31, you can toggle **experimental mode** on and off. If you toggle it off,
 Docker for Mac Beta uses the current generally available release of Docker
 Engine, the same as Stable Docker for Mac versions uses.
 
+You can check whether you are running experimental mode or not by typing `docker
+version` on the command line. Experimental mode is listed under `Server` data.
+If `Experimental` is `true`, the Docker is running in experimental mode, as
+shown here. (If `false`, Experimental mode is off.)
+
+```bash
+$ docker version
+Client:
+ Version:      1.13.0-rc3
+ API version:  1.25
+ Go version:   go1.7.3
+ Git commit:   4d92237
+ Built:        Tue Dec  6 01:15:44 2016
+ OS/Arch:      darwin/amd64
+
+Server:
+ Version:      1.13.0-rc3
+ API version:  1.25 (minimum version 1.12)
+ Go version:   go1.7.3
+ Git commit:   4d92237
+ Built:        Tue Dec  6 01:15:44 2016
+ OS/Arch:      linux/amd64
+ Experimental: true
+```
+
 You can use Docker to set up your own insecure
 [registry](/registry/introduction/). For details on this, see [Custom
 Registries](#custom-registries).
 
 ![Daemon](images/settings-advanced-experimental-beta.png)
 
-##### Daemon Advanced (JSON configuration file)
+#### Daemon Advanced (JSON configuration file)
 
 On the **Daemon -> Advanced dialog**, you can directly configure the daemon from
 the JSON file, and determine entirely how your containers will run. For a full
@@ -282,7 +307,7 @@ choose to discard or not apply changes when asked.
 
 ![Docker Daemon](images/settings-daemon-beta.png)
 
-#### File sharing
+### File sharing
 
 You can decide which directories on your Mac to share with containers.
 
@@ -306,7 +331,7 @@ outside of the `/Users` directory. In that case, share the drive where the
 Dockerfile and volume are located. Otherwise, you will get file not found or
 cannot start service errors at runtime. (See also [Volume mounting requires file sharing for any project directories outside of `/Users`](troubleshoot.md#volume-mounting-requires-file-sharing-for-any-project-directories-outside-of-users).)
 
-#### Privacy
+### Privacy
 
 You can set Docker for Mac to auto-send diagnostics, crash reports, and usage data. This information can help Docker improve the application and get more context for troubleshooting problems.
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -202,6 +202,25 @@ events or unexpected unmounts.
 
 ## Beta Release Notes
 
+### Beta 32 Release Notes (2016-12-07 1.13.0-rc3-beta32)
+
+**New**
+
+- Support for arm, aarch64, ppc64le architectures using qemu
+
+**Upgrades**
+
+- Docker 1.13.0-rc3
+- Docker Machine 0.9.0-rc2
+- Linux Kernel 4.8.12
+
+**Bug fixes and minor improvements**
+
+- VPNKit: Improved diagnostics
+- Fix vsock deadlock under heavy write load
+- On the beta channel you can't opt-out of analytics
+- If you opt-out of analytics, you're prompted for approval before a bug report is sent
+
 ### Beta 31 Release Notes (2016-12-01 1.13.0-rc2-beta31)
 
 **New**

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -133,14 +133,14 @@ Congratulations! You are up and running with Docker for Windows.
 
 Start your favorite shell (`cmd.exe`, PowerShell, or other) to check your versions of `docker` and `docker-compose`, and verify the installation.
 
-      PS C:\Users\samstevens> docker --version
-      Docker version 1.12.0, build 8eab29e, experimental
+      PS C:\Users\Vicky> docker --version
+      Docker version 1.13.0-rc3, build 4d92237
 
-      PS C:\Users\samstevens> docker-compose --version
-      docker-compose version 1.8.0, build d988a55
+      PS C:\Users\Vicky> docker-compose --version
+      docker-compose version 1.9.0, build 2585387
 
-      PS C:\Users\samstevens> docker-machine --version
-      docker-machine version 0.8.0, build b85aac1
+      PS C:\Users\Vicky> docker-machine --version
+      docker-machine version 0.9.0-rc2, build 7b19591
 
 ## Step 4. Explore the application and run examples
 
@@ -152,27 +152,26 @@ The next few steps take you through some examples. These are just suggestions fo
 
     Here is the output of `docker ps` run in a powershell. (In this example, no containers are running yet.)
 
-          PS C:\Users\samstevens> docker ps
+          PS C:\Users\Vicky> docker ps
           CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 
     Here is an example of command output for  `docker version`.
 
           PS C:\Users\Vicky> docker version
           Client:
-          Version:      1.12.0
-          API version:  1.24
-          Go version:   go1.6.3
-          Git commit:   8eab29e
-          Built:        Thu Jul 28 21:04:48 2016
+          Version:      1.13.0-rc3
+          API version:  1.25
+          Go version:   go1.7.3
+          Git commit:   4d92237
+          Built:        Tue Dec  6 01:15:44 2016
           OS/Arch:      windows/amd64
-          Experimental: true
 
           Server:
-          Version:      1.12.0
-          API version:  1.24
-          Go version:   go1.6.3
-          Git commit:   8eab29e
-          Built:        Thu Jul 28 21:04:48 2016
+          Version:      1.13.0-rc3
+          API version:  1.25 (minimum version 1.12)
+          Go version:   go1.7.3
+          Git commit:   4d92237
+          Built:        Tue Dec  6 01:15:44 2016
           OS/Arch:      linux/amd64
           Experimental: true
 
@@ -184,42 +183,52 @@ The next few steps take you through some examples. These are just suggestions fo
           Paused: 0
           Stopped: 0
           Images: 0
-          Server Version: 1.12.0
-          Storage Driver: aufs
-          Root Dir: /var/lib/docker/aufs
-          Backing Filesystem: extfs
-          Dirs: 0
-          Dirperm1 Supported: true
+          Server Version: 1.13.0-rc3
+          Storage Driver: overlay2
+            Backing Filesystem: extfs
+            Supports d_type: true
+            Native Overlay Diff: true
           Logging Driver: json-file
           Cgroup Driver: cgroupfs
           Plugins:
-          Volume: local
-          Network: host bridge null overlay
+            Volume: local
+            Network: bridge host macvlan null overlay
           Swarm: inactive
           Runtimes: runc
           Default Runtime: runc
-          Security Options: seccomp
-          Kernel Version: 4.4.16-moby
+          Init Binary: docker-init
+          containerd version: 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
+          runc version: 51371867a01c467f08af739783b8beafc154c4d7
+          init version: 949e6fa
+          Security Options:
+            seccomp
+              Profile: default
+          Kernel Version: 4.8.12-moby
           Operating System: Alpine Linux v3.4
           OSType: linux
           Architecture: x86_64
           CPUs: 2
-          Total Memory: 1.95 GiB
+          Total Memory: 1.934 GiB
           Name: moby
-          ID: BG6O:2VMH:OLNV:DDLF:SCSV:URRH:BW6M:INBW:OLAC:J7PX:XZVL:ADNB
+          ID: EODE:VBXI:Y4EL:JXRJ:STRS:HCAI:LDLF:P4KW:B5XU:QPNE:LKTM:RG32
           Docker Root Dir: /var/lib/docker
           Debug Mode (client): false
-          Debug Mode (server): false
+          Debug Mode (server): true
+            File Descriptors: 13
+            Goroutines: 21
+            System Time: 2016-12-07T19:02:41.3287973Z
+            EventsListeners: 0
           Registry: https://index.docker.io/v1/
           Experimental: true
           Insecure Registries:
-          127.0.0.0/8
+            127.0.0.0/8
+          Live Restore Enabled: false
 
     >**Note:** The outputs above are examples. Your output for commands like `docker version` and `docker info` will vary depending on your product versions (e.g., as you install newer versions).
 
 3.  Run `docker run hello-world` to test pulling an image from Docker Hub and starting a container.
 
-          PS C:\Users\samstevens> docker run hello-world
+          PS C:\Users\Vicky> docker run hello-world
 
           Hello from Docker.
           This message shows that your installation appears to be working correctly.
@@ -234,7 +243,7 @@ The next few steps take you through some examples. These are just suggestions fo
 
           $ docker run -it ubuntu bash
 
-          PS C:\Users\samstevens> docker run -it ubuntu bash
+          PS C:\Users\Vicky> docker run -it ubuntu bash
           Unable to find image 'ubuntu:latest' locally
           latest: Pulling from library/ubuntu
           5a132a7e7af1: Pull complete
@@ -252,7 +261,7 @@ The next few steps take you through some examples. These are just suggestions fo
 
       This will download the `nginx` container image and start it. Here is the output of running this command in a powershell.
 
-          PS C:\Users\samstevens> docker run -d -p 80:80 --name webserver nginx
+          PS C:\Users\Vicky> docker run -d -p 80:80 --name webserver nginx
           Unable to find image 'nginx:latest' locally
           latest: Pulling from library/nginx
 
@@ -272,7 +281,7 @@ The next few steps take you through some examples. These are just suggestions fo
 
 7.  Run `docker ps` while your webserver is running to see details on the container.
 
-          PS C:\Users\samstevens> docker ps
+          PS C:\Users\Vicky> docker ps
           CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS
           NAMES
           dfe13c68b3b8        nginx               "nginx -g 'daemon off"   3 days ago          Up 45 seconds       0.0.0.0:80->80/tcp, 443/tc
@@ -370,14 +379,12 @@ here. If you run `docker` commands and tasks under a different username than the
 one used here to set up sharing, your containers will not have permissions to
 access the mounted volumes.
 
->**Tip:** In general, shared drives are only required for volume mounting [Linux
+>**Tip:** Shared drives are only required for volume mounting [Linux
 containers](#switch-between-windows-and-linux-containers-beta-feature), and not
-for Windows containers. However, if the project lives outside of the `\Users`
-directory, you need to share the drive where the Dockerfile and volume are
-located even if you are using [Windows
-containers](#getting-started-with-windows-containers-beta-feature)). Runtime
-errors such as file not found or cannot start service may indicate shared drives
-are needed. (See also [Volume mounting requires shared drives for Linux containers and for any project directories outside of `C:\Users`](troubleshoot.md#volume-mounting-requires-shared-drives-for-linux-containers-and-for-any-project-directories-outside-of-cusers).)
+for Windows containers. For Linux containers, you need to share the drive where your project is located (i.e., where the Dockerfile and
+volume are located). Runtime errors such as file not found or cannot start
+service may indicate shared drives are needed. (See also [Volume mounting
+requires shared drives for Linux containers](troubleshoot.md#volume-mounting-requires-shared-drives-for-linux-containers).)
 
 See also [Verify domain user has permissions for shared
 drives](troubleshoot.md#verify-domain-user-has-permissions-for-shared-drives-volumes)
@@ -449,9 +456,17 @@ If you have containers that you wish to keep running across restarts, you should
 ### Docker daemon
 You can configure options on the Docker daemon in the given JSON configuration file, and determine how your containers will run.
 
+![Docker Daemon](images/docker-daemon.png)
+
 For a full list of options on the Docker daemon, see <a href="https://docs.docker.com/engine/reference/commandline/dockerd/" target="_blank">daemon</a> in the Docker Engine command line reference.
 
-![Docker Daemon](images/docker-daemon.png)
+In that topic, see also:
+
+* [Daemon configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/daemon-configuration-file)
+
+* [Linux configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/linux-configuration-file)
+
+* [Windows configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/windows-configuration-file)
 
 Note that updating these settings requires a reconfiguration and reboot of the Linux VM.
 
@@ -463,17 +478,50 @@ Microsoft Developer Network has preliminary/draft information on Windows contain
 
 This feature is not yet available on stable builds.
 
-See also [Shared Drives](#shared-drives)
-
-#### Getting started with Windows containers (Beta feature)
+#### Getting started with Windows containers
 
 If you are interested in working with Windows containers, here are some guides to help you get started.
 
 * [Build and Run Your First Windows Server Container (Blog Post)](https://blog.docker.com/2016/09/build-your-first-docker-windows-server-container/) gives a quick tour of how to build and run native Docker Windows containers on Windows 10 and Windows Server 2016 evaluation releases.
 
-* [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md) shows you how to use the [MusicStore](https://github.com/aspnet/MusicStore/blob/dev/README.md) application with Windows containers. The MusicStore is a standard .NET application and, [forked here to use containers](https://github.com/friism/MusicStore), is a good example of a multi-container application.
+* [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md)
+shows you how to use the
+[MusicStore](https://github.com/aspnet/MusicStore/blob/dev/README.md)
+application with Windows containers. The MusicStore is a standard .NET
+application and, [forked here to use
+containers](https://github.com/friism/MusicStore), is a good example of a
+multi-container application.
 
   >**Disclaimer:** This lab is still in work, and is based off of the blog, but you can test and leverage the example walkthroughs now, if you want to start experimenting. Please checking back as the lab evolves.
+
+#### About the Docker Windows containers specific dialogs
+
+When you switch to Windows containers, the Settings panel updates to show only
+those [dialogs](#docker-settings) that are active and apply to your Windows
+containers:
+
+  * [General](#general)
+  * [Proxies](#proxies)
+  * [Docker daemon](#docker-daemon)
+  * [Diagnose and Feedback](#diagnose-and-feedback)
+  * [Reset](#reset)
+
+(Per the release notes, these dialogs are newly implemented for Windows
+containers mode in [Beta
+32](release-notes.md#beta-32-release-notes-2016-12-07-1130-rc3-beta32)).
+
+Keep in mind that if you set proxies or daemon configuration in Windows
+containers mode, these apply only on Windows containers. If you switch back to
+Linux containers, proxies and daemon configurations return to what you had set
+for Linux containers. Your Windows container settings are retained and become
+available again when you switch back.
+
+The following settings are **_not available in Windows containers mode_**,
+because they do not apply to Windows containers:
+
+  * [Shared Drives](#shared-drives)
+  * [Network](#network)
+  * [Advanced (CPU and Memory configuration)](#advanced)
 
 ### Diagnose and Feedback
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -208,6 +208,39 @@ about both kinds of releases, and download stable and beta product installers at
 
 ## Beta Release Notes
 
+### Beta 32 Release Notes (2016-12-07 1.13.0-rc3-beta32)
+
+>**Important Note**:
+>
+>  Plugins installed using the experimental "managed plugins" feature in Docker 1.12 must be removed/uninstalled before upgrading.
+
+**New**
+
+- Windows containers settings panel and options are working. In previous releases, settings were not implemented for [Windows containers
+mode](index.md#switch-between-windows-and-linux-containers-beta-feature). (See
+[About the Docker Windows containers specific
+dialogs](index.md#about-the-docker-windows-containers-specific-dialogs).)
+- Windows containers: Restart from the settings panel works
+- Windows containers: Factory default
+- Windows containers: `Daemon.json` can be modified
+- Windows containers: Proxy settings can be modified
+- Support for arm, aarch64, ppc64le architectures using qemu
+
+**Upgrades**
+
+- Docker 1.13.0-rc3
+- Docker Machine 0.9.0-rc2
+- Linux Kernel 4.8.12
+
+**Bug fixes and minor changes**
+
+- Time drifts between Windows and Linux containers should disapear
+- VPNKit: Improved diagnostics
+- Improvements in drive sharing code
+- Removed the legacy "Disable oplocks" trick for enabling Windows Containers on older insider previews
+
+
+
 ### Beta 31 Release Notes (2016-12-01 1.13.0-rc2-beta31)
 
 **New**

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -58,17 +58,16 @@ applications](https://github.com/remy/nodemon#application-isnt-restarting)
 
 * **Docker for Windows issue on GitHub** - See the issue [Inotify on shared drives does not work](https://github.com/docker/for-win/issues/56#issuecomment-242135705)
 
-### Volume mounting requires shared drives for Linux containers and for any project directories outside of `C:\Users`
+### Volume mounting requires shared drives for Linux containers
 
 If you are using mounted volumes and get runtime errors indicating an
 application file is not found, a volume mount is denied, or a service cannot
-start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might
-need to enable [shared drives](index.md#shared-drives).
+start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might need
+to enable [shared drives](index.md#shared-drives).
 
-Volume mounting requires shared drives for Windows containers, but also for
-Linux containers if the project lives outside of the `C:\Users` directory. Go to
-<img src="images/whale-x.png"> --> **Settings** --> **Shared Drives** and share
-the drive that contains the Dockerfile and volume.
+Volume mounting requires shared drives for Linux containers (not for Windows
+containers). Go to <img src="images/whale-x.png"> --> **Settings** --> **Shared
+Drives** and share the drive that contains the Dockerfile and volume.
 
 ### Verify domain user has permissions for shared drives (volumes)
 


### PR DESCRIPTION
### Proposed changes

Beta 32 docs updates for Docker for Mac, Docker for Windows:

* release notes, with links to new features on d4win
* d4win description of activated settings for Windows containers mode
* corrected getting started and troubleshooting info re: shared drives requirement (it's only for Linux containers, not Windows)

### Please take a look

@MagnusS @jeanlaurent @dgageot @dave-tucker @dsheets 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>