### PR TITLE
Various Jekyll optimizations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ defaults:
       enginebranch: 1.13.x
       toc_min: 2
       toc_max: 3
+      tree: true
   - scope:
       path: "compose"
     values:

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -195,17 +195,22 @@ ng\:form {
         <div class="container-fluid">
           <div class="row">
             <div class="col-xs-12 col-sm-3 col-md-2 col-xl-2 docsidebarnav_section">
-              <div class="region region-hero-sub"><ul class="nav-sub">
-								{% assign tree = site.data.toc.toc %}
-								{% include tree.html %}
-							</ul>
+              <div class="region region-hero-sub">
+								{% if page.tree == false %}
+									<ul class="nav-sub"><li class="leaf"><a href="/">Back to the index</a></li></ul>
+								{% else %}
+									<ul class="nav-sub">
+									{% assign tree = site.data.toc.toc %}
+									{% include tree.html %}
+									</ul>
+								{% endif %}
               </div>
             </div>
             <div class="col-xs-12 col-sm-9 col-md-8 col-xl-9">
               <section class="section" id="DocumentationText">
 								{% if page.title %}<h1>{{ page.title }}</h1>{% endif %}
 								{% if page.advisory %}<blockquote style="border-left: 6px solid #FFD601; background: -webkit-gradient(linear, left top, left bottom, from(#FBFCFC), to(#EBEDEF));">{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>{% endif %}
-              {% include read_time.html %}
+              {% unless page.tree == false %}{% include read_time.html %}{% endunless %}
 							{{ content }}
 							{% if page.noratings != true %}
 							<div style="text-align: center; margin-top: 50px">
@@ -391,6 +396,7 @@ background-image: linear-gradient(to bottom, #75ae4c, #99c47c);
         </div>
         <div class="footer-copyright">
           <p class="copyright">Copyright &copy; {{ 'now' | date: "%Y" }} Docker Inc. All rights reserved.</p>
+					<p id="site-generation">Site generated {{ site.time}}.</p>
         </div>
       </div>
     </div>

--- a/allpagelinks.md
+++ b/allpagelinks.md
@@ -1,9 +1,16 @@
 ---
 title: All Page Links
 hide_from_sitemap: true
+layout: null
 ---
+
+# All site links for `docs.docker.com`
 
 {% assign pages = site.pages | sort:"path" %}
 {% for page in pages %}
-- [{{page.url}}]({{page.url}}) - {{ page.title }}
+  {% unless page.layout == null %}
+    {% unless page.title == nil %}
+- [{{page.title}}]({{page.url}})
+    {% endunless %}
+  {% endunless %}
 {% endfor %}

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -457,3 +457,9 @@ img.with-border {
   color: #155A74;
   padding-bottom: 5px;
 }
+
+#site-generation {
+  font-size: 9px;
+  color: #999;
+  font-style: italic;
+}

--- a/search.md
+++ b/search.md
@@ -4,6 +4,7 @@ keywords: Search, Docker, documentation, manual, guide, reference, api
 noratings: true
 notoc: true
 title: Search results
+tree: false
 ---
 
 <style type='text/css'>

--- a/sorry.md
+++ b/sorry.md
@@ -1,6 +1,8 @@
 ---
 title: "Sorry, we can't find that page"
 noratings: true
+notoc: true
+tree: false
 ---
 
 <script language="JavaScript">

--- a/thank-you-subscribing-docker-weekly.md
+++ b/thank-you-subscribing-docker-weekly.md
@@ -2,6 +2,7 @@
 description: We've sent you a welcome email with links to previous newsletters.
 keywords: Docker, documentation, manual, guide, reference, api
 title: Thank you for subscribing to Docker weekly
+tree: false
 ---
 
 We've sent you a welcome email with links to previous newsletters.


### PR DESCRIPTION
- Add `tree: true|false` front-matter key (default to true) to disable the left-hand nav tree on a per-page basis
- Disabling the tree also disables reading time
- Disabled tree on search, sorry, thank-you-subscribing-docker-weekly
- Use null layout for allpagelinks.md and limit it to pages that have a title (which leaves out redirects, which are not real pages)
- Add site-generation date and time to footer, in a tiny unobtrusive font
