### PR TITLE
Update networking.md

### DIFF
--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -112,7 +112,7 @@ container to random ports on the host.
 
 		docker run -d -P --name webserver nginx
 
-See the [run commmand](/engine/reference/commandline/run.md) for more details on
+See the [run command](/engine/reference/commandline/run.md) for more details on
 publish options used with `docker run`.
 
 #### A view into implementation


### PR DESCRIPTION
fix typo with triple "m" for command word

### Proposed changes

Fixed triple `m` for the word "command" on the page. Small typo.
