### PR TITLE
Default docker log name is container ID

### DIFF
--- a/engine/admin/logging/fluentd.md
+++ b/engine/admin/logging/fluentd.md
@@ -101,7 +101,7 @@ aggregate store.
           @type forward
         </source>
 
-        <match docker.**>
+        <match *>
           @type stdout
         </match>
 


### PR DESCRIPTION
The default docker log name is the 12 character container ID, the sample test.conf setup above filters for Docker.* which will not pick anything up unless users start their containers with at "Docker" tag

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
