### PR TITLE
Update fedora.md to correct systemd invocation

### DIFF
--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -152,7 +152,7 @@ Docker from the repository.
 4.  Start Docker.
 
     ```bash
-    $ sudo systemctl docker start
+    $ sudo systemctl start docker
     ```
 
 5.  Verify that `docker` is installed correctly by running the `hello-world`

--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -199,7 +199,7 @@ a new file each time you want to upgrade Docker.
 3.  Start Docker.
 
     ```bash
-    $ sudo systemctl docker start
+    $ sudo systemctl start docker
     ```
 
 4.  Verify that `docker` is installed correctly by running the `hello-world`


### PR DESCRIPTION
```systemctl docker start``` is not correct for systemd; it must be ```systemctl start docker```. This was probably a leftover from init script - an easy oversight when switching over.