### PR TITLE
Directing users to docker/whalesay search result

### DIFF
--- a/engine/getstarted/step_three.md
+++ b/engine/getstarted/step_three.md
@@ -26,7 +26,7 @@ image you'll use in the rest of this getting started.
 
     ![Browse Docker Hub](tutimg/image_found.png)
 
-3. Click on the **docker/whalesay** image in the results.
+3. Click on the **docker/whalesay** image in the results. You'll find it about halfway down.
 
     The browser displays the repository for the **whalesay** image.
 


### PR DESCRIPTION
### Proposed changes

Added line describing position of docker/whalesay official image in search results.

For some reason the official, most-downloaded, most-starred image is about halfway down the search results first page.  I didn't even see it.  I used the first one since it seemed good enough.  This line will help people actually find it.

### Related issues (optional)

As a general note for Docker Hub search, I suggest the search ranking formula weight official images, number of downloads, and number of stars more than it does currently.