### PR TITLE
move info about local users to note at the top

### DIFF
--- a/datacenter/ucp/2.0/guides/configuration/integrate-with-ldap.md
+++ b/datacenter/ucp/2.0/guides/configuration/integrate-with-ldap.md
@@ -8,8 +8,10 @@ title: Integrate with LDAP
 Docker UCP integrates with LDAP services, so that you can manage users from a
 single place.
 
-**Note:** When you switch from the built-in authentication to using LDAP
-authentication, all manually created users become inactive. Use the **Recovery admin username** and **Recovery admin password** fields to create a local user account that can be used to access UCP if the LDAP server becomes unreachable.
+When you switch from built-in authentication to LDAP authentication,
+all manually created users whose usernames do not match any LDAP search results
+become inactive with the exception of the recovery admin user which can still
+login with the recovery admin password.
 
 ## Configure the LDAP integration
 

--- a/datacenter/ucp/2.0/guides/configuration/integrate-with-ldap.md
+++ b/datacenter/ucp/2.0/guides/configuration/integrate-with-ldap.md
@@ -8,6 +8,9 @@ title: Integrate with LDAP
 Docker UCP integrates with LDAP services, so that you can manage users from a
 single place.
 
+**Note:** When you switch from the built-in authentication to using LDAP
+authentication, all manually created users become inactive. Use the **Recovery admin username** and **Recovery admin password** fields to create a local user account that can be used to access UCP if the LDAP server becomes unreachable.
+
 ## Configure the LDAP integration
 
 To configure UCP to authenticate users using an LDAP service, go to
@@ -89,5 +92,3 @@ You can also manually synchronize users by clicking the **Sync Now** button.
 
 When a user is removed from LDAP, that user becomes inactive after the LDAP
 synchronization runs.
-Also, when you switch from the built-in authentication to using LDAP
-authentication, all manually created users become inactive.

--- a/datacenter/ucp/2.1/guides/admin/configure/external-auth/index.md
+++ b/datacenter/ucp/2.1/guides/admin/configure/external-auth/index.md
@@ -9,6 +9,11 @@ Docker UCP integrates with LDAP directory services, so that you can manage
 users and groups from your organization's directory and it will automatically
 propagate that information to UCP and DTR.
 
+When you switch from built-in authentication to LDAP authentication,
+all manually created users whose usernames do not match any LDAP search results
+become inactive with the exception of the recovery admin user which can still
+login with the recovery admin password.
+
 ## Configure the LDAP integration
 
 To configure UCP to create and authenticate users using an LDAP directory,
@@ -21,41 +26,41 @@ Then configure your LDAP directory integration.
 
 **Authentication**
 
-| Field                                            | Description                                                                                                                                                    |
-|:-------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Field                                            | Description                                                                                                                                                                                |
+|:-------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Method                                           | The method used to create and authenticate users. The *LDAP* method uses a remote directory server to automatically create users and all logins will be forwarded to the directory server. |
-| Default permission for newly discovered accounts | The permission level assigned by default to a new user. [Learn more about default permission levels](../../manage-users/permission-levels.md).                 |
+| Default permission for newly discovered accounts | The permission level assigned by default to a new user. [Learn more about default permission levels](../../manage-users/permission-levels.md).                                             |
 
 **LDAP server configuration**
 
-| Field                   | Description                                                                                                                                         |
-|:------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
-| LDAP server URL         | The URL where the LDAP server can be reached.                                                                                                       |
-| Recovery admin username | The username for a recovery user that can access UCP even when the integration with LDAP is misconfigured or the LDAP server is offline.            |
+| Field                   | Description                                                                                                                                                                                      |
+|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| LDAP server URL         | The URL where the LDAP server can be reached.                                                                                                                                                    |
+| Recovery admin username | The username for a recovery user that can access UCP even when the integration with LDAP is misconfigured or the LDAP server is offline.                                                         |
 | Recovery admin password | The password for the recovery user which is securely salted and hashed and stored in UCP. The recovery admin user can use this password to login if the LDAP server is misconfigured or offline. |
-| Reader DN               | The distinguished name of the LDAP account used for searching entries in the LDAP server. As a best practice this should be an LDAP read-only user. |
-| Reader password         | The password of the account used for searching entries in the LDAP server.                                                                          |
+| Reader DN               | The distinguished name of the LDAP account used for searching entries in the LDAP server. As a best practice this should be an LDAP read-only user.                                              |
+| Reader password         | The password of the account used for searching entries in the LDAP server.                                                                                                                       |
 
 **LDAP security options**
 
-| Field                                   | Description                                                                                                                                   |
-|:----------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|
-| Skip verification of server certificate | Whether to verify the LDAP server certificate when using TLS. The connection is still encrypted, but vulnerable to man-in-the-middle attacks. |
+| Field                                   | Description                                                                                                                                                               |
+|:----------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Skip verification of server certificate | Whether to verify the LDAP server certificate when using TLS. The connection is still encrypted, but vulnerable to man-in-the-middle attacks.                             |
 | Use StartTLS                            | Whether to authenticate/encrypt the connection after connecting to the LDAP server over TCP. If you set the LDAP Server URL field with `ldaps://`, this field is ignored. |
 
 **User search configurations**
 
