### PR TITLE
fix(compose:extends): not supported from version 3

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -227,7 +227,7 @@ several options have been removed:
     `deploy`. Note that `deploy` configuration only takes effect when using
     `docker stack deploy`, and is ignored by `docker-compose`.
 
-- `extends`: This option has been removed. You wont be able to use `extends` along version "3"
+-   `extends`: This option has been removed for `version: "3"` Compose files.
 
 ### Version 1 to 2.x
 

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -227,6 +227,8 @@ several options have been removed:
     `deploy`. Note that `deploy` configuration only takes effect when using
     `docker stack deploy`, and is ignored by `docker-compose`.
 
+- `extends`: This option has been removed. You wont be able to use `extends` along version "3"
+
 ### Version 1 to 2.x
 
 In the majority of cases, moving from version 1 to 2 is a very simple process:

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -501,40 +501,6 @@ accessible to linked services. Only the internal port can be specified.
      - "3000"
      - "8000"
 
-### extends
-
-Extend another service, in the current file or another, optionally overriding
-configuration.
-
-You can use `extends` on any service together with other configuration keys.
-The `extends` value must be a dictionary defined with a required `service`
-and an optional `file` key.
-
-    extends:
-      file: common.yml
-      service: webapp
-
-The `service` the name of the service being extended, for example
-`web` or `database`. The `file` is the location of a Compose configuration
-file defining that service.
-
-If you omit the `file` Compose looks for the service configuration in the
-current file. The `file` value can be an absolute or relative path. If you
-specify a relative path, Compose treats it as relative to the location of the
-current file.
-
-You can extend a service that itself extends another. You can extend
-indefinitely. Compose does not support circular references and `docker-compose`
-returns an error if it encounters one.
-
-For more on `extends`, see the
-[the extends documentation](../extends.md#extending-services).
-
-> **Note:** This option is not yet supported when
-> [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
-> with a (version 3) Compose file. Use `docker-compose config` to generate a
-> configuration with all `extends` options resolved, and deploy from that.
-
 ### external_links
 
 Link to containers started outside this `docker-compose.yml` or even outside

--- a/compose/extends.md
+++ b/compose/extends.md
@@ -159,6 +159,8 @@ backup, include the `docker-compose.admin.yml` as well.
 
 ## Extending services
 
+> Up to version 2.1 , version 3 does not support `extends` yet.
+
 Docker Compose's `extends` keyword enables sharing of common configurations
 among different files, or even different projects entirely. Extending services
 is useful if you have several services that reuse a common set of configuration

--- a/compose/extends.md
+++ b/compose/extends.md
@@ -159,7 +159,7 @@ backup, include the `docker-compose.admin.yml` as well.
 
 ## Extending services
 
-> Up to version 2.1 , version 3 does not support `extends` yet.
+> Up to version 2.1 , version 3.x does not support `extends` yet.
 
 Docker Compose's `extends` keyword enables sharing of common configurations
 among different files, or even different projects entirely. Extending services


### PR DESCRIPTION
docker compose : `extends` is not supported since v3.

This PR update the compose reference, migration instructions , and add note to the extends documentation.

Fixes #1607