### PR TITLE
Fix broken link

### DIFF
--- a/engine/getstarted/step_three.md
+++ b/engine/getstarted/step_three.md
@@ -15,7 +15,7 @@ image you'll use in the rest of this getting started.
 
 ## Step 1: Locate the whalesay image
 
-1. Open your browser and  <a href="https://hub.docker.com/?utm_source=getting_started_guide&utm_medium=embedded_MacOSX&utm_campaign=find_whalesay" target=_blank> browse to the Docker Hub</a>.
+1. Open your browser and [browse the Docker Hub](https://hub.docker.com/?utm_source=getting_started_guide&utm_medium=embedded_MacOSX&utm_campaign=find_whalesay).
 
     ![Browse Docker Hub](tutimg/browse_and_search.png)
 


### PR DESCRIPTION
### Proposed changes

Fix link format by updating its format to markdown.

URL: https://docs.docker.com/engine/getstarted/step_three/
Screenshot:
![screen shot 2017-01-24 at 09 41 25](https://cloud.githubusercontent.com/assets/213251/22241912/4e3b35f8-e219-11e6-9d9c-63c015b76bbc.png)
