### PR TITLE
Update Jekyll version in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "github-pages", "105" #Update me once in a while: https://github.com/github/pages-gem/releases
+gem "github-pages", "112" #Update me once in a while: https://github.com/github/pages-gem/releases


### PR DESCRIPTION
Fixes a bug in jekyll-seo-tags plugin that causes
a malformed canonical URL (https://docs.docker.com/v1.12/v1.12/)