### PR TITLE
Exclude 'src' directory from build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+exclude: [src]


### PR DESCRIPTION
The files in the `src` directory are pre-render and we have the post-rendered HTML for this archive.