### PR TITLE
Update CS Engine redirects

### DIFF
--- a/cs-engine/1.12/release-notes/index.md
+++ b/cs-engine/1.12/release-notes/index.md
@@ -1,9 +1,6 @@
 ---
 description: The release notes for CS Docker Engine.
 keywords: docker, engine, release notes
-redirect_from:
-- /docker-trusted-registry/cs-engine/release-notes/
-- /cs-engine/release-notes/
 title: Commercially Supported Docker Engine release notes
 ---
 

--- a/cs-engine/1.13/release-notes.md
+++ b/cs-engine/1.13/release-notes.md
@@ -2,7 +2,9 @@
 title: CS Docker Engine 1.13 release notes
 description: Commercially supported Docker Engine release notes
 keywords: docker, engine, install, release notes
-
+redirect_from:
+- /docker-trusted-registry/cs-engine/release-notes/
+- /cs-engine/release-notes/
 ---
 
 This document describes the latest changes, additions, known issues, and fixes
@@ -14,6 +16,7 @@ back-ported fixes (security-related and priority defects) from the open source.
 It incorporates defect fixes that you can use in environments where new features
 cannot be adopted as quickly for consistency and compatibility reasons.
 
+[Looking for the release notes for Docker CS Engine 1.12?](/cs-engine/1.12/release-notes/index.md)
 
 ## CS Engine 1.13.1-cs3
 (23 Feb 2017)


### PR DESCRIPTION
### Proposed changes

If you try to go to `/cs-engine/release-notes/` you get redirected to 1.12 instead of 1.13. This fixes that and also adds a link from the 1.13 release notes to the 1.12 ones for customers who need to find those.

Thanks @pvnovarese for the report.
