### PR TITLE
add pointer to docker credential helpers

### DIFF
--- a/docker-id/index.md
+++ b/docker-id/index.md
@@ -41,9 +41,10 @@ For Docker Cloud, Hub, and Store, log in using the web interface.
 
 You can also log in using the `docker login` command. (You can read more about `docker login` [here](../engine/reference/commandline/login/).)
 
-> **Warning:** When you use the `docker login` command, your credentials are stored
-in your home directory in `.docker/config.json`. The password is base64 encoded in this
-file.
+> **Warning:** When you use the `docker login` command, your credentials are
+stored in your home directory in `.docker/config.json`. The password is base64
+encoded in this file. If you require secure storage for this password, use the
+[Docker credential helpers](https://github.com/docker/docker-credential-helpers).
 
 ## The Accounts API
 


### PR DESCRIPTION
Adding a pointer to the Docker Credential Helpers after #862 ( https://github.com/docker/docker-credential-helpers )

cc @NathanMcCauley for quick 👀 
and cc @londoncalling and @mstanleyjones for SA

Signed-off-by: LRubin <lrubin@docker.com>