### PR TITLE
added x-ref from scale reference to replicas in v3 Compose

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -301,7 +301,6 @@ ng\:form {
 								{% endif %}
 								<div id="side-toc"><div id="side-toc-title">On this page:</div><div id="side-toc-contents">{% include toc_pure_liquid.html html=my_content sanitize=true class="inline_toc" id="my_toc" toc_min=my_min toc_max=my_max page_name=my_name %}</div></div>
 								{% endunless %}
-								<div>{{content}}</div>
                 </section>
             </div>
           </div>

--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -13,3 +13,9 @@ Sets the number of containers to run for a service.
 Numbers are specified as arguments in the form `service=num`. For example:
 
     docker-compose scale web=2 worker=3
+
+>**Tip:** Alternatively, in
+[Compose file version 3.x](/compose/compose-file/index.md), you can specify
+[`replicas`](/compose/compose-file/index.md#replicas)
+under [`deploy`](/compose/compose-file/index.md#deploy) as part of the
+service configuration for [Swarm mode](/engine/swarm/).


### PR DESCRIPTION
### What changed

- Added x-ref to `replicas` from `scale` in Compose reference per user feedback

### Related issues

#1816 

### Reviewers

@funkydorian, @shin- 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

