### PR TITLE
fixed link in Compose file, modified on-page TOC

### DIFF
--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -4,6 +4,8 @@ keywords: fig, composition, compose version 1, docker
 redirect_from:
 - /compose/yml
 title: Compose file version 1 reference
+toc_max: 4
+toc_min: 1
 ---
 
 These topics describe version 1 of the Compose file format. This is the oldest

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -4,6 +4,8 @@ keywords: fig, composition, compose version 3, docker
 redirect_from:
 - /compose/yml
 title: Compose file version 2 reference
+toc_max: 4
+toc_min: 1
 ---
 
 These topics describe version 2 of the Compose file format.

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -5,6 +5,8 @@ redirect_from:
 - /compose/yml
 - /compose/compose-file-v3.md
 title: Compose file version 3 reference
+toc_max: 4
+toc_min: 1
 ---
 
 These topics describe version 3 of the Compose file format. This is the newest
@@ -34,8 +36,8 @@ As with `docker run`, options specified in the Dockerfile (e.g., `CMD`,
 specify them again in `docker-compose.yml`.
 
 You can use environment variables in configuration values with a Bash-like
-`${VARIABLE}` syntax - see [variable
-substitution](compose-file.md#variable-substitution) for full details.
+`${VARIABLE}` syntax - see
+[variable substitution](#variable-substitution) for full details.
 
 This section contains a list of all configuration options supported by a service
 definition in version 3.
@@ -263,7 +265,7 @@ resources:
 #### restart_policy
 
 Configures if and how to restart containers when they exit. Replaces
-[`restart`](compose-file.md#restart).
+[`restart`](compose-file-v2.md#cpushares-cpuquota-cpuset-domainname-hostname-ipc-macaddress-memlimit-memswaplimit-oomscoreadj-privileged-readonly-restart-shmsize-stdinopen-tty-user-workingdir).
 
 - `condition`: One of `none`, `on-failure` or `any` (default: `any`).
 - `delay`: How long to wait between restart attempts, specified as a


### PR DESCRIPTION
### What changed

- Fixed link to legacy `restart` in Compose file v3
- Fixed a link to `variable substitution` in Compose file v3
- Modified all Compose file version on-page TOCs (right side nav menus) to show down to level 4 headings

### Related issues:

#1808, #1823 

### Reviewers

@c-jonua, @mehdimahmoud, @shin- 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

