### PR TITLE
tip re: Windows encoding errors on file downloads

### DIFF
--- a/engine/getstarted-voting-app/deploy-app.md
+++ b/engine/getstarted-voting-app/deploy-app.md
@@ -15,6 +15,8 @@ The `docker-stack.yml` file must be located on a manager for the swarm where you
 
     Copy-and-paste the contents of that file into a file of the same name on your host.
 
+    >**Tip:** To avoid text encoding errors from a direct file download, especially on Windows, create the file directly in a Linux environment on your local machine and copy-paste the raw text from the original `docker-stack.yml`. A file downloaded on a Windows system might include `^M` line endings, which will prevent the app from running in the Docker Linux based environment.
+
 2.  Copy `docker-stack.yml` from your host machine onto the manager.
 
     ```


### PR DESCRIPTION
### What's changed

Added a tip re: text encoding problems with direct file downloads on Windows

### Related issues

[Issue # 75 on docker/example-voting-app](https://github.com/docker/example-voting-app/issues/75)


### Reviewers

@ManoMarks @samanta60 @Tirocigno

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
