### PR TITLE
Update instructions for systemd drop-ins

### DIFF
--- a/engine/admin/systemd.md
+++ b/engine/admin/systemd.md
@@ -36,9 +36,7 @@ The recommended way is to use a systemd drop-in file (as described in the <a
 target="_blank"
 href="https://www.freedesktop.org/software/systemd/man/systemd.unit.html">systemd.unit</a>
 documentation). These are local files named `<something>.conf` in the
-`/etc/systemd/system/docker.service.d` directory. This could also be
-`/etc/systemd/system/docker.service`, which also works for overriding the
-defaults from `/lib/systemd/system/docker.service`.
+`/etc/systemd/system/docker.service.d` directory.
 
 However, if you had previously used a package which had an `EnvironmentFile`
 (often pointing to `/etc/sysconfig/docker`) then for backwards compatibility,
@@ -160,7 +158,7 @@ you will need to add this configuration in the Docker systemd service file.
 1.  Create a systemd drop-in directory for the docker service:
 
     ```bash
-    $ mkdir /etc/systemd/system/docker.service.d
+    $ mkdir -p /etc/systemd/system/docker.service.d
     ```
 
 2.  Create a file called `/etc/systemd/system/docker.service.d/http-proxy.conf`


### PR DESCRIPTION
When creating a `/etc/systemd/system/docker.service` unit file, that file _replaces_ the default (`/lib/systemd/system/docker.service`) unit file.

While this may be intended by some, this section describes how to use "partial" unit files ("drop-ins") to override only certain properties of the default unit file.

This patch removes the mention of `/etc/systemd/system/docker.service` to prevent users from inadvertently replacing the default unit file.

Relates to https://github.com/docker/docker/issues/30063#issuecomment-272143484. Thanks @ijrandom for bringing this to our attention 👍 

ping @mstanleyjones PTAL