### PR TITLE
Fix language within devicemapper thinpool setup

### DIFF
--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -237,7 +237,7 @@ assumes that the Docker daemon is in the `stopped` state.
     $ vgcreate docker /dev/xvdf
     ```
 
-5.  Create a thin pool named `thinpool`.
+5.  Create a logical volume named `thinpool` and `thinpoolmeta`.
 
     In this example, the data logical is 95% of the 'docker' volume group size.
     Leaving this free space allows for auto expanding of either the data or


### PR DESCRIPTION
### Proposed changes

Previous language indicated that a user would be "creating a thin pool". This language is confusing as it indicates that the logical volume created is of the thin pool type; instead, the volume being created is a linear volume group which is then converted to a thin pool in step 6. This is an important nuance when implementing setup through configuration management tools such as Salt or Ansible. When initially provisioning the two logical volumes as thin pool, the error "Pool metadata LV docker/thinpoolmeta is of an unsupported type". Updating the language reflects the actual command behaviors. 

### Related issues (optional)

N/A