### PR TITLE
Remove links to non-existent anchors

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -8,9 +8,9 @@ title: Install Docker on Debian
 
 Docker is supported on the following versions of Debian:
 
- - [*Debian testing stretch (64-bit)*](debian.md#debian-wheezy-stable-7-x-64-bit)
- - [*Debian 8.0 Jessie (64-bit)*](debian.md#debian-jessie-80-64-bit)
- - [*Debian 7.7 Wheezy (64-bit)*](debian.md#debian-wheezy-stable-7-x-64-bit) (backports required)
+ - Debian testing stretch
+ - Debian 8.0 Jessie
+ - Debian 7.7 Wheezy (backports required)
 
  >**Note**: If you previously installed Docker using `APT`, make sure you update
  your `APT` sources to the new `APT` repository.


### PR DESCRIPTION
### Proposed changes

Remove links to non-existent anchors
Remove "64-bit" info from supported versions because we already cover that in the prerequisites

