### PR TITLE
Fix broken DTR storage link

### DIFF
--- a/datacenter/dtr/2.2/guides/admin/configure/external-storage/nfs.md
+++ b/datacenter/dtr/2.2/guides/admin/configure/external-storage/nfs.md
@@ -70,4 +70,4 @@ add it back again.
 
 ## Where to go next
 
-* [Configure where images are stored](configure-storage.md)
+* [Configure where images are stored](../)


### PR DESCRIPTION
Signed-off-by: Alex Mavrogiannis <alex.mavrogiannis@docker.com>
I'm not sure if the missing page was fully moved to the index, but this link will at least work now

I'm actually not sure if this target link is correct, or whether I should redirect to `./index.md`

### Proposed changes
Fixed a broken link, duh
