### PR TITLE
split out redirect note to system requirements for both mac and windows

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -18,9 +18,10 @@ Docker is a full development platform for creating containerized apps, and
 Docker for Mac is the best way to get started with Docker on a Mac.
 
 > **Got Docker for Mac?** If you have not yet installed Docker for Mac, please see [Install Docker for Mac](install.md) for an explanation of stable and beta
-channels, download and install information, and system requirements. The topic
-[What to know before you install](install.md#what-to-know-before-you-install) is
-now in that section.
+channels, system requirements, and download/install information.
+>
+**Looking for system requirements?** Check out
+[What to know before you install](install.md#what-to-know-before-you-install), which has moved to the new install topic.
 {: id="what-to-know-before-you-install" }
 
 ## Check versions of Docker Engine, Compose, and Machine

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -18,9 +18,10 @@ Docker for Windows is the best way to get started with Docker on Windows
 systems.
 
 > **Got Docker for Windows?** If you have not yet installed Docker for Windows, please see [Install Docker for Windows](install.md) for an explanation of stable
-and beta channels, download and install information and system requirements. The
-topic [What to know before you
-install](install.md#what-to-know-before-you-install) is now in that section.
+and beta channels, system requirements, and download/install information.
+>
+**Looking for system requirements?** Check out
+[What to know before you install](install.md#what-to-know-before-you-install), which has moved to the new install topic.
 {: id="what-to-know-before-you-install" }
 
 ## Check versions of Docker Engine, Compose, and Machine


### PR DESCRIPTION
### Proposed changes

Updated notes that act as manual redirects to system requirements topic, which moved to new `install.md` pages in both Docker for Mac and Docker for Windows.

Split out references to install in general vs. system requirements to make sure it catches the attention of users who already have the apps installed, but are looking for more details on hardware/software requirements.

### Related

#1947 

### Reviewers

@ijc25 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
