### PR TITLE
Fix docker-machine stop

### DIFF
--- a/engine/getstarted-voting-app/cleanup.md
+++ b/engine/getstarted-voting-app/cleanup.md
@@ -26,9 +26,9 @@ To shut down the voting app, simply stop the machines on which it is running. If
     Stopping "worker"...
     Machine "worker" was stopped.
 
-    $ docker-machine stop worker
-    Stopping "worker"...
-    Machine "worker" was stopped.
+    $ docker-machine stop manager
+    Stopping "manager"...
+    Machine "manager" was stopped.
     ```
 
 ## Restarting the voting app


### PR DESCRIPTION
### Proposed changes

The current version of the tutorial instructs to stop the worker twice. If I understand correctly, it should be: stop worker, then stop manager.