### PR TITLE
FIX Duplicate "are"

### DIFF
--- a/engine/getstarted-voting-app/node-setup.md
+++ b/engine/getstarted-voting-app/node-setup.md
@@ -43,7 +43,7 @@ in an elevated PowerShell per those instructions.
 ### Commands to create machines
 
 The Docker Machine commands to create local virtual machines on Mac and Windows
-are are as follows.
+are as follows.
 
 #### Mac
 


### PR DESCRIPTION
"on Mac and Windows are are as follows"
Removed the duplicated "are".

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
