### PR TITLE
Remove incorrect iptables-related information

### DIFF
--- a/engine/userguide/networking/default_network/container-communication.md
+++ b/engine/userguide/networking/default_network/container-communication.md
@@ -47,9 +47,9 @@ Docker will never make changes to your system `iptables` rules if you set
 `--iptables=false` when the daemon starts.  Otherwise the Docker server will
 append forwarding rules to the `DOCKER` filter chain.
 
-Docker will not delete or modify any pre-existing rules from the `DOCKER` filter
-chain. This allows the user to create in advance any rules required to further
-restrict access to the containers.
+Docker will flush any pre-existing rules from the `DOCKER` and `DOCKER-ISOLATION`
+filter chains, if they exist. For this reason, any rules needed to further
+restrict access to containers need to be added after Docker has started.
 
 Docker's forward rules permit all external source IPs by default. To allow only
 a specific IP or network to access the containers, insert a negated rule at the


### PR DESCRIPTION
At the current time, Docker flushes any pre-existing `DOCKER` and `DOCKER-ISOLATION` chains, meaning that the previous advice was misleading and led users in the wrong direction regarding restricting access to containers via iptables.

### Proposed changes

Modifies the paragraph regarding how Docker treats any rules in pre-existing `DOCKER` and `DOCKER-ISOLATION` chains at the time of startup, based on the current behavior of Docker.

### Related issues (optional)

Three existing issues in the docker/docker project reflect this current behavior, and the frustration around the current documentation:

https://github.com/docker/docker/issues/23987
https://github.com/docker/docker/issues/29184
https://github.com/docker/docker/issues/24848
