### PR TITLE
added hack room location to front page

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ notags: true
 
 <a href="/hackathon/"><img src="docs-hackathon-2.png" alt="Docker Docs Hackathon, April 17-22nd, 2017" style="max-width: 100%"></a>
 
-Fix docs bugs to claim the points, and cash in your points for prizes in [the swag store](http://www.cafepress.com/dockerdocshackathon). Every 10 points is worth $1 USD in store credit. Happening all DockerCon week, from April 17-21, 2017.
+Fix docs bugs to claim the points, and cash in your points for prizes in [the swag store](http://www.cafepress.com/dockerdocshackathon). Every 10 points is worth $1 USD in store credit. Happening all DockerCon week, from April 17-21, 2017. <font color="#ef4d53">Hack room at the conference: 4th floor, room 13A-13b.</font>
 
 [Hackathon details](/hackathon/){: class="button outline-btn" style="margin:20px"}[View available bugs on GitHub](https://github.com/docker/docker.github.io/milestone/9){: class="button outline-btn" style="margin:20px"} [Visit the rewards store](http://www.cafepress.com/dockerdocshackathon){: class="button outline-btn" style="margin:20px"}
 

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ notags: true
 
 <a href="/hackathon/"><img src="docs-hackathon-2.png" alt="Docker Docs Hackathon, April 17-22nd, 2017" style="max-width: 100%"></a>
 
-Fix docs bugs to claim the points, and cash in your points for prizes in [the swag store](http://www.cafepress.com/dockerdocshackathon). Every 10 points is worth $1 USD in store credit. Happening all DockerCon week, from April 17-21, 2017. <font color="#ef4d53">Hack room at the conference: 4th floor, room 13A-13b.</font>
+Fix docs bugs to claim the points, and cash in your points for prizes in [the swag store](http://www.cafepress.com/dockerdocshackathon). Every 10 points is worth $1 USD in store credit. Happening all DockerCon week, from April 17-21, 2017. <font color="#ef4d53">Hack room at the conference: 4th floor, room 13A-13B.</font>
 
 [Hackathon details](/hackathon/){: class="button outline-btn" style="margin:20px"}[View available bugs on GitHub](https://github.com/docker/docker.github.io/milestone/9){: class="button outline-btn" style="margin:20px"} [Visit the rewards store](http://www.cafepress.com/dockerdocshackathon){: class="button outline-btn" style="margin:20px"}
 


### PR DESCRIPTION
### What's changed

- We have the floor location of the onsite hackathon in Hackathon Details but not on front page. Adding floor and room to docs home page so people can find it at-a-glance.

### Reviewers

@johndmulhausen @mstanleyjones 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
