### PR TITLE
fix link to logging context

### DIFF
--- a/engine/admin/logging/log_tags.md
+++ b/engine/admin/logging/log_tags.md
@@ -42,7 +42,7 @@ original container name.
 
 For advanced usage, the generated tag's use [go
 templates](http://golang.org/pkg/text/template/) and the container's [logging
-context](https://github.com/docker/docker/blob/master/daemon/logger/context.go).
+context](https://github.com/docker/docker/blob/v1.13.0/daemon/logger/context.go).
 
 As an example of what is possible with the syslog logger, if you use the following
 command, you get the output that follows:


### PR DESCRIPTION
this source file no longer exists on "master",
so replacing the link with a permalink on the
1.13 tag.

fixes https://github.com/docker/docker/issues/30403