### PR TITLE
Update tail docs to match built-in docs

### DIFF
--- a/compose/reference/logs.md
+++ b/compose/reference/logs.md
@@ -12,7 +12,7 @@ Options:
 --no-color          Produce monochrome output.
 -f, --follow        Follow log output
 -t, --timestamps    Show timestamps
---tail              Number of lines to show from the end of the logs
+--tail="all"        Number of lines to show from the end of the logs
                     for each container.
 ```
 


### PR DESCRIPTION
Default value for tail helps me remember it's not a switch, but requires a value. This change makes it match the built-in docs.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
