### PR TITLE
need sudo to access key cache

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -92,7 +92,7 @@ Docker from the repository.
     Verify that the key ID is `58118E89F3A912897C070ADBF76221572C52609D`.
 
     ```bash
-    $ apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
+    $ sudo apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
 
       pub   4096R/2C52609D 2015-07-14
             Key fingerprint = 5811 8E89 F3A9 1289 7C07  0ADB F762 2157 2C52 609D

--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -80,7 +80,7 @@ Docker from the repository.
     Verify that the key ID is `58118E89F3A912897C070ADBF76221572C52609D`.
 
     ```bash
-    $ apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
+    $ sudo apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
 
       pub   4096R/2C52609D 2015-07-14
             Key fingerprint = 5811 8E89 F3A9 1289 7C07  0ADB F762 2157 2C52 609D


### PR DESCRIPTION
Needed sudo on following version of ubuntu:  `Linux precise64 3.2.0-23-generic #36-Ubuntu SMP`

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Minor code snippet change based on what I needed to get it working.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
