### PR TITLE
Exclude 'src' directory from build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+exclude: [src]


### PR DESCRIPTION
Jekyll was trying to build the src directory which contained templating stuff it didn't know about. We have the built HTML so we don't need to try to build from source in a non-Jekyll-compliant framework.