### PR TITLE
Fix usage of wait-for-postgres.sh

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -42,7 +42,7 @@ script:
               - "80:8000"
             depends_on:
               - "db"
-            command: ["./wait-for-it.sh", "db:5432", "--", "python", "app.py"]
+            command: ["./wait-for-it.sh", "db", "--", "python", "app.py"]
           db:
             image: postgres
 


### PR DESCRIPTION
The docker-compose example file passed `db:5432` as the `-h` option for psql. However, `-h` is to specify the hostname, and doesn't
accept a port number.
