### PR TITLE
Add archive admonition

### DIFF
--- a/articles/ambassador_pattern_linking/index.html
+++ b/articles/ambassador_pattern_linking/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/b2d_volume_resize/index.html
+++ b/articles/b2d_volume_resize/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/baseimages/index.html
+++ b/articles/baseimages/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/basics/index.html
+++ b/articles/basics/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/certificates/index.html
+++ b/articles/certificates/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/cfengine_process_management/index.html
+++ b/articles/cfengine_process_management/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/chef/index.html
+++ b/articles/chef/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/dockerfile_best-practices/index.html
+++ b/articles/dockerfile_best-practices/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/dsc/index.html
+++ b/articles/dsc/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/host_integration/index.html
+++ b/articles/host_integration/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/https/index.html
+++ b/articles/https/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/index.html
+++ b/articles/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/networking/index.html
+++ b/articles/networking/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/puppet/index.html
+++ b/articles/puppet/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/registry_mirror/index.html
+++ b/articles/registry_mirror/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/runmetrics/index.html
+++ b/articles/runmetrics/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/security/index.html
+++ b/articles/security/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/systemd/index.html
+++ b/articles/systemd/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/articles/using_supervisord/index.html
+++ b/articles/using_supervisord/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/contributing/contributing/index.html
+++ b/contributing/contributing/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/contributing/devenvironment/index.html
+++ b/contributing/devenvironment/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/contributing/docs_style-guide/index.html
+++ b/contributing/docs_style-guide/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/contributing/index.html
+++ b/contributing/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/css/docs.css
+++ b/css/docs.css
@@ -351,3 +351,16 @@ table.table tr td img {
 /* over-ride the prettyPrint colouring */
 
 .str, .atv { color: #48484C; }
+
+div.archive-admonition {
+  text-align: center;
+  background-color: #ffffb3;
+  color: #999;
+  padding-bottom: 2px;
+  padding-top: 10px;
+}
+
+div.archive-admonition a {
+  color: darkblue;
+  text-decoration: underline !important;
+}

--- a/docker-hub/accounts/index.html
+++ b/docker-hub/accounts/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/docker-hub/builds/index.html
+++ b/docker-hub/builds/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/docker-hub/index.html
+++ b/docker-hub/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/docker-hub/official_repos/index.html
+++ b/docker-hub/official_repos/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/docker-hub/repos/index.html
+++ b/docker-hub/repos/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/apt-cacher-ng/index.html
+++ b/examples/apt-cacher-ng/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/couchdb_data_volumes/index.html
+++ b/examples/couchdb_data_volumes/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/index.html
+++ b/examples/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/mongodb/index.html
+++ b/examples/mongodb/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/nodejs_web_app/index.html
+++ b/examples/nodejs_web_app/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/postgresql_service/index.html
+++ b/examples/postgresql_service/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/running_redis_service/index.html
+++ b/examples/running_redis_service/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/running_riak_service/index.html
+++ b/examples/running_riak_service/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/examples/running_ssh_service/index.html
+++ b/examples/running_ssh_service/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/faq/index.html
+++ b/faq/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/index.html
+++ b/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/SUSE/index.html
+++ b/installation/SUSE/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/amazon/index.html
+++ b/installation/amazon/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/archlinux/index.html
+++ b/installation/archlinux/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/binaries/index.html
+++ b/installation/binaries/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/centos/index.html
+++ b/installation/centos/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/cruxlinux/index.html
+++ b/installation/cruxlinux/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/debian/index.html
+++ b/installation/debian/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/fedora/index.html
+++ b/installation/fedora/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/frugalware/index.html
+++ b/installation/frugalware/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/gentoolinux/index.html
+++ b/installation/gentoolinux/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/google/index.html
+++ b/installation/google/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/index.html
+++ b/installation/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/mac/index.html
+++ b/installation/mac/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/openSUSE/index.html
+++ b/installation/openSUSE/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/oracle/index.html
+++ b/installation/oracle/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/rackspace/index.html
+++ b/installation/rackspace/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/rhel/index.html
+++ b/installation/rhel/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/softlayer/index.html
+++ b/installation/softlayer/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/ubuntulinux/index.html
+++ b/installation/ubuntulinux/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/installation/windows/index.html
+++ b/installation/windows/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/introduction/index.html
+++ b/introduction/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/introduction/understanding-docker/index.html
+++ b/introduction/understanding-docker/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/jsearch/index.html
+++ b/jsearch/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker-io_api/index.html
+++ b/reference/api/docker-io_api/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_io_accounts_api/index.html
+++ b/reference/api/docker_io_accounts_api/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api/index.html
+++ b/reference/api/docker_remote_api/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.0/index.html
+++ b/reference/api/docker_remote_api_v1.0/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.1/index.html
+++ b/reference/api/docker_remote_api_v1.1/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.10/index.html
+++ b/reference/api/docker_remote_api_v1.10/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.11/index.html
+++ b/reference/api/docker_remote_api_v1.11/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.12/index.html
+++ b/reference/api/docker_remote_api_v1.12/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.13/index.html
+++ b/reference/api/docker_remote_api_v1.13/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.14/index.html
+++ b/reference/api/docker_remote_api_v1.14/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.15/index.html
+++ b/reference/api/docker_remote_api_v1.15/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.16/index.html
+++ b/reference/api/docker_remote_api_v1.16/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.2/index.html
+++ b/reference/api/docker_remote_api_v1.2/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.3/index.html
+++ b/reference/api/docker_remote_api_v1.3/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.4/index.html
+++ b/reference/api/docker_remote_api_v1.4/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.5/index.html
+++ b/reference/api/docker_remote_api_v1.5/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.6/index.html
+++ b/reference/api/docker_remote_api_v1.6/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.7/index.html
+++ b/reference/api/docker_remote_api_v1.7/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.8/index.html
+++ b/reference/api/docker_remote_api_v1.8/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/docker_remote_api_v1.9/index.html
+++ b/reference/api/docker_remote_api_v1.9/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/hub_registry_spec/index.html
+++ b/reference/api/hub_registry_spec/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/index.html
+++ b/reference/api/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/registry_api/index.html
+++ b/reference/api/registry_api/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/registry_api_client_libraries/index.html
+++ b/reference/api/registry_api_client_libraries/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/api/remote_api_client_libraries/index.html
+++ b/reference/api/remote_api_client_libraries/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/builder/index.html
+++ b/reference/builder/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/commandline/cli/index.html
+++ b/reference/commandline/cli/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/commandline/index.html
+++ b/reference/commandline/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/index.html
+++ b/reference/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/reference/run/index.html
+++ b/reference/run/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/release-notes/index.html
+++ b/release-notes/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/terms/container/index.html
+++ b/terms/container/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/terms/filesystem/index.html
+++ b/terms/filesystem/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/terms/image/index.html
+++ b/terms/image/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/terms/index.html
+++ b/terms/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/terms/layer/index.html
+++ b/terms/layer/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/terms/registry/index.html
+++ b/terms/registry/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/terms/repository/index.html
+++ b/terms/repository/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/dockerhub/index.html
+++ b/userguide/dockerhub/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/dockerimages/index.html
+++ b/userguide/dockerimages/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/dockerizing/index.html
+++ b/userguide/dockerizing/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/dockerlinks/index.html
+++ b/userguide/dockerlinks/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/dockerrepos/index.html
+++ b/userguide/dockerrepos/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/dockervolumes/index.html
+++ b/userguide/dockervolumes/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/index.html
+++ b/userguide/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/level1/index.html
+++ b/userguide/level1/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/level2/index.html
+++ b/userguide/level2/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">

--- a/userguide/usingdocker/index.html
+++ b/userguide/usingdocker/index.html
@@ -42,6 +42,12 @@
   
 </head>
 <body>
+<div class="archive-admonition">
+  <p><b>This documentation is archived content for Docker 1.4.</b> You can view
+      documentation for <a href="https://docs.docker.com/">the latest version of Docker</a> or
+      choose a different version from the
+      <a href="https://docs.docker.com/docsarchive/">archive</a>.</p>
+</div>
 
 <div id="topmostnav" class="topmostnav_loggedout navbar navbar-static-top public">
   <div class="container">


### PR DESCRIPTION
Add archive admonition to the top of each page. For versions earlier than 1.12, this is a little bit of a brute-force exercise.

To see what it looks like, check out the PR and do `jekyll serve`.

It looks kind of like this:

<img width="1324" alt="screen shot 2017-03-07 at 3 15 28 pm" src="https://cloud.githubusercontent.com/assets/7674613/23682504/f53f42e0-0348-11e7-89c2-e9ffe95f00bc.png">

