### PR TITLE
Use the jekyll-include-cache plugin to shave off some page building time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 # Please ensure, before upgrading, that this version exists as a tag in starefossen/github-pages here:
 # https://hub.docker.com/r/starefossen/github-pages/tags/
 gem "github-pages", "112"
+gem "jekyll-include-cache"

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ gems:
   - jekyll-redirect-from
   - jekyll-seo-tag
   - jekyll-relative-links
+  - jekyll-include-cache
 
 webrick:
   headers:

--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -89,7 +89,7 @@
                 </ul>
             </div>
             <div class="ctrl-right">
-              {% include archive-list.html %}
+              {% include_cached archive-list.html %}
             </div>
         </div>
     </nav>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,7 +33,7 @@
             </div>
             <div class="ctrl-right">
                 <a href="javascript:void(0)" id="menu-toggle"><i class="fa fa-indent" aria-hidden="true"></i></a>
-                {% include archive-list.html %}
+                {% include_cached archive-list.html %}
             </div>
         </div>
     </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -181,7 +181,7 @@ else %}{% assign edit_url = "" %}{% endif %} {% break %} {% endif %} {% endfor %
 	</div>
 
 	<footer class="footer">
-		{% include footer.html %}
+		{% include_cached footer.html %}
 	</footer>
 	<link rel="stylesheet" href="/css/github.css">
 	<script src="/js/highlight.pack.js"></script>


### PR DESCRIPTION
This is a very naive first implementation which only caches truly static content like the footer and archives. If we could make use of this for building the left-hand nav tree, I think it would be pretty cool.

cc/ @allejo