### PR TITLE
Fix typo in plugin reference toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -695,7 +695,7 @@ reference:
     - path: /engine/reference/commandline/plugin/
       title: docker plugin
     - path: /engine/reference/commandline/plugin_create/
-      title: docker plugin disable
+      title: docker plugin create
     - path: /engine/reference/commandline/plugin_disable/
       title: docker plugin disable
     - path: /engine/reference/commandline/plugin_enable/


### PR DESCRIPTION
Fixed typo in toc for plugin reference, per #2704. 