### PR TITLE
[Debian] add gnupg2 requirement for stretch

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -93,6 +93,7 @@ from the repository.
          apt-transport-https \
          ca-certificates \
          curl \
+         gnupg2 \
          software-properties-common
     ```
 


### PR DESCRIPTION
Unlike jessie, debian stretch doesn't include `gnupg` by default.

This was already tackled with #292 but forgot during a refactoring (50e75ff936200c50462c8135c0ae6d1baddc2e3e).