### PR TITLE
Include example from latest docker docs

### DIFF
--- a/_data/engine-cli/docker_attach.yaml
+++ b/_data/engine-cli/docker_attach.yaml
@@ -1,6 +1,8 @@
 command: docker attach
 short: Attach to a running container
-long: Attach to a running container
+long: |2
+
+  Alias for `docker container attach`.
 usage: docker attach [OPTIONS] CONTAINER
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_commit.yaml
+++ b/_data/engine-cli/docker_commit.yaml
@@ -1,6 +1,7 @@
 command: docker commit
 short: Create a new image from a container's changes
-long: Create a new image from a container's changes
+long: |
+  Alias for `docker container commit`.
 usage: docker commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_container_attach.yaml
+++ b/_data/engine-cli/docker_container_attach.yaml
@@ -1,6 +1,72 @@
 command: docker container attach
 short: Attach to a running container
-long: Attach to a running container
+long: |
+  The **docker attach** command allows you to attach to a running container using
+  the container's ID or name, either to view its ongoing output or to control it
+  interactively.  You can attach to the same contained process multiple times
+  simultaneously, screen sharing style, or quickly view the progress of your
+  detached process.
+
+  To stop a container, use `CTRL-c`. This key sequence sends `SIGKILL` to the
+  container. You can detach from the container (and leave it running) using a
+  configurable key sequence. The default sequence is `CTRL-p CTRL-q`. You
+  configure the key sequence using the **--detach-keys** option or a configuration
+  file. See **config-json(5)** for documentation on using a configuration file.
+
+  It is forbidden to redirect the standard input of a `docker attach` command while
+  attaching to a tty-enabled container (i.e.: launched with `-t`).
+
+  # Override the detach sequence
+
+  If you want, you can configure an override the Docker key sequence for detach.
+  This is useful if the Docker default sequence conflicts with key sequence you
+  use for other applications. There are two ways to define your own detach key
+  sequence, as a per-container override or as a configuration property on  your
+  entire configuration.
+
+  To override the sequence for an individual container, use the
+  `--detach-keys="<sequence>"` flag with the `docker attach` command. The format of
+  the `<sequence>` is either a letter [a-Z], or the `ctrl-` combined with any of
+  the following:
+
+  * `a-z` (a single lowercase alpha character )
+  * `@` (at sign)
+  * `[` (left bracket)
+  * `\\` (two backward slashes)
+  *  `_` (underscore)
+  * `^` (caret)
+
+  These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
+  sequences. To configure a different configuration default key sequence for all
+  containers, see **docker(1)**.
+
+  # EXAMPLES
+
+  ## Attaching to a container
+
+  In this example the top command is run inside a container, from an image called
+  fedora, in detached mode. The ID from the container is passed into the **docker
+  attach** command:
+
+      # ID=$(sudo docker run -d fedora /usr/bin/top -b)
+      # sudo docker attach $ID
+      top - 02:05:52 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
+      Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+      Cpu(s):  0.1%!u(MISSING)s,  0.2%!s(MISSING)y,  0.0%!n(MISSING)i, 99.7%!i(MISSING)d,  0.0%!w(MISSING)a,  0.0%!h(MISSING)i,  0.0%!s(MISSING)i,  0.0%!s(MISSING)t
+      Mem:    373572k total,   355560k used,    18012k free,    27872k buffers
+      Swap:   786428k total,        0k used,   786428k free,   221740k cached
+
+      PID USER      PR  NI  VIRT  RES  SHR S %!C(MISSING)PU %!M(MISSING)EM    TIME+  COMMAND
+      1 root      20   0 17200 1116  912 R    0  0.3   0:00.03 top
+
+      top - 02:05:55 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
+      Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+      Cpu(s):  0.0%!u(MISSING)s,  0.2%!s(MISSING)y,  0.0%!n(MISSING)i, 99.8%!i(MISSING)d,  0.0%!w(MISSING)a,  0.0%!h(MISSING)i,  0.0%!s(MISSING)i,  0.0%!s(MISSING)t
+      Mem:    373572k total,   355244k used,    18328k free,    27872k buffers
+      Swap:   786428k total,        0k used,   786428k free,   221776k cached
+
+      PID USER      PR  NI  VIRT  RES  SHR S %!C(MISSING)PU %!M(MISSING)EM    TIME+  COMMAND
+      1 root      20   0 17208 1144  932 R    0  0.3   0:00.03 top
 usage: docker container attach [OPTIONS] CONTAINER
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_commit.yaml
+++ b/_data/engine-cli/docker_container_commit.yaml
@@ -1,6 +1,22 @@
 command: docker container commit
 short: Create a new image from a container's changes
-long: Create a new image from a container's changes
+long: "Create a new image from an existing container specified by name or\ncontainer
+  ID.  The new image will contain the contents of the\ncontainer filesystem, *excluding*
+  any data volumes. Refer to **docker-tag(1)**\nfor more information about valid image
+  and tag names.\n\nWhile the `docker commit` command is a convenient way of extending
+  an\nexisting image, you should prefer the use of a Dockerfile and `docker\nbuild`
+  for generating images that you intend to share with other\npeople.\n\n# EXAMPLES\n\n##
+  Creating a new image from an existing container\nAn existing Fedora based container
+  has had Apache installed while running\nin interactive mode with the bash shell.
+  Apache is also running. To\ncreate a new image run `docker ps` to find the container's
+  ID and then run:\n\n    # docker commit -m=\"Added Apache to Fedora base image\"
+  \\\n      -a=\"A D Ministrator\" 98bd7fc99854 fedora/fedora_httpd:20\n\nNote that
+  only a-z0-9-_. are allowed when naming images from an \nexisting container.\n\n##
+  Apply specified Dockerfile instructions while committing the image\nIf an existing
+  container was created without the DEBUG environment\nvariable set to \"true\", you
+  can create a new image based on that\ncontainer by first getting the container's
+  ID with `docker ps` and\nthen running:\n\n    # docker container commit -c=\"ENV
+  DEBUG true\" 98bd7fc99854 debug-image\n"
 usage: docker container commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_cp.yaml
+++ b/_data/engine-cli/docker_container_cp.yaml
@@ -1,12 +1,94 @@
 command: docker container cp
 short: Copy files/folders between a container and the local filesystem
