### PR TITLE
Fix compose links

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -26,7 +26,7 @@ sub-topics. This maps to the `<key>: <option>: <value>` indent structure of the
 Compose file.
 
 The best way to quickly grok the layout and syntax of a Compose file is to look
-at files for [sample applications](samples.md). A good place to start is the
+at files for [sample applications](/compose/samples.md). A good place to start is the
 version 3 Compose stack file we use for the voting app sample to illustrate
 multi-container apps, service definitions, swarm mode, the `deploy` key, and the
 `docker stack deploy` command. Click to show/hide the example file below. This

--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -11,7 +11,7 @@ Variables starting with `DOCKER_` are the same as those used to configure the
 Docker command-line client. If you're using `docker-machine`, then the `eval "$(docker-machine env my-docker-vm)"` command should set them to their correct values. (In this example, `my-docker-vm` is the name of a machine you created.)
 
 > **Note**: Some of these variables can also be provided using an
-> [environment file](../env-file.md)
+> [environment file](/compose/env-file.md)
 
 ## COMPOSE\_PROJECT\_NAME
 
@@ -95,7 +95,7 @@ using this character as path separator.
 
 ## Related Information
 
-- [User guide](../index.md)
-- [Installing Compose](../install.md)
-- [Compose file reference](../compose-file.md)
-- [Environment file](../env-file.md)
+- [User guide](/compose/index.md)
+- [Installing Compose](/compose/install.md)
+- [Compose file reference](/compose/compose-file.md)
+- [Environment file](/compose/env-file.md)


### PR DESCRIPTION
Problems caused by reorganizing the compose file references.

Fixes #1794
Fixes #1854
Fixes #1855
Fixes #2191 
Fixes #2267 
Fixes #2362 
Fixes #2363 
Fixes #2384 
Fixes #2434 
Fixes #2458 
Fixes #2490 
Fixes #2553 
Fixes #2560 
Fixes #2602 
Fixes #2616 
