### PR TITLE
Fix title in Engine API getting started

### DIFF
--- a/engine/api/getting-started.md
+++ b/engine/api/getting-started.md
@@ -540,7 +540,7 @@ $ curl --unix-socket /var/run/docker.sock\
 </section>
 </div>
 
-## What next?
+## Next steps
 
  - [Full documentation for the Python SDK.](https://docker-py.readthedocs.io)
  - [Full documentation for the Go SDK.](https://godoc.org/github.com/docker/docker/client)

--- a/engine/api/getting-started.md
+++ b/engine/api/getting-started.md
@@ -540,7 +540,7 @@ $ curl --unix-socket /var/run/docker.sock\
 </section>
 </div>
 
-## What next?
+## What next?
 
  - [Full documentation for the Python SDK.](https://docker-py.readthedocs.io)
  - [Full documentation for the Go SDK.](https://godoc.org/github.com/docker/docker/client)


### PR DESCRIPTION
A weird character was causing it to not be rendered correctly.

<img width="439" alt="screenshot 2017-01-20 12 14 24" src="https://cloud.githubusercontent.com/assets/40906/22151799/9841231a-df17-11e6-84c4-08bf10a33317.png">
