### PR TITLE
docker upgrade command fix

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -596,7 +596,7 @@ updates Docker if a new version is available.
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get upgrade docker-engine
+$ sudo apt-get install docker-engine
 ```
 
 ## Uninstallation


### PR DESCRIPTION
`apt-get upgrade` doesn't take an argument. To upgrade docker specifically would require `apt-get install docker-engine`.