### PR TITLE
Added a bit more detail to restart.md

### DIFF
--- a/compose/reference/restart.md
+++ b/compose/reference/restart.md
@@ -11,4 +11,8 @@ Options:
 -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds. (default: 10)
 ```
 
-Restarts services.
+Restarts all stopped and running services.
+
+If you make changes to your docker-compose.yml configuration these changes will not be reflected after running this command.
+
+For example, changes to environment variables (which are added after a container is built, but before the container's command is executed) will not be updated after restarting.


### PR DESCRIPTION
This killed me for a while, I expected that since environment variables were set after the build process that they would be reloaded on restart.
