### PR TITLE
added links to Toolbox installer downloads via Releases page

### DIFF
--- a/toolbox/overview.md
+++ b/toolbox/overview.md
@@ -25,16 +25,20 @@ Toolbox includes these Docker tools:
 
 * Oracle VirtualBox
 
-## Ready to get started?
+## Get Docker Toolbox
 
-Go to the <a href="https://www.docker.com/products/docker-toolbox" target="_blank">Docker Toolbox</a> product page and download Toolbox for Mac or Windows.
+1. Get the latest installers from the [Toolbox releases
+page](https://github.com/docker/toolbox/releases/):
 
-Choose the install instructions for your platform, and follow the steps:
+    * For Mac, download and run the "Latest release" `.pkg` installer (`DockerToolbox-<version>.pkg`)
 
-* [Install Docker Toolbox on macOS](toolbox_install_mac.md)
+    * For Windows, download and run the "Latest release" `.exe` installer (`DockerToolbox-<version>.exe`)
 
-* [Install Docker Toolbox for Windows](toolbox_install_windows.md)
+2. Choose the install instructions for your platform, and follow the steps:
 
+    * [Install Docker Toolbox on macOS](toolbox_install_mac.md)
+
+    * [Install Docker Toolbox for Windows](toolbox_install_windows.md)
 
 ## Next Steps
 


### PR DESCRIPTION
@friism @FrenchBen @nathanleclaire 

Added direct links to Toolbox installer binaries on [Toolbox releases page](https://github.com/docker/toolbox/releases/) to the Toolbox docs.

@FrenchBen let me know if you did push the Toolbox packages up to the links you suggested in the `cd-ee-launch` channel. I'll update these docs and Docker Store to those URL's as soon as they are working:

http://download.docker.com/mac/stable/Docker-Toolbox.pkg
http://download.docker.com/win/stable/Docker-Toolbox.exe

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

