### PR TITLE
Update content_trust.md

### DIFF
--- a/engine/security/trust/content_trust.md
+++ b/engine/security/trust/content_trust.md
@@ -267,7 +267,6 @@ you signed and pushed earlier:
 
 ```
 $  docker pull <username>/trusttest:testing
-Using default tag: latest
 Pull (1 of 1): <username>/trusttest:testing@sha256:d149ab53f871
 ...
 Tagging <username>/trusttest@sha256:d149ab53f871 as docker/trusttest:testing


### PR DESCRIPTION
### Proposed changes

Removed "Using default tag: latest" from sample command output.  The testing tag was specified in the command, so it would not being using the default tag.

### Unreleased project version (optional)

### Related issues (optional)
