### PR TITLE
Cloud: adds notes on using org namespaces for the tutorial

### DIFF
--- a/docker-cloud/getting-started/deploy-app/2_set_up.md
+++ b/docker-cloud/getting-started/deploy-app/2_set_up.md
@@ -73,8 +73,24 @@ For simplicity in this tutorial, we use an environment variable for your Docker 
 
 If you don't want to do this, make sure you substitute your username for $DOCKER_ID_USER whenever you see it in the example commands.
 
-```bash
+```none
 $ export DOCKER_ID_USER=my-username
 ```
+
+**If you are running the tutorial with an organization's resources:**
+
+By default, the `docker-cloud` CLI uses your default user namespace, meaning the
+repositories, nodes, and services associated with your individual Docker ID
+account name. To use the CLI to interact with objects that belong to an
+[organization](../../orgs.md), prefix these commands with
+`DOCKERCLOUD_NAMESPACE=my-organization`, or set this variable as in the example below.
+
+```none
+$ export `DOCKERCLOUD_NAMESPACE=my-organization`
+```
+
+
+ See the [CLI documentation](../../installing-cli.md#use-the-docker-cloud-cli-with-an-organization) for more information.
+
 
 Next up, we'll [Prepare the app](3_prepare_the_app.md).

--- a/docker-cloud/getting-started/deploy-app/4_push_to_cloud_registry.md
+++ b/docker-cloud/getting-started/deploy-app/4_push_to_cloud_registry.md
@@ -13,6 +13,13 @@ In this step you will take the image that you built in the previous step, and pu
 
 In step 2, you set your Docker Cloud username as an environment variable called **DOCKER_ID_USER**. If you skipped this step, change the `$DOCKER_ID_USER` to your Docker ID username before running this command.
 
+> **Note**: By default, the `docker-cloud` CLI uses your default user namespace,
+meaning the repositories, nodes, and services associated with your individual
+Docker ID account name. To use the CLI to interact with objects that belong to
+an [organization](../../orgs.md), prefix these commands with
+`DOCKERCLOUD_NAMESPACE=my-organization`. See the [CLI documentation](../../installing-cli.md#use-the-docker-cloud-cli-with-an-organization) for more information.
+
+
 First tag the image. Tags in this case denote different builds of an image.
 
 **Python quickstart**

--- a/docker-cloud/getting-started/deploy-app/5_deploy_the_app_as_a_service.md
+++ b/docker-cloud/getting-started/deploy-app/5_deploy_the_app_as_a_service.md
@@ -20,6 +20,12 @@ installed locally or not.
 
 ## Deploy app with Docker Engine installed locally
 
+> **Note**: By default, the `docker-cloud` CLI uses your default user namespace,
+meaning the repositories, nodes, and services associated with your individual
+Docker ID account name. To use the CLI to interact with objects that belong to
+an [organization](../../orgs.md), prefix these commands with
+`DOCKERCLOUD_NAMESPACE=my-organization`. See the [CLI documentation](../../installing-cli.md#use-the-docker-cloud-cli-with-an-organization) for more information.
+
 Start by running the service.
 
 ```bash


### PR DESCRIPTION
Closes #859 

Adds notes on using organization namespaces with the `docker-cloud` CLI.

cc @talex5 let me know if that looks about right.

Signed-off-by: LRubin <lrubin@docker.com>