### PR TITLE
removed checksums from d4mac-d4win installs for now

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -55,10 +55,7 @@ channels, see the [FAQs](/docker-for-mac/faqs.md#stable-and-edge-channels).
   <a class="button outline-btn" href="https://download.docker.com/mac/beta/Docker.dmg">Get Docker for Mac (Edge)</a>
   </td>
   </tr>
-  <tr>
-  <td><a href="https://download.docker.com/mac/stable/Docker.dmg.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: Docker.dmg SHA256</font></a></td>
-  <td><a href="https://download.docker.com/mac/beta/Docker.dmg.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: Docker.dmg SHA256</font></a></td>
-  </tr>
+
 </table>
 
 >**Important Notes**:

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -60,10 +60,6 @@ Edge channels, see the
   <a class="button outline-btn" href="https://download.docker.com/win/beta/InstallDocker.msi">Get Docker for Windows (Edge)</a>
   </td>
   </tr>
-  <tr>
-  <td><a href="https://download.docker.com/win/stable/InstallDocker.msi.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: InstallDocker.msi SHA256</font></a></td>
-  <td><a href="https://download.docker.com/win/beta/InstallDocker.msi.sha256sum"><font color="#BDBDBD" size="-1">Download checksum: InstallDocker.msi SHA256</font></a></td>
-  </tr>
 </table>
 
 >**Important Notes:**


### PR DESCRIPTION

### What's changed

- Removed checksums on Docker for Mac, Docker for Windows install pages until we can verify these as correct or get new ones (we don't have them on Docker Store at all)

### Related issues 

- Issue #2178 

### Reviewers

@karstengresch @FrenchBen @jeanlaurent @friism @ebriney


