### PR TITLE
Smallish typo

### DIFF
--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -202,7 +202,7 @@ Each tag represents a digest, similar to a Git hash. Some tags, such as
 `latest`, are updated often to point to a new digest. Others, such as
 `ubuntu:16.04`, represent a released software version and are not expected to
 update to point to a new digest often if at all. In Docker 1.13 and higher, when
-you create a service, it is constrained to create tasks using a specific digest\
+you create a service, it is constrained to create tasks using a specific digest
 of an image until you update the service using `service update` with the
 `--image` flag. If you use an older version of Docker Engine, you must remove
 and re-create the service to update its image.


### PR DESCRIPTION
### Proposed changes

Fixed a small typo on docker swarm documentation.