### PR TITLE
Update content_trust.md

### DIFF
--- a/engine/security/trust/content_trust.md
+++ b/engine/security/trust/content_trust.md
@@ -19,7 +19,7 @@ ability to use digital signatures for data sent to and received from remote
 Docker registries. These signatures allow client-side verification of the
 integrity and publisher of specific image tags.
 
-Currently, content trust is disabled by default. You must enable it by setting
+Currently, content trust is disabled by default. You can enable it by setting
 the `DOCKER_CONTENT_TRUST` environment variable. Refer to the
 [environment variables](../../reference/commandline/cli.md#environment-variables)
 and [Notary](../../reference/commandline/cli.md#notary) configuration

--- a/engine/security/trust/content_trust.md
+++ b/engine/security/trust/content_trust.md
@@ -19,8 +19,8 @@ ability to use digital signatures for data sent to and received from remote
 Docker registries. These signatures allow client-side verification of the
 integrity and publisher of specific image tags.
 
-Currently, content trust is disabled by default. You can enable it by setting
-the `DOCKER_CONTENT_TRUST` environment variable. Refer to the
+Currently, content trust is disabled by default. To enable it, set
+the `DOCKER_CONTENT_TRUST` environment variable to `1`. Refer to the
 [environment variables](../../reference/commandline/cli.md#environment-variables)
 and [Notary](../../reference/commandline/cli.md#notary) configuration
 for the docker client for more options.


### PR DESCRIPTION
Is "can" more appropriate here? I think although "must" can imply suggestions that someone should do something, it's better to use the most apparent meaning of a word in technical docs. Or, did I miss something?

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
