### PR TITLE
graphical and format updates for workflow steps on home page

### DIFF
--- a/_includes/content/typical_docker_workflow.md
+++ b/_includes/content/typical_docker_workflow.md
@@ -1,20 +1,23 @@
-### Typical Docker Platform Workflow
+### Typical Docker workflow
 
-1. Get your code and its dependencies into Docker [containers](engine/getstarted/step_two.md):
-   - [Write a Dockerfile](engine/getstarted/step_four.md) that specifies the execution
-     environment and pulls in your code.
-   - If your app depends on external applications (such as Redis, or
-     MySQL), simply [find them on a registry such as Docker Hub](docker-hub/repos.md), and refer to them in
-     [a Docker Compose file](compose/overview.md), along with a reference to your application, so they'll run
-     simultaneously.
-     - Software providers also distribute paid software via the [Docker Store](https://store.docker.com).
-   - Build, then run your containers on a virtual host via [Docker Machine](machine/overview.md) as you develop.
-2. Configure [networking](engine/tutorials/networkingcontainers.md) and
-   [storage](engine/tutorials/dockervolumes.md) for your solution, if needed.
-3. Upload builds to a registry ([ours](/engine/getstarted/step_six.md), [yours](/datacenter/dtr/2.0/index.md), or your cloud provider's), to collaborate with your team.
-4. If you're gonna need to scale your solution across multiple hosts (VMs or physical machines), [plan
-   for how you'll set up your Swarm cluster](engine/swarm/key-concepts.md) and [scale it to meet demand](engine/swarm/swarm-tutorial/index.md).
-   - Note: Use [Universal Control Plane](/datacenter/ucp/1.1/overview.md) and you can manage your
-     Swarm cluster using a friendly UI!
-5. Finally, deploy to your preferred
-   cloud provider (or, for redundancy, *multiple* cloud providers) with [Docker Cloud](/docker-cloud/index.md). Or, use [Docker Datacenter](https://www.docker.com/products/docker-datacenter), and deploy to your own on-premise hardware.
+<span style="font-size: 122%; color: #5D6D7E; font-weight: 150;">&#9312; Get your code and its dependencies into Docker [containers](engine/getstarted/step_two.md).</span>
+
+<span style="font-size: 110%; color: #5D6D7E; font-weight: 150; display: block; padding-left: 2em;">- [Write a Dockerfile](engine/getstarted/step_four.md) that
+defines the execution environment and pulls in your code.</span>
+
+<span style="font-size: 110%; color: #5D6D7E; font-weight: 150; display: block; padding-left: 2em;">- If your app depends on external services (such as Redis or MySQL), [find them on a registry like Docker Hub](docker-hub/repos.md), and refer to them in [a Docker Compose file](compose/overview.md), along with a call to your app, so they'll run simultaneously.</span>
+
+<span style="font-size: 110%; color: #5D6D7E; font-weight: 150; display: block; padding-left: 2em;">-  Software providers also distribute paid software on the [Docker Store](https://store.docker.com).</span>
+
+<span style="font-size: 110%; color: #5D6D7E; font-weight: 150; display: block; padding-left: 2em;">-  Build, then run your containers on a virtual host with [Docker Machine](machine/overview.md) as you develop.</span>
+<p />
+<span style="font-size: 122%; color: #5D6D7E; font-weight: 150;">&#9313; Configure [networking](engine/tutorials/networkingcontainers.md) and [storage](engine/tutorials/dockervolumes.md) for your solution, if needed.</span>
+
+<span style="font-size: 122%; color: #5D6D7E; font-weight: 150;">&#9314; Upload builds to a registry ([ours](/engine/getstarted/step_six.md) or [yours](/datacenter/dtr/2.0/index.md)) or your cloud providers to collaborate with your team.</span>
+
+<span style="font-size: 122%; color: #5D6D7E; font-weight: 150;">&#9315;
+To run your app as a set of services across multiple hosts, [set up a Swarm cluster](/engine/swarm/index.md) and
+[scale it to meet demand](/engine/swarm/swarm-tutorial/scale-service.md). Use [Universal Control Plane](/datacenter/ucp/1.1/overview.md) to manage your swarm in a friendly UI!</span>
+
+<span style="font-size: 122%; color: #5D6D7E; font-weight: 150;">&#9316;
+Deploy to your preferred cloud providers with [Docker Cloud](/docker-cloud/index.md), or use [Docker Datacenter](https://www.docker.com/products/docker-datacenter) to deploy to your own on-premise hardware.</span>

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -136,6 +136,7 @@
 }
 /* reset away from #008AB5 */
 
+/* removed hard-coded color for button links pre new CSS from Design */
 #DocumentationText a.button {
 }
 
@@ -144,6 +145,7 @@
     margin-top: 15px;
 }
 
+/*  hard coded color and other settings pre new CSS from Design */
 #DocumentationText .secondary-btn,
    button .secondary-btn {
      border: 2px solid #1488c6;
@@ -163,6 +165,12 @@
 #DocumentationText .secondary-btn:hover,
    button .secondary-btn:hover {
    opacity: .8;
+}
+
+/* box shadow for docs home page workflow*/
+
+#DocumentationText .boxer
+{box-shadow: 2px 2px #888, -2px -2px #F4D03F, 0px 0px 5px 5px #F4D03F;
 }
 
 #DocumentationText table {

--- a/engine/getstarted-voting-app/customize-app.md
+++ b/engine/getstarted-voting-app/customize-app.md
@@ -87,7 +87,7 @@ networking.
 [Build your own image](/engine/getstarted/step_four.md) in Get Started with
 Docker and topics on images in [Learn by example](/engine/tutorials/index.md).
 
-* For more about `docker-stack.yml` and the `docker stack deploy` command,
+* For more about the `docker-stack.yml` and the `docker stack deploy` commands,
 see [deploy](/compose/compose-file.md#deploy) in the [Compose file
 reference](/compose/compose-file.md) and [`docker stack
 deploy`](/engine/reference/commandline/stack_deploy.md) in the Docker Engine


### PR DESCRIPTION
Stop gap formatting updates to the "Typical Workflow .." on the docs home page

I know Design will give us the new graphical version of this soon, but in the meantime I thought it would be nice to spruce it up. Here is what I've done:

- Added new formatting and graphical circled images (embedded CSS for now)

- Simplified, shortened up some of the text

- Updated one or two of the links (e.g., "scale a swarm" now goes directly to a topic in the tutorial on how to scale a service).

Let me know if you think this is going in the right direction. You will need to look at it on the Netlify preview to see what it actually looks like.

@johndmulhausen @Raphaelbouchard @mstanleyjones @thaJeztah 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

