### PR TITLE
Update index.md

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -528,7 +528,7 @@ indefinitely. Compose does not support circular references and `docker-compose`
 returns an error if it encounters one.
 
 For more on `extends`, see the
-[the extends documentation](extends.md#extending-services).
+[the extends documentation](../extends.md#extending-services).
 
 > **Note:** This option is not yet supported when
 > [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)


### PR DESCRIPTION
The link that works is:

https://docs.docker.com/compose/extends

The doc currently routes to:

https://docs.docker.com/compose/compose-file/extends