### PR TITLE
updated installer links, release date for latest edge

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -52,7 +52,7 @@ channels, see the [FAQs](/docker-for-mac/faqs.md#stable-and-edge-channels).
   <a class="button outline-btn" href="https://download.docker.com/mac/stable/Docker.dmg">Get Docker for Mac (Stable)</a>
   </td>
   <td width="50%">
-  <a class="button outline-btn" href="https://download.docker.com/mac/beta/Docker.dmg">Get Docker for Mac (Edge)</a>
+  <a class="button outline-btn" href="https://download.docker.com/mac/edge/Docker.dmg">Get Docker for Mac (Edge)</a>
   </td>
   </tr>
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -335,7 +335,7 @@ events or unexpected unmounts.
 
 ## Edge Release Notes
 
-### Docker Community Edition 17.03.1-ce-mac3, 2017-03-21 (edge)
+### Docker Community Edition 17.03.1-ce-mac3, 2017-03-22 (edge)
 
 **Upgrades**
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -57,7 +57,7 @@ Edge channels, see the
   <a class="button outline-btn" href="https://download.docker.com/win/stable/InstallDocker.msi">Get Docker for Windows (Stable)</a>
   </td>
   <td width="50%">
-  <a class="button outline-btn" href="https://download.docker.com/win/beta/InstallDocker.msi">Get Docker for Windows (Edge)</a>
+  <a class="button outline-btn" href="https://download.docker.com/win/edge/InstallDocker.msi">Get Docker for Windows (Edge)</a>
   </td>
   </tr>
 </table>

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -303,7 +303,7 @@ We did not distribute a 1.12.4 stable release
 
 ## Edge Release Notes
 
-### Docker Community Edition 17.03.1 Release Notes (2017-03-21 17.03.1-ce-win3)
+### Docker Community Edition 17.03.1 Release Notes (2017-03-22 17.03.1-ce-win3)
 
 **Upgrades**
 


### PR DESCRIPTION
### What's changed

- updated release date for 17.03.1 (3/21 --> 3/22)
- update `edge` URL's (should have been included in previous PR but were not)

### Reviewers fyi

@guillaumerose @friism @jeanlaurent 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
