### PR TITLE
Add cloud.ca to the list of 3rd-party docker machine drivers.

### DIFF
--- a/machine/AVAILABLE_DRIVER_PLUGINS.md
+++ b/machine/AVAILABLE_DRIVER_PLUGINS.md
@@ -112,6 +112,19 @@ with Docker Inc.  Use 3rd party plugins at your own risk.
       </td>
     </tr>
     <tr>
+      <td>cloud.ca</td>
+      <td>
+        <a href=
+        "https://github.com/cloud-ca/docker-machine-driver-cloudca">https://github.com/cloud-ca/docker-machine-driver-cloudca</a>
+      </td>
+      <td>
+        <a href="https://github.com/cloud-ca">cloud.ca</a>
+      </td>
+      <td>
+        <a href="mailto:cloudmc@cloudops.com">cloudmc@cloudops.com</a>
+      </td>
+    </tr>
+    <tr>
       <td>Docker-In-Docker</td>
       <td>
         <a href=


### PR DESCRIPTION
### Proposed changes

Added [cloud.ca](https://cloud.ca) to the list of 3rd-party docker machine drivers.