### PR TITLE
Fixed bug in posh-docker setup instructions

### DIFF
--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -400,15 +400,18 @@ PowerShell Module as follows.
     command to a `$PROFILE` by typing these commands at the PowerShell prompt.
 
     ```none
-    Install-Module -Scope CurrentUser posh-docker -Force
-    Add-Content $PROFILE "`nInstall-Module posh-docker"
+    if (-Not (Test-Path $PROFILE)) {
+        New-Item $PROFILE –Type File –Force
+    }
+    
+    Add-Content $PROFILE "`nImport-Module posh-docker"
     ```
 
     This creates a `$PROFILE` if one does not already exist, and adds this line
     into the file:
 
     ```none
-    Install-Module posh-docker
+    Import-Module posh-docker
     ```
 
     To check that the file was properly created, or simply edit it manually,


### PR DESCRIPTION
There were two problems that this fixes.

1. Before this change, posh-docker was being installed twice. Once for the system (via NuGet) and secondly in the user's PowerShell context. This was confusing. I understand the reason was probably to create the user's $PROFILE file if it didn't already exist. I've replaced that functionality with clearer code.

2. The instructions had incorrectly said to add "Install-Module posh-docker" to the $PROFILE. Instead, this needed to be "Import-Module posh-docker".

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
