### PR TITLE
fix markdown in swarm doc

### DIFF
--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -328,8 +328,7 @@ Keep reading for more information and use cases for each of these methods.
 
 #### Publish a service's ports using the routing mesh
 
-To publish a service's ports externally to the swarm, use the `--publish
-<TARGET-PORT>:<SERVICE-PORT>` flag. The swarm
+To publish a service's ports externally to the swarm, use the `--publish <TARGET-PORT>:<SERVICE-PORT>` flag. The swarm
 makes the service accessible at the target port **on every swarm node**. If an
 external host connects to that port on any swarm node, the routing mesh routes
 it to a task. The external host does not need to know the IP addresses or


### PR DESCRIPTION
Something weird here happened where the backtick wasn't being detected as the opening of a code-format section. Will be curious to see if this fixes it.

Closes #1209 

Signed-off-by: LRubin <lrubin@docker.com>