### PR TITLE
Restart the docker daemon after group changes

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -188,7 +188,13 @@ To create the `docker` group and add your user:
 
     This ensures your user is running with the correct permissions.
 
-5.  Verify that your user is in the docker group by running `docker` without `sudo`.
+5.  Restart the `docker` daemon.
+
+    ```bash
+    $ sudo service docker restart
+    ```    
+
+6.  Verify that your user is in the docker group by running `docker` without `sudo`.
 
     ```bash
     $ docker run --rm hello-world


### PR DESCRIPTION
Otherwise the verification step won't work.



### Proposed changes

Added a new step to restart the docker daemon. You have to do this otherwise the verification step won't work.

