### PR TITLE
Add 'Why Docker for AWS/Azure' doc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -65,6 +65,8 @@ toc:
       title: Optional post-installation steps
   - sectiontitle: Docker for AWS
     section:
+    - path: /docker-for-aws/why/
+      title: Why Docker for AWS?
     - path: /docker-for-aws/
       title: Setup & Prerequisites
     - path: /docker-for-aws/iam-permissions/
@@ -81,6 +83,8 @@ toc:
       title: Release Notes
   - sectiontitle: Docker for Azure
     section:
+    - path: /docker-for-azure/why/
+      title: Why Docker for Azure?
     - path: /docker-for-azure/
       title: Setup & Prerequisites
     - path: /docker-for-azure/upgrade/

--- a/_includes/why_d4a.md
+++ b/_includes/why_d4a.md
@@ -1,0 +1,104 @@
+The [Docker for {{cloudprovider}}](https://docs.docker.com/docker-for-{{cloudprovider | downcase}}/)
+project was created and is being actively developed to ensure that Docker users
+can enjoy a fantastic out-of-the-box experience on {{cloudprovider}}. It is now
+generally available and can now be used by everyone.
+
+As an informed user, you might be curious to know what this project has to offer
+you for running your development, staging, or production workloads.
+
+## Native to Docker
+
+Docker for {{cloudprovider}} provides a Docker-native solution that avoids
+operational complexity and adding unneeded additional APIs to the Docker stack.
+
+Docker for {{cloudprovider}} allows you to interact with Docker directly
+(including native Docker orchestration), instead of distracting you with the
+need to navigate extra layers on top of Docker. You can focus instead on the
+thing that matters most: running your workloads. This will help you and your
+team to deliver more value to the business faster, to speak one common
+"language", and to have fewer details to keep in your head at once.
+
+The skills that you and your team have already learned, and will continue to
+learn, using Docker on the desktop or elsewhere will automatically carry over to
+using Docker on {{cloudprovider}}. The added consistency across clouds also
+helps to ensure that a migration or multi-cloud strategy is easier to accomplish
+in the future if desired.
+
+## Skip the boilerplate and maintenance work
+
+Docker for {{cloudprovider}} bootstraps all of the recommended infrastructure to
+start using Docker on {{cloudprovider}} automatically. You don't need to worry
+about rolling your own instances, security groups, or load balancers when using
+Docker for {{cloudprovider}}.
+
+Likewise, setting up and using Docker swarm mode functionality for container
+orchestration is managed across the cluster's lifecycle when you use Docker for
+{{cloudprovider}}. Docker has already coordinated the various bits of automation
+you would otherwise be gluing together on your own to bootstrap Docker swarm
+mode on these platforms. When the cluster is finished booting, you can jump
+right in and start running `docker service` commands.
+
+We also provide a prescriptive upgrade path that helps users upgrade between
+various versions of Docker in a smooth and automatic way. Instead of
+experiencing "maintenance dread" as you ponder your future responsibilities
+upgrading the software you are using, you can easily upgrade to new versions
+when they are released.
+
+## Minimal, Docker-focused base
+
+The custom Linux distribution used by Docker for {{cloudprovider}} is carefully
+developed and configured to run Docker well. Everything from the kernel
+configuration to the networking stack is customized to make it a favorable place
+to run Docker. For instance, we make sure that the kernel versions are
+compatible with the latest and greatest in Docker functionality, such as the
+`overlay2` storage driver.
+
+Instead of facing the trade-offs of a general purpose operating system, Docker's
+custom Linux distribution focuses on only one thing: providing the best _Docker_
+experience for you and your team.
+
+## Self-cleaning and self-healing
+
+Even the most conscientious admin can be caught off guard by issues such as
+unexpectedly aggressive logging or the Linux kernel killing memory-hungry
+processes. In Docker for {{cloudprovider}}, your cluster is resilient to a
+variety of such issues by default.
+
+Log rotation native to the host is configured for you automatically, so chatty
+logs won't use up all of your disk space. Likewise, the "system prune" option
+allows you to ensure unused Docker resources such as old images are cleaned up
+automatically. The lifecycle of nodes is managed using auto-scaling groups or
+similar constructs, so that if a node enters an unhealthy state for unforeseen
+reasons, the node will be taken out of load balancer rotation and/or replaced
+automatically and all of its container tasks will be rescheduled.
+
+These self-cleaning and self-healing properties are enabled by default and don't
+need configuration, so you can breathe easier as the risk of downtime is
+reduced.
+
+## Logging native to the platforms
+
+Centralized logging is a critical component of many modern infrastructure
+stacks. To have these logs indexed and searchable proves invaluable for
+debugging appliation and system issues as they come up. Out of the box, Docker
+for {{cloudprovider}} forwards logs from containers to a native cloud provider
+abstraction ({{cloudprovider_log_dest}}).
+
+## Next-generation Docker bug reporting tools
+
+One common pain point in open source issue reporting is effectively
+communicating the current state of your infrastructure and the issues you are
+seeing to the upstream. In Docker for {{cloudprovider}}, you receive new tools
+to communicate any issues you experience quickly and securely to Docker
+employees. The Docker for {{cloudprovider}} shell includes a `docker-diagnose`
+script which, at your request, will transmit detailed diagnostic information to
+Docker support staff to reduce the traditional
+"please-post-the-output-of-this-command" back and forth frequently encountered
+in bug reports.
+
+# Try it today
+
+Ready to get started? [Try Docker for {{cloudprovider}} today](https://docs.docker.com/docker-for-{{cloudprovider | downcase}}/).
+We'd be happy to hear your feedback via e-mail at docker-for-iaas@docker.com or
+in the issue repository
+[for {{cloudprovider}}](https://github.com/docker/for-{{cloudprovider | downcase}}).

--- a/docker-for-aws/why.md
+++ b/docker-for-aws/why.md
@@ -1,0 +1,9 @@
+---
+description: Why Docker for AWS?
+keywords: aws, amazon, iaas, why
+title: Why Docker for AWS?
+---
+
+{% assign cloudprovider_log_dest = 'CloudWatch' %}
+{% assign cloudprovider = 'AWS' %}
+{% include why_d4a.md %}

--- a/docker-for-azure/why.md
+++ b/docker-for-azure/why.md
@@ -1,0 +1,9 @@
+---
+description: Why Docker for Azure?
+keywords: azure, microsoft, iaas, why
+title: Why Docker for Azure?
+---
+
+{% assign cloudprovider_log_dest = 'a storage account in the created resource group' %}
+{% assign cloudprovider = 'Azure' %}
+{% include why_d4a.md %}

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -32,8 +32,15 @@ Docker on a different Linux distribution, consider
 
 ## On Cloud
 
-You can use Docker Cloud to automatically provision and manage your cloud
-instances:
+We provide official Docker solutions for running on AWS and Azure. You can read
+up on what Docker for AWS and Docker for Azure have to offer you
+[here](/docker-for-aws/why/) and [here](/docker-for-azure/why/) respectively.
+
+* [Docker for AWS](/docker-for-aws/)
+* [Docker for Azure](/docker-for-azure/)
+
+We also provide guides for connecting the following cloud providers to your
+Docker Cloud account to automatically provision and manage your cloud instances.
 
 * [Amazon Web Services setup guide](/docker-cloud/infrastructure/link-aws.md)
 * [DigitalOcean setup guide](/docker-cloud/infrastructure/link-do.md)
@@ -41,12 +48,6 @@ instances:
 * [Packet setup guide](/docker-cloud/infrastructure/link-packet.md)
 * [SoftLayer setup guide](/docker-cloud/infrastructure/link-softlayer.md)
 * [Use the Docker Cloud Agent to Bring your Own Host](/docker-cloud/infrastructure/byoh.md)
-
-You can also use our official Docker Editions if you'd like to manually manage
-your cloud instances:
-
-* [Docker for AWS](/docker-for-aws/)
-* [Docker for Azure](/docker-for-azure/)
 
 ## Prior releases
 


### PR DESCRIPTION
Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>

### Proposed changes

Add motivations doc for users of Docker for AWS/Azure.

### Related issues (optional)

Closes https://github.com/docker/editions/issues/643

@mstanleyjones @johndmulhausen Please take a look.  I feel this would make a good addition to our current documentation explaining _why_ users might want to use these products.  I'm not so sure about information architecture, e.g., where to place it so that it's accessible from both sections.  Open to ideas.

FYI @FrenchBen @friism 
