### PR TITLE
3 typo changes

### DIFF
--- a/engine/installation/linux/linux-postinstall.md
+++ b/engine/installation/linux/linux-postinstall.md
@@ -202,7 +202,7 @@ at `/etc/docker/daemon.json`.
     configuration.
 
     ```bash
-    sudo nano /etc/docker/daemon.json
+    $ sudo nano /etc/docker/daemon.json
     ```
 
 2.  Add a `dns` key with one or more IP addresses as values. If the file has
@@ -328,7 +328,7 @@ To configure UFW and allow incoming connections on the Docker port:
 3.  If you need to enable access to the Docker Remote API from external hosts
     and understand the security implications (see the section before this
     procedure), then configure UFW to allow incoming connections on the Docker port,
-    which is 2375 if you do not use TLS, and 2376 if you do.
+    which is `2375` if you do not use TLS, and `2376` if you do.
 
     ```bash
     $ sudo ufw allow 2376/tcp
@@ -373,7 +373,7 @@ memory and a 10% overall performance degradation, even if Docker is not running.
     ```
 
     If your GRUB configuration file has incorrect syntax, an error will occur.
-    In this case, steps 3 and 4.
+    In this case, repeat steps 3 and 4.
 
 6.  Reboot your system. Memory and swap accounting are enabled and the warning
     does not occur.


### PR DESCRIPTION
    ```bash
    sudo nano /etc/docker/daemon.json
    ```
Here a $ sign is missing and the command in the web site appears as "bash sudo nano /etc/docker/daemon.json", which is not correct. It shoud look like: "$ sudo nano /etc/docker/daemon.json".

"which is 2375 if you do not use TLS, and 2376 if you do."
On all other lines the ports are in backquotes, so I have added backquotes here also.

"In this case, steps 3 and 4."
Missing verb like "repeat", I have added it.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
