### PR TITLE
Expand menu items after 'click', not 'touchend'

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -44,7 +44,7 @@ function matches(inputTxt,searchTxt)
 function hookupTOCEvents()
 {
   // do after tree render
-  $('.expand-menu').on('mouseup touchend', function(elem) {
+  $('.expand-menu').on('click', function(elem) {
 //      menu = elem.currentTarget.nextElementSibling
     menu = elem.currentTarget.parentElement
     if (menu.classList.contains("menu-closed")) {


### PR DESCRIPTION
The problem with using 'touchend' is that if you scroll with your finger on a touch screen, like an an iPhone or on a PC laptop with a touch screen, the menu items will be expanded when you let go, even if you wanted to just scroll.

Fixes #1128 
