### PR TITLE
Correct repository details for ubuntu install

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -93,7 +93,7 @@ Docker from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-           "deb https://apt.dockerproject.org/repo/pool/ \
+           "deb https://apt.dockerproject.org/repo/ \
            ubuntu-$(lsb_release -cs) \
            main"
     ```

--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -94,7 +94,7 @@ Docker from the repository.
     ```bash
     $ sudo add-apt-repository \
            "deb https://apt.dockerproject.org/repo/pool/ \
-           $(lsb_release -cs) \
+           ubuntu-$(lsb_release -cs) \
            main"
     ```
 


### PR DESCRIPTION
Corrected the ubuntu apt repository to use the correct form ubuntu-<codename> which fixes https://github.com/docker/machine/issues/3184
