### PR TITLE
Fix v1.12 archive build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ permalink: pretty
 safe: false
 lsi: false
 url: https://docs.docker.com
-keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11"]
+keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12"]
 
 gems:
   - jekyll-redirect-from


### PR DESCRIPTION
Add the v1.12 archive directory to `keep_files` to
prevent Jekyll from removing the directory when
building the main docs.

ping @mstanleyjones @johndmulhausen PTAL