### PR TITLE
Use jekyll-relative-links, so natively Markdown links render w/full path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "
 gems:
   - jekyll-redirect-from
   - jekyll-seo-tag
+  - jekyll-relative-links
 
 webrick:
   headers:


### PR DESCRIPTION
Just enabling this plugin automagically makes markdown links pretty/absolute, even if they use relative paths.

Unfortunately, it's *just* Markdown links, so we still need JS + base munging of HTML and `| markdownify` links. But, this is a good chunk of our links that can be "natively beautiful" from now on.