### PR TITLE
Cloud: add notes about overriding the default user

### DIFF
--- a/apidocs/cloud-api-source/source/index.md
+++ b/apidocs/cloud-api-source/source/index.md
@@ -97,6 +97,13 @@ Examples:
 - The user wants to operate on the node cluster list endpoint in an organization called `exampleorg` (which they have permission to see):
     - https://cloud.docker.com/api/infra/v1/exampleorg/nodecluster/
 
+### Namespaced endpoints in the docker-cloud CLI
+
+If you are using namespaces with the `docker-cloud` CLI, set them by changing
+the value of the `DOCKERCLOUD_NAMESPACE` environment variable. You can either
+set this globally, or specify it before each CLI command. To learn more, see the
+[Docker Cloud CLI README](https://github.com/docker/dockercloud-cli#namespace).
+
 ## Stream API
 
 ```python

--- a/apidocs/docker-cloud/index.html
+++ b/apidocs/docker-cloud/index.html
@@ -119,6 +119,13 @@ in the request. The namespace is set before the resource in the URL schema:
 </ul></li>
 </ul>
 
+<h3 id="namespaced-endpoints-in-the-docker-cloud-cli">Namespaced endpoints in the docker-cloud CLI</h3>
+
+<p>If you are using namespaces with the <code class="prettyprint">docker-cloud</code> CLI, set them by changing
+the value of the <code class="prettyprint">DOCKERCLOUD_NAMESPACE</code> environment variable. You can either
+set this globally, or specify it before each CLI command. To learn more, see the
+<a href="https://github.com/docker/dockercloud-cli#namespace">Docker Cloud CLI README</a>.</p>
+
 <h2 id="stream-api">Stream API</h2>
 <pre class="highlight python"><code><span class="kn">import</span> <span class="nn">websocket</span>
 <span class="kn">import</span> <span class="nn">base64</span>

--- a/apidocs/layouts/single.html
+++ b/apidocs/layouts/single.html
@@ -119,6 +119,13 @@ in the request. The namespace is set before the resource in the URL schema:
 </ul></li>
 </ul>
 
+<h3 id="namespaced-endpoints-in-the-docker-cloud-cli">Namespaced endpoints in the docker-cloud CLI</h3>
+
+<p>If you are using namespaces with the <code class="prettyprint">docker-cloud</code> CLI, set them by changing
+the value of the <code class="prettyprint">DOCKERCLOUD_NAMESPACE</code> environment variable. You can either
+set this globally, or specify it before each CLI command. To learn more, see the
+<a href="https://github.com/docker/dockercloud-cli#namespace">Docker Cloud CLI README</a>.</p>
+
 <h2 id="stream-api">Stream API</h2>
 <pre class="highlight python"><code><span class="kn">import</span> <span class="nn">websocket</span>
 <span class="kn">import</span> <span class="nn">base64</span>

--- a/docker-cloud/installing-cli.md
+++ b/docker-cloud/installing-cli.md
@@ -22,11 +22,13 @@ Install the docker-cloud CLI either by running a Docker container, or by using t
 
 If you have Docker Engine installed locally, you can simply run the following command regardless of which operating system you are using.
 
-```
+```none
 docker run dockercloud/cli -h
 ```
 
-This runs a container that installs the docker-cloud CLI for you. Learn more about this container [here](https://github.com/docker/dockercloud-cli#docker-image).
+This runs a container that installs the docker-cloud CLI for you. Learn more
+about this container
+[here](https://github.com/docker/dockercloud-cli#docker-image).
 
 #### Install for Linux or Windows
 
@@ -63,7 +65,7 @@ First, you should log in using the `docker` CLI and the `docker login` command.
 Your Docker ID, which you also use to log in to Docker Hub, is also used for
 logging in to Docker Cloud.
 
-```bash
+```none
 $ docker login
 Username: user
 Password:
@@ -75,19 +77,44 @@ Login succeeded!
 
 See the [Developer documentation](/apidocs/docker-cloud.md) for more information on using the CLI and our APIs.
 
+
+## Use the docker-cloud CLI with an organization
+
+When you use the docker-cloud CLI, it authenticates against the Docker Cloud
+service with the user credentials saved by the `docker login` command. To use
+the CLI to interact with objects belonging to an [Organization](orgs.md), you
+must override the `DOCKERCLOUD_NAMESPACE` environment variable that sets this
+user.
+
+For example:
+
+```none
+$ export DOCKERCLOUD_NAMESPACE=myorganization
+```
+
+You can also set the `DOCKERCLOUD_NAMESPACE` variable before each CLI command.
+for example:
+
+```none
+$ DOCKERCLOUD_NAMESPACE=myteam docker container ps
+```
+
+To learn more, see the [Docker Cloud CLI README](https://github.com/docker/dockercloud-cli#namespace).
+
+
 ## Upgrade the docker-cloud CLI
 
 Periodically, Docker will add new features and fix bugs in the existing CLI. To use these new features, you must upgrade the CLI.
 
 #### Upgrade on the docker-cloud CLI on Linux or Windows
 
-```
+```none
 $ pip install -U docker-cloud
 ```
 
 #### Upgrade the docker-cloud CLI on macOS
 
-```
+```none
 $ brew update && brew upgrade docker-cloud
 ```
 
@@ -100,7 +127,7 @@ with other applications on your system, you may want to uninstall and reinstall.
 
 Open your terminal or command shell and execute the following command:
 
-```
+```none
 $ pip uninstall docker-cloud
 ```
 
@@ -108,6 +135,6 @@ $ pip uninstall docker-cloud
 
 Open your Terminal application and execute the following command:
 
-```
+```none
 $ brew uninstall docker-cloud
 ```


### PR DESCRIPTION
Clarifies how to user the `docker-cloud` cli with organizations/namespaces, points to the original README file. 

cc @amegianeg PTAL

Signed-off-by: LRubin <lrubin@docker.com>