### PR TITLE
Close 'code' html elements

### DIFF
--- a/engine/userguide/networking/default_network/configure-dns.md
+++ b/engine/userguide/networking/default_network/configure-dns.md
@@ -98,11 +98,11 @@ Four different options affect container domain name services.
     <code>--dns-opt=OPTION...</code>
     </p></td>
     <td><p>
-      Sets the options used by DNS resolvers by writing an <code>options<code>
-      line into the container's <code>/etc/resolv.conf<code>.
+      Sets the options used by DNS resolvers by writing an <code>options</code>
+      line into the container's <code>/etc/resolv.conf</code>.
     </p>
     <p>
-    See documentation for <code>resolv.conf<code> for a list of valid options
+    See documentation for <code>resolv.conf</code> for a list of valid options
     </p></td>
   </tr>
   <tr>


### PR DESCRIPTION
There were missing slashes in the closing tags, causing the page to display incorrectly.