### PR TITLE
adding d4mac, d4win beta 40 release notes

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -269,6 +269,27 @@ events or unexpected unmounts.
 
 ## Beta Release Notes
 
+### Beta 40 Release Notes (2017-01-31 1.13.1-beta40)
+
+**Upgrades**
+
+- [Docker 1.13.1-rc1](https://github.com/docker/docker/releases/tag/v1.13.1-rc1)
+- Linux kernel 4.9.6
+
+**New**
+
+- Allow to reset faulty `daemon.json` through a link in advanced subpanel
+- Add link to experimental features
+- Hide restart button in settings window
+- Increase the maximum number of vCPUs to 64
+
+**Bug fixes and minor improvements**
+
+- VPNKit: Avoid diagnostics to capture too much data
+- VPNKit: Fix a source of occasional packet loss (truncation) on the virtual ethernet link
+- HyperKit: Dump guest physical and linear address from VMCS when dumping state
+- HyperKit: Kernel boots with `panic=1` arg
+
 ### Beta 39 Release Notes (2017-01-26 1.13.0-beta39)
 
 **Upgrades**

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -258,6 +258,23 @@ We did not distribute a 1.12.4 stable release
 
 ## Beta Release Notes
 
+### Beta 40 Release Notes (2017-01-31 1.13.1-beta40)
+
+**Upgrades**
+
+- [Docker 1.13.1-rc1](https://github.com/docker/docker/releases/tag/v1.13.1-rc1)
+- Linux kernel 4.9.6
+
+**Bug fixes and minor improvements**
+
+- Fix startup error of `ObjectNotFound` in Set-VMFirmware
+- Add detailed logs when firewall is configured
+- Add a link to the Experimental Features documentation
+- Fixed the Copyright in About Dialog
+- VPNKit: Avoid diagnostics to capture too much data
+- VPNKit: fix a source of occasional packet loss (truncation) on the virtual ethernet link
+- Fix negotiation of TimeSync protocol version (via kernel update)
+
 ### Beta 39 Release Notes (2017-01-26 1.13.0-beta39)
 
 **Upgrades**


### PR DESCRIPTION
* added release notes for Beta 40 for Mac and Windows
* the only UI changes I could see are that a link was added to experimental features on the Daemon UI's for Mac and Windows. This is great, but I don't think this is worth a screen snap or even mention in the docs. (The docs describe experimental in some detail and also link to the features on GitHub). Please let me know if you disagree, and I'll add something. 

### Reviewers
@dgageot @justincormack @thaJeztah @mstanleyjones 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
