### PR TITLE
Fix broken link for devicemapper setup in 1.12

### DIFF
--- a/cs-engine/1.12/index.md
+++ b/cs-engine/1.12/index.md
@@ -99,7 +99,7 @@ to update its RHEL kernel.
 
     By default, the `devicemapper` graph driver does not come pre-configured in
     a production-ready state. Follow the documented step by step instructions to
-    [configure devicemapper with direct-lvm for production](../../engine/userguide/storagedriver/device-mapper-driver/#/for-a-direct-lvm-mode-configuration)
+    [configure devicemapper with direct-lvm for production](../../engine/userguide/storagedriver/device-mapper-driver/#configure-direct-lvm-mode-for-production)
     to achieve the best performance and reliability for your environment.
 
 6.  Configure the Docker daemon to start automatically when the system starts,


### PR DESCRIPTION
### Proposed changes
Fixed broken anchor link for 1.12 dm setup


### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
