### PR TITLE
Added clarification for deferred deletion

### DIFF
--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -325,6 +325,10 @@ assumes that the Docker daemon is in the `stopped` state.
     There are two ways to do this. You can set options on the command line if
     you start the daemon there:
 
+    > **Note**: The deferred deletion option, `dm.use_deferred_deletion=true`, is not yet supported
+    > on CentOS, RHEL, or Ubuntu 14.04 when using the default kernel.  Support was added in the
+    > upstream kernel version 3.18.
+
     ```none
     --storage-driver=devicemapper \
     --storage-opt=dm.thinpooldev=/dev/mapper/docker-thinpool \
@@ -346,9 +350,6 @@ assumes that the Docker daemon is in the `stopped` state.
        ]
     }
     ```
-
-    > **Note**: Always set both `dm.use_deferred_removal=true` and `dm.use_deferred_deletion=true`
-    > to prevent unintentionally leaking mount points.
 
 15. If using systemd and modifying the daemon configuration via unit or drop-in file, reload systemd to scan for changes.
 


### PR DESCRIPTION
Signed-off-by: Matt Bentley <matt.bentley@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added a warning that deferred deletion is not supported in older kernels

```
root@rhel7-test ~# cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.3 (Maipo)
root@rhel7-test ~# uname -a
Linux rhel7-test 3.10.0-514.10.2.el7.x86_64 #1 SMP Mon Feb 20 02:37:52 EST 2017 x86_64 x86_64 x86_64 GNU/Linux
root@rhel7-test ~# docker run -it --rm --cap-add SYS_ADMIN mbentley/check-deferred-deletion
Deferred deletion is not supported
```

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

See https://github.com/docker/docker/issues/31628#issuecomment-285742147