### PR TITLE
disable "testing" repos by default

### DIFF
--- a/engine/installation/linux/repo_files/centos/docker.repo
+++ b/engine/installation/linux/repo_files/centos/docker.repo
@@ -8,7 +8,7 @@ gpgkey=https://yum.dockerproject.org/gpg
 [docker-testing]
 name=Docker Repository
 baseurl=https://yum.dockerproject.org/repo/testing/centos/$releasever/
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 

--- a/engine/installation/linux/repo_files/fedora/docker.repo
+++ b/engine/installation/linux/repo_files/fedora/docker.repo
@@ -8,7 +8,7 @@ gpgkey=https://yum.dockerproject.org/gpg
 [docker-testing]
 name=Docker Repository
 baseurl=https://yum.dockerproject.org/repo/testing/fedora/$releasever/
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 

--- a/engine/installation/linux/repo_files/oracle/docker-ol6.repo
+++ b/engine/installation/linux/repo_files/oracle/docker-ol6.repo
@@ -8,7 +8,7 @@ gpgkey=https://yum.dockerproject.org/gpg
 [docker-testing]
 name=Docker Repository
 baseurl=https://yum.dockerproject.org/repo/testing/oraclelinux/6/
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 

--- a/engine/installation/linux/repo_files/oracle/docker-ol7.repo
+++ b/engine/installation/linux/repo_files/oracle/docker-ol7.repo
@@ -8,7 +8,7 @@ gpgkey=https://yum.dockerproject.org/gpg
 [docker-testing]
 name=Docker Repository
 baseurl=https://yum.dockerproject.org/repo/testing/oraclelinux/7/
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 


### PR DESCRIPTION
The documentation describes that the "testing" repository
is disabled by default;

> Optional: Enable the testing repository. This repository
> is included in the docker.repo file above but is disabled
> by default.

However, the repo-files had the testing repo enabled.

This patch updates the repo-files to disable the
repository by default.

ping @mstanleyjones PTAL