### PR TITLE
fix url to docker repo

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -78,8 +78,7 @@ Docker from the repository.
 
     Verify that the key ID is `58118E89F3A912897C070ADBF76221572C52609D`.
 
-    ```bash
-    $ apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
+    ```bash    $ apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
 
       pub   4096R/2C52609D 2015-07-14
             Key fingerprint = 5811 8E89 F3A9 1289 7C07  0ADB F762 2157 2C52 609D
@@ -93,8 +92,8 @@ Docker from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-           "deb https://apt.dockerproject.org/repo/ \
-           ubuntu-$(lsb_release -cs) \
+           "deb https://apt.dockerproject.org/repo/dists \
+           ubuntu $(lsb_release -cs) \
            main"
     ```
 


### PR DESCRIPTION
changed 
https://apt.dockerproject.org/repo/
into
https://apt.dockerproject.org/repo/dists/   (which is where the files are actually located)

and removed the '-' between ubuntu and $(lsb_release -cs)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
