### PR TITLE
EG about sharing dir btw host and container

### DIFF
--- a/docker-for-mac/osxfs.md
+++ b/docker-for-mac/osxfs.md
@@ -37,24 +37,31 @@ Docker user who started the containers.
 
 ### Namespaces
 
-Much of the OS X file system that is accessible to the user is also available to
-containers using the `-v` bind mount syntax. For example, the command 
+Much of the macOS file system that is accessible to the user is also available to
+containers using the `-v` bind mount syntax. The following command runs a container
+from an image called `r-base` and shares the macOS user's `~/Desktop/` directory as
+`/Desktop` in the container.
 
-`docker run -it -v ~/Desktop:/Desktop r-base bash`
+```bash
+$ docker run -it -v ~/Desktop:/Desktop r-base bash
+```
 
-runs the Docker image called `r-base`, shares the Desktop of OSX in `/Desktop` and 
-starts bash. You can see the folder called Desktop inside the container such that
+The user's `~/Desktop/` directory is now visible in the container as a directory
+under `/`.
 
 `root@2h30fa0c600e:/# ls
 bin  boot  Desktop  dev  etc  home  lib  lib32	lib64  libx32  media  mnt  opt	proc  root  run  sbin  srv  sys  tmp  usr  var`
 
-and, by default, you can share files in `/Users`, `/Volumes`, `/private`, and `/tmp` 
-directly. To add or remove directory trees that are exported to Docker, use the 
-**File sharing** tab in Docker preferences <img src="../images/whale-x.png"> -> **Preferences** ->
-**File sharing**. (See [Preferences](index.md#preferences).) All other paths
+By default, you can share files in `/Users/`, `/Volumes/`, `/private/`, and `/tmp` 
+directly.
+To add or remove directory trees that are exported to Docker, use the 
+**File sharing** tab in Docker preferences ![Docker Preferences]("docker-for-mac/images/whale-x.png) -> **Preferences** ->
+**File sharing**. (See [Preferences](index.md#preferences).)
+
+All other paths
 used in `-v` bind mounts are sourced from the Moby Linux VM running the Docker
 containers, so arguments such as `-v /var/run/docker.sock:/var/run/docker.sock`
-should work as expected. If an OS X path is not shared and does not exist in the
+should work as expected. If a macOS path is not shared and does not exist in the
 VM, an attempt to bind mount it will fail rather than create it in the VM. Paths
 that already exist in the VM and contain files are reserved by Docker and cannot
 be exported from OS X.

--- a/docker-for-mac/osxfs.md
+++ b/docker-for-mac/osxfs.md
@@ -38,10 +38,19 @@ Docker user who started the containers.
 ### Namespaces
 
 Much of the OS X file system that is accessible to the user is also available to
-containers using the `-v` bind mount syntax. By default, you can share files in
-`/Users`, `/Volumes`, `/private`, and `/tmp` directly. To add or remove
-directory trees that are exported to Docker, use the **File sharing** tab in
-Docker preferences <img src="../images/whale-x.png"> -> **Preferences** ->
+containers using the `-v` bind mount syntax. For example, the command 
+
+`docker run -it -v ~/Desktop:/Desktop r-base bash`
+
+runs the Docker image called `r-base`, shares the Desktop of OSX in `/Desktop` and 
+starts bash. You can see the folder called Desktop inside the container such that
+
+`root@2h30fa0c600e:/# ls
+bin  boot  Desktop  dev  etc  home  lib  lib32	lib64  libx32  media  mnt  opt	proc  root  run  sbin  srv  sys  tmp  usr  var`
+
+and, by default, you can share files in `/Users`, `/Volumes`, `/private`, and `/tmp` 
+directly. To add or remove directory trees that are exported to Docker, use the 
+**File sharing** tab in Docker preferences <img src="../images/whale-x.png"> -> **Preferences** ->
 **File sharing**. (See [Preferences](index.md#preferences).) All other paths
 used in `-v` bind mounts are sourced from the Moby Linux VM running the Docker
 containers, so arguments such as `-v /var/run/docker.sock:/var/run/docker.sock`


### PR DESCRIPTION
Very basic example is lacking here about how to share a directory and where it appears so added the example

`docker run -it -v ~/Desktop:/Desktop r-base bash`

and demonstrating it with bash.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The current docs are very inaccessible, simple demos missing about how to share the host directories with the containers. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
