### PR TITLE
Solve #1133

### DIFF
--- a/docker-cloud/apps/deploy-to-cloud-btn.md
+++ b/docker-cloud/apps/deploy-to-cloud-btn.md
@@ -21,7 +21,7 @@ The button redirects the user to the **Launch new Stack** wizard, with the stack
 
 The user can still modify the stack definition before deployment.
 
-> **Note**: You must be logged in to Docker Cloud for the **Deploy to Docker Cloud** button deployment to work correctly. If you are not logged in, you'll see a 404 error instead. 
+> Note: You must be **logged in** to Docker Cloud for the Deploy to Docker Cloud button deployment to work correctly. If you are not logged in, you'll see a **404** error instead. 
 
 ## Adding the 'Deploy to Docker Cloud' button in GitHub
 


### PR DESCRIPTION
### Proposed changes

<!--Tell us what you did and why-->
This would solve the issue #1133 for me.

Reason: When I read through the page, I only read the bold text and if it is meaningless, I also skip the non-bold text next to it.

Implementation:
- The note is about being logged in and seeing a 404 if not. So I made this bold.
- That it is about the deploy button is clear - I removed the bold text from it.
- That is is a note is clear be structure. Being a note should not rival with the content of the note - so i removed the bold text.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

This would solve the issue #1133 for me.
