### PR TITLE
fix missing '-y' parameter

### DIFF
--- a/engine/examples/mongodb.md
+++ b/engine/examples/mongodb.md
@@ -63,7 +63,7 @@ a MongoDB repository file for the package manager.
 # Installation:
 # Import MongoDB public GPG key AND create a MongoDB list file
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-RUN apt-get install --no-install-recommends software-properties-common
+RUN apt-get install -y --no-install-recommends software-properties-common
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu $(cat /etc/lsb-release | grep DISTRIB_CODENAME | cut -d= -f2)/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 ```
 


### PR DESCRIPTION
Fixed a cmd in the intro on `Creating a Dockerfile for MongoDB`.

### Proposed changes
The missing parameter leads to abort when installing `software-properties-common`, since `apt-get install` expects a confirmation.