### PR TITLE
Updating dockervolumes.md for Windows mounting

### DIFF
--- a/engine/tutorials/dockervolumes.md
+++ b/engine/tutorials/dockervolumes.md
@@ -128,7 +128,7 @@ docker run -v /Users/<path>:/<container path> ...
 On Windows, mount directories using:
 
 ```bash
-docker run -v c:\<path>:/c:\<container path>
+docker run -v //c/<path>:/<container path>
 ```
 
 All other paths come from your virtual machine's filesystem, so if you want


### PR DESCRIPTION
### Proposed changes

The code snippet for mounting Windows directories won't work: it will produce an "Invalid bind mount spec" error as Docker cannot properly read the path. The core error was addressed in Docker issue [#12590](https://github.com/docker/docker/issues/12590#issuecomment-96767796), this is just an update to the tutorial.

### Unreleased project version (optional)

N/A

### Related issues (optional)

https://github.com/docker/docker/issues/12590#issuecomment-96767796
