### PR TITLE
Add Azure page to TOC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -83,6 +83,8 @@ toc:
     section:
     - path: /docker-for-azure/
       title: Setup & Prerequisites
+    - path: /docker-for-azure/deploy/
+      title: Deploy applications
     - path: /docker-for-azure/upgrade/
       title: Upgrading
     - path: /docker-for-azure/faqs/


### PR DESCRIPTION
@FrenchBen when integrating the Docker for Azure docs into this repo, we left [this page](https://github.com/docker/docker.github.io/blob/ba905579952f741b7d80210d73ba1bec723f30b0/docker-for-azure/deploy.md) out of the left nav. I'm assuming this wasn't on purpose and this PR fixes that.