### PR TITLE
update to docker-compose rm reference per Compose v3

### DIFF
--- a/compose/reference/rm.md
+++ b/compose/reference/rm.md
@@ -5,19 +5,27 @@ title: docker-compose rm
 notoc: true
 ---
 
-```
+```none
 Usage: rm [options] [SERVICE...]
 
 Options:
     -f, --force   Don't ask to confirm removal
     -v            Remove any anonymous volumes attached to containers
-    -a, --all     Also remove one-off containers created by
-                  docker-compose run
 ```
 
 Removes stopped service containers.
 
 By default, anonymous volumes attached to containers will not be removed. You
-can override this with `-v`. To list all volumes, use `docker volume ls`.
+can override this with `-v`. To list all volumes,  use `docker volume ls`.
 
 Any data which is not in a volume will be lost.
+
+Running the command with no options will also remove one-off containers created
+by `docker-compose up` or `docker-compose run`:
+
+```none
+$ docker-compose rm
+Going to remove djangoquickstart_web_run_1
+Are you sure? [yN] y
+Removing djangoquickstart_web_run_1 ... done
+```


### PR DESCRIPTION
### What's changed

- removed `-a|--all` flags from list of options
- explained this flag is legacy for Compose v3
- added an example
- linked to Compose v3 docs

### Related issues 

#2281 

### Reviewers

@josesa, @dnephin , @shin- 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

