### PR TITLE
Update documentation for CreateLogGroup support in awslogs

### DIFF
--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -64,7 +64,13 @@ Log driver will return an error by default if the log group does not exist. Howe
 `awslogs-create-group` to `true` to automatically create the log group as needed.
 The `awslogs-create-group` option defaults to `false`.
 
-    docker run --log-driver=awslogs --log-opt awslogs-region=us-east-1 --log-opt awslogs-group=myLogGroup --log-opt awslogs-create-group=true ...
+```bash
+$ docker run --log-driver=awslogs \
+             --log-opt awslogs-region=us-east-1 \
+             --log-opt awslogs-group=myLogGroup \
+             --log-opt awslogs-create-group=true \
+             ...
+```
 
 > **Note:**
 > Your AWS IAM policy must include the `logs:CreateLogGroup` permission before you attempt to use `awslogs-create-group`.

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -58,6 +58,17 @@ specified, the container ID is used as the log stream.
 > at a time.  Using the same log stream for multiple containers concurrently
 > can cause reduced logging performance.
 
+### awslogs-create-group
+
+Log driver will return an error by default if the log group does not exist. However, you can set the
+`awslogs-create-group` to `true` to automatically create the log group as needed.
+The `awslogs-create-group` option defaults to `false`.
+
+    docker run --log-driver=awslogs --log-opt awslogs-region=us-east-1 --log-opt awslogs-group=myLogGroup --log-opt awslogs-create-group=true ...
+
+> **Note:**
+> Your AWS IAM policy must include the `logs:CreateLogGroup` permission before you attempt to use `awslogs-create-group`.
+
 ### tag
 
 Specify `tag` as an alternative to the `awslogs-stream` option. `tag` interprets template markup (e.g., `{% raw %}{{.ID}}{% endraw %}`, `{% raw %}{{.FullID}}{% endraw %}` or `{% raw %}{{.Name}}{% endraw %}` `{% raw %}docker.{{.ID}}{% endraw %}`). 

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -303,6 +303,7 @@ The `awslogs` supports the following options:
 | `awslogs-region`       | Sets the region where the logs are sent. If not set, the container's region is used. | `--log-opt awslogs-region=us-east-1` |
 | `awslogs-group`        | The log group to use for the logs. | `--log-opt awslogs-group=myLogGroup` |
 | `awslogs-stream`       | The log stream to use. If not specified, the container ID is used as the log stream. | `--log-opt awslogs-stream=myLogStream` |
+| `awslogs-create-group` | If the option is set to true, create the log group if the log group does not exist yet. | `--log-opt awslogs-create-group=true` |
 
 ### Examples
 
@@ -314,6 +315,7 @@ $ docker run \
          --log-driver=awslogs \
          --log-opt awslogs-region=us-east-1 \
          --log-opt awslogs-group=myLogGroup \
+         --log-opt awslogs-create-group=true \
          alpine sh
 ```
 


### PR DESCRIPTION
This fix updates the documetation for CreateLogGroup support in awslogs

This fix is related to
https://github.com/docker/docker/issues/29334
https://github.com/docker/docker/pull/29504

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

/cc @thaJeztah 