### PR TITLE
remove duplicate array in redirect_from directive

### DIFF
--- a/cs-engine/1.12/release-notes/prior-release-notes.md
+++ b/cs-engine/1.12/release-notes/prior-release-notes.md
@@ -4,7 +4,7 @@ keywords: docker, documentation, about, technology, understanding, enterprise, h
 redirect_from:
 - /docker-trusted-registry/cse-prior-release-notes/
 - /docker-trusted-registry/cs-engine/release-notes/prior-release-notes/
-- - /cs-engine/release-notes/prior-release-notes/
+- /cs-engine/release-notes/prior-release-notes/
 title: Release notes archive for Commercially Supported Docker Engine.
 ---
 


### PR DESCRIPTION
This PR fixes a build failure I saw locally with the latest version of github-pages.

```text
  Liquid Exception: undefined method `end_with?' for ["/cs-engine/release-notes/prior-release-notes/"]:Array in 404.md
  bundler: failed to load command: jekyll (/Users/parkr/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bin/jekyll)
  NoMethodError: undefined method `end_with?' for ["/cs-engine/release-notes/prior-release-notes/"]:Array
```