### PR TITLE
Use shallow clone and shallow checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,12 @@ COPY nginx.conf /etc/nginx/nginx.conf
 
 ENV VERSIONS="v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 v1.10 v1.11 v1.12 v1.13"
 
-RUN git clone https://www.github.com/docker/docker.github.io archive_source; \
+## Use shallow clone and shallow check-outs to only get the tip of each branch
+
+RUN git clone --depth 1 https://www.github.com/docker/docker.github.io archive_source; \
  for VER in $VERSIONS; do \
-		git --git-dir=./archive_source/.git --work-tree=./archive_source checkout ${VER} \
+    git --git-dir=./archive_source/.git --work-tree=./archive_source fetch origin ${VER}:${VER} --depth 1 \
+		&& git --git-dir=./archive_source/.git --work-tree=./archive_source checkout ${VER} \
 		&& mkdir -p target/${VER} \
 		&& jekyll build -s archive_source -d target/${VER} \
 		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$VER"'/#g' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 573BFD6B3D8FBC64107
 # Forward nginx request and error logs to docker log collector
 
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-	&& ln -sf /dev/stderr /var/log/nginx/error.log
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 
 COPY nginx.conf /etc/nginx/nginx.conf
 
@@ -33,16 +33,16 @@ ENV VERSIONS="v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 v1.10 v1.11 v1.12 v1.13"
 ## Use shallow clone and shallow check-outs to only get the tip of each branch
 
 RUN git clone --depth 1 https://www.github.com/docker/docker.github.io archive_source; \
- for VER in $VERSIONS; do \
+  for VER in $VERSIONS; do \
     git --git-dir=./archive_source/.git --work-tree=./archive_source fetch origin ${VER}:${VER} --depth 1 \
-		&& git --git-dir=./archive_source/.git --work-tree=./archive_source checkout ${VER} \
-		&& mkdir -p target/${VER} \
-		&& jekyll build -s archive_source -d target/${VER} \
-		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$VER"'/#g' \
-		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/'"$VER"'/#g' \
-		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/'"$VER"'/#g'; \
-	done; \
-	rm -rf archive_source
+    && git --git-dir=./archive_source/.git --work-tree=./archive_source checkout ${VER} \
+    && mkdir -p target/${VER} \
+    && jekyll build -s archive_source -d target/${VER} \
+    && find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$VER"'/#g' \
+    && find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/'"$VER"'/#g' \
+    && find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/'"$VER"'/#g'; \
+  done; \
+  rm -rf archive_source
 
 # This index file gets overwritten, but it serves a sort-of useful purpose in
 # making the docs/docs-base image browsable:


### PR DESCRIPTION
This does an initial shallow clone of the repo (just the tip of `master`) and then does a shallow fetch of each branch before checking it out, so we just get the tip of each of the archive branches.

This doesn't reduce the size of the image but reduces the time to do the `git clone` and `git fetch`es. It currently saves about 2 minutes locally and will save more as the repo grows and the number of branches in the archives increase.

Before:

```
real    10m7.755s
user    0m1.169s
sys    0m2.311s
```

After:

```
real    8m11.720s
user    0m1.115s
sys    0m2.141s
```