### PR TITLE
added "docker" to systemd is-active command

### DIFF
--- a/engine/admin/index.md
+++ b/engine/admin/index.md
@@ -87,7 +87,7 @@ Use the appropriate command below to check whether Docker is running:
 
 | Init system  | Command                     |
 |--------------|-----------------------------|
-| `systemd`    | `sudo systemctl is-active ` |
+| `systemd`    | `sudo systemctl is-active docker ` |
 | `upstart`    | `sudo status docker`        |
 
 You can also use Docker itself to check whether Docker is running:


### PR DESCRIPTION
The command was missing "docker" on the end for the systemd example.
