### PR TITLE
added info on usage data options for beta vs. stable

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -21,9 +21,9 @@ This topic also has more information about the two channels.
 
 A: Two different download channels are available for Docker for Mac:
 
-* The stable channel provides a general availability release-ready installer for a fully baked and tested, more reliable app. The stable version of Docker for Mac comes with the latest released version of Docker Engine. The release schedule is synched with Docker Engine releases and hotfixes.
+* The **stable channel** provides a general availability release-ready installer for a fully baked and tested, more reliable app. The stable version of Docker for Mac comes with the latest released version of Docker Engine. The release schedule is synched with Docker Engine releases and hotfixes. On the stable channel, you can select whether to send usage statistics and other data.
 
-* The beta channel provides an installer with new features we are working on, but is not necessarily fully tested. It comes with the experimental version of Docker Engine. Bugs, crashes and issues are more likely to occur with the beta app, but you get a chance to preview new functionality, experiment, and provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month.
+* The **beta channel** provides an installer with new features we are working on, but is not necessarily fully tested. It comes with the experimental version of Docker Engine. Bugs, crashes and issues are more likely to occur with the beta app, but you get a chance to preview new functionality, experiment, and provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. Usage statistics and crash reports are sent by default. You do not have the option to disable this on the beta channel.
 
 **Q: Can I switch back and forth between stable and beta versions of Docker for Mac?**
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -35,9 +35,9 @@ For more about stable and beta channels, see the
     <th style="font-size: x-large; font-family: arial">Beta channel</th>
   </tr>
   <tr valign="top">
-    <td width="50%">This installer is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
+    <td width="50%">This installer is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.<br><br>On the stable channel, you can select whether to send usage statistics and other data.
     </td>
-    <td width="50%">This installer offers cutting edge features and comes with the experimental version of Docker Engine, which is described in the [Docker Experimental Features README](https://github.com/docker/docker/tree/master/experimental) on GitHub.<br><br>This is the best channel to use if you want to experiment with features we are working on as they become available, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month.</td>
+    <td width="50%">This installer offers cutting edge features and comes with the experimental version of Docker Engine, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. <br><br>We collect usage data on betas across the board.</td>
   </tr>
   <tr valign="top">
   <td width="50%">

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -21,15 +21,15 @@ This topic also has more information about the two channels.
 
 A: Two different download channels are available for Docker for Windows:
 
-* The stable channel provides a general availability release-ready installer for a fully baked and tested, more reliable app. The stable version of Docker
+* The **stable channel** provides a general availability release-ready installer for a fully baked and tested, more reliable app. The stable version of Docker
 for Windows comes with the latest released version of Docker Engine.  The
-release schedule is synched with Docker Engine releases and hotfixes.
+release schedule is synched with Docker Engine releases and hotfixes.  On the stable channel, you can select whether to send usage statistics and other data.
 
-* The beta channel provides an installer with new features we are working on, but is not necessarily fully tested. It comes with the experimental version of
+* The **beta channel** provides an installer with new features we are working on, but is not necessarily fully tested. It comes with the experimental version of
 Docker Engine. Bugs, crashes and issues are more likely to occur with the beta
 app, but you get a chance to preview new functionality, experiment, and provide
 feedback as the apps evolve. Releases are typically more frequent than for
-stable, often one or more per month.
+stable, often one or more per month.  Usage statistics and crash reports are sent by default. You do not have the option to disable this on the beta channel.
 
 **Q: Can I switch back and forth between stable and beta versions of Docker for Windows?**
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -27,9 +27,9 @@ If you have not already done so, please install Docker for Windows. You can down
     <th style="font-size: x-large; font-family: arial">Beta channel</th>
   </tr>
   <tr valign="top">
-    <td width="50%">This installer is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
+    <td width="50%">This installer is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.<br><br>On the stable channel, you can select whether to send usage statistics and other data.
     </td>
-    <td width="50%">This installer offers cutting edge features and comes with the experimental version of Docker Engine, which is described in the [Docker Experimental Features README](https://github.com/docker/docker/tree/master/experimental) on GitHub.<br><br>This is the best channel to use if you want to experiment with features we are working on as they become available, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month.</td>
+    <td width="50%">This installer offers cutting edge features and comes with the experimental version of Docker Engine, which is described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. <br><br>We collect all usage data on betas across the board.</td>
   </tr>
   <tr valign="top">
   <td width="50%">


### PR DESCRIPTION
### Proposed changes
* Explained options to enable/disable usage data on Stable vs. Beta channels per a user comment on GitHub issues ["Can't disable usage statistics"](https://github.com/docker/for-mac/issues/1039). The comment was on d4mac, but added these explanations to both d4mac and d4win, as they apply to both.

* Updated content on both the Stable and Beta channel descriptions at the Download buttons, and also in the FAQs re: these channel options.

* Fixed some links to "Experimental README" in Stable and Beta channel descriptions.

### Related issues (optional)

d4mac GitHub issue: ["Can't disable usage statistics"](https://github.com/docker/for-mac/issues/1039)

### Please take a look

@jeanlaurent @friism 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>