### PR TITLE
fix imports since docker api pkg migration, fix example repository na…

### DIFF
--- a/engine/api/get-started.md
+++ b/engine/api/get-started.md
@@ -107,9 +107,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"golang.org/x/net/context"
 )
 
@@ -120,7 +120,7 @@ func main() {
 		panic(err)
 	}
 
-	_, err = cli.ImagePull(ctx, "alpine", types.ImagePullOptions{})
+	_, err = cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
…me to be canonical

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

github.com/docker/engine-api has been deprecated and redirects to github.com/docker/docker, as such, the examples in the golang getting started have incorrect imports.

Additionally, since some fe versions ago in docker engine, the library enforces that image repository names be canonical, so things like "alpine" don't work without prefacing the registry ("docker.io/library/alpine")

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
