### PR TITLE
Lots of formatting fixes to do with buttons

### DIFF
--- a/_includes/d4a_buttons.md
+++ b/_includes/d4a_buttons.md
@@ -4,27 +4,27 @@
 
 
 {% capture aws_blue_latest %}
-<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)</a>
+<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)</a>
 {% endcapture %}
 
 {% capture aws_blue_edge %}
-<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)</a>
+<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)</a>
 {% endcapture %}
 
 {% capture aws_blue_vpc_latest %}
-<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker-no-vpc.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)<br/><small>uses your existing VPC</small></a>
+<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker-no-vpc.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)<br/><small>uses your existing VPC</small></a>
 {% endcapture %}
 
 {% capture aws_blue_vpc_edge %}
-<a class="button darkblue-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker-no-vpc.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)<br/><small>uses your existing VPC</small></a>
+<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker-no-vpc.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)<br/><small>uses your existing VPC</small></a>
 {% endcapture %}
 
 {% capture azure_blue_latest %}
-<a class="button darkblue-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for Azure (stable)</a>
+<a class="button outline-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for Azure (stable)</a>
 {% endcapture %}
 
 {% capture azure_blue_edge %}
-<a class="button darkblue-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fedge%2FDocker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for Azure (edge)</a>
+<a class="button outline-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fedge%2FDocker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for Azure (edge)</a>
 {% endcapture %}
 
 {% capture azure_button_latest %}

--- a/css/temp.css
+++ b/css/temp.css
@@ -94,23 +94,6 @@ input.gsc-search-button-v2 {
   margin-top: 2px;
 }
 
