### PR TITLE
Fix Markdown; no need to install curl twice

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -64,13 +64,12 @@ Docker from the repository.
 1.  Install packages to allow `apt` to use a repository over HTTPS:
 
     ```bash
-    $ sudo apt-get -y --no-install-recommends install \
-        curl \
+    $ sudo apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
         curl \
         software-properties-common
-        ```
+    ```
 
 2.  Add Docker's official GPG key:
 


### PR DESCRIPTION
### Proposed changes

Tweaked the indentation of backticks in the markdown to fix rendering
Removed duplicate listing of curl in the apt-get install command
