### PR TITLE
added direct installer links, re-worked Toolbox intro pages

### DIFF
--- a/toolbox/overview.md
+++ b/toolbox/overview.md
@@ -25,14 +25,27 @@ Toolbox includes these Docker tools:
 
 * Oracle VirtualBox
 
-## Get Docker Toolbox
 
-1. Get the latest installers from the [Toolbox releases
-page](https://github.com/docker/toolbox/releases/):
+## Ready to get started?
 
-    * For Mac, download and run the "Latest release" `.pkg` installer (`DockerToolbox-<version>.pkg`)
+1. Get the latest Toolbox installer for your platform:
 
-    * For Windows, download and run the "Latest release" `.exe` installer (`DockerToolbox-<version>.exe`)
+    <table style="width:100%">
+      <tr>
+        <th style="font-size: medium; font-family: arial;  text-align: center">
+        Toolbox for Mac</th>
+        <th style="font-size: medium; font-family: arial; text-align: center">
+        Toolbox for Windows</th>
+      </tr>
+      <tr valign="top">
+        <td width="50%">
+        <a class="button darkblue-btn" href="https://download.docker.com/mac/stable/DockerToolbox.pkg">Get Docker Toolbox for Mac</a>
+        </td>
+        <td width="50%">
+        <a class="button darkblue-btn" href="https://download.docker.com/win/stable/DockerToolbox.exe">Get Docker Toolbox for Windows</a>
+        </td>
+      </tr>
+    </table>
 
 2. Choose the install instructions for your platform, and follow the steps:
 

--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -5,7 +5,17 @@ keywords: docker, documentation, install, toolbox, mac
 title: Install Docker Toolbox on macOS
 ---
 
-macOS users use Docker Toolbox to install Docker software. Docker Toolbox includes the following Docker tools:
+Docker Toolbox provides a way to use Docker on older Macs
+that do not meet
+minimal system requirements for [Docker for Mac](/docker-for-mac/index.md).
+
+If you have not done so already, download the installer here:
+
+<a class="button darkblue-btn" href="https://download.docker.com/mac/stable/DockerToolbox.pkg">Get Docker Toolbox for Mac</a>
+
+## What you get and how it works
+
+Docker Toolbox includes the following Docker tools:
 
 * Docker CLI client for running Docker Engine to create images and containers
 * Docker Machine so you can run Docker Engine commands from macOS terminals
@@ -14,10 +24,18 @@ macOS users use Docker Toolbox to install Docker software. Docker Toolbox includ
 * the Docker QuickStart shell preconfigured for a Docker command-line environment
 * Oracle VM VirtualBox
 
-Because the Docker Engine daemon uses Linux-specific kernel features, you can't
-run Docker Engine natively in macOS. Instead, you must use the Docker Machine
-command,  `docker-machine`,  to create and attach to a small Linux VM on your
-machine. This VM hosts Docker Engine for you on your Mac.
+Because the Docker Engine daemon uses Linux-specific
+kernel features, you can't run Docker Engine natively on
+macOS with Docker Toolbox. Instead, you must use the
+Docker Machine command,  `docker-machine`,  to create and
+attach to a small Linux VM on your machine. This VM hosts
+Docker Engine for you on your Mac.
+
+>**Tip:** One of the advantages of the newer
+[Docker for Mac](/docker-for-mac/index.md) solution is that
+it uses native virtualization and does not require
+VirtualBox to run Docker.
+
 
 ## Step 1: Check your version
 

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -5,7 +5,18 @@ keywords: docker, documentation, install, toolbox, win
 title: Install Docker Toolbox on Windows
 ---
 
-Windows users use Docker Toolbox to install Docker software. Docker Toolbox includes the following Docker tools:
+Docker Toolbox provides a way to use Docker on older
+Windows systems that do not
+meet minimal system requirements for the [Docker for
+Windows](/docker-for-windows/index.md) app.
+
+If you have not done so already, download the installer here:
+
+<a class="button darkblue-btn" href="https://download.docker.com/win/stable/DockerToolbox.exe">Get Docker Toolbox for Windows</a>
+
+## What you get and how it works
+
+Docker Toolbox includes the following Docker tools:
 
 * Docker CLI client for running Docker Engine to create images and containers
 * Docker Machine so you can run Docker Engine commands from Windows terminals
@@ -14,10 +25,18 @@ Windows users use Docker Toolbox to install Docker software. Docker Toolbox incl
 * the Docker QuickStart shell preconfigured for a Docker command-line environment
 * Oracle VM VirtualBox
 
-Because the Docker Engine daemon uses Linux-specific kernel features, you can't
-run Docker Engine natively in Windows. Instead, you must use the Docker Machine
-command,  `docker-machine`,  to create and attach to a small Linux VM on your
-machine. This VM hosts Docker Engine for you on your Windows system.
+Because the Docker Engine daemon uses Linux-specific
+kernel features, you can't run Docker Engine natively
+on Windows. Instead, you must use the Docker Machine
+command,  `docker-machine`, to create and attach to a
+small Linux VM on your machine. This VM hosts Docker Engine
+for you on your Windows system.
+
+>**Tip:** One of the advantages of the newer
+[Docker for
+Windows](/docker-for-windows/index.md) solution is that
+it uses native virtualization and does not require
+VirtualBox to run Docker.
 
 ## Step 1: Check your version
 


### PR DESCRIPTION

### What I did and why
* added the new direct links to Toolbox installers for Mac and Windows 
* re-worked Toolbox overview and install pages (Mac and Windows), but made sure I didn't change any of the step headings in install because other docs link to those topics

This will map better to what we are doing for product downloads per Docker Store, and makes the installers easier to get. Thanks @FrenchBen 

### Please review

@friism @FrenchBen @nathanleclaire 

### Related issues

#1096 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
