### PR TITLE
Modify Dockerfile to use shallow clones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,36 +2,32 @@ FROM starefossen/github-pages
 
 ENV VERSIONS="v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 v1.10 v1.11"
 
-# Create archive; check out each version, create HTML, tweak links
-RUN git clone https://www.github.com/docker/docker.github.io temp; \
- for VER in $VERSIONS; do \
-		git --git-dir=./temp/.git --work-tree=./temp checkout ${VER} \
-		&& mkdir -p allvbuild/${VER} \
-		&& jekyll build -s temp -d allvbuild/${VER} \
-		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$VER"'/#g' \
-		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/'"$VER"'/#g' \
-		&& find allvbuild/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/'"$VER"'/#g'; \
-	done; \
-	rm -rf temp
-
-COPY . allv
-
 ## Branch to pull from, per ref doc
 ENV ENGINE_BRANCH="1.12.x"
 ENV DISTRIBUTION_BRANCH="release/2.5"
 
-# The statements below pull reference docs from upstream locations,
-# then build the whole site to static HTML using Jekyll
+# The statements pull reference docs from upstream locations,
+# build the archives from Markdown to HTML,
+# then build the whole site (from allv) to static HTML (into allvbuild) using Jekyll
 
-RUN svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/reference allv/engine/reference \
- && svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/extend allv/engine/extend \
- && wget -O allv/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
- && svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_BRANCH/docs/spec allv/registry/spec \
- && wget -O allv/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
- && jekyll build -s allv -d allvbuild \
- && find allvbuild/engine/reference -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
- && find allvbuild/engine/extend -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
- && rm -rf allv
+RUN git clone --depth 1 --branch master https://www.github.com/docker/docker.github.io allv \
+    && svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/reference allv/engine/reference \
+    && svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/extend allv/engine/extend \
+    && wget -O allv/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
+    && svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_BRANCH/docs/spec allv/registry/spec \
+    && wget -O allv/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md; \
+    for VER in $VERSIONS; do \
+      git clone --depth 1 --branch $VER https://www.github.com/docker/docker.github.io temp \
+ 		  && jekyll build -s temp -d allv/${VER} \
+ 		  && find allv/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$VER"'/#g' \
+ 		  && find allv/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/'"$VER"'/#g' \
+ 		  && find allv/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/'"$VER"'/#g' \
+      && rm -Rf temp; \
+    done; \
+    jekyll build -s allv -d allvbuild \
+    && find allvbuild/engine/reference -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
+    && find allvbuild/engine/extend -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
+    && rm -rf allv
 
 # Serve the site, which is now all static HTML
 CMD jekyll serve -s /usr/src/app/allvbuild --no-watch -H 0.0.0.0 -P 4000


### PR DESCRIPTION
### Proposed changes

This changes the Dockerfile to use shallow clones to populate and layer the sources from the archives and master. This is an incremental improvement while we experiment with other more broad improvements (#941).

This takes about **2 minutes longer** to build the Dockerfile than the other version, but results in a Dockerfile that is over **300MB smaller** in size. It seems like this would make it faster to deploy.

To test, build the Dockerfile in this branch and build it again in master. Here are my results:

**master**:

```bash
$ time docker build --no-cache -f Dockerfile -t mistything .

real	7m57.189s
user	0m4.683s
sys	0m2.102s

$ docker images |grep mistything

mistything                 latest                                  f2495e274448        About a minute ago   1.9 GB
```

**this PR**:

```bash
$ time docker build --no-cache -f Dockerfile -t mistything .

Successfully built 2a8cf4f91450

real	9m21.299s
user	0m4.576s
sys	0m1.935s

$ docker images | grep mistything

mistything                 latest                                  2a8cf4f91450        12 minutes ago      1.588 GB

```

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
