### PR TITLE
Remove duplicate 'for details'

### DIFF
--- a/engine/installation/linux/ubuntulinux.md
+++ b/engine/installation/linux/ubuntulinux.md
@@ -311,7 +311,7 @@ makes the ownership of the Unix socket read/writable by the `docker` group.
 
 >**Warning**: The `docker` group is equivalent to the `root` user. For details
 on how this impacts security in your system, see [*Docker Daemon Attack
-Surface*](../../security/security.md#docker-daemon-attack-surface) for details.
+Surface*](../../security/security.md#docker-daemon-attack-surface).
 
 To create the `docker` group and add your user:
 


### PR DESCRIPTION
### Proposed changes

Remove a duplicate 'for details' in Docker Daemon Attack Surface line. Because grammar.

