### PR TITLE
Updated to remove 'json' from parsed output

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -509,7 +509,7 @@ at `/etc/docker/daemon.json`.
 
 2.  Add a `dns` key with one or more IP addresses as values. If the file has
     existing contents, you only need to add or edit the `dns` line.
-    ```json
+    ```bash
     {
     	"dns": ["8.8.8.8", "8.8.4.4"]
     }


### PR DESCRIPTION
The use of the ```json MD formatting erroneously displays the word 'json' before the expected json. This results in the highlighted command as 'json { "dns": ["8.8.8.8", "8.8.4.4"]}' instead of '{ "dns": ["8.8.8.8", "8.8.4.4"]}'. Using ```bash resolves this issue.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the left-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
