### PR TITLE
Move groupadd docker to it's own line

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -318,6 +318,7 @@ To create the `docker` group and add your user:
 1.  Log into Ubuntu as a user with `sudo` privileges.
 
 2.  Create the `docker` group.
+    
     ```bash
     $ sudo groupadd docker
     ```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. -->

<!--DO NOT edit files and directories listed in .NOT_EDITED_HERE.yaml.
    These are maintained in upstream repos and changes here will be lost.-->

### Describe the proposed changes

I added a new line between the _Create the docker group_ instruction and the code snippet. The code snippet is now on it own line when viewing the documentation.

#### Old
![old](https://cloud.githubusercontent.com/assets/849609/21016385/4fb63294-bd33-11e6-8987-d045626de27c.png)

#### New
![new](https://cloud.githubusercontent.com/assets/849609/21016395/57fc019a-bd33-11e6-8f7b-83963db18ff6.png)

### Unreleased project version
N/A

### Related issue
None

### Related issue or PR in another project
None

### Please take a look
N/A


<!-- To improve this template, edit .github/PULL_REQUEST_TEMPLATE.md. -->

Move the ```Create the `docker` group.``` example to its own line.