### PR TITLE
Add config to `wordpress` service

### DIFF
--- a/datacenter/ucp/2.1/guides/user/secrets/index.md
+++ b/datacenter/ucp/2.1/guides/user/secrets/index.md
@@ -105,6 +105,7 @@ configurations:
 | Image name           | wordpress:latest                                              |
 | Published ports      | target: 80, ingress:8000                                      |
 | Attached network     | wordpress-network                                             |
+| Secret               | wordpress-password-v1              						   |
 | Environment variable | WORDPRESS_DB_HOST=wordpress-db:3306                           |
 | Environment variable | WORDPRESS_DB_PASSWORD_FILE=/run/secrets/wordpress-password-v1 |
 


### PR DESCRIPTION
Fixes #1848

Add missing config to deploy the wordpress service without failing containers.