### PR TITLE
Fix the 1.13.1-cs1 release notes to include changes from 1.13 and 1.13.1

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -863,7 +863,7 @@ toc:
     title: Frequently Asked Questions
 - sectiontitle: CS Docker Engine
   section:
-  - sectiontitle: 1.13 Beta
+  - sectiontitle: 1.13
     section:
     - path: /cs-engine/1.13/
       title: Install

--- a/cs-engine/1.13/release-notes.md
+++ b/cs-engine/1.13/release-notes.md
@@ -18,5 +18,6 @@ cannot be adopted as quickly for consistency and compatibility reasons.
 
 (08 Feb 2017)
 
-Refer to the detailed lists [here](https://github.com/docker/docker/releases/tag/v1.13.0) and [here](https://github.com/docker/docker/releases/tag/v1.13.1) of all
-changes since the release of CS Engine 1.12.6-cs8.
+Refer to the detailed lists of changes since the release of CS Engine 1.12.6-cs8
+by reviewing the changes in [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)
+and [v1.13.1](https://github.com/docker/docker/releases/tag/v1.13.1).

--- a/cs-engine/1.13/release-notes.md
+++ b/cs-engine/1.13/release-notes.md
@@ -18,5 +18,5 @@ cannot be adopted as quickly for consistency and compatibility reasons.
 
 (08 Feb 2017)
 
-Refer to the [detailed list](https://github.com/docker/docker/releases/tag/v1.13.0) of all
+Refer to the detailed lists [here](https://github.com/docker/docker/releases/tag/v1.13.0) and [here](https://github.com/docker/docker/releases/tag/v1.13.1) of all
 changes since the release of CS Engine 1.12.6-cs8.


### PR DESCRIPTION
This also removes the "Beta" modifier from the CS-engine 1.13 section.

cc @cpuguy83 @mstanleyjones @joaofnfernandes