### PR TITLE
Clarify --opt encrypted option

### DIFF
--- a/swarm/networking.md
+++ b/swarm/networking.md
@@ -99,7 +99,8 @@ NETWORK ID          NAME                   DRIVER
 5262bbfe5616        node-1/bridge2         bridge
 ```
 
-`--opt encrypted` is a Docker Swarm-mode only feature. It's not supported in Swarm standalone. Network encryption requires key management which is outside the scope of Swarm.
+`--opt encrypted` is a feature only available in Docker Swarm mode. It's not supported in Swarm standalone.
+Network encryption requires key management, which is outside the scope of Swarm.
 
 ## Remove a network
 

--- a/swarm/networking.md
+++ b/swarm/networking.md
@@ -99,6 +99,8 @@ NETWORK ID          NAME                   DRIVER
 5262bbfe5616        node-1/bridge2         bridge
 ```
 
+`--opt encrypted` is a Docker Swarm-mode only feature. It's not supported in Swarm standalone. Network encryption requires key management which is outside the scope of Swarm.
+
 ## Remove a network
 
 To remove a network you can use its ID or its name. If two different networks


### PR DESCRIPTION
Signed-off-by: Dong Chen <dongluo.chen@docker.com>


### Proposed changes

Docker network encryption option is not supported in Swarm standalone.

### Related issues (optional)

https://github.com/docker/swarm/issues/2606
