### PR TITLE
Adds documentation about the `--ignore-override` option

### DIFF
--- a/compose/extends.md
+++ b/compose/extends.md
@@ -26,13 +26,17 @@ services.
 
 If a service is defined in both files Compose merges the configurations using
 the rules described in [Adding and overriding
-configuration](extends.md#adding-and-overriding-configuration).
+configuration](extends.md#adding-and-overriding-configuration). You can turn off
+the automatic use of `docker-compose.override.yml` with command-line option
+`--ignore-override`.
 
 To use multiple override files, or an override file with a different name, you
 can use the `-f` option to specify the list of files. Compose merges files in
 the order they're specified on the command line. See the [`docker-compose`
 command reference](./reference/overview.md) for more information about
-using `-f`.
+using `-f`. When using the `-f` option, the use of `--ignore-override` will
+have no effect as the full list of used files is whatever you define with the `-f`
+option.
 
 When you use multiple configuration files, you must make sure all paths in the
 files are relative to the base Compose file (the first Compose file specified


### PR DESCRIPTION
For PR https://github.com/docker/compose/pull/4543

When option `--ignore-override` is provided the `docker-compose.override.yml`
file, if it exists, will not be considered for any command. This option
has no effect when the `-f` option is used as that explicitly lists the
set of files to be considered.

Signed-off-by: Dennis Gove <dpgove@gmail.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
