### PR TITLE
Add term to search results page

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -239,10 +239,21 @@ function renderTopicsByTagTable(tagToLookup,divID)
 }
 function renderTagsPage()
 {
-  if(window.location.pathname.indexOf("/glossary/")>-1)
+  if(window.location.pathname.indexOf("/glossary/")>-1 || window.location.pathname.indexOf("/search/")>-1)
   {
-    var tagToLookup = decodeURI(queryString().term);
-    $("#keyword").html(tagToLookup);
+    var tagToLookup;
+    if (window.location.pathname.indexOf("/glossary/")>-1)
+    {
+      // Get ?term=<value>
+      tagToLookup = decodeURI(queryString().term);
+      $("#keyword").html(tagToLookup);
+    }
+    else
+    {
+      // Get ?q=<value>
+      tagToLookup = decodeURI(queryString().q);
+    }
+    // Get the term and definition
     for (i=0;i<glossary.terms.length;i++)
     {
       if (glossary.terms[i].term.toLowerCase()==tagToLookup.toLowerCase())

--- a/search.md
+++ b/search.md
@@ -3,7 +3,7 @@ description: Docker documentation search results
 keywords: Search, Docker, documentation, manual, guide, reference, api
 noratings: true
 notoc: true
-title: Docs search
+title: "Docs search <span id='searchTerm'></span>"
 tree: false
 ---
 
@@ -21,6 +21,9 @@ tree: false
 .gsc-control-cse, .gsc-control-cse-en { padding: 0px !important; }
 .gsc-result-info { padding-bottom: 0px !important; }
 </style>
+
+<div id="glossaryMatch"></div>
+
 <div id="my-cse1">
 <script>
   (function() {
@@ -33,5 +36,18 @@ tree: false
     s.parentNode.insertBefore(gcse, s);
   })();
 </script>
-<gcse:search></gcse:search>
+
+<gcse:searchresults-only></gcse:searchresults-only>
 </div>
+
+<script defer>
+setTimeout(function(){
+  $(document).ready(function() {
+    if (decodeURI(queryString().q) != "undefined" && decodeURI(queryString().q) && decodeURI(queryString().q).length > 0) {
+      $("#st-search-input").val(decodeURI(queryString().q));
+      $("#st-search-input").focus();
+      $("#searchTerm").html("results for: " + decodeURI(queryString().q))
+    }
+  });
+}, 1);
+</script>


### PR DESCRIPTION
### Proposed changes

Fixes #2708
Relates to #2691 (but does not fix it, since it is asking for a definition for Entrypoint to be added)

If a given search term (or phrase) exists verbatim in the glossary, show its definition above the search results.

To demo, go to the Netlify preview and search for a term like `docker` or `data volume`, and see that the definition is displayed. Now search for `foo` and see that nothing is displayed.

There is currently some logging info being displayed in the console log for debugging. I'll remove it when this is approved to merge.

I'm open to suggestions on the JS code. It's a little specialized to the search page, in the same way that the glossary definition display is specific to the glossary page. If we can reuse the logic in a better way, I am all for it.