### PR TITLE
Gemfile: add note about upgrade process of github-pages gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
-gem "github-pages", "112" #Update me once in a while: https://github.com/github/pages-gem/releases
+# Update me once in a while: https://github.com/github/pages-gem/releases
+# Please ensure, before upgrading, that this version exists as a tag in starefossen/github-pages here:
+# https://hub.docker.com/r/starefossen/github-pages/tags/
+gem "github-pages", "112"


### PR DESCRIPTION
The Gemfile cannot be upgraded to a newer version of the github-pages
gem without having a corresponding tag in the starefossen/github-pages
image. For future contributors, this is good to know so they don't
accidentally hold up a PR of theirs like I did in #1705. :wink: