### PR TITLE
List other keyservers to try for cs-engine install

### DIFF
--- a/cs-engine/1.12/index.md
+++ b/cs-engine/1.12/index.md
@@ -45,6 +45,10 @@ to update its RHEL kernel.
     $ sudo rpm --import "https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e"
     ```
 
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
+
 2.  Install yum-utils if necessary:
 
     ```bash
@@ -148,6 +152,10 @@ to update its RHEL kernel.
     $ curl -fsSL 'https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e' | sudo apt-key add -
     ```
 
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
+
 3.  Add the repository. In the  command below, the `lsb_release -cs` sub-command
     returns the name of your Ubuntu version, like `xenial` or `trusty`.
 
@@ -223,6 +231,10 @@ to update its RHEL kernel.
 
     This adds the repository of the latest version of CS Docker Engine. You can
     customize the URL to install an older version.
+
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
 
 3.  Install CS Docker Engine.
 

--- a/cs-engine/1.12/index.md
+++ b/cs-engine/1.12/index.md
@@ -45,9 +45,10 @@ to update its RHEL kernel.
     $ sudo rpm --import "https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e"
     ```
 
-    Note: if the key server above does not respond, you can try one of these:
-       - pgp.mit.edu
-       - keyserver.ubuntu.com
+    > **Note**: If the key server above does not respond, you can try one of these:
+    >
+    >  - pgp.mit.edu
+    >  - keyserver.ubuntu.com
 
 2.  Install yum-utils if necessary:
 

--- a/cs-engine/1.12/upgrade.md
+++ b/cs-engine/1.12/upgrade.md
@@ -180,6 +180,10 @@ Use these instructions to upgrade YUM-based systems.
     $ sudo rpm --import "https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e"
     ```
 
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
+
 3.  Install yum-utils if necessary:
 
     ```bash
@@ -224,6 +228,10 @@ Use these instructions to update APT-based systems.
     ```bash
     $ curl -s 'https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e' | sudo apt-key add --import
     ```
+
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
 
 3.  Install the HTTPS helper for apt (your system may already have it):
 

--- a/cs-engine/1.13/index.md
+++ b/cs-engine/1.13/index.md
@@ -48,6 +48,10 @@ to update its RHEL kernel.
     $ sudo rpm --import "https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e"
     ```
 
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
+
 2.  Install yum-utils if necessary:
 
     ```bash
@@ -151,6 +155,10 @@ to update its RHEL kernel.
     $ curl -fsSL 'https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e' | sudo apt-key add -
     ```
 
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
+
 3.  Add the repository. In the  command below, the `lsb_release -cs` sub-command
     returns the name of your Ubuntu version, like `xenial` or `trusty`.
 
@@ -226,6 +234,10 @@ to update its RHEL kernel.
 
     This adds the repository of the latest version of CS Docker Engine. You can
     customize the URL to install an older version.
+
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
 
 3.  Install CS Docker Engine.
 

--- a/cs-engine/1.13/upgrade.md
+++ b/cs-engine/1.13/upgrade.md
@@ -175,6 +175,10 @@ Use these instructions to upgrade YUM-based systems.
     $ sudo rpm --import "https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e"
     ```
 
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
+
 3.  Install yum-utils if necessary:
 
     ```bash
@@ -219,6 +223,10 @@ Use these instructions to update APT-based systems.
     ```bash
     $ curl -s 'https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e' | sudo apt-key add --import
     ```
+
+    Note: if the key server above does not respond, you can try one of these:
+       - pgp.mit.edu
+       - keyserver.ubuntu.com
 
 3.  Install the HTTPS helper for apt (your system may already have it):
 


### PR DESCRIPTION
Sometimes ha.pool.sks-keyservers.net goes down, so let's provide some
other keyservers to try in such cases.