### PR TITLE
Change cloud.docker.com/login to id.docker.com/login in site template

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -119,7 +119,7 @@ ng\:form {
               <li class="leaf menu-mlid-402"><a href="https://training.docker.com/" target="_blank">Training</a></li>
               <li class="leaf menu-mlid-2000"><a href="https://www.docker.com/partners/partner-program">Partners</a></li>
               <li class="leaf menu-mlid-602"><a href="https://blog.docker.com/" target="_blank">Blog</a></li>
-              <li class="leaf menu-mlid-2001"><a href="https://cloud.docker.com/login/" target="_blank">Log-In</a></li>
+              <li class="leaf menu-mlid-2001"><a href="https://id.docker.com/login/" target="_blank">Log-In</a></li>
               <li class="last leaf menu-mlid-2002"><a href="https://cloud.docker.com/" target="_blank">Sign-up</a></li>
             </ul>
             <ul class="nav-main">
@@ -185,7 +185,7 @@ ng\:form {
         <li class="leaf menu-mlid-402"><a href="https://training.docker.com/" target="_blank">Training</a></li>
         <li class="leaf menu-mlid-2000"><a href="https://www.docker.com/partners/partner-program">Partners</a></li>
         <li class="leaf menu-mlid-602"><a href="https://blog.docker.com/" target="_blank">Blog</a></li>
-        <li class="leaf menu-mlid-2001"><a href="https://cloud.docker.com/login/" target="_blank">Log-In</a></li>
+        <li class="leaf menu-mlid-2001"><a href="https://id.docker.com/login/" target="_blank">Log-In</a></li>
         <li class="last leaf menu-mlid-2002"><a href="https://cloud.docker.com/" target="_blank">Sign-up</a></li>
       </ul>
     </aside>


### PR DESCRIPTION
The old URL redirects to the new one, so let's use the new one. This currently comes in the W3C validator as "broken".