### PR TITLE
Added support for Beta channel deployment

### DIFF
--- a/_includes/d4a_buttons.md
+++ b/_includes/d4a_buttons.md
@@ -1,6 +1,20 @@
 {% capture aws_button_latest %}
-<a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank" id="aws-deploy">![Docker for AWS](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)</a>
+<a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank" class="aws-deploy">![Docker for AWS](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)</a>
+{% endcapture %}
+{% capture aws_blue_latest %}
+<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank">Deploy Docker for AWS (stable)</a>
+{% endcapture %}
+{% capture aws_blue_beta %}
+<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/beta/Docker.tmpl" data-rel="Beta-14" target="blank">Deploy Docker for AWS (beta)</a>
+{% endcapture %}
+
+{% capture azure_blue_latest %}
+<a class="button darkblue-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="blank">Deploy Docker for Azure (stable)</a>
+{% endcapture %}
+{% capture azure_blue_beta %}
+<a class="button darkblue-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fbeta%2FDocker.tmpl" data-rel="Beta-14" target="blank">Deploy Docker for Azure (beta)</a>
 {% endcapture %}
 {% capture azure_button_latest %}
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="_blank" class="_" id="azure-deploy">![Docker for Azure](http://azuredeploy.net/deploybutton.png)</a>
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="_blank" class="azure-deploy">![Docker for Azure](http://azuredeploy.net/deploybutton.png)</a>
 {% endcapture %}
+

--- a/_includes/d4a_buttons.md
+++ b/_includes/d4a_buttons.md
@@ -5,14 +5,14 @@
 <a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank">Deploy Docker for AWS (stable)</a>
 {% endcapture %}
 {% capture aws_blue_beta %}
-<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/beta/Docker.tmpl" data-rel="Beta-14" target="blank">Deploy Docker for AWS (beta)</a>
+<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl" data-rel="Beta-14" target="blank">Deploy Docker for AWS (beta)</a>
 {% endcapture %}
 
 {% capture azure_blue_latest %}
 <a class="button darkblue-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="blank">Deploy Docker for Azure (stable)</a>
 {% endcapture %}
 {% capture azure_blue_beta %}
-<a class="button darkblue-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fbeta%2FDocker.tmpl" data-rel="Beta-14" target="blank">Deploy Docker for Azure (beta)</a>
+<a class="button darkblue-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fedge%2FDocker.tmpl" data-rel="Beta-14" target="blank">Deploy Docker for Azure (beta)</a>
 {% endcapture %}
 {% capture azure_button_latest %}
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="_blank" class="azure-deploy">![Docker for Azure](http://azuredeploy.net/deploybutton.png)</a>

--- a/docker-for-aws/faqs.md
+++ b/docker-for-aws/faqs.md
@@ -4,11 +4,29 @@ keywords: aws faqs
 title: Docker for AWS Frequently asked questions (FAQ)
 ---
 
-## Can I use my own AMI?
+### Stable and beta channels
+
+Two different download channels are available for Docker for AWS:
+
+* The **stable channel** provides a general availability release-ready deployment
+  for a fully baked and tested, more reliable cluster. The stable version of Docker
+  for AWS comes with the latest released version of Docker Engine. The release
+  schedule is synched with Docker Engine releases and hotfixes. On the stable
+  channel, you can select whether to send usage statistics and other data.
+
+* The **beta channel** provides a deployment with new features we are working on,
+  but is not necessarily fully tested. It comes with the experimental version of
+  Docker Engine. Bugs, crashes and issues are more likely to occur with the beta
+  cluster, but you get a chance to preview new functionality, experiment, and provide
+  feedback as the deployment evolve. Releases are typically more frequent than for
+  stable, often one or more per month. Usage statistics and crash reports are sent
+  by default. You do not have the option to disable this on the beta channel.
+
+### Can I use my own AMI?
 
 No, at this time we only support the default Docker for AWS AMI.
 
-## How to use Docker for AWS with an AWS account in an EC2-Classic region.
+### How to use Docker for AWS with an AWS account in an EC2-Classic region.
 
 If you have an AWS account that was created before **December 4th, 2013** you have what is known as an **EC2-Classic** account on regions where you have previously deployed resources. **EC2-Classic** accounts don't have default VPC's or the associated subnets, etc. This causes a problem when using our CloudFormation template  because we are using the [Fn:GetAZs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html) function they provide to determine which availability zones you have access too. When used in a region where you have **EC2-Classic**, this function will return all availability zones for a region, even ones you don't have access too. When you have an **EC2-VPC** account, it will return only the availability zones you have access to.
 
@@ -39,27 +57,27 @@ There are a few work arounds that you can try to get Docker for AWS up and runni
 - https://aws.amazon.com/blogs/aws/amazon-ec2-update-virtual-private-clouds-for-everyone/
 
 
-## Can I use my existing VPC?
+### Can I use my existing VPC?
 
 Not at this time, but it is on our roadmap for future releases.
 
-## Which AWS regions will this work with.
+### Which AWS regions will this work with.
 
 Docker for AWS should work with all regions except for AWS China, which is a little different than the other regions.
 
-## How many Availability Zones does Docker for AWS use?
+### How many Availability Zones does Docker for AWS use?
 
 All of Amazons regions have at least 2 AZ's, and some have more. To make sure Docker for AWS works in all regions, only 2 AZ's are used even if more are available.
 
-## What do I do if I get "KeyPair error" on AWS?
+### What do I do if I get "KeyPair error" on AWS?
 As part of the prerequisites, you need to have an SSH key uploaded to the AWS region you are trying to deploy to.
 For more information about adding an SSH key pair to your account, please refer to the [Amazon EC2 Key Pairs docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
 
-## Where are my container logs?
+### Where are my container logs?
 
 All container logs are aggregated within [AWS CloudWatch](https://aws.amazon.com/cloudwatch/).
 
-## I have a problem/bug where do I report it?
+### I have a problem/bug where do I report it?
 
 Send an email to <docker-for-iaas@docker.com> or post to the [Docker for AWS](https://github.com/docker/for-aws) GitHub repositories.
 
@@ -77,11 +95,11 @@ Please provide this session ID to the maintainer debugging your issue.
 
 _Please note that your output will be slightly different from the above, depending on your swarm configuration_
 
-## Analytics
+### Analytics
 
 Docker for AWS sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for AWS.
 
-## How to run administrative commands?
+### How to run administrative commands?
 
 By default when you SSH into a manager, you will be logged in as the regular username: `docker` - It is possible however to run commands with elevated privileges by using `sudo`.
 For example to ping one of the nodes, after finding its IP via the Azure/AWS portal (e.g. 10.0.0.4), you could run:

--- a/docker-for-aws/faqs.md
+++ b/docker-for-aws/faqs.md
@@ -22,11 +22,11 @@ Two different download channels are available for Docker for AWS:
   stable, often one or more per month. Usage statistics and crash reports are sent
   by default. You do not have the option to disable this on the beta channel.
 
-### Can I use my own AMI?
+## Can I use my own AMI?
 
 No, at this time we only support the default Docker for AWS AMI.
 
-### How can I use Docker for AWS with an AWS account in an EC2-Classic region?
+## How can I use Docker for AWS with an AWS account in an EC2-Classic region?
 
 If you have an AWS account that was created before **December 4th, 2013** you have what is known as an **EC2-Classic** account on regions where you have previously deployed resources. **EC2-Classic** accounts don't have default VPC's or the associated subnets, etc. This causes a problem when using our CloudFormation template  because we are using the [Fn:GetAZs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html) function they provide to determine which availability zones you have access too. When used in a region where you have **EC2-Classic**, this function will return all availability zones for a region, even ones you don't have access too. When you have an **EC2-VPC** account, it will return only the availability zones you have access to.
 
@@ -38,18 +38,18 @@ If you have an **EC2-Classic** account, and you don't have access to the `a` and
 
 There isn't anything we can do right now to fix this issue, we have contacted Amazon, and we are hoping they will be able to provide us with a way to determine if an account is either **EC2-Classic** or **EC2-VPC**, so we can act accordingly.
 
-#### How to tell if you have this issue.
+### How to tell if you have this issue.
 
 This AWS documentation page will describe how you can tell if you have EC2-Classic, EC2-VPC or both.  http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html
 
-#### How to fix:
+### How to fix:
 There are a few work arounds that you can try to get Docker for AWS up and running for you.
 
 1. Use a region that doesn't have **EC2-Classic**. The most common region with this issue is `us-east-1`. So try another region, `us-west-1`, `us-west-2`, or the new `us-east-2`. These regions will more then likely be setup with **EC2-VPC** and you will not longer have this issue.
 2. Create an new AWS account, all new accounts will be setup using **EC2-VPC** and will not have this problem.
 3. You can try and contact AWS support to convert your **EC2-Classic** account to a **EC2-VPC** account. For more information checkout the following answer for **"Q. I really want a default VPC for my existing EC2 account. Is that possible?"** on https://aws.amazon.com/vpc/faqs/#Default_VPCs
 
-#### Helpful links:
+### Helpful links:
 - http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html
 - http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html
 - http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-vpc.html
@@ -57,27 +57,27 @@ There are a few work arounds that you can try to get Docker for AWS up and runni
 - https://aws.amazon.com/blogs/aws/amazon-ec2-update-virtual-private-clouds-for-everyone/
 
 
-### Can I use my existing VPC?
+## Can I use my existing VPC?
 
 Not at this time, but it is on our roadmap for future releases.
 
-### Which AWS regions will this work with?
+## Which AWS regions will this work with?
 
 Docker for AWS should work with all regions except for AWS China, which is a little different than the other regions.
 
-### How many Availability Zones does Docker for AWS use?
+## How many Availability Zones does Docker for AWS use?
 
 All of Amazons regions have at least 2 AZ's, and some have more. To make sure Docker for AWS works in all regions, only 2 AZ's are used even if more are available.
 
-### What do I do if I get `KeyPair error` on AWS?
+## What do I do if I get `KeyPair error` on AWS?
 As part of the prerequisites, you need to have an SSH key uploaded to the AWS region you are trying to deploy to.
 For more information about adding an SSH key pair to your account, please refer to the [Amazon EC2 Key Pairs docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
 
-### Where are my container logs?
+## Where are my container logs?
 
 All container logs are aggregated within [AWS CloudWatch](https://aws.amazon.com/cloudwatch/).
 
-### Where do I report problems or bugs?
+## Where do I report problems or bugs?
 
 Send an email to <docker-for-iaas@docker.com> or post to the [Docker for AWS](https://github.com/docker/for-aws) GitHub repositories.
 
@@ -95,11 +95,11 @@ Please provide this session ID to the maintainer debugging your issue.
 
 _Please note that your output will be slightly different from the above, depending on your swarm configuration_
 
-### Analytics
+## Analytics
 
 Docker for AWS sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for AWS.
 
-### How do I run administrative commands?
+## How do I run administrative commands?
 
 By default when you SSH into a manager, you will be logged in as the regular username: `docker` - It is possible however to run commands with elevated privileges by using `sudo`.
 For example to ping one of the nodes, after finding its IP via the Azure/AWS portal (e.g. 10.0.0.4), you could run:

--- a/docker-for-aws/faqs.md
+++ b/docker-for-aws/faqs.md
@@ -83,7 +83,7 @@ Send an email to <docker-for-iaas@docker.com> or post to the [Docker for AWS](ht
 
 In AWS, if your stack is misbehaving, please run the following diagnostic tool from one of the managers - this will collect your docker logs and send them to Docker:
 
-```
+```bash
 $ docker-diagnose
 OK hostname=manager1
 OK hostname=worker1
@@ -93,7 +93,7 @@ Your diagnostics session ID is 1234567890-xxxxxxxxxxxxxx
 Please provide this session ID to the maintainer debugging your issue.
 ```
 
-_Please note that your output will be slightly different from the above, depending on your swarm configuration_
+> **Note**: Your output will be slightly different from the above, depending on your swarm configuration.
 
 ## Analytics
 
@@ -103,8 +103,9 @@ Docker for AWS sends anonymized minimal analytics to Docker (heartbeat). These a
 
 By default when you SSH into a manager, you will be logged in as the regular username: `docker` - It is possible however to run commands with elevated privileges by using `sudo`.
 For example to ping one of the nodes, after finding its IP via the Azure/AWS portal (e.g. 10.0.0.4), you could run:
-```
+
+```bash
 $ sudo ping 10.0.0.4
 ```
 
-Note that access to Docker for AWS and Azure happens through a shell container that itself runs on Docker.
+> **Note**: Access to Docker for AWS and Azure happens through a shell container that itself runs on Docker.

--- a/docker-for-aws/faqs.md
+++ b/docker-for-aws/faqs.md
@@ -4,7 +4,7 @@ keywords: aws faqs
 title: Docker for AWS Frequently asked questions (FAQ)
 ---
 
-### Stable and beta channels
+## Stable and beta channels
 
 Two different download channels are available for Docker for AWS:
 
@@ -26,7 +26,7 @@ Two different download channels are available for Docker for AWS:
 
 No, at this time we only support the default Docker for AWS AMI.
 
-### How to use Docker for AWS with an AWS account in an EC2-Classic region.
+### How can I use Docker for AWS with an AWS account in an EC2-Classic region?
 
 If you have an AWS account that was created before **December 4th, 2013** you have what is known as an **EC2-Classic** account on regions where you have previously deployed resources. **EC2-Classic** accounts don't have default VPC's or the associated subnets, etc. This causes a problem when using our CloudFormation template  because we are using the [Fn:GetAZs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html) function they provide to determine which availability zones you have access too. When used in a region where you have **EC2-Classic**, this function will return all availability zones for a region, even ones you don't have access too. When you have an **EC2-VPC** account, it will return only the availability zones you have access to.
 
@@ -61,7 +61,7 @@ There are a few work arounds that you can try to get Docker for AWS up and runni
 
 Not at this time, but it is on our roadmap for future releases.
 
-### Which AWS regions will this work with.
+### Which AWS regions will this work with?
 
 Docker for AWS should work with all regions except for AWS China, which is a little different than the other regions.
 
@@ -69,7 +69,7 @@ Docker for AWS should work with all regions except for AWS China, which is a lit
 
 All of Amazons regions have at least 2 AZ's, and some have more. To make sure Docker for AWS works in all regions, only 2 AZ's are used even if more are available.
 
-### What do I do if I get "KeyPair error" on AWS?
+### What do I do if I get `KeyPair error` on AWS?
 As part of the prerequisites, you need to have an SSH key uploaded to the AWS region you are trying to deploy to.
 For more information about adding an SSH key pair to your account, please refer to the [Amazon EC2 Key Pairs docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
 
@@ -77,7 +77,7 @@ For more information about adding an SSH key pair to your account, please refer 
 
 All container logs are aggregated within [AWS CloudWatch](https://aws.amazon.com/cloudwatch/).
 
-### I have a problem/bug where do I report it?
+### Where do I report problems or bugs?
 
 Send an email to <docker-for-iaas@docker.com> or post to the [Docker for AWS](https://github.com/docker/for-aws) GitHub repositories.
 
@@ -99,7 +99,7 @@ _Please note that your output will be slightly different from the above, dependi
 
 Docker for AWS sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for AWS.
 
-### How to run administrative commands?
+### How do I run administrative commands?
 
 By default when you SSH into a manager, you will be logged in as the regular username: `docker` - It is possible however to run commands with elevated privileges by using `sudo`.
 For example to ping one of the nodes, after finding its IP via the Azure/AWS portal (e.g. 10.0.0.4), you could run:

--- a/docker-for-aws/faqs.md
+++ b/docker-for-aws/faqs.md
@@ -2,6 +2,7 @@
 description: Frequently asked questions
 keywords: aws faqs
 title: Docker for AWS Frequently asked questions (FAQ)
+toc_max: 2
 ---
 
 ## Stable and beta channels
@@ -38,11 +39,11 @@ If you have an **EC2-Classic** account, and you don't have access to the `a` and
 
 There isn't anything we can do right now to fix this issue, we have contacted Amazon, and we are hoping they will be able to provide us with a way to determine if an account is either **EC2-Classic** or **EC2-VPC**, so we can act accordingly.
 
-### How to tell if you have this issue.
+### How to tell if you are in the EC2-Classic region.
 
 This AWS documentation page will describe how you can tell if you have EC2-Classic, EC2-VPC or both.  http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html
 
-### How to fix:
+### Possible fixes to the EC2-Classic region issue:
 There are a few work arounds that you can try to get Docker for AWS up and running for you.
 
 1. Use a region that doesn't have **EC2-Classic**. The most common region with this issue is `us-east-1`. So try another region, `us-west-1`, `us-west-2`, or the new `us-east-2`. These regions will more then likely be setup with **EC2-VPC** and you will not longer have this issue.
@@ -95,9 +96,9 @@ Please provide this session ID to the maintainer debugging your issue.
 
 > **Note**: Your output will be slightly different from the above, depending on your swarm configuration.
 
-## Analytics
+## Metrics
 
-Docker for AWS sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for AWS.
+Docker for AWS sends anonymized minimal metrics to Docker (heartbeat). These metrics are used to monitor adoption and are critical to improve Docker for AWS.
 
 ## How do I run administrative commands?
 

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -13,9 +13,29 @@ redirect_from:
 
 If your account [has the proper
 permissions](https://docs.docker.com/docker-for-aws/iam-permissions/), you can
-use the following button to bootstrap Docker for AWS using CloudFormation:
+use the blow button from the stable or beta channel to bootstrap Docker for AWS using CloudFormation.For more about stable and beta
+channels, see the [FAQs](/docker-for-aws/faqs.md#stable-and-beta-channels).
 
-{{aws_button_latest}}
+
+<table style="width:100%">
+  <tr>
+    <th style="font-size: x-large; font-family: arial">Stable channel</th>
+    <th style="font-size: x-large; font-family: arial">Beta channel</th>
+  </tr>
+  <tr valign="top">
+    <td width="50%">This deployment is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
+    </td>
+    <td width="50%">This deployment offers cutting edge features and comes with the experimental version of Docker Engine, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. <br><br>We collect usage data on betas across the board.</td>
+  </tr>
+  <tr valign="top">
+  <td width="50%">
+  {{aws_blue_latest}}
+  </td>
+  <td width="50%">
+  {{aws_blue_beta}}
+  </td>
+  </tr>
+</table>
 
 ## Prerequisites
 
@@ -31,33 +51,6 @@ use the following button to bootstrap Docker for AWS using CloudFormation:
 - AWS account that support EC2-VPC (See the [FAQ for details about EC2-Classic](faqs.md))
 
 For more information about adding an SSH key pair to your account, please refer to the [Amazon EC2 Key Pairs docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
-
-
-## Deploy Docker for AWS
-
-If you have not already done so, please install Docker for Mac. You can download
-installers from the stable or beta channel. For more about stable and beta
-channels, see the [FAQs](/docker-for-aws/faqs.md#stable-and-beta-channels).
-
-<table style="width:100%">
-  <tr>
-    <th style="font-size: x-large; font-family: arial">Stable channel</th>
-    <th style="font-size: x-large; font-family: arial">Beta channel</th>
-  </tr>
-  <tr valign="top">
-    <td width="50%">This deployment is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
-    </td>
-    <td width="50%">This deployment offers cutting edge features and comes with the experimental version of Docker Engine, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. <br><br>We collect usage data on betas across the board.</td>
-  </tr>
-  <tr valign="top">
-  <td width="50%">
-  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank" class="aws-deploy">Deploy Docker for AWS (stable)</a>
-  </td>
-  <td width="50%">
-  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/beta/Docker.tmpl" data-rel="Beta-14" target="blank" class="aws-deploy">Deploy Docker for AWS (beta)</a>
-  </td>
-  </tr>
-</table>
 
 ## Configuration
 

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -32,6 +32,33 @@ use the following button to bootstrap Docker for AWS using CloudFormation:
 
 For more information about adding an SSH key pair to your account, please refer to the [Amazon EC2 Key Pairs docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
 
+
+## Deploy Docker for AWS
+
+If you have not already done so, please install Docker for Mac. You can download
+installers from the stable or beta channel. For more about stable and beta
+channels, see the [FAQs](/docker-for-aws/faqs.md#stable-and-beta-channels).
+
+<table style="width:100%">
+  <tr>
+    <th style="font-size: x-large; font-family: arial">Stable channel</th>
+    <th style="font-size: x-large; font-family: arial">Beta channel</th>
+  </tr>
+  <tr valign="top">
+    <td width="50%">This deployment is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
+    </td>
+    <td width="50%">This deployment offers cutting edge features and comes with the experimental version of Docker Engine, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. <br><br>We collect usage data on betas across the board.</td>
+  </tr>
+  <tr valign="top">
+  <td width="50%">
+  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank" id="aws-deploy">Deploy Docker for AWS (stable)</a>
+  </td>
+  <td width="50%">
+  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/beta/Docker.tmpl" data-rel="Beta-14" target="blank" id="aws-deploy">Deploy Docker for AWS (beta)</a>
+  </td>
+  </tr>
+</table>
+
 ## Configuration
 
 Docker for AWS is installed with a CloudFormation template that configures Docker in swarm-mode, running on instances backed custom AMIs. There are two ways you can deploy Docker for AWS. You can use the AWS Management Console (browser based), or use the AWS CLI. Both have the following configuration options.

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -51,10 +51,10 @@ channels, see the [FAQs](/docker-for-aws/faqs.md#stable-and-beta-channels).
   </tr>
   <tr valign="top">
   <td width="50%">
-  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank" id="aws-deploy">Deploy Docker for AWS (stable)</a>
+  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="Stable-1" target="blank" class="aws-deploy">Deploy Docker for AWS (stable)</a>
   </td>
   <td width="50%">
-  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/beta/Docker.tmpl" data-rel="Beta-14" target="blank" id="aws-deploy">Deploy Docker for AWS (beta)</a>
+  <a class="button darkblue-btn" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/beta/Docker.tmpl" data-rel="Beta-14" target="blank" class="aws-deploy">Deploy Docker for AWS (beta)</a>
   </td>
   </tr>
 </table>

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -2,6 +2,7 @@
 description: Frequently asked questions
 keywords: azure faqs
 title: Docker for Azure Frequently asked questions (FAQ)
+toc_max: 2
 ---
 
 ## FAQ
@@ -39,9 +40,9 @@ Please provide this session ID to the maintainer debugging your issue.
 
 > **Note**: Your output will be slightly different from the above, depending on your swarm configuration.
 
-## Analytics
+## Metrics
 
-Docker for Azure sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for Azure.
+Docker for Azure sends anonymized minimal metrics to Docker (heartbeat). These metrics are used to monitor adoption and are critical to improve Docker for Azure.
 
 ## How do I run administrative commands?
 

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -69,7 +69,7 @@ For example to ping one of the nodes, after finding its IP via the Azure/Azure p
 $ sudo ping 10.0.0.4
 ```
 
-Note that access to Docker for Azure and Azure happens through a shell container that itself runs on Docker.
+> **Note**: Access to Docker for Azure and Azure happens through a shell container that itself runs on Docker.
 
 
 ## What are the different Azure Regions?

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -23,28 +23,28 @@ Two different download channels are available for Docker for Azure:
   by default. You do not have the option to disable this on the beta channel.
 
 
-### Can I use my own VHD?
+## Can I use my own VHD?
 No, at this time we only support the default Docker for Azure VHD.
 
-### Can I specify the type of Storage Account I use for my VM instances?
+## Can I specify the type of Storage Account I use for my VM instances?
 
 Not at this time, but it is on our roadmap for future releases.
 
-### Which Azure regions will Docker for Azure work with?
+## Which Azure regions will Docker for Azure work with?
 
 Docker for Azure should work with all supported Azure Marketplace regions.
 
-### Where are my container logs?
+## Where are my container logs?
 
 All container logs are aggregated within the `xxxxlog` storage account.
 
-### Where do I report problems or bugs?
+## Where do I report problems or bugs?
 
 Send an email to <docker-for-iaas@docker.com> or post to the [Docker for Azure](https://github.com/docker/for-azure) GitHub repositories.
 
 In Azure, if your resource group is misbehaving, please run the following diagnostic tool from one of the managers - this will collect your docker logs and send them to Docker:
 
-```
+```bash
 $ docker-diagnose
 OK hostname=manager1
 OK hostname=worker1
@@ -54,28 +54,29 @@ Your diagnostics session ID is 1234567890-xxxxxxxxxxxxxx
 Please provide this session ID to the maintainer debugging your issue.
 ```
 
-_Please note that your output will be slightly different from the above, depending on your swarm configuration_
+> **Note**: Your output will be slightly different from the above, depending on your swarm configuration.
 
-### Analytics
+## Analytics
 
 Docker for Azure sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for Azure.
 
-### How do I run administrative commands?
+## How do I run administrative commands?
 
 By default when you SSH into a manager, you will be logged in as the regular username: `docker` - It is possible however to run commands with elevated privileges by using `sudo`.
 For example to ping one of the nodes, after finding its IP via the Azure/Azure portal (e.g. 10.0.0.4), you could run:
-```
+
+```bash
 $ sudo ping 10.0.0.4
 ```
 
 Note that access to Docker for Azure and Azure happens through a shell container that itself runs on Docker.
 
 
-### What are the different Azure Regions?
+## What are the different Azure Regions?
 All regions can be found here: [Microsoft Azure Regions](https://azure.microsoft.com/en-us/regions/)
 An exerpt of the above regions to use when you create your service principal are:
 
-```
+```none
 australiaeast
 australiasoutheast
 brazilsouth

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -72,8 +72,9 @@ Note that access to Docker for Azure and Azure happens through a shell container
 
 
 ### What are the different Azure Regions?
-All regions can be found here: https://azure.microsoft.com/en-us/regions/
+All regions can be found here: [Microsoft Azure Regions](https://azure.microsoft.com/en-us/regions/)
 An exerpt of the above regions to use when you create your service principal are:
+
 ```
 australiaeast
 australiasoutheast

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -4,22 +4,41 @@ keywords: azure faqs
 title: Docker for Azure Frequently asked questions (FAQ)
 ---
 
-## Can I use my own VHD?
+### Stable and beta channels
+
+Two different download channels are available for Docker for Azure:
+
+* The **stable channel** provides a general availability release-ready deployment
+  for a fully baked and tested, more reliable cluster. The stable version of Docker
+  for Azure comes with the latest released version of Docker Engine. The release
+  schedule is synched with Docker Engine releases and hotfixes. On the stable
+  channel, you can select whether to send usage statistics and other data.
+
+* The **beta channel** provides a deployment with new features we are working on,
+  but is not necessarily fully tested. It comes with the experimental version of
+  Docker Engine. Bugs, crashes and issues are more likely to occur with the beta
+  cluster, but you get a chance to preview new functionality, experiment, and provide
+  feedback as the deployment evolve. Releases are typically more frequent than for
+  stable, often one or more per month. Usage statistics and crash reports are sent
+  by default. You do not have the option to disable this on the beta channel.
+
+
+### Can I use my own VHD?
 No, at this time we only support the default Docker for Azure VHD.
 
-## Can I specify the type of Storage Account I use for my VM instances?
+### Can I specify the type of Storage Account I use for my VM instances?
 
 Not at this time, but it is on our roadmap for future releases.
 
-## Which Azure regions will Docker for Azure work with.
+### Which Azure regions will Docker for Azure work with.
 
 Docker for Azure should work with all supported Azure Marketplace regions.
 
-## Where are my container logs?
+### Where are my container logs?
 
 All container logs are aggregated within the `xxxxlog` storage account.
 
-## I have a problem/bug where do I report it?
+### I have a problem/bug where do I report it?
 
 Send an email to <docker-for-iaas@docker.com> or post to the [Docker for Azure](https://github.com/docker/for-azure) GitHub repositories.
 
@@ -37,16 +56,16 @@ Please provide this session ID to the maintainer debugging your issue.
 
 _Please note that your output will be slightly different from the above, depending on your swarm configuration_
 
-## Analytics
+### Analytics
 
 Docker for Azure sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for Azure.
 
-## How to run administrative commands?
+### How to run administrative commands?
 
 By default when you SSH into a manager, you will be logged in as the regular username: `docker` - It is possible however to run commands with elevated privileges by using `sudo`.
-For example to ping one of the nodes, after finding its IP via the Azure/AWS portal (e.g. 10.0.0.4), you could run:
+For example to ping one of the nodes, after finding its IP via the Azure/Azure portal (e.g. 10.0.0.4), you could run:
 ```
 $ sudo ping 10.0.0.4
 ```
 
-Note that access to Docker for AWS and Azure happens through a shell container that itself runs on Docker.
+Note that access to Docker for Azure and Azure happens through a shell container that itself runs on Docker.

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -4,24 +4,7 @@ keywords: azure faqs
 title: Docker for Azure Frequently asked questions (FAQ)
 ---
 
-## Stable and beta channels
-
-Two different download channels are available for Docker for Azure:
-
-* The **stable channel** provides a general availability release-ready deployment
-  for a fully baked and tested, more reliable cluster. The stable version of Docker
-  for Azure comes with the latest released version of Docker Engine. The release
-  schedule is synched with Docker Engine releases and hotfixes. On the stable
-  channel, you can select whether to send usage statistics and other data.
-
-* The **beta channel** provides a deployment with new features we are working on,
-  but is not necessarily fully tested. It comes with the experimental version of
-  Docker Engine. Bugs, crashes and issues are more likely to occur with the beta
-  cluster, but you get a chance to preview new functionality, experiment, and provide
-  feedback as the deployment evolve. Releases are typically more frequent than for
-  stable, often one or more per month. Usage statistics and crash reports are sent
-  by default. You do not have the option to disable this on the beta channel.
-
+## FAQ
 
 ## Can I use my own VHD?
 No, at this time we only support the default Docker for Azure VHD.

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -69,3 +69,34 @@ $ sudo ping 10.0.0.4
 ```
 
 Note that access to Docker for Azure and Azure happens through a shell container that itself runs on Docker.
+
+
+### What are the different Azure Regions?
+All regions can be found here: https://azure.microsoft.com/en-us/regions/
+An exerpt of the above regions to use when you create your service principal are:
+```
+australiaeast
+australiasoutheast
+brazilsouth
+canadacentral
+canadaeast
+centralindia
+centralus
+eastasia
+eastus
+eastus2
+japaneast
+japanwest
+northcentralus
+northeurope
+southcentralus
+southeastasia
+southindia
+uksouth
+ukwest
+westcentralus
+westeurope
+westindia
+westus
+westus2
+```

--- a/docker-for-azure/faqs.md
+++ b/docker-for-azure/faqs.md
@@ -4,7 +4,7 @@ keywords: azure faqs
 title: Docker for Azure Frequently asked questions (FAQ)
 ---
 
-### Stable and beta channels
+## Stable and beta channels
 
 Two different download channels are available for Docker for Azure:
 
@@ -30,7 +30,7 @@ No, at this time we only support the default Docker for Azure VHD.
 
 Not at this time, but it is on our roadmap for future releases.
 
-### Which Azure regions will Docker for Azure work with.
+### Which Azure regions will Docker for Azure work with?
 
 Docker for Azure should work with all supported Azure Marketplace regions.
 
@@ -38,7 +38,7 @@ Docker for Azure should work with all supported Azure Marketplace regions.
 
 All container logs are aggregated within the `xxxxlog` storage account.
 
-### I have a problem/bug where do I report it?
+### Where do I report problems or bugs?
 
 Send an email to <docker-for-iaas@docker.com> or post to the [Docker for Azure](https://github.com/docker/for-azure) GitHub repositories.
 
@@ -60,7 +60,7 @@ _Please note that your output will be slightly different from the above, dependi
 
 Docker for Azure sends anonymized minimal analytics to Docker (heartbeat). These analytics are used to monitor adoption and are critical to improve Docker for Azure.
 
-### How to run administrative commands?
+### How do I run administrative commands?
 
 By default when you SSH into a manager, you will be logged in as the regular username: `docker` - It is possible however to run commands with elevated privileges by using `sudo`.
 For example to ping one of the nodes, after finding its IP via the Azure/Azure portal (e.g. 10.0.0.4), you could run:

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -10,25 +10,8 @@ redirect_from:
 
 ## Quickstart
 
-If your account has the [proper
-permissions](https://docs.docker.com/docker-for-azure/#/prerequisites), you can
-generate the [Service
-Principal](https://docs.docker.com/docker-for-azure/#/service-principal) and
-then use the following button to bootstrap Docker for Azure using Azure Resource
-Manager:
-
-{{azure_button_latest}}
-
-## Prerequisites
-
-- Access to an Azure account with admin privileges
-- SSH key that you want to use when accessing your completed Docker install on Azure
-
-## Deploy Docker for Azure
-
-If you have not already done so, please install Docker for Mac. You can download
-installers from the stable or beta channel. For more about stable and beta
-channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-beta-channels).
+If your account has the [proper permissions](https://docs.docker.com/docker-for-azure/#/prerequisites), you can generate the [Service Principal](https://docs.docker.com/docker-for-azure/#/service-principal) and
+then use the below button from the stable or beta channel to bootstrap Docker for Azure using Azure Resource Manager. For more about stable and beta channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-beta-channels).
 
 <table style="width:100%">
   <tr>
@@ -42,13 +25,19 @@ channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-beta-channels).
   </tr>
   <tr valign="top">
   <td width="50%">
-  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="blank" class="azure-deploy">Deploy Docker for Azure (stable)</a>
+  {{azure_blue_latest}}
   </td>
   <td width="50%">
-  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fbeta%2FDocker.tmpl" data-rel="Beta-14" target="blank" class="azure-deploy">Deploy Docker for Azure (beta)</a>
+  {{azure_blue_beta}}
   </td>
   </tr>
 </table>
+
+## Prerequisites
+
+- Access to an Azure account with admin privileges
+- SSH key that you want to use when accessing your completed Docker install on Azure
+
 
 ## Configuration
 

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -24,6 +24,32 @@ Manager:
 - Access to an Azure account with admin privileges
 - SSH key that you want to use when accessing your completed Docker install on Azure
 
+## Deploy Docker for Azure
+
+If you have not already done so, please install Docker for Mac. You can download
+installers from the stable or beta channel. For more about stable and beta
+channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-beta-channels).
+
+<table style="width:100%">
+  <tr>
+    <th style="font-size: x-large; font-family: arial">Stable channel</th>
+    <th style="font-size: x-large; font-family: arial">Beta channel</th>
+  </tr>
+  <tr valign="top">
+    <td width="50%">This deployment is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
+    </td>
+    <td width="50%">This deployment offers cutting edge features and comes with the experimental version of Docker Engine, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. <br><br>We collect usage data on betas across the board.</td>
+  </tr>
+  <tr valign="top">
+  <td width="50%">
+  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="blank" id="azure-deploy">Deploy Docker for Azure (stable)</a>
+  </td>
+  <td width="50%">
+  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fbeta%2FDocker.tmpl" data-rel="Beta-14" target="blank" id="azure-deploy">Deploy Docker for Azure (beta)</a>
+  </td>
+  </tr>
+</table>
+
 ## Configuration
 
 Docker for Azure is installed with an Azure template that configures Docker in swarm-mode, running on VMs backed by a custom VHD. There are two ways you can deploy Docker for Azure. You can use the Azure Portal (browser based), or use the Azure CLI. Both have the following configuration options.

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -10,7 +10,7 @@ redirect_from:
 
 ## Quickstart
 
-If your account has the [proper permissions](https://docs.docker.com/docker-for-azure/#/prerequisites), you can generate the [Service Principal](https://docs.docker.com/docker-for-azure/#/service-principal) and
+If your account has the [proper permissions](#prerequisites), you can generate the [Service Principal](#service-principal) and
 then use the below button from the stable or beta channel to bootstrap Docker for Azure using Azure Resource Manager. For more about stable and beta channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-beta-channels).
 
 <table style="width:100%">
@@ -81,7 +81,7 @@ If you have multiple Azure subscriptions, make sure you're creating the Service 
 
 * `sp-name` is the name of the authentication app that the script creates with Azure. The name is not important, simply choose something you'll recognize in the Azure portal. Example: `sp1`.
 * `rg-name` is the name of the new resource group that will be created to deploy the resources (VMs, networks, storage accounts) associated with the swarm. The Service Principal will be scoped to this resource group. Example: `swarm1`.
-* `rg-region` is the name of Azure's region/location where the resource group will be created. This needs to be one of the regions supported by Azure e.g. `westus`, `centralus`, `eastus`.
+* `rg-region` is the name of Azure's region/location where the resource group will be created. This needs to be one of the regions supported by Azure e.g. `westus`, `centralus`, `eastus`. See our [FAQs](/docker-for-azure/faqs.md#what-are-the-different-azure-regions) for a list of regions.
 
 While `rg-name` and `rg-region` are optional, it's highly recommended that you create the resource group up front and scope the service principal to that specific resource group.
 

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -11,24 +11,19 @@ redirect_from:
 ## Quickstart
 
 If your account has the [proper permissions](#prerequisites), you can generate the [Service Principal](#service-principal) and
-then use the below button from the stable or beta channel to bootstrap Docker for Azure using Azure Resource Manager. For more about stable and beta channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-beta-channels).
+then use the below button from the stable channel to bootstrap Docker for Azure using Azure Resource Manager.
 
 <table style="width:100%">
   <tr>
     <th style="font-size: x-large; font-family: arial">Stable channel</th>
-    <th style="font-size: x-large; font-family: arial">Beta channel</th>
   </tr>
   <tr valign="top">
-    <td width="50%">This deployment is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
+    <td width="100%">This deployment is fully baked and tested, and comes with the latest GA version of Docker Engine. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>These releases follow a version schedule with a longer lead time than the betas, synched with Docker Engine releases and hotfixes.
     </td>
-    <td width="50%">This deployment offers cutting edge features and comes with the experimental version of Docker Engine, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. This channel is a continuation of the beta program, where you can provide feedback as the apps evolve. Releases are typically more frequent than for stable, often one or more per month. <br><br>We collect usage data on betas across the board.</td>
   </tr>
   <tr valign="top">
-  <td width="50%">
+  <td width="100%">
   {{azure_blue_latest}}
-  </td>
-  <td width="50%">
-  {{azure_blue_beta}}
   </td>
   </tr>
 </table>

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -42,10 +42,10 @@ channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-beta-channels).
   </tr>
   <tr valign="top">
   <td width="50%">
-  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="blank" id="azure-deploy">Deploy Docker for Azure (stable)</a>
+  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="Stable-1" target="blank" class="azure-deploy">Deploy Docker for Azure (stable)</a>
   </td>
   <td width="50%">
-  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fbeta%2FDocker.tmpl" data-rel="Beta-14" target="blank" id="azure-deploy">Deploy Docker for Azure (beta)</a>
+  <a class="button darkblue-btn" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fbeta%2FDocker.tmpl" data-rel="Beta-14" target="blank" class="azure-deploy">Deploy Docker for Azure (beta)</a>
   </td>
   </tr>
 </table>


### PR DESCRIPTION
### Proposed changes

Add beta channels to Docker for AWS and Docker for Azure

### Unreleased project version (optional)

Beta links will not work until the 1.13.1-rc has been released. 

