### PR TITLE
Correction of the Install-Module command

### DIFF
--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -329,16 +329,16 @@ If you would like to have handy tab completion for Docker commands, you can inst
     <br>
 3. To enable auto-completion of commands for the current PowerShell only, type:
 
-    `Import-Module posh-docker`
+    `Install-Module posh-docker`
 
 4. To make tab completion persistent across all PowerShell sessions, add the command to a `$PROFILE` by typing these commands at the PowerShell prompt.
 
         Install-Module -Scope CurrentUser posh-docker -Force
-        Add-Content $PROFILE "`nImport-Module posh-docker"
+        Add-Content $PROFILE "`nInstall-Module posh-docker"
 
     This creates a `$PROFILE` if one does not already exist, and adds this line into the file:
 
-    `Import-Module posh-docker`
+    `Install-Module posh-docker`
 
     <br>
     To check that the file was properly created, or simply edit it manually, type this in PowerShell:


### PR DESCRIPTION
The command line was Import-Module which seems to be wrong. It seemed to work for me with Install-Module. So I make the correction. Please note, I'm only a newbie, so check this twice please ;-)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the left-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
