### PR TITLE
Add docs for 17.04 Edge release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM docs/docker.github.io:docs-base
 # Debian Jesse. See the contents of docs-base at:
 # https://github.com/docker/docker.github.io/tree/docs-base
 
+# First, build non-edge (all of this is duplicated later -- that is on purpose)
+
 # Copy master into target directory (skipping files / folders in .dockerignore)
 # These files represent the current docs
 COPY . md_source
@@ -14,13 +16,10 @@ COPY . md_source
 # into static HTML in the "target" directory using Jekyll
 # then nuke the md_source directory.
 
-# Process this as an Edge release
-ENV EDGE 1
-
 ## Branch to pull from, per ref doc
 ## To get master from svn the svn branch needs to be 'trunk'. To get a branch from svn it needs to be 'branches/branchname'
-ENV ENGINE_SVN_BRANCH="branches/17.04.x"
-ENV ENGINE_BRANCH="17.04.x"
+ENV ENGINE_SVN_BRANCH="branches/17.03.x"
+ENV ENGINE_BRANCH="17.03.x"
 ENV DISTRIBUTION_SVN_BRANCH="branches/release/2.6"
 ENV DISTRIBUTION_BRANCH="release/2.6"
 
@@ -46,7 +45,88 @@ RUN svn co https://github.com/docker/docker/$ENGINE_SVN_BRANCH/docs/extend md_so
   && wget -O md_source/engine/api/v1.25/swagger.yaml https://raw.githubusercontent.com/docker/docker/v1.13.0/api/swagger.yaml \
   && wget -O md_source/engine/api/v1.26/swagger.yaml https://raw.githubusercontent.com/docker/docker/v17.03.0-ce/api/swagger.yaml \
   && wget -O md_source/engine/api/v1.27/swagger.yaml https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/api/swagger.yaml \
-	&& (if [ $EDGE -eq 1 ]; then jekyll build -s md_source -d target --config md_source/_config-edge.yml; else jekyll build -s md_source -d target; fi)\
+	&& jekyll build -s md_source -d target --config md_source/_config.yml \
 	&& rm -rf target/apidocs/layouts \
 	&& find target -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
 	&& rm -rf md_source
+
+	# Next, build edge
+
+	# Copy master into target directory (skipping files / folders in .dockerignore)
+	# These files represent the current docs
+	COPY . md_source
+
+	# Move built html into md_source directory so we can reuse the target directory
+	# to hold the static output.
+	# Pull reference docs from upstream locations, then build the master docs
+	# into static HTML in the "target" directory using Jekyll
+	# then nuke the md_source directory.
+
+	## Branch to pull from, per ref doc
+	## To get master from svn the svn branch needs to be 'trunk'. To get a branch from svn it needs to be 'branches/branchname'
+	ENV ENGINE_SVN_BRANCH="branches/17.04.x"
+	ENV ENGINE_BRANCH="17.04.x"
+	ENV DISTRIBUTION_SVN_BRANCH="branches/release/2.6"
+	ENV DISTRIBUTION_BRANCH="release/2.6"
+
+	RUN svn co https://github.com/docker/docker/$ENGINE_SVN_BRANCH/docs/extend md_source/engine/extend \
+		&& wget -O md_source/engine/api/v1.18.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/v1.18.md \
+		&& wget -O md_source/engine/api/v1.19.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/v1.19.md \
+		&& wget -O md_source/engine/api/v1.20.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/v1.20.md \
+		&& wget -O md_source/engine/api/v1.21.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/v1.21.md \
+		&& wget -O md_source/engine/api/v1.22.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/v1.22.md \
+		&& wget -O md_source/engine/api/v1.23.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/v1.23.md \
+		&& wget -O md_source/engine/api/v1.24.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/v1.24.md \
+		&& wget -O md_source/engine/api/version-history.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/api/version-history.md \
+		&& wget -O md_source/engine/reference/glossary.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/glossary.md \
+		&& wget -O md_source/engine/reference/builder.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/builder.md \
+		&& wget -O md_source/engine/reference/run.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/run.md \
+		&& wget -O md_source/engine/reference/commandline/cli.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/commandline/cli.md \
+		&& wget -O md_source/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
+		&& svn co https://github.com/docker/distribution/$DISTRIBUTION_SVN_BRANCH/docs/spec md_source/registry/spec \
+		&& rm md_source/registry/spec/api.md.tmpl \
+		&& wget -O md_source/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
+		&& rm -rf md_source/apidocs/cloud-api-source \
+		&& rm -rf md_source/tests \
+	  && wget -O md_source/engine/api/v1.25/swagger.yaml https://raw.githubusercontent.com/docker/docker/v1.13.0/api/swagger.yaml \
+	  && wget -O md_source/engine/api/v1.26/swagger.yaml https://raw.githubusercontent.com/docker/docker/v17.03.0-ce/api/swagger.yaml \
+	  && wget -O md_source/engine/api/v1.27/swagger.yaml https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/api/swagger.yaml \
+		&& jekyll build -s md_source -d target/edge --config md_source/_config-edge.yml \
+		&& rm -rf target/apidocs/layouts \
+		&& find target -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
+		# Replace / rewrite some URLs so that links in the edge directory go to the correct
+	  # location. Note that the order in which these replacements are done is
+	  # important. Changing the order may result in replacements being done
+		# multiple times.
+		# First, remove the domain from URLs that include the domain
+		&& VER="edge" \
+		&& BASEURL="$VER/" \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="http://docs-stage.docker.com/#href="/#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="https://docs-stage.docker.com/#src="/#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="https://docs.docker.com/#src="/#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="http://docs.docker.com/#href="/#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="http://docs.docker.com/#src="/#g' \
+		\
+		# Substitute https:// for schema-less resources (src="//analytics.google.com")
+		# We're replacing them to prevent them being seen as absolute paths below
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="//#href="https://#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="//#src="https://#g' \
+		\
+		# And some archive versions already have URLs starting with '/version/'
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/'"$BASEURL"'#href="/#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/'"$BASEURL"'#src="/#g' \
+		\
+		# Archived versions 1.7 and under use some absolute links, and v1.10 uses
+		# "relative" links to sources (href="./css/"). Remove those to make them
+		# work :)
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="\./#href="/#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="\./#src="/#g' \
+		\
+		# Create permalinks for archived versions
+		\
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="/#href="/'"$BASEURL"'#g' \
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#src="/#src="/'"$BASEURL"'#g' \
+		# Fix 'Back to Stable Docs' URL
+		&& find target/${VER} -type f -name '*.html' -print0 | xargs -0 sed -i 's#<li id="stable-cta"><a href="/edge/">Back to Stable docs</a></li>#<li id="stable-cta"><a href="/">Back to Stable docs</a></li>#g' \
+    && rm -rf md_source

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN svn co https://github.com/docker/docker/$ENGINE_SVN_BRANCH/docs/extend md_so
 	&& wget -O md_source/engine/reference/run.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/run.md \
 	&& wget -O md_source/engine/reference/commandline/cli.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/commandline/cli.md \
 	&& wget -O md_source/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
-	&& svn co https://github.com/docker/distribution/$DISTRIBUTION_SVN_BRANCH/docs/spec md_source/registry/spec \
+	&& svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_SVN_BRANCH/docs/spec md_source/registry/spec \
 	&& rm md_source/registry/spec/api.md.tmpl \
 	&& wget -O md_source/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
 	&& rm -rf md_source/apidocs/cloud-api-source \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN svn co https://github.com/docker/docker/$ENGINE_SVN_BRANCH/docs/extend md_so
 	&& wget -O md_source/engine/reference/run.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/run.md \
 	&& wget -O md_source/engine/reference/commandline/cli.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/reference/commandline/cli.md \
 	&& wget -O md_source/engine/deprecated.md https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/docs/deprecated.md \
-	&& svn co https://github.com/docker/distribution/branches/$DISTRIBUTION_SVN_BRANCH/docs/spec md_source/registry/spec \
+	&& svn co https://github.com/docker/distribution/$DISTRIBUTION_SVN_BRANCH/docs/spec md_source/registry/spec \
 	&& rm md_source/registry/spec/api.md.tmpl \
 	&& wget -O md_source/registry/configuration.md https://raw.githubusercontent.com/docker/distribution/$DISTRIBUTION_BRANCH/docs/configuration.md \
 	&& rm -rf md_source/apidocs/cloud-api-source \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ COPY . md_source
 # into static HTML in the "target" directory using Jekyll
 # then nuke the md_source directory.
 
+# Process this as an Edge release
+ENV EDGE 1
+
 ## Branch to pull from, per ref doc
 ## To get master from svn the svn branch needs to be 'trunk'. To get a branch from svn it needs to be 'branches/branchname'
 ENV ENGINE_SVN_BRANCH="branches/17.04.x"
@@ -43,7 +46,7 @@ RUN svn co https://github.com/docker/docker/$ENGINE_SVN_BRANCH/docs/extend md_so
   && wget -O md_source/engine/api/v1.25/swagger.yaml https://raw.githubusercontent.com/docker/docker/v1.13.0/api/swagger.yaml \
   && wget -O md_source/engine/api/v1.26/swagger.yaml https://raw.githubusercontent.com/docker/docker/v17.03.0-ce/api/swagger.yaml \
   && wget -O md_source/engine/api/v1.27/swagger.yaml https://raw.githubusercontent.com/docker/docker/$ENGINE_BRANCH/api/swagger.yaml \
-	&& jekyll build -s md_source -d target \
+	&& (if [ $EDGE -eq 1 ]; then jekyll build -s md_source -d target --config md_source/_config-edge.yml; else jekyll build -s md_source -d target; fi)\
 	&& rm -rf target/apidocs/layouts \
 	&& find target -type f -name '*.html' -print0 | xargs -0 sed -i 's#href="https://docs.docker.com/#href="/#g' \
 	&& rm -rf md_source

--- a/_config-edge.yml
+++ b/_config-edge.yml
@@ -1,0 +1,173 @@
+name: Docker CE Edge Documentation
+markdown: kramdown
+kramdown:
+  input: GFM
+  html_to_native: true
+  hard_wrap: false
+  syntax_highlighter: rouge
+  toc_levels: 2..3
+incremental: true
+permalink: pretty
+safe: false
+lsi: false
+url: https://docs.docker.com/edge/
+keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13"]
+edge: true  # set to true if the next expected release is going to the edge channel
+
+gems:
+  - jekyll-redirect-from
+  - jekyll-seo-tag
+  - jekyll-relative-links
+
+webrick:
+  headers:
+    Cache-Control: 600
+
+defaults:
+  -
+    scope:
+      path: ""
+      type: "pages"
+    values:
+      layout: docs
+      defaultassignee: johndmulhausen
+      enginebranch: 1.13.x
+      toc_min: 2
+      toc_max: 3
+      tree: true
+  - scope:
+      path: "compose"
+    values:
+      assignee: "londoncalling"
+  - scope:
+      path: "cs-engine"
+    values:
+      assignee: "joaofnfernandes"
+  - scope:
+      path: "datacenter"
+    values:
+      assignee: "joaofnfernandes"
+  - scope:
+      path: "docker-cloud"
+    values:
+      assignee: "londoncalling"
+  - scope:
+      path: "docker-for-mac"
+    values:
+      assignee: "londoncalling"
+  - scope:
+      path: "docker-for-windows"
+    values:
+      assignee: "londoncalling"
+  - scope:
+      path: "docker-hub"
+    values:
+      assignee: "johndmulhausen"
+  - scope:
+      path: "docker-store"
+    values:
+      assignee: "johndmulhausen"
+  - scope:
+      path: "engine"
+    values:
+      assignee: "mstanleyjones"
+  - scope:
+      path: "kitematic"
+    values:
+      assignee: "londoncalling"
+  - scope:
+      path: "machine"
+    values:
+      assignee: "londoncalling"
+  - scope:
+      path: "notary"
+    values:
+      assignee: "johndmulhausen"
+  - scope:
+      path: "registry"
+    values:
+      assignee: "joaofnfernandes"
+  - scope:
+      path: "swarm"
+    values:
+      assignee: "mstanleyjones"
+  - scope:
+      path: "toolbox"
+    values:
+      assignee: "londoncalling"
+  -
+    scope:
+      path: "datacenter"
+    values:
+      ucp_latest_image: "docker/ucp:2.1.2"
+      dtr_latest_image: "docker/dtr:2.2.3"
+  -
+    scope:
+      path: "datacenter/dtr/2.2"
+    values:
+      ucp_version: "2.1"
+      dtr_version: "2.2"
+      docker_image: "docker/dtr:2.2.3"
+  -
+    scope:
+      path: "datacenter/dtr/2.1"
+    values:
+      hide_from_sitemap: true
+      ucp_version: "2.0"
+      dtr_version: "2.1"
+  -
+    scope:
+      path: "datacenter/dtr/2.0"
+    values:
+      hide_from_sitemap: true
+      ucp_version: "1.1"
+      dtr_version: "2.0"
+  -
+    scope:
+      path: "datacenter/ucp/2.1"
+    values:
+      ucp_version: "2.1"
+      dtr_version: "2.2"
+      docker_image: "docker/ucp:2.1.2"
+  -
+    scope:
+      path: "datacenter/ucp/2.0"
+    values:
+      hide_from_sitemap: true
+      ucp_version: "2.0"
+      dtr_version: "2.1"
+      docker_image: "docker/ucp:2.0.3"
+  -
+    scope:
+      path: "datacenter/ucp/1.1"
+    values:
+      hide_from_sitemap: true
+      ucp_version: "1.1"
+      dtr_version: "2.0"
+  -
+    scope:
+      path: "apidocs/v1.3.3"
+    values:
+      hide_from_sitemap: true
+  -
+    scope:
+      path: "apidocs/v1.4.0"
+    values:
+      hide_from_sitemap: true
+  -
+    scope:
+      path: "apidocs/v2.0.0"
+    values:
+      hide_from_sitemap: true
+  -
+    scope:
+      path: "apidocs/v2.0.1"
+    values:
+      hide_from_sitemap: true
+
+# Assets
+#
+# We specify the directory for Jekyll so we can use @imports.
+sass:
+  sass_dir:          _scss
+  style:            :compressed

--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ safe: false
 lsi: false
 url: https://docs.docker.com
 keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13"]
-edge: true  # set to true if the next expected release is going to the edge channel
+edge: false  # set to true if the next expected release is going to the edge channel
 
 gems:
   - jekyll-redirect-from

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ safe: false
 lsi: false
 url: https://docs.docker.com
 keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13"]
+edge: true  # set to true if the next expected release is going to the edge channel
 
 gems:
   - jekyll-redirect-from

--- a/_data/docsarchive/archives.yaml
+++ b/_data/docsarchive/archives.yaml
@@ -1,4 +1,7 @@
 - archive:
+  name: edge
+  image: docs/docker.github.io:latest
+- archive:
   name: v17.03
   image: docs/docker.github.io:latest
   current: true

--- a/_data/engine-cli-edge/docker.yaml
+++ b/_data/engine-cli-edge/docker.yaml
@@ -1,0 +1,110 @@
+command: docker
+cname:
+- docker attach
+- docker build
+- docker checkpoint
+- docker commit
+- docker container
+- docker cp
+- docker create
+- docker deploy
+- docker diff
+- docker events
+- docker exec
+- docker export
+- docker history
+- docker image
+- docker images
+- docker import
+- docker info
+- docker inspect
+- docker kill
+- docker load
+- docker login
+- docker logout
+- docker logs
+- docker network
+- docker node
+- docker pause
+- docker plugin
+- docker port
+- docker ps
+- docker pull
+- docker push
+- docker rename
+- docker restart
+- docker rm
+- docker rmi
+- docker run
+- docker save
+- docker search
+- docker secret
+- docker service
+- docker stack
+- docker start
+- docker stats
+- docker stop
+- docker swarm
+- docker system
+- docker tag
+- docker top
+- docker unpause
+- docker update
+- docker version
+- docker volume
+- docker wait
+clink:
+- docker_attach.yaml
+- docker_build.yaml
+- docker_checkpoint.yaml
+- docker_commit.yaml
+- docker_container.yaml
+- docker_cp.yaml
+- docker_create.yaml
+- docker_deploy.yaml
+- docker_diff.yaml
+- docker_events.yaml
+- docker_exec.yaml
+- docker_export.yaml
+- docker_history.yaml
+- docker_image.yaml
+- docker_images.yaml
+- docker_import.yaml
+- docker_info.yaml
+- docker_inspect.yaml
+- docker_kill.yaml
+- docker_load.yaml
+- docker_login.yaml
+- docker_logout.yaml
+- docker_logs.yaml
+- docker_network.yaml
+- docker_node.yaml
+- docker_pause.yaml
+- docker_plugin.yaml
+- docker_port.yaml
+- docker_ps.yaml
+- docker_pull.yaml
+- docker_push.yaml
+- docker_rename.yaml
+- docker_restart.yaml
+- docker_rm.yaml
+- docker_rmi.yaml
+- docker_run.yaml
+- docker_save.yaml
+- docker_search.yaml
+- docker_secret.yaml
+- docker_service.yaml
+- docker_stack.yaml
+- docker_start.yaml
+- docker_stats.yaml
+- docker_stop.yaml
+- docker_swarm.yaml
+- docker_system.yaml
+- docker_tag.yaml
+- docker_top.yaml
+- docker_unpause.yaml
+- docker_update.yaml
+- docker_version.yaml
+- docker_volume.yaml
+- docker_wait.yaml
+

--- a/_data/engine-cli-edge/docker_attach.yaml
+++ b/_data/engine-cli-edge/docker_attach.yaml
@@ -1,0 +1,135 @@
+command: docker attach
+short: Attach to a running container
+long: |-
+  Use `docker attach` to attach to a running container using the container's ID
+  or name, either to view its ongoing output or to control it interactively.
+  You can attach to the same contained process multiple times simultaneously,
+  screen sharing style, or quickly view the progress of your detached process.
+
+  To stop a container, use `CTRL-c`. This key sequence sends `SIGKILL` to the
+  container. If `--sig-proxy` is true (the default),`CTRL-c` sends a `SIGINT` to
+  the container. You can detach from a container and leave it running using the
+   `CTRL-p CTRL-q` key sequence.
+
+  > **Note:**
+  > A process running as PID 1 inside a container is treated specially by
+  > Linux: it ignores any signal with the default action. So, the process
+  > will not terminate on `SIGINT` or `SIGTERM` unless it is coded to do
+  > so.
+
+  It is forbidden to redirect the standard input of a `docker attach` command
+  while attaching to a tty-enabled container (i.e.: launched with `-t`).
+
+  While a client is connected to container's stdio using `docker attach`, Docker
+  uses a ~1MB memory buffer to maximize the throughput of the application. If
+  this buffer is filled, the speed of the API connection will start to have an
+  effect on the process output writing speed. This is similar to other
+  applications like SSH. Because of this, it is not recommended to run
+  performance critical applications that generate a lot of output in the
+  foreground over a slow client connection. Instead, users should use the
+  `docker logs` command to get access to the logs.
+
+  ### Override the detach sequence
+
+  If you want, you can configure an override the Docker key sequence for detach.
+  This is useful if the Docker default sequence conflicts with key sequence you
+  use for other applications. There are two ways to define your own detach key
+  sequence, as a per-container override or as a configuration property on  your
+  entire configuration.
+
+  To override the sequence for an individual container, use the
+  `--detach-keys="<sequence>"` flag with the `docker attach` command. The format of
+  the `<sequence>` is either a letter [a-Z], or the `ctrl-` combined with any of
+  the following:
+
+  * `a-z` (a single lowercase alpha character )
+  * `@` (at sign)
+  * `[` (left bracket)
+  * `\\` (two backward slashes)
+  *  `_` (underscore)
+  * `^` (caret)
+
+  These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
+  sequences. To configure a different configuration default key sequence for all
+  containers, see [**Configuration file** section](cli.md#configuration-files).
+usage: docker attach [OPTIONS] CONTAINER
+pname: docker
+plink: docker.yaml
+options:
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: no-stdin
+  default_value: "false"
+  description: Do not attach STDIN
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy all received signals to the process
+examples: |-
+  ### Attach to and detach from a running container
+
+  ```bash
+  $ docker run -d --name topdemo ubuntu /usr/bin/top -b
+
+  $ docker attach topdemo
+
+  top - 02:05:52 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
+  Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+  Cpu(s):  0.1%us,  0.2%sy,  0.0%ni, 99.7%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
+  Mem:    373572k total,   355560k used,    18012k free,    27872k buffers
+  Swap:   786428k total,        0k used,   786428k free,   221740k cached
+
+  PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
+   1 root      20   0 17200 1116  912 R    0  0.3   0:00.03 top
+
+   top - 02:05:55 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
+   Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+   Cpu(s):  0.0%us,  0.2%sy,  0.0%ni, 99.8%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
+   Mem:    373572k total,   355244k used,    18328k free,    27872k buffers
+   Swap:   786428k total,        0k used,   786428k free,   221776k cached
+
+     PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
+         1 root      20   0 17208 1144  932 R    0  0.3   0:00.03 top
+
+
+   top - 02:05:58 up  3:06,  0 users,  load average: 0.01, 0.02, 0.05
+   Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+   Cpu(s):  0.2%us,  0.3%sy,  0.0%ni, 99.5%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
+   Mem:    373572k total,   355780k used,    17792k free,    27880k buffers
+   Swap:   786428k total,        0k used,   786428k free,   221776k cached
+
+   PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
+        1 root      20   0 17208 1144  932 R    0  0.3   0:00.03 top
+  ^C$
+
+  $ echo $?
+  0
+  $ docker ps -a | grep topdemo
+
+  7998ac8581f9        ubuntu:14.04        "/usr/bin/top -b"   38 seconds ago      Exited (0) 21 seconds ago                          topdemo
+  ```
+
+  ### Get the exit code of the container's command
+
+  And in this second example, you can see the exit code returned by the `bash`
+  process is returned by the `docker attach` command to its caller too:
+
+  ```bash
+      $ docker run --name test -d -it debian
+
+      275c44472aebd77c926d4527885bb09f2f6db21d878c75f0a1c212c03d3bcfab
+
+      $ docker attach test
+
+      root@f38c87f2a42d:/# exit 13
+
+      exit
+
+      $ echo $?
+
+      13
+
+      $ docker ps -a | grep test
+
+      275c44472aeb        debian:7            "/bin/bash"         26 seconds ago      Exited (13) 17 seconds ago                         test
+  ```
+

--- a/_data/engine-cli-edge/docker_build.yaml
+++ b/_data/engine-cli-edge/docker_build.yaml
@@ -1,0 +1,445 @@
+command: docker build
+short: Build an image from a Dockerfile
+long: |-
+  Builds Docker images from a Dockerfile and a "context". A build's context is
+  the files located in the specified `PATH` or `URL`. The build process can refer
+  to any of the files in the context. For example, your build can use an
+  [*ADD*](../builder.md#add) instruction to reference a file in the
+  context.
+
+  The `URL` parameter can refer to three kinds of resources: Git repositories,
+  pre-packaged tarball contexts and plain text files.
+
+  ### Git repositories
+
+  When the `URL` parameter points to the location of a Git repository, the
+  repository acts as the build context. The system recursively clones the
+  repository and its submodules using a `git clone --depth 1 --recursive`
+  command. This command runs in a temporary directory on your local host. After
+  the command succeeds, the directory is sent to the Docker daemon as the
+  context. Local clones give you the ability to access private repositories using
+  local user credentials, VPN's, and so forth.
+
+  Git URLs accept context configuration in their fragment section, separated by a
+  colon `:`.  The first part represents the reference that Git will check out,
+  this can be either a branch, a tag, or a commit SHA. The second part represents
+  a subdirectory inside the repository that will be used as a build context.
+
+  For example, run this command to use a directory called `docker` in the branch
+  `container`:
+
+  ```bash
+  $ docker build https://github.com/docker/rootfs.git#container:docker
+  ```
+
+  The following table represents all the valid suffixes with their build
+  contexts:
+
+  Build Syntax Suffix             | Commit Used           | Build Context Used
+  --------------------------------|-----------------------|-------------------
+  `myrepo.git`                    | `refs/heads/master`   | `/`
+  `myrepo.git#mytag`              | `refs/tags/mytag`     | `/`
+  `myrepo.git#mybranch`           | `refs/heads/mybranch` | `/`
+  `myrepo.git#abcdef`             | `sha1 = abcdef`       | `/`
+  `myrepo.git#:myfolder`          | `refs/heads/master`   | `/myfolder`
+  `myrepo.git#master:myfolder`    | `refs/heads/master`   | `/myfolder`
+  `myrepo.git#mytag:myfolder`     | `refs/tags/mytag`     | `/myfolder`
+  `myrepo.git#mybranch:myfolder`  | `refs/heads/mybranch` | `/myfolder`
+  `myrepo.git#abcdef:myfolder`    | `sha1 = abcdef`       | `/myfolder`
+
+
+  ### Tarball contexts
+
+  If you pass an URL to a remote tarball, the URL itself is sent to the daemon:
+
+  ```bash
+  $ docker build http://server/context.tar.gz
+  ```
+
+  The download operation will be performed on the host the Docker daemon is
+  running on, which is not necessarily the same host from which the build command
+  is being issued. The Docker daemon will fetch `context.tar.gz` and use it as the
+  build context. Tarball contexts must be tar archives conforming to the standard
+  `tar` UNIX format and can be compressed with any one of the 'xz', 'bzip2',
+  'gzip' or 'identity' (no compression) formats.
+
+  ### Text files
+
+  Instead of specifying a context, you can pass a single `Dockerfile` in the
+  `URL` or pipe the file in via `STDIN`. To pipe a `Dockerfile` from `STDIN`:
+
+  ```bash
+  $ docker build - < Dockerfile
+  ```
+
+  With Powershell on Windows, you can run:
+
+  ```powershell
+  Get-Content Dockerfile | docker build -
+  ```
+
+  If you use `STDIN` or specify a `URL` pointing to a plain text file, the system
+  places the contents into a file called `Dockerfile`, and any `-f`, `--file`
+  option is ignored. In this scenario, there is no context.
+
+  By default the `docker build` command will look for a `Dockerfile` at the root
+  of the build context. The `-f`, `--file`, option lets you specify the path to
+  an alternative file to use instead. This is useful in cases where the same set
+  of files are used for multiple builds. The path must be to a file within the
+  build context. If a relative path is specified then it is interpreted as
+  relative to the root of the context.
+
+  In most cases, it's best to put each Dockerfile in an empty directory. Then,
+  add to that directory only the files needed for building the Dockerfile. To
+  increase the build's performance, you can exclude files and directories by
+  adding a `.dockerignore` file to that directory as well. For information on
+  creating one, see the [.dockerignore file](../builder.md#dockerignore-file).
+
+  If the Docker client loses connection to the daemon, the build is canceled.
+  This happens if you interrupt the Docker client with `CTRL-c` or if the Docker
+  client is killed for any reason. If the build initiated a pull which is still
+  running at the time the build is cancelled, the pull is cancelled as well.
+usage: docker build [OPTIONS] PATH | URL | -
+pname: docker
+plink: docker.yaml
+options:
+- option: build-arg
+  default_value: '[]'
+  description: Set build-time variables
+- option: cache-from
+  default_value: '[]'
+  description: Images to consider as cache sources
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: compress
+  default_value: "false"
+  description: Compress the build context using gzip
+- option: cpu-period
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: file
+  shorthand: f
+  description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
+- option: force-rm
+  default_value: "false"
+  description: Always remove intermediate containers
+- option: isolation
+  description: Container isolation technology
+- option: label
+  default_value: '[]'
+  description: Set metadata for an image
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: network
+  default_value: default
+  description: |
+    Set the networking mode for the RUN instructions during build
+- option: no-cache
+  default_value: "false"
+  description: Do not use cache when building the image
+- option: pull
+  default_value: "false"
+  description: Always attempt to pull a newer version of the image
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the build output and print image ID on success
+- option: rm
+  default_value: "true"
+  description: Remove intermediate containers after a successful build
+- option: security-opt
+  default_value: '[]'
+  description: Security options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: squash
+  default_value: "false"
+  description: Squash newly built layers into a single new layer
+- option: tag
+  shorthand: t
+  default_value: '[]'
+  description: Name and optionally a tag in the 'name:tag' format
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+examples: |-
+  ### Build with PATH
+
+  ```bash
+  $ docker build .
+
+  Uploading context 10240 bytes
+  Step 1/3 : FROM busybox
+  Pulling repository busybox
+   ---> e9aa60c60128MB/2.284 MB (100%) endpoint: https://cdn-registry-1.docker.io/v1/
+  Step 2/3 : RUN ls -lh /
+   ---> Running in 9c9e81692ae9
+  total 24
+  drwxr-xr-x    2 root     root        4.0K Mar 12  2013 bin
+  drwxr-xr-x    5 root     root        4.0K Oct 19 00:19 dev
+  drwxr-xr-x    2 root     root        4.0K Oct 19 00:19 etc
+  drwxr-xr-x    2 root     root        4.0K Nov 15 23:34 lib
+  lrwxrwxrwx    1 root     root           3 Mar 12  2013 lib64 -> lib
+  dr-xr-xr-x  116 root     root           0 Nov 15 23:34 proc
+  lrwxrwxrwx    1 root     root           3 Mar 12  2013 sbin -> bin
+  dr-xr-xr-x   13 root     root           0 Nov 15 23:34 sys
+  drwxr-xr-x    2 root     root        4.0K Mar 12  2013 tmp
+  drwxr-xr-x    2 root     root        4.0K Nov 15 23:34 usr
+   ---> b35f4035db3f
+  Step 3/3 : CMD echo Hello world
+   ---> Running in 02071fceb21b
+   ---> f52f38b7823e
+  Successfully built f52f38b7823e
+  Removing intermediate container 9c9e81692ae9
+  Removing intermediate container 02071fceb21b
+  ```
+
+  This example specifies that the `PATH` is `.`, and so all the files in the
+  local directory get `tar`d and sent to the Docker daemon. The `PATH` specifies
+  where to find the files for the "context" of the build on the Docker daemon.
+  Remember that the daemon could be running on a remote machine and that no
+  parsing of the Dockerfile happens at the client side (where you're running
+  `docker build`). That means that *all* the files at `PATH` get sent, not just
+  the ones listed to [*ADD*](../builder.md#add) in the Dockerfile.
+
+  The transfer of context from the local machine to the Docker daemon is what the
+  `docker` client means when you see the "Sending build context" message.
+
+  If you wish to keep the intermediate containers after the build is complete,
+  you must use `--rm=false`. This does not affect the build cache.
+
+  ### Build with URL
+
+  ```bash
+  $ docker build github.com/creack/docker-firefox
+  ```
+
+  This will clone the GitHub repository and use the cloned repository as context.
+  The Dockerfile at the root of the repository is used as Dockerfile. You can
+  specify an arbitrary Git repository by using the `git://` or `git@` scheme.
+
+  ```bash
+  $ docker build -f ctx/Dockerfile http://server/ctx.tar.gz
+
+  Downloading context: http://server/ctx.tar.gz [===================>]    240 B/240 B
+  Step 1/3 : FROM busybox
+   ---> 8c2e06607696
+  Step 2/3 : ADD ctx/container.cfg /
+   ---> e7829950cee3
+  Removing intermediate container b35224abf821
+  Step 3/3 : CMD /bin/ls
+   ---> Running in fbc63d321d73
+   ---> 3286931702ad
+  Removing intermediate container fbc63d321d73
+  Successfully built 377c409b35e4
+  ```
+
+  This sends the URL `http://server/ctx.tar.gz` to the Docker daemon, which
+  downloads and extracts the referenced tarball. The `-f ctx/Dockerfile`
+  parameter specifies a path inside `ctx.tar.gz` to the `Dockerfile` that is used
+  to build the image. Any `ADD` commands in that `Dockerfile` that refer to local
+  paths must be relative to the root of the contents inside `ctx.tar.gz`. In the
+  example above, the tarball contains a directory `ctx/`, so the `ADD
+  ctx/container.cfg /` operation works as expected.
+
+  ### Build with -
+
+  ```bash
+  $ docker build - < Dockerfile
+  ```
+
+  This will read a Dockerfile from `STDIN` without context. Due to the lack of a
+  context, no contents of any local directory will be sent to the Docker daemon.
+  Since there is no context, a Dockerfile `ADD` only works if it refers to a
+  remote URL.
+
+  ```bash
+  $ docker build - < context.tar.gz
+  ```
+
+  This will build an image for a compressed context read from `STDIN`.  Supported
+  formats are: bzip2, gzip and xz.
+
+  ### Use a .dockerignore file
+
+  ```bash
+  $ docker build .
+
+  Uploading context 18.829 MB
+  Uploading context
+  Step 1/2 : FROM busybox
+   ---> 769b9341d937
+  Step 2/2 : CMD echo Hello world
+   ---> Using cache
+   ---> 99cc1ad10469
+  Successfully built 99cc1ad10469
+  $ echo ".git" > .dockerignore
+  $ docker build .
+  Uploading context  6.76 MB
+  Uploading context
+  Step 1/2 : FROM busybox
+   ---> 769b9341d937
+  Step 2/2 : CMD echo Hello world
+   ---> Using cache
+   ---> 99cc1ad10469
+  Successfully built 99cc1ad10469
+  ```
+
+  This example shows the use of the `.dockerignore` file to exclude the `.git`
+  directory from the context. Its effect can be seen in the changed size of the
+  uploaded context. The builder reference contains detailed information on
+  [creating a .dockerignore file](../builder.md#dockerignore-file)
+
+  ### Tag an image (-t)
+
+  ```bash
+  $ docker build -t vieux/apache:2.0 .
+  ```
+
+  This will build like the previous example, but it will then tag the resulting
+  image. The repository name will be `vieux/apache` and the tag will be `2.0`.
+  [Read more about valid tags](tag.md).
+
+  You can apply multiple tags to an image. For example, you can apply the `latest`
+  tag to a newly built image and add another tag that references a specific
+  version.
+  For example, to tag an image both as `whenry/fedora-jboss:latest` and
+  `whenry/fedora-jboss:v2.1`, use the following:
+
+  ```bash
+  $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
+  ```
+  ### Specify a Dockerfile (-f)
+
+  ```bash
+  $ docker build -f Dockerfile.debug .
+  ```
+
+  This will use a file called `Dockerfile.debug` for the build instructions
+  instead of `Dockerfile`.
+
+  ```bash
+  $ docker build -f dockerfiles/Dockerfile.debug -t myapp_debug .
+  $ docker build -f dockerfiles/Dockerfile.prod  -t myapp_prod .
+  ```
+
+  The above commands will build the current build context (as specified by the
+  `.`) twice, once using a debug version of a `Dockerfile` and once using a
+  production version.
+
+  ```bash
+  $ cd /home/me/myapp/some/dir/really/deep
+  $ docker build -f /home/me/myapp/dockerfiles/debug /home/me/myapp
+  $ docker build -f ../../../../dockerfiles/debug /home/me/myapp
+  ```
+
+  These two `docker build` commands do the exact same thing. They both use the
+  contents of the `debug` file instead of looking for a `Dockerfile` and will use
+  `/home/me/myapp` as the root of the build context. Note that `debug` is in the
+  directory structure of the build context, regardless of how you refer to it on
+  the command line.
+
+  > **Note:**
+  > `docker build` will return a `no such file or directory` error if the
+  > file or directory does not exist in the uploaded context. This may
+  > happen if there is no context, or if you specify a file that is
+  > elsewhere on the Host system. The context is limited to the current
+  > directory (and its children) for security reasons, and to ensure
+  > repeatable builds on remote Docker hosts. This is also the reason why
+  > `ADD ../file` will not work.
+
+  ### Use a custom parent cgroup (--cgroup-parent)
+
+  When `docker build` is run with the `--cgroup-parent` option the containers
+  used in the build will be run with the [corresponding `docker run`
+  flag](../run.md#specifying-custom-cgroups).
+
+  ### Set ulimits in container (--ulimit)
+
+  Using the `--ulimit` option with `docker build` will cause each build step's
+  container to be started using those [`--ulimit`
+  flag values](./run.md#set-ulimits-in-container-ulimit).
+
+  ### Set build-time variables (--build-arg)
+
+  You can use `ENV` instructions in a Dockerfile to define variable
+  values. These values persist in the built image. However, often
+  persistence is not what you want. Users want to specify variables differently
+  depending on which host they build an image on.
+
+  A good example is `http_proxy` or source versions for pulling intermediate
+  files. The `ARG` instruction lets Dockerfile authors define values that users
+  can set at build-time using the  `--build-arg` flag:
+
+  ```bash
+  $ docker build --build-arg HTTP_PROXY=http://10.20.30.2:1234 .
+  ```
+
+  This flag allows you to pass the build-time variables that are
+  accessed like regular environment variables in the `RUN` instruction of the
+  Dockerfile. Also, these values don't persist in the intermediate or final images
+  like `ENV` values do.
+
+  Using this flag will not alter the output you see when the `ARG` lines from the
+  Dockerfile are echoed during the build process.
+
+  For detailed information on using `ARG` and `ENV` instructions, see the
+  [Dockerfile reference](../builder.md).
+
+  ### Optional security options (--security-opt)
+
+  This flag is only supported on a daemon running on Windows, and only supports
+  the `credentialspec` option. The `credentialspec` must be in the format
+  `file://spec.txt` or `registry://keyname`.
+
+  ### Specify isolation technology for container (--isolation)
+
+  This option is useful in situations where you are running Docker containers on
+  Windows. The `--isolation=<value>` option sets a container's isolation
+  technology. On Linux, the only supported is the `default` option which uses
+  Linux namespaces. On Microsoft Windows, you can specify these values:
+
+
+  | Value     | Description                                                                                                                                                   |
+  |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value.  |
+  | `process` | Namespace isolation only.                                                                                                                                     |
+  | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                 |
+
+  Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
+
+
+  ### Squash an image's layers (--squash) **Experimental Only**
+
+  Once the image is built, squash the new layers into a new image with a single
+  new layer. Squashing does not destroy any existing image, rather it creates a new
+  image with the content of the squshed layers. This effectively makes it look
+  like all `Dockerfile` commands were created with a single layer. The build
+  cache is preserved with this method.
+
+  **Note**: using this option means the new image will not be able to take
+  advantage of layer sharing with other images and may use significantly more
+  space.
+
+  **Note**: using this option you may see significantly more space used due to
+  storing two copies of the image, one for the build cache with all the cache
+  layers in tact, and one for the squashed version.
+

--- a/_data/engine-cli-edge/docker_checkpoint.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint.yaml
@@ -1,0 +1,15 @@
+command: docker checkpoint
+short: Manage checkpoints
+long: Manage checkpoints
+usage: docker checkpoint
+pname: docker
+plink: docker.yaml
+cname:
+- docker checkpoint create
+- docker checkpoint ls
+- docker checkpoint rm
+clink:
+- docker_checkpoint_create.yaml
+- docker_checkpoint_ls.yaml
+- docker_checkpoint_rm.yaml
+

--- a/_data/engine-cli-edge/docker_checkpoint_create.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint_create.yaml
@@ -1,0 +1,13 @@
+command: docker checkpoint create
+short: Create a checkpoint from a running container
+long: Create a checkpoint from a running container
+usage: docker checkpoint create [OPTIONS] CONTAINER CHECKPOINT
+pname: docker checkpoint
+plink: docker_checkpoint.yaml
+options:
+- option: checkpoint-dir
+  description: Use a custom checkpoint storage directory
+- option: leave-running
+  default_value: "false"
+  description: Leave the container running after checkpoint
+

--- a/_data/engine-cli-edge/docker_checkpoint_ls.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint_ls.yaml
@@ -1,0 +1,11 @@
+command: docker checkpoint ls
+aliases: list
+short: List checkpoints for a container
+long: List checkpoints for a container
+usage: docker checkpoint ls [OPTIONS] CONTAINER
+pname: docker checkpoint
+plink: docker_checkpoint.yaml
+options:
+- option: checkpoint-dir
+  description: Use a custom checkpoint storage directory
+

--- a/_data/engine-cli-edge/docker_checkpoint_rm.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint_rm.yaml
@@ -1,0 +1,11 @@
+command: docker checkpoint rm
+aliases: remove
+short: Remove a checkpoint
+long: Remove a checkpoint
+usage: docker checkpoint rm [OPTIONS] CONTAINER CHECKPOINT
+pname: docker checkpoint
+plink: docker_checkpoint.yaml
+options:
+- option: checkpoint-dir
+  description: Use a custom checkpoint storage directory
+

--- a/_data/engine-cli-edge/docker_commit.yaml
+++ b/_data/engine-cli-edge/docker_commit.yaml
@@ -1,0 +1,105 @@
+command: docker commit
+short: Create a new image from a container's changes
+long: |-
+  It can be useful to commit a container's file changes or settings into a new
+  image. This allows you debug a container by running an interactive shell, or to
+  export a working dataset to another server. Generally, it is better to use
+  Dockerfiles to manage your images in a documented and maintainable way.
+  [Read more about valid image names and tags](tag.md).
+
+  The commit operation will not include any data contained in
+  volumes mounted inside the container.
+
+  By default, the container being committed and its processes will be paused
+  while the image is committed. This reduces the likelihood of encountering data
+  corruption during the process of creating the commit.  If this behavior is
+  undesired, set the `--pause` option to false.
+
+  The `--change` option will apply `Dockerfile` instructions to the image that is
+  created.  Supported `Dockerfile` instructions:
+  `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`LABEL`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
+usage: docker commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]
+pname: docker
+plink: docker.yaml
+options:
+- option: author
+  shorthand: a
+  description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Commit message
+- option: pause
+  shorthand: p
+  default_value: "true"
+  description: Pause container during commit
+examples: |-
+  ### Commit a container
+
+  ```bash
+  $ docker ps
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
+  c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+
+  $ docker commit c3f279d17e0a  svendowideit/testimage:version3
+
+  f5283438590d
+
+  $ docker images
+
+  REPOSITORY                        TAG                 ID                  CREATED             SIZE
+  svendowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
+  ```
+
+  ### Commit a container with new configurations
+
+  ```bash
+  $ docker ps
+
+  CONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
+  c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+
+  $ docker inspect -f "{{ .Config.Env }}" c3f279d17e0a
+
+  [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]
+
+  $ docker commit --change "ENV DEBUG true" c3f279d17e0a  svendowideit/testimage:version3
+
+  f5283438590d
+
+  $ docker inspect -f "{{ .Config.Env }}" f5283438590d
+
+  [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin DEBUG=true]
+  ```
+
+  ### Commit a container with new `CMD` and `EXPOSE` instructions
+
+  ```bash
+  $ docker ps
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
+  c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+
+  $ docker commit --change='CMD ["apachectl", "-DFOREGROUND"]' -c "EXPOSE 80" c3f279d17e0a  svendowideit/testimage:version4
+
+  f5283438590d
+
+  $ docker run -d svendowideit/testimage:version4
+
+  89373736e2e7f00bc149bd783073ac43d0507da250e999f3f1036e0db60817c0
+
+  $ docker ps
+
+  CONTAINER ID        IMAGE               COMMAND                 CREATED             STATUS              PORTS              NAMES
+  89373736e2e7        testimage:version4  "apachectl -DFOREGROU"  3 seconds ago       Up 2 seconds        80/tcp             distracted_fermat
+  c3f279d17e0a        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours                            focused_hamilton
+  ```
+

--- a/_data/engine-cli-edge/docker_container.yaml
+++ b/_data/engine-cli-edge/docker_container.yaml
@@ -1,0 +1,59 @@
+command: docker container
+short: Manage containers
+long: Manage containers.
+usage: docker container
+pname: docker
+plink: docker.yaml
+cname:
+- docker container attach
+- docker container commit
+- docker container cp
+- docker container create
+- docker container diff
+- docker container exec
+- docker container export
+- docker container inspect
+- docker container kill
+- docker container logs
+- docker container ls
+- docker container pause
+- docker container port
+- docker container prune
+- docker container rename
+- docker container restart
+- docker container rm
+- docker container run
+- docker container start
+- docker container stats
+- docker container stop
+- docker container top
+- docker container unpause
+- docker container update
+- docker container wait
+clink:
+- docker_container_attach.yaml
+- docker_container_commit.yaml
+- docker_container_cp.yaml
+- docker_container_create.yaml
+- docker_container_diff.yaml
+- docker_container_exec.yaml
+- docker_container_export.yaml
+- docker_container_inspect.yaml
+- docker_container_kill.yaml
+- docker_container_logs.yaml
+- docker_container_ls.yaml
+- docker_container_pause.yaml
+- docker_container_port.yaml
+- docker_container_prune.yaml
+- docker_container_rename.yaml
+- docker_container_restart.yaml
+- docker_container_rm.yaml
+- docker_container_run.yaml
+- docker_container_start.yaml
+- docker_container_stats.yaml
+- docker_container_stop.yaml
+- docker_container_top.yaml
+- docker_container_unpause.yaml
+- docker_container_update.yaml
+- docker_container_wait.yaml
+

--- a/_data/engine-cli-edge/docker_container_attach.yaml
+++ b/_data/engine-cli-edge/docker_container_attach.yaml
@@ -1,0 +1,16 @@
+command: docker container attach
+short: Attach to a running container
+long: Attach to a running container
+usage: docker container attach [OPTIONS] CONTAINER
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: no-stdin
+  default_value: "false"
+  description: Do not attach STDIN
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy all received signals to the process
+

--- a/_data/engine-cli-edge/docker_container_commit.yaml
+++ b/_data/engine-cli-edge/docker_container_commit.yaml
@@ -1,0 +1,22 @@
+command: docker container commit
+short: Create a new image from a container's changes
+long: Create a new image from a container's changes
+usage: docker container commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: author
+  shorthand: a
+  description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Commit message
+- option: pause
+  shorthand: p
+  default_value: "true"
+  description: Pause container during commit
+

--- a/_data/engine-cli-edge/docker_container_cp.yaml
+++ b/_data/engine-cli-edge/docker_container_cp.yaml
@@ -1,0 +1,19 @@
+command: docker container cp
+short: Copy files/folders between a container and the local filesystem
+long: |-
+  Copy files/folders between a container and the local filesystem
+
+  Use '-' as the source to read a tar archive from stdin
+  and extract it to a directory destination in a container.
+  Use '-' as the destination to stream a tar archive of a
+  container source to stdout.
+usage: "docker container cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp
+  [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH"
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: follow-link
+  shorthand: L
+  default_value: "false"
+  description: Always follow symbol link in SRC_PATH
+

--- a/_data/engine-cli-edge/docker_container_create.yaml
+++ b/_data/engine-cli-edge/docker_container_create.yaml
@@ -1,0 +1,279 @@
+command: docker container create
+short: Create a new container
+long: Create a new container
+usage: docker container create [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: |
+    Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-count
+  default_value: "0"
+  description: CPU count (Windows only)
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-rt-period
+  default_value: "0"
+  description: Limit CPU real-time period in microseconds
+- option: cpu-rt-runtime
+  default_value: "0"
+  description: Limit CPU real-time runtime in microseconds
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpus
+  default_value: "0.000"
+  description: Number of CPUs
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-option
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: 0s
+  description: Time between running the check (ns|us|ms|s|m|h) (default 0s)
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: 0s
+  description: |
+    Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: stop-timeout
+  default_value: "0"
+  description: Timeout (in seconds) to stop a container
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container
+

--- a/_data/engine-cli-edge/docker_container_diff.yaml
+++ b/_data/engine-cli-edge/docker_container_diff.yaml
@@ -1,0 +1,7 @@
+command: docker container diff
+short: Inspect changes to files or directories on a container's filesystem
+long: Inspect changes to files or directories on a container's filesystem
+usage: docker container diff CONTAINER
+pname: docker container
+plink: docker_container.yaml
+

--- a/_data/engine-cli-edge/docker_container_exec.yaml
+++ b/_data/engine-cli-edge/docker_container_exec.yaml
@@ -1,0 +1,32 @@
+command: docker container exec
+short: Run a command in a running container
+long: Run a command in a running container
+usage: docker container exec [OPTIONS] CONTAINER COMMAND [ARG...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: 'Detached mode: run command in the background'
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to the command
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+

--- a/_data/engine-cli-edge/docker_container_export.yaml
+++ b/_data/engine-cli-edge/docker_container_export.yaml
@@ -1,0 +1,11 @@
+command: docker container export
+short: Export a container's filesystem as a tar archive
+long: Export a container's filesystem as a tar archive
+usage: docker container export [OPTIONS] CONTAINER
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT
+

--- a/_data/engine-cli-edge/docker_container_inspect.yaml
+++ b/_data/engine-cli-edge/docker_container_inspect.yaml
@@ -1,0 +1,15 @@
+command: docker container inspect
+short: Display detailed information on one or more containers
+long: Display detailed information on one or more containers
+usage: docker container inspect [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes
+

--- a/_data/engine-cli-edge/docker_container_kill.yaml
+++ b/_data/engine-cli-edge/docker_container_kill.yaml
@@ -1,0 +1,12 @@
+command: docker container kill
+short: Kill one or more running containers
+long: Kill one or more running containers
+usage: docker container kill [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: signal
+  shorthand: s
+  default_value: KILL
+  description: Signal to send to the container
+

--- a/_data/engine-cli-edge/docker_container_logs.yaml
+++ b/_data/engine-cli-edge/docker_container_logs.yaml
@@ -1,0 +1,24 @@
+command: docker container logs
+short: Fetch the logs of a container
+long: Fetch the logs of a container
+usage: docker container logs [OPTIONS] CONTAINER
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: details
+  default_value: "false"
+  description: Show extra details provided to logs
+- option: follow
+  shorthand: f
+  default_value: "false"
+  description: Follow log output
+- option: since
+  description: Show logs since timestamp
+- option: tail
+  default_value: all
+  description: Number of lines to show from the end of the logs
+- option: timestamps
+  shorthand: t
+  default_value: "false"
+  description: Show timestamps
+

--- a/_data/engine-cli-edge/docker_container_ls.yaml
+++ b/_data/engine-cli-edge/docker_container_ls.yaml
@@ -1,0 +1,37 @@
+command: docker container ls
+aliases: ps, list
+short: List containers
+long: List containers
+usage: docker container ls [OPTIONS]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print containers using a Go template
+- option: last
+  shorthand: "n"
+  default_value: "-1"
+  description: Show n last created containers (includes all states)
+- option: latest
+  shorthand: l
+  default_value: "false"
+  description: Show the latest created container (includes all states)
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display numeric IDs
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes
+

--- a/_data/engine-cli-edge/docker_container_pause.yaml
+++ b/_data/engine-cli-edge/docker_container_pause.yaml
@@ -1,0 +1,7 @@
+command: docker container pause
+short: Pause all processes within one or more containers
+long: Pause all processes within one or more containers
+usage: docker container pause CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+

--- a/_data/engine-cli-edge/docker_container_port.yaml
+++ b/_data/engine-cli-edge/docker_container_port.yaml
@@ -1,0 +1,7 @@
+command: docker container port
+short: List port mappings or a specific mapping for the container
+long: List port mappings or a specific mapping for the container
+usage: docker container port CONTAINER [PRIVATE_PORT[/PROTO]]
+pname: docker container
+plink: docker_container.yaml
+

--- a/_data/engine-cli-edge/docker_container_prune.yaml
+++ b/_data/engine-cli-edge/docker_container_prune.yaml
@@ -1,0 +1,90 @@
+command: docker container prune
+short: Remove all stopped containers
+long: Removes all stopped containers.
+usage: docker container prune [OPTIONS]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation
+examples: |-
+  ### Prune containers
+
+  ```bash
+  $ docker container prune
+  WARNING! This will remove all stopped containers.
+  Are you sure you want to continue? [y/N] y
+  Deleted Containers:
+  4a7f7eebae0f63178aff7eb0aa39cd3f0627a203ab2df258c1a00b456cf20063
+  f98f9c2aa1eaf727e4ec9c0283bc7d4aa4762fbdba7f26191f26c97f64090360
+
+  Total reclaimed space: 212 B
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * until (`<timestamp>`) - only remove containers created before given timestamp
+
+  The `until` filter can be Unix timestamps, date formatted
+  timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
+  relative to the daemon machine’s time. Supported formats for date
+  formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the daemon will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long.
+
+  The following removes containers created more than 5 minutes ago:
+
+  ```bash
+  $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
+  61b9efa71024        busybox             "sh"                2017-01-04 13:23:33 -0800 PST   Exited (0) 41 seconds ago
+  53a9bc23a516        busybox             "sh"                2017-01-04 13:11:59 -0800 PST   Exited (0) 12 minutes ago
+
+  $ docker container prune --force --filter "until=5m"
+
+  Deleted Containers:
+  53a9bc23a5168b6caa2bfbefddf1b30f93c7ad57f3dec271fd32707497cb9369
+
+  Total reclaimed space: 25 B
+
+  $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
+  61b9efa71024        busybox             "sh"                2017-01-04 13:23:33 -0800 PST   Exited (0) 44 seconds ago
+  ```
+
+  The following removes containers created before `2017-01-04T13:10:00`:
+
+  ```bash
+  $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
+  53a9bc23a516        busybox             "sh"                2017-01-04 13:11:59 -0800 PST   Exited (0) 7 minutes ago
+  4a75091a6d61        busybox             "sh"                2017-01-04 13:09:53 -0800 PST   Exited (0) 9 minutes ago
+
+  $ docker container prune --force --filter "until=2017-01-04T13:10:00"
+
+  Deleted Containers:
+  4a75091a6d618526fcd8b33ccd6e5928ca2a64415466f768a6180004b0c72c6c
+
+  Total reclaimed space: 27 B
+
+  $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
+  53a9bc23a516        busybox             "sh"                2017-01-04 13:11:59 -0800 PST   Exited (0) 9 minutes ago
+  ```
+

--- a/_data/engine-cli-edge/docker_container_rename.yaml
+++ b/_data/engine-cli-edge/docker_container_rename.yaml
@@ -1,0 +1,7 @@
+command: docker container rename
+short: Rename a container
+long: Rename a container
+usage: docker container rename CONTAINER NEW_NAME
+pname: docker container
+plink: docker_container.yaml
+

--- a/_data/engine-cli-edge/docker_container_restart.yaml
+++ b/_data/engine-cli-edge/docker_container_restart.yaml
@@ -1,0 +1,12 @@
+command: docker container restart
+short: Restart one or more containers
+long: Restart one or more containers
+usage: docker container restart [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing the container
+

--- a/_data/engine-cli-edge/docker_container_rm.yaml
+++ b/_data/engine-cli-edge/docker_container_rm.yaml
@@ -1,0 +1,20 @@
+command: docker container rm
+short: Remove one or more containers
+long: Remove one or more containers
+usage: docker container rm [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the removal of a running container (uses SIGKILL)
+- option: link
+  shorthand: l
+  default_value: "false"
+  description: Remove the specified link
+- option: volumes
+  shorthand: v
+  default_value: "false"
+  description: Remove the volumes associated with the container
+

--- a/_data/engine-cli-edge/docker_container_run.yaml
+++ b/_data/engine-cli-edge/docker_container_run.yaml
@@ -1,0 +1,288 @@
+command: docker container run
+short: Run a command in a new container
+long: Run a command in a new container
+usage: docker container run [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: |
+    Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-count
+  default_value: "0"
+  description: CPU count (Windows only)
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-rt-period
+  default_value: "0"
+  description: Limit CPU real-time period in microseconds
+- option: cpu-rt-runtime
+  default_value: "0"
+  description: Limit CPU real-time runtime in microseconds
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpus
+  default_value: "0.000"
+  description: Number of CPUs
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: Run container in background and print container ID
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-option
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: 0s
+  description: Time between running the check (ns|us|ms|s|m|h) (default 0s)
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: 0s
+  description: |
+    Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy received signals to the process
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: stop-timeout
+  default_value: "0"
+  description: Timeout (in seconds) to stop a container
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container
+

--- a/_data/engine-cli-edge/docker_container_start.yaml
+++ b/_data/engine-cli-edge/docker_container_start.yaml
@@ -1,0 +1,22 @@
+command: docker container start
+short: Start one or more stopped containers
+long: Start one or more stopped containers
+usage: docker container start [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: attach
+  shorthand: a
+  default_value: "false"
+  description: Attach STDOUT/STDERR and forward signals
+- option: checkpoint
+  description: Restore from this checkpoint
+- option: checkpoint-dir
+  description: Use a custom checkpoint storage directory
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Attach container's STDIN
+

--- a/_data/engine-cli-edge/docker_container_stats.yaml
+++ b/_data/engine-cli-edge/docker_container_stats.yaml
@@ -1,0 +1,17 @@
+command: docker container stats
+short: Display a live stream of container(s) resource usage statistics
+long: Display a live stream of container(s) resource usage statistics
+usage: docker container stats [OPTIONS] [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-stream
+  default_value: "false"
+  description: Disable streaming stats and only pull the first result
+

--- a/_data/engine-cli-edge/docker_container_stop.yaml
+++ b/_data/engine-cli-edge/docker_container_stop.yaml
@@ -1,0 +1,12 @@
+command: docker container stop
+short: Stop one or more running containers
+long: Stop one or more running containers
+usage: docker container stop [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing it
+

--- a/_data/engine-cli-edge/docker_container_top.yaml
+++ b/_data/engine-cli-edge/docker_container_top.yaml
@@ -1,0 +1,7 @@
+command: docker container top
+short: Display the running processes of a container
+long: Display the running processes of a container
+usage: docker container top CONTAINER [ps OPTIONS]
+pname: docker container
+plink: docker_container.yaml
+

--- a/_data/engine-cli-edge/docker_container_unpause.yaml
+++ b/_data/engine-cli-edge/docker_container_unpause.yaml
@@ -1,0 +1,7 @@
+command: docker container unpause
+short: Unpause all processes within one or more containers
+long: Unpause all processes within one or more containers
+usage: docker container unpause CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+

--- a/_data/engine-cli-edge/docker_container_update.yaml
+++ b/_data/engine-cli-edge/docker_container_update.yaml
@@ -1,0 +1,44 @@
+command: docker container update
+short: Update configuration of one or more containers
+long: Update configuration of one or more containers
+usage: docker container update [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+options:
+- option: blkio-weight
+  default_value: "0"
+  description: |
+    Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-rt-period
+  default_value: "0"
+  description: Limit the CPU real-time period in microseconds
+- option: cpu-rt-runtime
+  default_value: "0"
+  description: Limit the CPU real-time runtime in microseconds
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: kernel-memory
+  description: Kernel memory limit
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: restart
+  description: Restart policy to apply when a container exits
+

--- a/_data/engine-cli-edge/docker_container_wait.yaml
+++ b/_data/engine-cli-edge/docker_container_wait.yaml
@@ -1,0 +1,7 @@
+command: docker container wait
+short: Block until one or more containers stop, then print their exit codes
+long: Block until one or more containers stop, then print their exit codes
+usage: docker container wait CONTAINER [CONTAINER...]
+pname: docker container
+plink: docker_container.yaml
+

--- a/_data/engine-cli-edge/docker_cp.yaml
+++ b/_data/engine-cli-edge/docker_cp.yaml
@@ -1,0 +1,93 @@
+command: docker cp
+short: Copy files/folders between a container and the local filesystem
+long: |-
+  The `docker cp` utility copies the contents of `SRC_PATH` to the `DEST_PATH`.
+  You can copy from the container's file system to the local machine or the
+  reverse, from the local filesystem to the container. If `-` is specified for
+  either the `SRC_PATH` or `DEST_PATH`, you can also stream a tar archive from
+  `STDIN` or to `STDOUT`. The `CONTAINER` can be a running or stopped container.
+  The `SRC_PATH` or `DEST_PATH` can be a file or directory.
+
+  The `docker cp` command assumes container paths are relative to the container's
+  `/` (root) directory. This means supplying the initial forward slash is optional;
+  The command sees `compassionate_darwin:/tmp/foo/myfile.txt` and
+  `compassionate_darwin:tmp/foo/myfile.txt` as identical. Local machine paths can
+  be an absolute or relative value. The command interprets a local machine's
+  relative paths as relative to the current working directory where `docker cp` is
+  run.
+
+  The `cp` command behaves like the Unix `cp -a` command in that directories are
+  copied recursively with permissions preserved if possible. Ownership is set to
+  the user and primary group at the destination. For example, files copied to a
+  container are created with `UID:GID` of the root user. Files copied to the local
+  machine are created with the `UID:GID` of the user which invoked the `docker cp`
+  command.  If you specify the `-L` option, `docker cp` follows any symbolic link
+  in the `SRC_PATH`.  `docker cp` does *not* create parent directories for
+  `DEST_PATH` if they do not exist.
+
+  Assuming a path separator of `/`, a first argument of `SRC_PATH` and second
+  argument of `DEST_PATH`, the behavior is as follows:
+
+  - `SRC_PATH` specifies a file
+      - `DEST_PATH` does not exist
+          - the file is saved to a file created at `DEST_PATH`
+      - `DEST_PATH` does not exist and ends with `/`
+          - Error condition: the destination directory must exist.
+      - `DEST_PATH` exists and is a file
+          - the destination is overwritten with the source file's contents
+      - `DEST_PATH` exists and is a directory
+          - the file is copied into this directory using the basename from
+            `SRC_PATH`
+  - `SRC_PATH` specifies a directory
+      - `DEST_PATH` does not exist
+          - `DEST_PATH` is created as a directory and the *contents* of the source
+             directory are copied into this directory
+      - `DEST_PATH` exists and is a file
+          - Error condition: cannot copy a directory to a file
+      - `DEST_PATH` exists and is a directory
+          - `SRC_PATH` does not end with `/.` (that is: _slash_ followed by _dot_)
+              - the source directory is copied into this directory
+          - `SRC_PATH` does end with `/.` (that is: _slash_ followed by _dot_)
+              - the *content* of the source directory is copied into this
+                directory
+
+  The command requires `SRC_PATH` and `DEST_PATH` to exist according to the above
+  rules. If `SRC_PATH` is local and is a symbolic link, the symbolic link, not
+  the target, is copied by default. To copy the link target and not the link, specify
+  the `-L` option.
+
+  A colon (`:`) is used as a delimiter between `CONTAINER` and its path. You can
+  also use `:` when specifying paths to a `SRC_PATH` or `DEST_PATH` on a local
+  machine, for example  `file:name.txt`. If you use a `:` in a local machine path,
+  you must be explicit with a relative or absolute path, for example:
+
+      `/path/to/file:name.txt` or `./file:name.txt`
+
+  It is not possible to copy certain system files such as resources under
+  `/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs-tmpfs), and mounts created by
+  the user in the container. However, you can still copy such files by manually
+  running `tar` in `docker exec`. Both of the following examples do the same thing
+  in different ways (consider `SRC_PATH` and `DEST_PATH` are directories):
+
+  ```bash
+  $ docker exec foo tar Ccf $(dirname SRC_PATH) - $(basename SRC_PATH) | tar Cxf DEST_PATH -
+  ```
+
+  ```bash
+  $ tar Ccf $(dirname SRC_PATH) - $(basename SRC_PATH) | docker exec -i foo tar Cxf DEST_PATH -
+  ```
+
+  Using `-` as the `SRC_PATH` streams the contents of `STDIN` as a tar archive.
+  The command extracts the content of the tar to the `DEST_PATH` in container's
+  filesystem. In this case, `DEST_PATH` must specify a directory. Using `-` as
+  the `DEST_PATH` streams the contents of the resource as a tar archive to `STDOUT`.
+usage: "docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp [OPTIONS]
+  SRC_PATH|- CONTAINER:DEST_PATH"
+pname: docker
+plink: docker.yaml
+options:
+- option: follow-link
+  shorthand: L
+  default_value: "false"
+  description: Always follow symbol link in SRC_PATH
+

--- a/_data/engine-cli-edge/docker_create.yaml
+++ b/_data/engine-cli-edge/docker_create.yaml
@@ -1,0 +1,375 @@
+command: docker create
+short: Create a new container
+long: |-
+  The `docker create` command creates a writeable container layer over the
+  specified image and prepares it for running the specified command.  The
+  container ID is then printed to `STDOUT`.  This is similar to `docker run -d`
+  except the container is never started.  You can then use the
+  `docker start <container_id>` command to start the container at any point.
+
+  This is useful when you want to set up a container configuration ahead of time
+  so that it is ready to start when you need it. The initial status of the
+  new container is `created`.
+
+  Please see the [run command](run.md) section and the [Docker run reference](../run.md) for more details.
+usage: docker create [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker
+plink: docker.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: |
+    Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-count
+  default_value: "0"
+  description: CPU count (Windows only)
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-rt-period
+  default_value: "0"
+  description: Limit CPU real-time period in microseconds
+- option: cpu-rt-runtime
+  default_value: "0"
+  description: Limit CPU real-time runtime in microseconds
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpus
+  default_value: "0.000"
+  description: Number of CPUs
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-option
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: 0s
+  description: Time between running the check (ns|us|ms|s|m|h) (default 0s)
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: 0s
+  description: |
+    Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: stop-timeout
+  default_value: "0"
+  description: Timeout (in seconds) to stop a container
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container
+examples: |-
+  ### Create and start a container
+
+  ```bash
+  $ docker create -t -i fedora bash
+
+  6d8af538ec541dd581ebc2a24153a28329acb5268abe5ef868c1f1a261221752
+
+  $ docker start -a -i 6d8af538ec5
+
+  bash-4.2#
+  ```
+
+  ### Initialize volumes
+
+  As of v1.4.0 container volumes are initialized during the `docker create` phase
+  (i.e., `docker run` too). For example, this allows you to `create` the `data`
+  volume container, and then use it from another container:
+
+  ```bash
+  $ docker create -v /data --name data ubuntu
+
+  240633dfbb98128fa77473d3d9018f6123b99c454b3251427ae190a7d951ad57
+
+  $ docker run --rm --volumes-from data ubuntu ls -la /data
+
+  total 8
+  drwxr-xr-x  2 root root 4096 Dec  5 04:10 .
+  drwxr-xr-x 48 root root 4096 Dec  5 04:11 ..
+  ```
+
+  Similarly, `create` a host directory bind mounted volume container, which can
+  then be used from the subsequent container:
+
+  ```bash
+  $ docker create -v /home/docker:/docker --name docker ubuntu
+
+  9aa88c08f319cd1e4515c3c46b0de7cc9aa75e878357b1e96f91e2c773029f03
+
+  $ docker run --rm --volumes-from docker ubuntu ls -la /docker
+
+  total 20
+  drwxr-sr-x  5 1000 staff  180 Dec  5 04:00 .
+  drwxr-xr-x 48 root root  4096 Dec  5 04:13 ..
+  -rw-rw-r--  1 1000 staff 3833 Dec  5 04:01 .ash_history
+  -rw-r--r--  1 1000 staff  446 Nov 28 11:51 .ashrc
+  -rw-r--r--  1 1000 staff   25 Dec  5 04:00 .gitconfig
+  drwxr-sr-x  3 1000 staff   60 Dec  1 03:28 .local
+  -rw-r--r--  1 1000 staff  920 Nov 28 11:51 .profile
+  drwx--S---  2 1000 staff  460 Dec  5 00:51 .ssh
+  drwxr-xr-x 32 1000 staff 1140 Dec  5 04:01 docker
+  ```
+
+
+  Set storage driver options per container.
+
+  ```bash
+  $ docker create -it --storage-opt size=120G fedora /bin/bash
+  ```
+
+  This (size) will allow to set the container rootfs size to 120G at creation time.
+  This option is only available for the `devicemapper`, `btrfs`, `overlay2`,
+  `windowsfilter` and `zfs` graph drivers.
+  For the `devicemapper`, `btrfs`, `windowsfilter` and `zfs` graph drivers,
+  user cannot pass a size less than the Default BaseFS Size.
+  For the `overlay2` storage driver, the size option is only available if the
+  backing fs is `xfs` and mounted with the `pquota` mount option.
+  Under these conditions, user can pass any size less then the backing fs size.
+
+  ### Specify isolation technology for container (--isolation)
+
+  This option is useful in situations where you are running Docker containers on
+  Windows. The `--isolation=<value>` option sets a container's isolation
+  technology. On Linux, the only supported is the `default` option which uses
+  Linux namespaces. On Microsoft Windows, you can specify these values:
+
+
+  | Value     | Description                                                                                                                                                   |
+  |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value if the
+  daemon is running on Windows server, or `hyperv` if running on Windows client.  |
+  | `process` | Namespace isolation only.                                                                                                                                     |
+  | `hyperv`   | Hyper-V hypervisor partition-based isolation.                                                                                                                  |
+
+  Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
+

--- a/_data/engine-cli-edge/docker_deploy.yaml
+++ b/_data/engine-cli-edge/docker_deploy.yaml
@@ -1,0 +1,79 @@
+command: docker deploy
+short: Deploy a new stack or update an existing stack
+long: |-
+  Create and update a stack from a `compose` or a `dab` file on the swarm. This command
+  has to be run targeting a manager node.
+usage: docker deploy [OPTIONS] STACK
+pname: docker
+plink: docker.yaml
+options:
+- option: bundle-file
+  description: Path to a Distributed Application Bundle file
+- option: compose-file
+  shorthand: c
+  description: Path to a Compose file
+- option: with-registry-auth
+  default_value: "false"
+  description: Send registry authentication details to Swarm agents
+examples: |-
+  ### Compose file
+
+  The `deploy` command supports compose file version `3.0` and above.
+
+  ```bash
+  $ docker stack deploy --compose-file docker-compose.yml vossibility
+
+  Ignoring unsupported options: links
+
+  Creating network vossibility_vossibility
+  Creating network vossibility_default
+  Creating service vossibility_nsqd
+  Creating service vossibility_logstash
+  Creating service vossibility_elasticsearch
+  Creating service vossibility_kibana
+  Creating service vossibility_ghollector
+  Creating service vossibility_lookupd
+  ```
+
+  You can verify that the services were correctly created
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME                               MODE        REPLICAS  IMAGE
+  29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+  7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+  9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+  axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+  ```
+
+  ### DAB file
+
+  ```bash
+  $ docker stack deploy --bundle-file vossibility-stack.dab vossibility
+
+  Loading bundle from vossibility-stack.dab
+  Creating service vossibility_elasticsearch
+  Creating service vossibility_kibana
+  Creating service vossibility_logstash
+  Creating service vossibility_lookupd
+  Creating service vossibility_nsqd
+  Creating service vossibility_vossibility-collector
+  ```
+
+  You can verify that the services were correctly created:
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME                               MODE        REPLICAS  IMAGE
+  29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+  7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+  9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+  axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+  ```
+

--- a/_data/engine-cli-edge/docker_diff.yaml
+++ b/_data/engine-cli-edge/docker_diff.yaml
@@ -1,0 +1,44 @@
+command: docker diff
+short: Inspect changes to files or directories on a container's filesystem
+long: |-
+  List the changed files and directories in a container᾿s filesystem since the
+  container was created. Three different types of change are tracked:
+
+  | Symbol | Description                     |
+  |--------|---------------------------------|
+  | `A`    | A file or directory was added   |
+  | `D`    | A file or directory was deleted |
+  | `C`    | A file or directory was changed |
+
+  You can use the full or shortened container ID or the container name set using
+  `docker run --name` option.
+usage: docker diff CONTAINER
+pname: docker
+plink: docker.yaml
+examples: |-
+  Inspect the changes to an `nginx` container:
+
+  ```bash
+  $ docker diff 1fdfd1f54c1b
+
+  C /dev
+  C /dev/console
+  C /dev/core
+  C /dev/stdout
+  C /dev/fd
+  C /dev/ptmx
+  C /dev/stderr
+  C /dev/stdin
+  C /run
+  A /run/nginx.pid
+  C /var/lib/nginx/tmp
+  A /var/lib/nginx/tmp/client_body
+  A /var/lib/nginx/tmp/fastcgi
+  A /var/lib/nginx/tmp/proxy
+  A /var/lib/nginx/tmp/scgi
+  A /var/lib/nginx/tmp/uwsgi
+  C /var/log/nginx
+  A /var/log/nginx/access.log
+  A /var/log/nginx/error.log
+  ```
+

--- a/_data/engine-cli-edge/docker_events.yaml
+++ b/_data/engine-cli-edge/docker_events.yaml
@@ -1,0 +1,332 @@
+command: docker events
+short: Get real time events from the server
+long: |-
+  Use `docker events` to get real-time events from the server. These events differ
+  per Docker object type.
+
+  ### Object types
+
+  #### Containers
+
+  Docker containers report the following events:
+
+  - `attach`
+  - `commit`
+  - `copy`
+  - `create`
+  - `destroy`
+  - `detach`
+  - `die`
+  - `exec_create`
+  - `exec_detach`
+  - `exec_start`
+  - `export`
+  - `health_status`
+  - `kill`
+  - `oom`
+  - `pause`
+  - `rename`
+  - `resize`
+  - `restart`
+  - `start`
+  - `stop`
+  - `top`
+  - `unpause`
+  - `update`
+
+  #### Images
+
+  Docker images report the following events:
+
+  - `delete`
+  - `import`
+  - `load`
+  - `pull`
+  - `push`
+  - `save`
+  - `tag`
+  - `untag`
+
+  #### Plugins
+
+  Docker plugins report the following events:
+
+  - `install`
+  - `enable`
+  - `disable`
+  - `remove`
+
+  #### Volumes
+
+  Docker volumes report the following events:
+
+  - `create`
+  - `mount`
+  - `unmount`
+  - `destroy`
+
+  #### Networks
+
+  Docker networks report the following events:
+
+  - `create`
+  - `connect`
+  - `disconnect`
+  - `destroy`
+
+  #### Daemons
+
+  Docker daemons report the following events:
+
+  - `reload`
+
+  ### Limiting, filtering, and formatting the output
+
+  #### Limit events by time
+
+  The `--since` and `--until` parameters can be Unix timestamps, date formatted
+  timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
+  relative to the client machine’s time. If you do not provide the `--since` option,
+  the command returns only new and/or live events.  Supported formats for date
+  formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the client will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long.
+
+  #### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
+  like to use multiple filters, pass multiple flags (e.g.,
+  `--filter "foo=bar" --filter "bif=baz"`)
+
+  Using the same filter multiple times will be handled as a *OR*; for example
+  `--filter container=588a23dac085 --filter container=a8f7720b8c22` will display
+  events for container 588a23dac085 *OR* container a8f7720b8c22
+
+  Using multiple filters will be handled as a *AND*; for example
+  `--filter container=588a23dac085 --filter event=start` will display events for
+  container container 588a23dac085 *AND* the event type is *start*
+
+  The currently supported filters are:
+
+  * container (`container=<name or id>`)
+  * daemon (`daemon=<name or id>`)
+  * event (`event=<event action>`)
+  * image (`image=<tag or id>`)
+  * label (`label=<key>` or `label=<key>=<value>`)
+  * network (`network=<name or id>`)
+  * plugin (`plugin=<name or id>`)
+  * type (`type=<container or image or volume or network or daemon>`)
+  * volume (`volume=<name or id>`)
+
+  #### Format
+
+  If a format (`--format`) is specified, the given template will be executed
+  instead of the default
+  format. Go's [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+
+  If a format is set to `{{json .}}`, the events are streamed as valid JSON
+  Lines. For information about JSON Lines, please refer to http://jsonlines.org/ .
+usage: docker events [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Format the output using the given Go template
+- option: since
+  description: Show all events created since timestamp
+- option: until
+  description: Stream events until this timestamp
+examples: |-
+  ### Basic example
+
+  You'll need two shells for this example.
+
+  **Shell 1: Listening for events:**
+
+  ```bash
+  $ docker events
+  ```
+
+  **Shell 2: Start and Stop containers:**
+
+  ```bash
+  $ docker create --name test alpine:latest top
+  $ docker start test
+  $ docker stop test
+  ```
+
+  **Shell 1: (Again .. now showing events):**
+
+  ```none
+  2017-01-05T00:35:58.859401177+08:00 container create 0fdb48addc82871eb34eb23a847cfd033dedd1a0a37bef2e6d9eb3870fc7ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:36:04.703631903+08:00 network connect e2e1f5ceda09d4300f3a846f0acfaa9a8bb0d89e775eb744c5acecd60e0529e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:36:09.830268747+08:00 container kill 0fdb...ff37 (image=alpine:latest, name=test, signal=15)
+  2017-01-05T00:36:09.840186338+08:00 container die 0fdb...ff37 (exitCode=143, image=alpine:latest, name=test)
+  2017-01-05T00:36:09.880113663+08:00 network disconnect e2e...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+  ```
+
+  To exit the `docker events` command, use `CTRL+C`.
+
+  ### Filter events by time
+
+  You can filter the output by an absolute timestamp or relative time on the host
+  machine, using the following different time syntaxes:
+
+  ```bash
+  $ docker events --since 1483283804
+  2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
+  2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
+  2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:36:09.830268747+08:00 container kill 0fdb...ff37 (image=alpine:latest, name=test, signal=15)
+  2017-01-05T00:36:09.840186338+08:00 container die 0fdb...ff37 (exitCode=143, image=alpine:latest, name=test)
+  2017-01-05T00:36:09.880113663+08:00 network disconnect e2e...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+
+  $ docker events --since '2017-01-05'
+  2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
+  2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
+  2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:36:09.830268747+08:00 container kill 0fdb...ff37 (image=alpine:latest, name=test, signal=15)
+  2017-01-05T00:36:09.840186338+08:00 container die 0fdb...ff37 (exitCode=143, image=alpine:latest, name=test)
+  2017-01-05T00:36:09.880113663+08:00 network disconnect e2e...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+
+  $ docker events --since '2013-09-03T15:49:29'
+  2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
+  2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
+  2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:36:09.830268747+08:00 container kill 0fdb...ff37 (image=alpine:latest, name=test, signal=15)
+  2017-01-05T00:36:09.840186338+08:00 container die 0fdb...ff37 (exitCode=143, image=alpine:latest, name=test)
+  2017-01-05T00:36:09.880113663+08:00 network disconnect e2e...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+
+  $ docker events --since '10m'
+  2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
+  2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
+  2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:36:09.830268747+08:00 container kill 0fdb...ff37 (image=alpine:latest, name=test, signal=15)
+  2017-01-05T00:36:09.840186338+08:00 container die 0fdb...ff37 (exitCode=143, image=alpine:latest, name=test)
+  2017-01-05T00:36:09.880113663+08:00 network disconnect e2e...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+  2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+  ```
+
+  ### Filter events by criteria
+
+  The following commands show several different ways to filter the `docker event`
+  output.
+
+  ```bash
+  $ docker events --filter 'event=stop'
+
+  2017-01-05T00:40:22.880175420+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:41:17.888104182+08:00 container stop 2a8f...4e78 (image=alpine, name=kickass_brattain)
+
+  $ docker events --filter 'image=alpine'
+
+  2017-01-05T00:41:55.784240236+08:00 container create d9cd...4d70 (image=alpine, name=happy_meitner)
+  2017-01-05T00:41:55.913156783+08:00 container start d9cd...4d70 (image=alpine, name=happy_meitner)
+  2017-01-05T00:42:01.106875249+08:00 container kill d9cd...4d70 (image=alpine, name=happy_meitner, signal=15)
+  2017-01-05T00:42:11.111934041+08:00 container kill d9cd...4d70 (image=alpine, name=happy_meitner, signal=9)
+  2017-01-05T00:42:11.119578204+08:00 container die d9cd...4d70 (exitCode=137, image=alpine, name=happy_meitner)
+  2017-01-05T00:42:11.173276611+08:00 container stop d9cd...4d70 (image=alpine, name=happy_meitner)
+
+  $ docker events --filter 'container=test'
+
+  2017-01-05T00:43:00.139719934+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:43:09.259951086+08:00 container kill 0fdb...ff37 (image=alpine:latest, name=test, signal=15)
+  2017-01-05T00:43:09.270102715+08:00 container die 0fdb...ff37 (exitCode=143, image=alpine:latest, name=test)
+  2017-01-05T00:43:09.312556440+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+
+  $ docker events --filter 'container=test' --filter 'container=d9cdb1525ea8'
+
+  2017-01-05T00:44:11.517071981+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
+  2017-01-05T00:44:17.685870901+08:00 container start d9cd...4d70 (image=alpine, name=happy_meitner)
+  2017-01-05T00:44:29.757658470+08:00 container kill 0fdb...ff37 (image=alpine:latest, name=test, signal=9)
+  2017-01-05T00:44:29.767718510+08:00 container die 0fdb...ff37 (exitCode=137, image=alpine:latest, name=test)
+  2017-01-05T00:44:29.815798344+08:00 container destroy 0fdb...ff37 (image=alpine:latest, name=test)
+
+  $ docker events --filter 'container=test' --filter 'event=stop'
+
+  2017-01-05T00:46:13.664099505+08:00 container stop a9d1...e130 (image=alpine, name=test)
+
+  $ docker events --filter 'type=volume'
+
+  2015-12-23T21:05:28.136212689Z volume create test-event-volume-local (driver=local)
+  2015-12-23T21:05:28.383462717Z volume mount test-event-volume-local (read/write=true, container=562f...5025, destination=/foo, driver=local, propagation=rprivate)
+  2015-12-23T21:05:28.650314265Z volume unmount test-event-volume-local (container=562f...5025, driver=local)
+  2015-12-23T21:05:28.716218405Z volume destroy test-event-volume-local (driver=local)
+
+  $ docker events --filter 'type=network'
+
+  2015-12-23T21:38:24.705709133Z network create 8b11...2c5b (name=test-event-network-local, type=bridge)
+  2015-12-23T21:38:25.119625123Z network connect 8b11...2c5b (name=test-event-network-local, container=b4be...c54e, type=bridge)
+
+  $ docker events --filter 'container=container_1' --filter 'container=container_2'
+
+  2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
+  2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+  2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (imager=redis:2.8)
+  2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+
+  $ docker events --filter 'type=volume'
+
+  2015-12-23T21:05:28.136212689Z volume create test-event-volume-local (driver=local)
+  2015-12-23T21:05:28.383462717Z volume mount test-event-volume-local (read/write=true, container=562fe10671e9273da25eed36cdce26159085ac7ee6707105fd534866340a5025, destination=/foo, driver=local, propagation=rprivate)
+  2015-12-23T21:05:28.650314265Z volume unmount test-event-volume-local (container=562fe10671e9273da25eed36cdce26159085ac7ee6707105fd534866340a5025, driver=local)
+  2015-12-23T21:05:28.716218405Z volume destroy test-event-volume-local (driver=local)
+
+  $ docker events --filter 'type=network'
+
+  2015-12-23T21:38:24.705709133Z network create 8b111217944ba0ba844a65b13efcd57dc494932ee2527577758f939315ba2c5b (name=test-event-network-local, type=bridge)
+  2015-12-23T21:38:25.119625123Z network connect 8b111217944ba0ba844a65b13efcd57dc494932ee2527577758f939315ba2c5b (name=test-event-network-local, container=b4be644031a3d90b400f88ab3d4bdf4dc23adb250e696b6328b85441abe2c54e, type=bridge)
+  ```
+
+  The `type=plugin` filter is experimental.
+
+  ```bash
+  $ docker events --filter 'type=plugin'
+
+  2016-07-25T17:30:14.825557616Z plugin pull ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
+  2016-07-25T17:30:14.888127370Z plugin enable ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
+  ```
+
+  ### Format the output
+
+  ```bash
+  $ docker events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
+
+  Type=container  Status=create  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+  Type=container  Status=attach  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+  Type=container  Status=start  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+  Type=container  Status=resize  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+  Type=container  Status=die  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+  Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+  ```
+
+  #### Format as JSON
+
+  ```none
+      $ docker events --format '{{json .}}'
+
+      {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+      {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+      {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
+      {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
+      {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+  ```
+

--- a/_data/engine-cli-edge/docker_exec.yaml
+++ b/_data/engine-cli-edge/docker_exec.yaml
@@ -1,0 +1,86 @@
+command: docker exec
+short: Run a command in a running container
+long: |-
+  The `docker exec` command runs a new command in a running container.
+
+  The command started using `docker exec` only runs while the container's primary
+  process (`PID 1`) is running, and it is not restarted if the container is
+  restarted.
+usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
+pname: docker
+plink: docker.yaml
+options:
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: 'Detached mode: run command in the background'
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to the command
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+examples: |-
+  ### Run `docker exec` on a running container
+
+  First, start a container.
+
+  ```bash
+  $ docker run --name ubuntu_bash --rm -i -t ubuntu bash
+  ```
+
+  This will create a container named `ubuntu_bash` and start a Bash session.
+
+  Next, execute a command on the container.
+
+  ```bash
+  $ docker exec -d ubuntu_bash touch /tmp/execWorks
+  ```
+
+  This will create a new file `/tmp/execWorks` inside the running container
+  `ubuntu_bash`, in the background.
+
+  Next, execute an interactive `bash` shell on the container.
+
+  ```bash
+  $ docker exec -it ubuntu_bash bash
+  ```
+
+  This will create a new Bash session in the container `ubuntu_bash`.
+
+  ### Try to run `docker exec` on a paused container
+
+  If the container is paused, then the `docker exec` command will fail with an error:
+
+  ```bash
+  $ docker pause test
+
+  test
+
+  $ docker ps
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                   PORTS               NAMES
+  1ae3b36715d2        ubuntu:latest       "bash"              17 seconds ago      Up 16 seconds (Paused)                       test
+
+  $ docker exec test ls
+
+  FATA[0000] Error response from daemon: Container test is paused, unpause the container before exec
+
+  $ echo $?
+  1
+  ```
+

--- a/_data/engine-cli-edge/docker_export.yaml
+++ b/_data/engine-cli-edge/docker_export.yaml
@@ -1,0 +1,28 @@
+command: docker export
+short: Export a container's filesystem as a tar archive
+long: |-
+  The `docker export` command does not export the contents of volumes associated
+  with the container. If a volume is mounted on top of an existing directory in
+  the container, `docker export` will export the contents of the *underlying*
+  directory, not the contents of the volume.
+
+  Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/engine/tutorials/dockervolumes/#backup-restore-or-migrate-data-volumes)
+  in the user guide for examples on exporting data in a volume.
+usage: docker export [OPTIONS] CONTAINER
+pname: docker
+plink: docker.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT
+examples: |-
+  ch of these commands has the same result.
+
+  ```bash
+  $ docker export red_panda > latest.tar
+  ```
+
+  ```bash
+  $ docker export --output="latest.tar" red_panda
+  ```
+

--- a/_data/engine-cli-edge/docker_history.yaml
+++ b/_data/engine-cli-edge/docker_history.yaml
@@ -1,0 +1,44 @@
+command: docker history
+short: Show the history of an image
+long: Show the history of an image
+usage: docker history [OPTIONS] IMAGE
+pname: docker
+plink: docker.yaml
+options:
+- option: human
+  shorthand: H
+  default_value: "true"
+  description: Print sizes and dates in human readable format
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs
+examples: |-
+  To see how the `docker:latest` image was built:
+
+  ```bash
+  $ docker history docker
+
+  IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+  3e23a5875458        8 days ago          /bin/sh -c #(nop) ENV LC_ALL=C.UTF-8            0 B
+  8578938dd170        8 days ago          /bin/sh -c dpkg-reconfigure locales &&    loc   1.245 MB
+  be51b77efb42        8 days ago          /bin/sh -c apt-get update && apt-get install    338.3 MB
+  4b137612be55        6 weeks ago         /bin/sh -c #(nop) ADD jessie.tar.xz in /        121 MB
+  750d58736b4b        6 weeks ago         /bin/sh -c #(nop) MAINTAINER Tianon Gravi <ad   0 B
+  511136ea3c5a        9 months ago                                                        0 B                 Imported from -
+  ```
+
+  To see how the `docker:apache` image was added to a container's base image:
+
+  ```bash
+  $ docker history docker:scm
+  IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+  2ac9d1098bf1        3 months ago        /bin/bash                                       241.4 MB            Added Apache to Fedora base image
+  88b42ffd1f7c        5 months ago        /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB
+  c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B
+  511136ea3c5a        19 months ago                                                       0 B                 Imported from -
+  ```
+

--- a/_data/engine-cli-edge/docker_image.yaml
+++ b/_data/engine-cli-edge/docker_image.yaml
@@ -1,0 +1,33 @@
+command: docker image
+short: Manage images
+long: Manage images.
+usage: docker image
+pname: docker
+plink: docker.yaml
+cname:
+- docker image build
+- docker image history
+- docker image import
+- docker image inspect
+- docker image load
+- docker image ls
+- docker image prune
+- docker image pull
+- docker image push
+- docker image rm
+- docker image save
+- docker image tag
+clink:
+- docker_image_build.yaml
+- docker_image_history.yaml
+- docker_image_import.yaml
+- docker_image_inspect.yaml
+- docker_image_load.yaml
+- docker_image_ls.yaml
+- docker_image_prune.yaml
+- docker_image_pull.yaml
+- docker_image_push.yaml
+- docker_image_rm.yaml
+- docker_image_save.yaml
+- docker_image_tag.yaml
+

--- a/_data/engine-cli-edge/docker_image_build.yaml
+++ b/_data/engine-cli-edge/docker_image_build.yaml
@@ -1,0 +1,85 @@
+command: docker image build
+short: Build an image from a Dockerfile
+long: Build an image from a Dockerfile
+usage: docker image build [OPTIONS] PATH | URL | -
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: build-arg
+  default_value: '[]'
+  description: Set build-time variables
+- option: cache-from
+  default_value: '[]'
+  description: Images to consider as cache sources
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: compress
+  default_value: "false"
+  description: Compress the build context using gzip
+- option: cpu-period
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit the CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: file
+  shorthand: f
+  description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
+- option: force-rm
+  default_value: "false"
+  description: Always remove intermediate containers
+- option: isolation
+  description: Container isolation technology
+- option: label
+  default_value: '[]'
+  description: Set metadata for an image
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: network
+  default_value: default
+  description: |
+    Set the networking mode for the RUN instructions during build
+- option: no-cache
+  default_value: "false"
+  description: Do not use cache when building the image
+- option: pull
+  default_value: "false"
+  description: Always attempt to pull a newer version of the image
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the build output and print image ID on success
+- option: rm
+  default_value: "true"
+  description: Remove intermediate containers after a successful build
+- option: security-opt
+  default_value: '[]'
+  description: Security options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: squash
+  default_value: "false"
+  description: Squash newly built layers into a single new layer
+- option: tag
+  shorthand: t
+  default_value: '[]'
+  description: Name and optionally a tag in the 'name:tag' format
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+

--- a/_data/engine-cli-edge/docker_image_history.yaml
+++ b/_data/engine-cli-edge/docker_image_history.yaml
@@ -1,0 +1,19 @@
+command: docker image history
+short: Show the history of an image
+long: Show the history of an image
+usage: docker image history [OPTIONS] IMAGE
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: human
+  shorthand: H
+  default_value: "true"
+  description: Print sizes and dates in human readable format
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs
+

--- a/_data/engine-cli-edge/docker_image_import.yaml
+++ b/_data/engine-cli-edge/docker_image_import.yaml
@@ -1,0 +1,15 @@
+command: docker image import
+short: Import the contents from a tarball to create a filesystem image
+long: Import the contents from a tarball to create a filesystem image
+usage: docker image import [OPTIONS] file|URL|- [REPOSITORY[:TAG]]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Set commit message for imported image
+

--- a/_data/engine-cli-edge/docker_image_inspect.yaml
+++ b/_data/engine-cli-edge/docker_image_inspect.yaml
@@ -1,0 +1,11 @@
+command: docker image inspect
+short: Display detailed information on one or more images
+long: Display detailed information on one or more images
+usage: docker image inspect [OPTIONS] IMAGE [IMAGE...]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+

--- a/_data/engine-cli-edge/docker_image_load.yaml
+++ b/_data/engine-cli-edge/docker_image_load.yaml
@@ -1,0 +1,15 @@
+command: docker image load
+short: Load an image from a tar archive or STDIN
+long: Load an image from a tar archive or STDIN
+usage: docker image load [OPTIONS]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: input
+  shorthand: i
+  description: Read from tar archive file, instead of STDIN
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the load output
+

--- a/_data/engine-cli-edge/docker_image_ls.yaml
+++ b/_data/engine-cli-edge/docker_image_ls.yaml
@@ -1,0 +1,28 @@
+command: docker image ls
+aliases: images, list
+short: List images
+long: List images
+usage: docker image ls [OPTIONS] [REPOSITORY[:TAG]]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all images (default hides intermediate images)
+- option: digests
+  default_value: "false"
+  description: Show digests
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs
+

--- a/_data/engine-cli-edge/docker_image_prune.yaml
+++ b/_data/engine-cli-edge/docker_image_prune.yaml
@@ -1,0 +1,140 @@
+command: docker image prune
+short: Remove unused images
+long: Remove all dangling images. If `-a` is specified, will also remove all images
+  not referenced by any container.
+usage: docker image prune [OPTIONS]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Remove all unused images, not just dangling ones
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation
+examples: |2-
+   output:
+
+  ```bash
+  $ docker image prune -a
+
+  WARNING! This will remove all images without at least one container associated to them.
+  Are you sure you want to continue? [y/N] y
+  Deleted Images:
+  untagged: alpine:latest
+  untagged: alpine@sha256:3dcdb92d7432d56604d4545cbd324b14e647b313626d99b889d0626de158f73a
+  deleted: sha256:4e38e38c8ce0b8d9041a9c4fefe786631d1416225e13b0bfe8cfa2321aec4bba
+  deleted: sha256:4fe15f8d0ae69e169824f25f1d4da3015a48feeeeebb265cd2e328e15c6a869f
+  untagged: alpine:3.3
+  untagged: alpine@sha256:4fa633f4feff6a8f02acfc7424efd5cb3e76686ed3218abf4ca0fa4a2a358423
+  untagged: my-jq:latest
+  deleted: sha256:ae67841be6d008a374eff7c2a974cde3934ffe9536a7dc7ce589585eddd83aff
+  deleted: sha256:34f6f1261650bc341eb122313372adc4512b4fceddc2a7ecbb84f0958ce5ad65
+  deleted: sha256:cf4194e8d8db1cb2d117df33f2c75c0369c3a26d96725efb978cc69e046b87e7
+  untagged: my-curl:latest
+  deleted: sha256:b2789dd875bf427de7f9f6ae001940073b3201409b14aba7e5db71f408b8569e
+  deleted: sha256:96daac0cb203226438989926fc34dd024f365a9a8616b93e168d303cfe4cb5e9
+  deleted: sha256:5cbd97a14241c9cd83250d6b6fc0649833c4a3e84099b968dd4ba403e609945e
+  deleted: sha256:a0971c4015c1e898c60bf95781c6730a05b5d8a2ae6827f53837e6c9d38efdec
+  deleted: sha256:d8359ca3b681cc5396a4e790088441673ed3ce90ebc04de388bfcd31a0716b06
+  deleted: sha256:83fc9ba8fb70e1da31dfcc3c88d093831dbd4be38b34af998df37e8ac538260c
+  deleted: sha256:ae7041a4cc625a9c8e6955452f7afe602b401f662671cea3613f08f3d9343b35
+  deleted: sha256:35e0f43a37755b832f0bbea91a2360b025ee351d7309dae0d9737bc96b6d0809
+  deleted: sha256:0af941dd29f00e4510195dd00b19671bc591e29d1495630e7e0f7c44c1e6a8c0
+  deleted: sha256:9fc896fc2013da84f84e45b3096053eb084417b42e6b35ea0cce5a3529705eac
+  deleted: sha256:47cf20d8c26c46fff71be614d9f54997edacfe8d46d51769706e5aba94b16f2b
+  deleted: sha256:2c675ee9ed53425e31a13e3390bf3f539bf8637000e4bcfbb85ee03ef4d910a1
+
+  Total reclaimed space: 16.43 MB
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * until (`<timestamp>`) - only remove images created before given timestamp
+
+  The `until` filter can be Unix timestamps, date formatted
+  timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
+  relative to the daemon machine’s time. Supported formats for date
+  formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the daemon will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long.
+
+  The following removes images created before `2017-01-04T00:00:00`:
+
+  ```bash
+  $ docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt}}\t{{.Size}}'
+  REPOSITORY          TAG                 IMAGE ID            CREATED AT                      SIZE
+  foo                 latest              2f287ac753da        2017-01-04 13:42:23 -0800 PST   3.98 MB
+  alpine              latest              88e169ea8f46        2016-12-27 10:17:25 -0800 PST   3.98 MB
+  busybox             latest              e02e811dd08f        2016-10-07 14:03:58 -0700 PDT   1.09 MB
+
+  $ docker image prune -a --force --filter "until=2017-01-04T00:00:00"
+
+  Deleted Images:
+  untagged: alpine:latest
+  untagged: alpine@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8
+  untagged: busybox:latest
+  untagged: busybox@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912
+  deleted: sha256:e02e811dd08fd49e7f6032625495118e63f597eb150403d02e3238af1df240ba
+  deleted: sha256:e88b3f82283bc59d5e0df427c824e9f95557e661fcb0ea15fb0fb6f97760f9d9
+
+  Total reclaimed space: 1.093 MB
+
+  $ docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt}}\t{{.Size}}'
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED AT                      SIZE
+  foo                 latest              2f287ac753da        2017-01-04 13:42:23 -0800 PST   3.98 MB
+  ```
+
+  The following removes images created more than 10 days (`240h`) ago:
+
+  ```bash
+  $ docker images
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  foo                 latest              2f287ac753da        14 seconds ago      3.98 MB
+  alpine              latest              88e169ea8f46        8 days ago          3.98 MB
+  debian              jessie              7b0a06c805e8        2 months ago        123 MB
+  busybox             latest              e02e811dd08f        2 months ago        1.09 MB
+  golang              1.7.0               138c2e655421        4 months ago        670 MB
+
+  $ docker image prune -a --force --filter "until=240h"
+
+  Deleted Images:
+  untagged: golang:1.7.0
+  untagged: golang@sha256:6765038c2b8f407fd6e3ecea043b44580c229ccfa2a13f6d85866cf2b4a9628e
+  deleted: sha256:138c2e6554219de65614d88c15521bfb2da674cbb0bf840de161f89ff4264b96
+  deleted: sha256:ec353c2e1a673f456c4b78906d0d77f9d9456cfb5229b78c6a960bfb7496b76a
+  deleted: sha256:fe22765feaf3907526b4921c73ea6643ff9e334497c9b7e177972cf22f68ee93
+  deleted: sha256:ff845959c80148421a5c3ae11cc0e6c115f950c89bc949646be55ed18d6a2912
+  deleted: sha256:a4320831346648c03db64149eafc83092e2b34ab50ca6e8c13112388f25899a7
+  deleted: sha256:4c76020202ee1d9709e703b7c6de367b325139e74eebd6b55b30a63c196abaf3
+  deleted: sha256:d7afd92fb07236c8a2045715a86b7d5f0066cef025018cd3ca9a45498c51d1d6
+  deleted: sha256:9e63c5bce4585dd7038d830a1f1f4e44cb1a1515b00e620ac718e934b484c938
+  untagged: debian:jessie
+  untagged: debian@sha256:c1af755d300d0c65bb1194d24bce561d70c98a54fb5ce5b1693beb4f7988272f
+  deleted: sha256:7b0a06c805e8f23807fb8856621c60851727e85c7bcb751012c813f122734c8d
+  deleted: sha256:f96222d75c5563900bc4dd852179b720a0885de8f7a0619ba0ac76e92542bbc8
+
+  Total reclaimed space: 792.6 MB
+
+  $ docker images
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
+  foo                 latest              2f287ac753da        About a minute ago   3.98 MB
+  alpine              latest              88e169ea8f46        8 days ago           3.98 MB
+  busybox             latest              e02e811dd08f        2 months ago         1.09 MB
+  ```
+

--- a/_data/engine-cli-edge/docker_image_pull.yaml
+++ b/_data/engine-cli-edge/docker_image_pull.yaml
@@ -1,0 +1,15 @@
+command: docker image pull
+short: Pull an image or a repository from a registry
+long: Pull an image or a repository from a registry
+usage: docker image pull [OPTIONS] NAME[:TAG|@DIGEST]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: all-tags
+  shorthand: a
+  default_value: "false"
+  description: Download all tagged images in the repository
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+

--- a/_data/engine-cli-edge/docker_image_push.yaml
+++ b/_data/engine-cli-edge/docker_image_push.yaml
@@ -1,0 +1,11 @@
+command: docker image push
+short: Push an image or a repository to a registry
+long: Push an image or a repository to a registry
+usage: docker image push [OPTIONS] NAME[:TAG]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+

--- a/_data/engine-cli-edge/docker_image_rm.yaml
+++ b/_data/engine-cli-edge/docker_image_rm.yaml
@@ -1,0 +1,16 @@
+command: docker image rm
+aliases: rmi, remove
+short: Remove one or more images
+long: Remove one or more images
+usage: docker image rm [OPTIONS] IMAGE [IMAGE...]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force removal of the image
+- option: no-prune
+  default_value: "false"
+  description: Do not delete untagged parents
+

--- a/_data/engine-cli-edge/docker_image_save.yaml
+++ b/_data/engine-cli-edge/docker_image_save.yaml
@@ -1,0 +1,11 @@
+command: docker image save
+short: Save one or more images to a tar archive (streamed to STDOUT by default)
+long: Save one or more images to a tar archive (streamed to STDOUT by default)
+usage: docker image save [OPTIONS] IMAGE [IMAGE...]
+pname: docker image
+plink: docker_image.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT
+

--- a/_data/engine-cli-edge/docker_image_tag.yaml
+++ b/_data/engine-cli-edge/docker_image_tag.yaml
@@ -1,0 +1,7 @@
+command: docker image tag
+short: Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+long: Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+usage: docker image tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
+pname: docker image
+plink: docker_image.yaml
+

--- a/_data/engine-cli-edge/docker_images.yaml
+++ b/_data/engine-cli-edge/docker_images.yaml
@@ -1,0 +1,328 @@
+command: docker images
+short: List images
+long: |-
+  The default `docker images` will show all top level
+  images, their repository and tags, and their size.
+
+  Docker images have intermediate layers that increase reusability,
+  decrease disk usage, and speed up `docker build` by
+  allowing each step to be cached. These intermediate layers are not shown
+  by default.
+
+  The `SIZE` is the cumulative space taken up by the image and all
+  its parent images. This is also the disk space used by the contents of the
+  Tar file created when you `docker save` an image.
+
+  An image will be listed more than once if it has multiple repository names
+  or tags. This single image (identifiable by its matching `IMAGE ID`)
+  uses up the `SIZE` listed only once.
+usage: docker images [OPTIONS] [REPOSITORY[:TAG]]
+pname: docker
+plink: docker.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all images (default hides intermediate images)
+- option: digests
+  default_value: "false"
+  description: Show digests
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only show numeric IDs
+examples: |-
+  ### List the most recently created images
+
+  ```bash
+  $ docker images
+
+  REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
+  <none>                    <none>              77af4d6b9913        19 hours ago        1.089 GB
+  committ                   latest              b6fa739cedf5        19 hours ago        1.089 GB
+  <none>                    <none>              78a85c484f71        19 hours ago        1.089 GB
+  docker                    latest              30557a29d5ab        20 hours ago        1.089 GB
+  <none>                    <none>              5ed6274db6ce        24 hours ago        1.089 GB
+  postgres                  9                   746b819f315e        4 days ago          213.4 MB
+  postgres                  9.3                 746b819f315e        4 days ago          213.4 MB
+  postgres                  9.3.5               746b819f315e        4 days ago          213.4 MB
+  postgres                  latest              746b819f315e        4 days ago          213.4 MB
+  ```
+
+  ### List images by name and tag
+
+  The `docker images` command takes an optional `[REPOSITORY[:TAG]]` argument
+  that restricts the list to images that match the argument. If you specify
+  `REPOSITORY`but no `TAG`, the `docker images` command lists all images in the
+  given repository.
+
+  For example, to list all images in the "java" repository, run this command :
+
+  ```bash
+  $ docker images java
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  java                8                   308e519aac60        6 days ago          824.5 MB
+  java                7                   493d82594c15        3 months ago        656.3 MB
+  java                latest              2711b1d6f3aa        5 months ago        603.9 MB
+  ```
+
+  The `[REPOSITORY[:TAG]]` value must be an "exact match". This means that, for example,
+  `docker images jav` does not match the image `java`.
+
+  If both `REPOSITORY` and `TAG` are provided, only images matching that
+  repository and tag are listed.  To find all local images in the "java"
+  repository with tag "8" you can use:
+
+  ```bash
+  $ docker images java:8
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  java                8                   308e519aac60        6 days ago          824.5 MB
+  ```
+
+  If nothing matches `REPOSITORY[:TAG]`, the list is empty.
+
+  ```bash
+  $ docker images java:0
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  ```
+
+  ### List the full length image IDs
+
+  ```bash
+  $ docker images --no-trunc
+
+  REPOSITORY                    TAG                 IMAGE ID                                                                  CREATED             SIZE
+  <none>                        <none>              sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182   19 hours ago        1.089 GB
+  committest                    latest              sha256:b6fa739cedf5ea12a620a439402b6004d057da800f91c7524b5086a5e4749c9f   19 hours ago        1.089 GB
+  <none>                        <none>              sha256:78a85c484f71509adeaace20e72e941f6bdd2b25b4c75da8693efd9f61a37921   19 hours ago        1.089 GB
+  docker                        latest              sha256:30557a29d5abc51e5f1d5b472e79b7e296f595abcf19fe6b9199dbbc809c6ff4   20 hours ago        1.089 GB
+  <none>                        <none>              sha256:0124422dd9f9cf7ef15c0617cda3931ee68346455441d66ab8bdc5b05e9fdce5   20 hours ago        1.089 GB
+  <none>                        <none>              sha256:18ad6fad340262ac2a636efd98a6d1f0ea775ae3d45240d3418466495a19a81b   22 hours ago        1.082 GB
+  <none>                        <none>              sha256:f9f1e26352f0a3ba6a0ff68167559f64f3e21ff7ada60366e2d44a04befd1d3a   23 hours ago        1.089 GB
+  tryout                        latest              sha256:2629d1fa0b81b222fca63371ca16cbf6a0772d07759ff80e8d1369b926940074   23 hours ago        131.5 MB
+  <none>                        <none>              sha256:5ed6274db6ceb2397844896966ea239290555e74ef307030ebb01ff91b1914df   24 hours ago        1.089 GB
+  ```
+
+  ### List image digests
+
+  Images that use the v2 or later format have a content-addressable identifier
+  called a `digest`. As long as the input used to generate the image is
+  unchanged, the digest value is predictable. To list image digest values, use
+  the `--digests` flag:
+
+  ```bash
+  $ docker images --digests
+  REPOSITORY                         TAG                 DIGEST                                                                    IMAGE ID            CREATED             SIZE
+  localhost:5000/test/busybox        <none>              sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536        9 weeks ago         2.43 MB
+  ```
+
+  When pushing or pulling to a 2.0 registry, the `push` or `pull` command
+  output includes the image digest. You can `pull` using a digest value. You can
+  also reference by digest in `create`, `run`, and `rmi` commands, as well as the
+  `FROM` image reference in a Dockerfile.
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * dangling (boolean - true or false)
+  * label (`label=<key>` or `label=<key>=<value>`)
+  * before (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filter images created before given id or references
+  * since (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filter images created since given id or references
+  * reference (pattern of an image reference) - filter images whose reference matches the specified pattern
+
+  #### Show untagged images (dangling)
+
+  ```bash
+  $ docker images --filter "dangling=true"
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  <none>              <none>              8abc22fbb042        4 weeks ago         0 B
+  <none>              <none>              48e5f45168b9        4 weeks ago         2.489 MB
+  <none>              <none>              bf747efa0e2f        4 weeks ago         0 B
+  <none>              <none>              980fe10e5736        12 weeks ago        101.4 MB
+  <none>              <none>              dea752e4e117        12 weeks ago        101.4 MB
+  <none>              <none>              511136ea3c5a        8 months ago        0 B
+  ```
+
+  This will display untagged images that are the leaves of the images tree (not
+  intermediary layers). These images occur when a new build of an image takes the
+  `repo:tag` away from the image ID, leaving it as `<none>:<none>` or untagged.
+  A warning will be issued if trying to remove an image when a container is presently
+  using it. By having this flag it allows for batch cleanup.
+
+  You can use this in conjunction with `docker rmi ...`:
+
+  ```bash
+  $ docker rmi $(docker images -f "dangling=true" -q)
+
+  8abc22fbb042
+  48e5f45168b9
+  bf747efa0e2f
+  980fe10e5736
+  dea752e4e117
+  511136ea3c5a
+  ```
+
+  > **Note**: Docker warns you if any containers exist that are using these
+  > untagged images.
+
+
+  #### Show images with a given label
+
+  The `label` filter matches images based on the presence of a `label` alone or a `label` and a
+  value.
+
+  The following filter matches images with the `com.example.version` label regardless of its value.
+
+  ```bash
+  $ docker images --filter "label=com.example.version"
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
+  match-me-1          latest              eeae25ada2aa        About a minute ago   188.3 MB
+  match-me-2          latest              dea752e4e117        About a minute ago   188.3 MB
+  ```
+
+  The following filter matches images with the `com.example.version` label with the `1.0` value.
+
+  ```bash
+  $ docker images --filter "label=com.example.version=1.0"
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
+  match-me            latest              511136ea3c5a        About a minute ago   188.3 MB
+  ```
+
+  In this example, with the `0.1` value, it returns an empty set because no matches were found.
+
+  ```bash
+  $ docker images --filter "label=com.example.version=0.1"
+  REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
+  ```
+
+  #### Filter images by time
+
+  The `before` filter shows only images created before the image with
+  given id or reference. For example, having these images:
+
+  ```bash
+  $ docker images
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
+  image1              latest              eeae25ada2aa        4 minutes ago        188.3 MB
+  image2              latest              dea752e4e117        9 minutes ago        188.3 MB
+  image3              latest              511136ea3c5a        25 minutes ago       188.3 MB
+  ```
+
+  Filtering with `before` would give:
+
+  ```bash
+  $ docker images --filter "before=image1"
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
+  image2              latest              dea752e4e117        9 minutes ago        188.3 MB
+  image3              latest              511136ea3c5a        25 minutes ago       188.3 MB
+  ```
+
+  Filtering with `since` would give:
+
+  ```bash
+  $ docker images --filter "since=image3"
+  REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
+  image1              latest              eeae25ada2aa        4 minutes ago        188.3 MB
+  image2              latest              dea752e4e117        9 minutes ago        188.3 MB
+  ```
+
+  #### Filter images by reference
+
+  The `reference` filter shows only images whose reference matches
+  the specified pattern.
+
+  ```bash
+      $ docker images
+
+      REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+      busybox             latest              e02e811dd08f        5 weeks ago         1.09 MB
+      busybox             uclibc              e02e811dd08f        5 weeks ago         1.09 MB
+      busybox             musl                733eb3059dce        5 weeks ago         1.21 MB
+      busybox             glibc               21c16b6787c6        5 weeks ago         4.19 MB
+  ```
+
+  Filtering with `reference` would give:
+
+  ```bash
+      $ docker images --filter=reference='busy*:*libc'
+      REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+      busybox             uclibc              e02e811dd08f        5 weeks ago         1.09 MB
+      busybox             glibc               21c16b6787c6        5 weeks ago         4.19 MB
+  ```
+
+  ### Format the output
+
+  The formatting option (`--format`) will pretty print container output
+  using a Go template.
+
+  Valid placeholders for the Go template are listed below:
+
+  | Placeholder | Description|
+  | ---- | ---- |
+  | `.ID` | Image ID |
+  | `.Repository` | Image repository |
+  | `.Tag` | Image tag |
+  | `.Digest` | Image digest |
+  | `.CreatedSince` | Elapsed time since the image was created |
+  | `.CreatedAt` | Time when the image was created |
+  | `.Size` | Image disk size |
+
+  When using the `--format` option, the `image` command will either
+  output the data exactly as the template declares or, when using the
+  `table` directive, will include column headers as well.
+
+  The following example uses a template without headers and outputs the
+  `ID` and `Repository` entries separated by a colon for all images:
+
+  ```bash
+  $ docker images --format "{{.ID}}: {{.Repository}}"
+
+  77af4d6b9913: <none>
+  b6fa739cedf5: committ
+  78a85c484f71: <none>
+  30557a29d5ab: docker
+  5ed6274db6ce: <none>
+  746b819f315e: postgres
+  746b819f315e: postgres
+  746b819f315e: postgres
+  746b819f315e: postgres
+  ```
+
+  To list all images with their repository and tag in a table format you
+  can use:
+
+  ```bash
+  $ docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}"
+
+  IMAGE ID            REPOSITORY                TAG
+  77af4d6b9913        <none>                    <none>
+  b6fa739cedf5        committ                   latest
+  78a85c484f71        <none>                    <none>
+  30557a29d5ab        docker                    latest
+  5ed6274db6ce        <none>                    <none>
+  746b819f315e        postgres                  9
+  746b819f315e        postgres                  9.3
+  746b819f315e        postgres                  9.3.5
+  746b819f315e        postgres                  latest
+  ```
+

--- a/_data/engine-cli-edge/docker_import.yaml
+++ b/_data/engine-cli-edge/docker_import.yaml
@@ -1,0 +1,72 @@
+command: docker import
+short: Import the contents from a tarball to create a filesystem image
+long: |-
+  You can specify a `URL` or `-` (dash) to take data directly from `STDIN`. The
+  `URL` can point to an archive (.tar, .tar.gz, .tgz, .bzip, .tar.xz, or .txz)
+  containing a filesystem or to an individual file on the Docker host.  If you
+  specify an archive, Docker untars it in the container relative to the `/`
+  (root). If you specify an individual file, you must specify the full path within
+  the host. To import from a remote location, specify a `URI` that begins with the
+  `http://` or `https://` protocol.
+
+  The `--change` option will apply `Dockerfile` instructions to the image
+  that is created.
+  Supported `Dockerfile` instructions:
+  `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
+usage: docker import [OPTIONS] file|URL|- [REPOSITORY[:TAG]]
+pname: docker
+plink: docker.yaml
+options:
+- option: change
+  shorthand: c
+  default_value: '[]'
+  description: Apply Dockerfile instruction to the created image
+- option: message
+  shorthand: m
+  description: Set commit message for imported image
+examples: |-
+  ### Import from a remote location
+
+  This will create a new untagged image.
+
+  ```bash
+  $ docker import http://example.com/exampleimage.tgz
+  ```
+
+  ### Import from a local file
+
+  - Import to docker via pipe and `STDIN`.
+
+    ```bash
+    $ cat exampleimage.tgz | docker import - exampleimagelocal:new
+    ```
+
+  - Import with a commit message.
+
+    ```bash
+    $ cat exampleimage.tgz | docker import --message "New image imported from tarball" - exampleimagelocal:new
+    ```
+
+  - Import to docker from a local archive.
+
+    ```bash
+      $ docker import /path/to/exampleimage.tgz
+    ```
+
+  ### Import from a local directory
+
+  ```bash
+  $ sudo tar -c . | docker import - exampleimagedir
+  ```
+
+  ### Import from a local directory with new configurations
+
+  ```bash
+  $ sudo tar -c . | docker import --change "ENV DEBUG true" - exampleimagedir
+  ```
+
+  Note the `sudo` in this example – you must preserve
+  the ownership of the files (especially root ownership) during the
+  archiving with tar. If you are not root (or the sudo command) when you
+  tar, then the ownerships might not get preserved.
+

--- a/_data/engine-cli-edge/docker_info.yaml
+++ b/_data/engine-cli-edge/docker_info.yaml
@@ -1,0 +1,224 @@
+command: docker info
+short: Display system-wide information
+long: |-
+  This command displays system wide information regarding the Docker installation.
+  Information displayed includes the kernel version, number of containers and images.
+  The number of images shown is the number of unique images. The same image tagged
+  under different names is counted only once.
+
+  If a format is specified, the given template will be executed instead of the
+  default format. Go's [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+
+  Depending on the storage driver in use, additional information can be shown, such
+  as pool name, data file, metadata file, data space used, total data space, metadata
+  space used, and total metadata space.
+
+  The data file is where the images are stored and the metadata file is where the
+  meta data regarding those images are stored. When run for the first time Docker
+  allocates a certain amount of data space and meta data space from the space
+  available on the volume where `/var/lib/docker` is mounted.
+usage: docker info [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+examples: |-
+  ### Show output
+
+  The example below shows the output for a daemon running on Red Hat Enterprise Linux,
+  using the `devicemapper` storage driver. As can be seen in the output, additional
+  information about the `devicemapper` storage driver is shown:
+
+  ```bash
+  $ docker info
+
+  Containers: 14
+   Running: 3
+   Paused: 1
+   Stopped: 10
+  Images: 52
+  Server Version: 1.10.3
+  Storage Driver: devicemapper
+   Pool Name: docker-202:2-25583803-pool
+   Pool Blocksize: 65.54 kB
+   Base Device Size: 10.74 GB
+   Backing Filesystem: xfs
+   Data file: /dev/loop0
+   Metadata file: /dev/loop1
+   Data Space Used: 1.68 GB
+   Data Space Total: 107.4 GB
+   Data Space Available: 7.548 GB
+   Metadata Space Used: 2.322 MB
+   Metadata Space Total: 2.147 GB
+   Metadata Space Available: 2.145 GB
+   Udev Sync Supported: true
+   Deferred Removal Enabled: false
+   Deferred Deletion Enabled: false
+   Deferred Deleted Device Count: 0
+   Data loop file: /var/lib/docker/devicemapper/devicemapper/data
+   Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
+   Library Version: 1.02.107-RHEL7 (2015-12-01)
+  Execution Driver: native-0.2
+  Logging Driver: json-file
+  Plugins:
+   Volume: local
+   Network: null host bridge
+  Kernel Version: 3.10.0-327.el7.x86_64
+  Operating System: Red Hat Enterprise Linux Server 7.2 (Maipo)
+  OSType: linux
+  Architecture: x86_64
+  CPUs: 1
+  Total Memory: 991.7 MiB
+  Name: ip-172-30-0-91.ec2.internal
+  ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+  Docker Root Dir: /var/lib/docker
+  Debug mode (client): false
+  Debug mode (server): false
+  Username: gordontheturtle
+  Registry: https://index.docker.io/v1/
+  Insecure registries:
+   myinsecurehost:5000
+   127.0.0.0/8
+  ```
+
+  ### Show debugging output
+
+  Here is a sample output for a daemon running on Ubuntu, using the overlay2
+  storage driver and a node that is part of a 2-node swarm:
+
+  ```bash
+  $ docker -D info
+
+  Containers: 14
+   Running: 3
+   Paused: 1
+   Stopped: 10
+  Images: 52
+  Server Version: 1.13.0
+  Storage Driver: overlay2
+   Backing Filesystem: extfs
+   Supports d_type: true
+   Native Overlay Diff: false
+  Logging Driver: json-file
+  Cgroup Driver: cgroupfs
+  Plugins:
+   Volume: local
+   Network: bridge host macvlan null overlay
+  Swarm: active
+   NodeID: rdjq45w1op418waxlairloqbm
+   Is Manager: true
+   ClusterID: te8kdyw33n36fqiz74bfjeixd
+   Managers: 1
+   Nodes: 2
+   Orchestration:
+    Task History Retention Limit: 5
+   Raft:
+    Snapshot Interval: 10000
+    Number of Old Snapshots to Retain: 0
+    Heartbeat Tick: 1
+    Election Tick: 3
+   Dispatcher:
+    Heartbeat Period: 5 seconds
+   CA Configuration:
+    Expiry Duration: 3 months
+   Node Address: 172.16.66.128 172.16.66.129
+   Manager Addresses:
+    172.16.66.128:2477
+  Runtimes: runc
+  Default Runtime: runc
+  Init Binary: docker-init
+  containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531
+  runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2
+  init version: N/A (expected: v0.13.0)
+  Security Options:
+   apparmor
+   seccomp
+    Profile: default
+  Kernel Version: 4.4.0-31-generic
+  Operating System: Ubuntu 16.04.1 LTS
+  OSType: linux
+  Architecture: x86_64
+  CPUs: 2
+  Total Memory: 1.937 GiB
+  Name: ubuntu
+  ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326
+  Docker Root Dir: /var/lib/docker
+  Debug Mode (client): true
+  Debug Mode (server): true
+   File Descriptors: 30
+   Goroutines: 123
+   System Time: 2016-11-12T17:24:37.955404361-08:00
+   EventsListeners: 0
+  Http Proxy: http://test:test@proxy.example.com:8080
+  Https Proxy: https://test:test@proxy.example.com:8080
+  No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com
+  Registry: https://index.docker.io/v1/
+  WARNING: No swap limit support
+  Labels:
+   storage=ssd
+   staging=true
+  Experimental: false
+  Insecure Registries:
+   127.0.0.0/8
+  Registry Mirrors:
+    http://192.168.1.2/
+    http://registry-mirror.example.com:5000/
+  Live Restore Enabled: false
+  ```
+
+  The global `-D` option causes all `docker` commands to output debug information.
+
+  ### Format the output
+
+  You can also specify the output format:
+
+  ```bash
+  $ docker info --format '{{json .}}'
+
+  {"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}
+  ```
+
+  ### Run `docker info` on Windows
+
+  Here is a sample output for a daemon running on Windows Server 2016:
+
+  ```none
+  E:\docker>docker info
+
+  Containers: 1
+   Running: 0
+   Paused: 0
+   Stopped: 1
+  Images: 17
+  Server Version: 1.13.0
+  Storage Driver: windowsfilter
+   Windows:
+  Logging Driver: json-file
+  Plugins:
+   Volume: local
+   Network: nat null overlay
+  Swarm: inactive
+  Default Isolation: process
+  Kernel Version: 10.0 14393 (14393.206.amd64fre.rs1_release.160912-1937)
+  Operating System: Windows Server 2016 Datacenter
+  OSType: windows
+  Architecture: x86_64
+  CPUs: 8
+  Total Memory: 3.999 GiB
+  Name: WIN-V0V70C0LU5P
+  ID: NYMS:B5VK:UMSL:FVDZ:EWB5:FKVK:LPFL:FJMQ:H6FT:BZJ6:L2TD:XH62
+  Docker Root Dir: C:\control
+  Debug Mode (client): false
+  Debug Mode (server): false
+  Registry: https://index.docker.io/v1/
+  Insecure Registries:
+   127.0.0.0/8
+  Registry Mirrors:
+    http://192.168.1.2/
+    http://registry-mirror.example.com:5000/
+  Live Restore Enabled: false
+  ```
+

--- a/_data/engine-cli-edge/docker_inspect.yaml
+++ b/_data/engine-cli-edge/docker_inspect.yaml
@@ -1,0 +1,84 @@
+command: docker inspect
+short: Return low-level information on Docker objects
+long: |-
+  By default, `docker inspect` will render all results in a JSON array. If the container and
+  image have the same name, this will return container JSON for unspecified type.
+  If a format is specified, the given template will be executed for each result.
+
+  Go's [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+usage: docker inspect [OPTIONS] NAME|ID [NAME|ID...]
+pname: docker
+plink: docker.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes if the type is container
+- option: type
+  description: Return JSON for specified type
+examples: |-
+  ### Get an instance's IP address
+
+  For the most part, you can pick out any field from the JSON in a fairly
+  straightforward manner.
+
+  ```bash
+  $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $INSTANCE_ID
+  ```
+
+  ### Get an instance's MAC address
+
+  ```bash
+  $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.MacAddress}}{{end}}' $INSTANCE_ID
+  ```
+
+  ### Get an instance's log path
+
+  ```bash
+  $ docker inspect --format='{{.LogPath}}' $INSTANCE_ID
+  ```
+
+  ### Get an instance's image name
+
+  ```bash
+  $ docker inspect --format='{{.Config.Image}}' $INSTANCE_ID
+  ```
+
+  ### List all port bindings
+
+  You can loop over arrays and maps in the results to produce simple text
+  output:
+
+  ```bash
+  $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
+  ```
+
+  ### Find a specific port mapping
+
+  The `.Field` syntax doesn't work when the field name begins with a
+  number, but the template language's `index` function does. The
+  `.NetworkSettings.Ports` section contains a map of the internal port
+  mappings to a list of external address/port objects. To grab just the
+  numeric public port, you use `index` to find the specific port map, and
+  then `index` 0 contains the first object inside of that. Then we ask for
+  the `HostPort` field to get the public address.
+
+  ```bash
+  $ docker inspect --format='{{(index (index .NetworkSettings.Ports "8787/tcp") 0).HostPort}}' $INSTANCE_ID
+  ```
+
+  ### Get a subsection in JSON format
+
+  If you request a field which is itself a structure containing other
+  fields, by default you get a Go-style dump of the inner values.
+  Docker adds a template function, `json`, which can be applied to get
+  results in JSON format.
+
+  ```bash
+  $ docker inspect --format='{{json .Config}}' $INSTANCE_ID
+  ```
+

--- a/_data/engine-cli-edge/docker_kill.yaml
+++ b/_data/engine-cli-edge/docker_kill.yaml
@@ -1,0 +1,18 @@
+command: docker kill
+short: Kill one or more running containers
+long: |-
+  The main process inside the container will be sent `SIGKILL`, or any
+  signal specified with option `--signal`.
+
+  > **Note**: `ENTRYPOINT` and `CMD` in the *shell* form run as a subcommand of
+  > `/bin/sh -c`, which does not pass signals. This means that the executable is
+  > not the container’s PID 1 and does not receive Unix signals.
+usage: docker kill [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: signal
+  shorthand: s
+  default_value: KILL
+  description: Signal to send to the container
+

--- a/_data/engine-cli-edge/docker_load.yaml
+++ b/_data/engine-cli-edge/docker_load.yaml
@@ -1,0 +1,45 @@
+command: docker load
+short: Load an image from a tar archive or STDIN
+long: |-
+  `docker load` loads a tarred repository from a file or the standard input stream.
+  It restores both images and tags.
+usage: docker load [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: input
+  shorthand: i
+  description: Read from tar archive file, instead of STDIN
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Suppress the load output
+examples: |-
+  ```bash
+  $ docker images
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+
+  $ docker load < busybox.tar.gz
+
+  Loaded image: busybox:latest
+  $ docker images
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+
+  $ docker load --input fedora.tar
+
+  Loaded image: fedora:rawhide
+
+  Loaded image: fedora:20
+
+  $ docker images
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+  fedora              rawhide             0d20aec6529d        7 weeks ago         387 MB
+  fedora              20                  58394af37342        7 weeks ago         385.5 MB
+  fedora              heisenbug           58394af37342        7 weeks ago         385.5 MB
+  fedora              latest              58394af37342        7 weeks ago         385.5 MB
+  ```
+

--- a/_data/engine-cli-edge/docker_login.yaml
+++ b/_data/engine-cli-edge/docker_login.yaml
@@ -1,0 +1,69 @@
+command: docker login
+short: Log in to a Docker registry
+long: "Login to a registry.\n\n### Login to a self-hosted registry\n\nIf you want
+  to login to a self-hosted registry you can specify this by\nadding the server name.\n\n```bash\n$
+  docker login localhost:8080\n```\n\n### Privileged user requirement\n\n`docker login`
+  requires user to use `sudo` or be `root`, except when:\n\n1.  connecting to a remote
+  daemon, such as a `docker-machine` provisioned `docker engine`.\n2.  user is added
+  to the `docker` group.  This will impact the security of your system; the `docker`
+  group is `root` equivalent.  See [Docker Daemon Attack Surface](https://docs.docker.com/security/security/#docker-daemon-attack-surface)
+  for details.\n\nYou can log into any public or private repository for which you
+  have\ncredentials.  When you log in, the command stores encoded credentials in\n`$HOME/.docker/config.json`
+  on Linux or `%USERPROFILE%/.docker/config.json` on Windows.\n\n### Credentials store\n\nThe
+  Docker Engine can keep user credentials in an external credentials store,\nsuch
+  as the native keychain of the operating system. Using an external store\nis more
+  secure than storing credentials in the Docker configuration file.\n\nTo use a credentials
+  store, you need an external helper program to interact\nwith a specific keychain
+  or external store. Docker requires the helper\nprogram to be in the client's host
+  `$PATH`.\n\nThis is the list of currently available credentials helpers and where\nyou
+  can download them from:\n\n- D-Bus Secret Service: https://github.com/docker/docker-credential-helpers/releases\n-
+  Apple macOS keychain: https://github.com/docker/docker-credential-helpers/releases\n-
+  Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases\n\nYou
+  need to specify the credentials store in `$HOME/.docker/config.json`\nto tell the
+  docker engine to use it:\n\n```json\n{\n\t\"credsStore\": \"osxkeychain\"\n}\n```\n\nIf
+  you are currently logged in, run `docker logout` to remove\nthe credentials from
+  the file and run `docker login` again.\n\n### Credential helper protocol\n\nCredential
+  helpers can be any program or script that follows a very simple protocol.\nThis
+  protocol is heavily inspired by Git, but it differs in the information shared.\n\nThe
+  helpers always use the first argument in the command to identify the action.\nThere
+  are only three possible values for that argument: `store`, `get`, and `erase`.\n\nThe
+  `store` command takes a JSON payload from the standard input. That payload carries\nthe
+  server address, to identify the credential, the user name, and either a password\nor
+  an identity token.\n\n```json\n{\n\t\"ServerURL\": \"https://index.docker.io/v1\",\n\t\"Username\":
+  \"david\",\n\t\"Secret\": \"passw0rd1\"\n}\n```\n\nIf the secret being stored is
+  an identity token, the Username should be set to\n`<token>`.\n\nThe `store` command
+  can write error messages to `STDOUT` that the docker engine\nwill show if there
+  was an issue.\n\nThe `get` command takes a string payload from the standard input.
+  That payload carries\nthe server address that the docker engine needs credentials
+  for. This is\nan example of that payload: `https://index.docker.io/v1`.\n\nThe `get`
+  command writes a JSON payload to `STDOUT`. Docker reads the user name\nand password
+  from this payload:\n\n```json\n{\n\t\"Username\": \"david\",\n\t\"Secret\": \"passw0rd1\"\n}\n```\n\nThe
+  `erase` command takes a string payload from `STDIN`. That payload carries\nthe server
+  address that the docker engine wants to remove credentials for. This is\nan example
+  of that payload: `https://index.docker.io/v1`.\n\nThe `erase` command can write
+  error messages to `STDOUT` that the docker engine\nwill show if there was an issue.\n\n###
+  Credential helpers\n\nCredential helpers are similar to the credential store above,
+  but act as the\ndesignated programs to handle credentials for *specific registries*.
+  The default\ncredential store (`credsStore` or the config file itself) will not
+  be used for\noperations concerning credentials of the specified registries.\n\n###
+  Logging out\n\nIf you are currently logged in, run `docker logout` to remove\nthe
+  credentials from the default store.\n\nCredential helpers are specified in a similar
+  way to `credsStore`, but\nallow for multiple helpers to be configured at a time.
+  Keys specify the\nregistry domain, and values specify the suffix of the program
+  to use\n(i.e. everything after `docker-credential-`).\nFor example:\n\n```json\n{\n
+  \ \"credHelpers\": {\n    \"registry.example.com\": \"registryhelper\",\n    \"awesomereg.example.org\":
+  \"hip-star\",\n    \"unicorn.example.io\": \"vcbait\"\n  }\n}\n```"
+usage: docker login [OPTIONS] [SERVER]
+pname: docker
+plink: docker.yaml
+options:
+- option: email
+  shorthand: e
+  description: Email
+- option: password
+  shorthand: p
+  description: Password
+- option: username
+  shorthand: u
+  description: Username
+

--- a/_data/engine-cli-edge/docker_logout.yaml
+++ b/_data/engine-cli-edge/docker_logout.yaml
@@ -1,0 +1,11 @@
+command: docker logout
+short: Log out from a Docker registry
+long: Log out from a Docker registry
+usage: docker logout [SERVER]
+pname: docker
+plink: docker.yaml
+examples: |-
+  ```bash
+  $ docker logout localhost:8080
+  ```
+

--- a/_data/engine-cli-edge/docker_logs.yaml
+++ b/_data/engine-cli-edge/docker_logs.yaml
@@ -1,0 +1,59 @@
+command: docker logs
+short: Fetch the logs of a container
+long: |-
+  The `docker logs` command batch-retrieves logs present at the time of execution.
+
+  > **Note**: this command is only functional for containers that are started with
+  > the `json-file` or `journald` logging driver.
+
+  For more information about selecting and configuring logging drivers, refer to
+  [Configure logging drivers](https://docs.docker.com/engine/admin/logging/overview/).
+
+  The `docker logs --follow` command will continue streaming the new output from
+  the container's `STDOUT` and `STDERR`.
+
+  Passing a negative number or a non-integer to `--tail` is invalid and the
+  value is set to `all` in that case.
+
+  The `docker logs --timestamps` command will add an [RFC3339Nano timestamp](https://golang.org/pkg/time/#pkg-constants)
+  , for example `2014-09-16T06:17:46.000000000Z`, to each
+  log entry. To ensure that the timestamps are aligned the
+  nano-second part of the timestamp will be padded with zero when necessary.
+
+  The `docker logs --details` command will add on extra attributes, such as
+  environment variables and labels, provided to `--log-opt` when creating the
+  container.
+
+  The `--since` option shows only the container logs generated after
+  a given date. You can specify the date as an RFC 3339 date, a UNIX
+  timestamp, or a Go duration string (e.g. `1m30s`, `3h`). Besides RFC3339 date
+  format you may also use RFC3339Nano, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the client will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp. When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long. You can combine the
+  `--since` option with either or both of the `--follow` or `--tail` options.
+usage: docker logs [OPTIONS] CONTAINER
+pname: docker
+plink: docker.yaml
+options:
+- option: details
+  default_value: "false"
+  description: Show extra details provided to logs
+- option: follow
+  shorthand: f
+  default_value: "false"
+  description: Follow log output
+- option: since
+  description: Show logs since timestamp
+- option: tail
+  default_value: all
+  description: Number of lines to show from the end of the logs
+- option: timestamps
+  shorthand: t
+  default_value: "false"
+  description: Show timestamps
+

--- a/_data/engine-cli-edge/docker_network.yaml
+++ b/_data/engine-cli-edge/docker_network.yaml
@@ -1,0 +1,25 @@
+command: docker network
+short: Manage networks
+long: |-
+  Manage networks. You can use subcommand to create, list, inspect, remove,
+  connect and disconnect networks.
+usage: docker network
+pname: docker
+plink: docker.yaml
+cname:
+- docker network connect
+- docker network create
+- docker network disconnect
+- docker network inspect
+- docker network ls
+- docker network prune
+- docker network rm
+clink:
+- docker_network_connect.yaml
+- docker_network_create.yaml
+- docker_network_disconnect.yaml
+- docker_network_inspect.yaml
+- docker_network_ls.yaml
+- docker_network_prune.yaml
+- docker_network_rm.yaml
+

--- a/_data/engine-cli-edge/docker_network_connect.yaml
+++ b/_data/engine-cli-edge/docker_network_connect.yaml
@@ -1,0 +1,92 @@
+command: docker network connect
+short: Connect a container to a network
+long: |-
+  Connects a container to a network. You can connect a container by name
+  or by ID. Once connected, the container can communicate with other containers in
+  the same network.
+usage: docker network connect [OPTIONS] NETWORK CONTAINER
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: ip
+  description: IP Address
+- option: ip6
+  description: IPv6 Address
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Add a link-local address for the container
+examples: |-
+  ### Connect a running container to a network
+
+  ```bash
+  $ docker network connect multi-host-network container1
+  ```
+
+  ### Connect a container to a network when it starts
+
+  You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
+
+  ```bash
+  $ docker run -itd --network=multi-host-network busybox
+  ```
+
+  ### Specify the IP address a container will use on a given network
+
+  You can specify the IP address you want to be assigned to the container's interface.
+
+  ```bash
+  $ docker network connect --ip 10.10.36.122 multi-host-network container2
+  ```
+
+  ### Use the legacy `--link` option
+
+  You can use `--link` option to link another container with a preferred alias
+
+  ```bash
+  $ docker network connect --link container1:c1 multi-host-network container2
+  ```
+
+  ### Create a network alias for a container
+
+  `--alias` option can be used to resolve the container by another name in the network
+  being connected to.
+
+  ```bash
+  $ docker network connect --alias db --alias mysql multi-host-network container2
+  ```
+
+  ### Network implications of stopping, pausing, or restarting containers
+
+  You can pause, restart, and stop containers that are connected to a network.
+  A container connects to its configured networks when it runs.
+
+  If specified, the container's IP address(es) is reapplied when a stopped
+  container is restarted. If the IP address is no longer available, the container
+  fails to start. One way to guarantee that the IP address is available is
+  to specify an `--ip-range` when creating the network, and choose the static IP
+  address(es) from outside that range. This ensures that the IP address is not
+  given to another container while this container is not on the network.
+
+  ```bash
+  $ docker network create --subnet 172.20.0.0/16 --ip-range 172.20.240.0/20 multi-host-network
+  ```
+
+  ```bash
+  $ docker network connect --ip 172.20.128.2 multi-host-network container2
+  ```
+
+  To verify the container is connected, use the `docker network inspect` command. Use `docker network disconnect` to remove a container from the network.
+
+  Once connected in network, containers can communicate using only another
+  container's IP address or name. For `overlay` networks or custom plugins that
+  support multi-host connectivity, containers connected to the same multi-host
+  network but launched from different Engines can also communicate in this way.
+
+  You can connect a container to one or more networks. The networks need not be the same type. For example, you can connect a single container bridge and overlay networks.
+

--- a/_data/engine-cli-edge/docker_network_create.yaml
+++ b/_data/engine-cli-edge/docker_network_create.yaml
@@ -1,0 +1,198 @@
+command: docker network create
+short: Create a network
+long: |-
+  Creates a new network. The `DRIVER` accepts `bridge` or `overlay` which are the
+  built-in network drivers. If you have installed a third party or your own custom
+  network driver you can specify that `DRIVER` here also. If you don't specify the
+  `--driver` option, the command automatically creates a `bridge` network for you.
+  When you install Docker Engine it creates a `bridge` network automatically. This
+  network corresponds to the `docker0` bridge that Engine has traditionally relied
+  on. When you launch a new container with  `docker run` it automatically connects to
+  this bridge network. You cannot remove this default bridge network, but you can
+  create new ones using the `network create` command.
+
+  ```bash
+  $ docker network create -d bridge my-bridge-network
+  ```
+
+  Bridge networks are isolated networks on a single Engine installation. If you
+  want to create a network that spans multiple Docker hosts each running an
+  Engine, you must create an `overlay` network. Unlike `bridge` networks, overlay
+  networks require some pre-existing conditions before you can create one. These
+  conditions are:
+
+  * Access to a key-value store. Engine supports Consul, Etcd, and ZooKeeper (Distributed store) key-value stores.
+  * A cluster of hosts with connectivity to the key-value store.
+  * A properly configured Engine `daemon` on each host in the cluster.
+
+  The `dockerd` options that support the `overlay` network are:
+
+  * `--cluster-store`
+  * `--cluster-store-opt`
+  * `--cluster-advertise`
+
+  To read more about these options and how to configure them, see ["*Get started
+  with multi-host network*"](https://docs.docker.com/engine/userguide/networking/get-started-overlay).
+
+  While not required, it is a good idea to install Docker Swarm to
+  manage the cluster that makes up your network. Swarm provides sophisticated
+  discovery and server management tools that can assist your implementation.
+
+  Once you have prepared the `overlay` network prerequisites you simply choose a
+  Docker host in the cluster and issue the following to create the network:
+
+  ```bash
+  $ docker network create -d overlay my-multihost-network
+  ```
+
+  Network names must be unique. The Docker daemon attempts to identify naming
+  conflicts but this is not guaranteed. It is the user's responsibility to avoid
+  name conflicts.
+usage: docker network create [OPTIONS] NETWORK
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: attachable
+  default_value: "false"
+  description: Enable manual container attachment
+- option: aux-address
+  default_value: map[]
+  description: Auxiliary IPv4 or IPv6 addresses used by Network driver
+- option: driver
+  shorthand: d
+  default_value: bridge
+  description: Driver to manage the Network
+- option: gateway
+  default_value: '[]'
+  description: IPv4 or IPv6 Gateway for the master subnet
+- option: internal
+  default_value: "false"
+  description: Restrict external access to the network
+- option: ip-range
+  default_value: '[]'
+  description: Allocate container ip from a sub-range
+- option: ipam-driver
+  default_value: default
+  description: IP Address Management Driver
+- option: ipam-opt
+  default_value: map[]
+  description: Set IPAM driver specific options
+- option: ipv6
+  default_value: "false"
+  description: Enable IPv6 networking
+- option: label
+  default_value: '[]'
+  description: Set metadata on a network
+- option: opt
+  shorthand: o
+  default_value: map[]
+  description: Set driver specific options
+- option: subnet
+  default_value: '[]'
+  description: Subnet in CIDR format that represents a network segment
+examples: |-
+  ### Connect containers
+
+  When you start a container, use the `--network` flag to connect it to a network.
+  This example adds the `busybox` container to the `mynet` network:
+
+  ```bash
+  $ docker run -itd --network=mynet busybox
+  ```
+
+  If you want to add a container to a network after the container is already
+  running, use the `docker network connect` subcommand.
+
+  You can connect multiple containers to the same network. Once connected, the
+  containers can communicate using only another container's IP address or name.
+  For `overlay` networks or custom plugins that support multi-host connectivity,
+  containers connected to the same multi-host network but launched from different
+  Engines can also communicate in this way.
+
+  You can disconnect a container from a network using the `docker network
+  disconnect` command.
+
+  ### Specify advanced options
+
+  When you create a network, Engine creates a non-overlapping subnetwork for the
+  network by default. This subnetwork is not a subdivision of an existing
+  network. It is purely for ip-addressing purposes. You can override this default
+  and specify subnetwork values directly using the `--subnet` option. On a
+  `bridge` network you can only create a single subnet:
+
+  ```bash
+  $ docker network create --driver=bridge --subnet=192.168.0.0/16 br0
+  ```
+
+  Additionally, you also specify the `--gateway` `--ip-range` and `--aux-address`
+  options.
+
+  ```bash
+  $ docker network create \
+    --driver=bridge \
+    --subnet=172.28.0.0/16 \
+    --ip-range=172.28.5.0/24 \
+    --gateway=172.28.5.254 \
+    br0
+  ```
+
+  If you omit the `--gateway` flag the Engine selects one for you from inside a
+  preferred pool. For `overlay` networks and for network driver plugins that
+  support it you can create multiple subnetworks.
+
+  ```bash
+  $ docker network create -d overlay \
+    --subnet=192.168.0.0/16 \
+    --subnet=192.170.0.0/16 \
+    --gateway=192.168.0.100 \
+    --gateway=192.170.0.100 \
+    --ip-range=192.168.1.0/24 \
+    --aux-address="my-router=192.168.1.5" --aux-address="my-switch=192.168.1.6" \
+    --aux-address="my-printer=192.170.1.5" --aux-address="my-nas=192.170.1.6" \
+    my-multihost-network
+  ```
+
+  Be sure that your subnetworks do not overlap. If they do, the network create
+  fails and Engine returns an error.
+
+  ### Bridge driver options
+
+  When creating a custom network, the default network driver (i.e. `bridge`) has
+  additional options that can be passed. The following are those options and the
+  equivalent docker daemon flags used for docker0 bridge:
+
+  | Option                                           | Equivalent  | Description                                           |
+  |--------------------------------------------------|-------------|-------------------------------------------------------|
+  | `com.docker.network.bridge.name`                 | -           | bridge name to be used when creating the Linux bridge |
+  | `com.docker.network.bridge.enable_ip_masquerade` | `--ip-masq` | Enable IP masquerading                                |
+  | `com.docker.network.bridge.enable_icc`           | `--icc`     | Enable or Disable Inter Container Connectivity        |
+  | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
+  | `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
+
+  The following arguments can be passed to `docker network create` for any
+  network driver, again with their approximate equivalents to `docker daemon`.
+
+  | Argument     | Equivalent     | Description                                |
+  |--------------|----------------|--------------------------------------------|
+  | `--gateway`  | -              | IPv4 or IPv6 Gateway for the master subnet |
+  | `--ip-range` | `--fixed-cidr` | Allocate IPs from a range                  |
+  | `--internal` | -              | Restrict external access to the network   |
+  | `--ipv6`     | `--ipv6`       | Enable IPv6 networking                     |
+  | `--subnet`   | `--bip`        | Subnet for network                         |
+
+  For example, let's use `-o` or `--opt` options to specify an IP address binding
+  when publishing ports:
+
+  ```bash
+  $ docker network create \
+      -o "com.docker.network.bridge.host_binding_ipv4"="172.19.0.1" \
+      simple-network
+  ```
+
+  ### Network internal mode
+
+  By default, when you connect a container to an `overlay` network, Docker also
+  connects a bridge network to it to provide external connectivity. If you want
+  to create an externally isolated `overlay` network, you can specify the
+  `--internal` option.
+

--- a/_data/engine-cli-edge/docker_network_disconnect.yaml
+++ b/_data/engine-cli-edge/docker_network_disconnect.yaml
@@ -1,0 +1,18 @@
+command: docker network disconnect
+short: Disconnect a container from a network
+long: |2-
+   a container from a network. The container must be running to
+  disconnect it from the network.
+usage: docker network disconnect [OPTIONS] NETWORK CONTAINER
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the container to disconnect from a network
+examples: |-
+  ```bash
+    $ docker network disconnect multi-host-network container1
+  ```
+

--- a/_data/engine-cli-edge/docker_network_inspect.yaml
+++ b/_data/engine-cli-edge/docker_network_inspect.yaml
@@ -1,0 +1,13 @@
+command: docker network inspect
+short: Display detailed information on one or more networks
+long: |-
+  Returns information about one or more networks. By default, this command renders
+  all results in a JSON object.
+usage: docker network inspect [OPTIONS] NETWORK [NETWORK...]
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+

--- a/_data/engine-cli-edge/docker_network_ls.yaml
+++ b/_data/engine-cli-edge/docker_network_ls.yaml
@@ -1,0 +1,93 @@
+command: docker network ls
+aliases: list
+short: List networks
+long: |-
+  Lists all the networks the Engine `daemon` knows about. This includes the
+  networks that span across multiple hosts in a cluster.
+usage: docker network ls [OPTIONS]
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Provide filter values (e.g. 'driver=bridge')
+- option: format
+  description: Pretty-print networks using a Go template
+- option: no-trunc
+  default_value: "false"
+  description: Do not truncate the output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display network IDs
+examples: "### List all networks\n\n```bash\n$ sudo docker network ls\nNETWORK ID
+  \         NAME                DRIVER          SCOPE\n7fca4eb8c647        bridge
+  \             bridge          local\n9f904ee27bf5        none                null
+  \           local\ncf03ee007fb4        host                host            local\n78b03ee04fc4
+  \       multi-host          overlay         swarm\n```\n\nUse the `--no-trunc` option
+  to display the full network id:\n\n```bash\n$ docker network ls --no-trunc\nNETWORK
+  ID                                                         NAME                DRIVER
+  \          SCOPE\n18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3
+  \  none                null             local\nc288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47
+  \  host                host             local\n7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185
+  \  bridge              bridge           local\n95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd
+  \  foo                 bridge           local\n63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161
+  \  dev                 bridge           local\n```\n\n### Filtering\n\nThe filtering
+  flag (`-f` or `--filter`) format is a `key=value` pair. If there\nis more than one
+  filter, then pass multiple flags (e.g. `--filter \"foo=bar\" --filter \"bif=baz\"`).\nMultiple
+  filter flags are combined as an `OR` filter. For example,\n`-f type=custom -f type=builtin`
+  returns both `custom` and `builtin` networks.\n\nThe currently supported filters
+  are:\n\n* driver\n* id (network's id)\n* label (`label=<key>` or `label=<key>=<value>`)\n*
+  name (network's name)\n* type (`custom|builtin`)\n\n#### Driver\n\nThe `driver`
+  filter matches networks based on their driver.\n\nThe following example matches
+  networks with the `bridge` driver:\n\n```bash\n$ docker network ls --filter driver=bridge\nNETWORK
+  ID          NAME                DRIVER            SCOPE\ndb9db329f835        test1
+  \              bridge            local\nf6e212da9dfd        test2               bridge
+  \           local\n```\n\n#### ID\n\nThe `id` filter matches on all or part of a
+  network's ID.\n\nThe following filter matches all networks with an ID containing
+  the\n`63d1ff1f77b0...` string.\n\n```bash\n$ docker network ls --filter id=63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161\nNETWORK
+  ID          NAME                DRIVER           SCOPE\n63d1ff1f77b0        dev
+  \                bridge           local\n```\n\nYou can also filter for a substring
+  in an ID as this shows:\n\n```bash\n$ docker network ls --filter id=95e74588f40d\nNETWORK
+  ID          NAME                DRIVER          SCOPE\n95e74588f40d        foo                 bridge
+  \         local\n\n$ docker network ls --filter id=95e\nNETWORK ID          NAME
+  \               DRIVER          SCOPE\n95e74588f40d        foo                 bridge
+  \         local\n```\n\n#### Label\n\nThe `label` filter matches networks based
+  on the presence of a `label` alone or a `label` and a\nvalue.\n\nThe following filter
+  matches networks with the `usage` label regardless of its value.\n\n```bash\n$ docker
+  network ls -f \"label=usage\"\nNETWORK ID          NAME                DRIVER         SCOPE\ndb9db329f835
+  \       test1               bridge         local\nf6e212da9dfd        test2               bridge
+  \        local\n```\n\nThe following filter matches networks with the `usage` label
+  with the `prod` value.\n\n```bash\n$ docker network ls -f \"label=usage=prod\"\nNETWORK
+  ID          NAME                DRIVER        SCOPE\nf6e212da9dfd        test2               bridge
+  \       local\n```\n\n#### Name\n\nThe `name` filter matches on all or part of a
+  network's name.\n\nThe following filter matches all networks with a name containing
+  the `foobar` string.\n\n```bash\n$ docker network ls --filter name=foobar\nNETWORK
+  ID          NAME                DRIVER       SCOPE\n06e7eef0a170        foobar              bridge
+  \      local\n```\n\nYou can also filter for a substring in a name as this shows:\n\n```bash\n$
+  docker network ls --filter name=foo\nNETWORK ID          NAME                DRIVER
+  \      SCOPE\n95e74588f40d        foo                 bridge       local\n06e7eef0a170
+  \       foobar              bridge       local\n```\n\n#### Type\n\nThe `type` filter
+  supports two values; `builtin` displays predefined networks\n(`bridge`, `none`,
+  `host`), whereas `custom` displays user defined networks.\n\nThe following filter
+  matches all user defined networks:\n\n```bash\n$ docker network ls --filter type=custom\nNETWORK
+  ID          NAME                DRIVER       SCOPE\n95e74588f40d        foo                 bridge
+  \      local  \n63d1ff1f77b0        dev                 bridge       local\n```\n\nBy
+  having this flag it allows for batch cleanup. For example, use this filter\nto delete
+  all user defined networks:\n\n```bash\n$ docker network rm `docker network ls --filter
+  type=custom -q`\n```\n\nA warning will be issued when trying to remove a network
+  that has containers\nattached.\n\n### Formatting\n\nThe formatting options (`--format`)
+  pretty-prints networks output\nusing a Go template.\n\nValid placeholders for the
+  Go template are listed below:\n\nPlaceholder | Description\n------------|------------------------------------------------------------------------------------------\n`.ID`
+  \      | Network ID\n`.Name`     | Network name\n`.Driver`   | Network driver\n`.Scope`
+  \   | Network scope (local, global)\n`.IPv6`     | Whether IPv6 is enabled on the
+  network or not.\n`.Internal` | Whether the network is internal or not.\n`.Labels`
+  \  | All labels assigned to the network.\n`.Label`    | Value of a specific label
+  for this network. For example `{{.Label \"project.version\"}}`\n\nWhen using the
+  `--format` option, the `network ls` command will either\noutput the data exactly
+  as the template declares or, when using the\n`table` directive, includes column
+  headers as well.\n\nThe following example uses a template without headers and outputs
+  the\n`ID` and `Driver` entries separated by a colon for all networks:\n\n```bash\n$
+  docker network ls --format \"{{.ID}}: {{.Driver}}\"\nafaaab448eb2: bridge\nd1584f8dc718:
+  host\n391df270dc66: null\n```"
+

--- a/_data/engine-cli-edge/docker_network_prune.yaml
+++ b/_data/engine-cli-edge/docker_network_prune.yaml
@@ -1,0 +1,72 @@
+command: docker network prune
+short: Remove all unused networks
+long: |-
+  Remove all unused networks. Unused networks are those which are not referenced
+  by any containers.
+usage: docker network prune [OPTIONS]
+pname: docker network
+plink: docker_network.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation
+examples: |-
+  ```bash
+  $ docker network prune
+
+  WARNING! This will remove all networks not used by at least one container.
+  Are you sure you want to continue? [y/N] y
+  Deleted Networks:
+  n1
+  n2
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * until (`<timestamp>`) - only remove networks created before given timestamp
+
+  The `until` filter can be Unix timestamps, date formatted
+  timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
+  relative to the daemon machine’s time. Supported formats for date
+  formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the daemon will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long.
+
+  The following removes networks created more than 5 minutes ago. Note that
+  system networks such as `bridge`, `host`, and `none` will never be pruned:
+
+  ```none
+  $ docker network ls
+
+  NETWORK ID          NAME                DRIVER              SCOPE
+  7430df902d7a        bridge              bridge              local
+  ea92373fd499        foo-1-day-ago       bridge              local
+  ab53663ed3c7        foo-1-min-ago       bridge              local
+  97b91972bc3b        host                host                local
+  f949d337b1f5        none                null                local
+
+  $ docker network prune --force --filter until=5m
+
+  Deleted Networks:
+  foo-1-day-ago
+
+  $ docker network ls
+
+  NETWORK ID          NAME                DRIVER              SCOPE
+  7430df902d7a        bridge              bridge              local
+  ab53663ed3c7        foo-1-min-ago       bridge              local
+  97b91972bc3b        host                host                local
+  f949d337b1f5        none                null                local
+  ```
+

--- a/_data/engine-cli-edge/docker_network_rm.yaml
+++ b/_data/engine-cli-edge/docker_network_rm.yaml
@@ -1,0 +1,33 @@
+command: docker network rm
+aliases: remove
+short: Remove one or more networks
+long: |-
+  Removes one or more networks by name or identifier. To remove a network,
+  you must first disconnect any containers connected to it.
+usage: docker network rm NETWORK [NETWORK...]
+pname: docker network
+plink: docker_network.yaml
+examples: |-
+  ### Remove a network
+
+  To remove the network named 'my-network':
+
+  ```bash
+    $ docker network rm my-network
+  ```
+
+  ### Remove multiple networks
+
+  To delete multiple networks in a single `docker network rm` command, provide
+  multiple network names or ids. The following example deletes a network with id
+  `3695c422697f` and a network named `my-network`:
+
+  ```bash
+    $ docker network rm 3695c422697f my-network
+  ```
+
+  When you specify multiple networks, the command attempts to delete each in turn.
+  If the deletion of one network fails, the command continues to the next on the
+  list and tries to delete that. The command reports success or failure for each
+  deletion.
+

--- a/_data/engine-cli-edge/docker_node.yaml
+++ b/_data/engine-cli-edge/docker_node.yaml
@@ -1,0 +1,23 @@
+command: docker node
+short: Manage Swarm nodes
+long: Manage nodes.
+usage: docker node
+pname: docker
+plink: docker.yaml
+cname:
+- docker node demote
+- docker node inspect
+- docker node ls
+- docker node promote
+- docker node ps
+- docker node rm
+- docker node update
+clink:
+- docker_node_demote.yaml
+- docker_node_inspect.yaml
+- docker_node_ls.yaml
+- docker_node_promote.yaml
+- docker_node_ps.yaml
+- docker_node_rm.yaml
+- docker_node_update.yaml
+

--- a/_data/engine-cli-edge/docker_node_demote.yaml
+++ b/_data/engine-cli-edge/docker_node_demote.yaml
@@ -1,0 +1,13 @@
+command: docker node demote
+short: Demote one or more nodes from manager in the swarm
+long: |-
+  motes an existing manager so that it is no longer a manager. This command
+  targets a docker engine that is a manager in the swarm.
+usage: docker node demote NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml
+examples: |-
+  ```bash
+  $ docker node demote <node name>
+  ```
+

--- a/_data/engine-cli-edge/docker_node_inspect.yaml
+++ b/_data/engine-cli-edge/docker_node_inspect.yaml
@@ -1,0 +1,120 @@
+command: docker node inspect
+short: Display detailed information on one or more nodes
+long: |-
+  Returns information about a node. By default, this command renders all results
+  in a JSON array. You can specify an alternate format to execute a
+  given template for each result. Go's
+  [text/template](http://golang.org/pkg/text/template/) package describes all the
+  details of the format.
+usage: docker node inspect [OPTIONS] self|NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+- option: pretty
+  default_value: "false"
+  description: Print the information in a human friendly format.
+examples: |-
+  ### Inspect a node
+
+  ```none
+  $ docker node inspect swarm-manager
+
+  [
+  {
+      "ID": "e216jshn25ckzbvmwlnh5jr3g",
+      "Version": {
+          "Index": 10
+      },
+      "CreatedAt": "2016-06-16T22:52:44.9910662Z",
+      "UpdatedAt": "2016-06-16T22:52:45.230878043Z",
+      "Spec": {
+          "Role": "manager",
+          "Availability": "active"
+      },
+      "Description": {
+          "Hostname": "swarm-manager",
+          "Platform": {
+              "Architecture": "x86_64",
+              "OS": "linux"
+          },
+          "Resources": {
+              "NanoCPUs": 1000000000,
+              "MemoryBytes": 1039843328
+          },
+          "Engine": {
+              "EngineVersion": "1.12.0",
+              "Plugins": [
+                  {
+                      "Type": "Volume",
+                      "Name": "local"
+                  },
+                  {
+                      "Type": "Network",
+                      "Name": "overlay"
+                  },
+                  {
+                      "Type": "Network",
+                      "Name": "null"
+                  },
+                  {
+                      "Type": "Network",
+                      "Name": "host"
+                  },
+                  {
+                      "Type": "Network",
+                      "Name": "bridge"
+                  },
+                  {
+                      "Type": "Network",
+                      "Name": "overlay"
+                  }
+              ]
+          }
+      },
+      "Status": {
+          "State": "ready",
+          "Addr": "168.0.32.137"
+      },
+      "ManagerStatus": {
+          "Leader": true,
+          "Reachability": "reachable",
+          "Addr": "168.0.32.137:2377"
+      }
+  }
+  ]
+  ```
+
+  ### Specify an output format
+
+  ```none
+  $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self
+
+  false
+
+  $ docker node inspect --pretty self
+  ID:                     e216jshn25ckzbvmwlnh5jr3g
+  Hostname:               swarm-manager
+  Joined at:              2016-06-16 22:52:44.9910662 +0000 utc
+  Status:
+   State:                 Ready
+   Availability:          Active
+   Address:               172.17.0.2
+  Manager Status:
+   Address:               172.17.0.2:2377
+   Raft Status:           Reachable
+   Leader:                Yes
+  Platform:
+   Operating System:      linux
+   Architecture:          x86_64
+  Resources:
+   CPUs:                  4
+   Memory:                7.704 GiB
+  Plugins:
+    Network:              overlay, bridge, null, host, overlay
+    Volume:               local
+  Engine Version:         1.12.0
+  ```
+

--- a/_data/engine-cli-edge/docker_node_ls.yaml
+++ b/_data/engine-cli-edge/docker_node_ls.yaml
@@ -1,0 +1,106 @@
+command: docker node ls
+aliases: list
+short: List nodes in the swarm
+long: |-
+  Lists all the nodes that the Docker Swarm manager knows about. You can filter
+  using the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section
+  for more information about available filter options.
+usage: docker node ls [OPTIONS]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display IDs
+examples: |-
+  ```bash
+  $ docker node ls
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready   Active
+  38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active
+  e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * [id](node_ls.md#id)
+  * [label](node_ls.md#label)
+  * [membership](node_ls.md#membership)
+  * [name](node_ls.md#name)
+  * [role](node_ls.md#role)
+
+  #### id
+
+  The `id` filter matches all or part of a node's id.
+
+  ```bash
+  $ docker node ls -f id=1
+
+  ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active
+  ```
+
+  #### label
+
+  The `label` filter matches nodes based on engine labels and on the presence of a `label` alone or a `label` and a value. Node labels are currently not used for filtering.
+
+  The following filter matches nodes with the `foo` label regardless of its value.
+
+  ```bash
+  $ docker node ls -f "label=foo"
+
+  ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active
+  ```
+
+  #### membersip
+
+  The `membership` filter matches nodes based on the presence of a `membership` and a value
+  `accepted` or `pending`.
+
+  The following filter matches nodes with the `membership` of `accepted`.
+
+  ```bash
+  $ docker node ls -f "membership=accepted"
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready   Active
+  38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active
+  ```
+
+  #### name
+
+  The `name` filter matches on all or part of a node hostname.
+
+  The following filter matches the nodes with a name equal to `swarm-master` string.
+
+  ```bash
+  $ docker node ls -f name=swarm-manager1
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+  ```
+
+  #### role
+
+  The `role` filter matches nodes based on the presence of a `role` and a value `worker` or `manager`.
+
+  The following filter matches nodes with the `manager` role.
+
+  ```bash
+  $ docker node ls -f "role=manager"
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+  ```
+

--- a/_data/engine-cli-edge/docker_node_promote.yaml
+++ b/_data/engine-cli-edge/docker_node_promote.yaml
@@ -1,0 +1,13 @@
+command: docker node promote
+short: Promote one or more nodes to manager in the swarm
+long: |-
+  Promotes a node to manager. This command targets a docker engine that is a
+  manager in the swarm.
+usage: docker node promote NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml
+examples: |-
+  ```bash
+  $ docker node promote <node name>
+  ```
+

--- a/_data/engine-cli-edge/docker_node_ps.yaml
+++ b/_data/engine-cli-edge/docker_node_ps.yaml
@@ -1,0 +1,89 @@
+command: docker node ps
+short: List tasks running on one or more nodes, defaults to current node
+long: Lists all the tasks on a Node that Docker knows about. You can filter using
+  the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section for more
+  information about available filter options.
+usage: docker node ps [OPTIONS] [NODE...]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: no-resolve
+  default_value: "false"
+  description: Do not map IDs to Names
+- option: no-trunc
+  default_value: "false"
+  description: Do not truncate output
+examples: |-
+  ```bash
+  $ docker node ps swarm-manager1
+  NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
+  redis.1.7q92v0nr1hcgts2amcjyqg3pq   redis:3.0.6  swarm-manager1  Running        Running 5 hours
+  redis.6.b465edgho06e318egmgjbqo4o   redis:3.0.6  swarm-manager1  Running        Running 29 seconds
+  redis.7.bg8c07zzg87di2mufeq51a2qp   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+  redis.9.dkkual96p4bb3s6b10r7coxxt   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+  redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * [name](#name)
+  * [id](#id)
+  * [label](#label)
+  * [desired-state](#desired-state)
+
+  #### name
+
+  The `name` filter matches on all or part of a task's name.
+
+  The following filter matches all tasks with a name containing the `redis` string.
+
+  ```bash
+  $ docker node ps -f name=redis swarm-manager1
+
+  NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
+  redis.1.7q92v0nr1hcgts2amcjyqg3pq   redis:3.0.6  swarm-manager1  Running        Running 5 hours
+  redis.6.b465edgho06e318egmgjbqo4o   redis:3.0.6  swarm-manager1  Running        Running 29 seconds
+  redis.7.bg8c07zzg87di2mufeq51a2qp   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+  redis.9.dkkual96p4bb3s6b10r7coxxt   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+  redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+  ```
+
+  #### id
+
+  The `id` filter matches a task's id.
+
+  ```bash
+  $ docker node ps -f id=bg8c07zzg87di2mufeq51a2qp swarm-manager1
+
+  NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
+  redis.7.bg8c07zzg87di2mufeq51a2qp   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+  ```
+
+  #### label
+
+  The `label` filter matches tasks based on the presence of a `label` alone or a `label` and a
+  value.
+
+  The following filter matches tasks with the `usage` label regardless of its value.
+
+  ```bash
+  $ docker node ps -f "label=usage"
+
+  NAME                               IMAGE        NODE            DESIRED STATE  CURRENT STATE
+  redis.6.b465edgho06e318egmgjbqo4o  redis:3.0.6  swarm-manager1  Running        Running 10 minutes
+  redis.7.bg8c07zzg87di2mufeq51a2qp  redis:3.0.6  swarm-manager1  Running        Running 9 minutes
+  ```
+
+
+  #### desired-state
+
+  The `desired-state` filter can take the values `running`, `shutdown`, and `accepted`.
+

--- a/_data/engine-cli-edge/docker_node_rm.yaml
+++ b/_data/engine-cli-edge/docker_node_rm.yaml
@@ -1,0 +1,48 @@
+command: docker node rm
+aliases: remove
+short: Remove one or more nodes from the swarm
+long: When run from a manager node, removes the specified nodes from a swarm.
+usage: docker node rm [OPTIONS] NODE [NODE...]
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force remove a node from the swarm
+examples: |-
+  ### Remove a stopped node from the swarm
+
+  ```bash
+  $ docker node rm swarm-node-02
+
+  Node swarm-node-02 removed from swarm
+  ```
+  ### Attempt to remove a running node from a swarm
+
+  Removes the specified nodes from the swarm, but only if the nodes are in the
+  down state. If you attempt to remove an active node you will receive an error:
+
+  ```non
+  $ docker node rm swarm-node-03
+
+  Error response from daemon: rpc error: code = 9 desc = node swarm-node-03 is not
+  down and can't be removed
+  ```
+
+  ### Forcibly remove an inaccessible node from a swarm
+
+  If you lose access to a worker node or need to shut it down because it has been
+  compromised or is not behaving as expected, you can use the `--force` option.
+  This may cause transient errors or interruptions, depending on the type of task
+  being run on the node.
+
+  ```bash
+  $ docker node rm --force swarm-node-03
+
+  Node swarm-node-03 removed from swarm
+  ```
+
+  A manager node must be demoted to a worker node (using `docker node demote`)
+  before you can remove it from the swarm.
+

--- a/_data/engine-cli-edge/docker_node_update.yaml
+++ b/_data/engine-cli-edge/docker_node_update.yaml
@@ -1,0 +1,51 @@
+command: docker node update
+short: Update a node
+long: Update metadata about a node, such as its availability, labels, or roles.
+usage: docker node update [OPTIONS] NODE
+pname: docker node
+plink: docker_node.yaml
+options:
+- option: availability
+  description: Availability of the node (active/pause/drain)
+- option: label-add
+  default_value: '[]'
+  description: Add or update a node label (key=value)
+- option: label-rm
+  default_value: '[]'
+  description: Remove a node label if exists
+- option: role
+  description: Role of the node (worker/manager)
+examples: |-
+  ### Add label metadata to a node
+
+  Add metadata to a swarm node using node labels. You can specify a node label as
+  a key with an empty value:
+
+  ``` bash
+  $ docker node update --label-add foo worker1
+  ```
+
+  To add multiple labels to a node, pass the `--label-add` flag for each label:
+
+  ```bash
+  $ docker node update --label-add foo --label-add bar worker1
+  ```
+
+  When you [create a service](service_create.md),
+  you can use node labels as a constraint. A constraint limits the nodes where the
+  scheduler deploys tasks for a service.
+
+  For example, to add a `type` label to identify nodes where the scheduler should
+  deploy message queue service tasks:
+
+  ``` bash
+  $ docker node update --label-add type=queue worker1
+  ```
+
+  The labels you set for nodes using `docker node update` apply only to the node
+  entity within the swarm. Do not confuse them with the docker daemon labels for
+  [dockerd](https://docs.docker.com/engine/userguide/labels-custom-metadata/#daemon-labels).
+
+  For more information about labels, refer to [apply custom
+  metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
+

--- a/_data/engine-cli-edge/docker_pause.yaml
+++ b/_data/engine-cli-edge/docker_pause.yaml
@@ -1,0 +1,21 @@
+command: docker pause
+short: Pause all processes within one or more containers
+long: |-
+  The `docker pause` command suspends all processes in the specified containers.
+  On Linux, this uses the cgroups freezer. Traditionally, when suspending a process
+  the `SIGSTOP` signal is used, which is observable by the process being suspended.
+  With the cgroups freezer the process is unaware, and unable to capture,
+  that it is being suspended, and subsequently resumed. On Windows, only Hyper-V
+  containers can be paused.
+
+  See the
+  [cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
+  for further details.
+usage: docker pause CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+examples: |-
+  ```bash
+  $ docker pause my_container
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin.yaml
+++ b/_data/engine-cli-edge/docker_plugin.yaml
@@ -1,0 +1,29 @@
+command: docker plugin
+short: Manage plugins
+long: Manage plugins.
+usage: docker plugin
+pname: docker
+plink: docker.yaml
+cname:
+- docker plugin create
+- docker plugin disable
+- docker plugin enable
+- docker plugin inspect
+- docker plugin install
+- docker plugin ls
+- docker plugin push
+- docker plugin rm
+- docker plugin set
+- docker plugin upgrade
+clink:
+- docker_plugin_create.yaml
+- docker_plugin_disable.yaml
+- docker_plugin_enable.yaml
+- docker_plugin_inspect.yaml
+- docker_plugin_install.yaml
+- docker_plugin_ls.yaml
+- docker_plugin_push.yaml
+- docker_plugin_rm.yaml
+- docker_plugin_set.yaml
+- docker_plugin_upgrade.yaml
+

--- a/_data/engine-cli-edge/docker_plugin_create.yaml
+++ b/_data/engine-cli-edge/docker_plugin_create.yaml
@@ -1,0 +1,34 @@
+command: docker plugin create
+short: Create a plugin from a rootfs and configuration. Plugin data directory must
+  contain config.json and rootfs directory.
+long: |-
+  Creates a plugin. Before creating the plugin, prepare the plugin's root filesystem as well as
+  [the config.json](../../extend/config.md)
+usage: docker plugin create [OPTIONS] PLUGIN PLUGIN-DATA-DIR
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: compress
+  default_value: "false"
+  description: Compress the context using gzip
+examples: |-
+  The following example shows how to create a sample `plugin`.
+
+  ```bash
+  $ ls -ls /home/pluginDir
+
+  4 -rw-r--r--  1 root root 431 Nov  7 01:40 config.json
+  0 drwxr-xr-x 19 root root 420 Nov  7 01:40 rootfs
+
+  $ docker plugin create plugin /home/pluginDir
+
+  plugin
+
+  $ docker plugin ls
+
+  ID                  NAME                TAG                 DESCRIPTION                  ENABLED
+  672d8144ec02        plugin              latest              A sample plugin for Docker   false
+  ```
+
+  The plugin can subsequently be enabled for local use or pushed to the public registry.
+

--- a/_data/engine-cli-edge/docker_plugin_disable.yaml
+++ b/_data/engine-cli-edge/docker_plugin_disable.yaml
@@ -1,0 +1,38 @@
+command: docker plugin disable
+short: Disable a plugin
+long: |-
+  ables a plugin. The plugin must be installed before it can be disabled,
+  see [`docker plugin install`](plugin_install.md). Without the `-f` option,
+  a plugin that has references (eg, volumes, networks) cannot be disabled.
+usage: docker plugin disable [OPTIONS] PLUGIN
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the disable of an active plugin
+examples: |-
+  The following example shows that the `sample-volume-plugin` plugin is installed
+  and enabled:
+
+  ```bash
+  $ docker plugin ls
+
+  ID                  NAME                             TAG                 DESCRIPTION                ENABLED
+  69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   true
+  ```
+
+  To disable the plugin, use the following command:
+
+  ```bash
+  $ docker plugin disable tiborvass/sample-volume-plugin
+
+  tiborvass/sample-volume-plugin
+
+  $ docker plugin ls
+
+  ID                  NAME                             TAG                 DESCRIPTION                ENABLED
+  69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   false
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_enable.yaml
+++ b/_data/engine-cli-edge/docker_plugin_enable.yaml
@@ -1,0 +1,36 @@
+command: docker plugin enable
+short: Enable a plugin
+long: |-
+  Enables a plugin. The plugin must be installed before it can be enabled,
+  see [`docker plugin install`](plugin_install.md).
+usage: docker plugin enable [OPTIONS] PLUGIN
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: timeout
+  default_value: "0"
+  description: HTTP client timeout (in seconds)
+examples: |-
+  The following example shows that the `sample-volume-plugin` plugin is installed,
+  but disabled:
+
+  ```bash
+  $ docker plugin ls
+
+  ID                  NAME                             TAG                 DESCRIPTION                ENABLED
+  69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   false
+  ```
+
+  To enable the plugin, use the following command:
+
+  ```bash
+  $ docker plugin enable tiborvass/sample-volume-plugin
+
+  tiborvass/sample-volume-plugin
+
+  $ docker plugin ls
+
+  ID                  NAME                             TAG                 DESCRIPTION                ENABLED
+  69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   true
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_inspect.yaml
+++ b/_data/engine-cli-edge/docker_plugin_inspect.yaml
@@ -1,0 +1,133 @@
+command: docker plugin inspect
+short: Display detailed information on one or more plugins
+long: |-
+  Returns information about a plugin. By default, this command renders all results
+  in a JSON array.
+usage: docker plugin inspect [OPTIONS] PLUGIN [PLUGIN...]
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+examples: |-
+  ```none
+  $ docker plugin inspect tiborvass/sample-volume-plugin:latest
+
+  {
+    "Id": "8c74c978c434745c3ade82f1bc0acf38d04990eaf494fa507c16d9f1daa99c21",
+    "Name": "tiborvass/sample-volume-plugin:latest",
+    "PluginReference": "tiborvas/sample-volume-plugin:latest",
+    "Enabled": true,
+    "Config": {
+      "Mounts": [
+        {
+          "Name": "",
+          "Description": "",
+          "Settable": null,
+          "Source": "/data",
+          "Destination": "/data",
+          "Type": "bind",
+          "Options": [
+            "shared",
+            "rbind"
+          ]
+        },
+        {
+          "Name": "",
+          "Description": "",
+          "Settable": null,
+          "Source": null,
+          "Destination": "/foobar",
+          "Type": "tmpfs",
+          "Options": null
+        }
+      ],
+      "Env": [
+        "DEBUG=1"
+      ],
+      "Args": null,
+      "Devices": null
+    },
+    "Manifest": {
+      "ManifestVersion": "v0",
+      "Description": "A test plugin for Docker",
+      "Documentation": "https://docs.docker.com/engine/extend/plugins/",
+      "Interface": {
+        "Types": [
+          "docker.volumedriver/1.0"
+        ],
+        "Socket": "plugins.sock"
+      },
+      "Entrypoint": [
+        "plugin-sample-volume-plugin",
+        "/data"
+      ],
+      "Workdir": "",
+      "User": {
+      },
+      "Network": {
+        "Type": "host"
+      },
+      "Capabilities": null,
+      "Mounts": [
+        {
+          "Name": "",
+          "Description": "",
+          "Settable": null,
+          "Source": "/data",
+          "Destination": "/data",
+          "Type": "bind",
+          "Options": [
+            "shared",
+            "rbind"
+          ]
+        },
+        {
+          "Name": "",
+          "Description": "",
+          "Settable": null,
+          "Source": null,
+          "Destination": "/foobar",
+          "Type": "tmpfs",
+          "Options": null
+        }
+      ],
+      "Devices": [
+        {
+          "Name": "device",
+          "Description": "a host device to mount",
+          "Settable": null,
+          "Path": "/dev/cpu_dma_latency"
+        }
+      ],
+      "Env": [
+        {
+          "Name": "DEBUG",
+          "Description": "If set, prints debug messages",
+          "Settable": null,
+          "Value": "1"
+        }
+      ],
+      "Args": {
+        "Name": "args",
+        "Description": "command line arguments",
+        "Settable": null,
+        "Value": [
+
+        ]
+      }
+    }
+  }
+  ```
+
+  (output formatted for readability)
+
+  ### Formatting the output
+
+  ```bash
+  $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest
+
+  8c74c978c434745c3ade82f1bc0acf38d04990eaf494fa507c16d9f1daa99c21
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_install.yaml
+++ b/_data/engine-cli-edge/docker_plugin_install.yaml
@@ -1,0 +1,48 @@
+command: docker plugin install
+short: Install a plugin
+long: |-
+  Installs and enables a plugin. Docker looks first for the plugin on your Docker
+  host. If the plugin does not exist locally, then the plugin is pulled from
+  the registry. Note that the minimum required registry version to distribute
+  plugins is 2.3.0
+usage: docker plugin install [OPTIONS] PLUGIN [KEY=VALUE...]
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: alias
+  description: Local name for plugin
+- option: disable
+  default_value: "false"
+  description: Do not enable the plugin on install
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: grant-all-permissions
+  default_value: "false"
+  description: Grant all permissions necessary to run the plugin
+examples: |-
+  The following example installs `vieus/sshfs` plugin and [sets](plugin_set.md) its
+  `DEBUG` environment variable to `1`. To install, `pull` the plugin from Docker
+  Hub and prompt the user to accept the list of privileges that the plugin needs,
+  set the plugin's parameters and enable the plugin.
+
+  ```bash
+  $ docker plugin install vieux/sshfs DEBUG=1
+
+  Plugin "vieux/sshfs" is requesting the following privileges:
+   - network: [host]
+   - device: [/dev/fuse]
+   - capabilities: [CAP_SYS_ADMIN]
+  Do you grant the above permissions? [y/N] y
+  vieux/sshfs
+  ```
+
+  After the plugin is installed, it appears in the list of plugins:
+
+  ```bash
+  $ docker plugin ls
+
+  ID                  NAME                  TAG                 DESCRIPTION                ENABLED
+  69553ca1d123        vieux/sshfs           latest              sshFS plugin for Docker    true
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_ls.yaml
+++ b/_data/engine-cli-edge/docker_plugin_ls.yaml
@@ -1,0 +1,80 @@
+command: docker plugin ls
+aliases: list
+short: List plugins
+long: |-
+  Lists all the plugins that are currently installed. You can install plugins
+  using the [`docker plugin install`](plugin_install.md) command.
+usage: docker plugin ls [OPTIONS]
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+examples: |-
+  ```bash
+  $ docker plugin ls
+
+  ID                  NAME                             TAG                 DESCRIPTION                ENABLED
+  69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   true
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * enabled (boolean - true or false, 0 or 1)
+  * capability (string - currently `volumedriver`, `networkdriver`, `ipamdriver`, or `authz`)
+
+  #### enabled
+
+  The `enabled` filter matches on plugins enabled or disabled.
+
+  #### capability
+
+  The `capability` filter matches on plugin capabilities. One plugin
+  might have multiple capabilities. Currently `volumedriver`, `networkdriver`,
+  `ipamdriver`, and `authz` are supported capabilities.
+
+  ```bash
+  $ docker plugin install --disable tiborvass/no-remove
+
+  tiborvass/no-remove
+
+  $ docker plugin ls --filter enabled=true
+
+  NAME                  TAG                 DESCRIPTION                ENABLED
+  ```
+
+
+  ### Formatting
+
+  The formatting options (`--format`) pretty-prints plugins output
+  using a Go template.
+
+  Valid placeholders for the Go template are listed below:
+
+  Placeholder    | Description
+  ---------------|------------------------------------------------------------------------------------------
+  `.ID`              | Plugin ID
+  `.Name`            | Plugin name
+  `.Description`     | Plugin description
+  `.Enabled`         | Whether plugin is enabled or not
+  `.PluginReference` | The reference used to push/pull from a registry
+
+  When using the `--format` option, the `plugin ls` command will either
+  output the data exactly as the template declares or, when using the
+  `table` directive, includes column headers as well.
+
+  The following example uses a template without headers and outputs the
+  `ID` and `Name` entries separated by a colon for all plugins:
+
+  ```bash
+  $ docker plugin ls --format "{{.ID}}: {{.Name}}"
+
+  4be01827a72e: tiborvass/no-remove
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_push.yaml
+++ b/_data/engine-cli-edge/docker_plugin_push.yaml
@@ -1,0 +1,26 @@
+command: docker plugin push
+short: Push a plugin to a registry
+long: |-
+  After you have created a plugin using `docker plugin create` and the plugin is
+  ready for distribution, use `docker plugin push` to share your images to Docker
+  Hub or a self-hosted registry.
+
+  Registry credentials are managed by [docker login](login.md).
+usage: docker plugin push [OPTIONS] PLUGIN[:TAG]
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+examples: |-
+  The following example shows how to push a sample `user/plugin`.
+
+  ```bash
+  $ docker plugin ls
+
+  ID                  NAME                  TAG                 DESCRIPTION                ENABLED
+  69553ca1d456        user/plugin           latest              A sample plugin for Docker false
+  $ docker plugin push user/plugin
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_rm.yaml
+++ b/_data/engine-cli-edge/docker_plugin_rm.yaml
@@ -1,0 +1,28 @@
+command: docker plugin rm
+aliases: remove
+short: Remove one or more plugins
+long: |-
+  Removes a plugin. You cannot remove a plugin if it is enabled, you must disable
+  a plugin using the [`docker plugin disable`](plugin_disable.md) before removing
+  it (or use --force, use of force is not recommended, since it can affect
+  functioning of running containers using the plugin).
+usage: docker plugin rm [OPTIONS] PLUGIN [PLUGIN...]
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the removal of an active plugin
+examples: |-
+  The following example disables and removes the `sample-volume-plugin:latest`
+  plugin:
+
+  ```bash
+  $ docker plugin disable tiborvass/sample-volume-plugin
+  tiborvass/sample-volume-plugin
+
+  $ docker plugin rm tiborvass/sample-volume-plugin:latest
+  tiborvass/sample-volume-plugin
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_set.yaml
+++ b/_data/engine-cli-edge/docker_plugin_set.yaml
@@ -1,0 +1,80 @@
+command: docker plugin set
+short: Change settings for a plugin
+long: |-
+  Change settings for a plugin. The plugin must be disabled.
+
+  The settings currently supported are:
+   * env variables
+   * source of mounts
+   * path of devices
+   * arg
+usage: docker plugin set PLUGIN KEY=VALUE [KEY=VALUE...]
+pname: docker plugin
+plink: docker_plugin.yaml
+examples: |-
+  ### Change an environment variable
+
+  The following example change the env variable `DEBUG` on the
+  `sample-volume-plugin` plugin.
+
+  ```bash
+  $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
+
+  [DEBUG=0]
+
+  $ docker plugin set tiborvass/sample-volume-plugin DEBUG=1
+
+  $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
+  [DEBUG=1]
+  ```
+
+  ### Change the source of a mount
+
+  The following example change the source of the `mymount` mount on
+  the `myplugin` plugin.
+
+  ```bash
+  $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}' myplugin
+  /foo
+
+  $ docker plugins set myplugin mymount.source=/bar
+
+  $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}' myplugin
+  /bar
+  ```
+
+  > **Note**: Since only `source` is settable in `mymount`,
+  > `docker plugins set mymount=/bar myplugin` would work too.
+
+  ### Change a device path
+
+  The following example change the path of the `mydevice` device on
+  the `myplugin` plugin.
+
+  ```bash
+  $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$device.Path}}{{end}}' myplugin
+  /dev/foo
+
+  $ docker plugins set myplugin mydevice.path=/dev/bar
+
+  $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$device.Path}}{{end}}' myplugin
+  /dev/bar
+  ```
+
+  > **Note**: Since only `path` is settable in `mydevice`,
+  > `docker plugins set mydevice=/dev/bar myplugin` would work too.
+
+  ### Change the source of the arguments
+
+  The following example change the source of the args on the `myplugin` plugin.
+
+  ```bash
+  $ docker plugin inspect -f '{{.Settings.Args}}' myplugin
+  ["foo", "bar"]
+
+  $ docker plugins set myplugin args="foo bar baz"
+
+  $ docker plugin inspect -f '{{.Settings.Args}}' myplugin
+  ["foo", "bar", "baz"]
+  ```
+

--- a/_data/engine-cli-edge/docker_plugin_upgrade.yaml
+++ b/_data/engine-cli-edge/docker_plugin_upgrade.yaml
@@ -1,0 +1,61 @@
+command: docker plugin upgrade
+short: Upgrade an existing plugin
+long: |-
+  Upgrades an existing plugin to the specified remote plugin image. If no remote
+  is specified, Docker will re-pull the current image and use the updated version.
+  All existing references to the plugin will continue to work.
+  The plugin must be disabled before running the upgrade.
+usage: docker plugin upgrade [OPTIONS] PLUGIN [REMOTE]
+pname: docker plugin
+plink: docker_plugin.yaml
+options:
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: grant-all-permissions
+  default_value: "false"
+  description: Grant all permissions necessary to run the plugin
+- option: skip-remote-check
+  default_value: "false"
+  description: |
+    Do not check if specified remote plugin matches existing plugin image
+examples: |-
+  The following example installs `vieus/sshfs` plugin, uses it to create and use
+  a volume, then upgrades the plugin.
+
+  ```bash
+  $ docker plugin install vieux/sshfs DEBUG=1
+
+  Plugin "vieux/sshfs:next" is requesting the following privileges:
+   - network: [host]
+   - device: [/dev/fuse]
+   - capabilities: [CAP_SYS_ADMIN]
+  Do you grant the above permissions? [y/N] y
+  vieux/sshfs:next
+
+  $ docker volume create -d vieux/sshfs:next -o sshcmd=root@1.2.3.4:/tmp/shared -o password=XXX sshvolume
+  sshvolume
+  $ docker run -it -v sshvolume:/data alpine sh -c "touch /data/hello"
+  $ docker plugin disable -f vieux/sshfs:next
+  viex/sshfs:next
+
+  # Here docker volume ls doesn't show 'sshfsvolume', since the plugin is disabled
+  $ docker volume ls
+  DRIVER              VOLUME NAME
+
+  $ docker plugin upgrade vieux/sshfs:next vieux/sshfs:next
+  Plugin "vieux/sshfs:next" is requesting the following privileges:
+   - network: [host]
+   - device: [/dev/fuse]
+   - capabilities: [CAP_SYS_ADMIN]
+  Do you grant the above permissions? [y/N] y
+  Upgrade plugin vieux/sshfs:next to vieux/sshfs:next
+  $ docker plugin enable vieux/sshfs:next
+  viex/sshfs:next
+  $ docker volume ls
+  DRIVER              VOLUME NAME
+  viuex/sshfs:next    sshvolume
+  $ docker run -it -v sshvolume:/data alpine sh -c "ls /data"
+  hello
+  ```
+

--- a/_data/engine-cli-edge/docker_port.yaml
+++ b/_data/engine-cli-edge/docker_port.yaml
@@ -1,0 +1,27 @@
+command: docker port
+short: List port mappings or a specific mapping for the container
+long: List port mappings or a specific mapping for the container
+usage: docker port CONTAINER [PRIVATE_PORT[/PROTO]]
+pname: docker
+plink: docker.yaml
+examples: |-
+  ### Show all mapped ports
+
+  You can find out all the ports mapped by not specifying a `PRIVATE_PORT`, or
+  just a specific mapping:
+
+  ```bash
+  $ docker ps
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
+  b650456536c7        busybox:latest      top                 54 minutes ago      Up 54 minutes       0.0.0.0:1234->9876/tcp, 0.0.0.0:4321->7890/tcp   test
+  $ docker port test
+  7890/tcp -> 0.0.0.0:4321
+  9876/tcp -> 0.0.0.0:1234
+  $ docker port test 7890/tcp
+  0.0.0.0:4321
+  $ docker port test 7890/udp
+  2014/06/24 11:53:36 Error: No public port '7890/udp' published for test
+  $ docker port test 7890
+  0.0.0.0:4321
+  ```
+

--- a/_data/engine-cli-edge/docker_ps.yaml
+++ b/_data/engine-cli-edge/docker_ps.yaml
@@ -1,0 +1,415 @@
+command: docker ps
+short: List containers
+long: List containers
+usage: docker ps [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Pretty-print containers using a Go template
+- option: last
+  shorthand: "n"
+  default_value: "-1"
+  description: Show n last created containers (includes all states)
+- option: latest
+  shorthand: l
+  default_value: "false"
+  description: Show the latest created container (includes all states)
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display numeric IDs
+- option: size
+  shorthand: s
+  default_value: "false"
+  description: Display total file sizes
+examples: |-
+  ### Prevent truncating output
+
+  Running `docker ps --no-trunc` showing 2 linked containers.
+
+  ```bash
+  $ docker ps
+
+  CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
+  4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
+  d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
+  ```
+
+  ### Show both running and stopped containers
+
+  The `docker ps` command only shows running containers by default. To see all
+  containers, use the `-a` (or `--all`) flag:
+
+  ```bash
+  $ docker ps -a
+  ```
+
+  `docker ps` groups exposed ports into a single range if possible. E.g., a
+  container that exposes TCP ports `100, 101, 102` displays `100-102/tcp` in
+  the `PORTS` column.
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
+  than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * id (container's id)
+  * label (`label=<key>` or `label=<key>=<value>`)
+  * name (container's name)
+  * exited (int - the code of exited containers. Only useful with `--all`)
+  * status (`created|restarting|running|removing|paused|exited|dead`)
+  * ancestor (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters containers that were created from the given image or a descendant.
+  * before (container's id or name) - filters containers created before given id or name
+  * since (container's id or name) - filters containers created since given id or name
+  * isolation (`default|process|hyperv`)   (Windows daemon only)
+  * volume (volume name or mount point) - filters containers that mount volumes.
+  * network (network id or name) - filters containers connected to the provided network
+  * health (starting|healthy|unhealthy|none) - filters containers based on healthcheck status
+
+  #### label
+
+  The `label` filter matches containers based on the presence of a `label` alone or a `label` and a
+  value.
+
+  The following filter matches containers with the `color` label regardless of its value.
+
+  ```bash
+  $ docker ps --filter "label=color"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  673394ef1d4c        busybox             "top"               47 seconds ago      Up 45 seconds                           nostalgic_shockley
+  d85756f57265        busybox             "top"               52 seconds ago      Up 51 seconds                           high_albattani
+  ```
+
+  The following filter matches containers with the `color` label with the `blue` value.
+
+  ```bash
+  $ docker ps --filter "label=color=blue"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  d85756f57265        busybox             "top"               About a minute ago   Up About a minute                       high_albattani
+  ```
+
+  #### name
+
+  The `name` filter matches on all or part of a container's name.
+
+  The following filter matches all containers with a name containing the `nostalgic_stallman` string.
+
+  ```bash
+  $ docker ps --filter "name=nostalgic_stallman"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  9b6247364a03        busybox             "top"               2 minutes ago       Up 2 minutes                            nostalgic_stallman
+  ```
+
+  You can also filter for a substring in a name as this shows:
+
+  ```bash
+  $ docker ps --filter "name=nostalgic"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  715ebfcee040        busybox             "top"               3 seconds ago       Up 1 second                             i_am_nostalgic
+  9b6247364a03        busybox             "top"               7 minutes ago       Up 7 minutes                            nostalgic_stallman
+  673394ef1d4c        busybox             "top"               38 minutes ago      Up 38 minutes                           nostalgic_shockley
+  ```
+
+  #### exited
+
+  The `exited` filter matches containers by exist status code. For example, to
+  filter for containers that have exited successfully:
+
+  ```bash
+  $ docker ps -a --filter 'exited=0'
+
+  CONTAINER ID        IMAGE             COMMAND                CREATED             STATUS                   PORTS                      NAMES
+  ea09c3c82f6e        registry:latest   /srv/run.sh            2 weeks ago         Exited (0) 2 weeks ago   127.0.0.1:5000->5000/tcp   desperate_leakey
+  106ea823fe4e        fedora:latest     /bin/sh -c 'bash -l'   2 weeks ago         Exited (0) 2 weeks ago                              determined_albattani
+  48ee228c9464        fedora:20         bash                   2 weeks ago         Exited (0) 2 weeks ago                              tender_torvalds
+  ```
+
+  #### Filter by exit signal
+
+  You can use a filter to locate containers that exited with status of `137`
+  meaning a `SIGKILL(9)` killed them.
+
+  ```none
+  $ docker ps -a --filter 'exited=137'
+
+  CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                       PORTS               NAMES
+  b3e1c0ed5bfe        ubuntu:latest       "sleep 1000"           12 seconds ago      Exited (137) 5 seconds ago                       grave_kowalevski
+  a2eb5558d669        redis:latest        "/entrypoint.sh redi   2 hours ago         Exited (137) 2 hours ago                         sharp_lalande
+  ```
+
+  Any of these events result in a `137` status:
+
+  * the `init` process of the container is killed manually
+  * `docker kill` kills the container
+  * Docker daemon restarts which kills all running containers
+
+  #### status
+
+  The `status` filter matches containers by status. You can filter using
+  `created`, `restarting`, `running`, `removing`, `paused`, `exited` and `dead`. For example,
+  to filter for `running` containers:
+
+  ```bash
+  $ docker ps --filter status=running
+
+  CONTAINER ID        IMAGE                  COMMAND             CREATED             STATUS              PORTS               NAMES
+  715ebfcee040        busybox                "top"               16 minutes ago      Up 16 minutes                           i_am_nostalgic
+  d5c976d3c462        busybox                "top"               23 minutes ago      Up 23 minutes                           top
+  9b6247364a03        busybox                "top"               24 minutes ago      Up 24 minutes                           nostalgic_stallman
+  ```
+
+  To filter for `paused` containers:
+
+  ```bash
+  $ docker ps --filter status=paused
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                      PORTS               NAMES
+  673394ef1d4c        busybox             "top"               About an hour ago   Up About an hour (Paused)                       nostalgic_shockley
+  ```
+
+  #### ancestor
+
+  The `ancestor` filter matches containers based on its image or a descendant of
+  it. The filter supports the following image representation:
+
+  - image
+  - image:tag
+  - image:tag@digest
+  - short-id
+  - full-id
+
+  If you don't specify a `tag`, the `latest` tag is used. For example, to filter
+  for containers that use the latest `ubuntu` image:
+
+  ```bash
+  $ docker ps --filter ancestor=ubuntu
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  919e1179bdb8        ubuntu-c1           "top"               About a minute ago   Up About a minute                       admiring_lovelace
+  5d1e4a540723        ubuntu-c2           "top"               About a minute ago   Up About a minute                       admiring_sammet
+  82a598284012        ubuntu              "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  bab2a34ba363        ubuntu              "top"               3 minutes ago        Up 3 minutes                            focused_yonath
+  ```
+
+  Match containers based on the `ubuntu-c1` image which, in this case, is a child
+  of `ubuntu`:
+
+  ```bash
+  $ docker ps --filter ancestor=ubuntu-c1
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  919e1179bdb8        ubuntu-c1           "top"               About a minute ago   Up About a minute                       admiring_lovelace
+  ```
+
+  Match containers based on the `ubuntu` version `12.04.5` image:
+
+  ```bash
+  $ docker ps --filter ancestor=ubuntu:12.04.5
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  ```
+
+  The following matches containers based on the layer `d0e008c6cf02` or an image
+  that have this layer in its layer stack.
+
+  ```bash
+  $ docker ps --filter ancestor=d0e008c6cf02
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  ```
+
+  #### Create time
+
+  ##### before
+
+  The `before` filter shows only containers created before the container with
+  given id or name. For example, having these containers created:
+
+  ```bash
+  $ docker ps
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS              PORTS              NAMES
+  9c3527ed70ce        busybox     "top"         14 seconds ago       Up 15 seconds                          desperate_dubinsky
+  4aace5031105        busybox     "top"         48 seconds ago       Up 49 seconds                          focused_hamilton
+  6e63f6ff38b0        busybox     "top"         About a minute ago   Up About a minute                      distracted_fermat
+  ```
+
+  Filtering with `before` would give:
+
+  ```bash
+  $ docker ps -f before=9c3527ed70ce
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS              PORTS              NAMES
+  4aace5031105        busybox     "top"         About a minute ago   Up About a minute                      focused_hamilton
+  6e63f6ff38b0        busybox     "top"         About a minute ago   Up About a minute                      distracted_fermat
+  ```
+
+  ##### since
+
+  The `since` filter shows only containers created since the container with given
+  id or name. For example, with the same containers as in `before` filter:
+
+  ```bash
+  $ docker ps -f since=6e63f6ff38b0
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+  9c3527ed70ce        busybox     "top"         10 minutes ago      Up 10 minutes                           desperate_dubinsky
+  4aace5031105        busybox     "top"         10 minutes ago      Up 10 minutes                           focused_hamilton
+  ```
+
+  #### volume
+
+  The `volume` filter shows only containers that mount a specific volume or have
+  a volume mounted in a specific path:
+
+  ```bash
+  $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
+  CONTAINER ID        MOUNTS
+  9c3527ed70ce        remote-volume
+
+  $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
+  CONTAINER ID        MOUNTS
+  9c3527ed70ce        remote-volume
+  ```
+
+  #### network
+
+  The `network` filter shows only containers that are connected to a network with
+  a given name or id.
+
+  The following filter matches all containers that are connected to a network
+  with a name containing `net1`.
+
+  ```bash
+  $ docker run -d --net=net1 --name=test1 ubuntu top
+  $ docker run -d --net=net2 --name=test2 ubuntu top
+
+  $ docker ps --filter network=net1
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+  9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+  ```
+
+  The network filter matches on both the network's name and id. The following
+  example shows all containers that are attached to the `net1` network, using
+  the network id as a filter;
+
+  ```bash
+  $ docker network inspect --format "{{.ID}}" net1
+
+  8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
+
+  $ docker ps --filter network=8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+  9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+  ```
+
+  #### publish and expose
+
+  The `publish` and `expose` filters show only containers that have published or exposed port with a given port
+  number, port range, and/or protocol. The default protocol is `tcp` when not specified.
+
+  The following filter matches all containers that have published port of 80:
+
+  ```bash
+  $ docker run -d --publish=80 busybox top
+  $ docker run -d --expose=8080 busybox top
+
+  $ docker ps -a
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                   NAMES
+  9833437217a5        busybox             "top"               5 seconds ago       Up 4 seconds        8080/tcp                dreamy_mccarthy
+  fc7e477723b7        busybox             "top"               50 seconds ago      Up 50 seconds       0.0.0.0:32768->80/tcp   admiring_roentgen
+
+  $ docker ps --filter publish=80
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS                   NAMES
+  fc7e477723b7        busybox             "top"               About a minute ago   Up About a minute   0.0.0.0:32768->80/tcp   admiring_roentgen
+  ```
+
+  The following filter matches all containers that have exposed TCP port in the range of `8000-8080`:
+  ```bash
+  $ docker ps --filter expose=8000-8080/tcp
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  9833437217a5        busybox             "top"               21 seconds ago      Up 19 seconds       8080/tcp            dreamy_mccarthy
+  ```
+
+  The following filter matches all containers that have exposed UDP port `80`:
+  ```bash
+  $ docker ps --filter publish=80/udp
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  ```
+
+  ### Formatting
+
+  The formatting option (`--format`) pretty-prints container output using a Go
+  template.
+
+  Valid placeholders for the Go template are listed below:
+
+  Placeholder   | Description
+  --------------|----------------------------------------------------------------------------------------------------
+  `.ID`         | Container ID
+  `.Image`      | Image ID
+  `.Command`    | Quoted command
+  `.CreatedAt`  | Time when the container was created.
+  `.RunningFor` | Elapsed time since the container was started.
+  `.Ports`      | Exposed ports.
+  `.Status`     | Container status.
+  `.Size`       | Container disk size.
+  `.Names`      | Container names.
+  `.Labels`     | All labels assigned to the container.
+  `.Label`      | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'`
+  `.Mounts`     | Names of the volumes mounted in this container.
+  `.Networks`   | Names of the networks attached to this container.
+
+  When using the `--format` option, the `ps` command will either output the data
+  exactly as the template declares or, when using the `table` directive, includes
+  column headers as well.
+
+  The following example uses a template without headers and outputs the `ID` and
+  `Command` entries separated by a colon for all running containers:
+
+  ```bash
+  $ docker ps --format "{{.ID}}: {{.Command}}"
+
+  a87ecb4f327c: /bin/sh -c #(nop) MA
+  01946d9d34d8: /bin/sh -c #(nop) MA
+  c1d3b0166030: /bin/sh -c yum -y up
+  41d50ecd2f57: /bin/sh -c #(nop) MA
+  ```
+
+  To list all running containers with their labels in a table format you can use:
+
+  ```bash
+  $ docker ps --format "table {{.ID}}\t{{.Labels}}"
+
+  CONTAINER ID        LABELS
+  a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd
+  01946d9d34d8
+  c1d3b0166030        com.docker.swarm.node=debian,com.docker.swarm.cpu=6
+  41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd
+  ```
+

--- a/_data/engine-cli-edge/docker_pull.yaml
+++ b/_data/engine-cli-edge/docker_pull.yaml
@@ -1,0 +1,237 @@
+command: docker pull
+short: Pull an image or a repository from a registry
+long: |-
+  Most of your images will be created on top of a base image from the
+  [Docker Hub](https://hub.docker.com) registry.
+
+  [Docker Hub](https://hub.docker.com) contains many pre-built images that you
+  can `pull` and try without needing to define and configure your own.
+
+  To download a particular image, or set of images (i.e., a repository),
+  use `docker pull`.
+
+  ### Proxy configuration
+
+  If you are behind an HTTP proxy server, for example in corporate settings,
+  before open a connect to registry, you may need to configure the Docker
+  daemon's proxy settings, using the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
+  environment variables. To set these environment variables on a host using
+  `systemd`, refer to the [control and configure Docker with systemd](https://docs.docker.com/engine/admin/systemd/#http-proxy)
+  for variables configuration.
+
+  ### Concurrent downloads
+
+  By default the Docker daemon will pull three layers of an image at a time.
+  If you are on a low bandwidth connection this may cause timeout issues and you may want to lower
+  this via the `--max-concurrent-downloads` daemon option. See the
+  [daemon documentation](dockerd.md) for more details.
+usage: docker pull [OPTIONS] NAME[:TAG|@DIGEST]
+pname: docker
+plink: docker.yaml
+options:
+- option: all-tags
+  shorthand: a
+  default_value: "false"
+  description: Download all tagged images in the repository
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+examples: |-
+  ### Pull an image from Docker Hub
+
+  To download a particular image, or set of images (i.e., a repository), use
+  `docker pull`. If no tag is provided, Docker Engine uses the `:latest` tag as a
+  default. This command pulls the `debian:latest` image:
+
+  ```bash
+  $ docker pull debian
+
+  Using default tag: latest
+  latest: Pulling from library/debian
+  fdd5d7827f33: Pull complete
+  a3ed95caeb02: Pull complete
+  Digest: sha256:e7d38b3517548a1c71e41bffe9c8ae6d6d29546ce46bf62159837aad072c90aa
+  Status: Downloaded newer image for debian:latest
+  ```
+
+  Docker images can consist of multiple layers. In the example above, the image
+  consists of two layers; `fdd5d7827f33` and `a3ed95caeb02`.
+
+  Layers can be reused by images. For example, the `debian:jessie` image shares
+  both layers with `debian:latest`. Pulling the `debian:jessie` image therefore
+  only pulls its metadata, but not its layers, because all layers are already
+  present locally:
+
+  ```bash
+  $ docker pull debian:jessie
+
+  jessie: Pulling from library/debian
+  fdd5d7827f33: Already exists
+  a3ed95caeb02: Already exists
+  Digest: sha256:a9c958be96d7d40df920e7041608f2f017af81800ca5ad23e327bc402626b58e
+  Status: Downloaded newer image for debian:jessie
+  ```
+
+  To see which images are present locally, use the [`docker images`](images.md)
+  command:
+
+  ```bash
+  $ docker images
+
+  REPOSITORY   TAG      IMAGE ID        CREATED      SIZE
+  debian       jessie   f50f9524513f    5 days ago   125.1 MB
+  debian       latest   f50f9524513f    5 days ago   125.1 MB
+  ```
+
+  Docker uses a content-addressable image store, and the image ID is a SHA256
+  digest covering the image's configuration and layers. In the example above,
+  `debian:jessie` and `debian:latest` have the same image ID because they are
+  actually the *same* image tagged with different names. Because they are the
+  same image, their layers are stored only once and do not consume extra disk
+  space.
+
+  For more information about images, layers, and the content-addressable store,
+  refer to [understand images, containers, and storage drivers](https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/).
+
+
+  ### Pull an image by digest (immutable identifier)
+
+  So far, you've pulled images by their name (and "tag"). Using names and tags is
+  a convenient way to work with images. When using tags, you can `docker pull` an
+  image again to make sure you have the most up-to-date version of that image.
+  For example, `docker pull ubuntu:14.04` pulls the latest version of the Ubuntu
+  14.04 image.
+
+  In some cases you don't want images to be updated to newer versions, but prefer
+  to use a fixed version of an image. Docker enables you to pull an image by its
+  *digest*. When pulling an image by digest, you specify *exactly* which version
+  of an image to pull. Doing so, allows you to "pin" an image to that version,
+  and guarantee that the image you're using is always the same.
+
+  To know the digest of an image, pull the image first. Let's pull the latest
+  `ubuntu:14.04` image from Docker Hub:
+
+  ```bash
+  $ docker pull ubuntu:14.04
+
+  14.04: Pulling from library/ubuntu
+  5a132a7e7af1: Pull complete
+  fd2731e4c50c: Pull complete
+  28a2f68d1120: Pull complete
+  a3ed95caeb02: Pull complete
+  Digest: sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+  Status: Downloaded newer image for ubuntu:14.04
+  ```
+
+  Docker prints the digest of the image after the pull has finished. In the example
+  above, the digest of the image is:
+
+      sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+
+  Docker also prints the digest of an image when *pushing* to a registry. This
+  may be useful if you want to pin to a version of the image you just pushed.
+
+  A digest takes the place of the tag when pulling an image, for example, to
+  pull the above image by digest, run the following command:
+
+  ```bash
+  $ docker pull ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+
+  sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2: Pulling from library/ubuntu
+  5a132a7e7af1: Already exists
+  fd2731e4c50c: Already exists
+  28a2f68d1120: Already exists
+  a3ed95caeb02: Already exists
+  Digest: sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+  Status: Downloaded newer image for ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+  ```
+
+  Digest can also be used in the `FROM` of a Dockerfile, for example:
+
+  ```Dockerfile
+  FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+  MAINTAINER some maintainer <maintainer@example.com>
+  ```
+
+  > **Note**: Using this feature "pins" an image to a specific version in time.
+  > Docker will therefore not pull updated versions of an image, which may include
+  > security updates. If you want to pull an updated image, you need to change the
+  > digest accordingly.
+
+
+  ### Pull from a different registry
+
+  By default, `docker pull` pulls images from [Docker Hub](https://hub.docker.com). It is also possible to
+  manually specify the path of a registry to pull from. For example, if you have
+  set up a local registry, you can specify its path to pull from it. A registry
+  path is similar to a URL, but does not contain a protocol specifier (`https://`).
+
+  The following command pulls the `testing/test-image` image from a local registry
+  listening on port 5000 (`myregistry.local:5000`):
+
+  ```bash
+  $ docker pull myregistry.local:5000/testing/test-image
+  ```
+
+  Registry credentials are managed by [docker login](login.md).
+
+  Docker uses the `https://` protocol to communicate with a registry, unless the
+  registry is allowed to be accessed over an insecure connection. Refer to the
+  [insecure registries](dockerd.md#insecure-registries) section for more information.
+
+
+  ### Pull a repository with multiple images
+
+  By default, `docker pull` pulls a *single* image from the registry. A repository
+  can contain multiple images. To pull all images from a repository, provide the
+  `-a` (or `--all-tags`) option when using `docker pull`.
+
+  This command pulls all images from the `fedora` repository:
+
+  ```bash
+  $ docker pull --all-tags fedora
+
+  Pulling repository fedora
+  ad57ef8d78d7: Download complete
+  105182bb5e8b: Download complete
+  511136ea3c5a: Download complete
+  73bd853d2ea5: Download complete
+  ....
+
+  Status: Downloaded newer image for fedora
+  ```
+
+  After the pull has completed use the `docker images` command to see the
+  images that were pulled. The example below shows all the `fedora` images
+  that are present locally:
+
+  ```bash
+  $ docker images fedora
+
+  REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
+  fedora       rawhide     ad57ef8d78d7    5 days ago   359.3 MB
+  fedora       20          105182bb5e8b    5 days ago   372.7 MB
+  fedora       heisenbug   105182bb5e8b    5 days ago   372.7 MB
+  fedora       latest      105182bb5e8b    5 days ago   372.7 MB
+  ```
+
+  ### Cancel a pull
+
+  Killing the `docker pull` process, for example by pressing `CTRL-c` while it is
+  running in a terminal, will terminate the pull operation.
+
+  ```bash
+  $ docker pull fedora
+
+  Using default tag: latest
+  latest: Pulling from library/fedora
+  a3ed95caeb02: Pulling fs layer
+  236608c7b546: Pulling fs layer
+  ^C
+  ```
+
+  > **Note**: Technically, the Engine terminates a pull operation when the
+  > connection between the Docker Engine daemon and the Docker Engine client
+  > initiating the pull is lost. If the connection with the Engine daemon is
+  > lost for other reasons than a manual interaction, the pull is also aborted.
+

--- a/_data/engine-cli-edge/docker_push.yaml
+++ b/_data/engine-cli-edge/docker_push.yaml
@@ -1,0 +1,52 @@
+command: docker push
+short: Push an image or a repository to a registry
+long: "Use `docker push` to share your images to the [Docker Hub](https://hub.docker.com)\nregistry
+  or to a self-hosted one.\n\nRefer to the [`docker tag`](tag.md) reference for more
+  information about valid\nimage and tag names.\n\nKilling the `docker push` process,
+  for example by pressing `CTRL-c` while it is\nrunning in a terminal, terminates
+  the push operation.\n\nProgress bars are shown during docker push, which show the
+  uncompressed size. The \nactual amount of data that's pushed will be compressed
+  before sending, so the uploaded\n size will not be reflected by the progress bar.
+  \n\nRegistry credentials are managed by [docker login](login.md).\n\n### Concurrent
+  uploads\n\nBy default the Docker daemon will push five layers of an image at a time.\nIf
+  you are on a low bandwidth connection this may cause timeout issues and you may
+  want to lower\nthis via the `--max-concurrent-uploads` daemon option. See the\n[daemon
+  documentation](dockerd.md) for more details."
+usage: docker push [OPTIONS] NAME[:TAG]
+pname: docker
+plink: docker.yaml
+options:
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+examples: |-
+  ### Push a new image to a registry
+
+  First save the new image by finding the container ID (using [`docker ps`](ps.md))
+  and then committing it to a new image name.  Note that only `a-z0-9-_.` are
+  allowed when naming images:
+
+  ```bash
+  $ docker commit c16378f943fe rhel-httpd
+  ```
+
+  Now, push the image to the registry using the image ID. In this example the
+  registry is on host named `registry-host` and listening on port `5000`. To do
+  this, tag the image with the host name or IP address, and the port of the
+  registry:
+
+  ```bash
+  $ docker tag rhel-httpd registry-host:5000/myadmin/rhel-httpd
+
+  $ docker push registry-host:5000/myadmin/rhel-httpd
+  ```
+
+  Check that this worked by running:
+
+  ```bash
+  $ docker images
+  ```
+
+  You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
+  listed.
+

--- a/_data/engine-cli-edge/docker_rename.yaml
+++ b/_data/engine-cli-edge/docker_rename.yaml
@@ -1,0 +1,11 @@
+command: docker rename
+short: Rename a container
+long: The `docker rename` command renames a container.
+usage: docker rename CONTAINER NEW_NAME
+pname: docker
+plink: docker.yaml
+examples: |-
+  ```bash
+  $ docker rename my_container my_new_container
+  ```
+

--- a/_data/engine-cli-edge/docker_restart.yaml
+++ b/_data/engine-cli-edge/docker_restart.yaml
@@ -1,0 +1,16 @@
+command: docker restart
+short: Restart one or more containers
+long: Restart one or more containers
+usage: docker restart [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing the container
+examples: |-
+  ```bash
+  $ docker restart my_container
+  ```
+

--- a/_data/engine-cli-edge/docker_rm.yaml
+++ b/_data/engine-cli-edge/docker_rm.yaml
@@ -1,0 +1,90 @@
+command: docker rm
+short: Remove one or more containers
+long: Remove one or more containers
+usage: docker rm [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the removal of a running container (uses SIGKILL)
+- option: link
+  shorthand: l
+  default_value: "false"
+  description: Remove the specified link
+- option: volumes
+  shorthand: v
+  default_value: "false"
+  description: Remove the volumes associated with the container
+examples: |-
+  ### Remove a container
+
+  This will remove the container referenced under the link
+  `/redis`.
+
+  ```bash
+  $ docker rm /redis
+
+  /redis
+  ```
+
+  ### Remove a link specified with `--link` on the default bridge network
+
+  This will remove the underlying link between `/webapp` and the `/redis`
+  containers on the default bridge network, removing all network communication
+  between the two containers. This does not apply when `--link` is used with
+  user-specified networks.
+
+  ```bash
+  $ docker rm --link /webapp/redis
+
+  /webapp/redis
+  ```
+
+  ### Force-remove a running container
+
+  This command will force-remove a running container.
+
+  ```bash
+  $ docker rm --force redis
+
+  redis
+  ```
+
+  The main process inside the container referenced under the link `redis` will receive
+  `SIGKILL`, then the container will be removed.
+
+  ### Remove all stopped containers
+
+  ```bash
+  $ docker rm $(docker ps -a -q)
+  ```
+
+  This command will delete all stopped containers. The command
+  `docker ps -a -q` will return all existing container IDs and pass them to
+  the `rm` command which will delete them. Any running containers will not be
+  deleted.
+
+  ### Remove a container and its volumes
+
+  ```bash
+  $ docker rm -v redis
+  redis
+  ```
+
+  This command will remove the container and any volumes associated with it.
+  Note that if a volume was specified with a name, it will not be removed.
+
+  ### Remove a container and selectively remove volumes
+
+  ```bash
+  $ docker create -v awesome:/foo -v /bar --name hello redis
+  hello
+  $ docker rm -v hello
+  ```
+
+  In this example, the volume for `/foo` will remain intact, but the volume for
+  `/bar` will be removed. The same behavior holds for volumes inherited with
+  `--volumes-from`.
+

--- a/_data/engine-cli-edge/docker_rmi.yaml
+++ b/_data/engine-cli-edge/docker_rmi.yaml
@@ -1,0 +1,91 @@
+command: docker rmi
+short: Remove one or more images
+long: Remove one or more images
+usage: docker rmi [OPTIONS] IMAGE [IMAGE...]
+pname: docker
+plink: docker.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force removal of the image
+- option: no-prune
+  default_value: "false"
+  description: Do not delete untagged parents
+examples: |-
+  You can remove an image using its short or long ID, its tag, or its digest. If
+  an image has one or more tag referencing it, you must remove all of them before
+  the image is removed. Digest references are removed automatically when an image
+  is removed by tag.
+
+  ```bash
+  $ docker images
+
+  REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
+  test1                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+  test                      latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+  test2                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+
+  $ docker rmi fd484f19954f
+
+  Error: Conflict, cannot delete image fd484f19954f because it is tagged in multiple repositories, use -f to force
+  2013/12/11 05:47:16 Error: failed to remove one or more images
+
+  $ docker rmi test1
+
+  Untagged: test1:latest
+
+  $ docker rmi test2
+
+  Untagged: test2:latest
+
+
+  $ docker images
+
+  REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
+  test                      latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+
+  $ docker rmi test
+
+  Untagged: test:latest
+  Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
+  ```
+
+  If you use the `-f` flag and specify the image's short or long ID, then this
+  command untags and removes all images that match the specified ID.
+
+  ```bash
+  $ docker images
+
+  REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
+  test1                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+  test                      latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+  test2                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+
+  $ docker rmi -f fd484f19954f
+
+  Untagged: test1:latest
+  Untagged: test:latest
+  Untagged: test2:latest
+  Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
+  ```
+
+  An image pulled by digest has no tag associated with it:
+
+  ```bash
+  $ docker images --digests
+
+  REPOSITORY                     TAG       DIGEST                                                                    IMAGE ID        CREATED         SIZE
+  localhost:5000/test/busybox    <none>    sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536    9 weeks ago     2.43 MB
+  ```
+
+  To remove an image using its digest:
+
+  ```bash
+  $ docker rmi localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+  Untagged: localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+  Deleted: 4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125
+  Deleted: ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2
+  Deleted: df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b
+  ```
+

--- a/_data/engine-cli-edge/docker_run.yaml
+++ b/_data/engine-cli-edge/docker_run.yaml
@@ -1,0 +1,897 @@
+command: docker run
+short: Run a command in a new container
+long: Run a command in a new container
+usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker
+plink: docker.yaml
+options:
+- option: add-host
+  default_value: '[]'
+  description: Add a custom host-to-IP mapping (host:ip)
+- option: attach
+  shorthand: a
+  default_value: '[]'
+  description: Attach to STDIN, STDOUT or STDERR
+- option: blkio-weight
+  default_value: "0"
+  description: |
+    Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
+- option: blkio-weight-device
+  default_value: '[]'
+  description: Block IO weight (relative device weight)
+- option: cap-add
+  default_value: '[]'
+  description: Add Linux capabilities
+- option: cap-drop
+  default_value: '[]'
+  description: Drop Linux capabilities
+- option: cgroup-parent
+  description: Optional parent cgroup for the container
+- option: cidfile
+  description: Write the container ID to the file
+- option: cpu-count
+  default_value: "0"
+  description: CPU count (Windows only)
+- option: cpu-percent
+  default_value: "0"
+  description: CPU percent (Windows only)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-rt-period
+  default_value: "0"
+  description: Limit CPU real-time period in microseconds
+- option: cpu-rt-runtime
+  default_value: "0"
+  description: Limit CPU real-time runtime in microseconds
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpus
+  default_value: "0.000"
+  description: Number of CPUs
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: credentialspec
+  description: Credential spec for managed service account (Windows only)
+- option: detach
+  shorthand: d
+  default_value: "false"
+  description: Run container in background and print container ID
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: device
+  default_value: '[]'
+  description: Add a host device to the container
+- option: device-read-bps
+  default_value: '[]'
+  description: Limit read rate (bytes per second) from a device
+- option: device-read-iops
+  default_value: '[]'
+  description: Limit read rate (IO per second) from a device
+- option: device-write-bps
+  default_value: '[]'
+  description: Limit write rate (bytes per second) to a device
+- option: device-write-iops
+  default_value: '[]'
+  description: Limit write rate (IO per second) to a device
+- option: disable-content-trust
+  default_value: "true"
+  description: Skip image verification
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-opt
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-option
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: entrypoint
+  description: Overwrite the default ENTRYPOINT of the image
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: expose
+  default_value: '[]'
+  description: Expose a port or a range of ports
+- option: group-add
+  default_value: '[]'
+  description: Add additional groups to join
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  default_value: 0s
+  description: Time between running the check (ns|us|ms|s|m|h) (default 0s)
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  default_value: 0s
+  description: |
+    Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
+- option: help
+  default_value: "false"
+  description: Print usage
+- option: hostname
+  shorthand: h
+  description: Container host name
+- option: init
+  default_value: "false"
+  description: |
+    Run an init inside the container that forwards signals and reaps processes
+- option: init-path
+  description: Path to the docker-init binary
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Keep STDIN open even if not attached
+- option: io-maxbandwidth
+  description: |
+    Maximum IO bandwidth limit for the system drive (Windows only)
+- option: io-maxiops
+  default_value: "0"
+  description: Maximum IOps limit for the system drive (Windows only)
+- option: ip
+  description: Container IPv4 address (e.g. 172.30.100.104)
+- option: ip6
+  description: Container IPv6 address (e.g. 2001:db8::33)
+- option: ipc
+  description: IPC namespace to use
+- option: isolation
+  description: Container isolation technology
+- option: kernel-memory
+  description: Kernel memory limit
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Set meta data on a container
+- option: label-file
+  default_value: '[]'
+  description: Read in a line delimited file of labels
+- option: link
+  default_value: '[]'
+  description: Add link to another container
+- option: link-local-ip
+  default_value: '[]'
+  description: Container IPv4/IPv6 link-local addresses
+- option: log-driver
+  description: Logging driver for the container
+- option: log-opt
+  default_value: '[]'
+  description: Log driver options
+- option: mac-address
+  description: Container MAC address (e.g. 92:d0:c6:0a:29:33)
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: memory-swappiness
+  default_value: "-1"
+  description: Tune container memory swappiness (0 to 100)
+- option: name
+  description: Assign a name to the container
+- option: net
+  default_value: default
+  description: Connect a container to a network
+- option: net-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: network
+  default_value: default
+  description: Connect a container to a network
+- option: network-alias
+  default_value: '[]'
+  description: Add network-scoped alias for the container
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: oom-kill-disable
+  default_value: "false"
+  description: Disable OOM Killer
+- option: oom-score-adj
+  default_value: "0"
+  description: Tune host's OOM preferences (-1000 to 1000)
+- option: pid
+  description: PID namespace to use
+- option: pids-limit
+  default_value: "0"
+  description: Tune container pids limit (set -1 for unlimited)
+- option: privileged
+  default_value: "false"
+  description: Give extended privileges to this container
+- option: publish
+  shorthand: p
+  default_value: '[]'
+  description: Publish a container's port(s) to the host
+- option: publish-all
+  shorthand: P
+  default_value: "false"
+  description: Publish all exposed ports to random ports
+- option: read-only
+  default_value: "false"
+  description: Mount the container's root filesystem as read only
+- option: restart
+  default_value: "no"
+  description: Restart policy to apply when a container exits
+- option: rm
+  default_value: "false"
+  description: Automatically remove the container when it exits
+- option: runtime
+  description: Runtime to use for this container
+- option: security-opt
+  default_value: '[]'
+  description: Security Options
+- option: shm-size
+  description: Size of /dev/shm, default value is 64MB
+- option: sig-proxy
+  default_value: "true"
+  description: Proxy received signals to the process
+- option: stop-signal
+  default_value: SIGTERM
+  description: Signal to stop a container, SIGTERM by default
+- option: stop-timeout
+  default_value: "0"
+  description: Timeout (in seconds) to stop a container
+- option: storage-opt
+  default_value: '[]'
+  description: Storage driver options for the container
+- option: sysctl
+  default_value: map[]
+  description: Sysctl options
+- option: tmpfs
+  default_value: '[]'
+  description: Mount a tmpfs directory
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: ulimit
+  default_value: '[]'
+  description: Ulimit options
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: userns
+  description: User namespace to use
+- option: uts
+  description: UTS namespace to use
+- option: volume
+  shorthand: v
+  default_value: '[]'
+  description: Bind mount a volume
+- option: volume-driver
+  description: Optional volume driver for the container
+- option: volumes-from
+  default_value: '[]'
+  description: Mount volumes from the specified container(s)
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container
+examples: |-
+  ### Assign name and allocate pseudo-TTY (--name, -it)
+
+  ```bash
+  $ docker run --name test -it debian
+
+  root@d6c0fe130dba:/# exit 13
+  $ echo $?
+  13
+  $ docker ps -a | grep test
+  d6c0fe130dba        debian:7            "/bin/bash"         26 seconds ago      Exited (13) 17 seconds ago                         test
+  ```
+
+  This example runs a container named `test` using the `debian:latest`
+  image. The `-it` instructs Docker to allocate a pseudo-TTY connected to
+  the container's stdin; creating an interactive `bash` shell in the container.
+  In the example, the `bash` shell is quit by entering
+  `exit 13`. This exit code is passed on to the caller of
+  `docker run`, and is recorded in the `test` container's metadata.
+
+  ### Capture container ID (--cidfile)
+
+  ```bash
+  $ docker run --cidfile /tmp/docker_test.cid ubuntu echo "test"
+  ```
+
+  This will create a container and print `test` to the console. The `cidfile`
+  flag makes Docker attempt to create a new file and write the container ID to it.
+  If the file exists already, Docker will return an error. Docker will close this
+  file when `docker run` exits.
+
+  ### Full container capabilities (--privileged)
+
+  ```bash
+  $ docker run -t -i --rm ubuntu bash
+  root@bc338942ef20:/# mount -t tmpfs none /mnt
+  mount: permission denied
+  ```
+
+  This will *not* work, because by default, most potentially dangerous kernel
+  capabilities are dropped; including `cap_sys_admin` (which is required to mount
+  filesystems). However, the `--privileged` flag will allow it to run:
+
+  ```bash
+  $ docker run -t -i --privileged ubuntu bash
+  root@50e3f57e16e6:/# mount -t tmpfs none /mnt
+  root@50e3f57e16e6:/# df -h
+  Filesystem      Size  Used Avail Use% Mounted on
+  none            1.9G     0  1.9G   0% /mnt
+  ```
+
+  The `--privileged` flag gives *all* capabilities to the container, and it also
+  lifts all the limitations enforced by the `device` cgroup controller. In other
+  words, the container can then do almost everything that the host can do. This
+  flag exists to allow special use-cases, like running Docker within Docker.
+
+  ### Set working directory (-w)
+
+  ```bash
+  $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
+  ```
+
+  The `-w` lets the command being executed inside directory given, here
+  `/path/to/dir/`. If the path does not exist it is created inside the container.
+
+  ### Set storage driver options per container
+
+  ```bash
+  $ docker run -it --storage-opt size=120G fedora /bin/bash
+  ```
+
+  This (size) will allow to set the container rootfs size to 120G at creation time.
+  This option is only available for the `devicemapper`, `btrfs`, `overlay2`,
+  `windowsfilter` and `zfs` graph drivers.
+  For the `devicemapper`, `btrfs`, `windowsfilter` and `zfs` graph drivers,
+  user cannot pass a size less than the Default BaseFS Size.
+  For the `overlay2` storage driver, the size option is only available if the
+  backing fs is `xfs` and mounted with the `pquota` mount option.
+  Under these conditions, user can pass any size less then the backing fs size.
+
+  ### Mount tmpfs (--tmpfs)
+
+  ```bash
+  $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
+  ```
+
+  The `--tmpfs` flag mounts an empty tmpfs into the container with the `rw`,
+  `noexec`, `nosuid`, `size=65536k` options.
+
+  ### Mount volume (-v, --read-only)
+
+  ```bash
+  $ docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
+  ```
+
+  The `-v` flag mounts the current working directory into the container. The `-w`
+  lets the command being executed inside the current working directory, by
+  changing into the directory to the value returned by `pwd`. So this
+  combination executes the command using the container, but inside the
+  current working directory.
+
+  ```bash
+  $ docker run -v /doesnt/exist:/foo -w /foo -i -t ubuntu bash
+  ```
+
+  When the host directory of a bind-mounted volume doesn't exist, Docker
+  will automatically create this directory on the host for you. In the
+  example above, Docker will create the `/doesnt/exist`
+  folder before starting your container.
+
+  ```bash
+  $ docker run --read-only -v /icanwrite busybox touch /icanwrite/here
+  ```
+
+  Volumes can be used in combination with `--read-only` to control where
+  a container writes files. The `--read-only` flag mounts the container's root
+  filesystem as read only prohibiting writes to locations other than the
+  specified volumes for the container.
+
+  ```bash
+  $ docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/static-docker-binary:/usr/bin/docker busybox sh
+  ```
+
+  By bind-mounting the docker unix socket and statically linked docker
+  binary (refer to [get the linux binary](
+  https://docs.docker.com/engine/installation/binaries/#/get-the-linux-binary)),
+  you give the container the full access to create and manipulate the host's
+  Docker daemon.
+
+  On Windows, the paths must be specified using Windows-style semantics.
+
+  ```powershell
+  PS C:\> docker run -v c:\foo:c:\dest microsoft/nanoserver cmd /s /c type c:\dest\somefile.txt
+  Contents of file
+
+  PS C:\> docker run -v c:\foo:d: microsoft/nanoserver cmd /s /c type d:\somefile.txt
+  Contents of file
+  ```
+
+  The following examples will fail when using Windows-based containers, as the
+  destination of a volume or bind-mount inside the container must be one of:
+  a non-existing or empty directory; or a drive other than C:. Further, the source
+  of a bind mount must be a local directory, not a file.
+
+  ```powershell
+  net use z: \\remotemachine\share
+  docker run -v z:\foo:c:\dest ...
+  docker run -v \\uncpath\to\directory:c:\dest ...
+  docker run -v c:\foo\somefile.txt:c:\dest ...
+  docker run -v c:\foo:c: ...
+  docker run -v c:\foo:c:\existing-directory-with-contents ...
+  ```
+
+  For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/engine/tutorials/dockervolumes/)
+
+  ### Publish or expose port (-p, --expose)
+
+  ```bash
+  $ docker run -p 127.0.0.1:80:8080 ubuntu bash
+  ```
+
+  This binds port `8080` of the container to port `80` on `127.0.0.1` of the host
+  machine. The [Docker User
+  Guide](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/)
+  explains in detail how to manipulate ports in Docker.
+
+  ```bash
+  $ docker run --expose 80 ubuntu bash
+  ```
+
+  This exposes port `80` of the container without publishing the port to the host
+  system's interfaces.
+
+  ### Set environment variables (-e, --env, --env-file)
+
+  ```bash
+  $ docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
+  ```
+
+  This sets simple (non-array) environmental variables in the container. For
+  illustration all three
+  flags are shown here. Where `-e`, `--env` take an environment variable and
+  value, or if no `=` is provided, then that variable's current value, set via
+  `export`, is passed through (i.e. `$MYVAR1` from the host is set to `$MYVAR1`
+  in the container). When no `=` is provided and that variable is not defined
+  in the client's environment then that variable will be removed from the
+  container's list of environment variables. All three flags, `-e`, `--env` and
+  `--env-file` can be repeated.
+
+  Regardless of the order of these three flags, the `--env-file` are processed
+  first, and then `-e`, `--env` flags. This way, the `-e` or `--env` will
+  override variables as needed.
+
+  ```bash
+  $ cat ./env.list
+  TEST_FOO=BAR
+  $ docker run --env TEST_FOO="This is a test" --env-file ./env.list busybox env | grep TEST_FOO
+  TEST_FOO=This is a test
+  ```
+
+  The `--env-file` flag takes a filename as an argument and expects each line
+  to be in the `VAR=VAL` format, mimicking the argument passed to `--env`. Comment
+  lines need only be prefixed with `#`
+
+  An example of a file passed with `--env-file`
+
+  ```bash
+  $ cat ./env.list
+  TEST_FOO=BAR
+
+  # this is a comment
+  TEST_APP_DEST_HOST=10.10.0.127
+  TEST_APP_DEST_PORT=8888
+  _TEST_BAR=FOO
+  TEST_APP_42=magic
+  helloWorld=true
+  123qwe=bar
+  org.spring.config=something
+
+  # pass through this variable from the caller
+  TEST_PASSTHROUGH
+  $ TEST_PASSTHROUGH=howdy docker run --env-file ./env.list busybox env
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  HOSTNAME=5198e0745561
+  TEST_FOO=BAR
+  TEST_APP_DEST_HOST=10.10.0.127
+  TEST_APP_DEST_PORT=8888
+  _TEST_BAR=FOO
+  TEST_APP_42=magic
+  helloWorld=true
+  TEST_PASSTHROUGH=howdy
+  HOME=/root
+  123qwe=bar
+  org.spring.config=something
+
+  $ docker run --env-file ./env.list busybox env
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  HOSTNAME=5198e0745561
+  TEST_FOO=BAR
+  TEST_APP_DEST_HOST=10.10.0.127
+  TEST_APP_DEST_PORT=8888
+  _TEST_BAR=FOO
+  TEST_APP_42=magic
+  helloWorld=true
+  TEST_PASSTHROUGH=
+  HOME=/root
+  123qwe=bar
+  org.spring.config=something
+  ```
+
+  ### Set metadata on container (-l, --label, --label-file)
+
+  A label is a `key=value` pair that applies metadata to a container. To label a container with two labels:
+
+  ```bash
+  $ docker run -l my-label --label com.example.foo=bar ubuntu bash
+  ```
+
+  The `my-label` key doesn't specify a value so the label defaults to an empty
+  string(`""`). To add multiple labels, repeat the label flag (`-l` or `--label`).
+
+  The `key=value` must be unique to avoid overwriting the label value. If you
+  specify labels with identical keys but different values, each subsequent value
+  overwrites the previous. Docker uses the last `key=value` you supply.
+
+  Use the `--label-file` flag to load multiple labels from a file. Delimit each
+  label in the file with an EOL mark. The example below loads labels from a
+  labels file in the current directory:
+
+  ```bash
+  $ docker run --label-file ./labels ubuntu bash
+  ```
+
+  The label-file format is similar to the format for loading environment
+  variables. (Unlike environment variables, labels are not visible to processes
+  running inside a container.) The following example illustrates a label-file
+  format:
+
+  ```none
+  com.example.label1="a label"
+
+  # this is a comment
+  com.example.label2=another\ label
+  com.example.label3
+  ```
+
+  You can load multiple label-files by supplying multiple  `--label-file` flags.
+
+  For additional information on working with labels, see [*Labels - custom
+  metadata in Docker*](https://docs.docker.com/engine/userguide/labels-custom-metadata/) in the Docker User
+  Guide.
+
+  ### Connect a container to a network (--network)
+
+  When you start a container use the `--network` flag to connect it to a network.
+  This adds the `busybox` container to the `my-net` network.
+
+  ```bash
+  $ docker run -itd --network=my-net busybox
+  ```
+
+  You can also choose the IP addresses for the container with `--ip` and `--ip6`
+  flags when you start the container on a user-defined network.
+
+  ```bash
+  $ docker run -itd --network=my-net --ip=10.10.9.75 busybox
+  ```
+
+  If you want to add a running container to a network use the `docker network connect` subcommand.
+
+  You can connect multiple containers to the same network. Once connected, the
+  containers can communicate easily need only another container's IP address
+  or name. For `overlay` networks or custom plugins that support multi-host
+  connectivity, containers connected to the same multi-host network but launched
+  from different Engines can also communicate in this way.
+
+  > **Note**: Service discovery is unavailable on the default bridge network.
+  > Containers can communicate via their IP addresses by default. To communicate
+  > by name, they must be linked.
+
+  You can disconnect a container from a network using the `docker network
+  disconnect` command.
+
+  ### Mount volumes from container (--volumes-from)
+
+  ```bash
+  $ docker run --volumes-from 777f7dc92da7 --volumes-from ba8c0c54f0f2:ro -i -t ubuntu pwd
+  ```
+
+  The `--volumes-from` flag mounts all the defined volumes from the referenced
+  containers. Containers can be specified by repetitions of the `--volumes-from`
+  argument. The container ID may be optionally suffixed with `:ro` or `:rw` to
+  mount the volumes in read-only or read-write mode, respectively. By default,
+  the volumes are mounted in the same mode (read write or read only) as
+  the reference container.
+
+  Labeling systems like SELinux require that proper labels are placed on volume
+  content mounted into a container. Without a label, the security system might
+  prevent the processes running inside the container from using the content. By
+  default, Docker does not change the labels set by the OS.
+
+  To change the label in the container context, you can add either of two suffixes
+  `:z` or `:Z` to the volume mount. These suffixes tell Docker to relabel file
+  objects on the shared volumes. The `z` option tells Docker that two containers
+  share the volume content. As a result, Docker labels the content with a shared
+  content label. Shared volume labels allow all containers to read/write content.
+  The `Z` option tells Docker to label the content with a private unshared label.
+  Only the current container can use a private volume.
+
+  ### Attach to STDIN/STDOUT/STDERR (-a)
+
+  The `-a` flag tells `docker run` to bind to the container's `STDIN`, `STDOUT`
+  or `STDERR`. This makes it possible to manipulate the output and input as
+  needed.
+
+  ```bash
+  $ echo "test" | docker run -i -a stdin ubuntu cat -
+  ```
+
+  This pipes data into a container and prints the container's ID by attaching
+  only to the container's `STDIN`.
+
+  ```bash
+  $ docker run -a stderr ubuntu echo test
+  ```
+
+  This isn't going to print anything unless there's an error because we've
+  only attached to the `STDERR` of the container. The container's logs
+  still store what's been written to `STDERR` and `STDOUT`.
+
+  ```bash
+  $ cat somefile | docker run -i -a stdin mybuilder dobuild
+  ```
+
+  This is how piping a file into a container could be done for a build.
+  The container's ID will be printed after the build is done and the build
+  logs could be retrieved using `docker logs`. This is
+  useful if you need to pipe a file or something else into a container and
+  retrieve the container's ID once the container has finished running.
+
+  ### Add host device to container (--device)
+
+  ```bash
+  $ docker run --device=/dev/sdc:/dev/xvdc \
+               --device=/dev/sdd --device=/dev/zero:/dev/nulo \
+               -i -t \
+               ubuntu ls -l /dev/{xvdc,sdd,nulo}
+
+  brw-rw---- 1 root disk 8, 2 Feb  9 16:05 /dev/xvdc
+  brw-rw---- 1 root disk 8, 3 Feb  9 16:05 /dev/sdd
+  crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/nulo
+  ```
+
+  It is often necessary to directly expose devices to a container. The `--device`
+  option enables that. For example, a specific block storage device or loop
+  device or audio device can be added to an otherwise unprivileged container
+  (without the `--privileged` flag) and have the application directly access it.
+
+  By default, the container will be able to `read`, `write` and `mknod` these devices.
+  This can be overridden using a third `:rwm` set of options to each `--device`
+  flag:
+
+  ```bash
+  $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
+
+  Command (m for help): q
+  $ docker run --device=/dev/sda:/dev/xvdc:r --rm -it ubuntu fdisk  /dev/xvdc
+  You will not be able to write the partition table.
+
+  Command (m for help): q
+
+  $ docker run --device=/dev/sda:/dev/xvdc:rw --rm -it ubuntu fdisk  /dev/xvdc
+
+  Command (m for help): q
+
+  $ docker run --device=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
+  fdisk: unable to open /dev/xvdc: Operation not permitted
+  ```
+
+  > **Note**: `--device` cannot be safely used with ephemeral devices. Block devices
+  > that may be removed should not be added to untrusted containers with
+  > `--device`.
+
+  ### Restart policies (--restart)
+
+  Use Docker's `--restart` to specify a container's *restart policy*. A restart
+  policy controls whether the Docker daemon restarts a container after exit.
+  Docker supports the following restart policies:
+
+  | Policy            | Result                                  |
+  |-------------------|-----------------------------------------|
+  | `no`              | Do not automatically restart the container when it exits. This is the default. |
+  | `failure`         | Restart only if the container exits with a non-zero exit status. Optionally, limit the number of restart retries the Docker daemon attempts. |
+  | `always`          | Always restart the container regardless of the exit status. When you specify always, the Docker daemon will try to restart the container indefinitely. The container will also always start on daemon startup, regardless of the current state of the container. |
+
+  ```bash
+  $ docker run --restart=always redis
+  ```
+
+  This will run the `redis` container with a restart policy of **always**
+  so that if the container exits, Docker will restart it.
+
+  More detailed information on restart policies can be found in the
+  [Restart Policies (--restart)](../run.md#restart-policies-restart)
+  section of the Docker run reference page.
+
+  ### Add entries to container hosts file (--add-host)
+
+  You can add other hosts into a container's `/etc/hosts` file by using one or
+  more `--add-host` flags. This example adds a static address for a host named
+  `docker`:
+
+  ```bash
+  $ docker run --add-host=docker:10.180.0.1 --rm -it debian
+
+  root@f38c87f2a42d:/# ping docker
+  PING docker (10.180.0.1): 48 data bytes
+  56 bytes from 10.180.0.1: icmp_seq=0 ttl=254 time=7.600 ms
+  56 bytes from 10.180.0.1: icmp_seq=1 ttl=254 time=30.705 ms
+  ^C--- docker ping statistics ---
+  2 packets transmitted, 2 packets received, 0% packet loss
+  round-trip min/avg/max/stddev = 7.600/19.152/30.705/11.553 ms
+  ```
+
+  Sometimes you need to connect to the Docker host from within your
+  container. To enable this, pass the Docker host's IP address to
+  the container using the `--add-host` flag. To find the host's address,
+  use the `ip addr show` command.
+
+  The flags you pass to `ip addr show` depend on whether you are
+  using IPv4 or IPv6 networking in your containers. Use the following
+  flags for IPv4 address retrieval for a network device named `eth0`:
+
+  ```bash
+  $ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print \$2}' | cut -d / -f 1`
+  $ docker run  --add-host=docker:${HOSTIP} --rm -it debian
+  ```
+
+  For IPv6 use the `-6` flag instead of the `-4` flag. For other network
+  devices, replace `eth0` with the correct device name (for example `docker0`
+  for the bridge device).
+
+  ### Set ulimits in container (--ulimit)
+
+  Since setting `ulimit` settings in a container requires extra privileges not
+  available in the default container, you can set these using the `--ulimit` flag.
+  `--ulimit` is specified with a soft and hard limit as such:
+  `<type>=<soft limit>[:<hard limit>]`, for example:
+
+  ```bash
+  $ docker run --ulimit nofile=1024:1024 --rm debian sh -c "ulimit -n"
+  1024
+  ```
+
+  > **Note**: If you do not provide a `hard limit`, the `soft limit` will be used
+  > for both values. If no `ulimits` are set, they will be inherited from
+  > the default `ulimits` set on the daemon.  `as` option is disabled now.
+  > In other words, the following script is not supported:
+  >
+  > ```bash
+  > $ docker run -it --ulimit as=1024 fedora /bin/bash`
+  > ```
+
+  The values are sent to the appropriate `syscall` as they are set.
+  Docker doesn't perform any byte conversion. Take this into account when setting the values.
+
+  #### For `nproc` usage
+
+  Be careful setting `nproc` with the `ulimit` flag as `nproc` is designed by Linux to set the
+  maximum number of processes available to a user, not to a container.  For example, start four
+  containers with `daemon` user:
+
+  ```bash
+  $ docker run -d -u daemon --ulimit nproc=3 busybox top
+
+  $ docker run -d -u daemon --ulimit nproc=3 busybox top
+
+  $ docker run -d -u daemon --ulimit nproc=3 busybox top
+
+  $ docker run -d -u daemon --ulimit nproc=3 busybox top
+  ```
+
+  The 4th container fails and reports "[8] System error: resource temporarily unavailable" error.
+  This fails because the caller set `nproc=3` resulting in the first three containers using up
+  the three processes quota set for the `daemon` user.
+
+  ### Stop container with signal (--stop-signal)
+
+  The `--stop-signal` flag sets the system call signal that will be sent to the container to exit.
+  This signal can be a valid unsigned number that matches a position in the kernel's syscall table, for instance 9,
+  or a signal name in the format SIGNAME, for instance SIGKILL.
+
+  ### Optional security options (--security-opt)
+
+  On Windows, this flag can be used to specify the `credentialspec` option.
+  The `credentialspec` must be in the format `file://spec.txt` or `registry://keyname`.
+
+  ### Stop container with timeout (--stop-timeout)
+
+  The `--stop-timeout` flag sets the timeout (in seconds) that a pre-defined (see `--stop-signal`) system call
+  signal that will be sent to the container to exit. After timeout elapses the container will be killed with SIGKILL.
+
+  ### Specify isolation technology for container (--isolation)
+
+  This option is useful in situations where you are running Docker containers on
+  Microsoft Windows. The `--isolation <value>` option sets a container's isolation
+  technology. On Linux, the only supported is the `default` option which uses
+  Linux namespaces. These two commands are equivalent on Linux:
+
+  ```
+  $ docker run -d busybox top
+  $ docker run -d --isolation default busybox top
+  ```
+
+  On Microsoft Windows, can take any of these values:
+
+
+  | Value     | Description                                                                                                                                                   |
+  |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value.  |
+  | `process` | Namespace isolation only.                                                                                                                                     |
+  | `hyperv`   | Hyper-V hypervisor partition-based isolation.                                                                                                                  |
+
+  On Windows, the default isolation for client is `hyperv`, and for server is
+  `process`. Therefore when running on Windows server without a `daemon` option
+  set, these two commands are equivalent:
+  ```
+  $ docker run -d --isolation default busybox top
+  $ docker run -d --isolation process busybox top
+  ```
+
+  If you have set the `--exec-opt isolation=hyperv` option on the Docker `daemon`,
+  if running on Windows server, any of these commands also result in `hyperv` isolation:
+
+  ```
+  $ docker run -d --isolation default busybox top
+  $ docker run -d --isolation hyperv busybox top
+  ```
+
+  ### Configure namespaced kernel parameters (sysctls) at runtime
+
+  The `--sysctl` sets namespaced kernel parameters (sysctls) in the
+  container. For example, to turn on IP forwarding in the containers
+  network namespace, run this command:
+
+  ```bash
+  $ docker run --sysctl net.ipv4.ip_forward=1 someimage
+  ```
+
+  > **Note**: Not all sysctls are namespaced. Docker does not support changing sysctls
+  > inside of a container that also modify the host system. As the kernel
+  > evolves we expect to see more sysctls become namespaced.
+
+  #### Currently supported sysctls
+
+  - `IPC Namespace`:
+
+    ```none
+    kernel.msgmax, kernel.msgmnb, kernel.msgmni, kernel.sem, kernel.shmall, kernel.shmmax, kernel.shmmni, kernel.shm_rmid_forced
+    Sysctls beginning with fs.mqueue.*
+    ```
+
+    If you use the `--ipc=host` option these sysctls will not be allowed.
+
+  - `Network Namespace`:
+
+    Sysctls beginning with net.*
+
+    If you use the `--network=host` option using these sysctls will not be allowed.
+

--- a/_data/engine-cli-edge/docker_save.yaml
+++ b/_data/engine-cli-edge/docker_save.yaml
@@ -1,0 +1,42 @@
+command: docker save
+short: Save one or more images to a tar archive (streamed to STDOUT by default)
+long: |-
+  Produces a tarred repository to the standard output stream.
+  Contains all parent layers, and all tags + versions, or specified `repo:tag`, for
+  each argument provided.
+usage: docker save [OPTIONS] IMAGE [IMAGE...]
+pname: docker
+plink: docker.yaml
+options:
+- option: output
+  shorthand: o
+  description: Write to a file, instead of STDOUT
+examples: |-
+  ### Create a backup that can then be used with `docker load`.
+
+  ```bash
+  $ docker save busybox > busybox.tar
+
+  $ ls -sh busybox.tar
+
+  2.7M busybox.tar
+
+  $ docker save --output busybox.tar busybox
+
+  $ ls -sh busybox.tar
+
+  2.7M busybox.tar
+
+  $ docker save -o fedora-all.tar fedora
+
+  $ docker save -o fedora-latest.tar fedora:latest
+  ```
+
+  ### Cherry-pick particular tags
+
+  You can even cherry-pick particular tags of an image repository.
+
+  ```bash
+  $ docker save -o ubuntu.tar ubuntu:lucid ubuntu:saucy
+  ```
+

--- a/_data/engine-cli-edge/docker_search.yaml
+++ b/_data/engine-cli-edge/docker_search.yaml
@@ -1,0 +1,90 @@
+command: docker search
+short: Search the Docker Hub for images
+long: |-
+  Search [Docker Hub](https://hub.docker.com) for images
+
+  See [*Find Public Images on Docker Hub*](https://docs.docker.com/engine/tutorials/dockerrepos/#searching-for-images) for
+  more details on finding shared images from the command line.
+
+  > **Note**: Search queries return a maximum of 25 results.
+usage: docker search [OPTIONS] TERM
+pname: docker
+plink: docker.yaml
+options:
+- option: automated
+  default_value: "false"
+  description: Only show automated builds
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: limit
+  default_value: "25"
+  description: Max number of search results
+- option: no-trunc
+  default_value: "false"
+  description: Don't truncate output
+- option: stars
+  shorthand: s
+  default_value: "0"
+  description: Only displays with at least x stars
+examples: "### Search images by name\n\nThis example displays images with a name containing
+  'busybox':\n\n```none\n$ docker search busybox\n\nNAME                             DESCRIPTION
+  \                                    STARS     OFFICIAL   AUTOMATED\nbusybox                          Busybox
+  base image.                             316       [OK]       \nprogrium/busybox
+  \                                                                50                   [OK]\nradial/busyboxplus
+  \              Full-chain, Internet enabled, busybox made...   8                    [OK]\nodise/busybox-python
+  \                                                            2                    [OK]\nazukiapp/busybox
+  \                This image is meant to be used as the base...   2                    [OK]\nofayau/busybox-jvm
+  \              Prepare busybox to install a 32 bits JVM.       1                    [OK]\nshingonoide/archlinux-busybox
+  \   Arch Linux, a lightweight and flexible Lin...   1                    [OK]\nodise/busybox-curl
+  \                                                              1                    [OK]\nofayau/busybox-libc32
+  \           Busybox with 32 bits (and 64 bits) libs         1                    [OK]\npeelsky/zulu-openjdk-busybox
+  \                                                    1                    [OK]\nskomma/busybox-data
+  \             Docker image suitable for data volume cont...   1                    [OK]\nelektritter/busybox-teamspeak
+  \   Lightweight teamspeak3 container based on...    1                    [OK]\nsocketplane/busybox
+  \                                                             1                    [OK]\noveits/docker-nginx-busybox
+  \     This is a tiny NginX docker image based on...   0                    [OK]\nggtools/busybox-ubuntu
+  \          Busybox ubuntu version with extra goodies       0                    [OK]\nnikfoundas/busybox-confd
+  \        Minimal busybox based distribution of confd     0                    [OK]\nopenshift/busybox-http-app
+  \                                                      0                    [OK]\njllopis/busybox
+  \                                                                 0                    [OK]\nswyckoff/busybox
+  \                                                                0                    [OK]\npowellquiring/busybox
+  \                                                           0                    [OK]\nwilliamyeh/busybox-sh
+  \           Docker image for BusyBox's sh                   0                    [OK]\nsimplexsys/busybox-cli-powered
+  \  Docker busybox images, with a few often us...   0                    [OK]\nfhisamoto/busybox-java
+  \          Busybox java                                    0                    [OK]\nscottabernethy/busybox
+  \                                                          0                    [OK]\nmarclop/busybox-solr\n```\n\n###
+  Display non-truncated description (--no-trunc)\n\nThis example displays images with
+  a name containing 'busybox',\nat least 3 stars and the description isn't truncated
+  in the output:\n\n```bash\n$ docker search --stars=3 --no-trunc busybox\nNAME                 DESCRIPTION
+  \                                                                              STARS
+  \    OFFICIAL   AUTOMATED\nbusybox              Busybox base image.                                                                       325
+  \      [OK]       \nprogrium/busybox                                                                                               50
+  \                  [OK]\nradial/busyboxplus   Full-chain, Internet enabled, busybox
+  made from scratch. Comes in git and cURL flavors.   8                    [OK]\n```\n\n###
+  Limit search results (--limit)\n\nThe flag `--limit` is the maximum number of results
+  returned by a search. This value could\nbe in the range between 1 and 100. The default
+  value of `--limit` is 25.\n\n\n### Filtering\n\nThe filtering flag (`-f` or `--filter`)
+  format is a `key=value` pair. If there is more\nthan one filter, then pass multiple
+  flags (e.g. `--filter \"foo=bar\" --filter \"bif=baz\"`)\n\nThe currently supported
+  filters are:\n\n* stars (int - number of stars the image has)\n* is-automated (true|false)
+  - is the image automated or not\n* is-official (true|false) - is the image official
+  or not\n\n\n#### stars\n\nThis example displays images with a name containing 'busybox'
+  and at\nleast 3 stars:\n\n```bash\n$ docker search --filter stars=3 busybox\n\nNAME
+  \                DESCRIPTION                                     STARS     OFFICIAL
+  \  AUTOMATED\nbusybox              Busybox base image.                             325
+  \      [OK]       \nprogrium/busybox                                                     50
+  \                  [OK]\nradial/busyboxplus   Full-chain, Internet enabled, busybox
+  made...   8                    [OK]\n```\n\n\n#### is-automated\n\nThis example
+  displays images with a name containing 'busybox'\nand are automated builds:\n\n```bash\n$
+  docker search --filter is-automated busybox\n\nNAME                 DESCRIPTION
+  \                                    STARS     OFFICIAL   AUTOMATED\nprogrium/busybox
+  \                                                    50                   [OK]\nradial/busyboxplus
+  \  Full-chain, Internet enabled, busybox made...   8                    [OK]\n```\n\n####
+  is-official\n\nThis example displays images with a name containing 'busybox', at
+  least\n3 stars and are official builds:\n\n```bash\n$ docker search --filter \"is-official=true\"
+  --filter \"stars=3\" busybox\n\nNAME                 DESCRIPTION                                     STARS
+  \    OFFICIAL   AUTOMATED\nprogrium/busybox                                                     50
+  \                  [OK]\nradial/busyboxplus   Full-chain, Internet enabled, busybox
+  made...   8                    [OK]\n```"
+

--- a/_data/engine-cli-edge/docker_secret.yaml
+++ b/_data/engine-cli-edge/docker_secret.yaml
@@ -1,0 +1,17 @@
+command: docker secret
+short: Manage Docker secrets
+long: Manage secrets.
+usage: docker secret
+pname: docker
+plink: docker.yaml
+cname:
+- docker secret create
+- docker secret inspect
+- docker secret ls
+- docker secret rm
+clink:
+- docker_secret_create.yaml
+- docker_secret_inspect.yaml
+- docker_secret_ls.yaml
+- docker_secret_rm.yaml
+

--- a/_data/engine-cli-edge/docker_secret_create.yaml
+++ b/_data/engine-cli-edge/docker_secret_create.yaml
@@ -1,0 +1,73 @@
+command: docker secret create
+short: Create a secret from a file or STDIN as content
+long: "Creates a secret using standard input or from a file for the secret content.
+  You must run this command on a manager node. \n\nFor detailed information about
+  using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/)."
+usage: docker secret create [OPTIONS] SECRET file|-
+pname: docker secret
+plink: docker_secret.yaml
+options:
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Secret labels
+examples: |-
+  ### Create a secret
+
+  ```bash
+  $ echo <secret> | docker secret create my_secret -
+  mhv17xfe3gh6xc4rij5orpfds
+
+  $ docker secret ls
+  ID                          NAME                    CREATED                                   UPDATED                                   SIZE
+  mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+  ```
+
+  ### Create a secret with a file
+
+  ```bash
+  $ docker secret create my_secret ./secret.json
+
+  mhv17xfe3gh6xc4rij5orpfds
+
+  $ docker secret ls
+
+  ID                          NAME                    CREATED                                   UPDATED                                   SIZE
+  mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+  ```
+
+  ### Create a secret with labels
+
+  ```bash
+  $ docker secret create --label env=dev \
+                         --label rev=20161102 \
+                         my_secret ./secret.json
+
+  jtn7g6aukl5ky7nr9gvwafoxh
+  ```
+
+  ```none
+  $ docker secret inspect my_secret
+
+  [
+      {
+          "ID": "jtn7g6aukl5ky7nr9gvwafoxh",
+          "Version": {
+              "Index": 541
+          },
+          "CreatedAt": "2016-11-03T20:54:12.924766548Z",
+          "UpdatedAt": "2016-11-03T20:54:12.924766548Z",
+          "Spec": {
+              "Name": "my_secret",
+              "Labels": {
+                  "env": "dev",
+                  "rev": "20161102"
+              },
+              "Data": null
+          },
+          "Digest": "sha256:4212a44b14e94154359569333d3fc6a80f6b9959dfdaff26412f4b2796b1f387",
+          "SecretSize": 1679
+      }
+  ]
+  ```
+

--- a/_data/engine-cli-edge/docker_secret_inspect.yaml
+++ b/_data/engine-cli-edge/docker_secret_inspect.yaml
@@ -1,0 +1,63 @@
+command: docker secret inspect
+short: Display detailed information on one or more secrets
+long: |-
+  Inspects the specified secret. This command has to be run targeting a manager
+  node.
+
+  By default, this renders all results in a JSON array. If a format is specified,
+  the given template will be executed for each result.
+
+  Go's [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+
+  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+usage: docker secret inspect [OPTIONS] SECRET [SECRET...]
+pname: docker secret
+plink: docker_secret.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+examples: |-
+  ### Inspect a secret by name or ID
+
+  You can inspect a secret, either by its *name*, or *ID*
+
+  For example, given the following secret:
+
+  ```bash
+  $ docker secret ls
+  ID                          NAME                    CREATED                                   UPDATED
+  mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC
+  ```
+
+  ```none
+  $ docker secret inspect secret.json
+
+  [
+      {
+          "ID": "mhv17xfe3gh6xc4rij5orpfds",
+              "Version": {
+              "Index": 1198
+          },
+          "CreatedAt": "2016-10-27T23:25:43.909181089Z",
+          "UpdatedAt": "2016-10-27T23:25:43.909181089Z",
+          "Spec": {
+              "Name": "secret.json"
+          }
+      }
+  ]
+  ```
+
+  ### Formatting
+
+  You can use the --format option to obtain specific information about a
+  secret. The following example command outputs the creation time of the
+  secret.
+
+  ```bash
+  $ docker secret inspect --format='{{.CreatedAt}}' mhv17xfe3gh6xc4rij5orpfds
+
+  2016-10-27 23:25:43.909181089 +0000 UTC
+  ```
+

--- a/_data/engine-cli-edge/docker_secret_ls.yaml
+++ b/_data/engine-cli-edge/docker_secret_ls.yaml
@@ -1,0 +1,23 @@
+command: docker secret ls
+aliases: list
+short: List secrets
+long: |-
+  Run this command on a manager node to list the secrets in the swarm.
+
+  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+usage: docker secret ls [OPTIONS]
+pname: docker secret
+plink: docker_secret.yaml
+options:
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display IDs
+examples: |-
+  ```bash
+  $ docker secret ls
+
+  ID                          NAME                    CREATED                                   UPDATED
+  mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC
+  ```
+

--- a/_data/engine-cli-edge/docker_secret_rm.yaml
+++ b/_data/engine-cli-edge/docker_secret_rm.yaml
@@ -1,0 +1,22 @@
+command: docker secret rm
+aliases: remove
+short: Remove one or more secrets
+long: |-
+  Removes the specified secrets from the swarm. This command has to be run
+  targeting a manager node.
+
+  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+usage: docker secret rm SECRET [SECRET...]
+pname: docker secret
+plink: docker_secret.yaml
+examples: |-
+  This example removes a secret:
+
+  ```bash
+  $ docker secret rm secret.json
+  sapth4csdo5b6wz2p5uimh5xg
+  ```
+
+  > **Warning**: Unlike `docker rm`, this command does not ask for confirmation
+  > before removing a secret.
+

--- a/_data/engine-cli-edge/docker_service.yaml
+++ b/_data/engine-cli-edge/docker_service.yaml
@@ -1,0 +1,25 @@
+command: docker service
+short: Manage services
+long: Manage services.
+usage: docker service
+pname: docker
+plink: docker.yaml
+cname:
+- docker service create
+- docker service inspect
+- docker service logs
+- docker service ls
+- docker service ps
+- docker service rm
+- docker service scale
+- docker service update
+clink:
+- docker_service_create.yaml
+- docker_service_inspect.yaml
+- docker_service_logs.yaml
+- docker_service_ls.yaml
+- docker_service_ps.yaml
+- docker_service_rm.yaml
+- docker_service_scale.yaml
+- docker_service_update.yaml
+

--- a/_data/engine-cli-edge/docker_service_create.yaml
+++ b/_data/engine-cli-edge/docker_service_create.yaml
@@ -1,0 +1,793 @@
+command: docker service create
+short: Create a new service
+long: |-
+  Creates a service as described by the specified parameters. You must run this
+  command on a manager node.
+usage: docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: constraint
+  default_value: '[]'
+  description: Placement constraints
+- option: container-label
+  default_value: '[]'
+  description: Container labels
+- option: dns
+  default_value: '[]'
+  description: Set custom DNS servers
+- option: dns-option
+  default_value: '[]'
+  description: Set DNS options
+- option: dns-search
+  default_value: '[]'
+  description: Set custom DNS search domains
+- option: endpoint-mode
+  description: Endpoint mode (vip or dnsrr)
+- option: env
+  shorthand: e
+  default_value: '[]'
+  description: Set environment variables
+- option: env-file
+  default_value: '[]'
+  description: Read in a file of environment variables
+- option: group
+  default_value: '[]'
+  description: Set one or more supplementary user groups for the container
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  description: Time between running the check (ns|us|ms|s|m|h)
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  description: Maximum time to allow one check to run (ns|us|ms|s|m|h)
+- option: host
+  default_value: '[]'
+  description: Set one or more custom host-to-IP mappings (host:ip)
+- option: hostname
+  description: Container hostname
+- option: label
+  shorthand: l
+  default_value: '[]'
+  description: Service labels
+- option: limit-cpu
+  default_value: "0.000"
+  description: Limit CPUs
+- option: limit-memory
+  default_value: 0 B
+  description: Limit Memory
+- option: log-driver
+  description: Logging driver for service
+- option: log-opt
+  default_value: '[]'
+  description: Logging driver options
+- option: mode
+  default_value: replicated
+  description: Service mode (replicated or global)
+- option: mount
+  description: Attach a filesystem mount to the service
+- option: name
+  description: Service name
+- option: network
+  default_value: '[]'
+  description: Network attachments
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: publish
+  shorthand: p
+  description: Publish a port as a node port
+- option: replicas
+  description: Number of tasks
+- option: reserve-cpu
+  default_value: "0.000"
+  description: Reserve CPUs
+- option: reserve-memory
+  default_value: 0 B
+  description: Reserve Memory
+- option: restart-condition
+  description: Restart when condition is met (none, on-failure, or any)
+- option: restart-delay
+  description: Delay between restart attempts (ns|us|ms|s|m|h)
+- option: restart-max-attempts
+  description: Maximum number of restarts before giving up
+- option: restart-window
+  description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
+- option: secret
+  description: Specify secrets to expose to the service
+- option: stop-grace-period
+  description: |
+    Time to wait before force killing a container (ns|us|ms|s|m|h)
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: update-delay
+  default_value: 0s
+  description: Delay between updates (ns|us|ms|s|m|h) (default 0s)
+- option: update-failure-action
+  default_value: pause
+  description: Action on update failure (pause|continue)
+- option: update-max-failure-ratio
+  default_value: "0"
+  description: Failure rate to tolerate during an update
+- option: update-monitor
+  default_value: 0s
+  description: |
+    Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
+- option: update-parallelism
+  default_value: "1"
+  description: |
+    Maximum number of tasks updated simultaneously (0 to update all at once)
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: with-registry-auth
+  default_value: "false"
+  description: Send registry authentication details to swarm agents
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container
+examples: |-
+  ### Create a service
+
+  ```bash
+  $ docker service create --name redis redis:3.0.6
+
+  dmu1ept4cxcfe8k8lhtux3ro3
+
+  $ docker service create --mode global --name redis2 redis:3.0.6
+
+  a8q9dasaafudfs8q8w32udass
+
+  $ docker service ls
+
+  ID            NAME    MODE        REPLICAS  IMAGE
+  dmu1ept4cxcf  redis   replicated  1/1       redis:3.0.6
+  a8q9dasaafud  redis2  global      1/1       redis:3.0.6
+  ```
+
+  ### Create a service with 5 replica tasks (--replicas)
+
+  Use the `--replicas` flag to set the number of replica tasks for a replicated
+  service. The following command creates a `redis` service with `5` replica tasks:
+
+  ```bash
+  $ docker service create --name redis --replicas=5 redis:3.0.6
+
+  4cdgfyky7ozwh3htjfw0d12qv
+  ```
+
+  The above command sets the *desired* number of tasks for the service. Even
+  though the command returns immediately, actual scaling of the service may take
+  some time. The `REPLICAS` column shows both the *actual* and *desired* number
+  of replica tasks for the service.
+
+  In the following example the desired state is  `5` replicas, but the current
+  number of `RUNNING` tasks is `3`:
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME   MODE        REPLICAS  IMAGE
+  4cdgfyky7ozw  redis  replicated  3/5       redis:3.0.7
+  ```
+
+  Once all the tasks are created and `RUNNING`, the actual number of tasks is
+  equal to the desired number:
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME   MODE        REPLICAS  IMAGE
+  4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
+  ```
+
+  ### Create a service with secrets
+
+  Use the `--secret` flag to give a container access to a
+  [secret](secret_create.md).
+
+  Create a service specifying a secret:
+
+  ```bash
+  $ docker service create --name redis --secret secret.json redis:3.0.6
+
+  4cdgfyky7ozwh3htjfw0d12qv
+  ```
+
+  Create a service specifying the secret, target, user/group ID and mode:
+
+  ```bash
+  $ docker service create --name redis \
+      --secret source=ssh-key,target=ssh \
+      --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 \
+      redis:3.0.6
+
+  4cdgfyky7ozwh3htjfw0d12qv
+  ```
+
+  Secrets are located in `/run/secrets` in the container.  If no target is
+  specified, the name of the secret will be used as the in memory file in the
+  container.  If a target is specified, that will be the filename.  In the
+  example above, two files will be created: `/run/secrets/ssh` and
+  `/run/secrets/app` for each of the secret targets specified.
+
+  ### Create a service with a rolling update policy
+
+  ```bash
+  $ docker service create \
+    --replicas 10 \
+    --name redis \
+    --update-delay 10s \
+    --update-parallelism 2 \
+    redis:3.0.6
+  ```
+
+  When you run a [service update](service_update.md), the scheduler updates a
+  maximum of 2 tasks at a time, with `10s` between updates. For more information,
+  refer to the [rolling updates
+  tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
+
+  ### Set environment variables (-e, --env)
+
+  This sets environmental variables for all tasks in a service. For example:
+
+  ```bash
+  $ docker service create --name redis_2 --replicas 5 --env MYVAR=foo redis:3.0.6
+  ```
+
+  ### Create a service with specific hostname (--hostname)
+
+  This option sets the docker service containers hostname to a specific string.
+  For example:
+
+  ```bash
+  $ docker service create --name redis --hostname myredis redis:3.0.6
+  ```
+
+  ### Set metadata on a service (-l, --label)
+
+  A label is a `key=value` pair that applies metadata to a service. To label a
+  service with two labels:
+
+  ```bash
+  $ docker service create \
+    --name redis_2 \
+    --label com.example.foo="bar"
+    --label bar=baz \
+    redis:3.0.6
+  ```
+
+  For more information about labels, refer to [apply custom
+  metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
+
+  ### Add bind-mounts or volumes
+
+  Docker supports two different kinds of mounts, which allow containers to read to
+  or write from files or directories on other containers or the host operating
+  system. These types are _data volumes_ (often referred to simply as volumes) and
+  _bind-mounts_.
+
+  Additionally, Docker supports `tmpfs` mounts.
+
+  A **bind-mount** makes a file or directory on the host available to the
+  container it is mounted within. A bind-mount may be either read-only or
+  read-write. For example, a container might share its host's DNS information by
+  means of a bind-mount of the host's `/etc/resolv.conf` or a container might
+  write logs to its host's `/var/log/myContainerLogs` directory. If you use
+  bind-mounts and your host and containers have different notions of permissions,
+  access controls, or other such details, you will run into portability issues.
+
+  A **named volume** is a mechanism for decoupling persistent data needed by your
+  container from the image used to create the container and from the host machine.
+  Named volumes are created and managed by Docker, and a named volume persists
+  even when no container is currently using it. Data in named volumes can be
+  shared between a container and the host machine, as well as between multiple
+  containers. Docker uses a _volume driver_ to create, manage, and mount volumes.
+  You can back up or restore volumes using Docker commands.
+
+  A **tmpfs** mounts a tmpfs inside a container for volatile data.
+
+  Consider a situation where your image starts a lightweight web server. You could
+  use that image as a base image, copy in your website's HTML files, and package
+  that into another image. Each time your website changed, you'd need to update
+  the new image and redeploy all of the containers serving your website. A better
+  solution is to store the website in a named volume which is attached to each of
+  your web server containers when they start. To update the website, you just
+  update the named volume.
+
+  For more information about named volumes, see
+  [Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).
+
+  The following table describes options which apply to both bind-mounts and named
+  volumes in a service:
+
+  <table>
+    <tr>
+      <th>Option</th>
+      <th>Required</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><b>types</b></td>
+      <td></td>
+      <td>
+        <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, or <tt>tmpfs</tt>. Defaults to <tt>volume</tt> if no type is specified.
+        <ul>
+          <li><tt>volume</tt>: mounts a [managed volume](volume_create.md) into the container.</li>
+          <li><tt>bind</tt>: bind-mounts a directory or file from the host into the container.</li>
+          <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
+        </ul></p>
+      </td>
+    </tr>
+    <tr>
+      <td><b>src</b> or <b>source</b></td>
+      <td>for <tt>type=bind</tt> only></td>
+      <td>
+        <ul>
+          <li>
+           <tt>type=volume</tt>: <tt>src</tt> is an optional way to specify the name of the volume (for example, <tt>src=my-volume</tt>).
+            If the named volume does not exist, it is automatically created. If no <tt>src</tt> is specified, the volume is
+            assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide.
+            A randomly-named volume has the same lifecycle as its container and is destroyed when the <i>container</i>
+            is destroyed (which is upon <tt>service update</tt>, or when scaling or re-balancing the service)
+          </li>
+          <li>
+            <tt>type=bind</tt>: <tt>src</tt> is required, and specifies an absolute path to the file or directory to bind-mount
+            (for example, <tt>src=/path/on/host/</tt>). An error is produced if the file or directory does not exist.
+          </li>
+          <li>
+            <tt>type=tmpfs</tt>: <tt>src</tt> is not supported.
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><p><b>dst</b> or <b>destination</b> or <b>target</b></p></td>
+      <td>yes</td>
+      <td>
+        <p>Mount path inside the container, for example <tt>/some/path/in/container/</tt>.
+        If the path does not exist in the container's filesystem, the Engine creates
+        a directory at the specified location before mounting the volume or bind-mount.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><p><b>readonly</b> or <b>ro</b></p></td>
+      <td></td>
+      <td>
+        <p>The Engine mounts binds and volumes <tt>read-write</tt> unless <tt>readonly</tt> option
+        is given when mounting the bind or volume.
+        <ul>
+          <li><tt>true</tt> or <tt>1</tt> or no value: Mounts the bind or volume read-only.</li>
+          <li><tt>false</tt> or <tt>0</tt>: Mounts the bind or volume read-write.</li>
+        </ul></p>
+      </td>
+    </tr>
+  </table>
+
+
+  #### Bind Propagation
+
+  Bind propagation refers to whether or not mounts created within a given
+  bind-mount or named volume can be propagated to replicas of that mount. Consider
+  a mount point `/mnt`, which is also mounted on `/tmp`. The propation settings
+  control whether a mount on `/tmp/a` would also be available on `/mnt/a`. Each
+  propagation setting has a recursive counterpoint. In the case of recursion,
+  consider that `/tmp/a` is also mounted as `/foo`. The propagation settings
+  control whether `/mnt/a` and/or `/tmp/a` would exist.
+
+  The `bind-propagation` option defaults to `rprivate` for both bind-mounts and
+  volume mounts, and is only configurable for bind-mounts. In other words, named
+  volumes do not support bind propagation.
+
+  - **`shared`**: Sub-mounts of the original mount are exposed to replica mounts,
+                  and sub-mounts of replica mounts are also propagated to the
+                  original mount.
+  - **`slave`**: similar to a shared mount, but only in one direction. If the
+                 original mount exposes a sub-mount, the replica mount can see it.
+                 However, if the replica mount exposes a sub-mount, the original
+                 mount cannot see it.
+  - **`private`**: The mount is private. Sub-mounts within it are not exposed to
+                   replica mounts, and sub-mounts of replica mounts are not
+                   exposed to the original mount.
+  - **`rshared`**: The same as shared, but the propagation also extends to and from
+                   mount points nested within any of the original or replica mount
+                   points.
+  - **`rslave`**: The same as `slave`, but the propagation also extends to and from
+                   mount points nested within any of the original or replica mount
+                   points.
+  - **`rprivate`**: The default. The same as `private`, meaning that no mount points
+                    anywhere within the original or replica mount points propagate
+                    in either direction.
+
+  For more information about bind propagation, see the
+  [Linux kernel documentation for shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
+
+  #### Options for Named Volumes
+
+  The following options can only be used for named volumes (`type=volume`);
+
+
+  <table>
+    <tr>
+      <th>Option</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><b>volume-driver</b></td>
+      <td>
+        <p>Name of the volume-driver plugin to use for the volume. Defaults to
+        <tt>"local"</tt>, to use the local volume driver to create the volume if the
+        volume does not exist.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><b>volume-label</b></td>
+      <td>
+        One or more custom metadata ("labels") to apply to the volume upon
+        creation. For example,
+        `volume-label=mylabel=hello-world,my-other-label=hello-mars`. For more
+        information about labels, refer to
+        <a href="https://docs.docker.com/engine/userguide/labels-custom-metadata/">apply custom metadata</a>.
+      </td>
+    </tr>
+    <tr>
+      <td><b>volume-nocopy</b></td>
+      <td>
+        By default, if you attach an empty volume to a container, and files or
+        directories already existed at the mount-path in the container (<tt>dst</tt>),
+        the Engine copies those files and directories into the volume, allowing
+        the host to access them. Set `volume-nocopy` to disables copying files
+        from the container's filesystem to the volume and mount the empty volume.
+
+        A value is optional:
+
+        <ul>
+          <li><tt>true</tt> or <tt>1</tt>: Default if you do not provide a value. Disables copying.</li>
+          <li><tt>false</tt> or <tt>0</tt>: Enables copying.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><b>volume-opt</b></td>
+      <td>
+        Options specific to a given volume driver, which will be passed to the
+        driver when creating the volume. Options are provided as a comma-separated
+        list of key/value pairs, for example,
+        <tt>volume-opt=some-option=some-value,some-other-option=some-other-value</tt>.
+        For available options for a given driver, refer to that driver's
+        documentation.
+      </td>
+    </tr>
+  </table>
+
+
+  #### Options for tmpfs
+
+  The following options can only be used for tmpfs mounts (`type=tmpfs`);
+
+
+  <table>
+    <tr>
+      <th>Option</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><b>tmpfs-size</b></td>
+      <td>Size of the tmpfs mount in bytes. Unlimited by default in Linux.</td>
+    </tr>
+    <tr>
+      <td><b>tmpfs-mode</b></td>
+      <td>File mode of the tmpfs in octal. (e.g. <tt>"700"</tt> or <tt>"0700"</tt>.) Defaults to <tt>"1777"</tt> in Linux.</td>
+    </tr>
+  </table>
+
+
+  #### Differences between "--mount" and "--volume"
+
+  The `--mount` flag supports most options that are supported by the `-v`
+  or `--volume` flag for `docker run`, with some important exceptions:
+
+  - The `--mount` flag allows you to specify a volume driver and volume driver
+    options *per volume*, without creating the volumes in advance. In contrast,
+    `docker run` allows you to specify a single volume driver which is shared
+    by all volumes, using the `--volume-driver` flag.
+
+  - The `--mount` flag allows you to specify custom metadata ("labels") for a volume,
+    before the volume is created.
+
+  - When you use `--mount` with `type=bind`, the host-path must refer to an *existing*
+    path on the host. The path will not be created for you and the service will fail
+    with an error if the path does not exist.
+
+  - The `--mount` flag does not allow you to relabel a volume with `Z` or `z` flags,
+    which are used for `selinux` labeling.
+
+  #### Create a service using a named volume
+
+  The following example creates a service that uses a named volume:
+
+  ```bash
+  $ docker service create \
+    --name my-service \
+    --replicas 3 \
+    --mount type=volume,source=my-volume,destination=/path/in/container,volume-label="color=red",volume-label="shape=round" \
+    nginx:alpine
+  ```
+
+  For each replica of the service, the engine requests a volume named "my-volume"
+  from the default ("local") volume driver where the task is deployed. If the
+  volume does not exist, the engine creates a new volume and applies the "color"
+  and "shape" labels.
+
+  When the task is started, the volume is mounted on `/path/in/container/` inside
+  the container.
+
+  Be aware that the default ("local") volume is a locally scoped volume driver.
+  This means that depending on where a task is deployed, either that task gets a
+  *new* volume named "my-volume", or shares the same "my-volume" with other tasks
+  of the same service. Multiple containers writing to a single shared volume can
+  cause data corruption if the software running inside the container is not
+  designed to handle concurrent processes writing to the same location. Also take
+  into account that containers can be re-scheduled by the Swarm orchestrator and
+  be deployed on a different node.
+
+  #### Create a service that uses an anonymous volume
+
+  The following command creates a service with three replicas with an anonymous
+  volume on `/path/in/container`:
+
+  ```bash
+  $ docker service create \
+    --name my-service \
+    --replicas 3 \
+    --mount type=volume,destination=/path/in/container \
+    nginx:alpine
+  ```
+
+  In this example, no name (`source`) is specified for the volume, so a new volume
+  is created for each task. This guarantees that each task gets its own volume,
+  and volumes are not shared between tasks. Anonymous volumes are removed after
+  the task using them is complete.
+
+  #### Create a service that uses a bind-mounted host directory
+
+  The following example bind-mounts a host directory at `/path/in/container` in
+  the containers backing the service:
+
+  ```bash
+  $ docker service create \
+    --name my-service \
+    --mount type=bind,source=/path/on/host,destination=/path/in/container \
+    nginx:alpine
+  ```
+
+  ### Set service mode (--mode)
+
+  The service mode determines whether this is a _replicated_ service or a _global_
+  service. A replicated service runs as many tasks as specified, while a global
+  service runs on each active node in the swarm.
+
+  The following command creates a global service:
+
+  ```bash
+  $ docker service create \
+   --name redis_2 \
+   --mode global \
+   redis:3.0.6
+  ```
+
+  ### Specify service constraints (--constraint)
+
+  You can limit the set of nodes where a task can be scheduled by defining
+  constraint expressions. Multiple constraints find nodes that satisfy every
+  expression (AND match). Constraints can match node or Docker Engine labels as
+  follows:
+
+
+  <table>
+    <tr>
+      <th>node attribute</th>
+      <th>matches</th>
+      <th>example</th>
+    </tr>
+    <tr>
+      <td><tt>node.id</tt></td>
+      <td>Node ID</td>
+      <td><tt>node.id == 2ivku8v2gvtg4</tt></td>
+    </tr>
+    <tr>
+      <td><tt>node.hostname</tt></td>
+      <td>Node hostname</td>
+      <td><tt>node.hostname != node-2</tt></td>
+    </tr>
+    <tr>
+      <td><tt>node.role</tt></td>
+      <td>Node role</td>
+      <td><tt>node.role == manager</tt></td>
+    </tr>
+    <tr>
+      <td><tt>node.labels</tt></td>
+      <td>user defined node labels</td>
+      <td><tt>node.labels.security == high</tt></td>
+    </tr>
+    <tr>
+      <td><tt>engine.labels</tt></td>
+      <td>Docker Engine's labels</td>
+      <td><tt>engine.labels.operatingsystem == ubuntu 14.04</tt></td>
+    </tr>
+  </table>
+
+
+  `engine.labels` apply to Docker Engine labels like operating system,
+  drivers, etc. Swarm administrators add `node.labels` for operational purposes by
+  using the [`docker node update`](node_update.md) command.
+
+  For example, the following limits tasks for the redis service to nodes where the
+  node type label equals queue:
+
+  ```bash
+  $ docker service create \
+    --name redis_2 \
+    --constraint 'node.labels.type == queue' \
+    redis:3.0.6
+  ```
+
+  ### Attach a service to an existing network (--network)
+
+  You can use overlay networks to connect one or more services within the swarm.
+
+  First, create an overlay network on a manager node the docker network create
+  command:
+
+  ```bash
+  $ docker network create --driver overlay my-network
+
+  etjpu59cykrptrgw0z0hk5snf
+  ```
+
+  After you create an overlay network in swarm mode, all manager nodes have
+  access to the network.
+
+  When you create a service and pass the --network flag to attach the service to
+  the overlay network:
+
+  ```bash
+  $ docker service create \
+    --replicas 3 \
+    --network my-network \
+    --name my-web \
+    nginx
+
+  716thylsndqma81j6kkkb5aus
+  ```
+
+  The swarm extends my-network to each node running the service.
+
+  Containers on the same network can access each other using
+  [service discovery](https://docs.docker.com/engine/swarm/networking/#use-swarm-mode-service-discovery).
+
+  ### Publish service ports externally to the swarm (-p, --publish)
+
+  You can publish service ports to make them available externally to the swarm
+  using the `--publish` flag:
+
+  ```bash
+  $ docker service create --publish <TARGET-PORT>:<SERVICE-PORT> nginx
+  ```
+
+  For example:
+
+  ```bash
+  $ docker service create --name my_web --replicas 3 --publish 8080:80 nginx
+  ```
+
+  When you publish a service port, the swarm routing mesh makes the service
+  accessible at the target port on every node regardless if there is a task for
+  the service running on the node. For more information refer to
+  [Use swarm mode routing mesh](https://docs.docker.com/engine/swarm/ingress/).
+
+  ### Publish a port for TCP only or UDP only
+
+  By default, when you publish a port, it is a TCP port. You can
+  specifically publish a UDP port instead of or in addition to a TCP port. When
+  you publish both TCP and UDP ports, Docker 1.12.2 and earlier require you to
+  add the suffix `/tcp` for TCP ports. Otherwise it is optional.
+
+  #### TCP only
+
+  The following two commands are equivalent.
+
+  ```bash
+  $ docker service create --name dns-cache -p 53:53 dns-cache
+
+  $ docker service create --name dns-cache -p 53:53/tcp dns-cache
+  ```
+
+  #### TCP and UDP
+
+  ```bash
+  $ docker service create --name dns-cache -p 53:53/tcp -p 53:53/udp dns-cache
+  ```
+
+  #### UDP only
+
+  ```bash
+  $ docker service create --name dns-cache -p 53:53/udp dns-cache
+  ```
+
+  ### Create services using templates
+
+  You can use templates for some flags of `service create`, using the syntax
+  provided by the Go's [text/template](http://golang.org/pkg/text/template/) package.
+
+  The supported flags are the following :
+
+  - `--hostname`
+  - `--mount`
+  - `--env`
+
+  Valid placeholders for the Go template are listed below:
+
+
+  <table>
+    <tr>
+      <th>Placeholder</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><tt>.Service.ID</tt></td>
+      <td>Service ID</td>
+    </tr>
+    <tr>
+      <td><tt>.Service.Name</tt></td>
+      <td>Service name</td>
+    </tr>
+    <tr>
+      <td><tt>.Service.Labels</tt></td>
+      <td>Service labels</td>
+    </tr>
+    <tr>
+      <td><tt>.Node.ID</tt></td>
+      <td>Node ID</td>
+    </tr>
+    <tr>
+      <td><tt>.Task.ID</tt></td>
+      <td>Task ID</td>
+    </tr>
+    <tr>
+      <td><tt>.Task.Name</tt></td>
+      <td>Task name</td>
+    </tr>
+    <tr>
+      <td><tt>.Task.Slot</tt></td>
+      <td>Task slot</td>
+    </tr>
+  </table>
+
+
+  #### Template example
+
+  In this example, we are going to set the template of the created containers based on the
+  service's name and the node's ID where it sits.
+
+  ```bash
+  $ docker service create --name hosttempl \
+                          --hostname="{{.Node.ID}}-{{.Service.Name}}"\
+                           busybox top
+
+  va8ew30grofhjoychbr6iot8c
+
+  $ docker service ps va8ew30grofhjoychbr6iot8c
+
+  ID            NAME         IMAGE                                                                                   NODE          DESIRED STATE  CURRENT STATE               ERROR  PORTS
+  wo41w8hg8qan  hosttempl.1  busybox:latest@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912  2e7a8a9c4da2  Running        Running about a minute ago
+
+  $ docker inspect --format="{{.Config.Hostname}}" hosttempl.1.wo41w8hg8qanxwjwsg4kxpprj
+
+  x3ti0erg11rjpg64m75kej2mz-hosttempl
+  ```
+

--- a/_data/engine-cli-edge/docker_service_inspect.yaml
+++ b/_data/engine-cli-edge/docker_service_inspect.yaml
@@ -1,0 +1,53 @@
+command: docker service inspect
+short: Display detailed information on one or more services
+long: |-
+  Inspects the specified service. This command has to be run targeting a manager
+  node.
+
+  By default, this renders all results in a JSON array. If a format is specified,
+  the given template will be executed for each result.
+
+  Go's [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+usage: docker service inspect [OPTIONS] SERVICE [SERVICE...]
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+- option: pretty
+  default_value: "false"
+  description: Print the information in a human friendly format.
+examples: "### Inspect a service by name or ID\n\nYou can inspect a service, either
+  by its *name*, or *ID*\n\nFor example, given the following service;\n\n```bash\n$
+  docker service ls\nID            NAME   MODE        REPLICAS  IMAGE\ndmu1ept4cxcf
+  \ redis  replicated  3/3       redis:3.0.6\n```\n\nBoth `docker service inspect
+  redis`, and `docker service inspect dmu1ept4cxcf`\nproduce the same result:\n\n```none\n$
+  docker service inspect redis\n\n[\n    {\n        \"ID\": \"dmu1ept4cxcfe8k8lhtux3ro3\",\n
+  \       \"Version\": {\n            \"Index\": 12\n        },\n        \"CreatedAt\":
+  \"2016-06-17T18:44:02.558012087Z\",\n        \"UpdatedAt\": \"2016-06-17T18:44:02.558012087Z\",\n
+  \       \"Spec\": {\n            \"Name\": \"redis\",\n            \"TaskTemplate\":
+  {\n                \"ContainerSpec\": {\n                    \"Image\": \"redis:3.0.6\"\n
+  \               },\n                \"Resources\": {\n                    \"Limits\":
+  {},\n                    \"Reservations\": {}\n                },\n                \"RestartPolicy\":
+  {\n                    \"Condition\": \"any\",\n                    \"MaxAttempts\":
+  0\n                },\n                \"Placement\": {}\n            },\n            \"Mode\":
+  {\n                \"Replicated\": {\n                    \"Replicas\": 1\n                }\n
+  \           },\n            \"UpdateConfig\": {},\n            \"EndpointSpec\":
+  {\n                \"Mode\": \"vip\"\n            }\n        },\n        \"Endpoint\":
+  {\n            \"Spec\": {}\n        }\n    }\n]\n```\n\n```bash\n$ docker service
+  inspect dmu1ept4cxcf\n\n[\n    {\n        \"ID\": \"dmu1ept4cxcfe8k8lhtux3ro3\",\n
+  \       \"Version\": {\n            \"Index\": 12\n        },\n        ...\n    }\n]\n```\n\n###
+  Formatting\n\nYou can print the inspect output in a human-readable format instead
+  of the default\nJSON output, by using the `--pretty` option:\n\n```bash\n$ docker
+  service inspect --pretty frontend\n\nID:\t\tc8wgl7q4ndfd52ni6qftkvnnp\nName:\t\tfrontend\nLabels:\n
+  - org.example.projectname=demo-app\nService Mode:\tREPLICATED\n Replicas:\t\t5\nPlacement:\nUpdateConfig:\n
+  Parallelism:\t0\nContainerSpec:\n Image:\t\tnginx:alpine\nResources:\nEndpoint Mode:
+  \ vip\nPorts:\n Name =\n Protocol = tcp\n TargetPort = 443\n PublishedPort = 4443\n```\n\nYou
+  can also use `--format pretty` for the same effect.\n\n\n#### Find the number of
+  tasks running as part of a service\n\nThe `--format` option can be used to obtain
+  specific information about a\nservice. For example, the following command outputs
+  the number of replicas\nof the \"redis\" service.\n\n```bash\n$ docker service inspect
+  --format='{{.Spec.Mode.Replicated.Replicas}}' redis\n\n10\n```"
+

--- a/_data/engine-cli-edge/docker_service_logs.yaml
+++ b/_data/engine-cli-edge/docker_service_logs.yaml
@@ -1,0 +1,62 @@
+command: docker service logs
+short: Fetch the logs of a service
+long: |-
+  The `docker service logs` command batch-retrieves logs present at the time of execution.
+
+  > **Note**: This command is only functional for services that are started with
+  > the `json-file` or `journald` logging driver.
+
+  For more information about selecting and configuring logging drivers, refer to
+  [Configure logging drivers](https://docs.docker.com/engine/admin/logging/overview/).
+
+  The `docker service logs --follow` command will continue streaming the new output from
+  the service's `STDOUT` and `STDERR`.
+
+  Passing a negative number or a non-integer to `--tail` is invalid and the
+  value is set to `all` in that case.
+
+  The `docker service logs --timestamps` command will add an [RFC3339Nano timestamp](https://golang.org/pkg/time/#pkg-constants)
+  , for example `2014-09-16T06:17:46.000000000Z`, to each
+  log entry. To ensure that the timestamps are aligned the
+  nano-second part of the timestamp will be padded with zero when necessary.
+
+  The `docker service logs --details` command will add on extra attributes, such as
+  environment variables and labels, provided to `--log-opt` when creating the
+  service.
+
+  The `--since` option shows only the service logs generated after
+  a given date. You can specify the date as an RFC 3339 date, a UNIX
+  timestamp, or a Go duration string (e.g. `1m30s`, `3h`). Besides RFC3339 date
+  format you may also use RFC3339Nano, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the client will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp. When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long. You can combine the
+  `--since` option with either or both of the `--follow` or `--tail` options.
+usage: docker service logs [OPTIONS] SERVICE
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: details
+  default_value: "false"
+  description: Show extra details provided to logs
+- option: follow
+  shorthand: f
+  default_value: "false"
+  description: Follow log output
+- option: no-resolve
+  default_value: "false"
+  description: Do not map IDs to Names
+- option: since
+  description: Show logs since timestamp
+- option: tail
+  default_value: all
+  description: Number of lines to show from the end of the logs
+- option: timestamps
+  shorthand: t
+  default_value: "false"
+  description: Show timestamps
+

--- a/_data/engine-cli-edge/docker_service_ls.yaml
+++ b/_data/engine-cli-edge/docker_service_ls.yaml
@@ -1,0 +1,93 @@
+command: docker service ls
+aliases: list
+short: List services
+long: |-
+  This command when run targeting a manager, lists services are running in the
+  swarm.
+usage: docker service ls [OPTIONS]
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display IDs
+examples: |-
+  On a manager node:
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME      MODE        REPLICAS    IMAGE
+  c8wgl7q4ndfd  frontend  replicated  5/5         nginx:alpine
+  dmu1ept4cxcf  redis     replicated  3/3         redis:3.0.6
+  iwe3278osahj  mongo     global      7/7         mongo:3.3
+  ```
+
+  The `REPLICAS` column shows both the *actual* and *desired* number of tasks for
+  the service.
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * [id](service_ls.md#id)
+  * [label](service_ls.md#label)
+  * [name](service_ls.md#name)
+
+  #### id
+
+  The `id` filter matches all or part of a service's id.
+
+  ```bash
+  $ docker service ls -f "id=0bcjw"
+  ID            NAME   MODE        REPLICAS  IMAGE
+  0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
+  ```
+
+  #### label
+
+  The `label` filter matches services based on the presence of a `label` alone or
+  a `label` and a value.
+
+  The following filter matches all services with a `project` label regardless of
+  its value:
+
+  ```bash
+  $ docker service ls --filter label=project
+  ID            NAME       MODE        REPLICAS  IMAGE
+  01sl1rp6nj5u  frontend2  replicated  1/1       nginx:alpine
+  36xvvwwauej0  frontend   replicated  5/5       nginx:alpine
+  74nzcxxjv6fq  backend    replicated  3/3       redis:3.0.6
+  ```
+
+  The following filter matches only services with the `project` label with the
+  `project-a` value.
+
+  ```bash
+  $ docker service ls --filter label=project=project-a
+  ID            NAME      MODE        REPLICAS  IMAGE
+  36xvvwwauej0  frontend  replicated  5/5       nginx:alpine
+  74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
+  ```
+
+  #### name
+
+  The `name` filter matches on all or part of a service's name.
+
+  The following filter matches services with a name containing `redis`.
+
+  ```bash
+  $ docker service ls --filter name=redis
+  ID            NAME   MODE        REPLICAS  IMAGE
+  0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
+  ```
+
+  <<<<<<< HEAD
+

--- a/_data/engine-cli-edge/docker_service_ps.yaml
+++ b/_data/engine-cli-edge/docker_service_ps.yaml
@@ -1,0 +1,138 @@
+command: docker service ps
+short: List the tasks of a service
+long: |-
+  Lists the tasks that are running as part of the specified services. This command
+  has to be run targeting a manager node.
+usage: docker service ps [OPTIONS] SERVICE
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: no-resolve
+  default_value: "false"
+  description: Do not map IDs to Names
+- option: no-trunc
+  default_value: "false"
+  description: Do not truncate output
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display task IDs
+examples: |-
+  ### List the tasks that are part of a service
+
+  The following command shows all the tasks that are part of the `redis` service:
+
+  ```bash
+  $ docker service ps redis
+
+  ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE          ERROR  PORTS
+  0qihejybwf1x   redis.1   redis:3.0.5  manager1  Running        Running 8 seconds
+  bk658fpbex0d   redis.2   redis:3.0.5  worker2   Running        Running 9 seconds
+  5ls5s5fldaqg   redis.3   redis:3.0.5  worker1   Running        Running 9 seconds
+  8ryt076polmc   redis.4   redis:3.0.5  worker1   Running        Running 9 seconds
+  1x0v8yomsncd   redis.5   redis:3.0.5  manager1  Running        Running 8 seconds
+  71v7je3el7rr   redis.6   redis:3.0.5  worker2   Running        Running 9 seconds
+  4l3zm9b7tfr7   redis.7   redis:3.0.5  worker2   Running        Running 9 seconds
+  9tfpyixiy2i7   redis.8   redis:3.0.5  worker1   Running        Running 9 seconds
+  3w1wu13yupln   redis.9   redis:3.0.5  manager1  Running        Running 8 seconds
+  8eaxrb2fqpbn   redis.10  redis:3.0.5  manager1  Running        Running 8 seconds
+  ```
+
+  In addition to _running_ tasks, the output also shows the task history. For
+  example, after updating the service to use the `redis:3.0.6` image, the output
+  may look like this:
+
+  ```bash
+  $ docker service ps redis
+
+  ID            NAME         IMAGE        NODE      DESIRED STATE  CURRENT STATE                   ERROR  PORTS
+  50qe8lfnxaxk  redis.1      redis:3.0.6  manager1  Running        Running 6 seconds ago
+  ky2re9oz86r9   \_ redis.1  redis:3.0.5  manager1  Shutdown       Shutdown 8 seconds ago
+  3s46te2nzl4i  redis.2      redis:3.0.6  worker2   Running        Running less than a second ago
+  nvjljf7rmor4   \_ redis.2  redis:3.0.6  worker2   Shutdown       Rejected 23 seconds ago        "No such image: redis@sha256:6…"
+  vtiuz2fpc0yb   \_ redis.2  redis:3.0.5  worker2   Shutdown       Shutdown 1 second ago
+  jnarweeha8x4  redis.3      redis:3.0.6  worker1   Running        Running 3 seconds ago
+  vs448yca2nz4   \_ redis.3  redis:3.0.5  worker1   Shutdown       Shutdown 4 seconds ago
+  jf1i992619ir  redis.4      redis:3.0.6  worker1   Running        Running 10 seconds ago
+  blkttv7zs8ee   \_ redis.4  redis:3.0.5  worker1   Shutdown       Shutdown 11 seconds ago
+  ```
+
+  The number of items in the task history is determined by the
+  `--task-history-limit` option that was set when initializing the swarm. You can
+  change the task history retention limit using the
+  [`docker swarm update`](swarm_update.md) command.
+
+  When deploying a service, docker resolves the digest for the service's
+  image, and pins the service to that digest. The digest is not shown by
+  default, but is printed if `--no-trunc` is used. The `--no-trunc` option
+  also shows the non-truncated task ID, and error-messages, as can be seen below;
+
+  ```bash
+  $ docker service ps --no-trunc redis
+
+  ID                          NAME         IMAGE                                                                                NODE      DESIRED STATE  CURRENT STATE            ERROR                                                                                           PORTS
+  50qe8lfnxaxksi9w2a704wkp7   redis.1      redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 5 minutes ago
+  ky2re9oz86r9556i2szb8a8af   \_ redis.1   redis:3.0.5@sha256:f8829e00d95672c48c60f468329d6693c4bdd28d1f057e755f8ba8b40008682e  worker2   Shutdown       Shutdown 5 minutes ago
+  bk658fpbex0d57cqcwoe3jthu   redis.2      redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Running        Running 5 seconds
+  nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
+  is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
+  Multiple filter flags are combined as an `OR` filter. For example,
+  `-f name=redis.1 -f name=redis.7` returns both `redis.1` and `redis.7` tasks.
+
+  The currently supported filters are:
+
+  * [id](#id)
+  * [name](#name)
+  * [node](#node)
+  * [desired-state](#desired-state)
+
+
+  #### id
+
+  The `id` filter matches on all or a prefix of a task's ID.
+
+  ```bash
+  $ docker service ps -f "id=8" redis
+
+  ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
+  8ryt076polmc   redis.4   redis:3.0.6  worker1   Running        Running 9 seconds
+  8eaxrb2fqpbn   redis.10  redis:3.0.6  manager1  Running        Running 8 seconds
+  ```
+
+  #### name
+
+  The `name` filter matches on task names.
+
+  ```bash
+  $ docker service ps -f "name=redis.1" redis
+  ID            NAME     IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
+  qihejybwf1x5  redis.1  redis:3.0.6  manager1  Running        Running 8 seconds
+  ```
+
+
+  #### node
+
+  The `node` filter matches on a node name or a node ID.
+
+  ```bash
+  $ docker service ps -f "node=manager1" redis
+  ID            NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
+  0qihejybwf1x  redis.1   redis:3.0.6  manager1  Running        Running 8 seconds
+  1x0v8yomsncd  redis.5   redis:3.0.6  manager1  Running        Running 8 seconds
+  3w1wu13yupln  redis.9   redis:3.0.6  manager1  Running        Running 8 seconds
+  8eaxrb2fqpbn  redis.10  redis:3.0.6  manager1  Running        Running 8 seconds
+  ```
+
+
+  #### desired-state
+
+  The `desired-state` filter can take the values `running`, `shutdown`, and `accepted`.
+

--- a/_data/engine-cli-edge/docker_service_rm.yaml
+++ b/_data/engine-cli-edge/docker_service_rm.yaml
@@ -1,0 +1,25 @@
+command: docker service rm
+aliases: remove
+short: Remove one or more services
+long: |-
+  Removes the specified services from the swarm. This command has to be run
+  targeting a manager node.
+usage: docker service rm SERVICE [SERVICE...]
+pname: docker service
+plink: docker_service.yaml
+examples: |-
+  Remove the `redis` service:
+
+  ```bash
+  $ docker service rm redis
+
+  redis
+
+  $ docker service ls
+
+  ID  NAME  MODE  REPLICAS  IMAGE
+  ```
+
+  > **Warning**: Unlike `docker rm`, this command does not ask for confirmation
+  > before removing a running service.
+

--- a/_data/engine-cli-edge/docker_service_scale.yaml
+++ b/_data/engine-cli-edge/docker_service_scale.yaml
@@ -1,0 +1,71 @@
+command: docker service scale
+short: Scale one or multiple replicated services
+long: |-
+  The scale command enables you to scale one or more replicated services either up
+  or down to the desired number of replicas. This command cannot be applied on
+  services which are global mode. The command will return immediately, but the
+  actual scaling of the service may take some time. To stop all replicas of a
+  service while keeping the service active in the swarm you can set the scale to 0.
+usage: docker service scale SERVICE=REPLICAS [SERVICE=REPLICAS...]
+pname: docker service
+plink: docker_service.yaml
+examples: |-
+  ### Scale a single service
+
+  The following command scales the "frontend" service to 50 tasks.
+
+  ```bash
+  $ docker service scale frontend=50
+
+  frontend scaled to 50
+  ```
+
+  The following command tries to scale a global service to 10 tasks and returns an error.
+
+  ```bash
+  $ docker service create --mode global --name backend backend:latest
+
+  b4g08uwuairexjub6ome6usqh
+
+  $ docker service scale backend=10
+
+  backend: scale can only be used with replicated mode
+  ```
+
+  Directly afterwards, run `docker service ls`, to see the actual number of
+  replicas.
+
+  ```bash
+  $ docker service ls --filter name=frontend
+
+  ID            NAME      MODE        REPLICAS  IMAGE
+  3pr5mlvu3fh9  frontend  replicated  15/50     nginx:alpine
+  ```
+
+  You can also scale a service using the [`docker service update`](service_update.md)
+  command. The following commands are equivalent:
+
+  ```bash
+  $ docker service scale frontend=50
+  $ docker service update --replicas=50 frontend
+  ```
+
+  ### Scale multiple services
+
+  The `docker service scale` command allows you to set the desired number of
+  tasks for multiple services at once. The following example scales both the
+  backend and frontend services:
+
+  ```bash
+  $ docker service scale backend=3 frontend=5
+
+  backend scaled to 3
+  frontend scaled to 5
+
+  $ docker service ls
+
+  ID            NAME      MODE        REPLICAS  IMAGE
+  3pr5mlvu3fh9  frontend  replicated  5/5       nginx:alpine
+  74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
+  ```
+

--- a/_data/engine-cli-edge/docker_service_update.yaml
+++ b/_data/engine-cli-edge/docker_service_update.yaml
@@ -1,0 +1,213 @@
+command: docker service update
+short: Update a service
+long: |-
+  Updates a service as described by the specified parameters. This command has to be run targeting a manager node.
+  The parameters are the same as [`docker service create`](service_create.md). Please look at the description there
+  for further information.
+
+  Normally, updating a service will only cause the service's tasks to be replaced with new ones if a change to the
+  service requires recreating the tasks for it to take effect. For example, only changing the
+  `--update-parallelism` setting will not recreate the tasks, because the individual tasks are not affected by this
+  setting. However, the `--force` flag will cause the tasks to be recreated anyway. This can be used to perform a
+  rolling restart without any changes to the service parameters.
+usage: docker service update [OPTIONS] SERVICE
+pname: docker service
+plink: docker_service.yaml
+options:
+- option: args
+  description: Service command args
+- option: constraint-add
+  default_value: '[]'
+  description: Add or update a placement constraint
+- option: constraint-rm
+  default_value: '[]'
+  description: Remove a constraint
+- option: container-label-add
+  default_value: '[]'
+  description: Add or update a container label
+- option: container-label-rm
+  default_value: '[]'
+  description: Remove a container label by its key
+- option: dns-add
+  default_value: '[]'
+  description: Add or update a custom DNS server
+- option: dns-option-add
+  default_value: '[]'
+  description: Add or update a DNS option
+- option: dns-option-rm
+  default_value: '[]'
+  description: Remove a DNS option
+- option: dns-rm
+  default_value: '[]'
+  description: Remove a custom DNS server
+- option: dns-search-add
+  default_value: '[]'
+  description: Add or update a custom DNS search domain
+- option: dns-search-rm
+  default_value: '[]'
+  description: Remove a DNS search domain
+- option: endpoint-mode
+  description: Endpoint mode (vip or dnsrr)
+- option: env-add
+  default_value: '[]'
+  description: Add or update an environment variable
+- option: env-rm
+  default_value: '[]'
+  description: Remove an environment variable
+- option: force
+  default_value: "false"
+  description: Force update even if no changes require it
+- option: group-add
+  default_value: '[]'
+  description: Add an additional supplementary user group to the container
+- option: group-rm
+  default_value: '[]'
+  description: |
+    Remove a previously added supplementary user group from the container
+- option: health-cmd
+  description: Command to run to check health
+- option: health-interval
+  description: Time between running the check (ns|us|ms|s|m|h)
+- option: health-retries
+  default_value: "0"
+  description: Consecutive failures needed to report unhealthy
+- option: health-timeout
+  description: Maximum time to allow one check to run (ns|us|ms|s|m|h)
+- option: host-add
+  default_value: '[]'
+  description: Add or update a custom host-to-IP mapping (host:ip)
+- option: host-rm
+  default_value: '[]'
+  description: Remove a custom host-to-IP mapping (host:ip)
+- option: hostname
+  description: Container hostname
+- option: image
+  description: Service image tag
+- option: label-add
+  default_value: '[]'
+  description: Add or update a service label
+- option: label-rm
+  default_value: '[]'
+  description: Remove a label by its key
+- option: limit-cpu
+  default_value: "0.000"
+  description: Limit CPUs
+- option: limit-memory
+  default_value: 0 B
+  description: Limit Memory
+- option: log-driver
+  description: Logging driver for service
+- option: log-opt
+  default_value: '[]'
+  description: Logging driver options
+- option: mount-add
+  description: Add or update a mount on a service
+- option: mount-rm
+  default_value: '[]'
+  description: Remove a mount by its target path
+- option: no-healthcheck
+  default_value: "false"
+  description: Disable any container-specified HEALTHCHECK
+- option: publish-add
+  description: Add or update a published port
+- option: publish-rm
+  description: Remove a published port by its target port
+- option: replicas
+  description: Number of tasks
+- option: reserve-cpu
+  default_value: "0.000"
+  description: Reserve CPUs
+- option: reserve-memory
+  default_value: 0 B
+  description: Reserve Memory
+- option: restart-condition
+  description: Restart when condition is met (none, on-failure, or any)
+- option: restart-delay
+  description: Delay between restart attempts (ns|us|ms|s|m|h)
+- option: restart-max-attempts
+  description: Maximum number of restarts before giving up
+- option: restart-window
+  description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
+- option: rollback
+  default_value: "false"
+  description: Rollback to previous specification
+- option: secret-add
+  description: Add or update a secret on a service
+- option: secret-rm
+  default_value: '[]'
+  description: Remove a secret
+- option: stop-grace-period
+  description: |
+    Time to wait before force killing a container (ns|us|ms|s|m|h)
+- option: tty
+  shorthand: t
+  default_value: "false"
+  description: Allocate a pseudo-TTY
+- option: update-delay
+  default_value: 0s
+  description: Delay between updates (ns|us|ms|s|m|h) (default 0s)
+- option: update-failure-action
+  default_value: pause
+  description: Action on update failure (pause|continue)
+- option: update-max-failure-ratio
+  default_value: "0"
+  description: Failure rate to tolerate during an update
+- option: update-monitor
+  default_value: 0s
+  description: |
+    Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
+- option: update-parallelism
+  default_value: "1"
+  description: |
+    Maximum number of tasks updated simultaneously (0 to update all at once)
+- option: user
+  shorthand: u
+  description: 'Username or UID (format: <name|uid>[:<group|gid>])'
+- option: with-registry-auth
+  default_value: "false"
+  description: Send registry authentication details to swarm agents
+- option: workdir
+  shorthand: w
+  description: Working directory inside the container
+examples: "### Update a service\n\n```bash\n$ docker service update --limit-cpu 2
+  redis\n```\n\n### Perform a rolling restart with no parameter changes\n\n```bash\n$
+  docker service update --force --update-parallelism 1 --update-delay 30s redis\n```\n\nIn
+  this example, the `--force` flag causes the service's tasks to be shut down\nand
+  replaced with new ones even though none of the other parameters would\nnormally
+  cause that to happen. The `--update-parallelism 1` setting ensures\nthat only one
+  task is replaced at a time (this is the default behavior). The\n`--update-delay
+  30s` setting introduces a 30 second delay between tasks, so\nthat the rolling restart
+  happens gradually.\n\n### Add or remove mounts\n\nUse the `--mount-add` or `--mount-rm`
+  options add or remove a service's bind-mounts\nor volumes.\n\nThe following example
+  creates a service which mounts the `test-data` volume to\n`/somewhere`. The next
+  step updates the service to also mount the `other-volume`\nvolume to `/somewhere-else`volume,
+  The last step unmounts the `/somewhere` mount\npoint, effectively removing the `test-data`
+  volume. Each command returns the\nservice name.\n\n- The `--mount-add` flag takes
+  the same parameters as the `--mount` flag on\n  `service create`. Refer to the [volumes
+  and\n  bind-mounts](service_create.md#volumes-and-bind-mounts-mount) section in
+  the\n  `service create` reference for details.\n\n- The `--mount-rm` flag takes
+  the `target` path of the mount.\n\n```bash\n$ docker service create \\\n    --name=myservice
+  \\\n    --mount \\\n      type=volume,source=test-data,target=/somewhere \\\n    nginx:alpine
+  \\\n    myservice\n\nmyservice\n\n$ docker service update \\\n    --mount-add \\\n
+  \     type=volume,source=other-volume,target=/somewhere-else \\\n    myservice\n\nmyservice\n\n$
+  docker service update --mount-rm /somewhere myservice\n\nmyservice\n```\n\n### Rolling
+  back to the previous version of a service \n\nUse the `--rollback` option to roll
+  back to the previous version of the service. \n\nThis will revert the service to
+  the configuration that was in place before the most recent `docker service update`
+  command.\n\nThe following example updates the number of replicas for the service
+  from 4 to 5, and then rolls back to the previous configuration.\n\n```bash\n$ docker
+  service update --replicas=5 web\n\nweb\n\n$ docker service ls\n\nID            NAME
+  \ MODE        REPLICAS  IMAGE\n80bvrzp6vxf3  web   replicated  0/5       nginx:alpine\n\n```\nRoll
+  back the `web` service... \n\n```bash\n$ docker service update --rollback web\n\nweb\n\n$
+  docker service ls\n\nID            NAME  MODE        REPLICAS  IMAGE\n80bvrzp6vxf3
+  \ web   replicated  0/4       nginx:alpine\n\n```\n\nOther options can be combined
+  with `--rollback` as well, for example, `--update-delay 0s` to execute the rollback
+  without a delay between tasks:\n\n```bash\n$ docker service update \\\n  --rollback
+  \\\n  --update-delay 0s\n  web\n\nweb\n\n```\n\n### Add or remove secrets\n\nUse
+  the `--secret-add` or `--secret-rm` options add or remove a service's\nsecrets.\n\nThe
+  following example adds a secret named `ssh-2` and removes `ssh-1`:\n\n```bash\n$
+  docker service update \\\n    --secret-add source=ssh-2,target=ssh-2 \\\n    --secret-rm
+  ssh-1 \\\n    myservice\n```\n\n### Update services using templates\n\nSome flags
+  of `service update` support the use of templating.\nSee [`service create`](./service_create.md#templating)
+  for the reference."
+

--- a/_data/engine-cli-edge/docker_stack.yaml
+++ b/_data/engine-cli-edge/docker_stack.yaml
@@ -1,0 +1,19 @@
+command: docker stack
+short: Manage Docker stacks
+long: Manage stacks.
+usage: docker stack
+pname: docker
+plink: docker.yaml
+cname:
+- docker stack deploy
+- docker stack ls
+- docker stack ps
+- docker stack rm
+- docker stack services
+clink:
+- docker_stack_deploy.yaml
+- docker_stack_ls.yaml
+- docker_stack_ps.yaml
+- docker_stack_rm.yaml
+- docker_stack_services.yaml
+

--- a/_data/engine-cli-edge/docker_stack_deploy.yaml
+++ b/_data/engine-cli-edge/docker_stack_deploy.yaml
@@ -1,0 +1,80 @@
+command: docker stack deploy
+aliases: up
+short: Deploy a new stack or update an existing stack
+long: |-
+  Create and update a stack from a `compose` or a `dab` file on the swarm. This command
+  has to be run targeting a manager node.
+usage: docker stack deploy [OPTIONS] STACK
+pname: docker stack
+plink: docker_stack.yaml
+options:
+- option: bundle-file
+  description: Path to a Distributed Application Bundle file
+- option: compose-file
+  shorthand: c
+  description: Path to a Compose file
+- option: with-registry-auth
+  default_value: "false"
+  description: Send registry authentication details to Swarm agents
+examples: |-
+  ### Compose file
+
+  The `deploy` command supports compose file version `3.0` and above."
+
+  ```bash
+  $ docker stack deploy --compose-file docker-compose.yml vossibility
+
+  Ignoring unsupported options: links
+
+  Creating network vossibility_vossibility
+  Creating network vossibility_default
+  Creating service vossibility_nsqd
+  Creating service vossibility_logstash
+  Creating service vossibility_elasticsearch
+  Creating service vossibility_kibana
+  Creating service vossibility_ghollector
+  Creating service vossibility_lookupd
+  ```
+
+  You can verify that the services were correctly created
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME                               MODE        REPLICAS  IMAGE
+  29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+  7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+  9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+  axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+  ```
+
+  ### DAB file
+
+  ```bash
+  $ docker stack deploy --bundle-file vossibility-stack.dab vossibility
+
+  Loading bundle from vossibility-stack.dab
+  Creating service vossibility_elasticsearch
+  Creating service vossibility_kibana
+  Creating service vossibility_logstash
+  Creating service vossibility_lookupd
+  Creating service vossibility_nsqd
+  Creating service vossibility_vossibility-collector
+  ```
+
+  You can verify that the services were correctly created:
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME                               MODE        REPLICAS  IMAGE
+  29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+  4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+  7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+  9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+  axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+  ```
+

--- a/_data/engine-cli-edge/docker_stack_ls.yaml
+++ b/_data/engine-cli-edge/docker_stack_ls.yaml
@@ -1,0 +1,18 @@
+command: docker stack ls
+aliases: list
+short: List stacks
+long: Lists the stacks.
+usage: docker stack ls
+pname: docker stack
+plink: docker_stack.yaml
+examples: |-
+  The following command shows all stacks and some additional information:
+
+  ```bash
+  $ docker stack ls
+
+  ID                 SERVICES
+  vossibility-stack  6
+  myapp              2
+  ```
+

--- a/_data/engine-cli-edge/docker_stack_ps.yaml
+++ b/_data/engine-cli-edge/docker_stack_ps.yaml
@@ -1,0 +1,36 @@
+command: docker stack ps
+short: List the tasks in the stack
+long: |-
+  Lists the tasks that are running as part of the specified stack. This
+  command has to be run targeting a manager node.
+usage: docker stack ps [OPTIONS] STACK
+pname: docker stack
+plink: docker_stack.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: no-resolve
+  default_value: "false"
+  description: Do not map IDs to Names
+- option: no-trunc
+  default_value: "false"
+  description: Do not truncate output
+examples: |-
+  ```bash
+  $ docker stack ps
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
+  is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
+  Multiple filter flags are combined as an `OR` filter. For example,
+  `-f name=redis.1 -f name=redis.7` returns both `redis.1` and `redis.7` tasks.
+
+  The currently supported filters are:
+
+  * id
+  * name
+  * desired-stat
+

--- a/_data/engine-cli-edge/docker_stack_rm.yaml
+++ b/_data/engine-cli-edge/docker_stack_rm.yaml
@@ -1,0 +1,10 @@
+command: docker stack rm
+aliases: remove, down
+short: Remove the stack
+long: |-
+  Remove the stack from the swarm. This command has to be run targeting
+  a manager node.
+usage: docker stack rm STACK
+pname: docker stack
+plink: docker_stack.yaml
+

--- a/_data/engine-cli-edge/docker_stack_services.yaml
+++ b/_data/engine-cli-edge/docker_stack_services.yaml
@@ -1,0 +1,78 @@
+command: docker stack services
+short: List the services in the stack
+long: |-
+  Lists the services that are running as part of the specified stack. This
+  command has to be run targeting a manager node.
+usage: docker stack services [OPTIONS] STACK
+pname: docker stack
+plink: docker_stack.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display IDs
+examples: |-
+  The following command shows all services in the `myapp` stack:
+
+  ```bash
+  $ docker stack services myapp
+
+  ID            NAME            REPLICAS  IMAGE                                                                          COMMAND
+  7be5ei6sqeye  myapp_web       1/1       nginx@sha256:23f809e7fd5952e7d5be065b4d3643fbbceccd349d537b62a123ef2201bc886f
+  dn7m7nhhfb9y  myapp_db        1/1       mysql@sha256:a9a5b559f8821fe73d58c3606c812d1c044868d42c63817fa5125fd9d8b7b539
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
+  is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
+  Multiple filter flags are combined as an `OR` filter.
+
+  The following command shows both the `web` and `db` services:
+
+  ```bash
+  $ docker stack services --filter name=myapp_web --filter name=myapp_db myapp
+
+  ID            NAME            REPLICAS  IMAGE                                                                          COMMAND
+  7be5ei6sqeye  myapp_web       1/1       nginx@sha256:23f809e7fd5952e7d5be065b4d3643fbbceccd349d537b62a123ef2201bc886f
+  dn7m7nhhfb9y  myapp_db        1/1       mysql@sha256:a9a5b559f8821fe73d58c3606c812d1c044868d42c63817fa5125fd9d8b7b539
+  ```
+
+  The currently supported filters are:
+
+  * id / ID (`--filter id=7be5ei6sqeye`, or `--filter ID=7be5ei6sqeye`)
+  * name (`--filter name=myapp_web`)
+  * label (`--filter label=key=value`)
+
+  ### Formatting
+
+  The formatting options (`--format`) pretty-prints services output
+  using a Go template.
+
+  Valid placeholders for the Go template are listed below:
+
+  Placeholder | Description
+  ------------|------------------------------------------------------------------------------------------
+  `.ID`       | Service ID
+  `.Name`     | Service name
+  `.Mode`     | Service mode (replicated, global)
+  `.Replicas` | Service replicas
+  `.Image`    | Service image
+
+  When using the `--format` option, the `stack services` command will either
+  output the data exactly as the template declares or, when using the
+  `table` directive, includes column headers as well.
+
+  The following example uses a template without headers and outputs the
+  `ID`, `Mode`, and `Replicas` entries separated by a colon for all services:
+
+  ```bash
+  $ docker stack services --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
+
+  0zmvwuiu3vue: replicated 10/10
+  fm6uf97exkul: global 5/5
+  ```
+

--- a/_data/engine-cli-edge/docker_start.yaml
+++ b/_data/engine-cli-edge/docker_start.yaml
@@ -1,0 +1,26 @@
+command: docker start
+short: Start one or more stopped containers
+long: Start one or more stopped containers
+usage: docker start [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: attach
+  shorthand: a
+  default_value: "false"
+  description: Attach STDOUT/STDERR and forward signals
+- option: checkpoint
+  description: Restore from this checkpoint
+- option: checkpoint-dir
+  description: Use a custom checkpoint storage directory
+- option: detach-keys
+  description: Override the key sequence for detaching a container
+- option: interactive
+  shorthand: i
+  default_value: "false"
+  description: Attach container's STDIN
+examples: |-
+  ```bash
+  $ docker start my_container
+  ```
+

--- a/_data/engine-cli-edge/docker_stats.yaml
+++ b/_data/engine-cli-edge/docker_stats.yaml
@@ -1,0 +1,111 @@
+command: docker stats
+short: Display a live stream of container(s) resource usage statistics
+long: |-
+  The `docker stats` command returns a live data stream for running containers. To limit data to one or more specific containers, specify a list of container names or ids separated by a space. You can specify a stopped container but stopped containers do not return any data.
+
+  If you want more detailed information about a container's resource usage, use the `/containers/(id)/stats` API endpoint.
+usage: docker stats [OPTIONS] [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Show all containers (default shows just running)
+- option: format
+  description: Pretty-print images using a Go template
+- option: no-stream
+  default_value: "false"
+  description: Disable streaming stats and only pull the first result
+examples: |-
+  Running `docker stats` on all running containers against a Linux daemon.
+
+  ```bash
+  $ docker stats
+  CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
+  1285939c1fd3        0.07%               796 KiB / 64 MiB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+  9c76f7834ae2        0.07%               2.746 MiB / 64 MiB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+  d1ea048f04e4        0.03%               4.583 MiB / 64 MiB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+  ```
+
+  Running `docker stats` on multiple containers by name and id against a Linux daemon.
+
+  ```bash
+  $ docker stats fervent_panini 5acfcb1b4fd1
+  CONTAINER           CPU %               MEM USAGE/LIMIT       MEM %               NET I/O
+  5acfcb1b4fd1        0.00%               115.2 MiB/1.045 GiB   11.03%              1.422 kB/648 B
+  fervent_panini      0.02%               11.08 MiB/1.045 GiB   1.06%               648 B/648 B
+  ```
+
+  Running `docker stats` on all running containers against a Windows daemon.
+
+  ```powershell
+  PS E:\> docker stats
+  CONTAINER           CPU %               PRIV WORKING SET    NET I/O             BLOCK I/O
+  09d3bb5b1604        6.61%               38.21 MiB           17.1 kB / 7.73 kB   10.7 MB / 3.57 MB
+  9db7aa4d986d        9.19%               38.26 MiB           15.2 kB / 7.65 kB   10.6 MB / 3.3 MB
+  3f214c61ad1d        0.00%               28.64 MiB           64 kB / 6.84 kB     4.42 MB / 6.93 MB
+  ```
+
+  Running `docker stats` on multiple containers by name and id against a Windows daemon.
+
+  ```powershell
+  PS E:\> docker ps -a
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  3f214c61ad1d        nanoserver          "cmd"               2 minutes ago       Up 2 minutes                            big_minsky
+  9db7aa4d986d        windowsservercore   "cmd"               2 minutes ago       Up 2 minutes                            mad_wilson
+  09d3bb5b1604        windowsservercore   "cmd"               2 minutes ago       Up 2 minutes                            affectionate_easley
+
+  PS E:\> docker stats 3f214c61ad1d mad_wilson
+  CONTAINER           CPU %               PRIV WORKING SET    NET I/O             BLOCK I/O
+  3f214c61ad1d        0.00%               46.25 MiB           76.3 kB / 7.92 kB   10.3 MB / 14.7 MB
+  mad_wilson          9.59%               40.09 MiB           27.6 kB / 8.81 kB   17 MB / 20.1 MB
+  ```
+
+  ### Formatting
+
+  The formatting option (`--format`) pretty prints container output
+  using a Go template.
+
+  Valid placeholders for the Go template are listed below:
+
+  Placeholder  | Description
+  ------------ | --------------------------------------------
+  `.Container` | Container name or ID (user input)
+  `.Name`      | Container name
+  `.ID`        | Container ID
+  `.CPUPerc`   | CPU percentage
+  `.MemUsage`  | Memory usage
+  `.NetIO`     | Network IO
+  `.BlockIO`   | Block IO
+  `.MemPerc`   | Memory percentage (Not available on Windows)
+  `.PIDs`      | Number of PIDs (Not available on Windows)
+
+
+  When using the `--format` option, the `stats` command either
+  outputs the data exactly as the template declares or, when using the
+  `table` directive, includes column headers as well.
+
+  The following example uses a template without headers and outputs the
+  `Container` and `CPUPerc` entries separated by a colon for all images:
+
+  ```bash
+  $ docker stats --format "{{.Container}}: {{.CPUPerc}}"
+
+  09d3bb5b1604: 6.61%
+  9db7aa4d986d: 9.19%
+  3f214c61ad1d: 0.00%
+  ```
+
+  To list all containers statistics with their name, CPU percentage and memory
+  usage in a table format you can use:
+
+  ```bash
+  $ docker stats --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}"
+
+  CONTAINER           CPU %               PRIV WORKING SET
+  1285939c1fd3        0.07%               796 KiB / 64 MiB
+  9c76f7834ae2        0.07%               2.746 MiB / 64 MiB
+  d1ea048f04e4        0.03%               4.583 MiB / 64 MiB
+  ```
+

--- a/_data/engine-cli-edge/docker_stop.yaml
+++ b/_data/engine-cli-edge/docker_stop.yaml
@@ -1,0 +1,18 @@
+command: docker stop
+short: Stop one or more running containers
+long: |-
+  The main process inside the container will receive `SIGTERM`, and after a grace
+  period, `SIGKILL`.
+usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: time
+  shorthand: t
+  default_value: "10"
+  description: Seconds to wait for stop before killing it
+examples: |-
+  ```bash
+  $ docker stop my_container
+  ```
+

--- a/_data/engine-cli-edge/docker_swarm.yaml
+++ b/_data/engine-cli-edge/docker_swarm.yaml
@@ -1,0 +1,23 @@
+command: docker swarm
+short: Manage Swarm
+long: Manage the swarm.
+usage: docker swarm
+pname: docker
+plink: docker.yaml
+cname:
+- docker swarm init
+- docker swarm join
+- docker swarm join-token
+- docker swarm leave
+- docker swarm unlock
+- docker swarm unlock-key
+- docker swarm update
+clink:
+- docker_swarm_init.yaml
+- docker_swarm_join.yaml
+- docker_swarm_join-token.yaml
+- docker_swarm_leave.yaml
+- docker_swarm_unlock.yaml
+- docker_swarm_unlock-key.yaml
+- docker_swarm_update.yaml
+

--- a/_data/engine-cli-edge/docker_swarm_init.yaml
+++ b/_data/engine-cli-edge/docker_swarm_init.yaml
@@ -1,0 +1,143 @@
+command: docker swarm init
+short: Initialize a swarm
+long: |-
+  Initialize a swarm. The docker engine targeted by this command becomes a manager
+  in the newly created single-node swarm.
+usage: docker swarm init [OPTIONS]
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: advertise-addr
+  description: 'Advertised address (format: <ip|interface>[:port])'
+- option: autolock
+  default_value: "false"
+  description: |
+    Enable manager autolocking (requiring an unlock key to start a stopped manager)
+- option: cert-expiry
+  default_value: 2160h0m0s
+  description: Validity period for node certificates (ns|us|ms|s|m|h)
+- option: dispatcher-heartbeat
+  default_value: 5s
+  description: Dispatcher heartbeat period (ns|us|ms|s|m|h)
+- option: external-ca
+  description: Specifications of one or more certificate signing endpoints
+- option: force-new-cluster
+  default_value: "false"
+  description: Force create a new cluster from current state
+- option: listen-addr
+  default_value: 0.0.0.0:2377
+  description: 'Listen address (format: <ip|interface>[:port])'
+- option: max-snapshots
+  default_value: "0"
+  description: Number of additional Raft snapshots to retain
+- option: snapshot-interval
+  default_value: "10000"
+  description: Number of log entries between Raft snapshots
+- option: task-history-limit
+  default_value: "5"
+  description: Task history retention limit
+examples: |-
+  ```bash
+  $ docker swarm init --advertise-addr 192.168.99.121
+  Swarm initialized: current node (bvz81updecsj6wjz393c09vti) is now a manager.
+
+  To add a worker to this swarm, run the following command:
+
+      docker swarm join \
+      --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx \
+      172.17.0.2:2377
+
+  To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
+  ```
+
+  `docker swarm init` generates two random tokens, a worker token and a manager token. When you join
+  a new node to the swarm, the node joins as a worker or manager node based upon the token you pass
+  to [swarm join](swarm_join.md).
+
+  After you create the swarm, you can display or rotate the token using
+  [swarm join-token](swarm_join_token.md).
+
+  ### `--autolock`
+
+  This flag enables automatic locking of managers with an encryption key. The
+  private keys and data stored by all managers will be protected by the
+  encryption key printed in the output, and will not be accessible without it.
+  Thus, it is very important to store this key in order to activate a manager
+  after it restarts. The key can be passed to `docker swarm unlock` to reactivate
+  the manager. Autolock can be disabled by running
+  `docker swarm update --autolock=false`. After disabling it, the encryption key
+  is no longer required to start the manager, and it will start up on its own
+  without user intervention.
+
+  ### `--cert-expiry`
+
+  This flag sets the validity period for node certificates.
+
+  ### `--dispatcher-heartbeat`
+
+  This flag sets the frequency with which nodes are told to use as a
+  period to report their health.
+
+  ### `--external-ca`
+
+  This flag sets up the swarm to use an external CA to issue node certificates. The value takes
+  the form `protocol=X,url=Y`. The value for `protocol` specifies what protocol should be used
+  to send signing requests to the external CA. Currently, the only supported value is `cfssl`.
+  The URL specifies the endpoint where signing requests should be submitted.
+
+  ### `--force-new-cluster`
+
+  This flag forces an existing node that was part of a quorum that was lost to restart as a single node Manager without losing its data.
+
+  ### `--listen-addr`
+
+  The node listens for inbound swarm manager traffic on this address. The default is to listen on
+  0.0.0.0:2377. It is also possible to specify a network interface to listen on that interface's
+  address; for example `--listen-addr eth0:2377`.
+
+  Specifying a port is optional. If the value is a bare IP address or interface
+  name, the default port 2377 will be used.
+
+  ### `--advertise-addr`
+
+  This flag specifies the address that will be advertised to other members of the
+  swarm for API access and overlay networking. If unspecified, Docker will check
+  if the system has a single IP address, and use that IP address with the
+  listening port (see `--listen-addr`). If the system has multiple IP addresses,
+  `--advertise-addr` must be specified so that the correct address is chosen for
+  inter-manager communication and overlay networking.
+
+  It is also possible to specify a network interface to advertise that interface's address;
+  for example `--advertise-addr eth0:2377`.
+
+  Specifying a port is optional. If the value is a bare IP address or interface
+  name, the default port 2377 will be used.
+
+  ### `--task-history-limit`
+
+  This flag sets up task history retention limit.
+
+  ### `--max-snapshots`
+
+  This flag sets the number of old Raft snapshots to retain in addition to the
+  current Raft snapshots. By default, no old snapshots are retained. This option
+  may be used for debugging, or to store old snapshots of the swarm state for
+  disaster recovery purposes.
+
+  ### `--snapshot-interval`
+
+  This flag specifies how many log entries to allow in between Raft snapshots.
+  Setting this to a higher number will trigger snapshots less frequently.
+  Snapshots compact the Raft log and allow for more efficient transfer of the
+  state to new managers. However, there is a performance cost to taking snapshots
+  frequently.
+
+  ### `--availability`
+
+  This flag specifies the availability of the node at the time the node joins a master.
+  Possible availability values are `active`, `pause`, or `drain`.
+
+  This flag is useful in certain situations. For example, a cluster may want to have
+  dedicated manager nodes that are not served as worker nodes. This could be achieved
+  by passing `--availability=drain` to `docker swarm init`.
+

--- a/_data/engine-cli-edge/docker_swarm_join-token.yaml
+++ b/_data/engine-cli-edge/docker_swarm_join-token.yaml
@@ -1,0 +1,15 @@
+command: docker swarm join-token
+short: Manage join tokens
+long: Manage join tokens
+usage: docker swarm join-token [OPTIONS] (worker|manager)
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display token
+- option: rotate
+  default_value: "false"
+  description: Rotate join token
+

--- a/_data/engine-cli-edge/docker_swarm_join.yaml
+++ b/_data/engine-cli-edge/docker_swarm_join.yaml
@@ -1,0 +1,81 @@
+command: docker swarm join
+short: Join a swarm as a node and/or manager
+long: |-
+  Join a node to a swarm. The node joins as a manager node or worker node based upon the token you
+  pass with the `--token` flag. If you pass a manager token, the node joins as a manager. If you
+  pass a worker token, the node joins as a worker.
+usage: docker swarm join [OPTIONS] HOST:PORT
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: advertise-addr
+  description: 'Advertised address (format: <ip|interface>[:port])'
+- option: listen-addr
+  default_value: 0.0.0.0:2377
+  description: 'Listen address (format: <ip|interface>[:port])'
+- option: token
+  description: Token for entry into the swarm
+examples: |-
+  ### Join a node to swarm as a manager
+
+  The example below demonstrates joining a manager node using a manager token.
+
+  ```bash
+  $ docker swarm join --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2 192.168.99.121:2377
+  This node joined a swarm as a manager.
+  $ docker node ls
+  ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
+  dkp8vy1dq1kxleu9g4u78tlag *  manager2  Ready   Active        Reachable
+  dvfxp4zseq4s0rih1selh0d20    manager1  Ready   Active        Leader
+  ```
+
+  A cluster should only have 3-7 managers at most, because a majority of managers must be available
+  for the cluster to function. Nodes that aren't meant to participate in this management quorum
+  should join as workers instead. Managers should be stable hosts that have static IP addresses.
+
+  ### Join a node to swarm as a worker
+
+  The example below demonstrates joining a worker node using a worker token.
+
+  ```bash
+  $ docker swarm join --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx 192.168.99.121:2377
+  This node joined a swarm as a worker.
+  $ docker node ls
+  ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
+  7ln70fl22uw2dvjn2ft53m3q5    worker2   Ready   Active
+  dkp8vy1dq1kxleu9g4u78tlag    worker1   Ready   Active        Reachable
+  dvfxp4zseq4s0rih1selh0d20 *  manager1  Ready   Active        Leader
+  ```
+
+  ### `--listen-addr value`
+
+  If the node is a manager, it will listen for inbound swarm manager traffic on this
+  address. The default is to listen on 0.0.0.0:2377. It is also possible to specify a
+  network interface to listen on that interface's address; for example `--listen-addr eth0:2377`.
+
+  Specifying a port is optional. If the value is a bare IP address, or interface
+  name, the default port 2377 will be used.
+
+  This flag is generally not necessary when joining an existing swarm.
+
+  ### `--advertise-addr value`
+
+  This flag specifies the address that will be advertised to other members of the
+  swarm for API access. If unspecified, Docker will check if the system has a
+  single IP address, and use that IP address with the listening port (see
+  `--listen-addr`). If the system has multiple IP addresses, `--advertise-addr`
+  must be specified so that the correct address is chosen for inter-manager
+  communication and overlay networking.
+
+  It is also possible to specify a network interface to advertise that interface's address;
+  for example `--advertise-addr eth0:2377`.
+
+  Specifying a port is optional. If the value is a bare IP address, or interface
+  name, the default port 2377 will be used.
+
+  This flag is generally not necessary when joining an existing swarm.
+
+  ### `--token string`
+
+  Secret value required for nodes to join the swar
+

--- a/_data/engine-cli-edge/docker_swarm_leave.yaml
+++ b/_data/engine-cli-edge/docker_swarm_leave.yaml
@@ -1,0 +1,42 @@
+command: docker swarm leave
+short: Leave the swarm
+long: |-
+  When you run this command on a worker, that worker leaves the swarm.
+
+  You can use the `--force` option on a manager to remove it from the swarm.
+  However, this does not reconfigure the swarm to ensure that there are enough
+  managers to maintain a quorum in the swarm. The safe way to remove a manager
+  from a swarm is to demote it to a worker and then direct it to leave the quorum
+  without using `--force`. Only use `--force` in situations where the swarm will
+  no longer be used after the manager leaves, such as in a single-node swarm.
+usage: docker swarm leave [OPTIONS]
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force this node to leave the swarm, ignoring warnings
+examples: |-
+  Consider the following swarm, as seen from the manager:
+
+  ```bash
+  $ docker node ls
+  ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
+  7ln70fl22uw2dvjn2ft53m3q5    worker2   Ready   Active
+  dkp8vy1dq1kxleu9g4u78tlag    worker1   Ready   Active
+  dvfxp4zseq4s0rih1selh0d20 *  manager1  Ready   Active        Leader
+  ```
+
+  To remove `worker2`, issue the following command from `worker2` itself:
+
+  ```bash
+  $ docker swarm leave
+  Node left the default swarm.
+  ```
+
+  The node will still appear in the node list, and marked as `down`. It no longer
+  affects swarm operation, but a long list of `down` nodes can clutter the node
+  list. To remove an inactive node from the list, use the [`node rm`](node_rm.md)
+  command.
+

--- a/_data/engine-cli-edge/docker_swarm_unlock-key.yaml
+++ b/_data/engine-cli-edge/docker_swarm_unlock-key.yaml
@@ -1,0 +1,15 @@
+command: docker swarm unlock-key
+short: Manage the unlock key
+long: Manage the unlock key
+usage: docker swarm unlock-key [OPTIONS]
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display token
+- option: rotate
+  default_value: "false"
+  description: Rotate unlock key
+

--- a/_data/engine-cli-edge/docker_swarm_unlock.yaml
+++ b/_data/engine-cli-edge/docker_swarm_unlock.yaml
@@ -1,0 +1,16 @@
+command: docker swarm unlock
+short: Unlock swarm
+long: |-
+  Unlocks a locked manager using a user-supplied unlock key. This command must be
+  used to reactivate a manager after its Docker daemon restarts if the autolock
+  setting is turned on. The unlock key is printed at the time when autolock is
+  enabled, and is also available from the `docker swarm unlock-key` command.
+usage: docker swarm unlock
+pname: docker swarm
+plink: docker_swarm.yaml
+examples: |-
+  ```bash
+  $ docker swarm unlock
+  Please enter unlock key:
+  ```
+

--- a/_data/engine-cli-edge/docker_swarm_update.yaml
+++ b/_data/engine-cli-edge/docker_swarm_update.yaml
@@ -1,0 +1,33 @@
+command: docker swarm update
+short: Update the swarm
+long: Updates a swarm with new parameter values. This command must target a manager
+  node.
+usage: docker swarm update [OPTIONS]
+pname: docker swarm
+plink: docker_swarm.yaml
+options:
+- option: autolock
+  default_value: "false"
+  description: Change manager autolocking setting (true|false)
+- option: cert-expiry
+  default_value: 2160h0m0s
+  description: Validity period for node certificates (ns|us|ms|s|m|h)
+- option: dispatcher-heartbeat
+  default_value: 5s
+  description: Dispatcher heartbeat period (ns|us|ms|s|m|h)
+- option: external-ca
+  description: Specifications of one or more certificate signing endpoints
+- option: max-snapshots
+  default_value: "0"
+  description: Number of additional Raft snapshots to retain
+- option: snapshot-interval
+  default_value: "10000"
+  description: Number of log entries between Raft snapshots
+- option: task-history-limit
+  default_value: "5"
+  description: Task history retention limit
+examples: |-
+  ```bash
+  $ docker swarm update --cert-expiry 720h
+  ```
+

--- a/_data/engine-cli-edge/docker_system.yaml
+++ b/_data/engine-cli-edge/docker_system.yaml
@@ -1,0 +1,17 @@
+command: docker system
+short: Manage Docker
+long: Manage docker.
+usage: docker system
+pname: docker
+plink: docker.yaml
+cname:
+- docker system df
+- docker system events
+- docker system info
+- docker system prune
+clink:
+- docker_system_df.yaml
+- docker_system_events.yaml
+- docker_system_info.yaml
+- docker_system_prune.yaml
+

--- a/_data/engine-cli-edge/docker_system_df.yaml
+++ b/_data/engine-cli-edge/docker_system_df.yaml
@@ -1,0 +1,59 @@
+command: docker system df
+short: Show docker disk usage
+long: |-
+  The `docker system df` command displays information regarding the
+  amount of disk space used by the docker daemon.
+usage: docker system df [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: verbose
+  shorthand: v
+  default_value: "false"
+  description: Show detailed information on space usage
+examples: |-
+  By default the command will just show a summary of the data used:
+
+  ```bash
+  $ docker system df
+
+  TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
+  Images              5                   2                   16.43 MB            11.63 MB (70%)
+  Containers          2                   0                   212 B               212 B (100%)
+  Local Volumes       2                   1                   36 B                0 B (0%)
+  ```
+
+  A more detailed view can be requested using the `-v, --verbose` flag:
+
+  ```bash
+  $ docker system df -v
+
+  Images space usage:
+
+  REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE                SHARED SIZE         UNIQUE SIZE         CONTAINERS
+  my-curl             latest              b2789dd875bf        6 minutes ago       11 MB               11 MB               5 B                 0
+  my-jq               latest              ae67841be6d0        6 minutes ago       9.623 MB            8.991 MB            632.1 kB            0
+  <none>              <none>              a0971c4015c1        6 minutes ago       11 MB               11 MB               0 B                 0
+  alpine              latest              4e38e38c8ce0        9 weeks ago         4.799 MB            0 B                 4.799 MB            1
+  alpine              3.3                 47cf20d8c26c        9 weeks ago         4.797 MB            4.797 MB            0 B                 1
+
+  Containers space usage:
+
+  CONTAINER ID        IMAGE               COMMAND             LOCAL VOLUMES       SIZE                CREATED             STATUS                      NAMES
+  4a7f7eebae0f        alpine:latest       "sh"                1                   0 B                 16 minutes ago      Exited (0) 5 minutes ago    hopeful_yalow
+  f98f9c2aa1ea        alpine:3.3          "sh"                1                   212 B               16 minutes ago      Exited (0) 48 seconds ago   anon-vol
+
+  Local Volumes space usage:
+
+  NAME                                                               LINKS               SIZE
+  07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e   2                   36 B
+  my-named-vol                                                       0                   0 B
+  ```
+
+  * `SHARED SIZE` is the amount of space that an image shares with another one (i.e. their common data)
+  * `UNIQUE SIZE` is the amount of space that is only used by a given image
+  * `SIZE` is the virtual size of the image, it is the sum of `SHARED SIZE` and `UNIQUE SIZE`
+
+  > **Note**: Network information is not shown because it doesn't consume the disk
+  > space.
+

--- a/_data/engine-cli-edge/docker_system_events.yaml
+++ b/_data/engine-cli-edge/docker_system_events.yaml
@@ -1,0 +1,17 @@
+command: docker system events
+short: Get real time events from the server
+long: Get real time events from the server
+usage: docker system events [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Filter output based on conditions provided
+- option: format
+  description: Format the output using the given Go template
+- option: since
+  description: Show all events created since timestamp
+- option: until
+  description: Stream events until this timestamp
+

--- a/_data/engine-cli-edge/docker_system_info.yaml
+++ b/_data/engine-cli-edge/docker_system_info.yaml
@@ -1,0 +1,11 @@
+command: docker system info
+short: Display system-wide information
+long: Display system-wide information
+usage: docker system info [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+

--- a/_data/engine-cli-edge/docker_system_prune.yaml
+++ b/_data/engine-cli-edge/docker_system_prune.yaml
@@ -1,0 +1,47 @@
+command: docker system prune
+short: Remove unused data
+long: Remove all unused containers, volumes, networks and images (both dangling and
+  unreferenced).
+usage: docker system prune [OPTIONS]
+pname: docker system
+plink: docker_system.yaml
+options:
+- option: all
+  shorthand: a
+  default_value: "false"
+  description: Remove all unused images not just dangling ones
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation
+examples: "```bash\n$ docker system prune -a\n\nWARNING! This will remove:\n\t- all
+  stopped containers\n\t- all volumes not used by at least one container\n\t- all
+  networks not used by at least one container\n\t- all images without at least one
+  container associated to them\nAre you sure you want to continue? [y/N] y\nDeleted
+  Containers:\n0998aa37185a1a7036b0e12cf1ac1b6442dcfa30a5c9650a42ed5010046f195b\n73958bfb884fa81fa4cc6baf61055667e940ea2357b4036acbbe25a60f442a4d\n\nDeleted
+  Volumes:\nnamed-vol\n\nDeleted Images:\nuntagged: my-curl:latest\ndeleted: sha256:7d88582121f2a29031d92017754d62a0d1a215c97e8f0106c586546e7404447d\ndeleted:
+  sha256:dd14a93d83593d4024152f85d7c63f76aaa4e73e228377ba1d130ef5149f4d8b\nuntagged:
+  alpine:3.3\ndeleted: sha256:695f3d04125db3266d4ab7bbb3c6b23aa4293923e762aa2562c54f49a28f009f\nuntagged:
+  alpine:latest\ndeleted: sha256:ee4603260daafe1a8c2f3b78fd760922918ab2441cbb2853ed5c439e59c52f96\ndeleted:
+  sha256:9007f5987db353ec398a223bc5a135c5a9601798ba20a1abba537ea2f8ac765f\ndeleted:
+  sha256:71fa90c8f04769c9721459d5aa0936db640b92c8c91c9b589b54abd412d120ab\ndeleted:
+  sha256:bb1c3357b3c30ece26e6604aea7d2ec0ace4166ff34c3616701279c22444c0f3\nuntagged:
+  my-jq:latest\ndeleted: sha256:6e66d724542af9bc4c4abf4a909791d7260b6d0110d8e220708b09e4ee1322e1\ndeleted:
+  sha256:07b3fa89d4b17009eb3988dfc592c7d30ab3ba52d2007832dffcf6d40e3eda7f\ndeleted:
+  sha256:3a88a5c81eb5c283e72db2dbc6d65cbfd8e80b6c89bb6e714cfaaa0eed99c548\n\nTotal
+  reclaimed space: 13.5 MB\n```\n\n### Filtering\n\nThe filtering flag (`-f` or `--filter`)
+  format is of \"key=value\". If there is more\nthan one filter, then pass multiple
+  flags (e.g., `--filter \"foo=bar\" --filter \"bif=baz\"`)\n\nThe currently supported
+  filters are:\n\n* until (`<timestamp>`) - only remove containers, images, and networks
+  created before given timestamp\n\nThe `until` filter can be Unix timestamps, date
+  formatted\ntimestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed\nrelative
+  to the daemon machine’s time. Supported formats for date\nformatted time stamps
+  include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,\n`2006-01-02T15:04:05.999999999`,
+  `2006-01-02Z07:00`, and `2006-01-02`. The local\ntimezone on the daemon will be
+  used if you do not provide either a `Z` or a\n`+-00:00` timezone offset at the end
+  of the timestamp.  When providing Unix\ntimestamps enter seconds[.nanoseconds],
+  where seconds is the number of seconds\nthat have elapsed since January 1, 1970
+  (midnight UTC/GMT), not counting leap\nseconds (aka Unix epoch or Unix time), and
+  the optional .nanoseconds field is a\nfraction of a second no more than nine digits
+  long."
+

--- a/_data/engine-cli-edge/docker_tag.yaml
+++ b/_data/engine-cli-edge/docker_tag.yaml
@@ -1,0 +1,61 @@
+command: docker tag
+short: Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+long: |-
+  An image name is made up of slash-separated name components, optionally prefixed
+  by a registry hostname. The hostname must comply with standard DNS rules, but
+  may not contain underscores. If a hostname is present, it may optionally be
+  followed by a port number in the format `:8080`. If not present, the command
+  uses Docker's public registry located at `registry-1.docker.io` by default. Name
+  components may contain lowercase letters, digits and separators. A separator
+  is defined as a period, one or two underscores, or one or more dashes. A name
+  component may not start or end with a separator.
+
+  A tag name must be valid ASCII and may contain lowercase and uppercase letters,
+  digits, underscores, periods and dashes. A tag name may not start with a
+  period or a dash and may contain a maximum of 128 characters.
+
+  You can group your images together using names and tags, and then upload them
+  to [*Share Images via Repositories*](https://docs.docker.com/engine/tutorials/dockerrepos/#/contributing-to-docker-hub).
+usage: docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
+pname: docker
+plink: docker.yaml
+examples: |-
+  ### Tag an image referenced by ID
+
+  To tag a local image with ID "0e5574283393" into the "fedora" repository with
+  "version1.0":
+
+  ```bash
+  $ docker tag 0e5574283393 fedora/httpd:version1.0
+  ```
+
+  ### Tag an image referenced by Name
+
+  To tag a local image with name "httpd" into the "fedora" repository with
+  "version1.0":
+
+  ```bash
+  $ docker tag httpd fedora/httpd:version1.0
+  ```
+
+  Note that since the tag name is not specified, the alias is created for an
+  existing local version `httpd:latest`.
+
+  ### Tag an image referenced by Name and Tag
+
+  To tag a local image with name "httpd" and tag "test" into the "fedora"
+  repository with "version1.0.test":
+
+  ```bash
+  $ docker tag httpd:test fedora/httpd:version1.0.test
+  ```
+
+  ### Tag an image for a private repository
+
+  To push an image to a private registry and not the central Docker
+  registry you must tag it with the registry hostname and port (if needed).
+
+  ```bash
+  $ docker tag 0e5574283393 myregistryhost:5000/fedora/httpd:version1.0
+  ```
+

--- a/_data/engine-cli-edge/docker_top.yaml
+++ b/_data/engine-cli-edge/docker_top.yaml
@@ -1,0 +1,7 @@
+command: docker top
+short: Display the running processes of a container
+long: Display the running processes of a container
+usage: docker top CONTAINER [ps OPTIONS]
+pname: docker
+plink: docker.yaml
+

--- a/_data/engine-cli-edge/docker_unpause.yaml
+++ b/_data/engine-cli-edge/docker_unpause.yaml
@@ -1,0 +1,17 @@
+command: docker unpause
+short: Unpause all processes within one or more containers
+long: |-
+  The `docker unpause` command un-suspends all processes in the specified containers.
+  On Linux, it does this using the cgroups freezer.
+
+  See the
+  [cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
+  for further details.
+usage: docker unpause CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+examples: |-
+  ```bash
+  $ docker unpause my_container
+  ```
+

--- a/_data/engine-cli-edge/docker_update.yaml
+++ b/_data/engine-cli-edge/docker_update.yaml
@@ -1,0 +1,123 @@
+command: docker update
+short: Update configuration of one or more containers
+long: |-
+  The `docker update` command dynamically updates container configuration.
+  You can use this command to prevent containers from consuming too many
+  resources from their Docker host.  With a single command, you can place
+  limits on a single container or on many. To specify more than one container,
+  provide space-separated list of container names or IDs.
+
+  With the exception of the `--kernel-memory` option, you can specify these
+  options on a running or a stopped container. On kernel version older than
+  4.6, you can only update `--kernel-memory` on a stopped container or on
+  a running container with kernel memory initialized.
+usage: docker update [OPTIONS] CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+options:
+- option: blkio-weight
+  default_value: "0"
+  description: |
+    Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
+- option: cpu-period
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) period
+- option: cpu-quota
+  default_value: "0"
+  description: Limit CPU CFS (Completely Fair Scheduler) quota
+- option: cpu-rt-period
+  default_value: "0"
+  description: Limit the CPU real-time period in microseconds
+- option: cpu-rt-runtime
+  default_value: "0"
+  description: Limit the CPU real-time runtime in microseconds
+- option: cpu-shares
+  shorthand: c
+  default_value: "0"
+  description: CPU shares (relative weight)
+- option: cpuset-cpus
+  description: CPUs in which to allow execution (0-3, 0,1)
+- option: cpuset-mems
+  description: MEMs in which to allow execution (0-3, 0,1)
+- option: kernel-memory
+  description: Kernel memory limit
+- option: memory
+  shorthand: m
+  description: Memory limit
+- option: memory-reservation
+  description: Memory soft limit
+- option: memory-swap
+  description: |
+    Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+- option: restart
+  description: Restart policy to apply when a container exits
+examples: |-
+  The following sections illustrate ways to use this command.
+
+  ### Update a container's cpu-shares
+
+  To limit a container's cpu-shares to 512, first identify the container
+  name or ID. You can use `docker ps` to find these values. You can also
+  use the ID returned from the `docker run` command.  Then, do the following:
+
+  ```bash
+  $ docker update --cpu-shares 512 abebf7571666
+  ```
+
+  ### Update a container with cpu-shares and memory
+
+  To update multiple resource configurations for multiple containers:
+
+  ```bash
+  $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
+  ```
+
+  ### Update a container's kernel memory constraints
+
+  You can update a container's kernel memory limit using the `--kernel-memory`
+  option. On kernel version older than 4.6, this option can be updated on a
+  running container only if the container was started with `--kernel-memory`.
+  If the container was started *without* `--kernel-memory` you need to stop
+  the container before updating kernel memory.
+
+  For example, if you started a container with this command:
+
+  ```bash
+  $ docker run -dit --name test --kernel-memory 50M ubuntu bash
+  ```
+
+  You can update kernel memory while the container is running:
+
+  ```bash
+  $ docker update --kernel-memory 80M test
+  ```
+
+  If you started a container *without* kernel memory initialized:
+
+  ```bash
+  $ docker run -dit --name test2 --memory 300M ubuntu bash
+  ```
+
+  Update kernel memory of running container `test2` will fail. You need to stop
+  the container before updating the `--kernel-memory` setting. The next time you
+  start it, the container uses the new value.
+
+  Kernel version newer than (include) 4.6 does not have this limitation, you
+  can use `--kernel-memory` the same way as other options.
+
+  ### Update a container's restart policy
+
+  You can change a container's restart policy on a running container. The new
+  restart policy takes effect instantly after you run `docker update` on a
+  container.
+
+  To update restart policy for one or more containers:
+
+  ```bash
+  $ docker update --restart=on-failure:3 abebf7571666 hopeful_morse
+  ```
+
+  Note that if the container is started with "--rm" flag, you cannot update the restart
+  policy for it. The `AutoRemove` and `RestartPolicy` are mutually exclusive for the
+  container.
+

--- a/_data/engine-cli-edge/docker_version.yaml
+++ b/_data/engine-cli-edge/docker_version.yaml
@@ -1,0 +1,54 @@
+command: docker version
+short: Show the Docker version information
+long: |-
+  By default, this will render all version information in an easy to read
+  layout. If a format is specified, the given template will be executed instead.
+
+  Go's [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+usage: docker version [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+examples: |-
+  ### Default output
+
+  ```bash
+  $ docker version
+
+  Client:
+  Version:      1.8.0
+  API version:  1.20
+  Go version:   go1.4.2
+  Git commit:   f5bae0a
+  Built:        Tue Jun 23 17:56:00 UTC 2015
+  OS/Arch:      linux/amd64
+
+  Server:
+  Version:      1.8.0
+  API version:  1.20
+  Go version:   go1.4.2
+  Git commit:   f5bae0a
+  Built:        Tue Jun 23 17:56:00 UTC 2015
+  OS/Arch:      linux/amd64
+  ```
+
+  ### Get the server version
+
+  ```bash
+  $ docker version --format '{{.Server.Version}}'
+
+  1.8.0
+  ```
+
+  ### Dump raw JSON data
+
+  ```bash
+  $ docker version --format '{{json .}}'
+
+  {"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
+  ```
+

--- a/_data/engine-cli-edge/docker_volume.yaml
+++ b/_data/engine-cli-edge/docker_volume.yaml
@@ -1,0 +1,21 @@
+command: docker volume
+short: Manage volumes
+long: |-
+  Manage volumes. You can use subcommand to create, list, inspect, remove
+  volumes.
+usage: docker volume COMMAND
+pname: docker
+plink: docker.yaml
+cname:
+- docker volume create
+- docker volume inspect
+- docker volume ls
+- docker volume prune
+- docker volume rm
+clink:
+- docker_volume_create.yaml
+- docker_volume_inspect.yaml
+- docker_volume_ls.yaml
+- docker_volume_prune.yaml
+- docker_volume_rm.yaml
+

--- a/_data/engine-cli-edge/docker_volume_create.yaml
+++ b/_data/engine-cli-edge/docker_volume_create.yaml
@@ -1,0 +1,105 @@
+command: docker volume create
+short: Create a volume
+long: |-
+  Creates a new volume that containers can consume and store data in. If a name is
+  not specified, Docker generates a random name.
+usage: docker volume create [OPTIONS] [VOLUME]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: driver
+  shorthand: d
+  default_value: local
+  description: Specify volume driver name
+- option: label
+  default_value: '[]'
+  description: Set metadata for a volume
+- option: name
+  description: Specify volume name
+- option: opt
+  shorthand: o
+  default_value: map[]
+  description: Set driver specific options
+examples: |-
+  Create a volume and then configure the container to use it:
+
+  ```bash
+  $ docker volume create hello
+
+  hello
+
+  $ docker run -d -v hello:/world busybox ls /world
+  ```
+
+  The mount is created inside the container's `/world` directory. Docker does not
+  support relative paths for mount points inside the container.
+
+  Multiple containers can use the same volume in the same time period. This is
+  useful if two containers need access to shared data. For example, if one
+  container writes and the other reads the data.
+
+  Volume names must be unique among drivers. This means you cannot use the same
+  volume name with two different drivers. If you attempt this `docker` returns an
+  error:
+
+  ```none
+  A volume named  "hello"  already exists with the "some-other" driver. Choose a different volume name.
+  ```
+
+  If you specify a volume name already in use on the current driver, Docker
+  assumes you want to re-use the existing volume and does not return an error.
+
+  ### Driver-specific options
+
+  Some volume drivers may take options to customize the volume creation. Use the
+  `-o` or `--opt` flags to pass driver options:
+
+  ```bash
+  $ docker volume create --driver fake \
+      --opt tardis=blue \
+      --opt timey=wimey \
+      foo
+  ```
+
+  These options are passed directly to the volume driver. Options for
+  different volume drivers may do different things (or nothing at all).
+
+  The built-in `local` driver on Windows does not support any options.
+
+  The built-in `local` driver on Linux accepts options similar to the linux
+  `mount` command. You can provide multiple options by passing the `--opt` flag
+  multiple times. Some `mount` options (such as the `o` option) can take a
+  comma-separated list of options. Complete list of available mount options can be
+  found [here](http://man7.org/linux/man-pages/man8/mount.8.html).
+
+  For example, the following creates a `tmpfs` volume called `foo` with a size of
+  100 megabyte and `uid` of 1000.
+
+  ```bash
+  $ docker volume create --driver local \
+      --opt type=tmpfs \
+      --opt device=tmpfs \
+      --opt o=size=100m,uid=1000 \
+      foo
+  ```
+
+  Another example that uses `btrfs`:
+
+  ```bash
+  $ docker volume create --driver local \
+      --opt type=btrfs \
+      --opt device=/dev/sda2 \
+      foo
+  ```
+
+  Another example that uses `nfs` to mount the `/path/to/dir` in `rw` mode from
+  `192.168.1.1`:
+
+  ```bash
+  $ docker volume create --driver local \
+      --opt type=nfs \
+      --opt o=addr=192.168.1.1,rw \
+      --opt device=:/path/to/dir \
+      foo
+  ```
+

--- a/_data/engine-cli-edge/docker_volume_inspect.yaml
+++ b/_data/engine-cli-edge/docker_volume_inspect.yaml
@@ -1,0 +1,33 @@
+command: docker volume inspect
+short: Display detailed information on one or more volumes
+long: |-
+  Returns information about a volume. By default, this command renders all results
+  in a JSON array. You can specify an alternate format to execute a
+  given template for each result. Go's
+  [text/template](http://golang.org/pkg/text/template/) package describes all the
+  details of the format.
+usage: docker volume inspect [OPTIONS] VOLUME [VOLUME...]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: format
+  shorthand: f
+  description: Format the output using the given Go template
+examples: |-
+  ```bash
+  $ docker volume create
+  85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
+  $ docker volume inspect 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
+  [
+    {
+        "Name": "85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d",
+        "Driver": "local",
+        "Mountpoint": "/var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data",
+        "Status": null
+    }
+  ]
+
+  $ docker volume inspect --format '{{ .Mountpoint }}' 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
+  /var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data
+  ```
+

--- a/_data/engine-cli-edge/docker_volume_ls.yaml
+++ b/_data/engine-cli-edge/docker_volume_ls.yaml
@@ -1,0 +1,169 @@
+command: docker volume ls
+aliases: list
+short: List volumes
+long: |-
+  List all the volumes known to Docker. You can filter using the `-f` or
+  `--filter` flag. Refer to the [filtering](#filtering) section for more
+  information about available filter options.
+usage: docker volume ls [OPTIONS]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: filter
+  shorthand: f
+  description: Provide filter values (e.g. 'dangling=true')
+- option: format
+  description: Pretty-print volumes using a Go template
+- option: quiet
+  shorthand: q
+  default_value: "false"
+  description: Only display volume names
+examples: |-
+  ### Create a volume
+  ```bash
+  $ docker volume create rosemary
+
+  rosemary
+
+  $ docker volume create tyler
+
+  tyler
+
+  $ docker volume ls
+
+  DRIVER              VOLUME NAME
+  local               rosemary
+  local               tyler
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * dangling (boolean - true or false, 0 or 1)
+  * driver (a volume driver's name)
+  * label (`label=<key>` or `label=<key>=<value>`)
+  * name (a volume's name)
+
+  #### dangling
+
+  The `dangling` filter matches on all volumes not referenced by any containers
+
+  ```bash
+  $ docker run -d  -v tyler:/tmpwork  busybox
+
+  f86a7dd02898067079c99ceacd810149060a70528eff3754d0b0f1a93bd0af18
+  $ docker volume ls -f dangling=true
+  DRIVER              VOLUME NAME
+  local               rosemary
+  ```
+
+  #### driver
+
+  The `driver` filter matches on all or part of a volume's driver name.
+
+  The following filter matches all volumes with a driver name containing the `local` string.
+
+  ```bash
+  $ docker volume ls -f driver=local
+
+  DRIVER              VOLUME NAME
+  local               rosemary
+  local               tyler
+  ```
+
+  #### label
+
+  The `label` filter matches volumes based on the presence of a `label` alone or
+  a `label` and a value.
+
+  First, let's create some volumes to illustrate this;
+
+  ```bash
+  $ docker volume create the-doctor --label is-timelord=yes
+
+  the-doctor
+  $ docker volume create daleks --label is-timelord=no
+
+  daleks
+  ```
+
+  The following example filter matches volumes with the `is-timelord` label
+  regardless of its value.
+
+  ```bash
+  $ docker volume ls --filter label=is-timelord
+
+  DRIVER              VOLUME NAME
+  local               daleks
+  local               the-doctor
+  ```
+
+  As the above example demonstrates, both volumes with `is-timelord=yes`, and
+  `is-timelord=no` are returned.
+
+  Filtering on both `key` *and* `value` of the label, produces the expected result:
+
+  ```bash
+  $ docker volume ls --filter label=is-timelord=yes
+
+  DRIVER              VOLUME NAME
+  local               the-doctor
+  ```
+
+  Specifying multiple label filter produces an "and" search; all conditions
+  should be met;
+
+  ```bash
+  $ docker volume ls --filter label=is-timelord=yes --filter label=is-timelord=no
+
+  DRIVER              VOLUME NAME
+  ```
+
+  #### name
+
+  The `name` filter matches on all or part of a volume's name.
+
+  The following filter matches all volumes with a name containing the `rose` string.
+
+  ```bash
+  $ docker volume ls -f name=rose
+
+  DRIVER              VOLUME NAME
+  local               rosemary
+  ```
+
+  ### Formatting
+
+  The formatting options (`--format`) pretty-prints volumes output
+  using a Go template.
+
+  Valid placeholders for the Go template are listed below:
+
+  Placeholder   | Description
+  --------------|------------------------------------------------------------------------------------------
+  `.Name`       | Network name
+  `.Driver`     | Network driver
+  `.Scope`      | Network scope (local, global)
+  `.Mountpoint` | Whether the network is internal or not.
+  `.Labels`     | All labels assigned to the volume.
+  `.Label`      | Value of a specific label for this volume. For example `{{.Label "project.version"}}`
+
+  When using the `--format` option, the `volume ls` command will either
+  output the data exactly as the template declares or, when using the
+  `table` directive, includes column headers as well.
+
+  The following example uses a template without headers and outputs the
+  `Name` and `Driver` entries separated by a colon for all volumes:
+
+  ```bash
+  $ docker volume ls --format "{{.Name}}: {{.Driver}}"
+
+  vol1: local
+  vol2: local
+  vol3: local
+  ```
+

--- a/_data/engine-cli-edge/docker_volume_prune.yaml
+++ b/_data/engine-cli-edge/docker_volume_prune.yaml
@@ -1,0 +1,25 @@
+command: docker volume prune
+short: Remove all unused volumes
+long: Remove all unused volumes. Unused volumes are those which are not referenced
+  by any conta
+usage: docker volume prune [OPTIONS]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Do not prompt for confirmation
+examples: |-
+  ```bash
+  $ docker volume prune
+
+  WARNING! This will remove all volumes not used by at least one container.
+  Are you sure you want to continue? [y/N] y
+  Deleted Volumes:
+  07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e
+  my-named-vol
+
+  Total reclaimed space: 36 B
+  ```
+

--- a/_data/engine-cli-edge/docker_volume_rm.yaml
+++ b/_data/engine-cli-edge/docker_volume_rm.yaml
@@ -1,0 +1,18 @@
+command: docker volume rm
+aliases: remove
+short: Remove one or more volumes
+long: Remove one or more volumes. You cannot remove a volume that is in use by a container.
+usage: docker volume rm [OPTIONS] VOLUME [VOLUME...]
+pname: docker volume
+plink: docker_volume.yaml
+options:
+- option: force
+  shorthand: f
+  default_value: "false"
+  description: Force the removal of one or more volumes
+examples: |-
+  ```bash
+    $ docker volume rm hello
+    hello
+  ```
+

--- a/_data/engine-cli-edge/docker_wait.yaml
+++ b/_data/engine-cli-edge/docker_wait.yaml
@@ -1,0 +1,35 @@
+command: docker wait
+short: Block until one or more containers stop, then print their exit codes
+long: Block until one or more containers stop, then print their exit codes
+usage: docker wait CONTAINER [CONTAINER...]
+pname: docker
+plink: docker.yaml
+examples: |-
+  Start a container in the background.
+
+  ```bash
+  $ docker run -dit --name=my_container ubuntu bash
+  ```
+
+  Run `docker wait`, which should block until the container exits.
+
+  ```bash
+  $ docker wait my_container
+  ```
+
+  In another terminal, stop the first container. The `docker wait` command above
+  returns the exit code.
+
+  ```bash
+  $ docker stop my_container
+  ```
+
+  This is the same `docker wait` command from above, but it now exits, returning
+  `0`.
+
+  ```bash
+  $ docker wait my_container
+
+  0
+  ```
+

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -115,7 +115,7 @@ guides:
     - path: /toolbox/faqs/troubleshoot/
       title: Troubleshooting
   - path: /release-notes/
-    title: Docker Release Notes
+    title: Docker release notes
 - sectiontitle: Get Started
   section:
   - path: /learn/

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -1,86 +1,86 @@
 {% capture tabChar %}	{% endcapture %}<!-- Make sure atom is using hard tabs -->
 {% capture dockerBaseDesc %}The base command for the Docker CLI.{% endcapture %}
-{% if page.datafolder and page.datafile %}
+{% if include.datafolder and include.datafile %}
 
 ## Description
 
-{% if page.datafile=="docker" %}<!-- docker.yaml is textless, so override -->
+{% if include.datafile=="docker" %}<!-- docker.yaml is textless, so override -->
 {{ dockerBaseDesc }}
 {% else %}
-{{ site.data[page.datafolder][page.datafile].short }}
+{{ site.data[include.datafolder][include.datafile].short }}
 {% endif %}
 
-{% if site.data[page.datafolder][page.datafile].usage %}
+{% if site.data[include.datafolder][include.datafile].usage %}
 
 ## Usage
 
 ```none
-{{ site.data[page.datafolder][page.datafile].usage | replace: tabChar,"" | strip }}{% if site.data[page.datafolder][page.datafile].cname %} COMMAND{% endif %}
+{{ site.data[include.datafolder][include.datafile].usage | replace: tabChar,"" | strip }}{% if site.data[include.datafolder][include.datafile].cname %} COMMAND{% endif %}
 ```
 
 {% endif %}
-{% if site.data[page.datafolder][page.datafile].options %}
+{% if site.data[include.datafolder][include.datafile].options %}
 
 ## Options
 
 | Name, shorthand | Default | Description |
-| ---- | ------- | ----------- |{% for option in  site.data[page.datafolder][page.datafile].options %}
+| ---- | ------- | ----------- |{% for option in  site.data[include.datafolder][include.datafile].options %}
 | `--{{ option.option }}{% if option.shorthand %}, -{{ option.shorthand }}{% endif %}` | {% if option.default_value and option.default_value != "[]" %}`{{ option.default_value }}`{% endif %} | {{ option.description | replace: "|","&#124;" | strip }} | {% endfor %}
 
 {% endif %}
 
-{% if site.data[page.datafolder][page.datafile].cname %}
+{% if site.data[include.datafolder][include.datafile].cname %}
 
 ## Child commands
 
 | Command | Description |
-| ------- | ----------- |{% for command in site.data[page.datafolder][page.datafile].cname %}{% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
-| [{{ command }}]({{ dataFileName | replace: "docker_","" }}/) | {{ site.data[page.datafolder][dataFileName].short }} |{% endfor %}
+| ------- | ----------- |{% for command in site.data[include.datafolder][include.datafile].cname %}{% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
+| [{{ command }}]({{ dataFileName | replace: "docker_","" }}/) | {{ site.data[include.datafolder][dataFileName].short }} |{% endfor %}
 
 {% endif %}
 
-{% unless site.data[page.datafolder][page.datafile].pname == page.datafile %}
+{% unless site.data[include.datafolder][include.datafile].pname == include.datafile %}
 
 ## Parent command
 
-{% capture parentfile %}{{ site.data[page.datafolder][page.datafile].plink | replace: ".yaml", "" | replace: "docker_","" }}{% endcapture %}
-{% capture parentdatafile %}{{ site.data[page.datafolder][page.datafile].plink | replace: ".yaml", "" }}{% endcapture %}
+{% capture parentfile %}{{ site.data[include.datafolder][include.datafile].plink | replace: ".yaml", "" | replace: "docker_","" }}{% endcapture %}
+{% capture parentdatafile %}{{ site.data[include.datafolder][include.datafile].plink | replace: ".yaml", "" }}{% endcapture %}
 
-{% if site.data[page.datafolder][page.datafile].pname == "docker" %}
+{% if site.data[include.datafolder][include.datafile].pname == "docker" %}
 {% capture parentDesc %}{{ dockerBaseDesc }}{% endcapture %}
 {% else %}
-{% capture parentDesc %}{{ site.data[page.datafolder][parentdatafile].short }}{% endcapture %}
+{% capture parentDesc %}{{ site.data[include.datafolder][parentdatafile].short }}{% endcapture %}
 {% endif %}
 
 | Command | Description |
 | ------- | ----------- |
-| [{{ site.data[page.datafolder][page.datafile].pname }}]({{ parentfile }}) | {{ parentDesc }}|
+| [{{ site.data[include.datafolder][include.datafile].pname }}]({{ parentfile }}) | {{ parentDesc }}|
 
 {% endunless %}
 
-{% unless site.data[page.datafolder][page.datafile].pname == "docker" or site.data[page.datafolder][page.datafile].pname == "dockerd" %}
+{% unless site.data[include.datafolder][include.datafile].pname == "docker" or site.data[include.datafolder][include.datafile].pname == "dockerd" %}
 
 ## Related commands
 
 | Command | Description |
-| ------- | ----------- |{% for command in site.data[page.datafolder][parentdatafile].cname %}{% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
-| [{{ command }}]({{ dataFileName | replace: "docker_","" }}/) | {{ site.data[page.datafolder][dataFileName].short }} |{% endfor %}
+| ------- | ----------- |{% for command in site.data[include.datafolder][parentdatafile].cname %}{% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
+| [{{ command }}]({{ dataFileName | replace: "docker_","" }}/) | {{ site.data[include.datafolder][dataFileName].short }} |{% endfor %}
 
 {% endunless %}
 
-{% unless site.data[page.datafolder][page.datafile].long == site.data[page.datafolder][page.datafile].short %}
+{% unless site.data[include.datafolder][include.datafile].long == site.data[include.datafolder][include.datafile].short %}
 
 ## Extended description
 
-{{ site.data[page.datafolder][page.datafile].long }}
+{{ site.data[include.datafolder][include.datafile].long }}
 
 {% endunless %}
 
-{% if site.data[page.datafolder][page.datafile].examples %}
+{% if site.data[include.datafolder][include.datafile].examples %}
 
 ## Examples
 
-{{ site.data[page.datafolder][page.datafile].examples }}
+{{ site.data[include.datafolder][include.datafile].examples }}
 
 {% endif %}
 

--- a/_includes/docker_platform_matrix.md
+++ b/_includes/docker_platform_matrix.md
@@ -1,17 +1,21 @@
 {% capture green-check %}![yes](/engine/installation/images/green-check.svg){: style="height: 14px"}{% endcapture %}
 
-| Platform                                                                                             | Docker EE         | Docker CE         |
-| ---------------------------------------------------------------------------------------------------- | ----------------- | ----------------- |
-| [Ubuntu](/engine/installation/linux/ubuntu.md)                                                       | {{ green-check }} | {{ green-check }} |
-| [Debian](/engine/installation/linux/debian.md)                                                       |                   | {{ green-check }} |
-| [Red Hat Enterprise Linux](/engine/installation/linux/rhel.md)                                       | {{ green-check }} |                   |
-| [CentOS](/engine/installation/linux/centos.md)                                                       | {{ green-check }} | {{ green-check }} |
-| [Fedora](/engine/installation/linux/fedora.md)                                                       |                   | {{ green-check }} |
-| [Oracle Linux](/engine/installation/linux/oracle.md)                                                 | {{ green-check }} |                   |
-| [SUSE Linux Enterprise Server](/engine/installation/linux/suse.md)                                   | {{ green-check }} |                   |
-| [Microsoft Windows Server 2016](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server){: target="_blank" class="_" } | {{ green-check }} |   |
-| [Microsoft Windows 10](/docker-for-windows/)                                                         |                   | {{ green-check }} |
-| [macOS](/docker-for-mac/)                                                                            |                   | {{ green-check }} |
-| [Microsoft Azure](/docker-for-azure/)                                                                | {{ green-check }} | {{ green-check }} |
-| [Amazon Web Services](/docker-for-aws/)                                                              | {{ green-check }} | {{ green-check }} |
+{% capture matrix %}
+| Platform                                                                                             | Docker EE         | Docker CE x86_64 | Docker CE ARM |
+| ---------------------------------------------------------------------------------------------------- | ----------------- | ----------------- | ----------------- |
+| [Ubuntu](/engine/installation/linux/ubuntu.md)                                                       | {{ green-check }} | {{ green-check }} | {{ green-check }} |
+| [Debian](/engine/installation/linux/debian.md)                                                       |                   | {{ green-check }} | {{ green-check }} |
+| [Red Hat Enterprise Linux](/engine/installation/linux/rhel.md)                                       | {{ green-check }} |                   |                   |
+| [CentOS](/engine/installation/linux/centos.md)                                                       | {{ green-check }} | {{ green-check }} |                   |
+| [Fedora](/engine/installation/linux/fedora.md)                                                       |                   | {{ green-check }} |                   |
+| [Oracle Linux](/engine/installation/linux/oracle.md)                                                 | {{ green-check }} |                   |                   |
+| [SUSE Linux Enterprise Server](/engine/installation/linux/suse.md)                                   | {{ green-check }} |                   |                   |
+| [Microsoft Windows Server 2016](/docker-ee-for-windows/install/)                                     | {{ green-check }} |                   |                   |
+| [Microsoft Windows 10](/docker-for-windows/)                                                         |                   | {{ green-check }} |                   |
+| [macOS](/docker-for-mac/)                                                                            |                   | {{ green-check }} |                   |
+| [Microsoft Azure](/docker-for-azure/)                                                                | {{ green-check }} | {{ green-check }} |                   |
+| [Amazon Web Services](/docker-for-aws/)                                                              | {{ green-check }} | {{ green-check }} |                   |
 {: style="width: 75%" }
+
+{% endcapture %}
+{{ matrix | markdownify }}

--- a/_includes/docker_schedule_matrix.md
+++ b/_includes/docker_schedule_matrix.md
@@ -1,18 +1,24 @@
-{% capture green-check %}![yes](/engine/installation/images/green-check.svg){: style="height: 14px"}{% endcapture %}
-
+{% capture green-check %}![yes](/engine/installation/images/green-check.svg){: style="height: 14px; display: inline-block"}{% endcapture %}
+{% capture superscript-link %}[1](#edge-footnote){: style="vertical-align: super; font-size: smaller;" }{% endcapture %}
 {: style="width: 75%" }
 
 | Month    | Docker CE Edge    | Docker CE Stable  | Docker EE         |
 |----------|-------------------|-------------------|-------------------|
 | January  | {{ green-check }} |                   |                   |
 | February | {{ green-check }} |                   |                   |
-| March    |                   | {{ green-check }} | {{ green-check }} |
+| March    | {{ green-check }}{{ superscript-link }}  | {{ green-check }} | {{ green-check }} |
 | April    | {{ green-check }} |                   |                   |
 | May      | {{ green-check }} |                   |                   |
-| June     |                   | {{ green-check }} | {{ green-check }} |
+| June     | {{ green-check }}{{ superscript-link }} | {{ green-check }} | {{ green-check }} |
 | July     | {{ green-check }} |                   |                   |
 | August   | {{ green-check }} |                   |                   |
-| September|                   | {{ green-check }} | {{ green-check }} |
+| September| {{ green-check }}{{ superscript-link }} | {{ green-check }} | {{ green-check }} |
 | October  | {{ green-check }} |                   |                   |
 | November | {{ green-check }} |                   |                   |
-| December |                   | {{ green-check }} | {{ green-check }} |
+| December | {{ green-check }}{{ superscript-link }} | {{ green-check }} | {{ green-check }} |
+
+`1`: On Linux distributions, these releases will only appear in the `stable`
+     channels, not the `edge` channels. For that reason, on Linux distributions,
+     you need to enable both channels.
+{: id="edge-footnote" }
+

--- a/_includes/docker_schedule_matrix.md
+++ b/_includes/docker_schedule_matrix.md
@@ -1,0 +1,18 @@
+{% capture green-check %}![yes](/engine/installation/images/green-check.svg){: style="height: 14px"}{% endcapture %}
+
+{: style="width: 75%" }
+
+| Month    | Docker CE Edge    | Docker CE Stable  | Docker EE         |
+|----------|-------------------|-------------------|-------------------|
+| January  | {{ green-check }} |                   |                   |
+| February | {{ green-check }} |                   |                   |
+| March    |                   | {{ green-check }} | {{ green-check }} |
+| April    | {{ green-check }} |                   |                   |
+| May      | {{ green-check }} |                   |                   |
+| June     |                   | {{ green-check }} | {{ green-check }} |
+| July     | {{ green-check }} |                   |                   |
+| August   | {{ green-check }} |                   |                   |
+| September|                   | {{ green-check }} | {{ green-check }} |
+| October  | {{ green-check }} |                   |                   |
+| November | {{ green-check }} |                   |                   |
+| December |                   | {{ green-check }} | {{ green-check }} |

--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -40,7 +40,7 @@
                                 <ul>
                                     <li><a href="https://cloud.docker.com/">Create Docker ID</a></li>
                                     <li><a href="https://cloud.docker.com/login">Sign In</a></li>
-                                </ul>                       
+                                </ul>
                             </div> -->
                         </div>
                     <!--/.nav-collapse -->
@@ -53,7 +53,7 @@
         <div class="row">
             <div class="hero-text">
                 <div class="hero-text-centered">
-                    <h1>Docker Documentation</h1>
+                    <h1>{{ site.name }}</h1>
                     <p>Docker provides a way to run applications securely isolated in a container, packaged with all its dependencies and libraries.</p>
                     <ul class="buttons">
                         <li><a class="button transparent-btn" href="/engine/installation/" target="_blank">Get Docker</a></li>

--- a/_includes/treebuilder.html
+++ b/_includes/treebuilder.html
@@ -12,3 +12,8 @@
   {% endif %}
   <li id="{{ section.node }}"{{ activeCSS }}><a href="{{ section.path }}">{{ section.title }}</a></li>
 {% endfor %}
+{% if site.edge == true %}
+  <li id="stable-cta"><a href="/">Back to Stable docs</a></li>
+{% else %}
+  <li id="edge-cta"><a href="/edge/">Try the CE Edge docs</a></li>
+{% endif %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -82,9 +82,12 @@ else %}{% assign edit_url = "" %}{% endif %} {% break %} {% endif %} {% endfor %
 				<div class="col-body">
 					<main class="col-content {% if page.landing == true %}main-content{%else%}content{% endif %}">
 						<section class="section">
-							{% if page.title %}
+							{% if page.url == '/' %}
+							<h1>{{ site.name }}</h1>
+							{% else %}
+								{% if page.title %}
 							<h1>{{ page.title }}</h1>{% endif %} {% if page.advisory %}
-							<blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>{% endif %} {% unless page.tree == false %}{% include read_time.html %}{% endunless %}{{ content }}
+							<blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>{% endif %}{% endif %} {% unless page.tree == false %}{% include read_time.html %}{% endunless %}{{ content }}
               <script language="JavaScript">
 							var x = document.links.length;
 							var baseHref = document.getElementsByTagName('base')[0].href

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -58,6 +58,7 @@ specified, the container ID is used as the log stream.
 > at a time.  Using the same log stream for multiple containers concurrently
 > can cause reduced logging performance.
 
+{% if site.edge == true %}
 ### awslogs-create-group
 
 Log driver will return an error by default if the log group does not exist. However, you can set the
@@ -75,9 +76,11 @@ $ docker run --log-driver=awslogs \
 > **Note:**
 > Your AWS IAM policy must include the `logs:CreateLogGroup` permission before you attempt to use `awslogs-create-group`.
 
+{% endif %}
+
 ### tag
 
-Specify `tag` as an alternative to the `awslogs-stream` option. `tag` interprets template markup (e.g., `{% raw %}{{.ID}}{% endraw %}`, `{% raw %}{{.FullID}}{% endraw %}` or `{% raw %}{{.Name}}{% endraw %}` `{% raw %}docker.{{.ID}}{% endraw %}`). 
+Specify `tag` as an alternative to the `awslogs-stream` option. `tag` interprets template markup (e.g., `{% raw %}{{.ID}}{% endraw %}`, `{% raw %}{{.FullID}}{% endraw %}` or `{% raw %}{{.Name}}{% endraw %}` `{% raw %}docker.{{.ID}}{% endraw %}`).
 See the [tag option documentation](log_tags.md) for details on all supported template substitutions.
 
 When both `awslogs-stream` and `tag` are specified, the value supplied for `awslogs-stream` will override the template specified with `tag`.

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -123,12 +123,13 @@ This example starts an `alpine` container with the `none` log driver.
 $ docker run -it --log-driver none alpine ash
 ```
 
+{% if site.edge == true %}
 ### Options for all drivers
 | Option            | Description | Example value |
 |-------------------|-------------|---------------|
 | `mode`            | Sets the logging mode, accepted values are `blocking` (default), and `non-blocking`. When `non-blocking` is set, if the log buffer fills up, log messages will be lost. How messages are dropped is left undefined. | `--log-opt mode=non-blocking`
 | `max-buffer-size` | Applicable only when `mode` is set to `non-blocking`, this sets the maxmimum size of the log buffer. Once this size is reach, log messages will be dropped. | `--log-opt max-buffer-size 5m`
-
+{% endif %}
 
 ## `json-file`
 

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -9,9 +9,9 @@ redirect_from:
 title: Install Docker
 ---
 
-## Docker variants
+## Docker editions
 
-Docker is available in multiple variants:
+Docker is available in two editions:
 
 - **Docker Enterprise Edition (Docker EE)** is designed for enterprise
   development and IT teams who build, ship, and run business critical
@@ -29,10 +29,12 @@ Docker is available in multiple variants:
   share containers and automate the development pipeline all from a single
   environment.
 
-  Docker CE gives you the option to run **stable** or **edge** builds.
+  Docker CE has both **stable** and **edge** channels.
 
   - **Stable** builds are released once per quarter.
-  - **Edge** builds are released once per month.
+  - **Edge** builds are released once per month, except during the months that
+    Edge builds are released. If you subscribe to the Edge channel, you should
+    also subscribe to the Stable channel.
 
   For more information about Docker CE, see
   [Docker Community Edition](https://www.docker.com/community-edition/){: target="_blank" class="_" }.
@@ -56,17 +58,9 @@ Digital Ocean, Packet, SoftLink, or Bring Your Own Cloud.
 
 ## Time-based release schedule
 
-Starting with Docker 17.03, Docker uses semantic versioning and a time-based
-release schedule, outlined below. There may be times when exceptions need to be
-made, but this is the goal.
-
-- Ideally, a Docker CE release is published the first week of each month.
-  - In March, June, September, and December, the release will be published to the
-    **stable** channel.
-  - The rest of the time, this monthly release will be published to the **edge**
-    channel.
-- At the end of the month in March, June, September, and December, a Docker EE
-  release is published.
+Starting with Docker 17.03, Docker uses a time-based release schedule, outlined
+below. For Docker CE Edge users, if you want to receive each month's release,
+you need to subscribe to both the Edge and Stable channels.
 
 {% include docker_schedule_matrix.md %}
 

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -54,6 +54,22 @@ platform.
 See also [Docker Cloud](#on-docker-cloud) for setup instructions for
 Digital Ocean, Packet, SoftLink, or Bring Your Own Cloud.
 
+## Time-based release schedule
+
+Starting with Docker 17.03, Docker uses semantic versioning and a time-based
+release schedule, outlined below. There may be times when exceptions need to be
+made, but this is the goal.
+
+- Ideally, a Docker CE release is published the first week of each month.
+  - In March, June, September, and December, the release will be published to the
+    **stable** channel.
+  - The rest of the time, this monthly release will be published to the **edge**
+    channel.
+- At the end of the month in March, June, September, and December, a Docker EE
+  release is published.
+
+{% include docker_schedule_matrix.md %}
+
 ### Prior releases
 
 Instructions for installing prior releases of Docker can be found in the

--- a/engine/installation/index.md
+++ b/engine/installation/index.md
@@ -31,10 +31,11 @@ Docker is available in two editions:
 
   Docker CE has both **stable** and **edge** channels.
 
-  - **Stable** builds are released once per quarter.
-  - **Edge** builds are released once per month, except during the months that
-    Edge builds are released. If you subscribe to the Edge channel, you should
-    also subscribe to the Stable channel.
+  - **Stable** builds are released once per quarter and are supported for 4
+    months.
+  - **Edge** builds are released once per month, and are supported for that
+    month only. If you subscribe to the Edge channel on Linux distributions, you
+    should also subscribe to the Stable channel.
 
   For more information about Docker CE, see
   [Docker Community Edition](https://www.docker.com/community-edition/){: target="_blank" class="_" }.
@@ -59,8 +60,7 @@ Digital Ocean, Packet, SoftLink, or Bring Your Own Cloud.
 ## Time-based release schedule
 
 Starting with Docker 17.03, Docker uses a time-based release schedule, outlined
-below. For Docker CE Edge users, if you want to receive each month's release,
-you need to subscribe to both the Edge and Stable channels.
+below.
 
 {% include docker_schedule_matrix.md %}
 

--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -30,6 +30,9 @@ Raspbian versions:
 - Jessie 8.0 (LTS) / Raspbian Jessie
 - Wheezy 7.7 (LTS)
 
+Docker CE is supported on both `x86_64` and `armhf` architectures for Jessie and
+Stretch.
+
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. If these are
@@ -130,21 +133,33 @@ from the repository.
     To also add the **edge** repository, add `edge` after `stable` on the last
     line of the command.
 
+    **amd64**:
+
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=amd64] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```
+
+    **armhf**:
+
+    ```bash
+    $ sudo add-apt-repository \
+       "deb [arch=armhf] {{ download-url-base }} \
+       $(lsb_release -cs) \
+       stable"
+    ```
+
 4.  **Wheezy only**: The version of `add-apt-repository` on Wheezy adds a `deb-src`
     repository that does not exist. You need to comment out this repository or
     running `apt-get update` will fail. Edit `/etc/apt/sources.list`. Find the
     line like the following, and comment it out or remove it:
-    
+
     ```none
     deb-src [arch=amd64] https://download.docker.com/linux/debian wheezy stable
     ```
-    
+
     Save and exit the file.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
@@ -223,9 +238,9 @@ If you cannot use Docker's repository to install Docker CE, you can download the
 a new file each time you want to upgrade Docker.
 
 1.  Go to [{{ download-url-base }}/dists/]({{ download-url-base }}/dists/),
-    choose your Ubuntu version, browse to `stable/pool/stable/amd64/`, and
-    download the `.deb` file for the Docker version you want to install and for
-    your version of Debian.
+    choose your Debian version, browse to `stable/pool/stable/`, choose either
+    `amd64` or `armhf`,and download the `.deb` file for the Docker version you
+    want to install and for your version of Debian.
 
     > **Note**: To install an **edge**  package, change the word
     > `stable` in the  URL to `edge`.

--- a/engine/installation/linux/oracle.md
+++ b/engine/installation/linux/oracle.md
@@ -32,11 +32,12 @@ Docker Community Edition (Docker CE) is not supported on Oracle Linux.
 
 ### OS requirements
 
-To install Docker, you need the 64-bit version of Oracle Linux 7 running the
-Unbreakable Enterprise Kernel Release 4 (4.1.12) or higher.
+To install Docker EE, you need the 64-bit version of Oracle Linux 7.3 running the
+Red Hat Compatible kernel (RHCK) 3.10.0-514 or higher. Older versions of Oracle
+Linux are not supported.
 
-The [OverlayFS2 storage driver](https://docs.docker.com/engine/userguide/storagedriver/overlayfs-driver/) is only supported
-when running the UEK4.
+The `device-mapper` graph driver is supported. OverlayFS and Brtfs are
+**not** supported.
 
 ### Uninstall old versions
 
@@ -234,13 +235,6 @@ instead of `yum -y install`, and pointing to the new file.
     ```bash
     $ sudo rm -rf /var/lib/docker
     ```
-
-    > **Note**: If you are using the `btrfs` graph driver, you will need to manually
-    > remove any subvolumes that were created by the Docker Engine before removing the
-    > rest of the data.
-    > Review the [Oracle Linux 7 Administrator Guide](http://docs.oracle.com/cd/E52668_01/E54669/html/ol7-use-case3-btrfs.html)
-    > for more information on how to remove btrfs subvolumes or see the output of
-    > `man btrfs-subvolume` for information on removing `btrfs` subvolumes.
 
 You must delete any edited configuration files manually.
 

--- a/engine/installation/linux/ubuntu.md
+++ b/engine/installation/linux/ubuntu.md
@@ -41,6 +41,8 @@ To install Docker, you need the 64-bit version of one of these Ubuntu versions:
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
+Docker CE is supported on both `x86_64` and `armhf` architectures.
+
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. If these are
@@ -110,7 +112,6 @@ The procedure for setting up the repository is different for [Docker CE](#docker
 
 2.  Add Docker's official GPG key:
 
-
     ```bash
     $ curl -fsSL {{ download-url-base}}/gpg | sudo apt-key add -
     ```
@@ -138,12 +139,20 @@ The procedure for setting up the repository is different for [Docker CE](#docker
     > example: If you are using `Linux Mint Rafaela`, you could use
     > `trusty`.
 
-    To also add the **edge** repository, add `edge` after `stable` on the last
-    line of the command.
+    **amd64**:
 
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=amd64] {{ download-url-base }} \
+       $(lsb_release -cs) \
+       stable"
+    ```
+
+    **armhf**:
+
+    ```bash
+    $ sudo add-apt-repository \
+       "deb [arch=armhf] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```
@@ -275,17 +284,18 @@ a new file each time you want to upgrade Docker.
 
     - **Docker CE**: Go to
       [{{ download-url-base }}/dists/]({{ download-url-base }}/dists/), choose your
-      Ubuntu version, browse to `stable/pool/stable/amd64/`, and download the
-      `.deb` file for the Docker version you want to install and for your
-      version of Ubuntu.
+      Ubuntu version, browse to `stable/pool/stable/`, choose either `amd64` or
+      `armhf`,and download the `.deb` file for the Docker version you want to
+      install and for your version of Ubuntu.
 
       > **Note**: To install an **edge**  package, change the word
       > `stable` in the  URL to `edge`.
       > [Learn about **stable** and **edge** channels](/engine/installation/).
 
     - **Docker EE**: Go to the Docker EE repository URL associated with your
-      trial or subscription in your browser. Go to `x86_64/stable-{{ minor-version }}` and download
-      the `.deb` file for the Docker version you want to install.
+      trial or subscription in your browser. Go to
+      `x86_64/stable-{{ minor-version }}` and download the `.deb` file for the
+      Docker version you want to install.
 
 2.  Install Docker, changing the path below to the path where you downloaded
     the Docker package.

--- a/engine/reference/commandline/attach.md
+++ b/engine/reference/commandline/attach.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/build.md
+++ b/engine/reference/commandline/build.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/checkpoint.md
+++ b/engine/reference/commandline/checkpoint.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/checkpoint_create.md
+++ b/engine/reference/commandline/checkpoint_create.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/checkpoint_ls.md
+++ b/engine/reference/commandline/checkpoint_ls.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/checkpoint_rm.md
+++ b/engine/reference/commandline/checkpoint_rm.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/commit.md
+++ b/engine/reference/commandline/commit.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container.md
+++ b/engine/reference/commandline/container.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_attach.md
+++ b/engine/reference/commandline/container_attach.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_commit.md
+++ b/engine/reference/commandline/container_commit.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_cp.md
+++ b/engine/reference/commandline/container_cp.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_create.md
+++ b/engine/reference/commandline/container_create.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_diff.md
+++ b/engine/reference/commandline/container_diff.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_exec.md
+++ b/engine/reference/commandline/container_exec.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_export.md
+++ b/engine/reference/commandline/container_export.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_inspect.md
+++ b/engine/reference/commandline/container_inspect.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_kill.md
+++ b/engine/reference/commandline/container_kill.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_logs.md
+++ b/engine/reference/commandline/container_logs.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_ls.md
+++ b/engine/reference/commandline/container_ls.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_pause.md
+++ b/engine/reference/commandline/container_pause.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_port.md
+++ b/engine/reference/commandline/container_port.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_prune.md
+++ b/engine/reference/commandline/container_prune.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_rename.md
+++ b/engine/reference/commandline/container_rename.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_restart.md
+++ b/engine/reference/commandline/container_restart.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_rm.md
+++ b/engine/reference/commandline/container_rm.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_run.md
+++ b/engine/reference/commandline/container_run.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_start.md
+++ b/engine/reference/commandline/container_start.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_stats.md
+++ b/engine/reference/commandline/container_stats.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_stop.md
+++ b/engine/reference/commandline/container_stop.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_top.md
+++ b/engine/reference/commandline/container_top.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_unpause.md
+++ b/engine/reference/commandline/container_unpause.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_update.md
+++ b/engine/reference/commandline/container_update.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/container_wait.md
+++ b/engine/reference/commandline/container_wait.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/cp.md
+++ b/engine/reference/commandline/cp.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/create.md
+++ b/engine/reference/commandline/create.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/deploy.md
+++ b/engine/reference/commandline/deploy.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/diff.md
+++ b/engine/reference/commandline/diff.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/docker.md
+++ b/engine/reference/commandline/docker.md
@@ -14,4 +14,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/dockerd.md
+++ b/engine/reference/commandline/dockerd.md
@@ -18,4 +18,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/events.md
+++ b/engine/reference/commandline/events.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/exec.md
+++ b/engine/reference/commandline/exec.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/export.md
+++ b/engine/reference/commandline/export.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/history.md
+++ b/engine/reference/commandline/history.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image.md
+++ b/engine/reference/commandline/image.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_build.md
+++ b/engine/reference/commandline/image_build.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_history.md
+++ b/engine/reference/commandline/image_history.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_import.md
+++ b/engine/reference/commandline/image_import.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_inspect.md
+++ b/engine/reference/commandline/image_inspect.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_load.md
+++ b/engine/reference/commandline/image_load.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_ls.md
+++ b/engine/reference/commandline/image_ls.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_prune.md
+++ b/engine/reference/commandline/image_prune.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_pull.md
+++ b/engine/reference/commandline/image_pull.md
@@ -12,5 +12,11 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}
 

--- a/engine/reference/commandline/image_push.md
+++ b/engine/reference/commandline/image_push.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_rm.md
+++ b/engine/reference/commandline/image_rm.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_save.md
+++ b/engine/reference/commandline/image_save.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/image_tag.md
+++ b/engine/reference/commandline/image_tag.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/images.md
+++ b/engine/reference/commandline/images.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/import.md
+++ b/engine/reference/commandline/import.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/info.md
+++ b/engine/reference/commandline/info.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/inspect.md
+++ b/engine/reference/commandline/inspect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/kill.md
+++ b/engine/reference/commandline/kill.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/load.md
+++ b/engine/reference/commandline/load.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/login.md
+++ b/engine/reference/commandline/login.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/logout.md
+++ b/engine/reference/commandline/logout.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/logs.md
+++ b/engine/reference/commandline/logs.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network.md
+++ b/engine/reference/commandline/network.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network_connect.md
+++ b/engine/reference/commandline/network_connect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network_create.md
+++ b/engine/reference/commandline/network_create.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network_disconnect.md
+++ b/engine/reference/commandline/network_disconnect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network_inspect.md
+++ b/engine/reference/commandline/network_inspect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network_ls.md
+++ b/engine/reference/commandline/network_ls.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network_prune.md
+++ b/engine/reference/commandline/network_prune.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/network_rm.md
+++ b/engine/reference/commandline/network_rm.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node.md
+++ b/engine/reference/commandline/node.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node_demote.md
+++ b/engine/reference/commandline/node_demote.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node_inspect.md
+++ b/engine/reference/commandline/node_inspect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node_ls.md
+++ b/engine/reference/commandline/node_ls.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node_promote.md
+++ b/engine/reference/commandline/node_promote.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node_ps.md
+++ b/engine/reference/commandline/node_ps.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node_rm.md
+++ b/engine/reference/commandline/node_rm.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/node_update.md
+++ b/engine/reference/commandline/node_update.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/pause.md
+++ b/engine/reference/commandline/pause.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin.md
+++ b/engine/reference/commandline/plugin.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_create.md
+++ b/engine/reference/commandline/plugin_create.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_disable.md
+++ b/engine/reference/commandline/plugin_disable.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_enable.md
+++ b/engine/reference/commandline/plugin_enable.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_inspect.md
+++ b/engine/reference/commandline/plugin_inspect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_install.md
+++ b/engine/reference/commandline/plugin_install.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_ls.md
+++ b/engine/reference/commandline/plugin_ls.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_push.md
+++ b/engine/reference/commandline/plugin_push.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_rm.md
+++ b/engine/reference/commandline/plugin_rm.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_set.md
+++ b/engine/reference/commandline/plugin_set.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/plugin_upgrade.md
+++ b/engine/reference/commandline/plugin_upgrade.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/port.md
+++ b/engine/reference/commandline/port.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/ps.md
+++ b/engine/reference/commandline/ps.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/pull.md
+++ b/engine/reference/commandline/pull.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/push.md
+++ b/engine/reference/commandline/push.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/rename.md
+++ b/engine/reference/commandline/rename.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/restart.md
+++ b/engine/reference/commandline/restart.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/rm.md
+++ b/engine/reference/commandline/rm.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/rmi.md
+++ b/engine/reference/commandline/rmi.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/run.md
+++ b/engine/reference/commandline/run.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/save.md
+++ b/engine/reference/commandline/save.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/search.md
+++ b/engine/reference/commandline/search.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/secret.md
+++ b/engine/reference/commandline/secret.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/secret_create.md
+++ b/engine/reference/commandline/secret_create.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/secret_inspect.md
+++ b/engine/reference/commandline/secret_inspect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/secret_ls.md
+++ b/engine/reference/commandline/secret_ls.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/secret_rm.md
+++ b/engine/reference/commandline/secret_rm.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service.md
+++ b/engine/reference/commandline/service.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_create.md
+++ b/engine/reference/commandline/service_create.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_inspect.md
+++ b/engine/reference/commandline/service_inspect.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_logs.md
+++ b/engine/reference/commandline/service_logs.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_ls.md
+++ b/engine/reference/commandline/service_ls.md
@@ -10,4 +10,10 @@ here, you'll need to find the string by searching this repo:
 
 https://www.github.com/docker/docker
 -->
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_ps.md
+++ b/engine/reference/commandline/service_ps.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_rm.md
+++ b/engine/reference/commandline/service_rm.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_scale.md
+++ b/engine/reference/commandline/service_scale.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/service_update.md
+++ b/engine/reference/commandline/service_update.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stack.md
+++ b/engine/reference/commandline/stack.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stack_deploy.md
+++ b/engine/reference/commandline/stack_deploy.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stack_ls.md
+++ b/engine/reference/commandline/stack_ls.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stack_ps.md
+++ b/engine/reference/commandline/stack_ps.md
@@ -14,4 +14,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stack_rm.md
+++ b/engine/reference/commandline/stack_rm.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stack_services.md
+++ b/engine/reference/commandline/stack_services.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/start.md
+++ b/engine/reference/commandline/start.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stats.md
+++ b/engine/reference/commandline/stats.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/stop.md
+++ b/engine/reference/commandline/stop.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm.md
+++ b/engine/reference/commandline/swarm.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm_init.md
+++ b/engine/reference/commandline/swarm_init.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm_join-token.md
+++ b/engine/reference/commandline/swarm_join-token.md
@@ -14,4 +14,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm_join.md
+++ b/engine/reference/commandline/swarm_join.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm_leave.md
+++ b/engine/reference/commandline/swarm_leave.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm_unlock-key.md
+++ b/engine/reference/commandline/swarm_unlock-key.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm_unlock.md
+++ b/engine/reference/commandline/swarm_unlock.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/swarm_update.md
+++ b/engine/reference/commandline/swarm_update.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/system.md
+++ b/engine/reference/commandline/system.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/system_df.md
+++ b/engine/reference/commandline/system_df.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/system_events.md
+++ b/engine/reference/commandline/system_events.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/system_info.md
+++ b/engine/reference/commandline/system_info.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/system_prune.md
+++ b/engine/reference/commandline/system_prune.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/tag.md
+++ b/engine/reference/commandline/tag.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/top.md
+++ b/engine/reference/commandline/top.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/unpause.md
+++ b/engine/reference/commandline/unpause.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/update.md
+++ b/engine/reference/commandline/update.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/version.md
+++ b/engine/reference/commandline/version.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/volume.md
+++ b/engine/reference/commandline/volume.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/volume_create.md
+++ b/engine/reference/commandline/volume_create.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/volume_inspect.md
+++ b/engine/reference/commandline/volume_inspect.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/volume_ls.md
+++ b/engine/reference/commandline/volume_ls.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/volume_prune.md
+++ b/engine/reference/commandline/volume_prune.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/volume_rm.md
+++ b/engine/reference/commandline/volume_rm.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/wait.md
+++ b/engine/reference/commandline/wait.md
@@ -12,4 +12,10 @@ here, you'll need to find the string by searching this repo:
 https://www.github.com/docker/docker
 -->
 
-{% include cli.md %}
+{% if site.edge == true %}
+  {% assign datafolder = "engine-cli-edge" %}
+{% else %}
+  {% assign datafolder = page.datafolder %}
+{% endif %}
+
+{% include cli.md datafolder=datafolder datafile=page.datafile %}

--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -255,6 +255,7 @@ If the swarm manager cannot resolve the image to a digest, all is not lost:
   - If this fails, the task fails to deploy and the manager tries again to deploy
     the task, possibly on a different worker node.
 
+{% if site.edge == true %}
 ### Control service scale and placement
 
 Swarm mode has two types of services, replicated and global. For replicated
@@ -301,6 +302,8 @@ additional placement preferences to further divide tasks over groups of nodes.
 For example, you can balance them over multiple racks within each datacenter.
 For more information on constraints, refer to the `docker service create`
 [CLI reference](/engine/reference/commandline/service_create.md).
+
+{% endif %}
 
 ### Reserving memory or number of CPUs for a service
 
@@ -571,7 +574,8 @@ $ docker service create \
 > with single quotes (`'`).
 >
 > For example, the `local` driver accepts mount options as a comma-separated
-> list in the `o` parameter. This example shows the correctly to escape the list.
+> list in the `o` parameter. This example shows the correcty to escape the list.
+>
 >     $ docker service create \
 >          --mount 'type=volume,src=<VOLUME-NAME>,dst=<CONTAINER-PATH>,volume-driver=local,volume-opt=type=nfs,volume-opt=device=<nfs-server>:<nfs-path>,"volume-opt=o=addr=<nfs-address>,vers=4,soft,timeo=180,bg,tcp,rw"'
 >         --name myservice \

--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -162,10 +162,10 @@ distributions. This includes RHEL and most of its forks. Currently, the
 following distributions support the driver:
 
 * RHEL/CentOS/Fedora
+* Oracle Linux
 * Ubuntu 12.04
 * Ubuntu 14.04
 * Debian
-* Arch Linux
 
 Docker hosts running the `devicemapper` storage driver default to a
 configuration mode known as `loop-lvm`. This mode uses sparse files to build
@@ -224,7 +224,7 @@ assumes that the Docker daemon is in the `stopped` state.
 
     The `thin-provisioning-tools` package allows you to activate and manage your
     pool.
-    
+
     ```bash
     $ sudo yum install -y lvm2
     ```

--- a/index.md
+++ b/index.md
@@ -18,11 +18,12 @@ your system configuration, and making your app more portable.
 The Docker CE Edge channel provides monthly releases which allow you to try
 new features of Docker and verify bug fixes quickly. Edge releases are only
 supported for one month, and a given Edge release will not receive any updates
-after this period.
+once a new edge release is available.
 
-Stable releases are not published to the Edge channel, so you still need to
-subscribe to the Stable channel as well. Commercial support is not available for
-Docker CE.
+Stable releases are not published to the Edge channel, so Linux repository users
+still need to subscribe to the Stable channel as well.
+
+Commercial support is not available for Docker CE.
 
 For information about all Docker release channels and expectations about
 support, see [Docker channels](/engine/installation/#docker-channels).

--- a/index.md
+++ b/index.md
@@ -9,6 +9,189 @@ notoc: true
 Docker packages your app with its dependencies, freeing you from worrying about
 your system configuration, and making your app more portable.
 
+{% if site.edge == true %}
+## Docker CE Edge
+
+The Docker CE Edge channel provides monthly releases which allow you to try
+new features of Docker and verify bug fixes quickly. Edge releases are only
+supported for one month, including security updates and high priority bug fixes
+only. When a new release becomes available in the Docker CE Edge channel,
+previous releases stop receiving updates. Commercial support is not available
+for Docker CE.
+
+For information about all Docker release channels and expectations about
+support, see [Docker channels](/engine/installation/#docker-channels)
+
+This page lists features that are only available in Docker CE Edge releases.
+Where applicable, the API and CLI reference documentation has been updated to
+reflect these features, but **full documentation for a given feature may not be
+available until a Docker CE Stable release incorporates the feature**.
+
+### Docker CE Edge new features
+
+<ul class="nav nav-tabs">
+  <li class="active"><a data-toggle="tab" data-target="#1704">17.04</a></li>
+  <!--<li><a data-toggle="tab" data-target="#1705">17.05</a></li>-->
+</ul>
+<div class="tab-content">
+<div id="1704" class="tab-pane fade in active">
+
+{% capture release-notes %}
+#### Docker CE Edge 17.04
+
+The following major features and changes are included in Docker CE Edge 17.04.
+Continue reading, or go straight to [API and CLI](#api-and-cli),
+[Daemon](#daemon), [Dockerfile](#dockerfile), [Services](#services), or
+[Stacks](#stacks).
+
+##### API and CLI
+
+- Add `--device-cgroup-rule` flag to give containers access to devices that appear
+  after the container is started. {% include github-pr.md pr=22563 %}
+
+- Allow swarm nodes to join with `--availability=drain` to prevent them from
+  taking non-manager workloads. {% include github-pr.md pr=24993 %}
+
+- Add `publish` and `expose` filters to `docker ps`, so that containers can be
+  filtered by port or port range for TCP or UDP protocols {% include github-pr.md pr=27557 %}
+
+- Add `--no-trunc` and `--format` flags to the `docker service ls` command, and
+  as well as the ability to specify the default format for `docker service ls`
+  using the `ServicesFormat` option to the Docker CLI. Also add a
+  `docker stack services` command. {% include github-pr.md pr=28199 %}
+
+- Add ability to filter plugins by whether they are enabled or disabled in
+  `docker plugin ls` output. {% include github-pr.md pr=28627 %}
+
+- Add `mode` option to `--log-opts` flag for both `docker` and `dockerd`. If set
+  to `non-blocking`, and the log buffer fills up, log messages will be lost, but
+  the container will not block. The `max-buffer-size` option controls the
+  maximum size of the ring buffer. Defaults to `blocking`, which will cause the
+  container to block if messages cannot be logged. See
+  [Options for all drivers](/engine/admin/logging/overview.md#options-for-all-drivers).
+  {% include github-pr.md pr=28762 %}
+
+- It is no longer possible to inadvertently pull images on an architecture where
+  they will not run. {% include github-pr.md pr=29001 %}
+
+- It is now possible to create AWS log groups when using the AWS logging driver.
+  See [`awslogs-create-group`](engine/admin/logging/awslogs.md#awslogs-create-group).
+  {% include github-pr.md pr=29504 %}
+
+- Add the ability to filter `docker network ls` output by creation time, using
+  the `{% raw %}{{CreatedAt}}{% endraw %}` format specifier.
+  {% include github-pr.md pr=29900 %}
+
+- Named but untagged images are now removed if you run `docker image prune` if
+  `--dangling-only` is set to `true`. {% include github-pr.md pr=30330 %}
+
+- Add `--add-host` flag to `docker build`, which will add entries to the
+  `/etc/hosts` file of a container created from that image. The `/etc/hosts`
+  file is not saved within the image itself. {% include github-pr.md pr=30383 %}
+
+- Prevent `docker network ls` from pulling all the endpoints, to reduce
+  impact on the network. {% include github-pr.md pr=30673 %}
+
+- Windows-specific commands and options no longer show in command help text on
+  non-Windows clients. {% include github-pr.md pr=30780 %}
+
+- When you specify an IP address when running `docker network connect`, the
+  IP address is now checked for validity. {% include github-pr.md pr=30807 %}
+
+- Add the ability to customize bind-mount consistency to be more appropriate
+  for some platforms and workloads. Options are `consistent` (the default),
+  `cached`, or `delegated`. {% include github-pr.md pr=31047 %}
+
+##### Daemon
+
+- Docker Daemon logging settings no longer affect the `docker build` command.
+  {% include github-pr.md pr=29552 %}
+
+- Add a `registry-mirrors` configuration option for the Docker daemon, which
+  replaces the daemon's registry mirrors with a new set of registry mirrors.
+  {% include github-pr.md pr=29650 %}
+
+- Add the ability to specify the default shared memory size for the Docker
+  daemon, using the `--default-shm-size` or the `default-shm-size` key in
+  `daemon.json`. {% include github-pr.md pr=29692 %}
+
+- Add a `no-new-privileges` configuration option for the Docker daemon, which
+  prevents unprivileged containers from gaining new privileges.
+  {% include github-pr.md pr=29984 %}
+
+- If a Docker client communicates with an older daemon and attempts to perform
+  an operation not supported by the daemon, an error is printed, which shows
+  the API versions of both the client and daemon.
+  {% include github-pr.md pr=30187 %}
+
+- The Docker daemon no longer depends upon `sqlite`. This change means that it
+  is not possible to upgrade the Docker daemon from version 1.9 directly to the
+  latest version. It is recommended to upgrade from one major version to the
+  next, in sequence. {% include github-pr.md pr=30208 %}  
+
+##### Dockerfile
+
+- Using the pattern `**/` in a Dockerfile now (correctly) behaves the same as
+  `**`. {% include github-pr.md pr=29043 %}
+
+- Time values less than 1 second are no longer allowed in health-check options
+  in the Dockerfile. {% include github-pr.md pr=31177 %}
+
+##### Services
+
+- When a service is updated with both `--secret-add` and `--secret-rm` in the
+  same operation, the order of operations is now changed so that the
+  `--secret-rm` always occurs first. {% include github-pr.md pr=29802 %}
+
+- Add the ability to create or update a service to be read-only using the
+  `--read-only` flag. {% include github-pr.md pr=30162 %}
+
+- Docker now updates swarm nodes if the swarm configuration is updated.
+  {% include github-pr.md pr=30259 %}
+
+- Add topology-aware placement preferences for Swarm services. This feature
+  allows services to be balanced over nodes based on a particular user-defined
+  property, such as which datacenter or rack they are located in.
+  See [Control service scale and placement](/engine/swarm/services.md#control-service-scale-and-placement).
+  {% include github-pr.md pr=30725 %}
+
+- Add the ability to customize the stop signal which will be sent to nodes, when
+  creating or updating a service. {% include github-pr.md pr=30754 %}
+
+- Add the ability to address a secret by name or prefix, as well as ID, when
+  updating it. {% include github-pr.md pr=30856 %}
+
+- Add the ability to roll back to a previous version of a service if an
+  updated service fails to deploy. Several flags are available at service
+  creation or update,to control the rollback action, failure threshold,
+  monitoring delay, rollback delay, and parallelism.
+  {% include github-pr.md pr=31108 %}
+
+- Add the ability to specify the stream when using the Docker service logs API.
+  {% include github-pr.md pr=31313 %}
+
+- Add `--tail` and `--since` flags to `docker service logs` command, to filter
+  the logs by time or to show the tail of the logs and show new content as it
+  is logged. {% include github-pr.md pr=31500 %}
+
+- Add a `--verbose` flag to the `docker inspect` command. For swarm networks,
+  this flag shows all nodes and services attached to the network.
+  {% include github-pr.md pr=31710 %}
+
+##### Stacks
+
+- Compose file version 3.2 is now supported. This includes support for different
+  types of endpoints and expands the options you can use when specifying mounts.
+  {% include github-pr.md pr=31795 %}
+
+{% endcapture %}
+{{ release-notes | markdownify }}
+</div>
+<!--<div id="1705" class="tab-pane fade">TAB 2 CONTENT</div>-->
+</div>
+
+{% endif %}
+
 <div class="row">
 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 block">
 {% capture basics %}

--- a/index.md
+++ b/index.md
@@ -5,22 +5,32 @@ landing: true
 title: Docker Documentation
 notoc: true
 ---
+{% assign page.title = site.name %}
 
 Docker packages your app with its dependencies, freeing you from worrying about
 your system configuration, and making your app more portable.
 
 {% if site.edge == true %}
+{% capture ce-edge-section %}
+
 ## Docker CE Edge
 
 The Docker CE Edge channel provides monthly releases which allow you to try
 new features of Docker and verify bug fixes quickly. Edge releases are only
-supported for one month, including security updates and high priority bug fixes
-only. When a new release becomes available in the Docker CE Edge channel,
-previous releases stop receiving updates. Commercial support is not available
-for Docker CE.
+supported for one month, and a given Edge release will not receive any updates
+after this period.
+
+Stable releases are not published to the Edge channel, so you still need to
+subscribe to the Stable channel as well. Commercial support is not available for
+Docker CE.
 
 For information about all Docker release channels and expectations about
-support, see [Docker channels](/engine/installation/#docker-channels)
+support, see [Docker channels](/engine/installation/#docker-channels).
+
+<!-- This button toggles the div below, and hides itself when clicked -->
+<a id="ce-edge-readmore-btn" onclick="$(this).hide(); ga('send', 'event', 'ce-edge-readmore', 'click', 'CE engagement');" data-target="#ce-edge-readmore" data-toggle="collapse" class="button outline-btn collapse in">Read more about Docker CE Edge releases</a>
+
+<div markdown="1" id="ce-edge-readmore" class="collapse" data-target="#ce-edge-readmore-btn" data-toggle="collapse">
 
 This page lists features that are only available in Docker CE Edge releases.
 Where applicable, the API and CLI reference documentation has been updated to
@@ -33,16 +43,17 @@ available until a Docker CE Stable release incorporates the feature**.
   <li class="active"><a data-toggle="tab" data-target="#1704">17.04</a></li>
   <!--<li><a data-toggle="tab" data-target="#1705">17.05</a></li>-->
 </ul>
-<div class="tab-content">
-<div id="1704" class="tab-pane fade in active">
+<div markdown="1" class="tab-content">
+<div markdown="1" id="1704" class="tab-pane fade in active">
 
-{% capture release-notes %}
 #### Docker CE Edge 17.04
 
 The following major features and changes are included in Docker CE Edge 17.04.
 Continue reading, or go straight to [API and CLI](#api-and-cli),
 [Daemon](#daemon), [Dockerfile](#dockerfile), [Services](#services), or
 [Stacks](#stacks).
+
+[Read the full release notes](https://github.com/docker/docker/releases/tag/v17.04.0-ce){: target="_blank" class="_" }
 
 ##### API and CLI
 
@@ -184,35 +195,33 @@ Continue reading, or go straight to [API and CLI](#api-and-cli),
   types of endpoints and expands the options you can use when specifying mounts.
   {% include github-pr.md pr=31795 %}
 
-{% endcapture %}
-{{ release-notes | markdownify }}
-</div>
+</div> <!-- 17.04 -->
 <!--<div id="1705" class="tab-pane fade">TAB 2 CONTENT</div>-->
-</div>
-
+</div> <!-- tab-content -->
+</div> <!-- ce-edge-readmore -->
+{% endcapture %} <!-- from line 13 -->
+{{ ce-edge-section | markdownify }}
 {% endif %}
 
 <div class="row">
-<div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 block">
-{% capture basics %}
+<div markdown="1" class="col-xs-12 col-sm-12 col-md-12 col-lg-6 block">
 ### Learn Docker basics
 
 Get started learning Docker concepts, tools, and commands. The examples show you
 how to build, push, and pull Docker images, and run them as containers. This
 tutorial stops short of teaching you how to deploy applications.
-{% endcapture %}{{ basics | markdownify }}
-{% capture basics %}[Start the basic tutorial](/engine/getstarted/){: class="button outline-btn"}{% endcapture %}{{ basics | markdownify }}
+
+[Start the basic tutorial](/engine/getstarted/){: class="button outline-btn"}
 </div>
 
-<div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 block">
-{% capture apps %}
+<div markdown="1" class="col-xs-12 col-sm-12 col-md-12 col-lg-6 block">
 ### Define and deploy apps in Swarm Mode
 
 Learn how to relate containers to each other, define them as services, and
 configure an application stack ready to deploy at scale in a production
 environment. Highlights Compose Version 3 new features and swarm mode.
-{% endcapture %}{{ apps | markdownify }}
-{% capture apps %}[Start the application tutorial](/engine/getstarted-voting-app/){: class="button outline-btn"}{% endcapture %}{{ apps | markdownify }}
+
+[Start the application tutorial](/engine/getstarted-voting-app/){: class="button outline-btn"}
 </div>
 </div>
 


### PR DESCRIPTION
Basic idea is to have some very lightweight docs (these) for features currently in only Edge releases, as well as setting the expectations for those features and their docs. 

I think maybe it is worthwhile organizing the list of release notes by "component", like daemon, client, swarm, etc. This is a first pass. I used the following queries to get here:

Impacts API (17): https://github.com/docker/docker/pulls?utf8=%E2%9C%93&q=is%3Apr%20milestone%3A17.04.0%20is%3Aclosed%20is%3Amerged%20%20label%3A%22impact%2Fapi%22%20

Impacts CLI (26): https://github.com/docker/docker/pulls?q=is%3Apr+milestone%3A17.04.0+is%3Aclosed+is%3Amerged+label%3Aimpact%2Fcli

Impacts Dockerfile (1): https://github.com/docker/docker/pulls?q=is%3Apr+milestone%3A17.04.0+is%3Aclosed+is%3Amerged+label%3Aimpact%2Fdockerfile

Impacts documentation (8): https://github.com/docker/docker/pulls?q=is%3Apr+milestone%3A17.04.0+is%3Aclosed+is%3Amerged+label%3Aimpact%2Fdocumentation 

Impacts changelog (59): https://github.com/docker/docker/pulls?utf8=%E2%9C%93&q=is%3Apr%20milestone%3A17.04.0%20is%3Aclosed%20is%3Amerged%20%20label%3A%22impact%2Fchangelog%22%20
