### PR TITLE
UCP upgrade offline for 2.1

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1172,6 +1172,8 @@ manuals:
           title: Install offline
         - path: /datacenter/ucp/2.1/guides/admin/upgrade/
           title: Upgrade
+        - path: /datacenter/ucp/2.1/guides/admin/upgrade-offline/
+          title: Upgrade offline
         - path: /datacenter/ucp/2.1/guides/admin/install/uninstall/
           title: Uninstall
       - sectiontitle: Configure

--- a/datacenter/ucp/2.1/guides/admin/upgrade-offline.md
+++ b/datacenter/ucp/2.1/guides/admin/upgrade-offline.md
@@ -1,0 +1,60 @@
+---
+description: Learn how to upgrade Docker Universal Control Plane. on a machine with
+  no internet access.
+keywords: docker, ucp, upgrade, offline
+title: Upgrade UCP offline
+---
+
+Upgrading Universal Control Plane is the same, whether your hosts have access to
+the internet or not.
+
+The only difference when upgrading on an offline host,
+is that instead of pulling the UCP images from Docker Store, you use a
+computer that is connected to the internet to download a single package with
+all the images. Then you copy that package to the host where you’ll upgrade UCP.
+
+## Versions available
+
+{% include components/ddc_url_list.html %}
+
+## Download the offline package
+
+Use a computer with internet access to download a single package with all
+UCP components:
+
+```bash
+$ wget <package-url> -O docker-datacenter.tar.gz
+```
+
+Now that you have the package in your local machine, you can transfer it to
+the machines where you want to upgrade UCP.
+
+For each machine that you want to manage with UCP:
+
+1.  Copy the offline package package to that machine.
+
+    ```bash
+    $ scp docker-datacenter.tar.gz <user>@<host>:/tmp
+    ```
+
+2.  Use ssh to login into the hosts where you transferred the package.
+
+3.  Load the UCP images.
+
+    Once the package is transferred to the hosts, you can use the
+    `docker load` command, to load the Docker images from the tar archive:
+
+    ```bash
+    $ docker load < docker-datacenter.tar.gz
+    ```
+
+## Upgrade UCP
+
+Now that the offline hosts have all the images needed to upgrade UCP,
+you can [upgrade Docker UCP](index.md).
+
+
+## Where to go next
+
+* [Upgrade UCP](index.md)
+* [Release Notes](release-notes.md)


### PR DESCRIPTION
Adjust the upgrade section so it is no longer a subsection of install
Display the bundle link and it only shows UCP images

* Closes #1835 as duplicate
* Fixes #1576
* Fixes #1628