-long: |-
-  Copy files/folders between a container and the local filesystem
-
-  Use '-' as the source to read a tar archive from stdin
-  and extract it to a directory destination in a container.
-  Use '-' as the destination to stream a tar archive of a
-  container source to stdout.
+long: "The `docker container cp` utility copies the contents of `SRC_PATH` to the
+  `DEST_PATH`.\nYou can copy from the container's file system to the local machine
+  or the\nreverse, from the local filesystem to the container. If `-` is specified
+  for\neither the `SRC_PATH` or `DEST_PATH`, you can also stream a tar archive from\n`STDIN`
+  or to `STDOUT`. The `CONTAINER` can be a running or stopped container.\nThe `SRC_PATH`
+  or `DEST_PATH` can be a file or directory.\n\nThe `docker container cp` command
+  assumes container paths are relative to the container's \n`/` (root) directory.
+  This means supplying the initial forward slash is optional; \nThe command sees `compassionate_darwin:/tmp/foo/myfile.txt`
+  and\n`compassionate_darwin:tmp/foo/myfile.txt` as identical. Local machine paths
+  can\nbe an absolute or relative value. The command interprets a local machine's\nrelative
+  paths as relative to the current working directory where `docker container cp` is\nrun.\n\nThe
+  `cp` command behaves like the Unix `cp -a` command in that directories are\ncopied
+  recursively with permissions preserved if possible. Ownership is set to\nthe user
+  and primary group at the destination. For example, files copied to a\ncontainer
+  are created with `UID:GID` of the root user. Files copied to the local\nmachine
+  are created with the `UID:GID` of the user which invoked the `docker container cp`\ncommand.
+  \ If you specify the `-L` option, `docker container cp` follows any symbolic link\nin
+  the `SRC_PATH`. `docker container cp` does *not* create parent directories for\n`DEST_PATH`
+  if they do not exist.\n\nAssuming a path separator of `/`, a first argument of `SRC_PATH`
+  and second\nargument of `DEST_PATH`, the behavior is as follows:\n\n- `SRC_PATH`
+  specifies a file\n    - `DEST_PATH` does not exist\n        - the file is saved
+  to a file created at `DEST_PATH`\n    - `DEST_PATH` does not exist and ends with
+  `/`\n        - Error condition: the destination directory must exist.\n    - `DEST_PATH`
+  exists and is a file\n        - the destination is overwritten with the source file's
+  contents\n    - `DEST_PATH` exists and is a directory\n        - the file is copied
+  into this directory using the basename from\n          `SRC_PATH`\n- `SRC_PATH`
+  specifies a directory\n    - `DEST_PATH` does not exist\n        - `DEST_PATH` is
+  created as a directory and the *contents* of the source\n           directory are
+  copied into this directory\n    - `DEST_PATH` exists and is a file\n        - Error
+  condition: cannot copy a directory to a file\n    - `DEST_PATH` exists and is a
+  directory\n        - `SRC_PATH` does not end with `/.` (that is: _slash_ followed
+  by _dot_)\n            - the source directory is copied into this directory\n        -
+  `SRC_PATH` does end with `/.` (that is: _slash_ followed by _dot_)\n            -
+  the *content* of the source directory is copied into this\n              directory\n\nThe
+  command requires `SRC_PATH` and `DEST_PATH` to exist according to the above\nrules.
+  If `SRC_PATH` is local and is a symbolic link, the symbolic link, not\nthe target,
+  is copied by default. To copy the link target and not the link, \nspecify the `-L`
+  option.\n\nA colon (`:`) is used as a delimiter between `CONTAINER` and its path.
+  You can\nalso use `:` when specifying paths to a `SRC_PATH` or `DEST_PATH` on a
+  local\nmachine, for example  `file:name.txt`. If you use a `:` in a local machine
+  path,\nyou must be explicit with a relative or absolute path, for example:\n\n    `/path/to/file:name.txt`
+  or `./file:name.txt`\n\nIt is not possible to copy certain system files such as
+  resources under\n`/proc`, `/sys`, `/dev`, tmpfs, and mounts created by the user
+  in the container.\nHowever, you can still copy such files by manually running `tar`
+  in `docker exec`.\nFor example (consider `SRC_PATH` and `DEST_PATH` are directories):\n\n
+  \   $ docker exec foo tar Ccf $(dirname SRC_PATH) - $(basename SRC_PATH) | tar Cxf
+  DEST_PATH -\n\nor\n\n    $ tar Ccf $(dirname SRC_PATH) - $(basename SRC_PATH) |
+  docker exec -i foo tar Cxf DEST_PATH -\n\n\nUsing `-` as the `SRC_PATH` streams
+  the contents of `STDIN` as a tar archive.\nThe command extracts the content of the
+  tar to the `DEST_PATH` in container's\nfilesystem. In this case, `DEST_PATH` must
+  specify a directory. Using `-` as\nthe `DEST_PATH` streams the contents of the resource
+  as a tar archive to `STDOUT`.\n\n# EXAMPLES\n\nSuppose a container has finished
+  producing some output as a file it saves\nto somewhere in its filesystem. This could
+  be the output of a build job or\nsome other computation. You can copy these outputs
+  from the container to a\nlocation on your local host.\n\nIf you want to copy the
+  `/tmp/foo` directory from a container to the\nexisting `/tmp` directory on your
+  host. If you run `docker container cp` in your `~`\n(home) directory on the local
+  host:\n\n    $ docker container cp compassionate_darwin:tmp/foo /tmp\n\nDocker creates
+  a `/tmp/foo` directory on your host. Alternatively, you can omit\nthe leading slash
+  in the command. If you execute this command from your home\ndirectory:\n\n    $
+  docker container cp compassionate_darwin:tmp/foo tmp\n\nIf `~/tmp` does not exist,
+  Docker will create it and copy the contents of\n`/tmp/foo` from the container into
+  this new directory. If `~/tmp` already\nexists as a directory, then Docker will
+  copy the contents of `/tmp/foo` from\nthe container into a directory at `~/tmp/foo`.\n\nWhen
+  copying a single file to an existing `LOCALPATH`, the `docker container cp` command\nwill
+  either overwrite the contents of `LOCALPATH` if it is a file or place it\ninto `LOCALPATH`
+  if it is a directory, overwriting an existing file of the same\nname if one exists.
+  For example, this command:\n\n    $ docker container cp sharp_ptolemy:/tmp/foo/myfile.txt
+  /test\n\nIf `/test` does not exist on the local machine, it will be created as a
+  file\nwith the contents of `/tmp/foo/myfile.txt` from the container. If `/test`\nexists
+  as a file, it will be overwritten. Lastly, if `/test` exists as a\ndirectory, the
+  file will be copied to `/test/myfile.txt`.\n\nNext, suppose you want to copy a file
+  or folder into a container. For example,\nthis could be a configuration file or
+  some other input to a long running\ncomputation that you would like to place into
+  a created container before it\nstarts. This is useful because it does not require
+  the configuration file or\nother input to exist in the container image.\n\nIf you
+  have a file, `config.yml`, in the current directory on your local host\nand wish
+  to copy it to an existing directory at `/etc/my-app.d` in a container,\nthis command
+  can be used:\n\n    $ docker container cp config.yml myappcontainer:/etc/my-app.d\n\nIf
+  you have several files in a local directory `/config` which you need to copy\nto
+  a directory `/etc/my-app.d` in a container:\n\n    $ docker container cp /config/.
+  myappcontainer:/etc/my-app.d\n\nThe above command will copy the contents of the
+  local `/config` directory into\nthe directory `/etc/my-app.d` in the container.\n\nFinally,
+  if you want to copy a symbolic link into a container, you typically\nwant to  copy
+  the linked target and not the link itself. To copy the target, use\nthe `-L` option,
+  for example:\n\n    $ ln -s /tmp/somefile /tmp/somefile.ln\n    $ docker container
+  cp -L /tmp/somefile.ln myappcontainer:/tmp/\n\nThis command copies content of the
+  local `/tmp/somefile` into the file\n`/tmp/somefile.ln` in the container. Without
+  `-L` option, the `/tmp/somefile.ln`\npreserves its symbolic link but not its content.\n"
 usage: "docker container cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp
   [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH"
 pname: docker container

--- a/_data/engine-cli/docker_container_create.yaml
+++ b/_data/engine-cli/docker_container_create.yaml
@@ -1,6 +1,73 @@
 command: docker container create
 short: Create a new container
-long: Create a new container
+long: "Creates a writeable container layer over the specified image and prepares it
+  for\nrunning the specified command. The container ID is then printed to STDOUT.
+  This\nis similar to **docker run -d** except the container is never started. You
+  can \nthen use the **docker start <container_id>** command to start the container
+  at\nany point.\n\nThe initial status of the container created with **docker create**
+  is 'created'.\n\n# OPTIONS \n\nThe `CONTAINER-DIR` must be an absolute path such
+  as `/src/docs`. The `HOST-DIR`\ncan be an absolute path or a `name` value. A `name`
+  value must start with an\nalphanumeric character, followed by `a-z0-9`, `_` (underscore),
+  `.` (period) or\n`-` (hyphen). An absolute path starts with a `/` (forward slash).\n\nIf
+  you supply a `HOST-DIR` that is an absolute path,  Docker bind-mounts to the\npath
+  you specify. If you supply a `name`, Docker creates a named volume by that\n`name`.
+  For example, you can specify either `/foo` or `foo` for a `HOST-DIR`\nvalue. If
+  you supply the `/foo` value, Docker creates a bind-mount. If you\nsupply the `foo`
+  specification, Docker creates a named volume.\n\nYou can specify multiple  **-v**
+  options to mount one or more mounts to a\ncontainer. To use these same mounts in
+  other containers, specify the\n**--volumes-from** option also.\n\nYou can add `:ro`
+  or `:rw` suffix to a volume to mount it  read-only or\nread-write mode, respectively.
+  By default, the volumes are mounted read-write.\nSee examples.\n\nLabeling systems
+  like SELinux require that proper labels are placed on volume\ncontent mounted into
+  a container. Without a label, the security system might\nprevent the processes running
+  inside the container from using the content. By\ndefault, Docker does not change
+  the labels set by the OS.\n\nTo change a label in the container context, you can
+  add either of two suffixes\n`:z` or `:Z` to the volume mount. These suffixes tell
+  Docker to relabel file\nobjects on the shared volumes. The `z` option tells Docker
+  that two containers\nshare the volume content. As a result, Docker labels the content
+  with a shared\ncontent label. Shared volume labels allow all containers to read/write
+  content.\nThe `Z` option tells Docker to label the content with a private unshared
+  label.\nOnly the current container can use a private volume.\n\nBy default bind
+  mounted volumes are `private`. That means any mounts done\ninside container will
+  not be visible on host and vice-a-versa. One can change\nthis behavior by specifying
+  a volume mount propagation property. Making a\nvolume `shared` mounts done under
+  that volume inside container will be\nvisible on host and vice-a-versa. Making a
+  volume `slave` enables only one\nway mount propagation and that is mounts done on
+  host under that volume\nwill be visible inside container but not the other way around.\n\nTo
+  control mount propagation property of volume one can use `:[r]shared`,\n`:[r]slave`
+  or `:[r]private` propagation flag. Propagation property can\nbe specified only for
+  bind mounted volumes and not for internal volumes or\nnamed volumes. For mount propagation
+  to work source mount point (mount point\nwhere source dir is mounted on) has to
+  have right propagation properties. For\nshared volumes, source mount point has to
+  be shared. And for slave volumes,\nsource mount has to be either shared or slave.\n\nUse
+  `df <source-dir>` to figure out the source mount and then use\n`findmnt -o TARGET,PROPAGATION
+  <source-mount-dir>` to figure out propagation\nproperties of source mount. If `findmnt`
+  utility is not available, then one\ncan look at mount entry for source mount point
+  in `/proc/self/mountinfo`. Look\nat `optional fields` and see if any propagaion
+  properties are specified.\n`shared:X` means mount is `shared`, `master:X` means
+  mount is `slave` and if\nnothing is there that means mount is `private`.\n\nTo change
+  propagation properties of a mount point use `mount` command. For\nexample, if one
+  wants to bind mount source directory `/foo` one can do\n`mount --bind /foo /foo`
+  and `mount --make-private --make-shared /foo`. This\nwill convert /foo into a `shared`
+  mount point. Alternatively one can directly\nchange propagation properties of source
+  mount. Say `/` is source mount for\n`/foo`, then use `mount --make-shared /` to
+  convert `/` into a `shared` mount.\n\n> **Note**:\n> When using systemd to manage
+  the Docker daemon's start and stop, in the systemd\n> unit file there is an option
+  to control mount propagation for the Docker daemon\n> itself, called `MountFlags`.
+  The value of this setting may cause Docker to not\n> see mount propagation changes
+  made on the mount point. For example, if this value\n> is `slave`, you may not be
+  able to use the `shared` or `rshared` propagation on\n> a volume.\n\n\nTo disable
+  automatic copying of data from the container path to the volume, use\nthe `nocopy`
+  flag. The `nocopy` flag can be set on bind mounts and named volumes.\n\n# EXAMPLES\n\n##
+  Specify isolation technology for container (--isolation)\n\nThis option is useful
+  in situations where you are running Docker containers on\nWindows. The `--isolation=<value>`
+  option sets a container's isolation\ntechnology. On Linux, the only supported is
+  the `default` option which uses\nLinux namespaces. On Microsoft Windows, you can
+  specify these values:\n\n* `default`: Use the value specified by the Docker daemon's
+  `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft
+  Windows uses `process` as its default value.\n* `process`: Namespace isolation only.\n*
+  `hyperv`: Hyper-V hypervisor partition-based isolation.\n\nSpecifying the `--isolation`
+  flag without a value is the same as setting `--isolation=\"default\"`.\n"
 usage: docker container create [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker container
 plink: docker_container.yaml
@@ -140,9 +207,9 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
 - option: ip
-  description: Container IPv4 address (e.g. 172.30.100.104)
+  description: IPv4 address (e.g., 172.30.100.104)
 - option: ip6
-  description: Container IPv6 address (e.g. 2001:db8::33)
+  description: IPv6 address (e.g., 2001:db8::33)
 - option: ipc
   description: IPC namespace to use
 - option: isolation
@@ -168,7 +235,7 @@ options:
   default_value: '[]'
   description: Log driver options
 - option: mac-address
-  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+  description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
 - option: memory
   shorthand: m
   description: Memory limit

--- a/_data/engine-cli/docker_container_diff.yaml
+++ b/_data/engine-cli/docker_container_diff.yaml
@@ -1,6 +1,45 @@
 command: docker container diff
-short: Inspect changes on a container's filesystem
-long: Inspect changes on a container's filesystem
+short: Inspect changes to files or directories on a container's filesystem
+long: |
+  List the changed files and directories in a container᾿s filesystem since the
+  container was created. Three different types of change are tracked:
+
+  | Symbol | Description                     |
+  |--------|---------------------------------|
+  | `A`    | A file or directory was added   |
+  | `D`    | A file or directory was deleted |
+  | `C`    | A file or directory was changed |
+
+  You can use the full or shortened container ID or the container name set using
+  **docker run --name** option.
+
+  # EXAMPLES
+
+  Inspect the changes to an `nginx` container:
+
+  ```bash
+  $ docker diff 1fdfd1f54c1b
+
+  C /dev
+  C /dev/console
+  C /dev/core
+  C /dev/stdout
+  C /dev/fd
+  C /dev/ptmx
+  C /dev/stderr
+  C /dev/stdin
+  C /run
+  A /run/nginx.pid
+  C /var/lib/nginx/tmp
+  A /var/lib/nginx/tmp/client_body
+  A /var/lib/nginx/tmp/fastcgi
+  A /var/lib/nginx/tmp/proxy
+  A /var/lib/nginx/tmp/scgi
+  A /var/lib/nginx/tmp/uwsgi
+  C /var/log/nginx
+  A /var/log/nginx/access.log
+  A /var/log/nginx/error.log
+  ```
 usage: docker container diff CONTAINER
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_exec.yaml
+++ b/_data/engine-cli/docker_container_exec.yaml
@@ -1,6 +1,18 @@
 command: docker container exec
 short: Run a command in a running container
-long: Run a command in a running container
+long: "Run a process in a running container.\n\nThe command started using `docker
+  exec` will only run while the container's primary\nprocess (`PID 1`) is running,
+  and will not be restarted if the container is restarted.\n\nIf the container is
+  paused, then the `docker exec` command will wait until the\ncontainer is unpaused,
+  and then run\n\n# CAPABILITIES\n\n`privileged` gives the process extended\n[Linux
+  capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html)\nwhen running
+  in a container. \n\nWithout this flag, the process run by `docker exec` in a running
+  container has\nthe same capabilities as the container, which may be limited. Set\n`--privileged`
+  to give all capabilities to the process.\n\n# USER\n`user` sets the username or
+  UID used and optionally the groupname or GID for the specified command.\n\n   The
+  followings examples are all valid:\n   --user [user | user:group | uid | uid:gid
+  | user:gid | uid:group ]\n\n   Without this argument the command will be run as
+  root in the container.\n"
 usage: docker container exec [OPTIONS] CONTAINER COMMAND [ARG...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_export.yaml
+++ b/_data/engine-cli/docker_container_export.yaml
@@ -1,6 +1,26 @@
 command: docker container export
 short: Export a container's filesystem as a tar archive
-long: Export a container's filesystem as a tar archive
+long: |
+  Export the contents of a container's filesystem using the full or shortened
+  container ID or container name. The output is exported to STDOUT and can be
+  redirected to a tar file.
+
+  Stream to a file instead of STDOUT by using **-o**.
+
+  # EXAMPLES
+  Export the contents of the container called angry_bell to a tar file
+  called angry_bell.tar:
+
+      # docker export angry_bell > angry_bell.tar
+      # docker export --output=angry_bell-latest.tar angry_bell
+      # ls -sh angry_bell.tar
+      321M angry_bell.tar
+      # ls -sh angry_bell-latest.tar
+      321M angry_bell-latest.tar
+
+  # See also
+  **docker-import(1)** to create an empty filesystem image
+  and import the contents of the tarball into it, then optionally tag it.
 usage: docker container export [OPTIONS] CONTAINER
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_kill.yaml
+++ b/_data/engine-cli/docker_container_kill.yaml
@@ -1,6 +1,8 @@
 command: docker container kill
 short: Kill one or more running containers
-long: Kill one or more running containers
+long: |
+  The main process inside each container specified will be sent SIGKILL,
+   or any signal specified with option --signal.
 usage: docker container kill [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_logs.yaml
+++ b/_data/engine-cli/docker_container_logs.yaml
@@ -1,6 +1,34 @@
 command: docker container logs
 short: Fetch the logs of a container
-long: Fetch the logs of a container
+long: |
+  The **docker container logs** command batch-retrieves whatever logs are present for
+  a container at the time of execution. This does not guarantee execution
+  order when combined with a docker run (i.e., your run may not have generated
+  any logs at the time you execute docker container logs).
+
+  The **docker container logs --follow** command combines commands **docker container logs** and
+  **docker attach**. It will first return all logs from the beginning and
+  then continue streaming new output from the container's stdout and stderr.
+
+  **Warning**: This command works only for the **json-file** or **journald**
+  logging drivers.
+
+  The `--since` option can be Unix timestamps, date formatted timestamps, or Go
+  duration strings (e.g. `10m`, `1h30m`) computed relative to the client machine's
+  time. Supported formats for date formatted time stamps include RFC3339Nano,
+  RFC3339, `2006-01-02T15:04:05`, `2006-01-02T15:04:05.999999999`,
+  `2006-01-02Z07:00`, and `2006-01-02`. The local timezone on the client will be
+  used if you do not provide either a `Z` or a `+-00:00` timezone offset at the
+  end of the timestamp.  When providing Unix timestamps enter
+  seconds[.nanoseconds], where seconds is the number of seconds that have elapsed
+  since January 1, 1970 (midnight UTC/GMT), not counting leap  seconds (aka Unix
+  epoch or Unix time), and the optional .nanoseconds field is a fraction of a
+  second no more than nine digits long. You can combine the `--since` option with
+  either or both of the `--follow` or `--tail` options.
+
+  The `docker container logs --details` command will add on extra attributes, such as
+  environment variables and labels, provided to `--log-opt` when creating the
+  container.
 usage: docker container logs [OPTIONS] CONTAINER
 pname: docker container
 plink: docker_container.yaml
@@ -13,7 +41,8 @@ options:
   default_value: "false"
   description: Follow log output
 - option: since
-  description: Show logs since timestamp
+  description: |
+    Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
 - option: tail
   default_value: all
   description: Number of lines to show from the end of the logs

--- a/_data/engine-cli/docker_container_ls.yaml
+++ b/_data/engine-cli/docker_container_ls.yaml
@@ -1,7 +1,103 @@
 command: docker container ls
 aliases: ps, list
 short: List containers
-long: List containers
+long: |
+  List the containers in the local repository. By default this shows only
+  the running containers.
+
+  ## Filters
+
+  Filter output based on these conditions:
+     - exited=<int> an exit code of <int>
+     - label=<key> or label=<key>=<value>
+     - status=(created|restarting|running|paused|exited|dead)
+     - name=<string> a container's name
+     - id=<ID> a container's ID
+     - is-task=(true|false) - containers that are a task (part of a service managed by swarm)
+     - before=(<container-name>|<container-id>)
+     - since=(<container-name>|<container-id>)
+     - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.
+     - volume=(<volume-name>|<mount-point-destination>)
+     - network=(<network-name>|<network-id>) - containers connected to the provided network
+     - health=(starting|healthy|unhealthy|none) - filters containers based on healthcheck status
+
+  ## Format
+
+     Pretty-print containers using a Go template.
+     Valid placeholders:
+        .ID - Container ID
+        .Image - Image ID
+        .Command - Quoted command
+        .CreatedAt - Time when the container was created.
+        .RunningFor - Elapsed time since the container was started.
+        .Ports - Exposed ports.
+        .Status - Container status.
+        .Size - Container disk size.
+        .Names - Container names.
+        .Labels - All labels assigned to the container.
+        .Label - Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
+        .Mounts - Names of the volumes mounted in this container.
+
+  # EXAMPLES
+  # Display all containers, including non-running
+
+      # docker container ls -a
+      CONTAINER ID        IMAGE                 COMMAND                CREATED             STATUS      PORTS    NAMES
+      a87ecb4f327c        fedora:20             /bin/sh -c #(nop) MA   20 minutes ago      Exit 0               desperate_brattain
+      01946d9d34d8        vpavlin/rhel7:latest  /bin/sh -c #(nop) MA   33 minutes ago      Exit 0               thirsty_bell
+      c1d3b0166030        acffc0358b9e          /bin/sh -c yum -y up   2 weeks ago         Exit 1               determined_torvalds
+      41d50ecd2f57        fedora:20             /bin/sh -c #(nop) MA   2 weeks ago         Exit 0               drunk_pike
+
+  # Display only IDs of all containers, including non-running
+
+      # docker container ls -a -q
+      a87ecb4f327c
+      01946d9d34d8
+      c1d3b0166030
+      41d50ecd2f57
+
+  # Display only IDs of all containers that have the name `determined_torvalds`
+
+      # docker container ls -a -q --filter=name=determined_torvalds
+      c1d3b0166030
+
+  # Display containers with their commands
+
+      # docker container ls --format "{{.ID}}: {{.Command}}"
+      a87ecb4f327c: /bin/sh -c #(nop) MA
+      01946d9d34d8: /bin/sh -c #(nop) MA
+      c1d3b0166030: /bin/sh -c yum -y up
+      41d50ecd2f57: /bin/sh -c #(nop) MA
+
+  # Display containers with their labels in a table
+
+      # docker container ls --format "table {{.ID}}\t{{.Labels}}"
+      CONTAINER ID        LABELS
+      a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd
+      01946d9d34d8
+      c1d3b0166030        com.docker.swarm.node=debian,com.docker.swarm.cpu=6
+      41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd
+
+  # Display containers with their node label in a table
+
+      # docker container ls --format 'table {{.ID}}\t{{(.Label "com.docker.swarm.node")}}'
+      CONTAINER ID        NODE
+      a87ecb4f327c        ubuntu
+      01946d9d34d8
+      c1d3b0166030        debian
+      41d50ecd2f57        fedora
+
+  # Display containers with `remote-volume` mounted
+
+      $ docker container ls --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
+      CONTAINER ID        MOUNTS
+      9c3527ed70ce        remote-volume
+
+  # Display containers with a volume mounted in `/data`
+
+      $ docker container ls --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
+      CONTAINER ID        MOUNTS
+      9c3527ed70ce        remote-volume
 usage: docker container ls [OPTIONS]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_pause.yaml
+++ b/_data/engine-cli/docker_container_pause.yaml
@@ -1,6 +1,18 @@
 command: docker container pause
 short: Pause all processes within one or more containers
-long: Pause all processes within one or more containers
+long: |
+  The `docker container pause` command suspends all processes in the specified containers.
+  On Linux, this uses the cgroups freezer. Traditionally, when suspending a process
+  the `SIGSTOP` signal is used, which is observable by the process being suspended.
+  With the cgroups freezer the process is unaware, and unable to capture,
+  that it is being suspended, and subsequently resumed. On Windows, only Hyper-V
+  containers can be paused.
+
+  See the [cgroups freezer documentation]
+  (https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt) for
+  further details.
+
+  **docker-container-unpause(1)** to unpause all processes within a container.
 usage: docker container pause CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_port.yaml
+++ b/_data/engine-cli/docker_container_port.yaml
@@ -1,6 +1,32 @@
 command: docker container port
 short: List port mappings or a specific mapping for the container
-long: List port mappings or a specific mapping for the container
+long: |
+  List port mappings for the CONTAINER, or lookup the public-facing port that is NAT-ed to the PRIVATE_PORT
+
+  # EXAMPLES
+
+      # docker ps
+      CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
+      b650456536c7        busybox:latest      top                 54 minutes ago      Up 54 minutes       0.0.0.0:1234->9876/tcp, 0.0.0.0:4321->7890/tcp   test
+
+  ## Find out all the ports mapped
+
+      # docker container port test
+      7890/tcp -> 0.0.0.0:4321
+      9876/tcp -> 0.0.0.0:1234
+
+  ## Find out a specific mapping
+
+      # docker container port test 7890/tcp
+      0.0.0.0:4321
+
+      # docker container port test 7890
+      0.0.0.0:4321
+
+  ## An example showing error for non-existent mapping
+
+      # docker container port test 7890/udp
+      2014/06/24 11:53:36 Error: No public port '7890/udp' published for test
 usage: docker container port CONTAINER [PRIVATE_PORT[/PROTO]]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_prune.yaml
+++ b/_data/engine-cli/docker_container_prune.yaml
@@ -5,6 +5,8 @@ usage: docker container prune [OPTIONS]
 pname: docker container
 plink: docker_container.yaml
 options:
+- option: filter
+  description: Provide filter values (e.g. 'until=<timestamp>')
 - option: force
   shorthand: f
   default_value: "false"

--- a/_data/engine-cli/docker_container_rename.yaml
+++ b/_data/engine-cli/docker_container_rename.yaml
@@ -1,6 +1,7 @@
 command: docker container rename
 short: Rename a container
-long: Rename a container
+long: |
+  Rename a container.  Container may be running, paused or stopped.
 usage: docker container rename CONTAINER NEW_NAME
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_restart.yaml
+++ b/_data/engine-cli/docker_container_restart.yaml
@@ -1,6 +1,7 @@
 command: docker container restart
 short: Restart one or more containers
-long: Restart one or more containers
+long: |
+  Restart each container listed.
 usage: docker container restart [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_rm.yaml
+++ b/_data/engine-cli/docker_container_rm.yaml
@@ -1,6 +1,43 @@
 command: docker container rm
 short: Remove one or more containers
-long: Remove one or more containers
+long: |
+  **docker container rm** will remove one or more containers from the host node. The
+  container name or ID can be used. This does not remove images. You cannot
+  remove a running container unless you use the **-f** option. To see all
+  containers on a host use the **docker container ls -a** command.
+
+  # EXAMPLES
+
+  ## Removing a container using its ID
+
+  To remove a container using its ID, find either from a **docker ps -a**
+  command, or use the ID returned from the **docker run** command, or retrieve
+  it from a file used to store it using the **docker run --cidfile**:
+
+      docker container rm abebf7571666
+
+  ## Removing a container using the container name
+
+  The name of the container can be found using the **docker ps -a**
+  command. The use that name as follows:
+
+      docker container rm hopeful_morse
+
+  ## Removing a container and all associated volumes
+
+      $ docker container rm -v redis
+      redis
+
+  This command will remove the container and any volumes associated with it.
+  Note that if a volume was specified with a name, it will not be removed.
+
+      $ docker create -v awesome:/foo -v /bar --name hello redis
+      hello
+      $ docker container rm -v hello
+
+  In this example, the volume for `/foo` will remain in tact, but the volume for
+  `/bar` will be removed. The same behavior holds for volumes inherited with
+  `--volumes-from`.
 usage: docker container rm [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_run.yaml
+++ b/_data/engine-cli/docker_container_run.yaml
@@ -1,6 +1,7 @@
 command: docker container run
 short: Run a command in a new container
-long: Run a command in a new container
+long: |
+  Alias for `docker run`.
 usage: docker container run [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker container
 plink: docker_container.yaml
@@ -146,9 +147,9 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
 - option: ip
-  description: Container IPv4 address (e.g. 172.30.100.104)
+  description: IPv4 address (e.g., 172.30.100.104)
 - option: ip6
-  description: Container IPv6 address (e.g. 2001:db8::33)
+  description: IPv6 address (e.g., 2001:db8::33)
 - option: ipc
   description: IPC namespace to use
 - option: isolation
@@ -174,7 +175,7 @@ options:
   default_value: '[]'
   description: Log driver options
 - option: mac-address
-  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+  description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
 - option: memory
   shorthand: m
   description: Memory limit

--- a/_data/engine-cli/docker_container_start.yaml
+++ b/_data/engine-cli/docker_container_start.yaml
@@ -1,6 +1,7 @@
 command: docker container start
 short: Start one or more stopped containers
-long: Start one or more stopped containers
+long: |
+  Start one or more containers.
 usage: docker container start [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_stats.yaml
+++ b/_data/engine-cli/docker_container_stats.yaml
@@ -1,6 +1,38 @@
 command: docker container stats
 short: Display a live stream of container(s) resource usage statistics
-long: Display a live stream of container(s) resource usage statistics
+long: |
+  Display a live stream of one or more containers' resource usage statistics
+
+  # Format
+
+     Pretty-print containers statistics using a Go template.
+     Valid placeholders:
+        .Container - Container name or ID.
+        .Name - Container name.
+        .ID - Container ID.
+        .CPUPerc - CPU percentage.
+        .MemUsage - Memory usage.
+        .NetIO - Network IO.
+        .BlockIO - Block IO.
+        .MemPerc - Memory percentage (Not available on Windows).
+        .PIDs - Number of PIDs (Not available on Windows).
+
+  # EXAMPLES
+
+  Running `docker container stats` on all running containers
+
+      $ docker container stats
+      CONTAINER           CPU %!M(MISSING)EM USAGE / LIMIT     MEM %!N(MISSING)ET I/O             BLOCK I/O
+      1285939c1fd3        0.07%! (MISSING)KiB / 64 MiB        1.21%! (MISSING)B / 648 B       3.568 MB / 512 KB
+      9c76f7834ae2        0.07%! (MISSING)MiB / 64 MiB      4.29%! (MISSING)KB / 648 B    12.4 MB / 0 B
+      d1ea048f04e4        0.03%! (MISSING)MiB / 64 MiB      6.30%! (MISSING)KB / 648 B    27.7 MB / 0 B
+
+  Running `docker container stats` on multiple containers by name and id.
+
+      $ docker container stats fervent_panini 5acfcb1b4fd1
+      CONTAINER           CPU %!M(MISSING)EM USAGE/LIMIT     MEM %!N(MISSING)ET I/O
+      5acfcb1b4fd1        0.00%! (MISSING)MiB/1.045 GiB   11.03%! (MISSING)kB/648 B
+      fervent_panini      0.02%! (MISSING)MiB/1.045 GiB   1.06%! (MISSING)B/648 B
 usage: docker container stats [OPTIONS] [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_stop.yaml
+++ b/_data/engine-cli/docker_container_stop.yaml
@@ -1,6 +1,7 @@
 command: docker container stop
 short: Stop one or more running containers
-long: Stop one or more running containers
+long: |
+  Stop a container (Send SIGTERM, and then SIGKILL after grace period)
 usage: docker container stop [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_top.yaml
+++ b/_data/engine-cli/docker_container_top.yaml
@@ -1,6 +1,17 @@
 command: docker container top
 short: Display the running processes of a container
-long: Display the running processes of a container
+long: |
+  Display the running process of the container. ps-OPTION can be any of the options you would pass to a Linux ps command.
+
+  All displayed information is from host's point of view.
+
+  # EXAMPLES
+
+  Run **docker container top** with the ps option of -x:
+
+      $ docker container top 8601afda2b -x
+      PID      TTY       STAT       TIME         COMMAND
+      16623    ?         Ss         0:00         sleep 99999
 usage: docker container top CONTAINER [ps OPTIONS]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_unpause.yaml
+++ b/_data/engine-cli/docker_container_unpause.yaml
@@ -1,6 +1,12 @@
 command: docker container unpause
 short: Unpause all processes within one or more containers
-long: Unpause all processes within one or more containers
+long: |
+  The `docker container unpause` command un-suspends all processes in a container.
+  On Linux, it does this using the cgroups freezer.
+
+  See the [cgroups freezer documentation]
+  (https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt) for
+  further details.
 usage: docker container unpause CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_update.yaml
+++ b/_data/engine-cli/docker_container_update.yaml
@@ -1,6 +1,50 @@
 command: docker container update
 short: Update configuration of one or more containers
-long: Update configuration of one or more containers
+long: "The **docker container update** command dynamically updates container configuration.\nYou
+  can use this command to prevent containers from consuming too many \nresources from
+  their Docker host.  With a single command, you can place \nlimits on a single container
+  or on many. To specify more than one container,\nprovide space-separated list of
+  container names or IDs.\n\nWith the exception of the **--kernel-memory** option,
+  you can specify these\noptions on a running or a stopped container. On kernel version
+  older than\n4.6, You can only update **--kernel-memory** on a stopped container
+  or on\na running container with kernel memory initialized.\n\n# OPTIONS\n\n## kernel-memory\n\nKernel
+  memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)\n\nNote that
+  on kernel version older than 4.6, you can not update kernel memory on\na running
+  container if the container is started without kernel memory initialized,\nin this
+  case, it can only be updated after it's stopped. The new setting takes\neffect when
+  the container is started.\n\n## memory\n\nMemory limit (format: <number><optional
+  unit>, where unit = b, k, m or g)\n\nNote that the memory should be smaller than
+  the already set swap memory limit.\nIf you want update a memory limit bigger than
+  the already set swap memory limit,\nyou should update swap memory limit at the same
+  time. If you don't set swap memory \nlimit on docker create/run but only memory
+  limit, the swap memory is double\nthe memory limit.\n\n# EXAMPLES\n\nThe following
+  sections illustrate ways to use this command.\n\n### Update a container's cpu-shares\n\nTo
+  limit a container's cpu-shares to 512, first identify the container\nname or ID.
+  You can use **docker ps** to find these values. You can also\nuse the ID returned
+  from the **docker run** command.  Then, do the following:\n\n```bash\n$ docker container
+  update --cpu-shares 512 abebf7571666\n```\n\n### Update a container with cpu-shares
+  and memory\n\nTo update multiple resource configurations for multiple containers:\n\n```bash\n$
+  docker container update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse\n```\n\n###
+  Update a container's kernel memory constraints\n\nYou can update a container's kernel
+  memory limit using the **--kernel-memory**\noption. On kernel version older than
+  4.6, this option can be updated on a\nrunning container only if the container was
+  started with **--kernel-memory**.\nIf the container was started *without* **--kernel-memory**
+  you need to stop\nthe container before updating kernel memory.\n\nFor example, if
+  you started a container with this command:\n\n```bash\n$ docker run -dit --name
+  test --kernel-memory 50M ubuntu bash\n```\n\nYou can update kernel memory while
+  the container is running:\n\n```bash\n$ docker container update --kernel-memory
+  80M test\n```\n\nIf you started a container *without* kernel memory initialized:\n\n```bash\n$
+  docker run -dit --name test2 --memory 300M ubuntu bash\n```\n\nUpdate kernel memory
+  of running container `test2` will fail. You need to stop\nthe container before updating
+  the **--kernel-memory** setting. The next time you\nstart it, the container uses
+  the new value.\n\nKernel version newer than (include) 4.6 does not have this limitation,
+  you\ncan use `--kernel-memory` the same way as other options.\n\n### Update a container's
+  restart policy\n\nYou can change a container's restart policy on a running container.
+  The new\nrestart policy takes effect instantly after you run `docker container update`
+  on a\ncontainer.\n\nTo update restart policy for one or more containers:\n\n```bash\n$
+  docker container update --restart=on-failure:3 abebf7571666 hopeful_morse\n```\n\nNote
+  that if the container is started with \"--rm\" flag, you cannot update the restart\npolicy
+  for it. The `AutoRemove` and `RestartPolicy` are mutually exclusive for the\ncontainer.\n"
 usage: docker container update [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_container_wait.yaml
+++ b/_data/engine-cli/docker_container_wait.yaml
@@ -1,6 +1,14 @@
 command: docker container wait
 short: Block until one or more containers stop, then print their exit codes
-long: Block until one or more containers stop, then print their exit codes
+long: |
+  Block until a container stops, then print its exit code.
+
+  # EXAMPLES
+
+      $ docker run -d fedora sleep 99
+      079b83f558a2bc52ecad6b2a5de13622d584e6bb1aea058c11b36511e85e7622
+      $ docker container wait 079b83f558a2bc
+      0
 usage: docker container wait CONTAINER [CONTAINER...]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_cp.yaml
+++ b/_data/engine-cli/docker_cp.yaml
@@ -1,12 +1,7 @@
 command: docker cp
 short: Copy files/folders between a container and the local filesystem
-long: |-
-  Copy files/folders between a container and the local filesystem
-
-  Use '-' as the source to read a tar archive from stdin
-  and extract it to a directory destination in a container.
-  Use '-' as the destination to stream a tar archive of a
-  container source to stdout.
+long: |
+  Alias for `docker container cp`.
 usage: "docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp [OPTIONS]
   SRC_PATH|- CONTAINER:DEST_PATH"
 pname: docker

--- a/_data/engine-cli/docker_create.yaml
+++ b/_data/engine-cli/docker_create.yaml
@@ -1,6 +1,7 @@
 command: docker create
 short: Create a new container
-long: Create a new container
+long: |
+  Alias for `docker container create`.
 usage: docker create [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker
 plink: docker.yaml
@@ -140,9 +141,9 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
 - option: ip
-  description: Container IPv4 address (e.g. 172.30.100.104)
+  description: IPv4 address (e.g., 172.30.100.104)
 - option: ip6
-  description: Container IPv6 address (e.g. 2001:db8::33)
+  description: IPv6 address (e.g., 2001:db8::33)
 - option: ipc
   description: IPC namespace to use
 - option: isolation
@@ -168,7 +169,7 @@ options:
   default_value: '[]'
   description: Log driver options
 - option: mac-address
-  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+  description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
 - option: memory
   shorthand: m
   description: Memory limit

--- a/_data/engine-cli/docker_diff.yaml
+++ b/_data/engine-cli/docker_diff.yaml
@@ -1,6 +1,7 @@
 command: docker diff
-short: Inspect changes on a container's filesystem
-long: Inspect changes on a container's filesystem
+short: Inspect changes to files or directories on a container's filesystem
+long: |
+  Alias for `docker container diff`.
 usage: docker diff CONTAINER
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_events.yaml
+++ b/_data/engine-cli/docker_events.yaml
@@ -1,6 +1,7 @@
 command: docker events
 short: Get real time events from the server
-long: Get real time events from the server
+long: |
+  Alias for `docker system events`.
 usage: docker events [OPTIONS]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_exec.yaml
+++ b/_data/engine-cli/docker_exec.yaml
@@ -1,6 +1,7 @@
 command: docker exec
 short: Run a command in a running container
-long: Run a command in a running container
+long: |
+  Alias for `docker container exec`.
 usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_export.yaml
+++ b/_data/engine-cli/docker_export.yaml
@@ -1,6 +1,7 @@
 command: docker export
 short: Export a container's filesystem as a tar archive
-long: Export a container's filesystem as a tar archive
+long: |
+  Alias for `docker container export`.
 usage: docker export [OPTIONS] CONTAINER
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_history.yaml
+++ b/_data/engine-cli/docker_history.yaml
@@ -1,6 +1,7 @@
 command: docker history
 short: Show the history of an image
-long: Show the history of an image
+long: |
+  Alias for `docker image history`.
 usage: docker history [OPTIONS] IMAGE
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_image_build.yaml
+++ b/_data/engine-cli/docker_image_build.yaml
@@ -1,6 +1,7 @@
 command: docker image build
 short: Build an image from a Dockerfile
-long: Build an image from a Dockerfile
+long: |
+  Alias for `docker build`.
 usage: docker image build [OPTIONS] PATH | URL | -
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_history.yaml
+++ b/_data/engine-cli/docker_image_history.yaml
@@ -1,6 +1,20 @@
 command: docker image history
 short: Show the history of an image
-long: Show the history of an image
+long: "Show the history of when and how an image was created.\n\n# EXAMPLES\n    $
+  docker history fedora\n    IMAGE          CREATED          CREATED BY                                      SIZE
+  \               COMMENT\n    105182bb5e8b   5 days ago       /bin/sh -c #(nop) ADD
+  file:71356d2ad59aa3119d   372.7 MB\n    73bd853d2ea5   13 days ago      /bin/sh
+  -c #(nop) MAINTAINER Lokesh Mandvekar   0 B\n    511136ea3c5a   10 months ago                                                    0
+  B                 Imported from -\n\n## Display comments in the image history\nThe
+  `docker commit` command has a **-m** flag for adding comments to the image. These
+  comments will be displayed in the image history.\n\n    $ sudo docker history docker:scm\n
+  \   IMAGE               CREATED             CREATED BY                                      SIZE
+  \               COMMENT\n    2ac9d1098bf1        3 months ago        /bin/bash                                       241.4
+  MB            Added Apache to Fedora base image\n    88b42ffd1f7c        5 months
+  ago        /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB            \n
+  \   c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh
+  Mandvekar   0 B                 \n    511136ea3c5a        19 months ago                                                       0
+  B                 Imported from -\n"
 usage: docker image history [OPTIONS] IMAGE
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_import.yaml
+++ b/_data/engine-cli/docker_image_import.yaml
@@ -1,6 +1,20 @@
 command: docker image import
 short: Import the contents from a tarball to create a filesystem image
-long: Import the contents from a tarball to create a filesystem image
+long: "Create a new filesystem image from the contents of a tarball (`.tar`,\n`.tar.gz`,
+  `.tgz`, `.bzip`, `.tar.xz`, `.txz`) into it, then optionally tag it.\n\n\n# EXAMPLES\n\n##
+  Import from a remote location\n\n    # docker image import http://example.com/exampleimage.tgz
+  example/imagerepo\n\n## Import from a local file\n\nImport to docker via pipe and
+  stdin:\n\n    # cat exampleimage.tgz | docker image import - example/imagelocal\n\nImport
+  with a commit message. \n\n    # cat exampleimage.tgz | docker image import --message
+  \"New image imported from tarball\" - exampleimagelocal:new\n\nImport to a Docker
+  image from a local file.\n\n    # docker image import /path/to/exampleimage.tgz
+  \n\n\n## Import from a local file and tag\n\nImport to docker via pipe and stdin:\n\n
+  \   # cat exampleimageV2.tgz | docker image import - example/imagelocal:V-2.0\n\n##
+  Import from a local directory\n\n    # tar -c . | docker image import - exampleimagedir\n\n##
+  Apply specified Dockerfile instructions while importing the image\nThis example
+  sets the docker image ENV variable DEBUG to true by default.\n\n    # tar -c . |
+  docker image import -c=\"ENV DEBUG true\" - exampleimagedir\n\n# See also\n**docker-export(1)**
+  to export the contents of a filesystem as a tar archive to STDOUT.\n"
 usage: docker image import [OPTIONS] file|URL|- [REPOSITORY[:TAG]]
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_load.yaml
+++ b/_data/engine-cli/docker_image_load.yaml
@@ -1,6 +1,31 @@
 command: docker image load
 short: Load an image from a tar archive or STDIN
-long: Load an image from a tar archive or STDIN
+long: |
+  Loads a tarred repository from a file or the standard input stream.
+  Restores both images and tags. Write image names or IDs imported it
+  standard output stream.
+
+  # EXAMPLES
+
+      $ docker images
+      REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+      busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+      $ docker load --input fedora.tar
+      # […]
+      Loaded image: fedora:rawhide
+      # […]
+      Loaded image: fedora:20
+      # […]
+      $ docker images
+      REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+      busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+      fedora              rawhide             0d20aec6529d        7 weeks ago         387 MB
+      fedora              20                  58394af37342        7 weeks ago         385.5 MB
+      fedora              heisenbug           58394af37342        7 weeks ago         385.5 MB
+      fedora              latest              58394af37342        7 weeks ago         385.5 MB
+
+  # See also
+  **docker-image-save(1)** to save one or more images to a tar archive (streamed to STDOUT by default).
 usage: docker image load [OPTIONS]
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_ls.yaml
+++ b/_data/engine-cli/docker_image_ls.yaml
@@ -1,7 +1,60 @@
 command: docker image ls
 aliases: images, list
 short: List images
-long: List images
+long: "This command lists the images stored in the local Docker repository.\n\nBy
+  default, intermediate images, used during builds, are not listed. Some of the\noutput,
+  e.g., image ID, is truncated, for space reasons. However the truncated\nimage ID,
+  and often the first few characters, are enough to be used in other\nDocker commands
+  that use the image ID. The output includes repository, tag, image\nID, date created
+  and the virtual size.\n\nThe title REPOSITORY for the first title may seem confusing.
+  It is essentially\nthe image name. However, because you can tag a specific image,
+  and multiple tags\n(image instances) can be associated with a single name, the name
+  is really a\nrepository for all tagged images of the same name. For example consider
+  an image\ncalled fedora. It may be tagged with 18, 19, or 20, etc. to manage different\nversions.\n\n##
+  Filters\n\nFilters the output based on these conditions:\n\n   - dangling=(true|false)
+  - find unused images\n   - label=<key> or label=<key>=<value>\n   - before=(<image-name>[:tag]|<image-id>|<image@digest>)\n
+  \  - since=(<image-name>[:tag]|<image-id>|<image@digest>)\n\n## Format\n\n   Pretty-print
+  images using a Go template.\n   Valid placeholders:\n      .ID - Image ID\n      .Repository
+  - Image repository\n      .Tag - Image tag\n      .Digest - Image digest\n      .CreatedSince
+  - Elapsed time since the image was created\n      .CreatedAt - Time when the image
+  was created\n      .Size - Image disk size\n\n# EXAMPLES\n\n## Listing the images\n\nTo
+  list the images in a local repository (not the registry) run:\n\n    docker image
+  ls\n\nThe list will contain the image repository name, a tag for the image, and
+  an\nimage ID, when it was created and its virtual size. Columns: REPOSITORY, TAG,\nIMAGE
+  ID, CREATED, and SIZE.\n\nThe `docker image ls` command takes an optional `[REPOSITORY[:TAG]]`
+  argument\nthat restricts the list to images that match the argument. If you specify\n`REPOSITORY`but
+  no `TAG`, the `docker image ls` command lists all images in the\ngiven repository.\n\n
+  \   docker image ls java\n\nThe `[REPOSITORY[:TAG]]` value must be an \"exact match\".
+  This means that, for example,\n`docker image ls jav` does not match the image `java`.\n\nIf
+  both `REPOSITORY` and `TAG` are provided, only images matching that\nrepository
+  and tag are listed.  To find all local images in the \"java\"\nrepository with tag
+  \"8\" you can use:\n\n    docker image ls java:8\n\nTo get a verbose list of images
+  which contains all the intermediate images\nused in builds use **-a**:\n\n    docker
+  image ls -a\n\nPreviously, the docker image ls command supported the --tree and
+  --dot arguments,\nwhich displayed different visualizations of the image data. Docker
+  core removed\nthis functionality in the 1.7 version. If you liked this functionality,
+  you can\nstill find it in the third-party dockviz tool: https://github.com/justone/dockviz.\n\n##
+  Listing images in a desired format\n\nWhen using the --format option, the image
+  command will either output the data \nexactly as the template declares or, when
+  using the `table` directive, will \ninclude column headers as well. You can use
+  special characters like `\\t` for\ninserting tab spacing between columns. \n\nThe
+  following example uses a template without headers and outputs the ID and \nRepository
+  entries separated by a colon for all images:\n\n    docker images --format \"{{.ID}}:
+  {{.Repository}}\"\n    77af4d6b9913: <none>\n    b6fa739cedf5: committ\n    78a85c484bad:
+  ipbabble\n    30557a29d5ab: docker\n    5ed6274db6ce: <none>\n    746b819f315e:
+  postgres\n    746b819f315e: postgres\n    746b819f315e: postgres\n    746b819f315e:
+  postgres\n\nTo list all images with their repository and tag in a table format you
+  can use:\n\n    docker images --format \"table {{.ID}}\\t{{.Repository}}\\t{{.Tag}}\"\n
+  \   IMAGE ID            REPOSITORY                TAG\n    77af4d6b9913        <none>
+  \                   <none>\n    b6fa739cedf5        committ                   latest\n
+  \   78a85c484bad        ipbabble                  <none>\n    30557a29d5ab        docker
+  \                   latest\n    5ed6274db6ce        <none>                    <none>\n
+  \   746b819f315e        postgres                  9\n    746b819f315e        postgres
+  \                 9.3\n    746b819f315e        postgres                  9.3.5\n
+  \   746b819f315e        postgres                  latest\n\nValid template placeholders
+  are listed above.\n\n## Listing only the shortened image IDs\n\nListing just the
+  shortened image IDs. This can be useful for some automated\ntools.\n\n    docker
+  image ls -q\n"
 usage: docker image ls [OPTIONS] [REPOSITORY[:TAG]]
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_prune.yaml
+++ b/_data/engine-cli/docker_image_prune.yaml
@@ -9,6 +9,8 @@ options:
   shorthand: a
   default_value: "false"
   description: Remove all unused images, not just dangling ones
+- option: filter
+  description: Provide filter values (e.g. 'until=<timestamp>')
 - option: force
   shorthand: f
   default_value: "false"

--- a/_data/engine-cli/docker_image_pull.yaml
+++ b/_data/engine-cli/docker_image_pull.yaml
@@ -1,6 +1,99 @@
 command: docker image pull
 short: Pull an image or a repository from a registry
-long: Pull an image or a repository from a registry
+long: "This command pulls down an image or a repository from a registry. If\nthere
+  is more than one image for a repository (e.g., fedora) then all\nimages for that
+  repository name can be pulled down including any tags\n(see the option **-a** or
+  **--all-tags**).\n\nIf you do not specify a `REGISTRY_HOST`, the command uses Docker's
+  public\nregistry located at `registry-1.docker.io` by default. \n\n# EXAMPLES\n\n###
+  Pull an image from Docker Hub\n\nTo download a particular image, or set of images
+  (i.e., a repository), use\n`docker image pull`. If no tag is provided, Docker Engine
+  uses the `:latest` tag as a\ndefault. This command pulls the `debian:latest` image:\n\n
+  \   $ docker image pull debian\n\n    Using default tag: latest\n    latest: Pulling
+  from library/debian\n    fdd5d7827f33: Pull complete\n    a3ed95caeb02: Pull complete\n
+  \   Digest: sha256:e7d38b3517548a1c71e41bffe9c8ae6d6d29546ce46bf62159837aad072c90aa\n
+  \   Status: Downloaded newer image for debian:latest\n\nDocker images can consist
+  of multiple layers. In the example above, the image\nconsists of two layers; `fdd5d7827f33`
+  and `a3ed95caeb02`.\n\nLayers can be reused by images. For example, the `debian:jessie`
+  image shares\nboth layers with `debian:latest`. Pulling the `debian:jessie` image
+  therefore\nonly pulls its metadata, but not its layers, because all layers are already\npresent
+  locally:\n\n    $ docker image pull debian:jessie\n\n    jessie: Pulling from library/debian\n
+  \   fdd5d7827f33: Already exists\n    a3ed95caeb02: Already exists\n    Digest:
+  sha256:a9c958be96d7d40df920e7041608f2f017af81800ca5ad23e327bc402626b58e\n    Status:
+  Downloaded newer image for debian:jessie\n\nTo see which images are present locally,
+  use the **docker-images(1)**\ncommand:\n\n    $ docker images\n\n    REPOSITORY
+  \  TAG      IMAGE ID        CREATED      SIZE\n    debian       jessie   f50f9524513f
+  \   5 days ago   125.1 MB\n    debian       latest   f50f9524513f    5 days ago
+  \  125.1 MB\n\nDocker uses a content-addressable image store, and the image ID is
+  a SHA256\ndigest covering the image's configuration and layers. In the example above,\n`debian:jessie`
+  and `debian:latest` have the same image ID because they are\nactually the *same*
+  image tagged with different names. Because they are the\nsame image, their layers
+  are stored only once and do not consume extra disk\nspace.\n\nFor more information
+  about images, layers, and the content-addressable store,\nrefer to [understand images,
+  containers, and storage drivers](https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/)\nin
+  the online documentation.\n\n\n## Pull an image by digest (immutable identifier)\n\nSo
+  far, you've pulled images by their name (and \"tag\"). Using names and tags is\na
+  convenient way to work with images. When using tags, you can `docker image pull`
+  an\nimage again to make sure you have the most up-to-date version of that image.\nFor
+  example, `docker image pull ubuntu:14.04` pulls the latest version of the Ubuntu\n14.04
+  image.\n\nIn some cases you don't want images to be updated to newer versions, but
+  prefer\nto use a fixed version of an image. Docker enables you to pull an image
+  by its\n*digest*. When pulling an image by digest, you specify *exactly* which version\nof
+  an image to pull. Doing so, allows you to \"pin\" an image to that version,\nand
+  guarantee that the image you're using is always the same.\n\nTo know the digest
+  of an image, pull the image first. Let's pull the latest\n`ubuntu:14.04` image from
+  Docker Hub:\n\n    $ docker image pull ubuntu:14.04\n\n    14.04: Pulling from library/ubuntu\n
+  \   5a132a7e7af1: Pull complete\n    fd2731e4c50c: Pull complete\n    28a2f68d1120:
+  Pull complete\n    a3ed95caeb02: Pull complete\n    Digest: sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2\n
+  \   Status: Downloaded newer image for ubuntu:14.04\n\nDocker prints the digest
+  of the image after the pull has finished. In the example\nabove, the digest of the
+  image is:\n\n    sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2\n\nDocker
+  also prints the digest of an image when *pushing* to a registry. This\nmay be useful
+  if you want to pin to a version of the image you just pushed.\n\nA digest takes
+  the place of the tag when pulling an image, for example, to \npull the above image
+  by digest, run the following command:\n\n    $ docker image pull ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2\n\n
+  \   sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2: Pulling
+  from library/ubuntu\n    5a132a7e7af1: Already exists\n    fd2731e4c50c: Already
+  exists\n    28a2f68d1120: Already exists\n    a3ed95caeb02: Already exists\n    Digest:
+  sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2\n    Status:
+  Downloaded newer image for ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2\n\nDigest
+  can also be used in the `FROM` of a Dockerfile, for example:\n\n    FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2\n
+  \   MAINTAINER some maintainer <maintainer@example.com>\n\n> **Note**: Using this
+  feature \"pins\" an image to a specific version in time.\n> Docker will therefore
+  not pull updated versions of an image, which may include \n> security updates. If
+  you want to pull an updated image, you need to change the\n> digest accordingly.\n\n##
+  Pulling from a different registry\n\nBy default, `docker image pull` pulls images
+  from Docker Hub. It is also possible to\nmanually specify the path of a registry
+  to pull from. For example, if you have\nset up a local registry, you can specify
+  its path to pull from it. A registry\npath is similar to a URL, but does not contain
+  a protocol specifier (`https://`).\n\nThe following command pulls the `testing/test-image`
+  image from a local registry\nlistening on port 5000 (`myregistry.local:5000`):\n\n
+  \   $ docker image pull myregistry.local:5000/testing/test-image\n\nRegistry credentials
+  are managed by **docker-login(1)**.\n\nDocker uses the `https://` protocol to communicate
+  with a registry, unless the\nregistry is allowed to be accessed over an insecure
+  connection. Refer to the\n[insecure registries](https://docs.docker.com/engine/reference/commandline/daemon/#insecure-registries)\nsection
+  in the online documentation for more information.\n\n\n## Pull a repository with
+  multiple images\n\nBy default, `docker image pull` pulls a *single* image from the
+  registry. A repository\ncan contain multiple images. To pull all images from a repository,
+  provide the\n`-a` (or `--all-tags`) option when using `docker image pull`.\n\nThis
+  command pulls all images from the `fedora` repository:\n\n    $ docker image pull
+  --all-tags fedora\n\n    Pulling repository fedora\n    ad57ef8d78d7: Download complete\n
+  \   105182bb5e8b: Download complete\n    511136ea3c5a: Download complete\n    73bd853d2ea5:
+  Download complete\n    ....\n\n    Status: Downloaded newer image for fedora\n\nAfter
+  the pull has completed use the `docker images` command to see the\nimages that were
+  pulled. The example below shows all the `fedora` images\nthat are present locally:\n\n
+  \   $ docker images fedora\n\n    REPOSITORY   TAG         IMAGE ID        CREATED
+  \     SIZE\n    fedora       rawhide     ad57ef8d78d7    5 days ago   359.3 MB\n
+  \   fedora       20          105182bb5e8b    5 days ago   372.7 MB\n    fedora       heisenbug
+  \  105182bb5e8b    5 days ago   372.7 MB\n    fedora       latest      105182bb5e8b
+  \   5 days ago   372.7 MB\n\n\n## Canceling a pull\n\nKilling the `docker image
+  pull` process, for example by pressing `CTRL-c` while it is\nrunning in a terminal,
+  will terminate the pull operation.\n\n    $ docker image pull fedora\n\n    Using
+  default tag: latest\n    latest: Pulling from library/fedora\n    a3ed95caeb02:
+  Pulling fs layer\n    236608c7b546: Pulling fs layer\n    ^C\n\n> **Note**: Technically,
+  the Engine terminates a pull operation when the\n> connection between the Docker
+  Engine daemon and the Docker Engine client\n> initiating the pull is lost. If the
+  connection with the Engine daemon is\n> lost for other reasons than a manual interaction,
+  the pull is also aborted.\n"
 usage: docker image pull [OPTIONS] NAME[:TAG|@DIGEST]
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_push.yaml
+++ b/_data/engine-cli/docker_image_push.yaml
@@ -1,10 +1,44 @@
 command: docker image push
 short: Push an image or a repository to a registry
-long: Push an image or a repository to a registry
+long: |
+  Use `docker image push` to share your images to the [Docker Hub](https://hub.docker.com)
+  registry or to a self-hosted one.
+
+  Refer to **docker-image-tag(1)** for more information about valid image and tag names.
+
+  Killing the **docker image push** process, for example by pressing **CTRL-c** while it
+  is running in a terminal, terminates the push operation.
+
+  Registry credentials are managed by **docker-login(1)**.
+
+  # EXAMPLES
+
+  ## Pushing a new image to a registry
+
+  First save the new image by finding the container ID (using **docker container ls**)
+  and then committing it to a new image name.  Note that only a-z0-9-_. are
+  allowed when naming images:
+
+      # docker container commit c16378f943fe rhel-httpd
+
+  Now, push the image to the registry using the image ID. In this example the
+  registry is on host named `registry-host` and listening on port `5000`. To do
+  this, tag the image with the host name or IP address, and the port of the
+  registry:
+
+      # docker image tag rhel-httpd registry-host:5000/myadmin/rhel-httpd
+      # docker image push registry-host:5000/myadmin/rhel-httpd
+
+  Check that this worked by running:
+
+      # docker image ls
+
+  You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
+  listed.
 usage: docker image push [OPTIONS] NAME[:TAG]
 pname: docker image
 plink: docker_image.yaml
 options:
 - option: disable-content-trust
   default_value: "true"
-  description: Skip image verification
+  description: Skip image signing

--- a/_data/engine-cli/docker_image_rm.yaml
+++ b/_data/engine-cli/docker_image_rm.yaml
@@ -1,7 +1,18 @@
 command: docker image rm
 aliases: rmi, remove
 short: Remove one or more images
-long: Remove one or more images
+long: |
+  Removes one or more images from the host node. This does not remove images from
+  a registry. You cannot remove an image of a running container unless you use the
+  **-f** option. To see all images on a host use the **docker image ls** command.
+
+  # EXAMPLES
+
+  ## Removing an image
+
+  Here is an example of removing an image:
+
+      docker image rm fedora/httpd
 usage: docker image rm [OPTIONS] IMAGE [IMAGE...]
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_save.yaml
+++ b/_data/engine-cli/docker_image_save.yaml
@@ -1,6 +1,25 @@
 command: docker image save
 short: Save one or more images to a tar archive (streamed to STDOUT by default)
-long: Save one or more images to a tar archive (streamed to STDOUT by default)
+long: |
+  Produces a tarred repository to the standard output stream. Contains all
+  parent layers, and all tags + versions, or specified repo:tag.
+
+  Stream to a file instead of STDOUT by using **-o**.
+
+  # EXAMPLES
+
+  Save all fedora repository images to a fedora-all.tar and save the latest
+  fedora image to a fedora-latest.tar:
+
+      $ docker image save fedora > fedora-all.tar
+      $ docker image save --output=fedora-latest.tar fedora:latest
+      $ ls -sh fedora-all.tar
+      721M fedora-all.tar
+      $ ls -sh fedora-latest.tar
+      367M fedora-latest.tar
+
+  # See also
+  **docker-image-load(1)** to load an image from a tar archive on STDIN.
 usage: docker image save [OPTIONS] IMAGE [IMAGE...]
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_image_tag.yaml
+++ b/_data/engine-cli/docker_image_tag.yaml
@@ -1,6 +1,31 @@
 command: docker image tag
 short: Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
-long: Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+long: "Assigns a new alias to an image in a registry. An alias refers to the\nentire
+  image name including the optional `TAG` after the ':'. \n\n# OPTIONS\n**NAME**\n
+  \  The image name which is made up of slash-separated name components, \n   optionally
+  prefixed by a registry hostname. The hostname must comply with \n   standard DNS
+  rules, but may not contain underscores. If a hostname is \n   present, it may optionally
+  be followed by a port number in the format \n   `:8080`. If not present, the command
+  uses Docker's public registry located at\n   `registry-1.docker.io` by default.
+  Name components may contain lowercase \n   letters, digits and separators. A separator
+  is defined as a period, one or\n   two underscores, or one or more dashes. A name
+  component may not start or end \n   with a separator.\n\n**TAG**\n   The tag assigned
+  to the image to version and distinguish images with the same\n   name. The tag name
+  must be valid ASCII and may contain lowercase and\n   uppercase letters, digits,
+  underscores, periods and hyphens. A tag name\n   may not start with a period or
+  a hyphen and may contain a maximum of 128\n   characters.\n\n# EXAMPLES\n\n## Tagging
+  an image referenced by ID\n\nTo tag a local image with ID \"0e5574283393\" into
+  the \"fedora\" repository with \n\"version1.0\":\n\n    docker image tag 0e5574283393
+  fedora/httpd:version1.0\n\n## Tagging an image referenced by Name\n\nTo tag a local
+  image with name \"httpd\" into the \"fedora\" repository with \n\"version1.0\":\n\n
+  \   docker image tag httpd fedora/httpd:version1.0\n\nNote that since the tag name
+  is not specified, the alias is created for an\nexisting local version `httpd:latest`.\n\n##
+  Tagging an image referenced by Name and Tag\n\nTo tag a local image with name \"httpd\"
+  and tag \"test\" into the \"fedora\"\nrepository with \"version1.0.test\":\n\n    docker
+  image tag httpd:test fedora/httpd:version1.0.test\n\n## Tagging an image for a private
+  repository\n\nTo push an image to a private registry and not the central Docker\nregistry
+  you must tag it with the registry hostname and port (if needed).\n\n    docker image
+  tag 0e5574283393 myregistryhost:5000/fedora/httpd:version1.0\n"
 usage: docker image tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
 pname: docker image
 plink: docker_image.yaml

--- a/_data/engine-cli/docker_images.yaml
+++ b/_data/engine-cli/docker_images.yaml
@@ -1,6 +1,7 @@
 command: docker images
 short: List images
-long: List images
+long: |
+  Alias for `docker image ls`.
 usage: docker images [OPTIONS] [REPOSITORY[:TAG]]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_import.yaml
+++ b/_data/engine-cli/docker_import.yaml
@@ -1,6 +1,7 @@
 command: docker import
 short: Import the contents from a tarball to create a filesystem image
-long: Import the contents from a tarball to create a filesystem image
+long: |
+  Alias for `docker image import`.
 usage: docker import [OPTIONS] file|URL|- [REPOSITORY[:TAG]]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_info.yaml
+++ b/_data/engine-cli/docker_info.yaml
@@ -1,6 +1,7 @@
 command: docker info
 short: Display system-wide information
-long: Display system-wide information
+long: |
+  Alias for `docker system info`.
 usage: docker info [OPTIONS]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_inspect.yaml
+++ b/_data/engine-cli/docker_inspect.yaml
@@ -1,6 +1,109 @@
 command: docker inspect
 short: Return low-level information on Docker objects
-long: Return low-level information on Docker objects
+long: "This displays the low-level information on Docker object(s) (e.g. container,
+  \nimage, volume,network, node, service, or task) identified by name or ID. By default,\nthis
+  will render all results in a JSON array. If the container and image have\nthe same
+  name, this will return container JSON for unspecified type. If a format\nis specified,
+  the given template will be executed for each result.\n\n# EXAMPLES\n\nGet information
+  about an image when image name conflicts with the container name,\ne.g. both image
+  and container are named rhel7:\n\n    $ docker inspect --type=image rhel7\n    [\n
+  \   {\n     \"Id\": \"fe01a428b9d9de35d29531e9994157978e8c48fa693e1bf1d221dffbbb67b170\",\n
+  \    \"Parent\": \"10acc31def5d6f249b548e01e8ffbaccfd61af0240c17315a7ad393d022c5ca2\",\n
+  \    ....\n    }\n    ]\n\n## Getting information on a container\n\nTo get information
+  on a container use its ID or instance name:\n\n    $ docker inspect d2cc496561d6\n
+  \   [{\n    \"Id\": \"d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47\",\n
+  \   \"Created\": \"2015-06-08T16:18:02.505155285Z\",\n    \"Path\": \"bash\",\n
+  \   \"Args\": [],\n    \"State\": {\n        \"Running\": false,\n        \"Paused\":
+  false,\n        \"Restarting\": false,\n        \"OOMKilled\": false,\n        \"Dead\":
+  false,\n        \"Pid\": 0,\n        \"ExitCode\": 0,\n        \"Error\": \"\",\n
+  \       \"StartedAt\": \"2015-06-08T16:18:03.643865954Z\",\n        \"FinishedAt\":
+  \"2015-06-08T16:57:06.448552862Z\"\n    },\n    \"Image\": \"ded7cd95e059788f2586a51c275a4f151653779d6a7f4dad77c2bd34601d94e4\",\n
+  \   \"NetworkSettings\": {\n        \"Bridge\": \"\",\n        \"SandboxID\": \"6b4851d1903e16dd6a567bd526553a86664361f31036eaaa2f8454d6f4611f6f\",\n
+  \       \"HairpinMode\": false,\n        \"LinkLocalIPv6Address\": \"\",\n        \"LinkLocalIPv6PrefixLen\":
+  0,\n        \"Ports\": {},\n        \"SandboxKey\": \"/var/run/docker/netns/6b4851d1903e\",\n
+  \       \"SecondaryIPAddresses\": null,\n        \"SecondaryIPv6Addresses\": null,\n
+  \       \"EndpointID\": \"7587b82f0dada3656fda26588aee72630c6fab1536d36e394b2bfbcf898c971d\",\n
+  \       \"Gateway\": \"172.17.0.1\",\n        \"GlobalIPv6Address\": \"\",\n        \"GlobalIPv6PrefixLen\":
+  0,\n        \"IPAddress\": \"172.17.0.2\",\n        \"IPPrefixLen\": 16,\n        \"IPv6Gateway\":
+  \"\",\n        \"MacAddress\": \"02:42:ac:12:00:02\",\n        \"Networks\": {\n
+  \           \"bridge\": {\n                \"NetworkID\": \"7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812\",\n
+  \               \"EndpointID\": \"7587b82f0dada3656fda26588aee72630c6fab1536d36e394b2bfbcf898c971d\",\n
+  \               \"Gateway\": \"172.17.0.1\",\n                \"IPAddress\": \"172.17.0.2\",\n
+  \               \"IPPrefixLen\": 16,\n                \"IPv6Gateway\": \"\",\n                \"GlobalIPv6Address\":
+  \"\",\n                \"GlobalIPv6PrefixLen\": 0,\n                \"MacAddress\":
+  \"02:42:ac:12:00:02\"\n            }\n        }\n\n    },\n    \"ResolvConfPath\":
+  \"/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/resolv.conf\",\n
+  \   \"HostnamePath\": \"/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/hostname\",\n
+  \   \"HostsPath\": \"/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/hosts\",\n
+  \   \"LogPath\": \"/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47-json.log\",\n
+  \   \"Name\": \"/adoring_wozniak\",\n    \"RestartCount\": 0,\n    \"Driver\": \"devicemapper\",\n
+  \   \"MountLabel\": \"\",\n    \"ProcessLabel\": \"\",\n    \"Mounts\": [\n      {\n
+  \       \"Source\": \"/data\",\n        \"Destination\": \"/data\",\n        \"Mode\":
+  \"ro,Z\",\n        \"RW\": false\n\t\"Propagation\": \"\"\n      }\n    ],\n    \"AppArmorProfile\":
+  \"\",\n    \"ExecIDs\": null,\n    \"HostConfig\": {\n        \"Binds\": null,\n
+  \       \"ContainerIDFile\": \"\",\n        \"Memory\": 0,\n        \"MemorySwap\":
+  0,\n        \"CpuShares\": 0,\n        \"CpuPeriod\": 0,\n        \"CpusetCpus\":
+  \"\",\n        \"CpusetMems\": \"\",\n        \"CpuQuota\": 0,\n        \"BlkioWeight\":
+  0,\n        \"OomKillDisable\": false,\n        \"Privileged\": false,\n        \"PortBindings\":
+  {},\n        \"Links\": null,\n        \"PublishAllPorts\": false,\n        \"Dns\":
+  null,\n        \"DnsSearch\": null,\n        \"DnsOptions\": null,\n        \"ExtraHosts\":
+  null,\n        \"VolumesFrom\": null,\n        \"Devices\": [],\n        \"NetworkMode\":
+  \"bridge\",\n        \"IpcMode\": \"\",\n        \"PidMode\": \"\",\n        \"UTSMode\":
+  \"\",\n        \"CapAdd\": null,\n        \"CapDrop\": null,\n        \"RestartPolicy\":
+  {\n            \"Name\": \"no\",\n            \"MaximumRetryCount\": 0\n        },\n
+  \       \"SecurityOpt\": null,\n        \"ReadonlyRootfs\": false,\n        \"Ulimits\":
+  null,\n        \"LogConfig\": {\n            \"Type\": \"json-file\",\n            \"Config\":
+  {}\n        },\n        \"CgroupParent\": \"\"\n    },\n    \"GraphDriver\": {\n
+  \       \"Name\": \"devicemapper\",\n        \"Data\": {\n            \"DeviceId\":
+  \"5\",\n            \"DeviceName\": \"docker-253:1-2763198-d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47\",\n
+  \           \"DeviceSize\": \"171798691840\"\n        }\n    },\n    \"Config\":
+  {\n        \"Hostname\": \"d2cc496561d6\",\n        \"Domainname\": \"\",\n        \"User\":
+  \"\",\n        \"AttachStdin\": true,\n        \"AttachStdout\": true,\n        \"AttachStderr\":
+  true,\n        \"ExposedPorts\": null,\n        \"Tty\": true,\n        \"OpenStdin\":
+  true,\n        \"StdinOnce\": true,\n        \"Env\": null,\n        \"Cmd\": [\n
+  \           \"bash\"\n        ],\n        \"Image\": \"fedora\",\n        \"Volumes\":
+  null,\n        \"VolumeDriver\": \"\",\n        \"WorkingDir\": \"\",\n        \"Entrypoint\":
+  null,\n        \"NetworkDisabled\": false,\n        \"MacAddress\": \"\",\n        \"OnBuild\":
+  null,\n        \"Labels\": {},\n        \"Memory\": 0,\n        \"MemorySwap\":
+  0,\n        \"CpuShares\": 0,\n        \"Cpuset\": \"\",\n        \"StopSignal\":
+  \"SIGTERM\"\n    }\n    }\n    ]\n## Getting the IP address of a container instance\n\nTo
+  get the IP address of a container use:\n\n    $ docker inspect --format='{{range
+  .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' d2cc496561d6\n    172.17.0.2\n\n##
+  Listing all port bindings\n\nOne can loop over arrays and maps in the results to
+  produce simple text\noutput:\n\n    $ docker inspect --format='{{range $p, $conf
+  := .NetworkSettings.Ports}} \\\n      {{$p}} -> {{(index $conf 0).HostPort}} {{end}}'
+  d2cc496561d6\n      80/tcp -> 80\n\nYou can get more information about how to write
+  a Go template from:\nhttps://golang.org/pkg/text/template/.\n\n## Getting size information
+  on a container\n\n    $ docker inspect -s d2cc496561d6\n    [\n    {\n    ....\n
+  \   \"SizeRw\": 0,\n    \"SizeRootFs\": 972,\n    ....\n    }\n    ]\n\n## Getting
+  information on an image\n\nUse an image's ID or name (e.g., repository/name[:tag])
+  to get information\nabout the image:\n\n    $ docker inspect ded7cd95e059\n    [{\n
+  \   \"Id\": \"ded7cd95e059788f2586a51c275a4f151653779d6a7f4dad77c2bd34601d94e4\",\n
+  \   \"Parent\": \"48ecf305d2cf7046c1f5f8fcbcd4994403173441d4a7f125b1bb0ceead9de731\",\n
+  \   \"Comment\": \"\",\n    \"Created\": \"2015-05-27T16:58:22.937503085Z\",\n    \"Container\":
+  \"76cf7f67d83a7a047454b33007d03e32a8f474ad332c3a03c94537edd22b312b\",\n    \"ContainerConfig\":
+  {\n        \"Hostname\": \"76cf7f67d83a\",\n        \"Domainname\": \"\",\n        \"User\":
+  \"\",\n        \"AttachStdin\": false,\n        \"AttachStdout\": false,\n        \"AttachStderr\":
+  false,\n        \"ExposedPorts\": null,\n        \"Tty\": false,\n        \"OpenStdin\":
+  false,\n        \"StdinOnce\": false,\n        \"Env\": null,\n        \"Cmd\":
+  [\n            \"/bin/sh\",\n            \"-c\",\n            \"#(nop) ADD file:4be46382bcf2b095fcb9fe8334206b584eff60bb3fad8178cbd97697fcb2ea83
+  in /\"\n        ],\n        \"Image\": \"48ecf305d2cf7046c1f5f8fcbcd4994403173441d4a7f125b1bb0ceead9de731\",\n
+  \       \"Volumes\": null,\n        \"VolumeDriver\": \"\",\n        \"WorkingDir\":
+  \"\",\n        \"Entrypoint\": null,\n        \"NetworkDisabled\": false,\n        \"MacAddress\":
+  \"\",\n        \"OnBuild\": null,\n        \"Labels\": {}\n    },\n    \"DockerVersion\":
+  \"1.6.0\",\n    \"Author\": \"Lokesh Mandvekar \\u003clsm5@fedoraproject.org\\u003e\",\n
+  \   \"Config\": {\n        \"Hostname\": \"76cf7f67d83a\",\n        \"Domainname\":
+  \"\",\n        \"User\": \"\",\n        \"AttachStdin\": false,\n        \"AttachStdout\":
+  false,\n        \"AttachStderr\": false,\n        \"ExposedPorts\": null,\n        \"Tty\":
+  false,\n        \"OpenStdin\": false,\n        \"StdinOnce\": false,\n        \"Env\":
+  null,\n        \"Cmd\": null,\n        \"Image\": \"48ecf305d2cf7046c1f5f8fcbcd4994403173441d4a7f125b1bb0ceead9de731\",\n
+  \       \"Volumes\": null,\n        \"VolumeDriver\": \"\",\n        \"WorkingDir\":
+  \"\",\n        \"Entrypoint\": null,\n        \"NetworkDisabled\": false,\n        \"MacAddress\":
+  \"\",\n        \"OnBuild\": null,\n        \"Labels\": {}\n    },\n    \"Architecture\":
+  \"amd64\",\n    \"Os\": \"linux\",\n    \"Size\": 186507296,\n    \"VirtualSize\":
+  186507296,\n    \"GraphDriver\": {\n        \"Name\": \"devicemapper\",\n        \"Data\":
+  {\n            \"DeviceId\": \"3\",\n            \"DeviceName\": \"docker-253:1-2763198-ded7cd95e059788f2586a51c275a4f151653779d6a7f4dad77c2bd34601d94e4\",\n
+  \           \"DeviceSize\": \"171798691840\"\n        }\n    }\n    }\n    ]\n"
 usage: docker inspect [OPTIONS] NAME|ID [NAME|ID...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_kill.yaml
+++ b/_data/engine-cli/docker_kill.yaml
@@ -1,6 +1,7 @@
 command: docker kill
 short: Kill one or more running containers
-long: Kill one or more running containers
+long: |
+  Alias for `docker container kill`.
 usage: docker kill [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_load.yaml
+++ b/_data/engine-cli/docker_load.yaml
@@ -1,6 +1,7 @@
 command: docker load
 short: Load an image from a tar archive or STDIN
-long: Load an image from a tar archive or STDIN
+long: |
+  Alias for `docker image load`.
 usage: docker load [OPTIONS]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_login.yaml
+++ b/_data/engine-cli/docker_login.yaml
@@ -1,8 +1,28 @@
 command: docker login
 short: Log in to a Docker registry
-long: |-
-  Log in to a Docker registry.
-  If no server is specified, the default is defined by the daemon.
+long: |
+  Log in to a Docker Registry located on the specified
+  `SERVER`.  You can specify a URL or a `hostname` for the `SERVER` value. If you
+  do not specify a `SERVER`, the command uses Docker's public registry located at
+  `https://registry-1.docker.io/` by default.  To get a username/password for Docker's public registry, create an account on Docker Hub.
+
+  `docker login` requires user to use `sudo` or be `root`, except when:
+
+  1.  connecting to  a remote daemon, such as a `docker-machine` provisioned `docker engine`.
+  2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](https://docs.docker.com/engine/security/security/#/docker-daemon-attack-surface) for details.
+
+  You can log into any public or private repository for which you have
+  credentials.  When you log in, the command stores encoded credentials in
+  `$HOME/.docker/config.json` on Linux or `%!U(MISSING)SERPROFILE%!/(MISSING).docker/config.json` on Windows.
+
+  # EXAMPLES
+
+  ## Login to a registry on your localhost
+
+      # docker login localhost:8080
+
+  # See also
+  **docker-logout(1)** to log out from a Docker registry.
 usage: docker login [OPTIONS] [SERVER]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_logout.yaml
+++ b/_data/engine-cli/docker_logout.yaml
@@ -1,8 +1,11 @@
 command: docker logout
 short: Log out from a Docker registry
-long: |-
-  Log out from a Docker registry.
-  If no server is specified, the default is defined by the daemon.
+long: "Log out of a Docker Registry located on the specified `SERVER`. You can\nspecify
+  a URL or a `hostname` for the `SERVER` value. If you do not specify a\n`SERVER`,
+  the command attempts to log you out of Docker's public registry\nlocated at `https://registry-1.docker.io/`
+  by default.  \n\n# EXAMPLES\n\n## Log out from a registry on your localhost\n\n
+  \   # docker logout localhost:8080\n\n# See also\n**docker-login(1)** to log in
+  to a Docker registry server.\n"
 usage: docker logout [SERVER]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_logs.yaml
+++ b/_data/engine-cli/docker_logs.yaml
@@ -1,6 +1,7 @@
 command: docker logs
 short: Fetch the logs of a container
-long: Fetch the logs of a container
+long: |
+  Alias for `docker container logs`.
 usage: docker logs [OPTIONS] CONTAINER
 pname: docker
 plink: docker.yaml
@@ -13,7 +14,8 @@ options:
   default_value: "false"
   description: Follow log output
 - option: since
-  description: Show logs since timestamp
+  description: |
+    Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
 - option: tail
   default_value: all
   description: Number of lines to show from the end of the logs

--- a/_data/engine-cli/docker_network_connect.yaml
+++ b/_data/engine-cli/docker_network_connect.yaml
@@ -9,16 +9,13 @@ long: |
   $ docker network connect multi-host-network container1
   ```
 
-  You can also use the `docker run --net=<network-name>` option to start a container and immediately connect it to a network.
+  You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
 
   ```bash
-  $ docker run -itd --net=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::8822 busybox
+  $ docker run -itd --network=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::8822 busybox
   ```
-
   You can pause, restart, and stop containers that are connected to a network.
-  Paused containers remain connected and can be revealed by a `network inspect`.
-  When the container is stopped, it does not appear on the network until you restart
-  it.
+  A container connects to its configured networks when it runs.
 
   If specified, the container's IP address(es) is reapplied when a stopped
   container is restarted. If the IP address is no longer available, the container
@@ -51,9 +48,9 @@ options:
   default_value: '[]'
   description: Add network-scoped alias for the container
 - option: ip
-  description: IP Address
+  description: IPv4 address (e.g., 172.30.100.104)
 - option: ip6
-  description: IPv6 Address
+  description: IPv6 address (e.g., 2001:db8::33)
 - option: link
   default_value: '[]'
   description: Add link to another container

--- a/_data/engine-cli/docker_network_create.yaml
+++ b/_data/engine-cli/docker_network_create.yaml
@@ -28,21 +28,21 @@ long: "Creates a new network. The `DRIVER` accepts `bridge` or `overlay` which a
   -d overlay my-multihost-network\n```\n\nNetwork names must be unique. The Docker
   daemon attempts to identify naming\nconflicts but this is not guaranteed. It is
   the user's responsibility to avoid\nname conflicts.\n\n## Connect containers\n\nWhen
-  you start a container use the `--net` flag to connect it to a network.\nThis adds
-  the `busybox` container to the `mynet` network.\n\n```bash\n$ docker run -itd --net=mynet
-  busybox\n```\n\nIf you want to add a container to a network after the container
-  is already\nrunning use the `docker network connect` subcommand.\n\nYou can connect
-  multiple containers to the same network. Once connected, the\ncontainers can communicate
-  using only another container's IP address or name.\nFor `overlay` networks or custom
-  plugins that support multi-host connectivity,\ncontainers connected to the same
-  multi-host network but launched from different\nEngines can also communicate in
-  this way.\n\nYou can disconnect a container from a network using the `docker network\ndisconnect`
-  command.\n\n## Specifying advanced options\n\nWhen you create a network, Engine
-  creates a non-overlapping subnetwork for the\nnetwork by default. This subnetwork
-  is not a subdivision of an existing network.\nIt is purely for ip-addressing purposes.
-  You can override this default and\nspecify subnetwork values directly using the
-  `--subnet` option. On a\n`bridge` network you can only create a single subnet:\n\n```bash\n$
-  docker network create -d bridge --subnet=192.168.0.0/16 br0\n```\n\nAdditionally,
+  you start a container use the `--network` flag to connect it to a network.\nThis
+  adds the `busybox` container to the `mynet` network.\n\n```bash\n$ docker run -itd
+  --network=mynet busybox\n```\n\nIf you want to add a container to a network after
+  the container is already\nrunning use the `docker network connect` subcommand.\n\nYou
+  can connect multiple containers to the same network. Once connected, the\ncontainers
+  can communicate using only another container's IP address or name.\nFor `overlay`
+  networks or custom plugins that support multi-host connectivity,\ncontainers connected
+  to the same multi-host network but launched from different\nEngines can also communicate
+  in this way.\n\nYou can disconnect a container from a network using the `docker
+  network\ndisconnect` command.\n\n## Specifying advanced options\n\nWhen you create
+  a network, Engine creates a non-overlapping subnetwork for the\nnetwork by default.
+  This subnetwork is not a subdivision of an existing network.\nIt is purely for ip-addressing
+  purposes. You can override this default and\nspecify subnetwork values directly
+  using the `--subnet` option. On a\n`bridge` network you can only create a single
+  subnet:\n\n```bash\n$ docker network create -d bridge --subnet=192.168.0.0/16 br0\n```\n\nAdditionally,
   you also specify the `--gateway` `--ip-range` and `--aux-address`\noptions.\n\n```bash\n$
   docker network create \\\n  --driver=bridge \\\n  --subnet=172.28.0.0/16 \\\n  --ip-range=172.28.5.0/24
   \\\n  --gateway=172.28.5.254 \\\n  br0\n```\n\nIf you omit the `--gateway` flag

--- a/_data/engine-cli/docker_network_ls.yaml
+++ b/_data/engine-cli/docker_network_ls.yaml
@@ -3,11 +3,12 @@ aliases: list
 short: List networks
 long: "Lists all the networks the Engine `daemon` knows about. This includes the\nnetworks
   that span across multiple hosts in a cluster, for example:\n\n```bash\n    $ docker
-  network ls\n    NETWORK ID          NAME                DRIVER\n    7fca4eb8c647
-  \       bridge              bridge\n    9f904ee27bf5        none                null\n
-  \   cf03ee007fb4        host                host\n    78b03ee04fc4        multi-host
-  \         overlay\n```\n\nUse the `--no-trunc` option to display the full network
-  id:\n\n```bash\n$ docker network ls --no-trunc\nNETWORK ID                                                         NAME
+  network ls\n    NETWORK ID          NAME                DRIVER          SCOPE\n
+  \   7fca4eb8c647        bridge              bridge          local\n    9f904ee27bf5
+  \       none                null            local\n    cf03ee007fb4        host
+  \               host            local\n    78b03ee04fc4        multi-host          overlay
+  \        swarm\n```\n\nUse the `--no-trunc` option to display the full network id:\n\n```bash\n$
+  docker network ls --no-trunc\nNETWORK ID                                                         NAME
   \               DRIVER\n18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3
   \  none                null                \nc288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47
   \  host                host                \n7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185

--- a/_data/engine-cli/docker_network_prune.yaml
+++ b/_data/engine-cli/docker_network_prune.yaml
@@ -5,6 +5,8 @@ usage: docker network prune [OPTIONS]
 pname: docker network
 plink: docker_network.yaml
 options:
+- option: filter
+  description: Provide filter values (e.g. 'until=<timestamp>')
 - option: force
   shorthand: f
   default_value: "false"

--- a/_data/engine-cli/docker_pause.yaml
+++ b/_data/engine-cli/docker_pause.yaml
@@ -1,6 +1,7 @@
 command: docker pause
 short: Pause all processes within one or more containers
-long: Pause all processes within one or more containers
+long: |
+  Alias for `docker container pause`.
 usage: docker pause CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_plugin_create.yaml
+++ b/_data/engine-cli/docker_plugin_create.yaml
@@ -1,7 +1,9 @@
 command: docker plugin create
-short: Create a plugin from a rootfs and config
-long: Create a plugin from a rootfs and config
-usage: docker plugin create [OPTIONS] PLUGIN[:tag] PATH-TO-ROOTFS(rootfs + config.json)
+short: Create a plugin from a rootfs and configuration. Plugin data directory must
+  contain config.json and rootfs directory.
+long: Create a plugin from a rootfs and configuration. Plugin data directory must
+  contain config.json and rootfs directory.
+usage: docker plugin create [OPTIONS] PLUGIN PLUGIN-DATA-DIR
 pname: docker plugin
 plink: docker_plugin.yaml
 options:

--- a/_data/engine-cli/docker_plugin_disable.yaml
+++ b/_data/engine-cli/docker_plugin_disable.yaml
@@ -1,6 +1,11 @@
 command: docker plugin disable
 short: Disable a plugin
 long: Disable a plugin
-usage: docker plugin disable PLUGIN
+usage: docker plugin disable [OPTIONS] PLUGIN
 pname: docker plugin
 plink: docker_plugin.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the disable of an active plugin

--- a/_data/engine-cli/docker_plugin_inspect.yaml
+++ b/_data/engine-cli/docker_plugin_inspect.yaml
@@ -1,7 +1,7 @@
 command: docker plugin inspect
 short: Display detailed information on one or more plugins
 long: Display detailed information on one or more plugins
-usage: docker plugin inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]
+usage: docker plugin inspect [OPTIONS] PLUGIN [PLUGIN...]
 pname: docker plugin
 plink: docker_plugin.yaml
 options:

--- a/_data/engine-cli/docker_plugin_install.yaml
+++ b/_data/engine-cli/docker_plugin_install.yaml
@@ -5,9 +5,14 @@ usage: docker plugin install [OPTIONS] PLUGIN [KEY=VALUE...]
 pname: docker plugin
 plink: docker_plugin.yaml
 options:
+- option: alias
+  description: Local name for plugin
 - option: disable
   default_value: "false"
   description: Do not enable the plugin on install
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
 - option: grant-all-permissions
   default_value: "false"
   description: Grant all permissions necessary to run the plugin

--- a/_data/engine-cli/docker_plugin_ls.yaml
+++ b/_data/engine-cli/docker_plugin_ls.yaml
@@ -6,6 +6,12 @@ usage: docker plugin ls [OPTIONS]
 pname: docker plugin
 plink: docker_plugin.yaml
 options:
+- option: format
+  description: Pretty-print plugins using a Go template
 - option: no-trunc
   default_value: "false"
   description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display plugin IDs

--- a/_data/engine-cli/docker_plugin_push.yaml
+++ b/_data/engine-cli/docker_plugin_push.yaml
@@ -1,6 +1,10 @@
 command: docker plugin push
 short: Push a plugin to a registry
 long: Push a plugin to a registry
-usage: docker plugin push PLUGIN[:TAG]
+usage: docker plugin push [OPTIONS] PLUGIN[:TAG]
 pname: docker plugin
 plink: docker_plugin.yaml
+options:
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image signing

--- a/_data/engine-cli/docker_port.yaml
+++ b/_data/engine-cli/docker_port.yaml
@@ -1,6 +1,7 @@
 command: docker port
 short: List port mappings or a specific mapping for the container
-long: List port mappings or a specific mapping for the container
+long: |
+  Alias for `docker container port`.
 usage: docker port CONTAINER [PRIVATE_PORT[/PROTO]]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -1,6 +1,7 @@
 command: docker ps
 short: List containers
-long: List containers
+long: |
+  Alias for `docker container ls`.
 usage: docker ps [OPTIONS]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -1,6 +1,7 @@
 command: docker pull
 short: Pull an image or a repository from a registry
-long: Pull an image or a repository from a registry
+long: |
+  Alias for `docker image pull`.
 usage: docker pull [OPTIONS] NAME[:TAG|@DIGEST]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_push.yaml
+++ b/_data/engine-cli/docker_push.yaml
@@ -1,10 +1,11 @@
 command: docker push
 short: Push an image or a repository to a registry
-long: Push an image or a repository to a registry
+long: |
+  Alias for `docker image push`.
 usage: docker push [OPTIONS] NAME[:TAG]
 pname: docker
 plink: docker.yaml
 options:
 - option: disable-content-trust
   default_value: "true"
-  description: Skip image verification
+  description: Skip image signing

--- a/_data/engine-cli/docker_rename.yaml
+++ b/_data/engine-cli/docker_rename.yaml
@@ -1,6 +1,7 @@
 command: docker rename
 short: Rename a container
-long: Rename a container
+long: |
+  Alias for `docker container rename`.
 usage: docker rename CONTAINER NEW_NAME
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_restart.yaml
+++ b/_data/engine-cli/docker_restart.yaml
@@ -1,6 +1,7 @@
 command: docker restart
 short: Restart one or more containers
-long: Restart one or more containers
+long: |
+  Alias for `docker container restart`.
 usage: docker restart [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_rm.yaml
+++ b/_data/engine-cli/docker_rm.yaml
@@ -1,6 +1,7 @@
 command: docker rm
 short: Remove one or more containers
-long: Remove one or more containers
+long: |
+  Alias for `docker container rm`.
 usage: docker rm [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_rmi.yaml
+++ b/_data/engine-cli/docker_rmi.yaml
@@ -1,6 +1,7 @@
 command: docker rmi
 short: Remove one or more images
-long: Remove one or more images
+long: |
+  Alias for `docker image rm`.
 usage: docker rmi [OPTIONS] IMAGE [IMAGE...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -146,9 +146,9 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
 - option: ip
-  description: Container IPv4 address (e.g. 172.30.100.104)
+  description: IPv4 address (e.g., 172.30.100.104)
 - option: ip6
-  description: Container IPv6 address (e.g. 2001:db8::33)
+  description: IPv6 address (e.g., 2001:db8::33)
 - option: ipc
   description: IPC namespace to use
 - option: isolation
@@ -174,7 +174,7 @@ options:
   default_value: '[]'
   description: Log driver options
 - option: mac-address
-  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+  description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
 - option: memory
   shorthand: m
   description: Memory limit

--- a/_data/engine-cli/docker_save.yaml
+++ b/_data/engine-cli/docker_save.yaml
@@ -1,6 +1,7 @@
 command: docker save
 short: Save one or more images to a tar archive (streamed to STDOUT by default)
-long: Save one or more images to a tar archive (streamed to STDOUT by default)
+long: |
+  Alias for `docker image save`.
 usage: docker save [OPTIONS] IMAGE [IMAGE...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_search.yaml
+++ b/_data/engine-cli/docker_search.yaml
@@ -1,6 +1,42 @@
 command: docker search
 short: Search the Docker Hub for images
-long: Search the Docker Hub for images
+long: |
+  Search Docker Hub for images that match the specified `TERM`. The table
+  of images returned displays the name, description (truncated by default), number
+  of stars awarded, whether the image is official, and whether it is automated.
+
+  *Note* - Search queries will only return up to 25 results
+
+  ## Filter
+
+     Filter output based on these conditions:
+     - stars=<numberOfStar>
+     - is-automated=(true|false)
+     - is-official=(true|false)
+
+  # EXAMPLES
+
+  ## Search Docker Hub for ranked images
+
+  Search a registry for the term 'fedora' and only display those images
+  ranked 3 or higher:
+
+      $ docker search --filter=stars=3 fedora
+      NAME                  DESCRIPTION                                    STARS OFFICIAL  AUTOMATED
+      mattdm/fedora         A basic Fedora image corresponding roughly...  50
+      fedora                (Semi) Official Fedora base image.             38
+      mattdm/fedora-small   A small Fedora image on which to build. Co...  8
+      goldmann/wildfly      A WildFly application server running on a ...  3               [OK]
+
+  ## Search Docker Hub for automated images
+
+  Search Docker Hub for the term 'fedora' and only display automated images
+  ranked 1 or higher:
+
+      $ docker search --filter=is-automated=true --filter=stars=1 fedora
+      NAME               DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
+      goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
+      tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]
 usage: docker search [OPTIONS] TERM
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_secret_create.yaml
+++ b/_data/engine-cli/docker_secret_create.yaml
@@ -1,7 +1,7 @@
 command: docker secret create
-short: Create a secret using stdin as content
-long: Create a secret using stdin as content
-usage: docker secret create [OPTIONS] SECRET
+short: Create a secret from a file or STDIN as content
+long: Create a secret from a file or STDIN as content
+usage: docker secret create [OPTIONS] SECRET file|-
 pname: docker secret
 plink: docker_secret.yaml
 options:

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -35,13 +35,11 @@ options:
 - option: health-cmd
   description: Command to run to check health
 - option: health-interval
-  default_value: none
   description: Time between running the check (ns|us|ms|s|m|h)
 - option: health-retries
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
 - option: health-timeout
-  default_value: none
   description: Maximum time to allow one check to run (ns|us|ms|s|m|h)
 - option: host
   default_value: '[]'
@@ -80,7 +78,6 @@ options:
   shorthand: p
   description: Publish a port as a node port
 - option: replicas
-  default_value: none
   description: Number of tasks
 - option: reserve-cpu
   default_value: "0.000"
@@ -91,18 +88,14 @@ options:
 - option: restart-condition
   description: Restart when condition is met (none, on-failure, or any)
 - option: restart-delay
-  default_value: none
   description: Delay between restart attempts (ns|us|ms|s|m|h)
 - option: restart-max-attempts
-  default_value: none
   description: Maximum number of restarts before giving up
 - option: restart-window
-  default_value: none
   description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
 - option: secret
   description: Specify secrets to expose to the service
 - option: stop-grace-period
-  default_value: none
   description: |
     Time to wait before force killing a container (ns|us|ms|s|m|h)
 - option: tty

--- a/_data/engine-cli/docker_service_ps.yaml
+++ b/_data/engine-cli/docker_service_ps.yaml
@@ -1,7 +1,7 @@
 command: docker service ps
-short: List the tasks of a service
-long: List the tasks of a service
-usage: docker service ps [OPTIONS] SERVICE
+short: List the tasks of one or more services
+long: List the tasks of one or more services
+usage: docker service ps [OPTIONS] SERVICE [SERVICE...]
 pname: docker service
 plink: docker_service.yaml
 options:

--- a/_data/engine-cli/docker_service_update.yaml
+++ b/_data/engine-cli/docker_service_update.yaml
@@ -58,13 +58,11 @@ options:
 - option: health-cmd
   description: Command to run to check health
 - option: health-interval
-  default_value: none
   description: Time between running the check (ns|us|ms|s|m|h)
 - option: health-retries
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
 - option: health-timeout
-  default_value: none
   description: Maximum time to allow one check to run (ns|us|ms|s|m|h)
 - option: host-add
   default_value: '[]'
@@ -106,7 +104,6 @@ options:
 - option: publish-rm
   description: Remove a published port by its target port
 - option: replicas
-  default_value: none
   description: Number of tasks
 - option: reserve-cpu
   default_value: "0.000"
@@ -117,13 +114,10 @@ options:
 - option: restart-condition
   description: Restart when condition is met (none, on-failure, or any)
 - option: restart-delay
-  default_value: none
   description: Delay between restart attempts (ns|us|ms|s|m|h)
 - option: restart-max-attempts
-  default_value: none
   description: Maximum number of restarts before giving up
 - option: restart-window
-  default_value: none
   description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
 - option: rollback
   default_value: "false"
@@ -134,7 +128,6 @@ options:
   default_value: '[]'
   description: Remove a secret
 - option: stop-grace-period
-  default_value: none
   description: |
     Time to wait before force killing a container (ns|us|ms|s|m|h)
 - option: tty

--- a/_data/engine-cli/docker_stack_ps.yaml
+++ b/_data/engine-cli/docker_stack_ps.yaml
@@ -5,10 +5,6 @@ usage: docker stack ps [OPTIONS] STACK
 pname: docker stack
 plink: docker_stack.yaml
 options:
-- option: all
-  shorthand: a
-  default_value: "false"
-  description: Display all tasks
 - option: filter
   shorthand: f
   description: Filter output based on conditions provided

--- a/_data/engine-cli/docker_start.yaml
+++ b/_data/engine-cli/docker_start.yaml
@@ -1,6 +1,7 @@
 command: docker start
 short: Start one or more stopped containers
-long: Start one or more stopped containers
+long: |
+  Alias for `docker container start`.
 usage: docker start [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -1,6 +1,7 @@
 command: docker stats
 short: Display a live stream of container(s) resource usage statistics
-long: Display a live stream of container(s) resource usage statistics
+long: |
+  Alias for `docker container stats`.
 usage: docker stats [OPTIONS] [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_stop.yaml
+++ b/_data/engine-cli/docker_stop.yaml
@@ -1,6 +1,7 @@
 command: docker stop
 short: Stop one or more running containers
-long: Stop one or more running containers
+long: |
+  Alias for `docker container stop`.
 usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_swarm_init.yaml
+++ b/_data/engine-cli/docker_swarm_init.yaml
@@ -11,6 +11,9 @@ options:
   default_value: "false"
   description: |
     Enable manager autolocking (requiring an unlock key to start a stopped manager)
+- option: availability
+  default_value: active
+  description: Availability of the node (active/pause/drain)
 - option: cert-expiry
   default_value: 2160h0m0s
   description: Validity period for node certificates (ns|us|ms|s|m|h)

--- a/_data/engine-cli/docker_swarm_join.yaml
+++ b/_data/engine-cli/docker_swarm_join.yaml
@@ -7,6 +7,9 @@ plink: docker_swarm.yaml
 options:
 - option: advertise-addr
   description: 'Advertised address (format: <ip|interface>[:port])'
+- option: availability
+  default_value: active
+  description: Availability of the node (active/pause/drain)
 - option: listen-addr
   default_value: 0.0.0.0:2377
   description: 'Listen address (format: <ip|interface>[:port])'

--- a/_data/engine-cli/docker_system_events.yaml
+++ b/_data/engine-cli/docker_system_events.yaml
@@ -1,6 +1,140 @@
 command: docker system events
 short: Get real time events from the server
-long: Get real time events from the server
+long: |+
+  Get event information from the Docker daemon. Information can include historical
+  information and real-time information.
+
+  Docker containers will report the following events:
+
+      attach, commit, copy, create, destroy, detach, die, exec_create, exec_detach, exec_start, export, kill, oom, pause, rename, resize, restart, start, stop, top, unpause, update
+
+  Docker images report the following events:
+
+      delete, import, load, pull, push, save, tag, untag
+
+  Docker volumes report the following events:
+
+      create, mount, unmount, destroy
+
+  Docker networks report the following events:
+
+      create, connect, disconnect, destroy
+
+  # OPTIONS
+
+  The `--since` and `--until` parameters can be Unix timestamps, date formatted
+  timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
+  relative to the client machine's time. If you do not provide the `--since` option,
+  the command returns only new and/or live events.  Supported formats for date
+  formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the client will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long.
+
+  # EXAMPLES
+
+  ## Listening for Docker events
+
+  After running docker events a container 786d698004576 is started and stopped
+  (The container name has been shortened in the output below):
+
+      # docker events
+      2015-01-28T20:21:31.000000000-08:00 59211849bc10: (from whenry/testimage:latest) start
+      2015-01-28T20:21:31.000000000-08:00 59211849bc10: (from whenry/testimage:latest) die
+      2015-01-28T20:21:32.000000000-08:00 59211849bc10: (from whenry/testimage:latest) stop
+
+  ## Listening for events since a given date
+  Again the output container IDs have been shortened for the purposes of this document:
+
+      # docker events --since '2015-01-28'
+      2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
+      2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+      2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
+      2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+      2015-01-28T20:25:40.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
+      2015-01-28T20:25:42.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
+      2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+      2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
+      2015-01-28T20:25:46.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
+
+  The following example outputs all events that were generated in the last 3 minutes,
+  relative to the current time on the client machine:
+
+      # docker events --since '3m'
+      2015-05-12T11:51:30.999999999Z07:00  4386fb97867d: (from ubuntu-1:14.04) die
+      2015-05-12T15:52:12.999999999Z07:00  4386fb97867d: (from ubuntu-1:14.04) stop
+      2015-05-12T15:53:45.999999999Z07:00  7805c1d35632: (from redis:2.8) die
+      2015-05-12T15:54:03.999999999Z07:00  7805c1d35632: (from redis:2.8) stop
+
+  If you do not provide the --since option, the command returns only new and/or
+  live events.
+
+  ## Format
+
+  If a format (`--format`) is specified, the given template will be executed
+  instead of the default format. Go's **text/template** package describes all the
+  details of the format.
+
+      # docker events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
+      Type=container  Status=create  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+      Type=container  Status=attach  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+      Type=container  Status=start  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+      Type=container  Status=resize  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+      Type=container  Status=die  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+      Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+
+  If a format is set to `{{json .}}`, the events are streamed as valid JSON
+  Lines. For information about JSON Lines, please refer to http://jsonlines.org/ .
+
+      # docker events --format '{{json .}}'
+      {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+      {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+      {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
+      {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
+      {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+
+  ## Filters
+
+      $ docker events --filter 'event=stop'
+      2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+      2014-09-03T17:42:14.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+
+      $ docker events --filter 'image=ubuntu-1:14.04'
+      2014-05-10T17:42:14.999999999Z07:00 container start 4386fb97867d (image=ubuntu-1:14.04)
+      2014-05-10T17:42:14.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
+      2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+
+      $ docker events --filter 'container=7805c1d35632'
+      2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:2.8)
+      2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image= redis:2.8)
+
+      $ docker events --filter 'container=7805c1d35632' --filter 'container=4386fb97867d'
+      2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
+      2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+      2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:2.8)
+      2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+
+      $ docker events --filter 'container=7805c1d35632' --filter 'event=stop'
+      2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+
+      $ docker events --filter 'type=volume'
+      2015-12-23T21:05:28.136212689Z volume create test-event-volume-local (driver=local)
+      2015-12-23T21:05:28.383462717Z volume mount test-event-volume-local (read/write=true, container=562fe10671e9273da25eed36cdce26159085ac7ee6707105fd534866340a5025, destination=/foo, driver=local, propagation=rprivate)
+      2015-12-23T21:05:28.650314265Z volume unmount test-event-volume-local (container=562fe10671e9273da25eed36cdce26159085ac7ee6707105fd534866340a5025, driver=local)
+      2015-12-23T21:05:28.716218405Z volume destroy test-event-volume-local (driver=local)
+
+      $ docker events --filter 'type=network'
+      2015-12-23T21:38:24.705709133Z network create 8b111217944ba0ba844a65b13efcd57dc494932ee2527577758f939315ba2c5b (name=test-event-network-local, type=bridge)
+      2015-12-23T21:38:25.119625123Z network connect 8b111217944ba0ba844a65b13efcd57dc494932ee2527577758f939315ba2c5b (name=test-event-network-local, container=b4be644031a3d90b400f88ab3d4bdf4dc23adb250e696b6328b85441abe2c54e, type=bridge)
+
+      $ docker events --filter 'type=plugin' (experimental)
+      2016-07-25T17:30:14.825557616Z plugin pull ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
+      2016-07-25T17:30:14.888127370Z plugin enable ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
+
 usage: docker system events [OPTIONS]
 pname: docker system
 plink: docker_system.yaml

--- a/_data/engine-cli/docker_system_info.yaml
+++ b/_data/engine-cli/docker_system_info.yaml
@@ -1,6 +1,68 @@
 command: docker system info
 short: Display system-wide information
-long: Display system-wide information
+long: "This command displays system wide information regarding the Docker installation.\nInformation
+  displayed includes the kernel version, number of containers and images.\nThe number
+  of images shown is the number of unique images. The same image tagged\nunder different
+  names is counted only once.\n\nIf a format is specified, the given template will
+  be executed instead of the\ndefault format. Go's **text/template** package\ndescribes
+  all the details of the format.\n\nDepending on the storage driver in use, additional
+  information can be shown, such\nas pool name, data file, metadata file, data space
+  used, total data space, metadata\nspace used, and total metadata space.\n\nThe data
+  file is where the images are stored and the metadata file is where the\nmeta data
+  regarding those images are stored. When run for the first time Docker\nallocates
+  a certain amount of data space and meta data space from the space\navailable on
+  the volume where `/var/lib/docker` is mounted.\n\n# EXAMPLES\n\n## Display Docker
+  system information\n\nHere is a sample output for a daemon running on Ubuntu, using
+  the overlay2\nstorage driver:\n\n    $ docker -D info\n    Containers: 14\n     Running:
+  3\n     Paused: 1\n     Stopped: 10\n    Images: 52\n    Server Version: 1.13.0\n
+  \   Storage Driver: overlay2\n     Backing Filesystem: extfs\n     Supports d_type:
+  true\n     Native Overlay Diff: false\n    Logging Driver: json-file\n    Cgroup
+  Driver: cgroupfs\n    Plugins:\n     Volume: local\n     Network: bridge host macvlan
+  null overlay\n    Swarm: active\n     NodeID: rdjq45w1op418waxlairloqbm\n     Is
+  Manager: true\n     ClusterID: te8kdyw33n36fqiz74bfjeixd\n     Managers: 1\n     Nodes:
+  2\n     Orchestration:\n      Task History Retention Limit: 5\n     Raft:\n      Snapshot
+  Interval: 10000\n      Number of Old Snapshots to Retain: 0\n      Heartbeat Tick:
+  1\n      Election Tick: 3\n     Dispatcher:\n      Heartbeat Period: 5 seconds\n
+  \    CA Configuration:\n      Expiry Duration: 3 months\n     Node Address: 172.16.66.128
+  172.16.66.129\n     Manager Addresses:\n      172.16.66.128:2477\n    Runtimes:
+  runc\n    Default Runtime: runc\n    Init Binary: docker-init\n    containerd version:
+  8517738ba4b82aff5662c97ca4627e7e4d03b531\n    runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2\n
+  \   init version: N/A (expected: v0.13.0)\n    Security Options:\n     apparmor\n
+  \    seccomp\n      Profile: default\n    Kernel Version: 4.4.0-31-generic\n    Operating
+  System: Ubuntu 16.04.1 LTS\n    OSType: linux\n    Architecture: x86_64\n    CPUs:
+  2\n    Total Memory: 1.937 GiB\n    Name: ubuntu\n    ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326\n
+  \   Docker Root Dir: /var/lib/docker\n    Debug Mode (client): true\n    Debug Mode
+  (server): true\n     File Descriptors: 30\n     Goroutines: 123\n     System Time:
+  2016-11-12T17:24:37.955404361-08:00\n     EventsListeners: 0\n    Http Proxy: http://test:test@proxy.example.com:8080\n
+  \   Https Proxy: https://test:test@proxy.example.com:8080\n    No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com\n
+  \   Registry: https://index.docker.io/v1/\n    WARNING: No swap limit support\n
+  \   Labels:\n     storage=ssd\n     staging=true\n    Experimental: false\n    Insecure
+  Registries:\n     127.0.0.0/8\n    Registry Mirrors:\n      http://192.168.1.2/\n
+  \     http://registry-mirror.example.com:5000/\n    Live Restore Enabled: false\n\n\n\nThe
+  global `-D` option tells all `docker` commands to output debug information.\n\nThe
+  example below shows the output for a daemon running on Red Hat Enterprise Linux,\nusing
+  the devicemapper storage driver. As can be seen in the output, additional\ninformation
+  about the devicemapper storage driver is shown:\n\n    $ docker info\n    Containers:
+  14\n     Running: 3\n     Paused: 1\n     Stopped: 10\n    Untagged Images: 52\n
+  \   Server Version: 1.10.3\n    Storage Driver: devicemapper\n     Pool Name: docker-202:2-25583803-pool\n
+  \    Pool Blocksize: 65.54 kB\n     Base Device Size: 10.74 GB\n     Backing Filesystem:
+  xfs\n     Data file: /dev/loop0\n     Metadata file: /dev/loop1\n     Data Space
+  Used: 1.68 GB\n     Data Space Total: 107.4 GB\n     Data Space Available: 7.548
+  GB\n     Metadata Space Used: 2.322 MB\n     Metadata Space Total: 2.147 GB\n     Metadata
+  Space Available: 2.145 GB\n     Udev Sync Supported: true\n     Deferred Removal
+  Enabled: false\n     Deferred Deletion Enabled: false\n     Deferred Deleted Device
+  Count: 0\n     Data loop file: /var/lib/docker/devicemapper/devicemapper/data\n
+  \    Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata\n     Library
+  Version: 1.02.107-RHEL7 (2015-12-01)\n    Execution Driver: native-0.2\n    Logging
+  Driver: json-file\n    Plugins:\n     Volume: local\n     Network: null host bridge\n
+  \   Kernel Version: 3.10.0-327.el7.x86_64\n    Operating System: Red Hat Enterprise
+  Linux Server 7.2 (Maipo)\n    OSType: linux\n    Architecture: x86_64\n    CPUs:
+  1\n    Total Memory: 991.7 MiB\n    Name: ip-172-30-0-91.ec2.internal\n    ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S\n
+  \   Docker Root Dir: /var/lib/docker\n    Debug mode (client): false\n    Debug
+  mode (server): false\n    Username: gordontheturtle\n    Registry: https://index.docker.io/v1/\n
+  \   Insecure registries:\n     myinsecurehost:5000\n     127.0.0.0/8\n\nYou can
+  also specify the output format:\n\n    $ docker info --format '{{json .}}'\n\t{\"ID\":\"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S\",\"Containers\":14,
+  ...}\n"
 usage: docker system info [OPTIONS]
 pname: docker system
 plink: docker_system.yaml

--- a/_data/engine-cli/docker_system_prune.yaml
+++ b/_data/engine-cli/docker_system_prune.yaml
@@ -9,6 +9,8 @@ options:
   shorthand: a
   default_value: "false"
   description: Remove all unused images not just dangling ones
+- option: filter
+  description: Provide filter values (e.g. 'until=<timestamp>')
 - option: force
   shorthand: f
   default_value: "false"

--- a/_data/engine-cli/docker_tag.yaml
+++ b/_data/engine-cli/docker_tag.yaml
@@ -1,6 +1,7 @@
 command: docker tag
 short: Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
-long: Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+long: |
+  Alias for `docker image tag`.
 usage: docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_top.yaml
+++ b/_data/engine-cli/docker_top.yaml
@@ -1,17 +1,7 @@
 command: docker top
 short: Display the running processes of a container
 long: |
-  Display the running process of the container. ps-OPTION can be any of the options you would pass to a Linux ps command.
-
-  All displayed information is from host's point of view.
-
-  # EXAMPLES
-
-  Run **docker top** with the ps option of -x:
-
-      $ docker top 8601afda2b -x
-      PID      TTY       STAT       TIME         COMMAND
-      16623    ?         Ss         0:00         sleep 99999
+  Alias for `docker container top`.
 usage: docker top CONTAINER [ps OPTIONS]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_unpause.yaml
+++ b/_data/engine-cli/docker_unpause.yaml
@@ -1,6 +1,7 @@
 command: docker unpause
 short: Unpause all processes within one or more containers
-long: Unpause all processes within one or more containers
+long: |
+  Alias for `docker container unpause`.
 usage: docker unpause CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_update.yaml
+++ b/_data/engine-cli/docker_update.yaml
@@ -1,6 +1,7 @@
 command: docker update
 short: Update configuration of one or more containers
-long: Update configuration of one or more containers
+long: |
+  Alias for `docker container update`.
 usage: docker update [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_volume.yaml
+++ b/_data/engine-cli/docker_volume.yaml
@@ -6,13 +6,13 @@ long: |
   management.
 
   Data volumes persist data independent of a container's life cycle. When you
-  delete a container, the Engine daemon does not delete any data volumes. You can
+  delete a container, the Docker daemon does not delete any data volumes. You can
   share volumes across multiple containers. Moreover, you can share data volumes
   with other computing resources in your system.
 
   To see help for a subcommand, use:
 
-      docker volume CMD help
+      docker volume COMMAND --help
 
   For full details on using docker volume visit Docker's online documentation.
 usage: docker volume COMMAND

--- a/_data/engine-cli/docker_volume_ls.yaml
+++ b/_data/engine-cli/docker_volume_ls.yaml
@@ -2,7 +2,7 @@ command: docker volume ls
 aliases: list
 short: List volumes
 long: |
-  Lists all the volumes Docker knows about. You can filter using the `-f` or
+  Lists all the volumes Docker manages. You can filter using the `-f` or
   `--filter` flag. The filtering format is a `key=value` pair. To specify
   more than one filter,  pass multiple flags (for example,
   `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_wait.yaml
+++ b/_data/engine-cli/docker_wait.yaml
@@ -1,6 +1,7 @@
 command: docker wait
 short: Block until one or more containers stop, then print their exit codes
-long: Block until one or more containers stop, then print their exit codes
+long: |
+  Alias for `docker container wait`.
 usage: docker wait CONTAINER [CONTAINER...]
 pname: docker
 plink: docker.yaml


### PR DESCRIPTION
### Proposed changes

Fixes the need to have hard-coded examples introduced in https://github.com/docker/docker.github.io/pull/1069 and adds them to the CLI as seen within the `docker/docker` repo

cc @johndmulhausen @mstanleyjones 