### PR TITLE
Add instructions for manual start of Docker daemon

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -145,9 +145,13 @@ Docker from the repository.
     $ sudo yum -y install docker-engine-<VERSION_STRING>
     ```
 
-    The Docker daemon starts automatically.
+4.  Start Docker.
 
-4.  Verify that `docker` is installed correctly by running the `hello-world`
+    ```bash
+    $ sudo systemctl docker start
+    ```
+
+5.  Verify that `docker` is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -188,9 +192,13 @@ a new file each time you want to upgrade Docker.
     $ sudo yum -y install /path/to/package.rpm
     ```
 
-    The Docker daemon starts automatically.
+3.  Start Docker.
 
-3.  Verify that `docker` is installed correctly by running the `hello-world`
+    ```bash
+    $ sudo systemctl docker start
+    ```
+
+4.  Verify that `docker` is installed correctly by running the `hello-world`
     image.
 
     ```bash

--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -149,9 +149,13 @@ Docker from the repository.
     $ sudo dnf -y install docker-engine-<VERSION_STRING>
     ```
 
-    The Docker daemon starts automatically.
+4.  Start Docker.
 
-4.  Verify that `docker` is installed correctly by running the `hello-world`
+    ```bash
+    $ sudo systemctl docker start
+    ```
+
+5.  Verify that `docker` is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -192,9 +196,13 @@ a new file each time you want to upgrade Docker.
     $ sudo dnf -y install /path/to/package.rpm
     ```
 
-    The Docker daemon starts automatically.
+3.  Start Docker.
 
-3.  Verify that `docker` is installed correctly by running the `hello-world`
+    ```bash
+    $ sudo systemctl docker start
+    ```
+
+4.  Verify that `docker` is installed correctly by running the `hello-world`
     image.
 
     ```bash

--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -148,9 +148,13 @@ Docker from the repository.
     $ sudo yum -y install docker-engine-<VERSION_STRING>
     ```
 
-    The Docker daemon starts automatically.
+4.  Start Docker.
 
-4.  Verify that `docker` is installed correctly by running the `hello-world`
+    ```bash
+    $ sudo systemctl docker start
+    ```
+
+5.  Verify that `docker` is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -192,9 +196,13 @@ need to download a new file each time you want to upgrade Docker.
     $ sudo yum install /path/to/package.rpm
     ```
 
-    The Docker daemon starts automatically.
+3.  Start Docker.
 
-3.  Verify that `docker` is installed correctly by running the `hello-world`
+    ```bash
+    $ sudo systemctl docker start
+    ```
+
+4.  Verify that `docker` is installed correctly by running the `hello-world`
     image.
 
     ```bash


### PR DESCRIPTION
Docker daemon did not automatically start for me; running `sudo docker run hello` resulted in the following error message: 
```bash
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.
```

After starting the docker daemon manually using `dockerd`, I saw the expected information.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
