### PR TITLE
Added a new remove unofficial docker step

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -26,6 +26,13 @@ version of Docker, remove it using the following command:
 $ sudo yum -y remove docker
 ```
 
+You may also have to remove the package `docker-selinux` which conflicts with
+the official `docker-engine` package.  Remove it with the following command:
+  
+```bash
+$ sudo yum -y remove docker-selinux
+```
+
 The contents of `/var/lib/docker` are not removed, so any images, containers,
 or volumes you created using the older version of Docker are preserved.
 

--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -29,6 +29,13 @@ of Docker, remove it using the following command:
 $ sudo dnf -y remove docker
 ```
 
+You may also have to remove the package `docker-selinux` which conflicts with the 
+official `docker-engine` package. Remove it with the following command:
+
+```bash
+$ sudo dnf -y remove docker-selinux
+```
+
 The contents of `/var/lib/docker` are not removed, so any images, containers,
 or volumes you created using the older version of Docker are preserved.
 

--- a/engine/installation/linux/oracle.md
+++ b/engine/installation/linux/oracle.md
@@ -31,6 +31,13 @@ remove it using the following command:
 $ sudo yum -y remove docker
 ```
 
+You may also have to remove the package `docker-engine-selinux` which conflicts with
+the official `docker-engine` package.  Remove it with the following command:
+
+```bash
+$ sudo yum -y remove docker-engine-selinux
+```
+
 The contents of `/var/lib/docker` are not removed, so any images, containers,
 or volumes you created using the older version of Docker are preserved.
 

--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -27,6 +27,13 @@ version of Docker, remove it using the following command:
 $ sudo yum -y remove docker
 ```
 
+You may also have to remove the package `docker-selinux` which will conflict with
+the new official `docker-engine` package.  Remove it with the following command:
+
+```bash
+$ sudo yum -y remove docker-selinux
+```
+
 The contents of `/var/lib/docker` are not removed, so any images, containers,
 or volumes you created using the older version of Docker are preserved.
 

--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -27,8 +27,8 @@ version of Docker, remove it using the following command:
 $ sudo yum -y remove docker
 ```
 
-You may also have to remove the package `docker-selinux` which will conflict with
-the new official `docker-engine` package.  Remove it with the following command:
+You may also have to remove the package `docker-selinux` which conflicts with
+the official `docker-engine` package.  Remove it with the following command:
 
 ```bash
 $ sudo yum -y remove docker-selinux


### PR DESCRIPTION
I found an error when trying to install the official docker-engine, as there a second package that conflicts with the new package.  Added instructions on how to remove it.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
