### PR TITLE
remove confusing sentence from "publishing" section

### DIFF
--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -335,10 +335,9 @@ $ docker service create --name my_web \
 ```
 
 Three tasks will run on up to three nodes. You don't need to know which nodes
-are running the tasks, as long as exactly three tasks are running at all times.
-Connecting to port 8080 on **any** of the 10 nodes will connect you to one of
-the three `nginx` tasks. You can test this using `curl` (the HTML output is
-truncated):
+are running the tasks; connecting to port 8080 on **any** of the 10 nodes will
+connect you to one of the three `nginx` tasks. You can test this using `curl`
+(the HTML output is truncated):
 
 ```bash
 $ curl localhost:8080


### PR DESCRIPTION
### Proposed changes

The routing mesh should work irregardless of all replicas being up or not, so removing this sentence.

### Related issues (optional)

Was added in https://github.com/docker/docker.github.io/pull/1091

