### PR TITLE
Corrected a typo and error in docker start command

### DIFF
--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -57,7 +57,7 @@ Docker from the repository.
 
 #### Set up the repository
 
-1.  Install the `dnf-plugins.core` package which provides the commands to manage
+1.  Install the `dnf-plugins-core` package which provides the commands to manage
     your DNF repositories from the command line.
 
     ```bash
@@ -152,7 +152,7 @@ Docker from the repository.
 4.  Start Docker.
 
     ```bash
-    $ sudo systemctl docker start
+    $ sudo systemctl start docker
     ```
 
 5.  Verify that `docker` is installed correctly by running the `hello-world`

--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -152,7 +152,7 @@ Docker from the repository.
 4.  Start Docker.
 
     ```bash
-    $ sudo systemctl start docker
+    $ sudo systemctl docker start
     ```
 
 5.  Verify that `docker` is installed correctly by running the `hello-world`


### PR DESCRIPTION
- Corrected a typo in comment.
- Corrected a command to start docker.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
