### PR TITLE
Update step_six.md with working remove command

### DIFF
--- a/engine/getstarted/step_six.md
+++ b/engine/getstarted/step_six.md
@@ -125,14 +125,14 @@ locally.
     In the next step, you will remove both versions of the `docker-whale` image
     from your local system. They share the same ID. Make a note of it.
 
-3.  Use the `docker image remove`  command to remove the images. You can refer
-    to an image by its ID or its name. Since they share an ID, if you wanted to
+3.  Use the `docker rmi` command to remove the images. You can refer to an
+    image by its ID or its name. Since they share an ID, if you wanted to
     keep one of them, you'd need to refer to the other one by name. For this
-    example, use the ID to remove both of them. Your ID will be different from
-    the one below.
+    example, use the ID along with the `-f` option to remove both of them.
+    Your ID will be different from the one below.
 
     ```bash
-    $ docker image remove 7d9495d03763
+    $ docker rmi 7d9495d03763 -f
     ```
 
 4.  When you use `docker run` it automatically downloads (pulls) images that


### PR DESCRIPTION
The tutorial's recommended command to remove a Docker image elicited the message: "docker: 'image' is not a docker command." This change updates the tutorial to use a working command instead.