### PR TITLE
voting app graceful shutdown, d4win compatibility

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -148,6 +148,8 @@ guides:
       title: Try out the voting app
     - path: /engine/getstarted-voting-app/customize-app/
       title: Customize the app and redeploy
+    - path: /engine/getstarted-voting-app/cleanup/
+      title: Graceful shutdown, reboot, and clean-up
   - sectiontitle: Learn by example
     section:
     - path: /engine/tutorials/networkingcontainers/

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -109,7 +109,7 @@ guarantees (i.e., not officially supported). For more information, see
 
 Looking for information on using Windows containers?
 
-* [Switch between Windows and Linux containers](#switch-between-windows-and-linux-containers) describes the Linux / Windows containers toggle in Docker for Windows and points you to the tutorial mentioned above.
+* [Switch between Windows and Linux containers](/docker-for-windows/index.md#switch-between-windows-and-linux-containers) describes the Linux / Windows containers toggle in Docker for Windows and points you to the tutorial mentioned above.
 <p />
 * [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md)
 provides a tutorial on how to set up and run Windows containers on Windows 10 or

--- a/engine/getstarted-voting-app/cleanup.md
+++ b/engine/getstarted-voting-app/cleanup.md
@@ -1,0 +1,127 @@
+---
+description: Graceful shutdown, reboot, clean-up
+keywords: voting app, docker-machine
+title: Graceful shutdown, reboot, and clean-up
+---
+
+
+The voting app will continue to run on the swarm while the `manager` and `worker` machines are running, unless you explicitly stop it.
+
+## Stopping the voting app
+
+To shut down the voting app, simply stop the machines on which it is running. If you are using local hosts, follow the steps below. If you are using cloud hosts, stop them per your cloud setup.
+
+1.  Open a terminal window and run `docker-machine ls` to list the current machines.
+
+    ```
+    $ docker-machine ls
+    NAME      ACTIVE   DRIVER       STATE     URL                         SWARM   DOCKER    ERRORS
+    manager   -        virtualbox   Running   tcp://192.168.99.100:2376           v1.13.1   
+    worker    -        virtualbox   Running   tcp://192.168.99.101:2376           v1.13.1   
+    ```
+2.  Use `docker-machine stop` to stop each machine, beginning with the worker.
+
+    ```
+    $ docker-machine stop worker
+    Stopping "worker"...
+    Machine "worker" was stopped.
+
+    $ docker-machine stop worker
+    Stopping "worker"...
+    Machine "worker" was stopped.
+    ```
+
+## Restarting the voting app
+
+If you want to come back to your `manager` and `worker` machines later, you can
+keep them around. One advantage of this is that you can simply restart the
+machines to launch the sample voting app again.
+
+To restart local machines, follow the steps below. To restart cloud instances,
+start them per your cloud setup.
+
+1.  Open a terminal window and list the machines.
+
+    ```
+    $ docker-machine ls
+    NAME      ACTIVE   DRIVER       STATE     URL   SWARM   DOCKER    ERRORS
+    manager   -        virtualbox   Stopped                 Unknown   
+    worker    -        virtualbox   Stopped                 Unknown   
+    ```
+
+3.  Run `docker-machine start` to start each machine, beginning with the manager.
+
+    ```
+    $ docker-machine start manager
+    Starting "manager"...
+    (manager) Check network to re-create if needed...
+    (manager) Waiting for an IP...
+    Machine "manager" was started.
+    Waiting for SSH to be available...
+    Detecting the provisioner...
+    Started machines may have new IP addresses. You may need to re-run the `docker-machine env` command.
+
+    $ docker-machine start worker
+    Starting "worker"...
+    (worker) Check network to re-create if needed...
+    (worker) Waiting for an IP...
+    Machine "worker" was started.
+    Waiting for SSH to be available...
+    Detecting the provisioner...
+    Started machines may have new IP addresses. You may need to re-run the `docker-machine env` command.
+    ```
+
+3.  Run the following commands to log into the manager and see if the swarm is up.
+
+    ```
+    docker-machine ssh manager
+
+    docker@manager:~$ docker stack services vote
+    ID            NAME             MODE        REPLICAS  IMAGE
+    74csdxb99tg9  vote_visualizer  replicated  1/1       dockersamples/visualizer:stable
+    jm0g1vahcid9  vote_redis       replicated  2/2       redis:alpine
+    mkk6lee494t4  vote_db          replicated  1/1       postgres:9.4
+    o3sl1wr35yd6  vote_worker      replicated  1/1       dockersamples/examplevotingapp_worker:latest
+    qcc8dw2zafc1  vote_vote        replicated  2/2       dockersamples/examplevotingapp_vote:after
+    x5wcvknlnnh7  vote_result      replicated  1/1       dockersamples/examplevotingapp_result:after
+    ```
+
+At this point, the app is back up. The web pages you looked at in the [test drive](test-drive.md) should be available, and you could experiment, modify the app, and [redeploy](customize-app.md).
+
+>**Tip:** If you set docker-machine environment variables to talk to a particular Docker machine, you'll need to unset them or simply open a new
+terminal window to do other work. However, for the voting app tutorial we never
+explicitly set docker-machine environment variables, since we immediately `ssh`
+directly into the `manager` and `worker` and run all of our swarm commands on
+those nodes. So you can ignore docker-machine caveats about setting environment
+variables in this context.
+
+## Removing the machines
+
+If you prefer to remove your local machines altogether, use `docker-machine rm`
+to do so. (Or, `docker-machine rm -f` will force-remove running machines.)
+
+```
+$ docker-machine rm worker
+About to remove worker
+WARNING: This action will delete both local reference and remote instance.
+Are you sure? (y/n): y
+Successfully removed worker
+
+$ docker-machine rm manager
+About to remove manager
+WARNING: This action will delete both local reference and remote instance.
+Are you sure? (y/n): y
+Successfully removed manager
+```
+
+The Docker images you pulled were all running on the virtual machines you
+created (either local or cloud), so no other cleanup of images or processes is
+needed once you stop and/or remove the virtual machines.
+
+## What's next?
+
+See the [Docker Machine topics](/machine/overview/) for more on working
+with `docker-machine`.
+
+Check out the [list of resources](customize-app.md#resources) for more on Docker
+labs, sample apps, and swarm mode.

--- a/engine/getstarted-voting-app/customize-app.md
+++ b/engine/getstarted-voting-app/customize-app.md
@@ -4,7 +4,6 @@ keywords: multi-container, services, swarm mode, cluster, voting app, docker-sta
 title: Customize the app and redeploy
 ---
 
-
 In this step, we'll make a simple change to the application and redeploy it.
 We'll change the focus of the poll from Cats or Dogs to .NET or Java.
 
@@ -93,7 +92,11 @@ in the Docker Engine command line reference.
 
 * To learn about all new features in Compose, see
 [Compose file version 3 reference](/compose/compose-file/index.md) and
-[Compose file versions and upgrading](/compose/compose-file/compose-versioning.md)
+[Compose file versions and upgrading](/compose/compose-file/compose-versioning.md).
 
 * For more about swarm mode, start with the
 [Swarm mode overview](/engine/swarm/index.md).
+
+## What's next?
+
+* To learn about shutting down the sample app and cleaning up, see [Graceful shutdown, reboot, and clean-up](cleanup.md).

--- a/engine/getstarted-voting-app/index.md
+++ b/engine/getstarted-voting-app/index.md
@@ -30,6 +30,9 @@ If you are totally new to Docker, you might continue through
 the full [Get Started with Docker tutorial](/engine/getstarted/index.md)
 first, then come back.
 
+>**Note:** If you are using Docker for Windows, you will not be able to
+follow along with the [machine setup](node-setup.md) part of this tutorial because it relies on a legacy driver that is incompatible with Docker for Windows. However, you can use a cloud setup instead, as described in the relevant steps.
+
 ## What you'll learn and do
 
 In this tutorial, you'll learn how to:

--- a/engine/getstarted-voting-app/node-setup.md
+++ b/engine/getstarted-voting-app/node-setup.md
@@ -13,6 +13,16 @@ virtual machines on a single system. (See [Docker Machine
 Overview](/machine/overview.md) to learn more.) We'll also verify the setup, and
 run some basic commmands to interact with the machines.
 
+>**Note:** If you are using Docker for Windows, you will not be able to
+follow along with this machine setup part of the tutorial because it relies on
+using the Docker Machine legacy `virtualbox` driver, which is not compatible
+with Docker for Windows.  (See [What to know before you
+install](/docker-for-windows/install.md#what-to-know-before-you-install)).
+However, if you set up your Dockerized instances in the cloud, you can follow
+the rest of the steps to create a swarm and deploy this sample app. You can use
+[Docker Cloud](/docker-cloud/index.md) or you can [use Docker Machine to
+provision hosts on your cloud provider](/machine/get-started-cloud.md).
+
 ## Create manager and worker machines
 
 The Docker Machine command to create a local virtual machine is:

--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -87,6 +87,18 @@ or `worker2` in our example). After you create the nodes, you can run all
 swarm commands as shown from the Mac terminal or Windows PowerShell with
 Docker for Mac or Docker for Windows running.
 
+
+>**Note:** If you are using Docker for Windows, you will not be able to
+use Docker Machine to create nodes locally because that worklfow relies on using
+a legacy `virtualbox` driver, which is not compatible with Docker for Windows.
+(See [What to know before you
+install](/docker-for-windows/install.md#what-to-know-before-you-install)).
+However, if you set up your Dockerized instances in the cloud, you can follow
+the rest of the steps to create a swarm and deploy this sample app. There are a
+few ways to do this. You can use [Docker Cloud](/docker-cloud/index.md) or you
+can [use Docker Machine to provision hosts on your cloud
+provider](/machine/get-started-cloud.md).
+
 ### The IP address of the manager machine
 
 The IP address must be assigned to a network interface available to the host

--- a/manuals.md
+++ b/manuals.md
@@ -30,6 +30,7 @@ Free downloadables that help your device use Docker containers.
 | [Docker for Windows](/docker-for-windows) | Docker desktop solution that includes everything a developer needs to create and test applications on a Windows system|
 | [Docker for Linux](/engine/installation/#on-linux) | Installation guides for running Docker on all supported Linux distros. |
 | [Docker Compose](/compose/overview/) | Enables you to define, build, and run multi-container applications |
+| [Docker Machine](/machine/overview/) | Enables you to provision and manage Dockerized hosts.|
 | [Docker Notary](/notary/getting_started/) | Allows the signing of container images to enable Docker Content Trust |
 | [Docker Registry](/registry/) | The software that powers Docker Hub and Docker Store, Registry stores and distributes container images |
 


### PR DESCRIPTION
### What changed

1. Added topic on graceful app shutdown to voting app sample per feedback from @karptonite on issue #1919 

2. Added caveats and alternative paths for Docker for Windows users for both the voting app sample and swarm sample (they can't use `docker-machine` `virtualbox` driver with Hyper-V, they could be some of the thumbs-downs on those tutorials).

3. Added Docker Machine to Manuals table.

4. Fixed link in Docker for Windows to containers toggle topic.

5. Miscellaneous related touch-ups.

### Related issues

#1919 


### Reviewers

@ManoMarks @johndmulhausen @karptonite

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
