### PR TITLE
Add troubleshooting tip for default https port

### DIFF
--- a/engine/security/certificates.md
+++ b/engine/security/certificates.md
@@ -43,7 +43,7 @@ The following illustrates a configuration with custom certificates:
     └── localhost:5000          <-- Hostname:port
        ├── client.cert          <-- Client certificate
        ├── client.key           <-- Client key
-       └── localhost.crt        <-- Certificate authority that signed
+       └── ca.crt               <-- Certificate authority that signed
                                     the registry certificate
 ```
 
@@ -74,6 +74,16 @@ following error message:
 
 ```
 Missing key KEY_NAME for client certificate CERT_NAME. Note that CA certificates should use the extension .crt.
+```
+
+If the Docker registry is accessed without a port number, do not add the port to the directory name.  The following shows the configuration for a registry on default port 443 which is accessed with `docker login my-https.registry.example.com`:
+
+```
+    /etc/docker/certs.d/
+    └── my-https.registry.example.com          <-- Hostname without port
+       ├── client.cert
+       ├── client.key
+       └── ca.crt
 ```
 
 ## Related Information


### PR DESCRIPTION
### Proposed changes

- Added a tip when using the default https port.  The previous instructions state that the port must always be specified, but this is not accurate.
- Rename the CA certificate file to ca.crt: It is not the cert of the server, but of the CA.  Naming this the name of the server is not wrong, but could be confusing.