### PR TITLE
Fix markdown rendering of example configuration

### DIFF
--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -256,11 +256,11 @@ updates.
 - `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
 - `max_failure_ratio`: Failure rate to tolerate during an update.
 
-<!-- fix code block after list -->
-
+```
     update_config:
       parallelism: 2
       delay: 10s
+```
 
 #### resources
 

--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -256,6 +256,8 @@ updates.
 - `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
 - `max_failure_ratio`: Failure rate to tolerate during an update.
 
+<!-- fix code block after list -->
+
     update_config:
       parallelism: 2
       delay: 10s
@@ -287,6 +289,8 @@ Configures if and how to restart containers when they exit. Replaces
 - `window`: How long to wait before deciding if a restart has succeeded,
   specified as a [duration](compose-file.md#specifying-durations) (default:
   decide immediately).
+
+<!-- fix code block after list -->
 
     restart_policy:
       condition: on-failure

--- a/compose/compose-file.md
+++ b/compose/compose-file.md
@@ -290,13 +290,13 @@ Configures if and how to restart containers when they exit. Replaces
   specified as a [duration](compose-file.md#specifying-durations) (default:
   decide immediately).
 
-<!-- fix code block after list -->
-
+```
     restart_policy:
       condition: on-failure
       delay: 5s
       max_attempts: 3
       window: 120s
+```
 
 #### labels
 


### PR DESCRIPTION
### Proposed changes

Fix markdown formatting of example config in compose/compose-file.md in the `update_config` and `restart_policy` section.
Added comments between list and code block. This renders the lines as a code block, instead of a paragraph within a list item. The problem only happens when a code block is used directly after a list.

stackexchange on the topic:
http://meta.stackexchange.com/questions/34292/code-blocks-after-a-list-but-not-within-a-list-in-markdown-is-it-possible
