### PR TITLE
Fix documentation regarding protocol 50 (ESP)

### DIFF
--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -483,7 +483,7 @@ Your key-value store service may require additional ports.
 Check your vendor's documentation and open any required ports.
 
 If you are planning on creating an overlay network with encryption (`--opt encrypted`),
-you will also need to ensure port 50 (ESP) is open.
+you will also need to ensure protocol 50 (ESP) traffic is allowed.
 
 Once you have several machines provisioned, you can use Docker Swarm to quickly
 form them into a swarm which includes a discovery service as well.


### PR DESCRIPTION
The documentation should clarify that its protocol 50 and not port 50 that should be allowed between nodes.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Fixed documentation to clarify that instead of opening port 50, protocol 50 should be allowed.


