### PR TITLE
Fixed absolute links in external content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/referen
  && svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_BRANCH/docs/spec allv/registry/spec \
  && wget -O allv/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
  && jekyll build -s allv -d allvbuild \
+ && find allvbuild/engine/reference -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
+ && find allvbuild/engine/extend -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
  && rm -rf allv
 
 # Serve the site, which is now all static HTML


### PR DESCRIPTION
### Proposed changes

The files we’re pulling from docker/docker may include links to `docs.docker.com`. And we can’t forbid that because relative links wouldn’t make sense in the context of `docker/docker` repository in some situations. So let’s just fix these links right after they get imported.

This is necessary for tests in #849 to pass.
