### PR TITLE
live-restore not compatible with any type of swarm

### DIFF
--- a/engine/admin/live-restore.md
+++ b/engine/admin/live-restore.md
@@ -70,9 +70,10 @@ You must restart Docker to flush the buffers.
 
 You can modify the kernel's buffer size by changing `/proc/sys/fs/pipe-max-size`.
 
-## Live restore and swarm mode
+## Live restore and swarm
 
-The live restore option is not compatible with Docker Engine swarm mode. When
-the Docker Engine runs in swarm mode, the orchestration feature manages tasks
-and keeps containers running according to a service specification.
+The live restore option is not compatible with Docker Engine swarm mode or
+standalone swarm. When the Docker Engine runs with swarm, the orchestration
+feature manages tasks and keeps containers running according to a service
+specification.
 

--- a/engine/admin/live-restore.md
+++ b/engine/admin/live-restore.md
@@ -70,10 +70,10 @@ You must restart Docker to flush the buffers.
 
 You can modify the kernel's buffer size by changing `/proc/sys/fs/pipe-max-size`.
 
-## Live restore and swarm
+## Live restore and swarm services
 
-The live restore option is not compatible with Docker Engine swarm mode or
-standalone swarm. When the Docker Engine runs with swarm, the orchestration
-feature manages tasks and keeps containers running according to a service
-specification.
+The live restore feature is not compatible with Docker instances that run
+services using swarm mode or a standalone swarm. The orchestration features
+provided by swarm mode or a standalone swarm manage tasks and keep containers
+running according to a service specification, so live restore is not necessary.
 


### PR DESCRIPTION
Intent is to make it clearer that live-restore is incompatible with both swarm
mode and standalone swarm.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>