### PR TITLE
software-properties-common is required for add-apt-repository

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -65,6 +65,7 @@ Docker from the repository.
 
     ```bash
     $ sudo apt-get install apt-transport-https \
+                           software-properties-common \
                            ca-certificates
     ```
 


### PR DESCRIPTION
software-properties-common is not included in minimal server / cloud installs, and is required for the step "add-apt-repository" to work