### PR TITLE
17.03 CE mac2 hotfix release notes, improvements on notes and x-refs

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -8,9 +8,12 @@ The Docker for Mac install package includes everything you need to run Docker on
 a Mac. This topic describes pre-install considerations, and how to download and
 install Docker for Mac.
 
-> **Already have Docker for Mac?** If you already have Docker for Mac installed, and are ready to get started, skip to [Getting started](index.md) to
-work through the rest of the Docker for Mac tour and information, or jump over
-to the tutorials at [Learn Docker](/learn.md).
+> **Already have Docker for Mac?** If you already have
+Docker for Mac installed, and are ready to get started, skip to
+[Get started with Docker for Mac](index.md) for a quick tour of
+the command line, preferences, and tools.
+>
+>**Looking for Release Notes?** [Get release notes for all versions here](release-notes.md).
 
 ## Download Docker for Mac
 
@@ -129,8 +132,8 @@ channels, see the [FAQs](/docker-for-mac/faqs.md#stable-and-edge-channels).
 2.  Double-click `Docker.app` to start Docker.
 
 	  ![Docker app in Hockeyapp](/docker-for-mac/images/docker-app-in-apps.png
-	  
-	  You will be asked to authorize `Docker.app` with your system password after you launch it. 
+
+	  You will be asked to authorize `Docker.app` with your system password after you launch it.
 	  Privileged access is needed to install networking components and links to the Docker apps.
 
 	  The whale in the top status bar indicates that Docker is running, and accessible from a terminal.

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -12,13 +12,25 @@ release. The documentation is always updated for each release.
 For system requirements, please see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
-Release notes for _stable_ and _beta_ releases are listed below. You can learn
-about both kinds of releases, and download stable and beta product installers at
+Release notes for _stable_ and _edge_ releases are listed below. (Starting with
+the CE release model, `beta` releases are called `edge` releases.) You can learn
+about both kinds of releases, and download stable and edge product installers at
 [Download Docker for Mac](install.md#download-docker-for-mac).
 
 ## Stable Release Notes
 
-### Docker Community Edition 17.03.0, 2017-03-02 (stable)
+### Docker Community Edition 17.03.0-ce-mac2, 2017-03-06 (stable)
+
+**Hotfixes**
+
+- Set the ethernet MTU to 1500 to prevent a hyperkit crash
+- Fix docker build on private images
+
+**Upgrades**
+
+- [Docker Credential Helpers 0.4.2](https://github.com/docker/docker-credential-helpers/releases/tag/v0.4.2)
+
+### Docker Community Edition 17.03.0-ce-mac1, 2017-03-02 (stable)
 
 **New**
 
@@ -50,16 +62,15 @@ about both kinds of releases, and download stable and beta product installers at
 - Parses aliases from /etc/hosts (docker/for-mac#983)
 - Can resolve DNS requests via servers listed in the /etc/resolver directory on the host
 - Limit vCPUs to 64
-- Fix for swap not being mounted
-- Fix aufs xattr delete issue (docker/docker#30245)
-- osxfs: catch EPERM when reading extended attributes of non-files
-- VPNKit: fix unmarshalling of DNS packets containing pointers to pointers to labels
-- VPNKit: set the Recursion Available bit on DNS responses from the cache
+- Fixed for swap not being mounted
+- Fixed aufs xattr delete issue (docker/docker#30245)
+- osxfs: Catch EPERM when reading extended attributes of non-files
+- VPNKit: Fixed unmarshalling of DNS packets containing pointers to pointers to labels
+- VPNKit: Set the Recursion Available bit on DNS responses from the cache
 - VPNKit: Avoid diagnostics to capture too much data
-- VPNKit: Fix a source of occasional packet loss (truncation) on the virtual ethernet link
+- VPNKit: Fixed a source of occasional packet loss (truncation) on the virtual ethernet link
 - HyperKit: Dump guest physical and linear address from VMCS when dumping state
 - HyperKit: Kernel boots with panic=1 arg
-
 
 ### Docker for Mac 1.13.1, 2017-02-09 (stable)
 
@@ -324,7 +335,18 @@ events or unexpected unmounts.
 
 ## Edge Release Notes
 
-### Docker Community Edition 17.03.0 Release Notes (2017-03-02 17.03.0-ce-mac1)
+### Docker Community Edition 17.03.0-ce-mac2, 2017-03-06 (edge)
+
+**Hotfixes**
+
+- Set the ethernet MTU to 1500 to prevent a hyperkit crash
+- Fix docker build on private images
+
+**Upgrades**
+
+- [Docker Credential Helpers 0.4.2](https://github.com/docker/docker-credential-helpers/releases/tag/v0.4.2)
+
+### Docker Community Edition 17.03.0-ce-mac1, 2017-03-02 (edge)
 
 **New**
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -8,9 +8,13 @@ The Docker for Windows install package includes everything you need to run
 Docker on a Windows system. This topic describes pre-install considerations, and
 how to download and install Docker for Windows.
 
-> **Already have Docker for Windows?** If you already have Docker for Windows installed, and are ready to get started, skip to [Getting started](index.md) to
-work through the rest of the Docker for Windows tour and information, or jump
-over to the tutorials at [Learn Docker](/learn.md).
+> **Already have Docker for Windows?** If you already have Docker for
+Windows installed, and are ready to get started, skip to
+[Get started with Docker for Windows](index.md) for a quick tour of
+the command line, settings, and tools.
+>
+>**Looking for Release Notes?** [Get release notes for all
+versions here](release-notes.md).
 
 ## Download Docker for Windows
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -12,8 +12,9 @@ release. The documentation is always updated for each release.
 For system requirements, please see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
-Release notes for _stable_ and _beta_ releases are listed below. You can learn
-about both kinds of releases, and download stable and beta product installers at
+Release notes for _stable_ and _edge_ releases are listed below. (Starting with
+the CE release model, `beta` releases are called `edge` releases.) You can learn
+about both kinds of releases, and download stable and edge product installers at
 [Download Docker for Windows](install.md#download-docker-for-windows).
 
 ## Stable Release Notes


### PR DESCRIPTION
### What changed

* added release notes for 17.03 CE-MAC-2 hotfixes
* made headings formats for stable and edge releases more consistent in release notes
* more updates for `beta` to `edge` terminology in release notes intro
* improved notes on install pages for Mac and Windows to send users to release notes and Getting Started, more clearly

### FYI

@ebriney, @friism, @jeanlaurent 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
