### PR TITLE
Update install.md to fix image render

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -128,7 +128,7 @@ channels, see the [FAQs](/docker-for-mac/faqs.md#stable-and-edge-channels).
 
 2.  Double-click `Docker.app` to start Docker.
 
-	  ![Docker app in Hockeyapp](/docker-for-mac/images/docker-app-in-apps.png
+	  ![Docker app in Hockeyapp](/docker-for-mac/images/docker-app-in-apps.png)
 
 	  You will be asked to authorize `Docker.app` with your system password after you launch it.
 	  Privileged access is needed to install networking components and links to the Docker apps.


### PR DESCRIPTION
## Bug
[Docker for Mac](https://docs.docker.com/docker-for-mac/install/#install-and-run-docker-for-mac) `install.md` was not displaying an image properly. Instead it showed the improperly formatted Markdown.

<img width="671" alt="screen shot 2017-03-10 at 2 26 01 pm" src="https://cloud.githubusercontent.com/assets/13735131/23809950/96d2fb64-059d-11e7-9159-3aac2dd902b0.png">

## Fix
Simple edit to complete the Markdown to render the image properly.

