### PR TITLE
Update install.md to refer to version 1.11.1

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -34,7 +34,7 @@ To install Compose, do the following:
     The following is an example command illustrating the format:
 
     ```bash
-    $ curl -L "https://github.com/docker/compose/releases/download/1.10.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    $ curl -L "https://github.com/docker/compose/releases/download/1.11.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     ```
 
     If you have problems installing with `curl`, see


### PR DESCRIPTION
### Proposed changes

Updated Docker Compose version in install command from 1.10.0 to 1.11.1.

This is just to get the installation instructions up to date with the latest version of Docker Compose, which I believe is now the default installed on Mac and Windows.