### PR TITLE
Fixes typo of "captains" in footer menu

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -73,7 +73,7 @@
                         <li><a href="https://www.docker.com/technologies/overview">Open Source</a></li>
                         <li><a href="https://www.docker.com/community/events">Events</a></li>
                         <li><a href="https://forums.docker.com/" target="_blank">Forums</a></li>
-                        <li><a href="https://www.docker.com/community/docker-captains">Docker Captians</a></li>
+                        <li><a href="https://www.docker.com/community/docker-captains">Docker Captains</a></li>
                         <li><a href="https://www.docker.com/docker-community/scholarships">Scholarships</a></li>
                         <li><a href="https://blog.docker.com/curated/">Community News</a></li>
                     </ul>


### PR DESCRIPTION
Fixes a small spelling error in the footing menu from "captians" to "captains"