### PR TITLE
UCP upgrade offline for 2.1

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1161,14 +1161,16 @@ manuals:
           title: Install offline
         - path: /datacenter/ucp/2.1/guides/admin/install/uninstall/
           title: Uninstall
-        - sectiontitle: Upgrade
-          section:
-          - path: /datacenter/ucp/2.1/guides/admin/upgrade/release-notes/
-            title: Release notes
-          - path: /datacenter/ucp/2.1/guides/admin/upgrade/incompatibilities-and-breaking-changes/
-            title: Incompatibilities and breaking changes
-          - path: /datacenter/ucp/2.1/guides/admin/upgrade/
-            title: Upgrade
+      - sectiontitle: Upgrade
+        section:
+        - path: /datacenter/ucp/2.1/guides/admin/upgrade/release-notes/
+          title: Release notes
+        - path: /datacenter/ucp/2.1/guides/admin/upgrade/incompatibilities-and-breaking-changes/
+          title: Incompatibilities and breaking changes
+        - path: /datacenter/ucp/2.1/guides/admin/upgrade/
+          title: Upgrade
+        - path: /datacenter/ucp/2.1/guides/admin/upgrade/upgrade-offline/
+          title: Upgrade offline
       - sectiontitle: Configure
         section:
         - path: /datacenter/ucp/2.1/guides/admin/configure/license-your-installation/

--- a/_includes/components/ucp_url_list.html
+++ b/_includes/components/ucp_url_list.html
@@ -1,0 +1,21 @@
+<!-- Start of ucp_url_list.html, displays a list of DDC tar files -->
+{% for data in site.data.ddc_offline_files %}
+{% if data.ucp-version == page.ucp_version %}
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <div class="list-group center-block">
+            {% for tar-file in data.tar-files %}
+            {% if tar-file.description contains 'UCP' %}
+            {{ tar-file.description }}
+            <a href="{{ tar-file.url }}" target="_blank" class="list-group-item">
+                {{ tar-file.url }}
+                <span class="badge"><span class="glyphicon glyphicon-chevron-down"></span></span>
+            </a>
+            {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endfor %}
+<!-- End of ucp_url_list.html -->

--- a/datacenter/ucp/2.1/guides/admin/upgrade/upgrade-offline.md
+++ b/datacenter/ucp/2.1/guides/admin/upgrade/upgrade-offline.md
@@ -1,17 +1,17 @@
 ---
-description: Learn how to install Docker Universal Control Plane. on a machine with
+description: Learn how to upgrade Docker Universal Control Plane. on a machine with
   no internet access.
-keywords: docker, ucp, install, offline
-title: Install UCP offline
+keywords: docker, ucp, upgrade, offline
+title: Upgrade UCP offline
 ---
 
-The procedure to install Docker Universal Control Plane on a host is the same,
+The procedure to upgrade Docker Universal Control Plane on a host is the same,
 whether that host has access to the internet or not.
 
-The only difference when installing on an offline host,
+The only difference when upgrading on an offline host,
 is that instead of pulling the UCP images from Docker Hub, you use a
 computer that is connected to the internet to download a single package with
-all the images. Then you copy that package to the host where you’ll install UCP.
+all the images. Then you copy that package to the host where you’ll upgrade UCP.
 
 ## Versions available
 
@@ -27,7 +27,7 @@ $ wget <package-url> -O docker-datacenter.tar.gz
 ```
 
 Now that you have the package in your local machine, you can transfer it to
-the machines where you want to install UCP.
+the machines where you want to upgrade UCP.
 
 For each machine that you want to manage with UCP:
 
@@ -48,13 +48,13 @@ For each machine that you want to manage with UCP:
     $ docker load < docker-datacenter.tar.gz
     ```
 
-## Install UCP
+## Upgrade UCP
 
-Now that the offline hosts have all the images needed to install UCP,
-you can [install Docker UCP on that host](index.md).
+Now that the offline hosts have all the images needed to upgrade UCP,
+you can [upgrade Docker UCP](index.md).
 
 
 ## Where to go next
 
-* [Install UCP](index.md).
-* [System requirements](system-requirements.md)
+* [Upgrade UCP](index.md)
+* [Release Notes](release-notes.md)


### PR DESCRIPTION
### Proposed changes
Add Upgrade offline section
Adjust the upgrade section so it is no longer a subsection of install
Display the bundle link and it only shows UCP images

Signed-off-by: Ryan Zhang <ryan.zhang@docker.com>

### Related issues (optional)

Fixes #1576 
Fixes #1628 
