### PR TITLE
Update repository setup step for Linux Mint users

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -101,6 +101,11 @@ Docker from the repository.
 
     To disable the `testing` repository, you can edit `/etc/apt/sources.list`
     and remove the word `testing` from the appropriate line in the file.
+    
+    > **Note**: Sometimes, in a distribution like Linux Mint, you might have
+    > to change **ubuntu-$(lsb_release -cs)** to your parent Ubuntu distribution.
+    > example: If you are using **Linux Mint Rafaela**, you could type in **ubuntu-trusty**
+
 
 #### Install Docker
 

--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -103,8 +103,8 @@ Docker from the repository.
     and remove the word `testing` from the appropriate line in the file.
     
     > **Note**: Sometimes, in a distribution like Linux Mint, you might have
-    > to change **ubuntu-$(lsb_release -cs)** to your parent Ubuntu distribution.
-    > example: If you are using **Linux Mint Rafaela**, you could type in **ubuntu-trusty**
+    > to change `ubuntu-$(lsb_release -cs)` to your parent Ubuntu distribution.
+    > example: If you are using `Linux Mint Rafaela`, you could type in `ubuntu-trusty`
 
 
 #### Install Docker


### PR DESCRIPTION
### Proposed changes
Add a note to remind people using distributions derived from Ubuntu(Linux Mint)
to change the ubuntu-$(lsb_release -cs) part to their parent Ubuntu release

The output of $(lsb_release -cs) won't necessarily be a stable Ubuntu release, it would
sometimes be something like 'rafaelia' and there could be problems in the installation
<!--Tell us what you did and why-->


### Related issues (optional)
https://github.com/docker/docker.github.io/issues/1516
