### PR TITLE
using github url for yaml.v2 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,6 @@
 	branch = 45e771701b814666a7eb299e6c7a57d0b1799e91
 [submodule "tests/src/gopkg.in/yaml.v2"]
 	path = tests/src/gopkg.in/yaml.v2
-	url = https://gopkg.in/yaml.v2
+	url = https://github.com/go-yaml/yaml.git
 	branch = a5b47d31c556af34a302ce5d659e6fea44d90de0
 


### PR DESCRIPTION
This is an attempt to fix Github pages build…

This is the answer that @sanscontext got from Github support: 

```
Hello Laura,

Sorry for the trouble here, we don't have parsers in place for all of the Jekyll errors.

From our internal logs I see this:

Cloning into 'tests/src/gopkg.in/yaml.v2'...
error: RPC failed; result=22, HTTP code = 301
fatal: The remote end hung up unexpectedly
Clone of 'https://gopkg.in/yaml.v2' into submodule path 'tests/src/gopkg.in/yaml.v2' failed

Which I believe is referring to this:

https://github.com/docker/docker.github.io/blob/ae629e574198ba47182878ff720e3b63df294599/.gitmodules#L9

Is that URL correct? I would have thought it would be something like this:

https://github.com/go-yaml/yaml.git

I am not sure what you are trying to do there though so it may be correct.

Regards,
Daniel
@danayel
GitHub Support
```

I'm now using `https://github.com/go-yaml/yaml.git` instead of `https://gopkg.in/yaml.v2`

Signed-off-by: Adrien Duermael <adrien@duermael.com>