### PR TITLE
Trigger build of docs-base after successful build of archive branch

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# If this is an archive branch (like v1.4 or v1.11),
+# build and push the docs-base branch at the end of
+# a successful build of the branch
+
+if [[ $SOURCE_BRANCH == ^v1\.[0-9]+$ ]]; then
+  git checkout docs-base
+  docker build -t docs/docker.github.io:docs-base .
+  docker push docs/docker.github.io:docs-base
+fi


### PR DESCRIPTION
cc/ @pchico83

This Docker Hub / Cloud hook is invoked after a successful build of an archive branch that matches the regex (like `v1.4` or `v1.11`). If the Docker Hub / Cloud build succeeded and this is an archive branch, the `docs-base` branch is checked out, built, tagged, and pushed. 

This doesn't use the Hub API because we don't want to expose the trigger URL in Github.

If this works it needs to be cherry-picked to every archive branch. It's safe to put in other branches too because it will be a no-op in them.