### PR TITLE
Configure nginx to redirect to 404.html

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,5 +13,6 @@ http {
       include /etc/nginx/mime.types;
     }
     listen 4000;
+    error_page 403 404 /404.html;
   }
 }


### PR DESCRIPTION
## Before
Try to access a page that doesn't exist

![screen shot 2017-02-13 at 14 58 43](https://cloud.githubusercontent.com/assets/1525937/22907249/08552ba4-f1fd-11e6-8751-103357dcaaf6.png)

## After
Try to access a page that doesn't exist
![screen shot 2017-02-13 at 14 59 20](https://cloud.githubusercontent.com/assets/1525937/22907270/18b1e460-f1fd-11e6-8da4-49758f516da5.png)

By default Nginx doesn't allow listing directories if an index.html doesn't exist in that directory. In that case users will also see the 404 page.
- [ ] Consider removing all the cruft and logic we have on 404.html. Maybe the 404.html should have it's own layout that doesn't have those two side bars and puts search at the center