### PR TITLE
Update consistency of <manager-IP>:<port>

### DIFF
--- a/engine/getstarted-voting-app/test-drive.md
+++ b/engine/getstarted-voting-app/test-drive.md
@@ -12,7 +12,7 @@ worker nodes, containers and services on a visualizer.
 
 ## Vote for cats and dogs
 
-Go to `<MANAGER-IP:>5000` in a web browser to view the voting page from a user perspective.
+Go to `<MANAGER-IP>:5000` in a web browser to view the voting page from a user perspective.
 
 ![Voting web page](images/vote.png)
 
@@ -20,7 +20,7 @@ Click on either cats or dogs to vote.
 
 ## View the results tally
 
-Now, go to `MANAGER-IP:5001` in a web browser to view the voting results tally, as one might do in the role of poll coordinator. The tally is shown by percentage in the current configuration of the app.
+Now, go to `<MANAGER-IP>:5001` in a web browser to view the voting results tally, as one might do in the role of poll coordinator. The tally is shown by percentage in the current configuration of the app.
 
 ![Results web page](images/vote-results.png)
 
@@ -32,7 +32,7 @@ examples.
 
 ## Use the visualizer to monitor the app
 
-Go to `<MANAGER-IP:>8080` to get a visual map of how the application is
+Go to `<MANAGER-IP>:8080` to get a visual map of how the application is
 deployed.
 
 ![Visualizer web page](images/visualizer.png)


### PR DESCRIPTION
On the "Sample app overview" page all blocks of IP address and port are shown as <manager-IP>:5000 or <manager-IP>:5001.
On this page "Try it out and vote" I see some inconsistency of these forms and fixed them, because I think the style format must be in the form "<manager-IP>:5000", e.g., colon after character ">".

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
