### PR TITLE
added more detail for Compose env

### DIFF
--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -5,21 +5,25 @@ title: Declare default environment variables in file
 notoc: true
 ---
 
-Compose supports declaring default environment variables in an environment
-file named `.env` placed in the folder `docker-compose` command is executed from
+Compose supports declaring default environment variables in an environment file
+named `.env` placed in the folder where the `docker-compose` command is executed
 *(current working directory)*.
 
-Compose expects each line in an env file to be in `VAR=VAL` format. Lines
-beginning with `#` (i.e. comments) are ignored, as are blank lines.
+## Syntax Rules
 
-> Note: Values present in the environment at runtime will always override
-> those defined inside the `.env` file. Similarly, values passed via
-> command-line arguments take precedence as well.
+These syntax rules apply to the `.env` file:
 
-Those environment variables will be used for
-[variable substitution](compose-file.md#variable-substitution) in your Compose
-file, but can also be used to define the following
-[CLI variables](reference/envvars.md):
+* Compose expects each line in an `env` file to be in `VAR=VAL` format.
+* Lines beginning with `#` (i.e. comments) are ignored.
+* Blank lines are ignored.
+* There is no special handling of quotation marks.
+
+## Compose file and CLI variables
+
+The environment variables you define here will be used for [variable
+substitution](compose-file/index.md#variable-substitution) in your Compose file,
+and can also be used to define the following [CLI
+variables](reference/envvars.md):
 
 - `COMPOSE_API_VERSION`
 - `COMPOSE_CONVERT_WINDOWS_PATHS`
@@ -30,6 +34,10 @@ file, but can also be used to define the following
 - `DOCKER_CERT_PATH`
 - `DOCKER_HOST`
 - `DOCKER_TLS_VERIFY`
+
+> **Note:** Values present in the environment at runtime will always override
+> those defined inside the `.env` file. Similarly, values passed via
+> command-line arguments take precedence as well.
 
 ## More Compose documentation
 


### PR DESCRIPTION
### What's changed

- explicitly stated that quotes are ignored
- added bullets and headings
- fixed link to `variable substitution` in Compose file reference


### Related issues

#123 

### Reviewers

@shin- @dnephin @Stasmo @sstaszkiewicz-copperleaf

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
