### PR TITLE
Remove 1.10.0 references from install.md

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -54,7 +54,7 @@ To install Compose, do the following:
     ```bash
     $ docker-compose --version
 
-    docker-compose version: 1.10.0
+    docker-compose version: 1.11.1
     ```
 
 ## Alternative install options
@@ -80,7 +80,7 @@ Compose can also be run inside a container, from a small bash script wrapper.
 To install compose as a container run:
 
 ```bash
-$ curl -L https://github.com/docker/compose/releases/download/1.10.0/run.sh > /usr/local/bin/docker-compose
+$ curl -L https://github.com/docker/compose/releases/download/1.11.1/run.sh > /usr/local/bin/docker-compose
 $ chmod +x /usr/local/bin/docker-compose
 ```
 


### PR DESCRIPTION
These were missed from PR #1819 so also needed updating to 1.11.1.

### Proposed changes

In my previous PR (#1819) I updated the install command to refer to 1.11.1 instead of 1.10.0, but missed out a couple of other references to the version which I hadn't noticed.  This corrects the inconsistency.

### Related issues (optional)

#1819