### PR TITLE
removed on-page topic menu from Compose CLI ref pages

### DIFF
--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -2,6 +2,7 @@
 description: Declare default environment variables in a file
 keywords: fig, composition, compose, docker, orchestration, environment, env file
 title: Declare default environment variables in file
+notoc: true
 ---
 
 Compose supports declaring default environment variables in an environment

--- a/compose/link-env-deprecated.md
+++ b/compose/link-env-deprecated.md
@@ -4,6 +4,7 @@ keywords: fig, composition, compose, docker, orchestration, cli, reference
 redirect_from:
 - /compose/env
 title: Link environment variables (superseded)
+notoc: true
 ---
 
 > **Note:** Environment variables are no longer the recommended method for connecting to linked services. Instead, you should use the link name (by default, the name of the linked service) as the hostname to connect to. See the [docker-compose.yml documentation](compose-file.md#links) for details.

--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -2,6 +2,8 @@
 description: docker-compose build
 keywords: fig, composition, compose, docker, orchestration, cli, build
 title: docker-compose build
+notoc: true
+
 ---
 
 ```

--- a/compose/reference/bundle.md
+++ b/compose/reference/bundle.md
@@ -2,6 +2,7 @@
 description: Create a distributed application bundle from the Compose file.
 keywords: fig, composition, compose, docker, orchestration, cli, bundle
 title: docker-compose bundle
+notoc: true
 ---
 
 ```

--- a/compose/reference/config.md
+++ b/compose/reference/config.md
@@ -2,6 +2,7 @@
 description: Config validates and view the compose file.
 keywords: fig, composition, compose, docker, orchestration, cli, config
 title: docker-compose config
+notoc: true
 ---
 
 ```:

--- a/compose/reference/create.md
+++ b/compose/reference/create.md
@@ -2,6 +2,7 @@
 description: Create creates containers for a service.
 keywords: fig, composition, compose, docker, orchestration, cli, create
 title: docker-compose create
+notoc: true
 ---
 
 ```

--- a/compose/reference/down.md
+++ b/compose/reference/down.md
@@ -2,6 +2,7 @@
 description: docker-compose down
 keywords: fig, composition, compose, docker, orchestration, cli, down
 title: docker-compose down
+notoc: true
 ---
 
 ```

--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -2,6 +2,7 @@
 description: Compose CLI environment variables
 keywords: fig, composition, compose, docker, orchestration, cli, reference
 title: Compose CLI environment variables
+notoc: true
 ---
 
 Several environment variables are available for you to configure the Docker Compose command-line behaviour.

--- a/compose/reference/events.md
+++ b/compose/reference/events.md
@@ -2,6 +2,7 @@
 description: Receive real time events from containers.
 keywords: fig, composition, compose, docker, orchestration, cli, events
 title: docker-compose events
+notoc: true
 ---
 
 ```

--- a/compose/reference/exec.md
+++ b/compose/reference/exec.md
@@ -2,6 +2,7 @@
 description: docker-compose exec
 keywords: fig, composition, compose, docker, orchestration, cli, exec
 title: docker-compose exec
+notoc: true
 ---
 
 ```

--- a/compose/reference/help.md
+++ b/compose/reference/help.md
@@ -2,6 +2,7 @@
 description: docker-compose help
 keywords: fig, composition, compose, docker, orchestration, cli, help
 title: docker-compose help
+notoc: true
 ---
 
 ```

--- a/compose/reference/index.md
+++ b/compose/reference/index.md
@@ -2,6 +2,7 @@
 description: Compose CLI reference
 keywords: fig, composition, compose, docker, orchestration, cli,  reference
 title: Compose command-line reference
+notoc: true
 ---
 
 The following pages describe the usage information for the [docker-compose](overview.md) subcommands. You can also see this information by running `docker-compose [SUBCOMMAND] --help` from the command line.

--- a/compose/reference/kill.md
+++ b/compose/reference/kill.md
@@ -2,6 +2,7 @@
 description: Forces running containers to stop.
 keywords: fig, composition, compose, docker, orchestration, cli,  kill
 title: docker-compose kill
+notoc: true
 ---
 
 ```

--- a/compose/reference/logs.md
+++ b/compose/reference/logs.md
@@ -2,6 +2,7 @@
 description: Displays log output from services.
 keywords: fig, composition, compose, docker, orchestration, cli,  logs
 title: docker-compose logs
+notoc: true
 ---
 
 ```

--- a/compose/reference/overview.md
+++ b/compose/reference/overview.md
@@ -4,6 +4,7 @@ keywords: fig, composition, compose, docker, orchestration, cli,  docker-compose
 redirect_from:
 - /compose/reference/docker-compose/
 title: Overview of docker-compose CLI
+notoc: true
 ---
 
 This page provides the usage information for the `docker-compose` Command.

--- a/compose/reference/pause.md
+++ b/compose/reference/pause.md
@@ -2,6 +2,7 @@
 description: Pauses running containers for a service.
 keywords: fig, composition, compose, docker, orchestration, cli, pause
 title: docker-compose pause
+notoc: true
 ---
 
 ```

--- a/compose/reference/port.md
+++ b/compose/reference/port.md
@@ -2,6 +2,7 @@
 description: Prints the public port for a port binding.s
 keywords: fig, composition, compose, docker, orchestration, cli,  port
 title: docker-compose port
+notoc: true
 ---
 
 ```

--- a/compose/reference/ps.md
+++ b/compose/reference/ps.md
@@ -2,6 +2,7 @@
 description: Lists containers.
 keywords: fig, composition, compose, docker, orchestration, cli,  ps
 title: docker-compose ps
+notoc: true
 ---
 
 ```none

--- a/compose/reference/pull.md
+++ b/compose/reference/pull.md
@@ -2,6 +2,7 @@
 description: Pulls service images.
 keywords: fig, composition, compose, docker, orchestration, cli,  pull
 title: docker-compose pull
+notoc: true
 ---
 
 ```

--- a/compose/reference/push.md
+++ b/compose/reference/push.md
@@ -2,6 +2,7 @@
 description: Pushes service images.
 keywords: fig, composition, compose, docker, orchestration, cli,  push
 title: docker-compose push
+notoc: true
 ---
 
 ```

--- a/compose/reference/restart.md
+++ b/compose/reference/restart.md
@@ -2,6 +2,7 @@
 description: Restarts Docker Compose services.
 keywords: fig, composition, compose, docker, orchestration, cli,  restart
 title: docker-compose restart
+notoc: true
 ---
 
 ```

--- a/compose/reference/rm.md
+++ b/compose/reference/rm.md
@@ -2,6 +2,7 @@
 description: Removes stopped service containers.
 keywords: fig, composition, compose, docker, orchestration, cli,  rm
 title: docker-compose rm
+notoc: true
 ---
 
 ```

--- a/compose/reference/run.md
+++ b/compose/reference/run.md
@@ -2,6 +2,7 @@
 description: Runs a one-off command on a service.
 keywords: fig, composition, compose, docker, orchestration, cli,  run
 title: docker-compose run
+notoc: true
 ---
 
 ```

--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -2,6 +2,7 @@
 description: Sets the number of containers to run for a service.
 keywords: fig, composition, compose, docker, orchestration, cli,  scale
 title: docker-compose scale
+notoc: true
 ---
 
 ```

--- a/compose/reference/start.md
+++ b/compose/reference/start.md
@@ -2,6 +2,7 @@
 description: Starts existing containers for a service.
 keywords: fig, composition, compose, docker, orchestration, cli,  start
 title: docker-compose start
+notoc: true
 ---
 
 ```

--- a/compose/reference/stop.md
+++ b/compose/reference/stop.md
@@ -2,6 +2,7 @@
 description: 'Stops running containers without removing them. '
 keywords: fig, composition, compose, docker, orchestration, cli, stop
 title: docker-compose stop
+notoc: true
 ---
 
 ```

--- a/compose/reference/top.md
+++ b/compose/reference/top.md
@@ -2,6 +2,7 @@
 description: Displays the running processes.
 keywords: fig, composition, compose, docker, orchestration, cli, top
 title: docker-compose top
+notoc: true
 ---
 
 ```none

--- a/compose/reference/unpause.md
+++ b/compose/reference/unpause.md
@@ -2,6 +2,7 @@
 description: Unpauses paused containers for a service.
 keywords: fig, composition, compose, docker, orchestration, cli, unpause
 title: docker-compose unpause
+notoc: true
 ---
 
 ```

--- a/compose/reference/up.md
+++ b/compose/reference/up.md
@@ -2,6 +2,7 @@
 description: Builds, (re)creates, starts, and attaches to containers for a service.
 keywords: fig, composition, compose, docker, orchestration, cli,  up
 title: docker-compose up
+notoc: true
 ---
 
 ```

--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -2,6 +2,7 @@
 description: How to control service startup order in Docker Compose
 keywords: documentation, docs,  docker, compose, startup, order
 title: Controlling startup order in Compose
+notoc: true
 ---
 
 You can control the order of service startup with the


### PR DESCRIPTION
Removed on-page TOC menus from Compose CLI reference pages with one or fewer subtopics on the page, since it's not needed.

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

