### PR TITLE
added missing descriptions for update_config options

### DIFF
--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -253,8 +253,8 @@ updates.
 - `delay`: The time to wait between updating a group of containers.
 - `failure_action`: What to do if an update fails. One of `continue` or `pause`
   (default: `pause`).
-- `monitor`: TODO
-- `max_failure_ratio`: TODO
+- `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
+- `max_failure_ratio`: Failure rate to tolerate during an update.
 
     update_config:
       parallelism: 2


### PR DESCRIPTION

### Updates info

* added missing descriptions for `monitor` and `max_failure_ratio` to Compose file

### Related issues

#1376 

[PR 30186](https://github.com/docker/docker/pull/30186) on `docker/docker` 

### Please review

@caervs @thaJeztah @dnephin @shin- 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
