### PR TITLE
restore docker-compose docs that were lost during migration

### DIFF
--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -1113,7 +1113,7 @@ then read-write will be used.
 >     - container_name
 >     - container_name:rw
 
-### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, oom_score_adj, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
+### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, mem\_swappiness, oom\_score\_adj, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
 
 > **Note:** Resource constraint options (`cpu_shares`, `cpu_quota`, `cpuset`,
 > `mem_limit`, `memswap_limit`) have been removed in
@@ -1139,6 +1139,7 @@ Each of these is a single value, analogous to its
 
     mem_limit: 1000000000
     memswap_limit: 2000000000
+    mem_swappiness: 10
     privileged: true
 
     oom_score_adj: 500

--- a/compose/reference/rm.md
+++ b/compose/reference/rm.md
@@ -10,8 +10,7 @@ Usage: rm [options] [SERVICE...]
 Options:
     -f, --force   Don't ask to confirm removal
     -v            Remove any anonymous volumes attached to containers
-    -a, --all     Also remove one-off containers created by
-                  docker-compose run
+    -a, --all     Deprecated - no effect.
 ```
 
 Removes stopped service containers.

--- a/compose/swarm.md
+++ b/compose/swarm.md
@@ -6,6 +6,13 @@ keywords: documentation, docs,  docker, compose, orchestration, containers, swar
 title: Use Compose with Swarm
 ---
 
+> **Note:** “Swarm” here refers to [Docker Swarm](/swarm/overview.md), a product
+> separate from Docker Engine. It does _not_ refer to [swarm mode](/engine/swarm),
+> which is a built-in feature of Docker Engine introduced in version 1.12.
+>
+> Integration between Compose and swarm mode is at the experimental stage. See
+> [Docker Stacks and Bundles](bundles.md) for details.
+
 Docker Compose and [Docker Swarm](/swarm/overview.md) aim to have full integration, meaning
 you can point a Compose app at a Swarm cluster and have it all just work as if
 you were using a single Docker host.


### PR DESCRIPTION
During the migration of the docs from the docker-compose repository to the
docker.github.io repository, some changes were made in the docker/compose 
registry after the initial import in the `vnext-compose` branch.

The first import in vnext-compose was taken from the [docs-v1.8.0-2016-08-03](https://github.com/docker/compose/tree/docs-v1.8.0-2016-08-03)
tag, corresponding with this commit https://github.com/docker/compose/commit/429320a4f8f4040b273fd4d1be9f1d0b1283dc23 (cherry-picked
from https://github.com/docker/compose/commit/589fb4925e7620cf2631b491acc5e2df4f96b69c).
The last commit in the docs directory in docker/compose, before the docs were removed was
https://github.com/docker/compose/commit/f65f89ad8c26684a314d9099fe35bcea07dbe5dc

And the following changes were made on master
https://github.com/docker/compose/compare/589fb4925e7620cf2631b491acc5e2df4f96b69c...f65f89ad8c26684a314d9099fe35bcea07dbe5dc

of those https://github.com/docker/compose/commit/f65f89ad8c26684a314d9099fe35bcea07dbe5dc, https://github.com/docker/compose/commit/6fe5d2b54351143ee4eab090ccd58c5067985078, and https://github.com/docker/compose/commit/dada36f732ed7f7fc05c0f9841a432c490c7ff9c were already added through https://github.com/docker/docker.github.io/pull/285

This PR adds the missing changes from;

- https://github.com/docker/compose/commit/4cba653eeb3c054557a02b23b905da8a11bbc8e5 (https://github.com/docker/compose/pull/3814)
- https://github.com/docker/compose/commit/17f46f8999e66e3dbb8f8438002caf17fe6065a6 (https://github.com/docker/compose/pull/3808)
- https://github.com/docker/compose/commit/d824cb9b0678ec2ad460b034231c00c05df8c0fe (https://github.com/docker/compose/pull/3542)


ping @shin-, @mstanleyjones 