### PR TITLE
Fix platform matrix table

### DIFF
--- a/_includes/docker_platform_matrix.md
+++ b/_includes/docker_platform_matrix.md
@@ -10,7 +10,7 @@
 | [Oracle Linux](/engine/installation/linux/oracle.md)                                                 | {{ green-check }} |                   |
 | [SUSE Linux Enterprise Server](/engine/installation/linux/suse.md)                                   | {{ green-check }} |                   |
 | [Microsoft Windows Server 2016](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server){: target="_blank" class="_" } | {{ green-check }} |   |
-| [Microsoft Windows 10](/docker-for-windows/))                                                        |                   | {{ green-check }} |
+| [Microsoft Windows 10](/docker-for-windows/)                                                         |                   | {{ green-check }} |
 | [macOS](/docker-for-mac/)                                                                            |                   | {{ green-check }} |
 | [Microsoft Azure](/docker-for-azure/)                                                                | {{ green-check }} | {{ green-check }} |
 | [Amazon Web Services](/docker-for-aws/)                                                              | {{ green-check }} | {{ green-check }} |

--- a/_includes/docker_platform_matrix.md
+++ b/_includes/docker_platform_matrix.md
@@ -1,17 +1,17 @@
 {% capture green-check %}![yes](/engine/installation/images/green-check.svg){: style="height: 14px"}{% endcapture %}
 
-| Platform                                                                             | Docker EE         | Docker CE         |
-|:-------------------------------------------------------------------------------------|:-----------------:|:-----------------:|
-| [Ubuntu](linux/ubuntulinux.md)                                                       | {{ green-check }} | {{ green-check }} |
-| [Debian](linux/debian.md)                                                            |                   | {{ green-check }} |
-| [Red Hat Enterprise Linux](linux/rhel.md)                                            | {{ green-check }} |                   |
-| [CentOS](linux/centos.md)                                                            | {{ green-check }} | {{ green-check }} |
-| [Fedora](linux/fedora.md)                                                            |                   | {{ green-check }} |
-| [Oracle Linux](linux/oracle.md)                                                      | {{ green-check }} |                   |
-| [SUSE Linux Enterprise Server](linux/suse.md)                                        | {{ green-check }} |                   |
-| [Microsoft Windows Server 2016](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server){: target="_blank" class="_" } | {{ green-check }} |                   |
-| [Microsoft Windows 10](/docker-for-windows/))                                        |                   | {{ green-check }} |
-| [macOS](/docker-for-mac/)                                                            |                   | {{ green-check }} |
-| [Microsoft Azure](/docker-cloud/infrastructure/link-aws.md)                          | {{ green-check }} | {{ green-check }} |
-| [Amazon Web Services](/docker-cloud/infrastructure/link-aws.md)                      | {{ green-check }} | {{ green-check }} |
+| Platform                                                                                             | Docker EE         | Docker CE         |
+| ---------------------------------------------------------------------------------------------------- | ----------------- | ----------------- |
+| [Ubuntu](/engine/installation/linux/ubuntu.md)                                                       | {{ green-check }} | {{ green-check }} |
+| [Debian](/engine/installation/linux/debian.md)                                                       |                   | {{ green-check }} |
+| [Red Hat Enterprise Linux](/engine/installation/linux/rhel.md)                                       | {{ green-check }} |                   |
+| [CentOS](/engine/installation/linux/centos.md)                                                       | {{ green-check }} | {{ green-check }} |
+| [Fedora](/engine/installation/linux/fedora.md)                                                       |                   | {{ green-check }} |
+| [Oracle Linux](/engine/installation/linux/oracle.md)                                                 | {{ green-check }} |                   |
+| [SUSE Linux Enterprise Server](/engine/installation/linux/suse.md)                                   | {{ green-check }} |                   |
+| [Microsoft Windows Server 2016](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server){: target="_blank" class="_" } | {{ green-check }} |   |
+| [Microsoft Windows 10](/docker-for-windows/))                                                        |                   | {{ green-check }} |
+| [macOS](/docker-for-mac/)                                                                            |                   | {{ green-check }} |
+| [Microsoft Azure](/docker-for-azure/)                                                                | {{ green-check }} | {{ green-check }} |
+| [Amazon Web Services](/docker-for-aws/)                                                              | {{ green-check }} | {{ green-check }} |
 {: style="width: 75%" }

--- a/css/style.css
+++ b/css/style.css
@@ -423,6 +423,23 @@ a.button.outline-btn {
     color: #1488C6;
 }
 
+/*
+*
+* tables  *********************************************************************
+*
+*/
+
+
+th, td.th {
+  font-weight: bold;
+}
+
+.content table {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+
 
 /*
 *

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -48,23 +48,7 @@ the following matrix to choose the best installation path for you. The links
 under **Platform** take you straight to the installation instructions for that
 platform.
 
-{% capture green-check %}![yes](images/green-check.svg){: style="height: 14px"}{% endcapture %}
-
-| Platform                                                                             | Docker EE         | Docker CE         |
-|:-------------------------------------------------------------------------------------|:-----------------:|:-----------------:|
-| [Ubuntu](linux/ubuntulinux.md)                                                       | {{ green-check }} | {{ green-check }} |
-| [Debian](linux/debian.md)                                                            |                   | {{ green-check }} |
-| [Red Hat Enterprise Linux](linux/rhel.md)                                            | {{ green-check }} |                   |
-| [CentOS](linux/centos.md)                                                            | {{ green-check }} | {{ green-check }} |
-| [Fedora](linux/fedora.md)                                                            |                   | {{ green-check }} |
-| [Oracle Linux](linux/oracle.md)                                                      | {{ green-check }} |                   |
-| [SUSE Linux Enterprise Server](linux/suse.md)                                        | {{ green-check }} |                   |
-| [Microsoft Windows Server 2016](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server){: target="_blank" class="_" } | {{ green-check }} |                   |
-| [Microsoft Windows 10](/docker-for-windows/))                                        |                   | {{ green-check }} |
-| [macOS](/docker-for-mac/)                                                            |                   | {{ green-check }} |
-| [Microsoft Azure](/docker-cloud/infrastructure/link-aws.md)                          | {{ green-check }} | {{ green-check }} |
-| [Amazon Web Services](/docker-cloud/infrastructure/link-aws.md)                      | {{ green-check }} | {{ green-check }} |
-{: style="width: 75%" }
+{% include docker_platform_matrix.md %}
 
 See also [Docker Cloud](#on-docker-cloud) for setup instructions for
 Digital Ocean, Packet, SoftLink, or Bring Your Own Cloud.

--- a/engine/installation/linux/suse.md
+++ b/engine/installation/linux/suse.md
@@ -3,7 +3,6 @@ description: Instructions for installing Docker on OpenSUSE and SLES
 keywords: Docker, Docker documentation, requirements, apt, installation, suse, opensuse, sles, rpm, install, uninstall, upgrade, update
 redirect_from:
 - /engine/installation/SUSE/
-- /engine/installation/linux/SUSE/
 title: Get Docker for and SLES
 ---
 


### PR DESCRIPTION
Platform matrix links were not working in all contexts

Added some vertical space around tables and bolded table headers by default, at the same time.