### PR TITLE
Fix Windows container reference

### DIFF
--- a/engine/admin/live-restore.md
+++ b/engine/admin/live-restore.md
@@ -11,7 +11,7 @@ option helps reduce container downtime due to daemon crashes, planned outages,
 or upgrades.
 
 > **Note**: Live restore is not supported on Windows containers, but it does work
-for Linux containers running on Windows.
+for Linux containers running on Docker for Windows.
 
 ## Enable the live restore option
 


### PR DESCRIPTION
### Proposed changes

Clarified the sentence on running Linux containers on Windows. You can't do that, but you can run Linux containers with *Docker for Windows*, which spins up a Moby VM for Linux containers.
