### PR TITLE
Cloud: docker is no longer optional in this 2nd tutorial

### DIFF
--- a/docker-cloud/getting-started/deploy-app/1_introduction.md
+++ b/docker-cloud/getting-started/deploy-app/1_introduction.md
@@ -16,7 +16,7 @@ This tutorial assumes that you have:
 
 - a free <a href="https://hub.docker.com/" target="_blank">Docker ID account</a>.
 - at least one node running. If you don't have any nodes set up in Docker Cloud yet, [start here](../../getting-started/your_first_node.md) to set these up.
-- (optional) Docker Engine installed - see the installation guides for <a href="/engine/installation/" target="_blank">macOS, Windows and Linux</a>.
+- Docker Engine installed - see the installation guides for <a href="/engine/installation/" target="_blank">macOS, Windows and Linux</a>. You'll use the `docker login` command to connect to your account in Docker Cloud, so you can run `docker-cloud` CLI commands.
 
 Let's get started!
 


### PR DESCRIPTION
Closes #1013 by clarifying that you do need `docker` installed, but it's used to log in so you can run `docker-cloud` commands.

@fermayo for 👀 ?

Signed-off-by: LRubin <lrubin@docker.com>