### PR TITLE
Note that China and US Gov Cloud are not supported.

### DIFF
--- a/docker-for-aws/faqs.md
+++ b/docker-for-aws/faqs.md
@@ -104,7 +104,7 @@ If you are using the `10.0.0.0/16` CIDR in your VPC. When you create a docker ne
 
 ## Which AWS regions will this work with?
 
-Docker for AWS should work with all regions except for AWS China, which is a little different than the other regions.
+Docker for AWS should work with all regions except for AWS US Gov Cloud (us-gov-west-1) and AWS China, which are a little different than the other regions.
 
 ## How many Availability Zones does Docker for AWS use?
 

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -85,6 +85,8 @@ If you need to install Docker for AWS with an existing VPC, you need to do a few
 
 For more information about adding an SSH key pair to your account, please refer to the [Amazon EC2 Key Pairs docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
 
+Note that the China and US Gov Cloud AWS partitions are not currently supported.
+
 ### Configuration
 
 Docker for AWS is installed with a CloudFormation template that configures Docker in swarm-mode, running on instances backed custom AMIs. There are two ways you can deploy Docker for AWS. You can use the AWS Management Console (browser based), or use the AWS CLI. Both have the following configuration options.


### PR DESCRIPTION
I may not be in full conformance to the contribution guidelines because the page `CONTRIBUTING.md` contains a broken link to the actual guidelines.
(currently the broken link is https://github.com/docker/docker.github.io/blob/master/opensource/project/who-written-for

### Proposed changes

The US Gov cloud region is not supported in this template.  This
seems like useful info to have before trying.  This PR adds a note
in the prerequisites area and in the FAQ.

