### PR TITLE
Add info about fetching credentials from IAM role

### DIFF
--- a/registry/storage-drivers/s3.md
+++ b/registry/storage-drivers/s3.md
@@ -20,10 +20,10 @@ Amazon S3 or S3 compatible services for object storage.
       <code>accesskey</code>
     </td>
     <td>
-      yes
+      no
     </td>
     <td>
-      Your AWS Access Key.
+      Your AWS Access Key. If you use [IAM roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html), omit to fetch temporary credentials from IAM.
     </td>
   </tr>
   <tr>
@@ -31,10 +31,10 @@ Amazon S3 or S3 compatible services for object storage.
       <code>secretkey</code>
     </td>
     <td>
-      yes
+      no
     </td>
     <td>
-      Your AWS Secret Key.
+      Your AWS Secret Key. If you use [IAM roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html), omit to fetch temporary credentials from IAM.
     </td>
   </tr>
   <tr>
@@ -160,7 +160,10 @@ Amazon S3 or S3 compatible services for object storage.
 
 `secretkey`: Your aws secret key.
 
-**Note** You can provide empty strings for your access and secret keys if you plan on running the driver on an ec2 instance and will handle authentication with the instance's credentials.
+> **Note** You can provide empty strings for your access and secret keys to run the driver
+> on an ec2 instance and will handle authentication with the instance's credentials. If you
+> use [IAM roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html),
+> omit these keys to fetch temporary credentials from IAM.
 
 `region`: The name of the aws region in which you would like to store objects (for example `us-east-1`). For a list of regions, you can look at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 


### PR DESCRIPTION
Fixes https://github.com/docker/distribution/issues/741

@stevvooe PTAL. I'm a little out of my depth. There was already advice about setting these to an empty string for one behavior, and now we have another behavior if they are completely omitted. Is that right?