### PR TITLE
move system auth description

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -124,16 +124,14 @@ channels, see the [FAQs](/docker-for-mac/faqs.md#stable-and-beta-channels).
 
 	  ![Install Docker app](/docker-for-mac/images/docker-app-drag.png)
 
-	  You will be asked to authorize `Docker.app` with your system password during
-    the install process. Privileged access is needed to install  networking
-    components and links to the Docker apps.
-
 2.  Double-click `Docker.app` to start Docker.
 
-	  ![Docker app in Hockeyapp](/docker-for-mac/images/docker-app-in-apps.png)
+	  ![Docker app in Hockeyapp](/docker-for-mac/images/docker-app-in-apps.png
+	  
+	  You will be asked to authorize `Docker.app` with your system password after you launch it. 
+	  Privileged access is needed to install networking components and links to the Docker apps.
 
-	  The whale in the top status bar indicates that Docker is running, and
-    accessible from a terminal.
+	  The whale in the top status bar indicates that Docker is running, and accessible from a terminal.
 
 	  ![Whale in menu bar](/docker-for-mac/images/whale-in-menu-bar.png)
 


### PR DESCRIPTION
The requirement to auth to one's local system was in step 1, install, when in practice, the auth comes during step 2, first launch.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
