### PR TITLE
copyedits and improvements to Compose reference

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -783,12 +783,14 @@ toc:
     title: Docker Stacks and Distributed Application Bundles
   - path: /compose/swarm/
     title: Using Compose with Swarm
-  - path: /compose/django/
-    title: "Quickstart: Compose and Django"
-  - path: /compose/rails/
-    title: "Quickstart: Compose and Rails"
-  - path: /compose/wordpress/
-    title: "Quickstart: Compose and WordPress"
+  - sectiontitle: Quickstart examples
+    section:
+    - path: /compose/django/
+      title: "Quickstart: Compose and Django"
+    - path: /compose/rails/
+      title: "Quickstart: Compose and Rails"
+    - path: /compose/wordpress/
+      title: "Quickstart: Compose and WordPress"
   - path: /compose/env-file/
     title: Environment file
   - path: /compose/environment-variables/
@@ -802,11 +804,11 @@ toc:
   - sectiontitle: Compose File Reference
     section:
     - path: /compose/compose-file/
-      title: Version 3 reference
+      title: Version 3
     - path: /compose/compose-file/compose-file-v2/
-      title: Version 2 reference
+      title: Version 2
     - path: /compose/compose-file/compose-file-v1/
-      title: Version 1 reference
+      title: Version 1
     - path: /compose/compose-file/compose-versioning/
       title: About versions and upgrading
   - sectiontitle: Command-line Reference

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -7,15 +7,16 @@ title: Compose file versions and upgrading
 The Compose file is a [YAML](http://yaml.org/) file defining services,
 networks, and volumes for a Docker application.
 
-Thes Compose file formats are now specified in these references, specific to each version.
+The Compose file formats are now specified in these references, specific to each version.
 
-- [Version 3](index.md) (most current, and recommended)
+| **Reference file**       | **What changed in this version** |
+|  -------------------     |    ------------------            |
+|[Version 3](index.md) (most current, and recommended) |[Version 3 updates](#version-3) |
+| [Version 2](compose-file-v2.md)  |[Version 2 updates](#version-2) |
+| [Version 1](compose-file-v1.md) | [Version 1 updates](#version-1) |
 
-- [Version 2](compose-file-v2.md)
-
-- [Version 1](compose-file-v1.md)
-
-The topics below explain the differences among the versions, Docker Engine compatibility, and how to upgrade.
+The topics below explain the differences among the versions, Docker Engine
+compatibility, and [how to upgrade](#upgrading).
 
 ## Compatibility matrix
 
@@ -146,9 +147,9 @@ A more extended example, defining volumes and networks:
 
 Several other options were added to support networking, such as:
 
-* aliases
+* [`aliases`](compose-file-v2.md#aliases)
 
-* The `depends_on` option can be used in place of links to indicate dependencies
+* The [`depends_on`](compose-file-v2.md#dependson) option can be used in place of links to indicate dependencies
 between services and startup order.
 
       version: '2'
@@ -163,9 +164,9 @@ between services and startup order.
         db:
           image: postgres
 
-* ipv4_address, ipv6_address
+* [`ipv4_address`, `ipv6_address`](compose-file-v2.md#ipv4address-ipv6address)
 
-[Variable substitution](compose-file-v2.md#variable-substitution) was added in Version 2.
+[Variable substitution](compose-file-v2.md#variable-substitution) also was added in Version 2.
 
 ### Version 2.1
 


### PR DESCRIPTION





* Copyedits

* improved Versioning and Upgrading page to clarify links to reference pages vs. links to "what changed" in each version

* linked more options from Versioning and Upgrading into the appropriate file reference

* collapsed Quickstart examples under a menu to make the left-side TOC easier to scan

### Reviewers

@dnephin @shin- @ManoMarks @mstanleyjones @johndmulhausen 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

