### PR TITLE
Update host_integration.md

### DIFF
--- a/engine/admin/host_integration.md
+++ b/engine/admin/host_integration.md
@@ -78,7 +78,8 @@ in the `/etc/systemd/system` directory, e.g.
 If you need to pass options to the redis container (such as `--env`),
 then you'll need to use `docker run` rather than `docker start`. This will
 create a new container every time the service is started, which will be stopped
-and removed when the service is stopped.
+and removed when the service is stopped. Make sure you don't use "`-d`" for
+"detached mode". The command run from "`ExecStart`" needs to run in the foreground.
 
     [Service]
     ...


### PR DESCRIPTION
### Proposed changes
Typically, when you run an image from the command line, you would use "-d" for "detached mode", and when that appears to work, someone might paste the working command line into "ExecStart", which would then mysteriously fail because ExecStart expects a foreground process.

My change points out that possible mistake.
