### PR TITLE
update ubuntu installation instructions

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -87,19 +87,18 @@ Docker from the repository.
       uid                  Docker Release Tool (releasedocker) <docker@docker.com>
     ```
 
-3.  Use the following command to set up the **stable** repository. To also
-    enable the **testing** repository, add the words `testing` after `main` on
-    the last line.
-    **Do not use these unstable repositories on production systems or for non-testing workloads.**
+3.  Use the following command to set up the **stable** repository.
 
     ```bash
-    $ sudo apt-get install software-properties-common
     $ sudo add-apt-repository \
            "deb https://apt.dockerproject.org/repo/ \
            ubuntu-$(lsb_release -cs) \
            main"
     ```
 
+    To also enable the **testing** repository, add the words `testing` after
+    `main` on the last line. **Do not use these unstable repositories on
+    production systems or for non-testing workloads.**
     To disable the `testing` repository, you can edit `/etc/apt/sources.list`
     and remove the word `testing` from the appropriate line in the file.
 


### PR DESCRIPTION
the `software-properties-common` package is already
installed in step one, so there's not need to re-install
it in step 3.

Also moved the instructions for adding the "testing" repository
after the instructions for adding the "main" repository. The
warning "Do not use these unstable repositories on production
systems or for non-testing workloads." war prominently visible,
and therefore gave the impression it was refering to the instructions below;

<img width="833" alt="screen shot 2017-02-06 at 7 20 28 pm" src="https://cloud.githubusercontent.com/assets/1804568/22676707/e78974b2-eca1-11e6-876b-c8c5b1108bc9.png">
