### PR TITLE
Fixing a typo

### DIFF
--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -106,10 +106,10 @@ examples: |-
   {% raw %}
   $ docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
-  CONTAINER           CPU %               PRIV WORKING SET
-  1285939c1fd3        0.07%               796 KiB / 64 MiB
-  9c76f7834ae2        0.07%               2.746 MiB / 64 MiB
-  d1ea048f04e4        0.03%               4.583 MiB / 64 MiB
+  CONTAINER              CPU %               PRIV WORKING SET
+  fervent_panini         0.07%               796 KiB / 64 MiB
+  ecstatic_kilby         0.07%               2.746 MiB / 64 MiB
+  quizzical_nobel        0.03%               4.583 MiB / 64 MiB
   {% endraw %}
   ```
 

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -104,7 +104,7 @@ examples: |-
 
   ```bash
   {% raw %}
-  $ docker stats --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}"
+  $ docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
   CONTAINER           CPU %               PRIV WORKING SET
   1285939c1fd3        0.07%               796 KiB / 64 MiB

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -106,7 +106,7 @@ examples: |-
   {% raw %}
   $ docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
-  CONTAINER              CPU %               PRIV WORKING SET
+  NAME                   CPU %               PRIV WORKING SET
   fervent_panini         0.07%               796 KiB / 64 MiB
   ecstatic_kilby         0.07%               2.746 MiB / 64 MiB
   quizzical_nobel        0.03%               4.583 MiB / 64 MiB


### PR DESCRIPTION
Instructions says to list name but the format lists container id
