### PR TITLE
Fix root_ca, json structure in Notary client config docs

### DIFF
--- a/notary/reference/client-config.md
+++ b/notary/reference/client-config.md
@@ -25,10 +25,10 @@ JSON keys to learn more about the configuration section corresponding to that ke
   <a href="client-config.md#trust_dir-section-optional">"trust_dir"</a> : "~/.docker/trust",
   <a href="client-config.md#remote_server-section-optional">"remote_server"</a>: {
     "url": "https://my-notary-server.my-private-registry.com",
-    "root-ca": "./fixtures/root-ca.crt",
+    "root_ca": "./fixtures/root-ca.crt",
     "tls_client_cert": "./fixtures/secure.example.com.crt",
     "tls_client_key": "./fixtures/secure.example.com.crt"
-  }
+  },
   <a href="client-config.md#trust_pinning-section-optional">"trust_pinning"</a>: {
     "certs": {
       "docker.com/notary": ["49cf5c6404a35fa41d5a5aa2ce539dfee0d7a2176d0da488914a38603b1f4292"]
@@ -58,7 +58,7 @@ Remote server example:
 ```json
 "remote_server": {
   "url": "https://my-notary-server.my-private-registry.com",
-  "root-ca": "./fixtures/root-ca.crt",
+  "root_ca": "./fixtures/root-ca.crt",
   "tls_client_cert": "./fixtures/secure.example.com.crt",
   "tls_client_key": "./fixtures/secure.example.com.crt"
 }
@@ -78,7 +78,7 @@ Remote server example:
 			`-s` or `--server`.</td>
 	</tr>
 	<tr>
-		<td valign="top"><code>root-ca</code></td>
+		<td valign="top"><code>root_ca</code></td>
 		<td valign="top">no</td>
 		<td valign="top"><p>The path to the file containing the root CA with which to verify
 			the TLS certificate of the Notary server, for example if it is self-signed.


### PR DESCRIPTION
The JSON key should be `"root_ca"` instead of `"root-ca"`, and a comma was missing.  Ports over https://github.com/docker/notary/pull/1080

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>

