### PR TITLE
Fix script formatting

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -68,9 +68,8 @@ Docker from the repository.
         curl \
         apt-transport-https \
         ca-certificates \
-        curl \
         software-properties-common
-        ```
+    ```
 
 2.  Add Docker's official GPG key:
 


### PR DESCRIPTION
Formatting of the section "Install packages to allow `apt` to use a repository over HTTPS" in documentation "Get Docker for Ubuntu"

### Proposed changes

- fix formatting
- remove duplication of `curl`