### PR TITLE
Fix typo in Oracle install instructions

### DIFF
--- a/engine/installation/linux/oracle.md
+++ b/engine/installation/linux/oracle.md
@@ -44,8 +44,8 @@ You can install Docker in different ways, depending on your needs:
   upgrades completely manually.
 
 - Some users cannot use third-party repositories, and must rely on
-  the version of Docker in the Red Hat repositories. This version of Docker may
-  be out of date. Those users should consult the Red Hat documentation and not
+  the version of Docker in the Oracle repositories. This version of Docker may
+  be out of date. Those users should consult the Oracle documentation and not
   follow these procedures.
 
 ### Install using the repository


### PR DESCRIPTION
### Proposed changes

Fix typo that refers to Red Hat instead of Oracle

### Unreleased project version (optional)

Engine 1.13

### Related issues (optional)

Problem pointed out in #1159.