### PR TITLE
Don't fetch the registry api template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/extend 
  && wget -O allv/engine/reference/commandline/cli.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/commandline/cli.md \
  && wget -O allv/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
  && svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_BRANCH/docs/spec allv/registry/spec \
+ && rm allv/registry/spec/api.md.tmpl \
  && wget -O allv/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
  && rm -rf allv/apidocs/cloud-api-source \
  && rm -rf allv/tests \


### PR DESCRIPTION
This file causes build errors (see https://jenkins.dockerproject.org/job/docker/job/docker-github-io.b3m3d0/job/PR-1340/2/console) and it only used by the Registry project, not by us. We consume the files that they generate using the template.

cc @stevvooe 