### PR TITLE
fixed Windows Server installer checksum visible text

### DIFF
--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -72,7 +72,7 @@ For more about Stable and Edge channels, see the
   </td>
   <td width="33%"><a href="https://download.docker.com/win/edge/InstallDocker.msi.sha256sum"><font color="#BDBDBD" size="-1">Checksum: InstallDocker.msi SHA256</font></a>
   </td>
-  <td width="33%"><a href="https://download.docker.com/win/edge/Docker%20for%20Windows%20Installer.exe.sha256sum"><font color="#BDBDBD" size="-1">Checksum: InstallDocker.msi SHA256</font></a>
+  <td width="33%"><a href="https://download.docker.com/win/edge/Docker%20for%20Windows%20Installer.exe.sha256sum"><font color="#BDBDBD" size="-1">Checksum: InstallDocker.exe SHA256</font></a>
   </td>
   </tr>
 </table>


### PR DESCRIPTION
### What's changed

- Copy-edit Windows Server 2016 Edge installer Checksum visible text for installer name

### Related

- PR #2657 for docs update for Docker for Mac and Windows `1704-ce` release

### Reviewers, fyi

@friism @jeanlaurent @nandhini @mstanleyjones 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
