### PR TITLE
Fix docs about what protocol must be allowed for network encryption

### DIFF
--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -105,7 +105,7 @@ If you are using Docker Machine, you can get the manager IP with either
 
 The tutorial uses `manager1` : `192.168.99.100`.
 
-### Open ports between the hosts
+### Open protocols and ports between the hosts
 
 The following ports must be available. On some systems, these ports are open by default.
 
@@ -114,7 +114,7 @@ The following ports must be available. On some systems, these ports are open by 
 * **TCP** and **UDP port 4789** for overlay network traffic
 
 If you are planning on creating an overlay network with encryption (`--opt encrypted`),
-you will also need to ensure port 50 (ESP) is open.
+you will also need to ensure ip protocol 50 (ESP) traffic is allowed.
 
 ## What's next?
 


### PR DESCRIPTION
- This was inadvertently changed to `port` in cb3d925f7fdf87ba8ff1968261bda76a04d4964e

Signed-off-by: Alessandro Boch <aboch@docker.com>
