### PR TITLE
simplify home page of voting app example

### DIFF
--- a/engine/getstarted-voting-app/customize-app.md
+++ b/engine/getstarted-voting-app/customize-app.md
@@ -72,7 +72,6 @@ did not change.
 * [Introducing Docker 1.13.0](https://blog.docker.com/2017/01/whats-new-in-docker-1-13/) blog post
 from [Docker Core Engineering](https://blog.docker.com/author/core_eng/)
 
-
 * A deeper dive voting app walkthrough is available on
 [Docker Labs](https://github.com/docker/labs/) as [Deploying an app to a Swarm](https://github.com/docker/labs/blob/master/beginner/chapters/votingapp.md).
 The lab walkthrough provides more technical detail on deployment configuration,
@@ -88,10 +87,13 @@ networking.
 Docker and topics on images in [Learn by example](/engine/tutorials/index.md).
 
 * For more about the `docker-stack.yml` and the `docker stack deploy` commands,
-see [deploy](/compose/compose-file.md#deploy) in the [Compose file
-reference](/compose/compose-file.md) and [`docker stack
-deploy`](/engine/reference/commandline/stack_deploy.md) in the Docker Engine
-command line reference.
+see [deploy](/compose/compose-file.md#deploy) in the Compose file reference and
+[`docker stack deploy`](/engine/reference/commandline/stack_deploy.md)
+in the Docker Engine command line reference.
 
-* To learn more about swarm mode, start with the
+* To learn about all new features in Compose, see
+[Compose file version 3 reference](/compose/compose-file/index.md) and
+[Compose file versions and upgrading](/compose/compose-file/compose-versioning.md)
+
+* For more about swarm mode, start with the
 [Swarm mode overview](/engine/swarm/index.md).

--- a/engine/getstarted-voting-app/index.md
+++ b/engine/getstarted-voting-app/index.md
@@ -53,7 +53,7 @@ A [service](/engine/reference/glossary.md#service) is a bit of executable code d
 a specific task. A service can run in one or more
 containers. Defining a service configuration for your app
 (above and beyond `docker run` commands in a Dockerfile) enables you to
-deploy the app to a swarm and manage it as a distributed, 
+deploy the app to a swarm and manage it as a distributed,
 multi-container application.
 
 The voting app you are about to deploy is composed
@@ -98,9 +98,7 @@ The `depends_on` key allows you to specify that a service is only
 deployed after another service. In our example, `vote` only deploys
 after `redis`.
 
-The `deploy` key specifies aspects of a swarm deployment, as described below in
-[Compose Version 3 features and
-compatibility](#compose-v3-features-and-compatibility).
+The `deploy` key specifies aspects of a swarm deployment. For example, in this configuration we create _replicas_ of the `vote` and `result` services (2 containers of each will be deployed to the swarm), and we constrain some services (`db` and `visualizer`) to run only on a `manager` node.
 
 ## docker-stack.yml deployment configuration file
 
@@ -118,15 +116,15 @@ For this tutorial, the images are pre-built, and we will use `docker-stack.yml`
 (a Version 3 Compose file) instead of a Dockerfile
 to run the images. When we deploy, each image will run as a service in a
 container (or in multiple containers, for those that have replicas defined to
-scale the app).
+scale the app). This example relies on Compose version 3, which is designed to be compatible with Docker Engine swarm mode.
 
 To follow along with the example, you need only have Docker running and the copy
 of `docker-stack.yml` we provide
 [here](https://github.com/docker/example-voting-app/blob/master/docker-stack.yml).
-This file defines all the services shown in the [table
-above](#services-and-images-overview), their base images, configuration details
-such as ports, networks, volumes, application dependencies, and the swarm
-configuration.
+This file defines all the services shown in the
+[table above](#services-and-images-overview), their base images,
+configuration details such as ports, networks, volumes,
+application dependencies, and the swarm configuration.
 
 ```
 version: "3"
@@ -218,70 +216,16 @@ volumes:
   db-data:
 ```
 
-## Compose Version 3 features and compatibility
+## Docker stacks and services
 
-To deploy the voting application, we will run the `docker stack deploy` command
-with this `docker-stack.yml` file to pull the referenced images and launch the
-services in a swarm as configured in the `.yml`.
+To deploy the voting app, we will run the `docker stack deploy` command with
+this `docker-stack.yml` file to pull the referenced images and launch the
+services in a swarm.  This allows us to run the application across multiple
+servers, and use swarm mode for load balancing and performance. Rather than
+thinking about running individual containers, we can start to model deployments
+as application stacks and services.
 
-Note that at the top of the `docker-stack.yml` file, the version is indicated as
-`version: "3" `. The voting app example relies on Compose version 3, which is
-designed to be cross-compatible with Compose and Docker Engine swarm mode.
-
-Before we get started, let's take a look at some aspects of Compose files and
-deployment options that are new in Compose Version 3, and that we want to highlight in
-this walkthrough.
-
-- [docker-stack.yml](#docker-stackyml)
-  - [deploy key and swarm mode](#deploy-key-and-swarm-mode)
-- [docker stack deploy command](#docker-stack-deploy-command)
-- [Docker stacks and services](#docker-stacks-and-services)
-
-### docker-stack.yml
-
-`docker-stack.yml` is a new type of [Compose file](/compose/compose-file.md)
-only compatible with Compose Version 3.
-
-#### deploy key and swarm mode
-
-The [deploy](/compose/compose-file.md#deploy) key allows you to specify various properties of a swarm deployment.
-
-For example, the voting app configuration uses this to create replicas of the
-`vote` and `result` services (2 containers of each will be deployed to the
-swarm).
-
-The voting app also uses the `deploy` key to constrain some services to run only
-on a manager node.
-
-### docker stack deploy command
-
-[docker stack deploy](/engine/reference/commandline/stack_deploy.md)
-is the command we will use to deploy with `docker-stack.yml`.
-
-* This command supports only `version: "3" ` Compose files.
-
-* It does not support the `build` key supported in standard Compose files, which
-builds based on a Dockerfile. You need to use pre-built images
-with `docker stack deploy`.
-
-* It can take the place of running `docker compose up` to run
-Version 3 compatible applications.
-
-### Docker stacks and services
-
-Taken together, these new options can help when you want to configure an app to
-run its component functions across multiple servers, and use swarm mode for load
-balancing and performance. Rather than thinking about running individual
-containers, we can start to model deployments as application stacks and
-services.
-
-### Compose file reference
-
-For more on what's new in Compose Version 3:
-
-* [Introducing Docker 1.13.0](https://blog.docker.com/2017/01/whats-new-in-docker-1-13/) blog post from [Docker Core Engineering](https://blog.docker.com/author/core_eng/)
-
-* [Versioning](/compose/compose-file.md#versioning), [Version 3](/compose/compose-file.md#version-3), and  [Upgrading](/compose/compose-file.md#upgrading) in [Compose file reference](/compose/compose-file.md)
+If you are interested in learning more about new Compose version 3.x features, Docker Engine 1.13.x, and swarm mode integration, check out the [list of resources](customize-app.md#resources) at the end of this tutorial.
 
 ## What's next?
 

--- a/index.md
+++ b/index.md
@@ -6,8 +6,8 @@ title: Docker Documentation
 notoc: true
 ---
 
-Docker packages your app with its dependencies, freeing you from worrying about your
-system configuration, and making your app more portable.
+Docker packages your app with its dependencies, freeing you from worrying about
+your system configuration, and making your app more portable.
 
 <table>
 <tr valign="top">
@@ -15,9 +15,9 @@ system configuration, and making your app more portable.
 {% capture basics %}
 ### Learn the basics of Docker
 
-The basic tutorial introduces Docker concepts, tools, and commands. The examples show you how to build, push,
-and pull Docker images, and run them as containers. This
-tutorial stops short of teaching you how to deploy applications.
+The basic tutorial introduces Docker concepts, tools, and commands. The examples
+show you how to build, push, and pull Docker images, and run them as containers.
+This tutorial stops short of teaching you how to deploy applications.
 {% endcapture %}{{ basics | markdownify }}
 </td>
 <td width="50%">
@@ -25,9 +25,10 @@ tutorial stops short of teaching you how to deploy applications.
 {% capture apps %}
 ### Define and deploy applications
 
-The define-and-deploy tutorial shows how to relate
-containers to each other and define them as services in an application that is ready to deploy at scale in a
-production environment. Highlights [Compose Version 3 new features](/engine/getstarted-voting-app/index.md#compose-version-3-features-and-compatibility) and swarm mode.
+The define-and-deploy tutorial shows how to relate containers to each other and
+define them as services in an application that is ready to deploy at scale in a
+production environment. Highlights Compose Version 3 new features and swarm
+mode.
 {% endcapture %}{{ apps | markdownify }}
 
 </td></tr>

--- a/learn.md
+++ b/learn.md
@@ -25,7 +25,7 @@ tutorial stops short of teaching you how to deploy applications.
 
 The define-and-deploy tutorial shows how to relate
 containers to each other and define them as services in an application that is ready to deploy at scale in a
-production environment. Highlights [Compose Version 3 new features](/engine/getstarted-voting-app/index.md#compose-version-3-features-and-compatibility) and swarm mode.
+production environment. Highlights Compose Version 3 new features and swarm mode.
 {% endcapture %}{{ apps | markdownify }}
 
 </td></tr>


### PR DESCRIPTION
Simplified home page of voting app example:

- removed the section on "new features in Compose v3"
- folded in some of the information that was in that section to the intro to the `.yml` file
- linked to "resources" list of links at end of the tutorial for more (and added a few more links to that section on v3 Compose)
- fixed some links (to Compose v3 and versioning sections)

Reviewers: @mstanleyjones @johndmulhausen 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

