### PR TITLE
clarified Compose file topic structure, and file examples

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -16,6 +16,21 @@ For a Compose/Docker Engine compatibility matrix, and detailed guidelines on
 versions and upgrading, see
 [Compose file versions and upgrading](compose-versioning.md).
 
+## Compose file structure and examples
+
+The topics on this reference page are organized alphabetically by top-level key
+to reflect the structure of the Compose file itself. Top-level keys that define
+a section in the configuration file such as `build`, `deploy`, `depends_on`,
+`networks`, and so on, are listed with the options that support them as
+sub-topics. This maps to the `<key>: <option>: <value>` indent structure of the Compose file.
+
+Example snip-its of how to define particular options are included on this
+reference page, but we suggest also taking a look at some samples that include
+full Compose files. A good place to start are the [sample
+applications](samples.md#sample-applications) in [Docker
+Labs](https://github.com/docker/labs/) and the [voting app sample
+walk-through](/engine/getstarted-voting-app/index.md).
+
 ## Service configuration reference
 
 The Compose file is a [YAML](http://yaml.org/) file defining

--- a/engine/getstarted-voting-app/index.md
+++ b/engine/getstarted-voting-app/index.md
@@ -89,16 +89,18 @@ of a Dockerfile to specify the images. When we deploy, each image will run as a
 service in a container (or in multiple containers, for those that have replicas
 defined to scale the app).
 
-To follow along, you need only have Docker running and a [copy of
-the `docker-stack.yml` file provided
-**here**](https://github.com/docker/example-voting-app/blob/master/docker-stack.yml).
+To follow along, you need only have Docker running and a copy of the
+`docker-stack.yml`
+file that we provide.
 
 This file defines all the services we want to use along with details about how
 and where those services will run; their base images, configuration
 details such as ports, networks, volumes, application dependencies, and the
 swarm configuration.
 
-Here is an example of one of the services fully defined:
+This **example snip-it** taken from our `docker-stack.yml` shows one of the
+services fully defined. (The full file is
+[**here**](https://github.com/docker/example-voting-app/blob/master/docker-stack.yml).)
 
 ```
 vote:


### PR DESCRIPTION

### What's changed

- In Compose file v.3, linked to topics that have examples of Compose files (Docker Labs, Voting app getting started sample)

- In Voting app getting started sample, moved link to full Compose file closer to the example snip-it of a service on the first page

### Related issues

#1250 

### Reviewers

@sbrattla @shin- @dnephin @ManoMarks 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
