### PR TITLE
added Toolbox, Windows 7/8 to node setup

### DIFF
--- a/engine/getstarted-voting-app/index.md
+++ b/engine/getstarted-voting-app/index.md
@@ -20,7 +20,7 @@ Docker Engine.
 If you haven't yet downloaded Docker or installed it, go to [Get
 Docker](/engine/getstarted/step_one.md#step-1-get-docker) and grab Docker for
 your platform.  You can follow along and run this example using [Docker for Mac](/docker-for-mac/install.md),
-[Docker for Windows](/docker-for-windows/install.md), [Docker Toolbox](/toolbox/toolbox_install_windows.md) for Windows 7 or 8, or [Docker for Linux](/installation/linux/index.md). 
+[Docker for Windows](/docker-for-windows/install.md), [Docker Toolbox](/toolbox/overview.md), or [Docker for Linux](/installation/linux/index.md).
 
 If you are totally new to Docker, you might want to work through the [Get
 Started with Docker tutorial](/engine/getstarted/index.md) first, then come

--- a/engine/getstarted-voting-app/index.md
+++ b/engine/getstarted-voting-app/index.md
@@ -19,8 +19,8 @@ Docker Engine.
 
 If you haven't yet downloaded Docker or installed it, go to [Get
 Docker](/engine/getstarted/step_one.md#step-1-get-docker) and grab Docker for
-your platform.  You can follow along and run this example using [Docker for Mac](/docker-for-mac/index.md),
-[Docker for Windows](/docker-for-windows/index.md), or [Docker for Linux](/installation/linux/index.md).
+your platform.  You can follow along and run this example using [Docker for Mac](/docker-for-mac/install.md),
+[Docker for Windows](/docker-for-windows/install.md), [Docker Toolbox](/toolbox/toolbox_install_windows.md) for Windows 7 or 8, or [Docker for Linux](/installation/linux/index.md). 
 
 If you are totally new to Docker, you might want to work through the [Get
 Started with Docker tutorial](/engine/getstarted/index.md) first, then come

--- a/engine/getstarted-voting-app/node-setup.md
+++ b/engine/getstarted-voting-app/node-setup.md
@@ -40,15 +40,14 @@ example](/machine/drivers/hyper-v#example) reference topic to set up a new
 external network switch (a one-time task), reboot, and then
 [create the machines (nodes)](/machine/drivers/hyper-v.md#create-the-nodes-with-docker-machine-and-the-microsoft-hyper-v-driver)
 in an elevated PowerShell per those instructions.
-<p />
-* **Docker Toolbox and VirtualBox driver on Windows 7 or 8** - Docker for Windows requires Windows 10 Pro (see system requirements [What to know
-before you
-install](/docker-for-windows/install.md#what-to-know-before-you-install)). If
-your system is running an earlier version of Windows, you can run Docker by
-installing [Docker Toolbox](/toolbox/toolbox_install_windows.md), which includes
-`docker-machine` and Oracle VirtualBox. You'll use the `virtualbox` driver
-to create machines.
 
+<p />
+* **Docker Toolbox and VirtualBox driver on Windows 7 or 8** - Docker for Windows requires Windows 10 Pro (see system requirements [What to know before
+you  install](/docker-for-windows/install.md#what-to-know-before-you-install)).
+If your system is running an earlier version of Windows, you can run Docker by
+installing [Docker Toolbox](/toolbox/toolbox_install_windows.md), which includes
+`docker-machine` and Oracle VirtualBox. You'll use the `virtualbox` driver to
+create machines.
 
 ### Commands to create machines
 
@@ -63,12 +62,13 @@ docker-machine create --driver virtualbox MACHINE-NAME
 
 #### Windows (Running Docker for Windows)
 
+This must be done in an elevated PowerShell, using a custom-created external
+network switch. See [Hyper-V example](/machine/drivers/hyper-v#example).
+
 ```none
 docker-machine create -d hyperv --hyperv-virtual-switch "NETWORK-SWITCH"
 MACHINE-NAME
 ```
-
-This must be done in an elevated PowerShell, using a custom-created external network switch. See [Hyper-V example](/machine/drivers/hyper-v#example).
 
 #### Windows 7 or 8 (Running Docker Toolbox)
 
@@ -78,13 +78,15 @@ docker-machine create --driver virtualbox MACHINE-NAME
 
 ## Create manager and worker machines
 
-Create two machines and name them to anticipate what their roles will be in the swarm:
+Create two machines and name them to anticipate what their roles will be in the
+swarm:
 
 * manager
 
 * worker
 
-Here is an example of creating the `manager` on Docker for Mac. Create this one, then do the same for `worker`.
+Here is an example of creating the `manager` on Docker for Mac. Create this one,
+then do the same for `worker`.
 
 ```none
 $  docker-machine create --driver virtualbox manager

--- a/engine/getstarted-voting-app/node-setup.md
+++ b/engine/getstarted-voting-app/node-setup.md
@@ -16,11 +16,12 @@ run some basic commands to interact with the machines.
 
 * **Docker Machine** - These steps rely on use of
 [Docker Machine](/machine/get-started.md) (`docker-machine`), which
-comes auto-installed with both Docker for Mac and Docker for Windows.
+comes auto-installed with both Docker for Mac and Docker for Windows. It is also
+available with [Docker Toolbox](/toolbox/overview.md), a good solution especially for earlier Windows operating systems, as described below.
 
 <p />
 
-* **VirtualBox driver on Docker for Mac** - On Docker for Mac, you'll
+* **VirtualBox driver on Docker for Mac** - On [Docker for Mac](docker-for-mac/index.md), you'll
 use `docker-machine` with the `virtualbox` driver to create machines. If you had
 a legacy installation of Docker Toolbox, you already have Oracle VirtualBox
 installed as part of that. If you started fresh with Docker for Mac, then you
@@ -32,13 +33,22 @@ here](https://www.virtualbox.org/wiki/Downloads), and follow install
 instructions. You do not need to start VirtualBox. The `docker-machine create`
 command will call it via the driver.
 <p />
-* **Hyper-V driver on Docker for Windows** - On Docker for Windows, you
+* **Hyper-V driver on Docker for Windows** - On [Docker for Windows](docker-for-windows/index.md), you
 will use `docker-machine` with the [`Hyper-V`](/machine/drivers/hyper-v/) driver
 to create machines. You will need to follow the instructions in the [Hyper-V
 example](/machine/drivers/hyper-v#example) reference topic to set up a new
 external network switch (a one-time task), reboot, and then
 [create the machines (nodes)](/machine/drivers/hyper-v.md#create-the-nodes-with-docker-machine-and-the-microsoft-hyper-v-driver)
 in an elevated PowerShell per those instructions.
+<p />
+* **Docker Toolbox and VirtualBox driver on Windows 7 or 8** - Docker for Windows requires Windows 10 Pro (see system requirements [What to know
+before you
+install](/docker-for-windows/install.md#what-to-know-before-you-install)). If
+your system is running an earlier version of Windows, you can run Docker by
+installing [Docker Toolbox](/toolbox/toolbox_install_windows.md), which includes
+`docker-machine` and Oracle VirtualBox. You'll use the `virtualbox` driver
+to create machines.
+
 
 ### Commands to create machines
 
@@ -51,7 +61,7 @@ are as follows.
 docker-machine create --driver virtualbox MACHINE-NAME
 ```
 
-#### Windows
+#### Windows (Running Docker for Windows)
 
 ```none
 docker-machine create -d hyperv --hyperv-virtual-switch "NETWORK-SWITCH"
@@ -59,6 +69,12 @@ MACHINE-NAME
 ```
 
 This must be done in an elevated PowerShell, using a custom-created external network switch. See [Hyper-V example](/machine/drivers/hyper-v#example).
+
+#### Windows 7 or 8 (Running Docker Toolbox)
+
+```none
+docker-machine create --driver virtualbox MACHINE-NAME
+```
 
 ## Create manager and worker machines
 


### PR DESCRIPTION
### What changed

- added Docker Toolbox links and info to "Got Docker" topics on sample app overview, and to Node Setup to cover Windows 7, 8 users

- added a new section on creating machines using `virtualbox` driver for Windows 7, 8 users

### Related PR

#2301  (the current PR will supersede this one)

### Reviewers, fyi

@fredyagomez @friism @mstanleyjones 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>


