### PR TITLE
Update posh-docker install instructions

### DIFF
--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -327,20 +327,26 @@ If you would like to have handy tab completion for Docker commands, you can inst
     <br>
     To check that the policy is set properly, run `get-executionpolicy`, which should return `RemoteSigned`.
     <br>
-3. To enable auto-completion of commands for the current PowerShell only, type:
+3. To install the posh-docker PowerShell Module on your computer (requires administrator access), type:
 
     `Install-Module posh-docker`
+    
+    Alternatively, install the module for the current user (administrator access not required):
+    
+    `Install-Module -Scope CurrentUser posh-docker`
 
-4. To make tab completion persistent across all PowerShell sessions, add the command to a `$PROFILE` by typing these commands at the PowerShell prompt.
+4. To enable auto-completion of commands for the current PowerShell only, type:
 
-        Install-Module -Scope CurrentUser posh-docker -Force
-        Add-Content $PROFILE "`nInstall-Module posh-docker"
+    `Import-Module posh-docker`
+
+    To make tab completion persistent across future PowerShell sessions, add the command to a `$PROFILE` by typing this commands at the PowerShell prompt:
+
+    ``Add-Content $PROFILE "`nImport-Module posh-docker"``
 
     This creates a `$PROFILE` if one does not already exist, and adds this line into the file:
 
-    `Install-Module posh-docker`
+    `Import-Module posh-docker`
 
-    <br>
     To check that the file was properly created, or simply edit it manually, type this in PowerShell:
 
     `Notepad $PROFILE`


### PR DESCRIPTION
Installing the posh-docker module does not cause it to get imported into a PowerShell session. Use the Import-Module cmdlet to import it.


### Proposed changes

Changed the instructions to include running Import-Module. After running Install-Module you have to run Import-Module to load the module in the current session. Also, the $PROFILE should not attempt to (re-)install the module for every new session, instead we should be importing it. I also clarified the difference between default install option which installs on the system and requires admin access vs installing for the user which doesn't.
