### PR TITLE
Fix the command for generating content trust delegation cert.

### DIFF
--- a/engine/security/trust/trust_delegation.md
+++ b/engine/security/trust/trust_delegation.md
@@ -74,7 +74,7 @@ can self-sign the certificate (in this example, creating a certificate that is
 valid for 1 year):
 
 ```
-$ openssl x509 -req -days 365 -in delegation.csr -signkey delegation.key -out delegation.crt
+$ openssl x509 -req -sha256 -days 365 -in delegation.csr -signkey delegation.key -out delegation.crt
 ```
 
 Then they need to give you `delegation.crt`, whether it is self-signed or signed


### PR DESCRIPTION
The command provided for generating delegation certificate for Content Trust requires SHA256.

```
# notary delegation add docker.io/quiq/logspout targets/releases delegation.crt --all-paths -p

* fatal: unable to parse valid public key certificate from PEM file delegation.crt: invalid certificate: certificate with CN notary-delegation uses invalid SHA1 signature algorithm
```

Certificate was generated per instructions from the docs and it misses `-sha256`.
By default, SHA1 is used which is insecure and what notary.docker.io complains about.
```
# openssl genrsa -out delegation.key 2048
# openssl req -new -sha256 -subj ‘/C=US/ST=MT/L=Bozeman/O=Quiq/CN=notary-delegation‘ -key delegation.key -out delegation.csr
# openssl x509 -req -days 365 -in delegation.csr -signkey delegation.key -out delegation.crt
# openssl x509 -text -noout -in delegation.crt
...
    Signature Algorithm: sha1WithRSAEncryption
...
```