### PR TITLE
Fix yml file in compose alias example

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -638,7 +638,7 @@ In the example below, three services are provided (`web`, `worker`, and `db`), a
       worker:
         build: ./worker
         networks:
-        - legacy
+          - legacy
 
       db:
         image: mysql


### PR DESCRIPTION
### Proposed changes

Fix yml file in compose alias example because the syntax was invalid

