### PR TITLE
Update upstream package names

### DIFF
--- a/engine/installation/linux/oracle.md
+++ b/engine/installation/linux/oracle.md
@@ -45,10 +45,8 @@ installed, uninstall them, along with associated dependencies.
 
 ```bash
 $ sudo yum remove docker \
-                  docker-common \
-                  container-selinux \
-                  docker-selinux \
                   docker-engine
+                  docker-engine-selinux \
 ```
 
 It's OK if `yum` reports that none of these packages are installed.


### PR DESCRIPTION
Oracle Linux never shipped the upstream (RHEL) Docker packages but did ship `docker-engine-selinux` which would need to be removed.

Though, given the new Docker EE/CE naming convention, yum would just replace any existing `docker-engine` and `docker-engine-selinux` packages anyway.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
