### PR TITLE
added link target for legacy system requirements location 

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -17,8 +17,11 @@ Welcome to Docker for Mac!
 Docker is a full development platform for creating containerized apps, and
 Docker for Mac is the best way to get started with Docker on a Mac.
 
-> **Got Docker for Mac?** If you have not yet installed Docker for Mac, please see [Install Docker for Mac](install.md) for an explanation of stable and beta channels, download and install information.
-
+> **Got Docker for Mac?** If you have not yet installed Docker for Mac, please see [Install Docker for Mac](install.md) for an explanation of stable and beta
+channels, download and install information, and system requirements. The topic
+[What to know before you install](install.md#what-to-know-before-you-install) is
+now in that section.
+{: id="what-to-know-before-you-install" }
 
 ## Check versions of Docker Engine, Compose, and Machine
 

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -59,15 +59,15 @@ channels, see the [FAQs](/docker-for-mac/faqs.md#stable-and-beta-channels).
 >**Important Notes**:
 >
 > - Docker for Mac requires OS X El Capitan 10.11 or newer macOS release running on a 2010 or
->   newer Mac, with Intel's  hardware support for MMU virtualization. The app will run on 10.10.3 Yosemite, but with limited support. Please see
->   [What to know before you install](index.md#what-to-know-before-you-install)
->   for a full explanation and list of prerequisites.
+   newer Mac, with Intel's  hardware support for MMU virtualization. The app will run on 10.10.3 Yosemite, but with limited support. Please see
+   [What to know before you install](#what-to-know-before-you-install)
+   for a full explanation and list of prerequisites.
 >
 > - You can switch between beta and stable versions, but you must have only one
->   app installed at a time. Also, you will need to save images and export
->   containers you want to keep before uninstalling the current version before
->   installing another. For more about this, see the
->   [FAQs about beta and stable channels](faqs.md#stable-and-beta-channels).
+   app installed at a time. Also, you will need to save images and export
+   containers you want to keep before uninstalling the current version before
+   installing another. For more about this, see the
+   [FAQs about beta and stable channels](faqs.md#stable-and-beta-channels).
 
 ##  What to know before you install
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -17,7 +17,11 @@ Docker is a full development platform for creating containerized apps, and
 Docker for Windows is the best way to get started with Docker on Windows
 systems.
 
-> **Got Docker for Windows?** If you have not yet installed Docker for Windows, please see [Install Docker for Windows](install.md) for an explanation of stable and beta channels, download and install information.
+> **Got Docker for Windows?** If you have not yet installed Docker for Windows, please see [Install Docker for Windows](install.md) for an explanation of stable
+and beta channels, download and install information and system requirements. The
+topic [What to know before you
+install](install.md#what-to-know-before-you-install) is now in that section.
+{: id="what-to-know-before-you-install" }
 
 ## Check versions of Docker Engine, Compose, and Machine
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -65,7 +65,7 @@ beta channels, see the
 > - Docker for Windows requires 64bit Windows 10 Pro, Enterprise and Education
 >   (1511 November update, Build 10586 or later) and Microsoft Hyper-V. Please
 >   see
->   [What to know before you install](/docker-for-windows/index.md#what-to-know-before-you-install)
+>   [What to know before you install](/docker-for-windows/#what-to-know-before-you-install)
 >   for a full list of prerequisites.
 >
 > - You can switch between beta and stable versions, but you must have only one


### PR DESCRIPTION
### What changed

- added link target (id) for legacy location of system requirements for Docker for Mac and Windows so that hard-coded links in template responses to certain classes of bug report reference won't break

- updated the note in Docker for Mac and Windows home pages to x-ref specifically to system requirements in the install page, and say that the topic moved there.

- directly fixed the links on the install pages for both Mac and Windows to link to the on-page topic system requirements (that was a mistake in previous link updates I made in the docs, not the same problem as in the templates)

**Explanation:** The links breaking in the app templates is due to the fact that we restructured all the docs to split out install topics (`install.md` from the rest of the getting started (`index.md`). The above updates should catch the template links at the note. At some point, if you want to modify the link from `index.md#what-to-know-before-install` to `install.md#what-to-know-before-install`, then those links would go directly to the topic.

### Related issues

https://github.com/docker/pinata/issues/6624

### Reviewers

@ijc25 @friism @jeanlaurent @ebriney 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

