### PR TITLE
remove apidocs/layout after jekyll build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/extend 
  && rm -rf allv/tests \
  && wget -O allv/engine/api/v1.25/swagger.yaml https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/api/swagger.yaml \
  && jekyll build -s allv -d allvbuild \
- && rm -rf allv/apidocs/layouts \
+ && rm -rf allvbuild/apidocs/layouts \
  && find allvbuild -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
  && rm -rf allv
 


### PR DESCRIPTION
### Proposed changes

I made a mistake in #1357. I removed apidocs/layout from the source and not from the output of jekyll build. It's now fixed, and it fixes broken links for #1068. 