### PR TITLE
Update docker-machine create command

### DIFF
--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -23,9 +23,9 @@ The new solutions come with their own native virtualization solutions rather
 than Oracle VirtualBox, so keep the following considerations in mind when using
 Machine to create local VMs.
 
-* **Docker for Mac** - You can use `docker-machine --create` with the `virtualbox` driver to create additional local machines.
+* **Docker for Mac** - You can use `docker-machine create` with the `virtualbox` driver to create additional local machines.
 
-* **Docker for Windows** - You can use `docker-machine --create` with the `hyperv` driver to create additional local machines.
+* **Docker for Windows** - You can use `docker-machine create` with the `hyperv` driver to create additional local machines.
 
 #### If you are using Docker for Windows
 


### PR DESCRIPTION
If `docker-machine --create` is invoked, the user will receive an error: "Incorrect Usage."  This PR changes the example command to `docker-machine create`.
