### PR TITLE
Trigger build of docs-base after successful build of archive branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,3 @@
 FROM starefossen/github-pages:onbuild
 
-ONBUILD RUN git clone https://www.github.com/docker/docker.github.io docs
-
-ONBUILD WORKDIR docs
-
-ONBUILD RUN git checkout v1.12
-
-ONBUILD COPY . /usr/src/app
-
 CMD bundle update && bundle exec jekyll serve -d /_site --watch -H 0.0.0.0 -P 4000

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# If this is an archive branch (like v1.4 or v1.11),
+# build and push the docs-base branch at the end of
+# a successful build of the branch
+
+if [[ $SOURCE_BRANCH =~ ^v1\.[0-9]+$ ]]; then
+  git fetch origin docs-base:docs-base --depth 1 || ( echo "Couldn't fetch docs-base." && exit 1 )
+  git checkout docs-base || ( echo "Couldn't check out docs-base." && exit 1 )
+  docker build -t docs/docker.github.io:docs-base . || ( echo "Couldn't build docs-base Dockerfile." && exit 1 )
+  docker push docs/docker.github.io:docs-base || ( echo "Coudn't push new docs-base image." && exit 1 )
+fi


### PR DESCRIPTION
Bring v1.12 up to date with v1.4..v1.11. Needed to make a couple tweaks since v1.12 actually builds from source.