### PR TITLE
Adds style for warnings and notes

### DIFF
--- a/_scss/_notes.scss
+++ b/_scss/_notes.scss
@@ -1,0 +1,35 @@
+/*
+* Infos, notes, and warnings
+*/
+
+$info-color: #1488C6;
+$warning-color: #aa6708;
+$danger-color: #ce4844;
+
+blockquote {
+  border-left-color: $info-color;
+}
+
+blockquote > p:first-child {
+  margin-top: 0;
+}
+
+blockquote > p > strong {
+  color: $info-color;
+}
+
+blockquote.warning {
+  border-left-color: $warning-color;
+}
+
+blockquote.warning > p > strong {
+  color: $warning-color;
+}
+
+blockquote.danger {
+  border-left-color: $danger-color;
+}
+
+blockquote.danger > p > strong {
+  color: $danger-color;
+}

--- a/css/style.scss
+++ b/css/style.scss
@@ -15,3 +15,4 @@
 @import "github";
 @import "overrides";
 @import "mobile";
+@import "notes";

--- a/test.md
+++ b/test.md
@@ -358,20 +358,31 @@ Bootstrap JS are loaded.
 
 ## Admonitions (notes)
 
-> **Note**: This is a note.
+> **Note**: This is a note using the old note style
 
-> **Info**: This is an info.
+> **This is a note using the new style**
+>
+> And you include a small description here telling users to be on the lookout
 
-> **Tip**: This is a tip.
+> **Be careful out there**
+>
+> Add the `warning` class to your blockquotes if you want to tell users
+> to be careful about something.
+{: .warning}
 
-> **Warning**: This is a warning.
+> **Ouch, don't do that!**
+>
+> Use the `danger` class to let people know this is dangerous or they
+> should pay close attention to this part of the road.
+>
+> You can also add more paragraphs here if your explanation is
+> super complex.
+{: .danger}
 
-> **Caution**: This is a caution.
 
-> **Note**: One line of note text
-> another line of note text
-
-> **Note**: This is a note with a list and a table in it.
+> **This is a crazy note**
+>
+> This note has tons of content in it:
 >
 > - List item 1
 > - List item 2
@@ -382,6 +393,7 @@ Bootstrap JS are loaded.
 > | Row 2 column 1 | Row 2 column 2 |
 >
 > And another sentence to top it all off.
+
 
 ## Comments
 
@@ -548,6 +560,3 @@ authorizedkeys:
   volumes:
     /root:/user:rw
 ```
-
-
-


### PR DESCRIPTION
This PR adds a way for us to have warnings and notes.

![screen shot 2017-04-11 at 14 41 23](https://cloud.githubusercontent.com/assets/1525937/24932128/fc5a030c-1ec4-11e7-9110-e7d5e1ec5d58.png)

It also maintains backwards compatibility with the older note style so that we can start migrating slowly (the first note in the screenshot).