### PR TITLE
Jenkinsfile: avoid container collisions (unique tags)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,11 @@ wrappedNode(label: 'linux && x86_64') {
     are not generated when building with Jekyll. */
   sh "awk '/jekyll-redirect-from/{n=1}; n {n--; next}; 1' < _config.yml > _config.yml.tmp"
   sh "mv _config.yml.tmp _config.yml"
-  
-  sh "docker build -t docs `pwd`"
-  sh "docker build -t tests `pwd`/tests"
-  sh "docker run -v /usr/src/app/allvbuild --name docs docs /bin/true"
-  sh "docker run --rm --volumes-from docs -v `pwd`:/docs tests"
-  sh "docker rm -fv docs"
-  sh "docker rmi docs tests"
+
+  sh "docker build -t docs:${JOB_BASE_NAME}-${BUILD_NUMBER} `pwd`"
+  sh "docker build -t tests:${JOB_BASE_NAME}-${BUILD_NUMBER} `pwd`/tests"
+  sh "docker run -v /usr/src/app/allvbuild --name docs-${JOB_BASE_NAME}-${BUILD_NUMBER} docs:${JOB_BASE_NAME}-${BUILD_NUMBER} /bin/true"
+  sh "docker run --rm --volumes-from docs-${JOB_BASE_NAME}-${BUILD_NUMBER} -v `pwd`:/docs tests:${JOB_BASE_NAME}-${BUILD_NUMBER}"
+  sh "docker rm -fv docs-${JOB_BASE_NAME}-${BUILD_NUMBER}"
+  sh "docker rmi docs:${JOB_BASE_NAME}-${BUILD_NUMBER} tests:${JOB_BASE_NAME}-${BUILD_NUMBER}"
 }


### PR DESCRIPTION
### Proposed changes

<s>Added one command in the Jenkinsfile to remove all Docker containers that might be present before running the tests. (because we've had issues where the container name was already taken)
`sh "docker rm -fv $(docker ps -a -q)"`</s>

Now tagging images and containers with JOB_BASE_NAME and BUILD_NUMBER to avoid collisions.


cc @joaofnfernandes 