### PR TITLE
fix the verify step in cloud tutorial

### DIFF
--- a/docker-cloud/getting-started/deploy-app/4_push_to_cloud_registry.md
+++ b/docker-cloud/getting-started/deploy-app/4_push_to_cloud_registry.md
@@ -36,14 +36,12 @@ $ docker push $DOCKER_ID_USER/quickstart-python
 ```
 $ docker push $DOCKER_ID_USER/quickstart-go
 ```
-## Verify the image location
-After the push command completes, verify that the image is now in Docker Cloud's registry. Do this by running the `docker-cloud repository ls` command. You should see only one of the images below.
 
-```
-$ docker-cloud repository ls
-NAME                                    DESCRIPTION
-my-username/quickstart-python
-my-username/quickstart-go
-```
+## Verify the image location
+
+After the push command completes, verify that the image is now in Docker Cloud's
+registry. Do this by logging in to [Docker Cloud](https://cloud.docker.com) and
+clicking  **Repositories** in the left navigation. Your image should appear in
+the repository list.
 
 Next: [Deploy the app as a Docker Cloud service](5_deploy_the_app_as_a_service.md).


### PR DESCRIPTION
For #824 

Removes the `docker-cloud repository ls` which only lists external registries. Updates to have the reader log in and visually verify.

Also fixed some formatting while I was in there.
 
Signed-off-by: LRubin <lrubin@docker.com>