-/* CTA button for downloads and stuff */
-
-.darkblue-btn,
-.cta-btn  {
-  background-color: #1488C6;
-  padding: 12px 15px 10px 15px;
-  margin: 20px 20px 20px 0;
-  display: inline-block;
-}
-
-/* In case you want a row of them */
-
-.darkblue-btn.right,
-.cta-btn.right {
-  margin: 20px 0 20px 20px;
-}
-
 /* Make table headings  bold, give tables some breathing room */
 
 th, td.th {
@@ -132,4 +115,9 @@ h4,
 h5,
 h6 {
     clear: both;
+}
+
+/* This needs some space at the bottom */
+.button.outline-btn {
+  margin-bottom: 20px;
 }

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -12,7 +12,7 @@ redirect_from:
 ## Docker Enterprise Edition (EE) for AWS
 This deployment is fully baked and tested, and comes with the latest Enterprise Edition version of Docker. <br/>This release is maintained and receives <strong>security and critical bugfixes for one year</strong>.
 
-<a class="button darkblue-btn" href="https://store.docker.com/editions/enterprise/docker-ee-aws?tab=description" target="_blank">Deploy Docker Enterprise Edition (EE) for AWS</a>
+<a class="button outline-btn" href="https://store.docker.com/editions/enterprise/docker-ee-aws?tab=description" target="_blank">Deploy Docker Enterprise Edition (EE) for AWS</a>
 
 
 ## Docker Community Edition (CE) for AWS
@@ -40,13 +40,10 @@ using CloudFormation. For more about stable and edge channels, see the
   </td>
   <td width="50%">
   {{aws_blue_edge}}
+  {{aws_blue_vpc_edge}}
   </td>
   </tr>
   <tr valign="top">
-  <td width="50%">
-  </td>
-  <td width="50%">
-  {{aws_blue_vpc_edge}}
   </td>
   </tr>
 </table>

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -43,9 +43,6 @@ using CloudFormation. For more about stable and edge channels, see the
   {{aws_blue_vpc_edge}}
   </td>
   </tr>
-  <tr valign="top">
-  </td>
-  </tr>
 </table>
 
 ### Deployment options

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -11,7 +11,7 @@ redirect_from:
 ## Docker Enterprise Edition (EE) for Azure
 This deployment is fully baked and tested, and comes with the latest Enterprise Edition version of Docker. <br/>This release is maintained and receives <strong>security and critical bugfixes for one year</strong>.
 
-<a class="button darkblue-btn" href="https://store.docker.com/editions/enterprise/docker-ee-azure?tab=description" target="_blank">Deploy Docker Enterprise Edition (EE) for Azure</a>
+<a class="button outline-btn" href="https://store.docker.com/editions/enterprise/docker-ee-azure?tab=description" target="_blank">Deploy Docker Enterprise Edition (EE) for Azure</a>
 
 
 ## Docker Community Edition (CE) for Azure
@@ -19,7 +19,7 @@ This deployment is fully baked and tested, and comes with the latest Enterprise 
 ### Quickstart
 
 If your account has the [proper permissions](#prerequisites), you can generate the [Service Principal](#service-principal) and
-then choose from the stable or edge channel to bootstrap Docker for Azure using Azure Resource Manager. 
+then choose from the stable or edge channel to bootstrap Docker for Azure using Azure Resource Manager.
 For more about stable and edge channels, see the [FAQs](/docker-for-azure/faqs.md#stable-and-edge-channels)
 <table style="width:100%">
   <tr>

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -46,13 +46,15 @@ channels, see the [FAQs](/docker-for-mac/faqs.md#stable-and-edge-channels).
   </tr>
   <tr valign="top">
   <td width="50%">
-  <a class="button darkblue-btn" href="https://download.docker.com/mac/stable/Docker.dmg">Get Docker for Mac (Stable)</a><br><br>
-  <a href="https://download.docker.com/mac/stable/Docker.dmg.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: Docker.dmg SHA256</font></a>
+  <a class="button outline-btn" href="https://download.docker.com/mac/stable/Docker.dmg">Get Docker for Mac (Stable)</a>
   </td>
   <td width="50%">
-  <a class="button darkblue-btn" href="https://download.docker.com/mac/beta/Docker.dmg">Get Docker for Mac (Edge)</a><br><br>
-  <a href="https://download.docker.com/mac/beta/Docker.dmg.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: Docker.dmg SHA256</font></a>
+  <a class="button outline-btn" href="https://download.docker.com/mac/beta/Docker.dmg">Get Docker for Mac (Edge)</a>
   </td>
+  </tr>
+  <tr>
+  <td><a href="https://download.docker.com/mac/stable/Docker.dmg.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: Docker.dmg SHA256</font></a></td>
+  <td><a href="https://download.docker.com/mac/beta/Docker.dmg.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: Docker.dmg SHA256</font></a></td>
   </tr>
 </table>
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -50,13 +50,15 @@ Edge channels, see the
   </tr>
   <tr valign="top">
   <td width="50%">
-  <a class="button darkblue-btn" href="https://download.docker.com/win/stable/InstallDocker.msi">Get Docker for Windows (Stable)</a><br><br>
-  <a href="https://download.docker.com/win/stable/InstallDocker.msi.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: InstallDocker.msi SHA256</font></a>
+  <a class="button outline-btn" href="https://download.docker.com/win/stable/InstallDocker.msi">Get Docker for Windows (Stable)</a>
   </td>
   <td width="50%">
-  <a class="button darkblue-btn" href="https://download.docker.com/win/beta/InstallDocker.msi">Get Docker for Windows (Edge)</a><br><br>
-  <a href="https://download.docker.com/win/beta/InstallDocker.msi.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: InstallDocker.msi SHA256</font></a>
+  <a class="button outline-btn" href="https://download.docker.com/win/beta/InstallDocker.msi">Get Docker for Windows (Edge)</a>
   </td>
+  </tr>
+  <tr>
+  <td><a href="https://download.docker.com/win/stable/InstallDocker.msi.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: InstallDocker.msi SHA256</font></a></td>
+  <td><a href="https://download.docker.com/win/beta/InstallDocker.msi.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: InstallDocker.msi SHA256</font></a></td>
   </tr>
 </table>
 

--- a/engine/getstarted/step_one.md
+++ b/engine/getstarted/step_one.md
@@ -23,11 +23,13 @@ title: Install Docker and run hello-world
 
 ### Docker for Mac
 
-Docker for Mac is our newest offering for the Mac. It runs as a native Mac application and uses <a href="https://github.com/mist64/xhyve/" target="_blank">xhyve</a> to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
+Docker for Mac is our newest offering for the Mac. It runs as a native Mac application and uses
+[xhyve](https://github.com/mist64/xhyve/){: target="_blank" class="_" } to virtualize
+the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-<a class="button darkblue-btn" href="https://download.docker.com/mac/stable/Docker.dmg">Get Docker for Mac</a>
+<a class="button outline-btn" href="https://download.docker.com/mac/stable/Docker.dmg">Get Docker for Mac</a>
 
-**Requirements**
+#### Requirements
 
 - Mac must be a 2010 or newer model, with Intel's hardware support for memory management unit (MMU) virtualization; i.e., Extended Page Tables (EPT)
 
@@ -39,7 +41,9 @@ Docker for Mac is our newest offering for the Mac. It runs as a native Mac appli
 
 #### Docker Toolbox for the Mac
 
-If you have an earlier Mac that doesn't meet the Docker for Mac prerequisites, <a href="https://www.docker.com/products/docker-toolbox" target="_blank">get Docker Toolbox</a> for the Mac.
+If you have an earlier Mac that doesn't meet the Docker for Mac prerequisites,
+[get Docker Toolbox](https://www.docker.com/products/docker-toolbox){: target="_blank" class="_" }
+for the Mac.
 
 See [Docker Toolbox Overview](/toolbox/overview.md) for help on installing Docker with Toolbox.
 
@@ -47,9 +51,9 @@ See [Docker Toolbox Overview](/toolbox/overview.md) for help on installing Docke
 
 Docker for Windows is our newest offering for PCs. It runs as a native Windows application and uses Hyper-V to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-<a class="button darkblue-btn" href="https://download.docker.com/win/stable/InstallDocker.msi">Get Docker for Windows</a>
+<a class="button outline-btn" href="https://download.docker.com/win/stable/InstallDocker.msi">Get Docker for Windows</a>
 
-**Requirements**
+#### Requirements
 
 * 64bit Windows 10 Pro, Enterprise and Education (1511 November update, Build 10586 or later). In the future we will support more versions of Windows 10.
 
@@ -57,7 +61,8 @@ Docker for Windows is our newest offering for PCs. It runs as a native Windows a
 
 #### Docker Toolbox for Windows
 
-If you have an earlier Windows system that doesn't meet the Docker for Windows prerequisites, <a href="https://www.docker.com/products/docker-toolbox" target="_blank">get Docker Toolbox</a>.
+If you have an earlier Windows system that doesn't meet the Docker for Windows prerequisites,
+[get Docker Toolbox](https://www.docker.com/products/docker-toolbox){: target="_blank" class="_" }.
 
 See [Docker Toolbox Overview](/toolbox/overview.md) for help on installing Docker with Toolbox.
 

--- a/test.md
+++ b/test.md
@@ -158,11 +158,11 @@ Some tables in markdown and html.
   </tr>
   <tr valign="top">
   <td width="50%">
-  <a class="button darkblue-btn" href="/">Go to the docs!</a><br><br>
+  <a class="button outline-btn" href="/">Go to the docs!</a><br><br>
   <a href="/"><font color="#BDBDBD" size="-1">It is dark here. You are likely to be eaten by a grue.</font></a>
   </td>
   <td width="50%">
-  <a class="button darkblue-btn" href="/">Go to the docs!</a><br><br>
+  <a class="button outline-btn" href="/">Go to the docs!</a><br><br>
   <a href="/"><font color="#BDBDBD" size="-1">It is dark here. You are likely to be eaten by a grue.</font></a>
   </td>
   </tr>

--- a/toolbox/overview.md
+++ b/toolbox/overview.md
@@ -39,10 +39,10 @@ Toolbox includes these Docker tools:
       </tr>
       <tr valign="top">
         <td width="50%" style="font-size: medium; font-family: arial;  text-align: center">
-        <a class="button darkblue-btn" href="https://download.docker.com/mac/stable/DockerToolbox.pkg">Get Docker Toolbox for Mac</a>
+        <a class="button outline-btn" href="https://download.docker.com/mac/stable/DockerToolbox.pkg">Get Docker Toolbox for Mac</a>
         </td>
         <td width="50%" style="font-size: medium; font-family: arial;  text-align: center">
-        <a class="button darkblue-btn" href="https://download.docker.com/win/stable/DockerToolbox.exe">Get Docker Toolbox for Windows</a>
+        <a class="button outline-btn" href="https://download.docker.com/win/stable/DockerToolbox.exe">Get Docker Toolbox for Windows</a>
         </td>
       </tr>
     </table>

--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -11,13 +11,7 @@ minimal system requirements for [Docker for Mac](/docker-for-mac/index.md).
 
 If you have not done so already, download the installer here:
 
-<table style="width:50%; border: 0">
-  <tr valign="top">
-    <td width="100%" style="font-size: medium; font-family: arial;  text-align: center; background-color: #F9FAFB">
-    <a class="button darkblue-btn" href="https://download.docker.com/mac/stable/DockerToolbox.pkg">Get Docker Toolbox for Mac</a>
-    </td>
-  </tr>
-</table>
+[Get Docker Toolbox for Mac](https://download.docker.com/mac/stable/DockerToolbox.pkg){: class="button outline-btn" }
 
 ## What you get and how it works
 

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -12,13 +12,7 @@ Windows](/docker-for-windows/index.md) app.
 
 If you have not done so already, download the installer here:
 
-<table style="width:50%; border:0">
-  <tr valign="top">
-    <td width="100%" style="font-size: medium; font-family: arial;  text-align: center; background-color: #F9FAFB">
-    <a class="button primary-btn" href="https://download.docker.com/win/stable/DockerToolbox.exe">Get Docker Toolbox for Windows</a>
-    </td>
-  </tr>
-</table>
+[Get Docker Toolbox for Windows](href="https://download.docker.com/win/stable/DockerToolbox.exe"){: class="button outline-btn" }
 
 ## What you get and how it works
 


### PR DESCRIPTION
- Change all the dark blue buttons to outline buttons to match the current theme

- The outline buttons need some padding at the bottom or they will crush into the next header

- A single button doesn't need to be inside a table so I removed tables where unnecessary

- A few tables were relying on `<br />` within a `<td>`. I just added another `<tr>` and put the second line's content there.

- Updated the examples of buttons in `test.md`.

This doesn't address a few things for follow-up work:

- We really need to figure out how to use cards for horizontal content so we can avoid having two-column 50% tables.
- I didn't change all of the HTML links into Markdown format, though I did change some.
- Probably in mobile, this kind of button should change from `inline-block` to `inline` and stack vertically.


@FrenchBen @nathanleclaire PTAL at D4A
@londoncalling PTAL at D4M, D4W, Toolbox
@johndmulhausen @jsouth PTAL overall