### PR TITLE
Fix URLs for docs-hosted repo files for 1.13 in archive

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -72,7 +72,7 @@ Docker from the repository.
     ```bash
     $ sudo yum-config-manager \
         --add-repo \
-        https://docs.docker.com/engine/installation/linux/repo_files/centos/docker.repo
+        https://docs.docker.com/v1.13/engine/installation/linux/repo_files/centos/docker.repo
     ```
 
 3.  **Optional**: Enable the **testing** repository. This repository is included

--- a/engine/installation/linux/fedora.md
+++ b/engine/installation/linux/fedora.md
@@ -76,7 +76,7 @@ Docker from the repository.
     ```bash
     $ sudo dnf config-manager \
         --add-repo \
-        https://docs.docker.com/engine/installation/linux/repo_files/fedora/docker.repo
+        https://docs.docker.com/v1.13/engine/installation/linux/repo_files/fedora/docker.repo
     ```
 
 3.  **Optional**: Enable the **testing** repository. This repository is included

--- a/engine/installation/linux/oracle.md
+++ b/engine/installation/linux/oracle.md
@@ -89,7 +89,7 @@ Docker from the repository.
     ```bash
     $ sudo yum-config-manager \
         --add-repo \
-        https://docs.docker.com/engine/installation/linux/repo_files/oracle/docker-ol7.repo
+        https://docs.docker.com/v1.13/engine/installation/linux/repo_files/oracle/docker-ol7.repo
     ```
 
     **Oracle Linux 6**:
@@ -97,7 +97,7 @@ Docker from the repository.
     ```bash
     $ sudo yum-config-manager \
         --add-repo \
-        https://docs.docker.com/engine/installation/linux/repo_files/oracle/docker-ol6.repo
+        https://docs.docker.com/v1.13/engine/installation/linux/repo_files/oracle/docker-ol6.repo
     ```
 
 3.  **Optional**: Enable the **testing** repository. This repository is included

--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -73,7 +73,7 @@ Docker from the repository.
     ```bash
     $ sudo yum-config-manager \
         --add-repo \
-        https://docs.docker.com/engine/installation/linux/repo_files/centos/docker.repo
+        https://docs.docker.com/v1.13/engine/installation/linux/repo_files/centos/docker.repo
     ```
 
     > **Note**: The link above is correct for RHEL as well as CentOS.

--- a/engine/reference/commandline/cli.md
+++ b/engine/reference/commandline/cli.md
@@ -168,6 +168,7 @@ attach`, `docker exec`, `docker run` or `docker start` command.
 Following is a sample `config.json` file:
 
 ```json
+{% raw %}
 {
   "HttpHeaders": {
     "MyHeader": "MyValue"
@@ -183,6 +184,7 @@ Following is a sample `config.json` file:
     "unicorn.example.com": "vcbait"
   }
 }
+{% endraw %}
 ```
 
 ### Notary


### PR DESCRIPTION
Hosting the `.repo` files was weird for us, and a quick fix. Now that `v1.13` is in the archives, we need those links to point to the archived `.repo` files instead. This PR does that.

cc/ @fxdgear 

@johndmulhausen we will need to rebuild / re-push `docs-base` for this one.