### PR TITLE
2 small changes

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -168,7 +168,7 @@ from the repository.
     ```
 
     The contents of the list depend upon which repositories are enabled,
-    and will be specific to your version of Debian (indicated by the `stretch`
+    and will be specific to your version of Debian (indicated by the `jessie`
     suffix on the version, in this example). Choose a specific version to
     install. The second column is the version string. The third column is the
     repository name, which indicates which repository the package is from and
@@ -213,7 +213,7 @@ a new file each time you want to upgrade Docker.
     for your version of Debian.
 
     > **Note**: To install an **edge**  package, change the word
-    > `stable` in the > URL to `edge`.
+    > `stable` in the URL to `edge`.
 
 2.  Install Docker CE, changing the path below to the path where you downloaded
     the Docker package.


### PR DESCRIPTION
"(indicated by the stretch suffix on the version, in this example)"
The example uses jessie, not stretch.

"change the word stable in the > URL to edge"
I do not know why this character ">" appeared, maybe it is a mistake and I have removed it?

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
