### PR TITLE
Leave a forward pointer to delegation roles in ddc doc

### DIFF
--- a/datacenter/ucp/2.0/guides/content-trust/index.md
+++ b/datacenter/ucp/2.0/guides/content-trust/index.md
@@ -31,7 +31,7 @@ that need sign the image, before it is trusted to run in the UCP cluster. If
 you specify multiple teams, the image needs to be signed by a member of each
 team, or someone that is a member of all those teams.
 If you don't specify any team, the image will be trusted as long as it is signed
-by any UCP user.
+by any UCP user whose keys are trusted in a Notary delegation role.
 
 ## Set up the Docker Notary CLI client
 


### PR DESCRIPTION
Leave a short forward pointer to delegations so that this doc's outline is better represented from teh summary.  Affects UCP 2.0.x

 cc @joaofnfernandes 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>