### PR TITLE
browse to docker hub link now in markup

### DIFF
--- a/engine/getstarted/step_three.md
+++ b/engine/getstarted/step_three.md
@@ -15,7 +15,7 @@ image you'll use in the rest of this getting started.
 
 ## Step 1: Locate the whalesay image
 
-1. Open your browser and  <a href="https://hub.docker.com/?utm_source=getting_started_guide&utm_medium=embedded_MacOSX&utm_campaign=find_whalesay" target=_blank> browse to the Docker Hub</a>.
+1. Open your browser and  ![browse to the Docker Hub](https://hub.docker.com/?utm_source=getting_started_guide&utm_medium=embedded_MacOSX&utm_campaign=find_whalesay)
 
     ![Browse Docker Hub](tutimg/browse_and_search.png)
 


### PR DESCRIPTION
### Proposed changes

Change browse to docker hub link on the getting started step three page to markup language link rather then an anchor tag because it was showing as an anchor element on the site rather then a normal link. 

Can be seen at https://docs.docker.com/engine/getstarted/step_three/

