### PR TITLE
Update to new Docker version scheme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . md_source
 # then nuke the md_source directory.
 
 ## Branch to pull from, per ref doc
-ENV ENGINE_BRANCH="1.13.x"
+ENV ENGINE_BRANCH="17.03.x"
 ENV DISTRIBUTION_BRANCH="release/2.5"
 
 RUN svn co https://github.com/docker/docker/branches/$ENGINE_BRANCH/docs/extend md_source/engine/extend \

--- a/_data/not_edited_here.yaml
+++ b/_data/not_edited_here.yaml
@@ -16,15 +16,15 @@ overrides:
 
 - path: /engine/deprecated.md
   description: Docker Engine deprecation reference
-  source: https://github.com/docker/docker/tree/1.13.x/docs/deprecated.md
+  source: https://github.com/docker/docker/tree/17.03.x/docs/deprecated.md
 
 - path: /engine/extend/
   description: References for Docker Engine plugin system
-  source: https://github.com/docker/docker/tree/1.13.x/docs/extend/
+  source: https://github.com/docker/docker/tree/17.03.x/docs/extend/
 
 - path: /engine/reference/
   description: Docker Engine CLI and API references
-  source: https://github.com/docker/docker/tree/1.13.x/docs/reference/
+  source: https://github.com/docker/docker/tree/17.03.x/docs/reference/
 
 - path: /notary/reference/
   description: Reference docs for Docker Notary


### PR DESCRIPTION
### Proposed changes

Docker has implemented a new version scheme. The mechanism that pulls docs from upstream need to reflect this.

Line 40 of the Dockerfile can't be updated because the `1.13.0` tag contains the definitive Swagger file for the 1.25 API.

@thaJeztah @johndmulhausen PTAL

Fixes #1907 
