### PR TITLE
replaced href by src in img tag (v1.7)

### DIFF
--- a/articles/ambassador_pattern_linking/index.html
+++ b/articles/ambassador_pattern_linking/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/b2d_volume_resize/index.html
+++ b/articles/b2d_volume_resize/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/baseimages/index.html
+++ b/articles/baseimages/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/basics/index.html
+++ b/articles/basics/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/certificates/index.html
+++ b/articles/certificates/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/cfengine_process_management/index.html
+++ b/articles/cfengine_process_management/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/chef/index.html
+++ b/articles/chef/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/configuring/index.html
+++ b/articles/configuring/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/dockerfile_best-practices/index.html
+++ b/articles/dockerfile_best-practices/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/dsc/index.html
+++ b/articles/dsc/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/host_integration/index.html
+++ b/articles/host_integration/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/https/README/index.html
+++ b/articles/https/README/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/https/index.html
+++ b/articles/https/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/networking/index.html
+++ b/articles/networking/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/puppet/index.html
+++ b/articles/puppet/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/registry_mirror/index.html
+++ b/articles/registry_mirror/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/runmetrics/index.html
+++ b/articles/runmetrics/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/security/index.html
+++ b/articles/security/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/systemd/index.html
+++ b/articles/systemd/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/articles/using_supervisord/index.html
+++ b/articles/using_supervisord/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/README/index.html
+++ b/compose/README/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/cli/index.html
+++ b/compose/cli/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/completion/index.html
+++ b/compose/completion/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/django/index.html
+++ b/compose/django/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/env/index.html
+++ b/compose/env/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/extends/index.html
+++ b/compose/extends/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/index.html
+++ b/compose/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/install/index.html
+++ b/compose/install/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/production/index.html
+++ b/compose/production/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/rails/index.html
+++ b/compose/rails/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/wordpress/index.html
+++ b/compose/wordpress/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/compose/yml/index.html
+++ b/compose/yml/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-hub/accounts/index.html
+++ b/docker-hub/accounts/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-hub/builds/index.html
+++ b/docker-hub/builds/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-hub/index.html
+++ b/docker-hub/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-hub/official_repos/index.html
+++ b/docker-hub/official_repos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-hub/repos/index.html
+++ b/docker-hub/repos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-hub/userguide/index.html
+++ b/docker-hub/userguide/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/adminguide/index.html
+++ b/docker-trusted-registry/adminguide/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/configuration/index.html
+++ b/docker-trusted-registry/configuration/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/index.html
+++ b/docker-trusted-registry/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/install/index.html
+++ b/docker-trusted-registry/install/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/prior-release-notes/index.html
+++ b/docker-trusted-registry/prior-release-notes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/quick-start/index.html
+++ b/docker-trusted-registry/quick-start/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/release-notes/index.html
+++ b/docker-trusted-registry/release-notes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/support/index.html
+++ b/docker-trusted-registry/support/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker-trusted-registry/userguide/index.html
+++ b/docker-trusted-registry/userguide/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/ambassador_pattern_linking/index.html
+++ b/docker/articles/ambassador_pattern_linking/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/b2d_volume_resize/index.html
+++ b/docker/articles/b2d_volume_resize/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/baseimages/index.html
+++ b/docker/articles/baseimages/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/basics/index.html
+++ b/docker/articles/basics/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/certificates/index.html
+++ b/docker/articles/certificates/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/cfengine_process_management/index.html
+++ b/docker/articles/cfengine_process_management/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/chef/index.html
+++ b/docker/articles/chef/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/configuring/index.html
+++ b/docker/articles/configuring/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/dockerfile_best-practices/index.html
+++ b/docker/articles/dockerfile_best-practices/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/dsc/index.html
+++ b/docker/articles/dsc/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/host_integration/index.html
+++ b/docker/articles/host_integration/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/https/README/index.html
+++ b/docker/articles/https/README/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/https/index.html
+++ b/docker/articles/https/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/networking/index.html
+++ b/docker/articles/networking/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/puppet/index.html
+++ b/docker/articles/puppet/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/registry_mirror/index.html
+++ b/docker/articles/registry_mirror/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/runmetrics/index.html
+++ b/docker/articles/runmetrics/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/security/index.html
+++ b/docker/articles/security/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/systemd/index.html
+++ b/docker/articles/systemd/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/articles/using_supervisord/index.html
+++ b/docker/articles/using_supervisord/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/docker-hub/accounts/index.html
+++ b/docker/docker-hub/accounts/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/docker-hub/builds/index.html
+++ b/docker/docker-hub/builds/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/docker-hub/index.html
+++ b/docker/docker-hub/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/docker-hub/official_repos/index.html
+++ b/docker/docker-hub/official_repos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/docker-hub/repos/index.html
+++ b/docker/docker-hub/repos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/docker-hub/userguide/index.html
+++ b/docker/docker-hub/userguide/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/apt-cacher-ng/index.html
+++ b/docker/examples/apt-cacher-ng/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/couchdb_data_volumes/index.html
+++ b/docker/examples/couchdb_data_volumes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/mongodb/index.html
+++ b/docker/examples/mongodb/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/nodejs_web_app/index.html
+++ b/docker/examples/nodejs_web_app/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/postgresql_service/index.html
+++ b/docker/examples/postgresql_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/running_redis_service/index.html
+++ b/docker/examples/running_redis_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/running_riak_service/index.html
+++ b/docker/examples/running_riak_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/examples/running_ssh_service/index.html
+++ b/docker/examples/running_ssh_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/SUSE/index.html
+++ b/docker/installation/SUSE/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/amazon/index.html
+++ b/docker/installation/amazon/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/archlinux/index.html
+++ b/docker/installation/archlinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/azure/index.html
+++ b/docker/installation/azure/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/binaries/index.html
+++ b/docker/installation/binaries/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/centos/index.html
+++ b/docker/installation/centos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/cruxlinux/index.html
+++ b/docker/installation/cruxlinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/debian/index.html
+++ b/docker/installation/debian/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/fedora/index.html
+++ b/docker/installation/fedora/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/frugalware/index.html
+++ b/docker/installation/frugalware/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/gentoolinux/index.html
+++ b/docker/installation/gentoolinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/google/index.html
+++ b/docker/installation/google/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/index.html
+++ b/docker/installation/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/joyent/index.html
+++ b/docker/installation/joyent/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/mac/index.html
+++ b/docker/installation/mac/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/oracle/index.html
+++ b/docker/installation/oracle/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/rackspace/index.html
+++ b/docker/installation/rackspace/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/rhel/index.html
+++ b/docker/installation/rhel/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/softlayer/index.html
+++ b/docker/installation/softlayer/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/ubuntulinux/index.html
+++ b/docker/installation/ubuntulinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/installation/windows/index.html
+++ b/docker/installation/windows/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/introduction/understanding-docker/index.html
+++ b/docker/introduction/understanding-docker/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/misc/faq/index.html
+++ b/docker/misc/faq/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/misc/index.html
+++ b/docker/misc/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/advanced-contributing/index.html
+++ b/docker/project/advanced-contributing/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/coding-style/index.html
+++ b/docker/project/coding-style/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/create-pr/index.html
+++ b/docker/project/create-pr/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/doc-style/index.html
+++ b/docker/project/doc-style/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/find-an-issue/index.html
+++ b/docker/project/find-an-issue/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/get-help/index.html
+++ b/docker/project/get-help/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/make-a-contribution/index.html
+++ b/docker/project/make-a-contribution/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/review-pr/index.html
+++ b/docker/project/review-pr/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/set-up-dev-env/index.html
+++ b/docker/project/set-up-dev-env/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/set-up-git/index.html
+++ b/docker/project/set-up-git/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/software-req-win/index.html
+++ b/docker/project/software-req-win/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/software-required/index.html
+++ b/docker/project/software-required/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/test-and-docs/index.html
+++ b/docker/project/test-and-docs/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/who-written-for/index.html
+++ b/docker/project/who-written-for/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/project/work-issue/index.html
+++ b/docker/project/work-issue/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/README/index.html
+++ b/docker/reference/api/README/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker-io_api/index.html
+++ b/docker/reference/api/docker-io_api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_io_accounts_api/index.html
+++ b/docker/reference/api/docker_io_accounts_api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_remote_api/index.html
+++ b/docker/reference/api/docker_remote_api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_remote_api_v1.14/index.html
+++ b/docker/reference/api/docker_remote_api_v1.14/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_remote_api_v1.15/index.html
+++ b/docker/reference/api/docker_remote_api_v1.15/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_remote_api_v1.16/index.html
+++ b/docker/reference/api/docker_remote_api_v1.16/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_remote_api_v1.17/index.html
+++ b/docker/reference/api/docker_remote_api_v1.17/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_remote_api_v1.18/index.html
+++ b/docker/reference/api/docker_remote_api_v1.18/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/docker_remote_api_v1.19/index.html
+++ b/docker/reference/api/docker_remote_api_v1.19/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/hub_registry_spec/index.html
+++ b/docker/reference/api/hub_registry_spec/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/api/remote_api_client_libraries/index.html
+++ b/docker/reference/api/remote_api_client_libraries/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/builder/index.html
+++ b/docker/reference/builder/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/attach/index.html
+++ b/docker/reference/commandline/attach/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/build/index.html
+++ b/docker/reference/commandline/build/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/cli/index.html
+++ b/docker/reference/commandline/cli/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/commit/index.html
+++ b/docker/reference/commandline/commit/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/cp/index.html
+++ b/docker/reference/commandline/cp/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/create/index.html
+++ b/docker/reference/commandline/create/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/daemon/index.html
+++ b/docker/reference/commandline/daemon/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/diff/index.html
+++ b/docker/reference/commandline/diff/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/events/index.html
+++ b/docker/reference/commandline/events/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/exec/index.html
+++ b/docker/reference/commandline/exec/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/export/index.html
+++ b/docker/reference/commandline/export/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/history/index.html
+++ b/docker/reference/commandline/history/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/images/index.html
+++ b/docker/reference/commandline/images/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/import/index.html
+++ b/docker/reference/commandline/import/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/info/index.html
+++ b/docker/reference/commandline/info/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/inspect/index.html
+++ b/docker/reference/commandline/inspect/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/kill/index.html
+++ b/docker/reference/commandline/kill/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/load/index.html
+++ b/docker/reference/commandline/load/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/login/index.html
+++ b/docker/reference/commandline/login/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/logout/index.html
+++ b/docker/reference/commandline/logout/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/logs/index.html
+++ b/docker/reference/commandline/logs/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/pause/index.html
+++ b/docker/reference/commandline/pause/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/port/index.html
+++ b/docker/reference/commandline/port/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/ps/index.html
+++ b/docker/reference/commandline/ps/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/pull/index.html
+++ b/docker/reference/commandline/pull/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/push/index.html
+++ b/docker/reference/commandline/push/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/rename/index.html
+++ b/docker/reference/commandline/rename/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/restart/index.html
+++ b/docker/reference/commandline/restart/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/rm/index.html
+++ b/docker/reference/commandline/rm/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/rmi/index.html
+++ b/docker/reference/commandline/rmi/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/run/index.html
+++ b/docker/reference/commandline/run/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/save/index.html
+++ b/docker/reference/commandline/save/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/search/index.html
+++ b/docker/reference/commandline/search/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/start/index.html
+++ b/docker/reference/commandline/start/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/stats/index.html
+++ b/docker/reference/commandline/stats/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/stop/index.html
+++ b/docker/reference/commandline/stop/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/tag/index.html
+++ b/docker/reference/commandline/tag/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/top/index.html
+++ b/docker/reference/commandline/top/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/unpause/index.html
+++ b/docker/reference/commandline/unpause/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/version/index.html
+++ b/docker/reference/commandline/version/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/commandline/wait/index.html
+++ b/docker/reference/commandline/wait/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/glossary/index.html
+++ b/docker/reference/glossary/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/logging/journald/index.html
+++ b/docker/reference/logging/journald/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/reference/run/index.html
+++ b/docker/reference/run/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/static_files/README/index.html
+++ b/docker/static_files/README/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/dockerhub/index.html
+++ b/docker/userguide/dockerhub/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/dockerimages/index.html
+++ b/docker/userguide/dockerimages/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/dockerizing/index.html
+++ b/docker/userguide/dockerizing/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/dockerlinks/index.html
+++ b/docker/userguide/dockerlinks/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/dockerrepos/index.html
+++ b/docker/userguide/dockerrepos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/dockervolumes/index.html
+++ b/docker/userguide/dockervolumes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/index.html
+++ b/docker/userguide/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/labels-custom-metadata/index.html
+++ b/docker/userguide/labels-custom-metadata/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/level1/index.html
+++ b/docker/userguide/level1/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/level2/index.html
+++ b/docker/userguide/level2/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/docker/userguide/usingdocker/index.html
+++ b/docker/userguide/usingdocker/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/apt-cacher-ng/index.html
+++ b/examples/apt-cacher-ng/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/couchdb_data_volumes/index.html
+++ b/examples/couchdb_data_volumes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/mongodb/index.html
+++ b/examples/mongodb/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/nodejs_web_app/index.html
+++ b/examples/nodejs_web_app/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/postgresql_service/index.html
+++ b/examples/postgresql_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/running_redis_service/index.html
+++ b/examples/running_redis_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/running_riak_service/index.html
+++ b/examples/running_riak_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/examples/running_ssh_service/index.html
+++ b/examples/running_ssh_service/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/SUSE/index.html
+++ b/installation/SUSE/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/amazon/index.html
+++ b/installation/amazon/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/archlinux/index.html
+++ b/installation/archlinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/azure/index.html
+++ b/installation/azure/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/binaries/index.html
+++ b/installation/binaries/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/centos/index.html
+++ b/installation/centos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/cruxlinux/index.html
+++ b/installation/cruxlinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/debian/index.html
+++ b/installation/debian/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/fedora/index.html
+++ b/installation/fedora/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/frugalware/index.html
+++ b/installation/frugalware/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/gentoolinux/index.html
+++ b/installation/gentoolinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/google/index.html
+++ b/installation/google/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/index.html
+++ b/installation/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/joyent/index.html
+++ b/installation/joyent/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/mac/index.html
+++ b/installation/mac/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/oracle/index.html
+++ b/installation/oracle/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/rackspace/index.html
+++ b/installation/rackspace/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/rhel/index.html
+++ b/installation/rhel/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/softlayer/index.html
+++ b/installation/softlayer/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/ubuntulinux/index.html
+++ b/installation/ubuntulinux/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/installation/windows/index.html
+++ b/installation/windows/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/introduction/understanding-docker/index.html
+++ b/introduction/understanding-docker/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/kitematic/faq/index.html
+++ b/kitematic/faq/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/kitematic/index.html
+++ b/kitematic/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/kitematic/known-issues/index.html
+++ b/kitematic/known-issues/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/kitematic/minecraft-server/index.html
+++ b/kitematic/minecraft-server/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/kitematic/nginx-web-server/index.html
+++ b/kitematic/nginx-web-server/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/kitematic/rethinkdb-dev-database/index.html
+++ b/kitematic/rethinkdb-dev-database/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/kitematic/userguide/index.html
+++ b/kitematic/userguide/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/last_page/index.html
+++ b/linux/last_page/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/started/index.html
+++ b/linux/started/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/step_five/index.html
+++ b/linux/step_five/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/step_four/index.html
+++ b/linux/step_four/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/step_one/index.html
+++ b/linux/step_one/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/step_six/index.html
+++ b/linux/step_six/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/step_three/index.html
+++ b/linux/step_three/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/linux/step_two/index.html
+++ b/linux/step_two/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/last_page/index.html
+++ b/mac/last_page/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/started/index.html
+++ b/mac/started/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/step_five/index.html
+++ b/mac/step_five/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/step_four/index.html
+++ b/mac/step_four/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/step_one/index.html
+++ b/mac/step_one/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/step_six/index.html
+++ b/mac/step_six/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/step_three/index.html
+++ b/mac/step_three/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/mac/step_two/index.html
+++ b/mac/step_two/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/machine/index.html
+++ b/machine/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/machine/install-machine/index.html
+++ b/machine/install-machine/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/misc/faq/index.html
+++ b/misc/faq/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/misc/index.html
+++ b/misc/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/code/index.html
+++ b/opensource/code/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/community/index.html
+++ b/opensource/community/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/governance/board-profiles/index.html
+++ b/opensource/governance/board-profiles/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/governance/conduct-code/index.html
+++ b/opensource/governance/conduct-code/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/governance/dgab-info/index.html
+++ b/opensource/governance/dgab-info/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/how-to-contribute/index.html
+++ b/opensource/how-to-contribute/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/issues/index.html
+++ b/opensource/issues/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/meetups/index.html
+++ b/opensource/meetups/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/opensource/test/index.html
+++ b/opensource/test/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/advanced-contributing/index.html
+++ b/project/advanced-contributing/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/coding-style/index.html
+++ b/project/coding-style/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/create-pr/index.html
+++ b/project/create-pr/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/doc-style/index.html
+++ b/project/doc-style/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/find-an-issue/index.html
+++ b/project/find-an-issue/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/get-help/index.html
+++ b/project/get-help/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/make-a-contribution/index.html
+++ b/project/make-a-contribution/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/review-pr/index.html
+++ b/project/review-pr/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/set-up-dev-env/index.html
+++ b/project/set-up-dev-env/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/set-up-git/index.html
+++ b/project/set-up-git/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/software-req-win/index.html
+++ b/project/software-req-win/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/software-required/index.html
+++ b/project/software-required/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/test-and-docs/index.html
+++ b/project/test-and-docs/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/who-written-for/index.html
+++ b/project/who-written-for/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/project/work-issue/index.html
+++ b/project/work-issue/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/README/index.html
+++ b/reference/api/README/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker-io_api/index.html
+++ b/reference/api/docker-io_api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_io_accounts_api/index.html
+++ b/reference/api/docker_io_accounts_api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_remote_api/index.html
+++ b/reference/api/docker_remote_api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_remote_api_v1.14/index.html
+++ b/reference/api/docker_remote_api_v1.14/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_remote_api_v1.15/index.html
+++ b/reference/api/docker_remote_api_v1.15/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_remote_api_v1.16/index.html
+++ b/reference/api/docker_remote_api_v1.16/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_remote_api_v1.17/index.html
+++ b/reference/api/docker_remote_api_v1.17/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_remote_api_v1.18/index.html
+++ b/reference/api/docker_remote_api_v1.18/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/docker_remote_api_v1.19/index.html
+++ b/reference/api/docker_remote_api_v1.19/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/hub_registry_spec/index.html
+++ b/reference/api/hub_registry_spec/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/api/remote_api_client_libraries/index.html
+++ b/reference/api/remote_api_client_libraries/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/builder/index.html
+++ b/reference/builder/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/attach/index.html
+++ b/reference/commandline/attach/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/build/index.html
+++ b/reference/commandline/build/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/cli/index.html
+++ b/reference/commandline/cli/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/commit/index.html
+++ b/reference/commandline/commit/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/cp/index.html
+++ b/reference/commandline/cp/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/create/index.html
+++ b/reference/commandline/create/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/daemon/index.html
+++ b/reference/commandline/daemon/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/diff/index.html
+++ b/reference/commandline/diff/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/events/index.html
+++ b/reference/commandline/events/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/exec/index.html
+++ b/reference/commandline/exec/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/export/index.html
+++ b/reference/commandline/export/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/history/index.html
+++ b/reference/commandline/history/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/images/index.html
+++ b/reference/commandline/images/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/import/index.html
+++ b/reference/commandline/import/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/info/index.html
+++ b/reference/commandline/info/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/inspect/index.html
+++ b/reference/commandline/inspect/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/kill/index.html
+++ b/reference/commandline/kill/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/load/index.html
+++ b/reference/commandline/load/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/login/index.html
+++ b/reference/commandline/login/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/logout/index.html
+++ b/reference/commandline/logout/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/logs/index.html
+++ b/reference/commandline/logs/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/pause/index.html
+++ b/reference/commandline/pause/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/port/index.html
+++ b/reference/commandline/port/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/ps/index.html
+++ b/reference/commandline/ps/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/pull/index.html
+++ b/reference/commandline/pull/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/push/index.html
+++ b/reference/commandline/push/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/rename/index.html
+++ b/reference/commandline/rename/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/restart/index.html
+++ b/reference/commandline/restart/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/rm/index.html
+++ b/reference/commandline/rm/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/rmi/index.html
+++ b/reference/commandline/rmi/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/run/index.html
+++ b/reference/commandline/run/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/save/index.html
+++ b/reference/commandline/save/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/search/index.html
+++ b/reference/commandline/search/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/start/index.html
+++ b/reference/commandline/start/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/stats/index.html
+++ b/reference/commandline/stats/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/stop/index.html
+++ b/reference/commandline/stop/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/tag/index.html
+++ b/reference/commandline/tag/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/top/index.html
+++ b/reference/commandline/top/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/unpause/index.html
+++ b/reference/commandline/unpause/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/version/index.html
+++ b/reference/commandline/version/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/commandline/wait/index.html
+++ b/reference/commandline/wait/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/glossary/index.html
+++ b/reference/glossary/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/logging/journald/index.html
+++ b/reference/logging/journald/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/reference/run/index.html
+++ b/reference/run/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/authentication/index.html
+++ b/registry/authentication/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/configuration/index.html
+++ b/registry/configuration/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/deploying/index.html
+++ b/registry/deploying/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/help/index.html
+++ b/registry/help/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/index.html
+++ b/registry/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/introduction/index.html
+++ b/registry/introduction/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/notifications/index.html
+++ b/registry/notifications/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/spec/api/index.html
+++ b/registry/spec/api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/spec/auth/token/index.html
+++ b/registry/spec/auth/token/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/spec/implementations/index.html
+++ b/registry/spec/implementations/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/spec/manifest-v2-1/index.html
+++ b/registry/spec/manifest-v2-1/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/storage-drivers/azure/index.html
+++ b/registry/storage-drivers/azure/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/storage-drivers/filesystem/index.html
+++ b/registry/storage-drivers/filesystem/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/storage-drivers/inmemory/index.html
+++ b/registry/storage-drivers/inmemory/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/storage-drivers/rados/index.html
+++ b/registry/storage-drivers/rados/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/storage-drivers/s3/index.html
+++ b/registry/storage-drivers/s3/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/registry/storagedrivers/index.html
+++ b/registry/storagedrivers/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/release-notes/index.html
+++ b/release-notes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/static_files/README/index.html
+++ b/static_files/README/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/api/swarm-api/index.html
+++ b/swarm/api/swarm-api/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/discovery/index.html
+++ b/swarm/discovery/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/index.html
+++ b/swarm/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/install-manual/index.html
+++ b/swarm/install-manual/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/install-w-machine/index.html
+++ b/swarm/install-w-machine/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/release-notes/index.html
+++ b/swarm/release-notes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/scheduler/filter/index.html
+++ b/swarm/scheduler/filter/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/swarm/scheduler/strategy/index.html
+++ b/swarm/scheduler/strategy/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/dockerhub/index.html
+++ b/userguide/dockerhub/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/dockerimages/index.html
+++ b/userguide/dockerimages/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/dockerizing/index.html
+++ b/userguide/dockerizing/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/dockerlinks/index.html
+++ b/userguide/dockerlinks/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/dockerrepos/index.html
+++ b/userguide/dockerrepos/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/dockervolumes/index.html
+++ b/userguide/dockervolumes/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/labels-custom-metadata/index.html
+++ b/userguide/labels-custom-metadata/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/level1/index.html
+++ b/userguide/level1/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/level2/index.html
+++ b/userguide/level2/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/userguide/usingdocker/index.html
+++ b/userguide/usingdocker/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/last_page/index.html
+++ b/windows/last_page/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/started/index.html
+++ b/windows/started/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/step_five/index.html
+++ b/windows/step_five/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/step_four/index.html
+++ b/windows/step_four/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/step_one/index.html
+++ b/windows/step_one/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/step_six/index.html
+++ b/windows/step_six/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/step_three/index.html
+++ b/windows/step_three/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">

--- a/windows/step_two/index.html
+++ b/windows/step_two/index.html
@@ -29,7 +29,7 @@
       <header class="main-header">
         <div class="row">
           <div class="large-3 columns">
-            <a href="/"><img class="logo" href="/dist/assets/images/logo.png"></a>
+            <a href="/"><img class="logo" src="/dist/assets/images/logo.png"></a>
           </div>
           <div class="large-9 columns">
             <ul class="nav-global">


### PR DESCRIPTION
### Proposed changes

Fixed a few img tags, replacing `href` by `src` in **v1.7**.
I need this for my new tests to pass: #849 

It's the reason why we can't see the Docker logo on some pages, like this one: https://docs.docker.com/v1.7/registry/introduction/

