### PR TITLE
docker swarm does not respect depends_on

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -348,6 +348,10 @@ Simple example:
 > for a service to be ready, see [Controlling startup order](/compose/startup-order.md)
 > for more on this problem and strategies for solving it.
 
+> **Note:** This option is ignored when
+> [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
+> with a (version 3) Compose file.
+
 A healthcheck indicates you want a dependency to wait
 for another container to be "healthy" (i.e. its healthcheck advertises a
 successful state) before starting.


### PR DESCRIPTION
### Proposed changes

Swarmkit does not seem to have the concept of starting services in a particular order.

Tested with docker 1.13.1. Also, `docker-compose bundle` warns us about depends_on being unsupported.

It should be obvious from the documentation.