### PR TITLE
Updated miscellaneous list of options for each format

### DIFF
--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -475,7 +475,7 @@ is specified, then read-write will be used.
      - service_name
      - service_name:ro
 
-### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, oom_score_adj, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
+### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
 
 Each of these is a single value, analogous to its
 [docker run](/engine/reference/run.md) counterpart.

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -913,9 +913,6 @@ Each of these is a single value, analogous to its
     stdin_open: true
     tty: true
 
-> **Note:** The following options are only available for
-> [version 2](compose-versioning.md#version-2) and up:
->  `oom_score_adj`
 
 ## Specifying durations
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1072,6 +1072,29 @@ There are several things to note, depending on which
 See [Docker Volumes](/engine/userguide/dockervolumes.md) and
 [Volume Plugins](/engine/extend/plugins_volume.md) for more information.
 
+### domainname, hostname, ipc, mac\_address, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
+
+Each of these is a single value, analogous to its
+[docker run](/engine/reference/run.md) counterpart.
+
+    user: postgresql
+    working_dir: /code
+
+    domainname: foo.com
+    hostname: foo
+    ipc: host
+    mac_address: 02:42:ac:11:65:43
+
+    privileged: true
+
+    restart: always
+
+    read_only: true
+    shm_size: 64M
+    stdin_open: true
+    tty: true
+
+
 ## Specifying durations
 
 Some configuration options, such as the `interval` and `timeout` sub-options for


### PR DESCRIPTION
### Proposed changes

1. Re-included list of miscellaneous options in v3 docs that had gone missing, removing obsolete ones
2. Removed the note about `oom_score_adj` only being available in v2 since it's now in the document explicitly named v2
3. Removed `oom_score_adj` from the v1 list.

### Related issues (optional)

- https://github.com/docker/compose/issues/4506
- A couple others I can't seem to find anymore.