### PR TITLE
Update digital-ocean.md

### DIFF
--- a/machine/drivers/digital-ocean.md
+++ b/machine/drivers/digital-ocean.md
@@ -27,14 +27,14 @@ Control Panel and pass that to `docker-machine create` with the `--digitalocean-
 -   `--digitalocean-ssh-port`: SSH port.
 -   `--digitalocean-ssh-key-fingerprint`: Use an existing SSH key instead of creating a new one, see [SSH keys](https://developers.digitalocean.com/documentation/v2/#ssh-keys).
 
-The DigitalOcean driver will use `ubuntu-15-10-x64` as the default image.
+The DigitalOcean driver will use `ubuntu-16-04-x64` as the default image.
 
 ####  Environment variables and default values
 
 | CLI option                          | Environment variable              | Default            |
 | ----------------------------------- | --------------------------------- | ------------------ |
 | **`--digitalocean-access-token`**   | `DIGITALOCEAN_ACCESS_TOKEN`       | -                  |
-| `--digitalocean-image`              | `DIGITALOCEAN_IMAGE`              | `ubuntu-15-10-x64` |
+| `--digitalocean-image`              | `DIGITALOCEAN_IMAGE`              | `ubuntu-16-04-x64` |
 | `--digitalocean-region`             | `DIGITALOCEAN_REGION`             | `nyc3`             |
 | `--digitalocean-size`               | `DIGITALOCEAN_SIZE`               | `512mb`            |
 | `--digitalocean-ipv6`               | `DIGITALOCEAN_IPV6`               | `false`            |


### PR DESCRIPTION
### Proposed changes

Update default image version. It was changed to `ubuntu-16-04-x64` here: https://github.com/docker/machine/commit/6c39ec9e3fabf93e82162f2d9574478dadda2768

And that commit was released with docker-machine v0.8.0.