### PR TITLE
remove reference to overlay2 as a filesystem

### DIFF
--- a/engine/userguide/storagedriver/selectadriver.md
+++ b/engine/userguide/storagedriver/selectadriver.md
@@ -67,8 +67,8 @@ backing filesystem:
 
 |Storage driver |Commonly used on |Disabled on                                         |
 |---------------|-----------------|----------------------------------------------------|
-|`overlay`      |`ext4` `xfs`     |`btrfs` `aufs` `overlay` `overlay2` `zfs` `eCryptfs`|
-|`overlay2`     |`ext4` `xfs`     |`btrfs` `aufs` `overlay` `overlay2` `zfs` `eCryptfs`|
+|`overlay`      |`ext4` `xfs`     |`btrfs` `aufs` `overlay` `zfs` `eCryptfs`|
+|`overlay2`     |`ext4` `xfs`     |`btrfs` `aufs` `overlay` `zfs` `eCryptfs`|
 |`aufs`         |`ext4` `xfs`     |`btrfs` `aufs` `eCryptfs`                           |
 |`btrfs`        |`btrfs` _only_   |   N/A                                              |
 |`devicemapper` |`direct-lvm`     |   N/A                                              |


### PR DESCRIPTION
`overlay2` was incorrectly included as a filesystem that the `overlay` and `overlay2` storage drivers can't run on. `overlay2` is the name of the storage driver, but the filesystem is just called `overlay`. It was called `overlayfs` in older versions or the kernel, which would have helped disambiguate this, but I think we should continue to use `overlay` as the name of the filesystem because that's what the kernel uses now.