### PR TITLE
Fix missing database user for Wordpress service

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -40,7 +40,7 @@ Compose to set up and run WordPress. Before starting, you'll need to have
            - db_data:/var/lib/mysql
          restart: always
          environment:
-           MYSQL_ROOT_PASSWORD: wordpress
+           MYSQL_ROOT_PASSWORD: somewordpress
            MYSQL_DATABASE: wordpress
            MYSQL_USER: wordpress
            MYSQL_PASSWORD: wordpress

--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -54,6 +54,7 @@ Compose to set up and run WordPress. Before starting, you'll need to have
          restart: always
          environment:
            WORDPRESS_DB_HOST: db:3306
+           WORDPRESS_DB_USER: wordpress
            WORDPRESS_DB_PASSWORD: wordpress
     volumes:
         db_data:


### PR DESCRIPTION
It defaults to root if not specified. see here https://hub.docker.com/_/wordpress/

Adding the new environment variable `WORDPRESS_DB_USER` fixes the issue #2748 