### PR TITLE
clarified scripts logic for compose startup order

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -47,7 +47,7 @@ script:
           db:
             image: postgres
 
-    >**Tip:** There are limitations to this first solution; e.g., it doesn't verify when specific service is really ready. If you add more arguments to the command, you'll need to use the `bash shift` command with a loop, as shown in the next example.
+    >**Tip:** There are limitations to this first solution; e.g., it doesn't verify when a specific service is really ready. If you add more arguments to the command, you'll need to use the `bash shift` command with a loop, as shown in the next example.
 
 -   Alternatively, write your own wrapper script to perform a more application-specific health
     check. For example, you might want to wait until Postgres is definitely

--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -47,6 +47,8 @@ script:
           db:
             image: postgres
 
+    >**Tip:** There are limitations to this first solution; e.g., it doesn't verify when specific service is really ready. If you add more arguments to the command, you'll need to use the `bash shift` command with a loop, as shown in the next example.
+
 -   Alternatively, write your own wrapper script to perform a more application-specific health
     check. For example, you might want to wait until Postgres is definitely
     ready to accept commands:


### PR DESCRIPTION

### What's changed

Added a note on scripts for specifying startup order in Compose, per user feedback.

### Related issues

https://github.com/docker/docker.github.io/issues/376

### Reviewers

@shin- @dnephin @johndmulhausen 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

