### PR TITLE
Go code: ImagePull: repository name must be canonical

### DIFF
--- a/engine/api/index.md
+++ b/engine/api/index.md
@@ -56,7 +56,7 @@ As an example, the `docker run` command can be easily implemented in various pro
   		panic(err)
   	}
 
-  	_, err = cli.ImagePull(ctx, "alpine", types.ImagePullOptions{})
+  	_, err = cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
   	if err != nil {
   		panic(err)
   	}


### PR DESCRIPTION
### Proposed changes

Corrected documentation because example Go code results in panic.

If name given to imagePull is not canonical (see here for a description of a "canonical" name : https://github.com/docker/distribution/blob/245ca46/reference/normalize.go#L19-L23 ), the Go example panics : `repository name must be canonical`
