### PR TITLE
Update contact method for getting offline DB file

### DIFF
--- a/datacenter/dtr/2.2/guides/admin/configure/set-up-vulnerability-scans.md
+++ b/datacenter/dtr/2.2/guides/admin/configure/set-up-vulnerability-scans.md
@@ -133,9 +133,9 @@ Your choice is saved automatically.
 
 ### Update CVE database - offline mode
 
-To update the CVE database for your DTR instance when it cannot contact the update server, you download and install a `.tar` file that contains the database updates. Contact your Docker Support representative for an updated database file.
+To update the CVE database for your DTR instance when it cannot contact the update server, you download and install a `.tar` file that contains the database updates. Contact us at [nautilus-feedback@docker.com](mailto:nautilus-feedback@docker.com?Subject=Need%20CVE%20database%20file) for an updated database file.
 
-<!-- TODO: update when Store updates available.
+<!-- TODO: update when Store updates available: https://docker.atlassian.net/browse/MER-1444
 1. Log in to the Docker Store.
 
     If you are a member of an Organization managing licenses using Docker Store,


### PR DESCRIPTION
Temporary fix until we get to docker/dhe-deploy#4075

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

We need a temporary way to get DB .tar files to users (who have offline mode for their DB updates). B/c Store team won't get to the ideal solution until after their 17 Feb sprint starts, we'll manually email users links. Support Team shouldn't handle this (since they'll be the middle man, haven't been onboarded on this situation yet, and will add more logistic chaos).

(I'm aware the email is "nautilus" which is an internal name - it's a google group we already have, so easy to use this one for now)

### Related issues (optional)
relates to docker/dhe-deploy#4075, https://docker.atlassian.net/browse/MER-1444

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
