### PR TITLE
Use armhf/hello-world for Raspbian tutorial

### DIFF
--- a/engine/installation/linux/raspbian.md
+++ b/engine/installation/linux/raspbian.md
@@ -9,7 +9,7 @@ title: Install on Raspbian
 Docker is supported on the following versions of Raspbian:
 
  - *Raspbian Jessie*
- 
+
  >**Note**: If you previously installed Docker using `APT`, make sure you update
  your `APT` sources to the new `APT` repository.
 
@@ -85,7 +85,7 @@ Before installing Docker, make sure you have set your `APT` repository correctly
 
 4. Verify `docker` is installed correctly.
 
-        $ sudo docker run hello-world
+        $ sudo docker run armhf/hello-world
 
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message. Then, it exits.


### PR DESCRIPTION
### Proposed changes

Someone had trouble with the Raspbian tutorial following the command `docker run hello-world` which only works on Intel/AMD CPU's. So I had a look where this tutorial is and fixed it.

Using `docker run armhf/hello-world` works for ARM CPU's.

### Related issues (optional)

https://github.com/docker/docker/issues/29710
