### PR TITLE
move redirects from older install page to here

### DIFF
--- a/cs-engine/1.13/index.md
+++ b/cs-engine/1.13/index.md
@@ -2,6 +2,11 @@
 title: Install CS Docker Engine 1.13
 description: Learn how to install the commercially supported version of Docker Engine.
 keywords: docker, engine, install
+redirect_from:
+- /docker-trusted-registry/install/engine-ami-launch/
+- /docker-trusted-registry/install/install-csengine/
+- /docker-trusted-registry/cs-engine/install/
+- /cs-engine/install/
 ---
 
 Follow these instructions to install CS Docker Engine, the commercially


### PR DESCRIPTION
Moving redirects from v 1.12 CS engine install page to this newest version. 

Found these legacy redirects on Manuals tab of docs site.