### PR TITLE
Make sure the job cleans up after itself

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,4 +19,5 @@ wrappedNode(label: 'linux && x86_64') {
   sh "docker run --rm --volumes-from docs-${JOB_BASE_NAME}-${BUILD_NUMBER} -v `pwd`:/docs tests:${JOB_BASE_NAME}-${BUILD_NUMBER}"
   sh "docker rm -fv docs-${JOB_BASE_NAME}-${BUILD_NUMBER}"
   sh "docker rmi docs:${JOB_BASE_NAME}-${BUILD_NUMBER} tests:${JOB_BASE_NAME}-${BUILD_NUMBER}"
+  deleteDir()
 }


### PR DESCRIPTION
This modifies the `Jenkinsfile` to clean up junk at the beginning and the end because old cruft leftover from failed jobs has been making the submodule init fail, despite the supposed cleanup at the beginning of the job.

cc/ @andrewhsu @aduermael 