### PR TITLE
Use fixed $releasever for CentOS / RHEL

### DIFF
--- a/engine/installation/linux/repo_files/centos/docker.repo
+++ b/engine/installation/linux/repo_files/centos/docker.repo
@@ -1,27 +1,27 @@
 [docker-main]
 name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+baseurl=https://yum.dockerproject.org/repo/main/centos/7/
 enabled=1
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 
 [docker-testing]
 name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/testing/centos/$releasever/
+baseurl=https://yum.dockerproject.org/repo/testing/centos/7/
 enabled=1
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 
 [docker-beta]
 name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/beta/centos/$releasever/
+baseurl=https://yum.dockerproject.org/repo/beta/centos/7/
 enabled=0
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 
 [docker-nightly]
 name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/nightly/centos/$releasever/
+baseurl=https://yum.dockerproject.org/repo/nightly/centos/7/
 enabled=0
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg


### PR DESCRIPTION
The repo-files used in the installation instructions currently use `$releasever`
to configure the right YUM repository to use, however _Server_ releases output
the version in a different format (i.e., `7Server` instead of just `7`).

Given that we don't have separate repositories for "Server" and "Desktop" editions,
and we only support version 7, setting the repo-files to use a fixed version.

This issue was originally reported in
https://github.com/docker/docker/issues/23376

And fixed through 2b36087597b67b23c8309fe9330a60f17952496b, but this change
got lost during the rewrite of the installation docs.


ping @mstanleyjones PTAL