### PR TITLE
Update !#/bin/bash to !#/bin/sh startup-order.md

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -53,7 +53,7 @@ script:
     check. For example, you might want to wait until Postgres is definitely
     ready to accept commands:
 
-        #!/bin/bash
+        #!/bin/sh
         # wait-for-postgres.sh
 
         set -e


### PR DESCRIPTION
### Proposed changes

Changed `!#/bin/bash` to `!#/bin/sh` because the script above was throwing `standard_init_linux.go:178: exec user process caused "no such file or directory"`.  Maybe I was doing something incorrectly, but switching to `sh` allowed it to run.

