### PR TITLE
Dockerfile - don’t copy files from /usr/src/app/allvbuild to /_site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/referen
  && rm -rf allv
 
 # Serve the site, which is now all static HTML
-CMD jekyll serve -s /usr/src/app/allvbuild -d /_site --no-watch -H 0.0.0.0 -P 4000
+CMD jekyll serve -s /usr/src/app/allvbuild --no-watch -H 0.0.0.0 -P 4000


### PR DESCRIPTION
### Proposed changes

`jekyll serve -s /usr/src/app/allvbuild -d /_site --no-watch -H 0.0.0.0 -P 4000` builds what's in  `/usr/src/app/allvbuild` and puts result in `/_site`. 

But everything has already been built `/usr/src/app/allvbuild`, so we could just serve what's in there instead of copying ~800MB when running the container:

`jekyll serve -s /usr/src/app/allvbuild --no-watch -H 0.0.0.0 -P 4000`