### PR TITLE
Fix: Start Docker Section

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -148,7 +148,7 @@ Docker from the repository.
 4.  Start Docker.
 
     ```bash
-    $ sudo systemctl docker start
+    $ sudo systemctl start docker
     ```
 
 5.  Verify that `docker` is installed correctly by running the `hello-world`
@@ -195,7 +195,7 @@ a new file each time you want to upgrade Docker.
 3.  Start Docker.
 
     ```bash
-    $ sudo systemctl docker start
+    $ sudo systemctl start docker
     ```
 
 4.  Verify that `docker` is installed correctly by running the `hello-world`


### PR DESCRIPTION
'sudo systemctl docker start' doesn't work.
It should be 'sudo systemctl start docker'.
Details at http://www.unix.com/man-page/centos/1/systemctl