### PR TITLE
Adjust heading level

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -37,7 +37,7 @@ tutorial](/engine/getstarted-voting-app/index.md).
 
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="headingThree">
-      <h4 class="panel-title" id="collapsible-group-item-3"> <a class="" role="button" data-toggle="collapse" data-parent="#accordion" data-target="#collapseThree" aria-expanded="true" aria-controls="collapseThree"> Example Compose file version 3 </a> </h4>
+      <h5 class="panel-title" id="collapsible-group-item-3"> <a class="" role="button" data-toggle="collapse" data-parent="#accordion" data-target="#collapseThree" aria-expanded="true" aria-controls="collapseThree"> Example Compose file version 3 </a> </h5>
     </div>
     <div id="collapseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree" aria-expanded="true">
       <div class="panel-body">


### PR DESCRIPTION
Fixes #2617 

Since `toc_max` is 4, the `<h4>` in the table is causing HTML to leak into the right-hand nav. This fixes it by changing that to a level-5 heading.

cc/ @londoncalling 