### PR TITLE
Change mount syntax on windows from //c/ to c:\

### DIFF
--- a/engine/tutorials/dockervolumes.md
+++ b/engine/tutorials/dockervolumes.md
@@ -130,7 +130,7 @@ docker run -v /Users/<path>:/<container path> ...
 On Windows, mount directories using:
 
 ```bash
-docker run -v //c/<path>:/<container path>
+docker run -v c:\<path>:c:\<container path>
 ```
 
 All other paths come from your virtual machine's filesystem, so if you want


### PR DESCRIPTION
### Proposed changes

Changed the syntax of `-v` option for windows version. It doesn't work if you pass `//c/path`, but works if you pass `c:\path`
