### PR TITLE
Fix a markdown rendering issue

### DIFF
--- a/engine/reference/commandline/service_create.md
+++ b/engine/reference/commandline/service_create.md
@@ -128,6 +128,7 @@ $ docker service create \
 ### Create a docker service with specific hostname (--hostname)
 
 This option sets the docker service containers hostname to a specific string. For example:
+
 ```bash
 $ docker service create \
   --name redis \


### PR DESCRIPTION
### Proposed changes

The first snippet for “Create a docker service with specific hostname” is not properly rendered in the official docs: https://docs.docker.com/engine/reference/commandline/service_create/#/create-a-docker-service-with-specific-hostname---hostname

This fixes the rendering issue by adding a newline (somehow github markdown has different rendering rules and does not encounter it).