### PR TITLE
Fix spacing of summary bar links for Docker for Mac/Windows

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,8 +42,8 @@
                 </div>
                 <div class="col-xs-12 col-sm-3 col-md-3">
                     <ul class="footer_links">
-                        <li><a href="https://www.docker.com/docker-mac">Docker for Mac </a></li>
-                        <li class="break"><a href="https://www.docker.com/docker-windows">Docker for Windows(PC)</a></li>
+                        <li><a href="https://www.docker.com/docker-mac">Docker for Mac</a></li>
+                        <li class="break"><a href="https://www.docker.com/docker-windows">Docker for Windows (PC)</a></li>
                         <li><a href="https://www.docker.com/docker-aws" class="web30">Docker for AWS</a></li>
                         <li class="break"><a href="https://www.docker.com/docker-microsoft-azure">Docker for Azure</a></li>
                         <li><a href="https://www.docker.com/docker-windows-server">Docker for Windows Server</a></li>


### PR DESCRIPTION
* Docker for Mac had a trailing space after the link
* Docker for Windows (PC) was missing a space before the brackets.
