### PR TITLE
Add Dockerize and ASP.NET Core doc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1248,6 +1248,8 @@ samples:
     title: Samples home
   - path: /engine/examples/apt-cacher-ng/
     title: apt-cacher-ng
+  - path: /engine/examples/dotnetcore/
+    title: Dockerize a .NET application
   - path: /compose/aspnet-mssql-compose/
     title: ASP.NET Core + SQL Server on Linux
   - path: /engine/examples/couchdb_data_volumes/

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -25,13 +25,16 @@ This example demonstrates how to dockerize an ASP.NET Core application.
 4. The `Dockerfile` assumes that your application is called `aspnetapp`. Change the `Dockerfile` to use the .dll file of your project.
 
   For Linux Containers:
+
   ```dockerfile
   FROM microsoft/aspnetcore:1.1
   WORKDIR /app
   COPY published ./
   ENTRYPOINT ["dotnet", "aspnetapp.dll"]
   ```
+
   For Windows Containers:
+
   ```dockerfile
   FROM microsoft/dotnet:1.1-runtime-nanoserver
   WORKDIR /app
@@ -39,20 +42,25 @@ This example demonstrates how to dockerize an ASP.NET Core application.
   COPY published ./
   ENTRYPOINT ["dotnet", "aspnetapp.dll"]
   ```
+
 5. To make your build context as small as possible add a [`.dockerignore` file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) to your project folder and copy the following into it.
+
 ```dockerignore
 *
 !published
 ```
