### PR TITLE
Formatting messed up with button on release pages

### DIFF
--- a/_includes/d4a_buttons.md
+++ b/_includes/d4a_buttons.md
@@ -5,26 +5,32 @@
 
 {% capture aws_blue_latest %}
 <a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)</a>
+<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture aws_blue_edge %}
 <a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)</a>
+<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture aws_blue_vpc_latest %}
 <a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker-no-vpc.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)<br/><small>uses your existing VPC</small></a>
+<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture aws_blue_vpc_edge %}
 <a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker-no-vpc.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)<br/><small>uses your existing VPC</small></a>
+<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture azure_blue_latest %}
 <a class="button outline-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for Azure (stable)</a>
+<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture azure_blue_edge %}
 <a class="button outline-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fedge%2FDocker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for Azure (edge)</a>
+<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture azure_button_latest %}


### PR DESCRIPTION
### Proposed changes

/docker-for-aws/release-notes.md
/docker-for-azure/release-notes.md

Both have wrapping issues with text after buttons.

/_includes/d4a_buttons.md is used to insert the buttons on those pages.

Because the anchor tag uses the button class it applies a float:left and causes wrapping issues after. 

A simple div tag with class clearfix can fix this. The buttons are also used inside a couple tables, but there is no need for float: left in those cases and the div causes no issues.

### Related issues (optional)
Fixes: #2634 