### PR TITLE
Added - to the end of apt-key add

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -71,7 +71,7 @@ Docker from the repository.
 2.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -s http://yum.dockerproject.org/gpg | sudo apt-key add
+    $ curl -s http://yum.dockerproject.org/gpg | sudo apt-key add -
     ```
 
     > **Note**: The URL is correct, even for Linux distributions that use `APT`.


### PR DESCRIPTION
Without it the following error message was shown:

gpg: can't open `': No such file or directory

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
