### PR TITLE
Remove duplicate curl installation instruction

### DIFF
--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -68,7 +68,6 @@ Docker from the repository.
         curl \
         apt-transport-https \
         ca-certificates \
-        curl \
         software-properties-common
         ```
 


### PR DESCRIPTION
### Proposed changes

Remove duplicated apt installation of curl from the repository installation instructions.