+
 > **Note:** If you are using Windows Containers on [Docker for Windows](https://docs.docker.com/docker-for-windows/) be sure to check that you are properly switched to Windows Containers. Do this by opening the system tray up arrow and right clicking on the Docker whale icon for a popup menu. In the popup menu make sure you select 'Switch to Windows Containers'. 
 
 ## Build and run the Docker image
 1. Open the command prompt and navigate to your project folder.
 2. Use the following commands to build and run your Docker image:
+
 ```console
 docker build -t aspnetapp .
 docker run -d -p 80:80 aspnetapp
 ```
+
 ## View your web page running from your container
 * If you are using a Linux container you can simply browse to http://localhost:80 to access your app in a web browser.
 * If you are using the Nano [Windows Container](https://docs.docker.com/docker-for-windows/) there is currently a bug that affects how [Windows 10 talks to Containers via "NAT"](https://github.com/Microsoft/Virtualization-Documentation/issues/181#issuecomment-252671828) (Network Address Translation). Today you must hit the IP of the container directly. You can get the IP address of your container with the following steps:

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -1,9 +1,7 @@
 ---
-description: Create a Docker image by layering your ASP.NET Core app on debian
-for Linux Containers or with Windows Nano Server containers using a Dockerfile.
-keywords: docker, dockerize, dockerizing, dotnet, .NET, Core, article, example,
-platform, installation, containers, images, image, dockerfile, build, asp.net,
-asp.net core title: Dockerizing a .NET application
+description: Create a Docker image by layering your ASP.NET Core app on debian for Linux Containers or with Windows Nano Server containers using a Dockerfile.
+keywords: dockerize, dockerizing, dotnet, .NET, Core, article, example, platform, installation, containers, images, image, dockerfile, build, asp.net, asp.net core
+title: Dockerizing a .NET application
 ---
 
 ## Introduction
@@ -16,19 +14,19 @@ This example demonstrates how to dockerize an ASP.NET Core application.
 - Develop and run your ASP.NET Core apps cross-platform on Windows, MacOS and
   Linux
 - Great for modern cloud-based apps, such as web apps, IoT apps and mobile
-  backends 
+  backends
 - ASP.NET Core apps can run on [.NET
   Core](https://www.microsoft.com/net/core/platform) or on the full [.NET
   Framework](https://www.microsoft.com/net/framework)
 - Designed to provide an optimized development framework for apps that are
   deployed to the cloud or run on-premise
-- Modular components with minimal overhead retain flexibility while 
+- Modular components with minimal overhead retain flexibility while
 constructing your solutions
 
 ## Prerequisites
 
-This example assumes you already have an ASP.NET Core app 
-on your machine. If you are new to ASP.NET you can follow a [simple 
+This example assumes you already have an ASP.NET Core app
+on your machine. If you are new to ASP.NET you can follow a [simple
 tutorial](https://www.asp.net/get-started) to initialize a project or clone our [ASP.NET Docker Sample](https://github.com/dotnet/dotnet-docker-samples/tree/master/aspnetapp).
 
 ## Create a Dockerfile for an ASP.NET Core application
@@ -36,8 +34,8 @@ tutorial](https://www.asp.net/get-started) to initialize a project or clone our 
 1.  Create a `Dockerfile` in your project folder.
 2.  Add the text below to your `Dockerfile` for either Linux or [Windows
    Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/).
-    The tags below are multi-arch meaning they will pull either Windows or 
-    Linux containers depending on what mode is set in [Docker for 
+    The tags below are multi-arch meaning they will pull either Windows or
+    Linux containers depending on what mode is set in [Docker for
 Windows](https://docs.docker.com/docker-for-windows/). Read more on [switching containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
 3.  The `Dockerfile` assumes that your application is called `aspnetapp`. Change
    the `Dockerfile` to use the DLL file of your project.
@@ -62,7 +60,7 @@ ENTRYPOINT ["dotnet", "aspnetapp.dll"]
 ```
 
 4.  To make your build context as small as possible add a [`.dockerignore`
-   file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) 
+   file](https://docs.docker.com/engine/reference/builder/#dockerignore-file)
    to your project folder and copy the following into it.
 
 ```dockerignore
@@ -85,14 +83,14 @@ $ docker run -d -p 8080:80 --name myapp aspnetapp
 * Go to [localhost:8080](http://localhost:8080) to access your app in a web browser.
 * If you are using the Nano [Windows
   Container](https://docs.docker.com/docker-for-windows/) and have not updated
-   to the Windows Creator Update there is a bug affecting how [Windows 10 
+   to the Windows Creator Update there is a bug affecting how [Windows 10
    talks to Containers via
   "NAT"](https://github.com/Microsoft/Virtualization-Documentation/issues/181#issuecomment-252671828)
   (Network Address Translation). You must hit the IP of the container
   directly. You can get the IP address of your container with the following
   steps:
   1.  Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" myapp`
-  2.  Copy the container ip address and paste into your browser. 
+  2.  Copy the container ip address and paste into your browser.
   (For example, `172.16.240.197`)
 
 ## Further reading

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -1,0 +1,66 @@
+---
+description: Create a Docker image by layering your ASP.NET Core app on debian for Linux Containers or with Windows Nano Server containers using a Dockerfile.
+keywords: docker, dockerize, dockerizing, dotnet, .NET, Core, article, example, platform, installation, containers, images, image, dockerfile, build, asp.net, asp.net core
+title: Dockerizing a .NET Application
+---
+
+## Introduction
+
+This example demonstrates how to dockerize an ASP.NET Core application.
+
+> **Note:** This example assumes you already have a published ASP.NET Core app on your machine. If you are new to ASP.NET you can follow a [simple tutorial](https://www.asp.net/get-started) to initialize a project.
+
+## Why build ASP.NET Core?
+- [Open-source](https://github.com/aspnet/home)
+- Develop and run your ASP.NET Core apps cross-platform on Windows, Mac and Linux
+- Great for modern cloud-based apps, such as web apps, IoT apps and mobile backends 
+- ASP.NET Core apps can run on [.NET Core](https://www.microsoft.com/net/core/platform) or on the full [.NET Framework](https://www.microsoft.com/net/framework)
+- Architected to provide an optimized development framework for apps that are deployed to the cloud or run on-premises
+- Modular components with minimal overhead retain flexibility while constructing your solutions
+
+## Create a Dockerfile for an ASP.NET Core Application
+1. If you haven't already, publish your project locally by running `dotnet restore` and `dotnet publish -o published`.
+2. Create a `Dockerfile` in your project folder next to your published folder.
+3. Add the text below to your `Dockerfile` for either Linux or [Windows Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/).
+4. The `Dockerfile` assumes that your application is called `aspnetapp`. Change the `Dockerfile` to use the .dll file of your project.
+
+  For Linux Containers:
+  ```dockerfile
+  FROM microsoft/aspnetcore:1.1
+  WORKDIR /app
+  COPY published ./
+  ENTRYPOINT ["dotnet", "aspnetapp.dll"]
+  ```
+  For Windows Containers:
+  ```dockerfile
+  FROM microsoft/dotnet:1.1-runtime-nanoserver
+  WORKDIR /app
+  ENV ASPNETCORE_URLS http://+:80
+  COPY published ./
+  ENTRYPOINT ["dotnet", "aspnetapp.dll"]
+  ```
+5. To make your build context as small as possible add a [`.dockerignore` file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) to your project folder and copy the following into it.
+```dockerignore
+*
+!published
+```
+> **Note:** If you are using Windows Containers on [Docker for Windows](https://docs.docker.com/docker-for-windows/) be sure to check that you are properly switched to Windows Containers. Do this by opening the system tray up arrow and right clicking on the Docker whale icon for a popup menu. In the popup menu make sure you select 'Switch to Windows Containers'. 
+
+## Build and run the Docker image
+1. Open the command prompt and navigate to your project folder.
+2. Use the following commands to build and run your Docker image:
+```console
+docker build -t aspnetapp .
+docker run -d -p 80:80 aspnetapp
+```
+## View your web page running from your container
+* If you are using a Linux container you can simply browse to http://localhost:80 to access your app in a web browser.
+* If you are using the Nano [Windows Container](https://docs.docker.com/docker-for-windows/) there is currently a bug that affects how [Windows 10 talks to Containers via "NAT"](https://github.com/Microsoft/Virtualization-Documentation/issues/181#issuecomment-252671828) (Network Address Translation). Today you must hit the IP of the container directly. You can get the IP address of your container with the following steps:
+  1. Run `docker ps` and copy the hash of your container ID.
+  2. Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" HASH` where `HASH` is replaced with your container ID.
+  3. Copy the container ip address and paste into your browser with port 80. (Ex: 172.16.240.197:80)
+
+## Further reading
+  - [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/)
+  - [Microsoft ASP.NET Core on Docker Hub](https://hub.docker.com/r/microsoft/aspnetcore/)
+  - [ASP.NET Core with Docker Tools for Visual Studio](https://blogs.msdn.microsoft.com/webdev/2016/11/16/new-docker-tools-for-visual-studio/)

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -89,7 +89,7 @@ $ docker run -d -p 8080:80 --name myapp aspnetapp
   (Network Address Translation). You must hit the IP of the container
   directly. You can get the IP address of your container with the following
   steps:
-  1.  Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" myapp`
+  1.  Run `docker inspect -f "{% raw %}{{ .NetworkSettings.Networks.nat.IPAddress }}{% endraw %}" myapp`
   2.  Copy the container ip address and paste into your browser.
   (For example, `172.16.240.197`)
 

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -82,7 +82,7 @@ $ docker run -d -p 8080:80 --name myapp aspnetapp
 
 ## View the web page running from a container
 
-* Go to [localhost:80](http://localhost:80) to access your app in a web browser.
+* Go to [localhost:8080](http://localhost:8080) to access your app in a web browser.
 * If you are using the Nano [Windows
   Container](https://docs.docker.com/docker-for-windows/) and have not updated
    to the Windows Creator Update there is a bug affecting how [Windows 10 
@@ -92,8 +92,8 @@ $ docker run -d -p 8080:80 --name myapp aspnetapp
   directly. You can get the IP address of your container with the following
   steps:
   1.  Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" myapp`
-  2.  Copy the container ip address and paste into your browser with port 80. 
-  (e.g.: `172.16.240.197`:80)
+  2.  Copy the container ip address and paste into your browser. 
+  (For example, `172.16.240.197`)
 
 ## Further reading
 

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -1,74 +1,102 @@
 ---
-description: Create a Docker image by layering your ASP.NET Core app on debian for Linux Containers or with Windows Nano Server containers using a Dockerfile.
-keywords: docker, dockerize, dockerizing, dotnet, .NET, Core, article, example, platform, installation, containers, images, image, dockerfile, build, asp.net, asp.net core
-title: Dockerizing a .NET Application
+description: Create a Docker image by layering your ASP.NET Core app on debian
+for Linux Containers or with Windows Nano Server containers using a Dockerfile.
+keywords: docker, dockerize, dockerizing, dotnet, .NET, Core, article, example,
+platform, installation, containers, images, image, dockerfile, build, asp.net,
+asp.net core title: Dockerizing a .NET application
 ---
 
 ## Introduction
 
 This example demonstrates how to dockerize an ASP.NET Core application.
 
-> **Note:** This example assumes you already have a published ASP.NET Core app on your machine. If you are new to ASP.NET you can follow a [simple tutorial](https://www.asp.net/get-started) to initialize a project.
-
 ## Why build ASP.NET Core?
 - [Open-source](https://github.com/aspnet/home)
-- Develop and run your ASP.NET Core apps cross-platform on Windows, Mac and Linux
-- Great for modern cloud-based apps, such as web apps, IoT apps and mobile backends 
-- ASP.NET Core apps can run on [.NET Core](https://www.microsoft.com/net/core/platform) or on the full [.NET Framework](https://www.microsoft.com/net/framework)
-- Architected to provide an optimized development framework for apps that are deployed to the cloud or run on-premises
-- Modular components with minimal overhead retain flexibility while constructing your solutions
+- Develop and run your ASP.NET Core apps cross-platform on Windows, MacOS and
+  Linux
+- Great for modern cloud-based apps, such as web apps, IoT apps and mobile
+  backends 
+- ASP.NET Core apps can run on [.NET
+  Core](https://www.microsoft.com/net/core/platform) or on the full [.NET
+  Framework](https://www.microsoft.com/net/framework)
+- Designed to provide an optimized development framework for apps that are
+  deployed to the cloud or run on-premise
+- Modular components with minimal overhead retain flexibility while 
+  constructing
+  your solutions
 
-## Create a Dockerfile for an ASP.NET Core Application
-1. If you haven't already, publish your project locally by running `dotnet restore` and `dotnet publish -o published`.
-2. Create a `Dockerfile` in your project folder next to your published folder.
-3. Add the text below to your `Dockerfile` for either Linux or [Windows Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/).
-4. The `Dockerfile` assumes that your application is called `aspnetapp`. Change the `Dockerfile` to use the .dll file of your project.
+## Prerequisites
+This example assumes you already have an ASP.NET Core app 
+on your machine. If you are new to ASP.NET you can follow a [simple 
+tutorial](https://www.asp.net/get-started) to initialize a project or clone our [ASP.NET Docker Sample](https://github.com/dotnet/dotnet-docker-samples/tree/master/aspnetapp).
 
-  For Linux Containers:
+## Create a Dockerfile for an ASP.NET Core application
+1.  Create a `Dockerfile` in your project folder.
+2.  Add the text below to your `Dockerfile` for either Linux or [Windows
+   Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/).
+    The tags below are multi-arch meaning they will pull either Windows or 
+    Linux containers depending on what mode is set in [Docker for 
+Windows](https://docs.docker.com/docker-for-windows/). Read more on [switching containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
+3.  The `Dockerfile` assumes that your application is called `aspnetapp`. Change
+   the `Dockerfile` to use the DLL file of your project.
 
-  ```dockerfile
-  FROM microsoft/aspnetcore:1.1
-  WORKDIR /app
-  COPY published ./
-  ENTRYPOINT ["dotnet", "aspnetapp.dll"]
-  ```
+```dockerfile
+FROM microsoft/aspnetcore-build:1.1 AS build-env
+WORKDIR /app
 
-  For Windows Containers:
+# Copy csproj and restore as distinct layers
+COPY *.csproj ./
+RUN dotnet restore
 
-  ```dockerfile
-  FROM microsoft/dotnet:1.1-runtime-nanoserver
-  WORKDIR /app
-  ENV ASPNETCORE_URLS http://+:80
-  COPY published ./
-  ENTRYPOINT ["dotnet", "aspnetapp.dll"]
-  ```
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish -c Release -o out
 
-5. To make your build context as small as possible add a [`.dockerignore` file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) to your project folder and copy the following into it.
-
-```dockerignore
-*
-!published
+# Build runtime image
+FROM microsoft/aspnetcore:1.1
+WORKDIR /app
+COPY --from=build-env /app/out .
+ENTRYPOINT ["dotnet", "aspnetapp.dll"]
 ```
 
-> **Note:** If you are using Windows Containers on [Docker for Windows](https://docs.docker.com/docker-for-windows/) be sure to check that you are properly switched to Windows Containers. Do this by opening the system tray up arrow and right clicking on the Docker whale icon for a popup menu. In the popup menu make sure you select 'Switch to Windows Containers'. 
+4.  To make your build context as small as possible add a [`.dockerignore`
+   file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) 
+   to
+   your project folder and copy the following into it.
+
+```dockerignore
+bin\
+obj\
+```
 
 ## Build and run the Docker image
-1. Open the command prompt and navigate to your project folder.
-2. Use the following commands to build and run your Docker image:
+1.  In the command prompt and navigate to your project folder.
+2.  Use the following commands to build and run your Docker image:
 
 ```console
 docker build -t aspnetapp .
 docker run -d -p 80:80 aspnetapp
 ```
 
-## View your web page running from your container
-* If you are using a Linux container you can simply browse to http://localhost:80 to access your app in a web browser.
-* If you are using the Nano [Windows Container](https://docs.docker.com/docker-for-windows/) there is currently a bug that affects how [Windows 10 talks to Containers via "NAT"](https://github.com/Microsoft/Virtualization-Documentation/issues/181#issuecomment-252671828) (Network Address Translation). Today you must hit the IP of the container directly. You can get the IP address of your container with the following steps:
-  1. Run `docker ps` and copy the hash of your container ID.
-  2. Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" HASH` where `HASH` is replaced with your container ID.
-  3. Copy the container ip address and paste into your browser with port 80. (Ex: 172.16.240.197:80)
+## View the web page running from a container
+* Go to [localhost:80](http://localhost:80) to access your app in a web browser.
+* If you are using the Nano [Windows
+  Container](https://docs.docker.com/docker-for-windows/) and have not updated
+   to the Windows Creator Update there is a bug affecting how [Windows 10 
+   talks to Containers via
+  "NAT"](https://github.com/Microsoft/Virtualization-Documentation/issues/181#issuecomment-252671828)
+  (Network Address Translation). You must hit the IP of the container
+  directly. You can get the IP address of your container with the following
+  steps:
+  1.  Run `docker ps` and copy the hash of your container ID.
+  2.  Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}"
+     HASH` where `HASH` is replaced with your container ID.
+  3.  Copy the container ip address and paste into your browser with port 80.
+     (Ex: 172.16.240.197:80)
 
 ## Further reading
   - [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/)
-  - [Microsoft ASP.NET Core on Docker Hub](https://hub.docker.com/r/microsoft/aspnetcore/)
-  - [ASP.NET Core with Docker Tools for Visual Studio](https://blogs.msdn.microsoft.com/webdev/2016/11/16/new-docker-tools-for-visual-studio/)
+  - [Microsoft ASP.NET Core on Docker
+    Hub](https://hub.docker.com/r/microsoft/aspnetcore/)
+  - [ASP.NET Core with Docker Tools for Visual
+    Studio](https://blogs.msdn.microsoft.com/webdev/2016/11/16/new-docker-tools-for-visual-studio/)

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -11,6 +11,7 @@ asp.net core title: Dockerizing a .NET application
 This example demonstrates how to dockerize an ASP.NET Core application.
 
 ## Why build ASP.NET Core?
+
 - [Open-source](https://github.com/aspnet/home)
 - Develop and run your ASP.NET Core apps cross-platform on Windows, MacOS and
   Linux
@@ -22,15 +23,16 @@ This example demonstrates how to dockerize an ASP.NET Core application.
 - Designed to provide an optimized development framework for apps that are
   deployed to the cloud or run on-premise
 - Modular components with minimal overhead retain flexibility while 
-  constructing
-  your solutions
+constructing your solutions
 
 ## Prerequisites
+
 This example assumes you already have an ASP.NET Core app 
 on your machine. If you are new to ASP.NET you can follow a [simple 
 tutorial](https://www.asp.net/get-started) to initialize a project or clone our [ASP.NET Docker Sample](https://github.com/dotnet/dotnet-docker-samples/tree/master/aspnetapp).
 
 ## Create a Dockerfile for an ASP.NET Core application
+
 1.  Create a `Dockerfile` in your project folder.
 2.  Add the text below to your `Dockerfile` for either Linux or [Windows
    Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/).
@@ -61,8 +63,7 @@ ENTRYPOINT ["dotnet", "aspnetapp.dll"]
 
 4.  To make your build context as small as possible add a [`.dockerignore`
    file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) 
-   to
-   your project folder and copy the following into it.
+   to your project folder and copy the following into it.
 
 ```dockerignore
 bin\
@@ -70,15 +71,17 @@ obj\
 ```
 
 ## Build and run the Docker image
+
 1.  In the command prompt and navigate to your project folder.
 2.  Use the following commands to build and run your Docker image:
 
 ```console
-docker build -t aspnetapp .
-docker run -d -p 80:80 aspnetapp
+$ docker build -t aspnetapp .
+$ docker run -d -p 8080:80 --name myapp aspnetapp
 ```
 
 ## View the web page running from a container
+
 * Go to [localhost:80](http://localhost:80) to access your app in a web browser.
 * If you are using the Nano [Windows
   Container](https://docs.docker.com/docker-for-windows/) and have not updated
@@ -88,13 +91,12 @@ docker run -d -p 80:80 aspnetapp
   (Network Address Translation). You must hit the IP of the container
   directly. You can get the IP address of your container with the following
   steps:
-  1.  Run `docker ps` and copy the hash of your container ID.
-  2.  Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}"
-     HASH` where `HASH` is replaced with your container ID.
-  3.  Copy the container ip address and paste into your browser with port 80.
-     (Ex: 172.16.240.197:80)
+  1.  Run `docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" myapp`
+  2.  Copy the container ip address and paste into your browser with port 80. 
+  (e.g.: `172.16.240.197`:80)
 
 ## Further reading
+
   - [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/)
   - [Microsoft ASP.NET Core on Docker
     Hub](https://hub.docker.com/r/microsoft/aspnetcore/)

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -1,7 +1,7 @@
 ---
 description: Create a Docker image by layering your ASP.NET Core app on debian for Linux Containers or with Windows Nano Server containers using a Dockerfile.
 keywords: dockerize, dockerizing, dotnet, .NET, Core, article, example, platform, installation, containers, images, image, dockerfile, build, asp.net, asp.net core
-title: Dockerizing a .NET application
+title: Dockerize a .NET application
 ---
 
 ## Introduction


### PR DESCRIPTION
### Proposed changes

Add "Dockerize an ASP.NET Core app" documentation to the Docker engine examples section.

This doc takes the user through adding a Dockerfile and .dockerignore file to a simple ASP.NET Core application. It includes both Linux and Windows Container options for writing the Dockerfile. It then instructs the user on how to build and run the Docker container and view it in the browser.
