### PR TITLE
clarified logging into a swarm manager to list nodes

### DIFF
--- a/engine/getstarted-voting-app/create-swarm.md
+++ b/engine/getstarted-voting-app/create-swarm.md
@@ -99,7 +99,7 @@ Now, we'll add our Docker machines to a [swarm](/engine/swarm/index.md).
 
 ### List the nodes in the swarm
 
-Log into the manager and run `docker node ls`.
+Log into the manager (e.g., `docker-machine ssh manager`) and run `docker node ls`.
 
 ```
   docker@manager:~$ docker node ls


### PR DESCRIPTION
Added a reminder about how to log into a swarm node in a later step in this task.

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