-| Field                         | Description                                                                                                                            |
-|:------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|
-| Base DN                       | The distinguished name of the node in the directory tree where the search should start looking for users.                              |
-| Username attribute            | The LDAP attribute to use as username on UCP. Only user entries with a valid username will be created. A valid username is no longer than 100 characters and does not contain any unprintable characters, whitespace characters, or any of the following characters: `/` `\` `[` `]` `:` `;` `|` `=` `,` `+` `*` `?` `<` `>` `'` `"`. |
-| Full name attribute           | The LDAP attribute to use as the user's full name for display purposes. If left empty, UCP will not create new users with a full name value. |
-| Filter                        | The LDAP search filter used to find users. If you leave this field empty, all directory entries in the search scope with valid username attributes are created as users. |
-| Search scope                  | Whether to perform the LDAP search on a single level of the LDAP tree, or search through the full LDAP tree starting at the Base DN.   |
-| Match group members           | Whether to further filter users by selecting those who are also members of a specific group on the directory server. This feature is helpful if the LDAP server does not support `memberOf` search filters. |
+| Field                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|:------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Base DN                       | The distinguished name of the node in the directory tree where the search should start looking for users.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Username attribute            | The LDAP attribute to use as username on UCP. Only user entries with a valid username will be created. A valid username is no longer than 100 characters and does not contain any unprintable characters, whitespace characters, or any of the following characters: `/` `\` `[` `]` `:` `;` `|` `=` `,` `+` `*` `?` `<` `>` `'` `"`.                                                                                                                                                                                                                                                         |
+| Full name attribute           | The LDAP attribute to use as the user's full name for display purposes. If left empty, UCP will not create new users with a full name value.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Filter                        | The LDAP search filter used to find users. If you leave this field empty, all directory entries in the search scope with valid username attributes are created as users.                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Search scope                  | Whether to perform the LDAP search on a single level of the LDAP tree, or search through the full LDAP tree starting at the Base DN.                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Match group members           | Whether to further filter users by selecting those who are also members of a specific group on the directory server. This feature is helpful if the LDAP server does not support `memberOf` search filters.                                                                                                                                                                                                                                                                                                                                                                                   |
 | Iterate through group members | If `Match Group Members` is selected, this option searches for users by first iterating over the target group's membership and makes a separate LDAP query for each member, as opposed to first querying for all users which match the above search query and intersecting those with the set of group members. This option can be more efficient in situations where the number of members of the target group is significantly smaller than the number of users which would match the above search filter or if your directory server does not support simple pagination of search results. |
-| Group DN                      | If `Match Group Members` is selected, this specifies the distinguished name of the group from which to select users.                   |
-| Group member attribute        | If `Match Group Members` is selected, the value of this group attribute corresponds to the distinguished names of the members of the group. |
+| Group DN                      | If `Match Group Members` is selected, this specifies the distinguished name of the group from which to select users.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Group member attribute        | If `Match Group Members` is selected, the value of this group attribute corresponds to the distinguished names of the members of the group.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 ![](../../../images/ldap-integration-2.png){: .with-border}
 
@@ -67,10 +72,10 @@ configurations will be synced as a user.
 
 **Advanced LDAP configuration**
 
-| Field                      | Description                                         |
-|:---------------------------|:----------------------------------------------------|
-| No simple pagination       | If your LDAP server doesn't support pagination.     |
-| Enable sync of admin users | Whether to import LDAP users as UCP administrators. |
+| Field                      | Description                                                                                                                                                                                                                 |
+|:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| No simple pagination       | If your LDAP server doesn't support pagination.                                                                                                                                                                             |
+| Enable sync of admin users | Whether to import LDAP users as UCP administrators.                                                                                                                                                                         |
 | LDAP Match Method          | If admin user sync is enabled, this option specifies whether to match admin user entries using a search query or by selecting them as members from a group. For the expanded options, refer to the options described below. |
 
 
@@ -108,10 +113,10 @@ remain a system admin.
 
 **Test LDAP connection**
 
-| Field    | Description                                                              |
-|:---------|:-------------------------------------------------------------------------|
+| Field    | Description                                                                                                                                          |
+|:---------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | Username | The username with which the user will login to this application. This value should correspond to the Username Attribute specified in the form above. |
-| Password | The user's password used to authenticate (BIND) to the directory server. |
+| Password | The user's password used to authenticate (BIND) to the directory server.                                                                             |
 
 Before you save the configuration changes, you should test that the integration
 is correctly configured. You can do this by providing the credentials of an


### PR DESCRIPTION
To prevent users from configuring LDAP and *then* realizing their local users are deleted, it should also be stated at the beginning that a recovery admin should be created and that all the local users are deleted.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
