### PR TITLE
added better description of disk image beta 39 feature

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -307,15 +307,12 @@ containers and images are stored.
 
 ##### Disk image location (Beta)
 
-Starting with Beta 39, the labels on this dialog were updated as follows.
+Starting with Beta 39, _storage image_ is referred to as _disk image_, and is tracked by the app.  If you attempt to move the disk image to a location that already has one, you will get a prompt asking if you want to use the existing image or replace it. For Beta releases going forward, the labels on this dialog were updated as follows.
 
 *  **Storage location** is renamed to **Disk image location**
 *  **Change location** button is renamed to **move disk image**
 
 ![Beta Advanced settings](images/settings-advanced-beta.png)
-
-
-
 
 ### HTTP proxy settings
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -277,7 +277,7 @@ events or unexpected unmounts.
 
 **New**
 
-- More options when moving disk image
+- More options when moving disk image (see [Storage location](index.md#storage-location) under Advanced preference settings)
 - Filesharing and daemon table empty fields are editable
 - DNS forwarder ignores responses from malfunctioning servers ([docker/for-mac#1025](https://github.com/docker/for-mac/issues/1025))
 - DNS forwarder send all queries in parallel, process results in order


### PR DESCRIPTION
Added description of disk image options for d4mac and linked from the Beta 39 release note for this item into the docs topic on it.

@dsheets @dave-tucker 

@simonferquel per your Slack comment, I'll cover this on Windows when it's in, I made no changes to Windows docs with regard to this for now

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
