### PR TITLE
FIX  repo URL at add-apt-repository

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -116,8 +116,8 @@ Docker from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-           "deb https://apt.dockerproject.org/repo/pool/ \
-           $(lsb_release -cs) \
+           "deb https://apt.dockerproject.org/repo/ \
+           debian-$(lsb_release -cs) \
            main"
     ```
 


### PR DESCRIPTION
With the past version the apt-get update results in a 403 for the docker repository when using a Jessie. Looking at the repo structure I assume that now will also work on the other Debian releases.