### PR TITLE
CI - don't allow absolute links to docs.docker.com

### DIFF
--- a/docker-cloud/builds/advanced.md
+++ b/docker-cloud/builds/advanced.md
@@ -86,7 +86,7 @@ docker build --build-arg CUSTOM=$VAR -t $IMAGE_NAME
 used by the builder, so you must include a similar build command in the hook or
 the automated build will fail.
 
-To learn more about Docker build-time variables, see the [docker build documentation]( https://docs.docker.com/engine/reference/commandline/build/#/set-build-time-variables---build-arg).
+To learn more about Docker build-time variables, see the [docker build documentation](/engine/reference/commandline/build/#/set-build-time-variables---build-arg).
 
 #### Two-phase build
 

--- a/docker-cloud/builds/automated-build.md
+++ b/docker-cloud/builds/automated-build.md
@@ -85,7 +85,7 @@ the code repository service where the image's source code is stored.
 
 10. For each branch or tag, enable or disable the **Build Caching** toggle.
 
-    [Build caching](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache) can save time if you are building a large image frequently or have many dependencies. You might want to leave build caching disabled to make sure all of your dependencies are resolved at build time, or if you have a large layer that is quicker to build locally.
+    [Build caching](/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache) can save time if you are building a large image frequently or have many dependencies. You might want to leave build caching disabled to make sure all of your dependencies are resolved at build time, or if you have a large layer that is quicker to build locally.
 
 11. Click **Save** to save the settings, or click **Save and build** to save and
 run an initial test.

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -82,7 +82,7 @@ enabled](troubleshoot.md#virtualization-must-be-enabled) in Troubleshooting.
 <p />
 * Nested virtualization scenarios, such as running Docker for Windows on a VMWare or Parallels instance, might work, but come with no guarantees (i.e., not officially supported).
 <p />
-* **What the Docker for Windows install includes**: The installation provides [Docker Engine](https://docs.docker.com/engine/userguide/intro/), Docker CLI client, [Docker Compose](https://docs.docker.com/compose/overview/), and [Docker Machine](https://docs.docker.com/machine/overview/).
+* **What the Docker for Windows install includes**: The installation provides [Docker Engine](/engine/userguide/intro/), Docker CLI client, [Docker Compose](/compose/overview/), and [Docker Machine](/machine/overview/).
 
 ### About Windows containers and Windows Server 2016
 
@@ -458,15 +458,15 @@ You can configure options on the Docker daemon in the given JSON configuration f
 
 ![Docker Daemon](images/docker-daemon.png)
 
-For a full list of options on the Docker daemon, see <a href="https://docs.docker.com/engine/reference/commandline/dockerd/" target="_blank">daemon</a> in the Docker Engine command line reference.
+For a full list of options on the Docker daemon, see [daemon](/engine/reference/commandline/dockerd/) in the Docker Engine command line reference.
 
 In that topic, see also:
 
-* [Daemon configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/daemon-configuration-file)
+* [Daemon configuration file](/engine/reference/commandline/dockerd/daemon-configuration-file)
 
-* [Linux configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/linux-configuration-file)
+* [Linux configuration file](/engine/reference/commandline/dockerd/linux-configuration-file)
 
-* [Windows configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/windows-configuration-file)
+* [Windows configuration file](/engine/reference/commandline/dockerd/windows-configuration-file)
 
 Note that updating these settings requires a reconfiguration and reboot of the Linux VM.
 

--- a/engine/installation/binaries.md
+++ b/engine/installation/binaries.md
@@ -125,7 +125,7 @@ is `https://get.docker.com/builds/Linux/x86_64/docker-1.11.0.tgz`.
 > **Note** These instructions are for Docker Engine 1.11 and up. Engine 1.10 and
 > under consists of a single binary, and instructions for those versions are
 > different. To install version 1.10 or below, follow the instructions in the
-> [1.10 documentation](https://docs.docker.com/v1.10/engine/installation/binaries/){:target="_blank"}.
+> [1.10 documentation](/v1.10/engine/installation/binaries/){:target="_blank"}.
 
 #### Verify downloaded files
 

--- a/machine/concepts.md
+++ b/machine/concepts.md
@@ -37,7 +37,7 @@ For a complete list of `docker-machine` subcommands, see the [Docker Machine sub
 
 Users using their own Docker Registry will experience `x509: certificate signed by unknown authority` 
 error messages if their registry is signed by custom root Certificate Authority and it is 
-not registered with Docker Engine. As discussed in the [Docker Engine documentation](https://docs.docker.com/engine/security/certificates/#/understanding-the-configuration)
+not registered with Docker Engine. As discussed in the [Docker Engine documentation](/engine/security/certificates/#/understanding-the-configuration)
 certificates should be placed at `/etc/docker/certs.d/hostname/ca.crt` 
 where `hostname` is your Registry server's hostname.
 


### PR DESCRIPTION
### Describe the proposed changes

Added a test to prevent absolute links to `docs.docker.com`. 
Also made a few absolute links relative for this test to pass.


