### PR TITLE
Dockerfile - remove absolute links to docs.docker.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,15 @@ RUN git clone https://www.github.com/docker/docker.github.io temp; \
 		&& mkdir -p allvbuild/${VER} \
 		&& jekyll build -s temp -d allvbuild/${VER} \
 		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="http://docs.docker.com/#href="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com#href="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="http://docs.docker.com#href="/'"$VER"'/#g' \
 		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/'"$VER"'/#g' \
-		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/'"$VER"'/#g'; \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="https://docs.docker.com/#src="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="http://docs.docker.com/#src="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="https://docs.docker.com#src="/'"$VER"'/#g' \
+		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="http://docs.docker.com#src="/'"$VER"'/#g'; \
 	done; \
 	rm -rf temp
 
@@ -24,12 +31,21 @@ ENV DISTRIBUTION_BRANCH="release/2.5"
 # then build the whole site to static HTML using Jekyll
 
 RUN svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/reference allv/engine/reference \
- && svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/extend allv/engine/extend \
- && wget -O allv/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
- && svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_BRANCH/docs/spec allv/registry/spec \
- && wget -O allv/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
- && jekyll build -s allv -d allvbuild \
- && rm -rf allv
+	&& svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/extend allv/engine/extend \
+	&& wget -O allv/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
+	&& svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_BRANCH/docs/spec allv/registry/spec \
+	&& wget -O allv/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
+	&& jekyll build -s allv -d allvbuild \
+	&& rm -rf allv
+
+RUN find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
+	&& find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="http://docs.docker.com/#href="/#g' \
+	&& find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com#href="/#g' \
+	&& find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="http://docs.docker.com#href="/#g' \
+	&& find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="https://docs.docker.com/#src="/#g' \
+	&& find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="http://docs.docker.com/#src="/#g' \
+	&& find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="https://docs.docker.com#src="/#g' \
+	&& find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="http://docs.docker.com#src="/#g'
 
 # Serve the site, which is now all static HTML
 CMD jekyll serve -s /usr/src/app/allvbuild -d /_site --no-watch -H 0.0.0.0 -P 4000


### PR DESCRIPTION
### Proposed changes

Most absolute links to `docs.docker.com` were made relative when building the Docker image. Most of them but these ones:
- links to `http://docs.docker.com` (`http` without the `s`)
- absolute links in `<img>` tags
- absolute links in current version (only `/v1.x` folders were considered)

@johndmulhausen I don't really like to be permissive with markdown writing. I would personally parse these markdowns in the tests to fix the root cause not the symptoms. But that's your call, at least we make sure there aren't any absolute links to `docs.docker.com` in the image. 🙂

cc @gdevillele 