### PR TITLE
Update SUSE.md

### DIFF
--- a/engine/installation/linux/SUSE.md
+++ b/engine/installation/linux/SUSE.md
@@ -35,7 +35,7 @@ Otherwise execute the following command:
 
     $ sudo SUSEConnect -p sle-module-containers/12/x86_64 -r ''
 
-    >**Note:** currently the `-r ''` flag is required to avoid a known limitation of `SUSEConnect`.
+> **Note:** currently the `-r ''` flag is required to avoid a known limitation of `SUSEConnect`.
 
 The [Virtualization:containers project](https://build.opensuse.org/project/show/Virtualization:containers)
 on the [Open Build Service](https://build.opensuse.org/) contains also bleeding


### PR DESCRIPTION
### The proposed changes

The command how to [install docker in SUSE SLE](https://docs.docker.com/engine/installation/linux/SUSE/#/suse-linux-enterprise) contains a note which should not be part of the command.


### Please take a look

It is caused by a wrong indentation of the note text in the Markdown file.