### PR TITLE
Update btrfs-driver.md for reclaiming blocks

### DIFF
--- a/engine/userguide/storagedriver/btrfs-driver.md
+++ b/engine/userguide/storagedriver/btrfs-driver.md
@@ -260,6 +260,7 @@ daemon` at startup, or adding it to the `DOCKER_OPTS` line to the Docker config
 
 Your Docker host is now configured to use the `btrfs` storage driver.
 
+
 ## Btrfs and Docker performance
 
 There are several factors that influence Docker's performance under the `btrfs`
@@ -310,6 +311,24 @@ performance. This is because they bypass the storage driver and do not incur
 any of the potential overheads introduced by thin provisioning and
 copy-on-write. For this reason, you should place heavy write workloads on data
 volumes.
+
+- **Balance BTRFS**. Enable a cronjob to rebalance your BTRFS devices. e.g. 
+Spread the subvolume's blocks evenly across your raid devices, and reclaim 
+unused blocks. Without doing this, snapshots and subvolumes that docker 
+removes will leave allocated blocks fillingup the BTRFS root volume. Once full 
+you won't be able to re-balance, resulting in a potentially unrecoverable 
+state without adding an additional storage device. If you would rather not 
+automate this with crond, another option is to run a re-balance manually 
+outside peak use times since the operation can be disk I/O intensive. This 
+command will claim all chunks that are 1% used or less:
+
+  $ sudo btrfs filesystem balance start -dusage=1 /var/lib/docker
+
+  Dumping filters: flags 0x1, state 0x0, force is off
+  DATA (flags 0x2): balancing, usage=1
+  Done, had to relocate 673 out of 842 chunks
+
+More information on this topic can be read on the [BTRFS Wiki](https://btrfs.wiki.kernel.org/index.php/Balance_Filters#Balancing_to_fix_filesystem_full_errors).
 
 ## Related Information
 


### PR DESCRIPTION
eventually the disk will become full and you can't rebalance.  Adding this step to the configuration instructions to help prevent users from getting in to a state which their device becomes full.

### Proposed changes

Added a step to explain how to rebalance the btrfs.  otherwise it will eventually become full and users will have a bad time, since docker will become unresponsive and complain the disk is full.  This will be masked by btrfs if they only type 'df -h', since the filesystem will show that it's not actually full.

