### PR TITLE
Update debian.md

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -66,7 +66,7 @@ Docker from the repository.
     **Jessie or Stretch**:
 
     ```bash
-    $ sudo apt-get install -y --no-install-recommends
+    $ sudo apt-get install -y --no-install-recommends \
          apt-transport-https \
          ca-certificates \
          curl \


### PR DESCRIPTION
Backslash missing at the end of a line in a multi-line bash command. The original was not copy-pasteable.