### PR TITLE
update sample output regarding package version information

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -129,11 +129,11 @@ Docker from the repository.
 
     ```bash
     $ apt-cache madison docker-engine
-
-    docker-engine | 1.13.0-0~xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
-    docker-engine | 1.12.3-0~xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
-    docker-engine | 1.12.2-0~xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
-    docker-engine | 1.12.1-0~xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
+    
+    docker-engine | 1.13.0-0~ubuntu-xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
+    docker-engine | 1.12.6-0~ubuntu-xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
+    docker-engine | 1.12.5-0~ubuntu-xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
+    docker-engine | 1.12.4-0~ubuntu-xenial | https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
     ```
 
     The contents of the list depend upon which repositories are enabled,


### PR DESCRIPTION
On my ubuntu 16.04 it is shown as `1.13.0-0~ubuntu-xenial` instead of `1.13.0-0~xenial`
