### PR TITLE
Update Task2, Step1 in 'set-up-dev-env.md'

### DIFF
--- a/opensource/project/set-up-dev-env.md
+++ b/opensource/project/set-up-dev-env.md
@@ -92,7 +92,7 @@ can take over 15 minutes to complete.
 
 1. Open a terminal.
 
-   For [Docker Toolbox](/toolbox/overview.md) users, use `docker-machine status your_vm_name` to make sure your VM is running. You
+   For [Docker Toolbox](../../toolbox/overview.md) users, use `docker-machine status your_vm_name` to make sure your VM is running. You
    may need to run `eval "$(docker-machine env your_vm_name)"` to initialize your
    shell environment.
 

--- a/opensource/project/set-up-dev-env.md
+++ b/opensource/project/set-up-dev-env.md
@@ -92,7 +92,7 @@ can take over 15 minutes to complete.
 
 1. Open a terminal.
 
-   For <a href="/toolbox/overview/" target="_blank">Docker Toolbox</a> users, use `docker-machine status your_vm_name` to make sure your VM is running. You
+   For [Docker Toolbox](/toolbox/overview.md) users, use `docker-machine status your_vm_name` to make sure your VM is running. You
    may need to run `eval "$(docker-machine env your_vm_name)"` to initialize your
    shell environment.
 

--- a/opensource/project/set-up-dev-env.md
+++ b/opensource/project/set-up-dev-env.md
@@ -92,7 +92,7 @@ can take over 15 minutes to complete.
 
 1. Open a terminal.
 
-   For Mac users, use `docker-machine status your_vm_name` to make sure your VM is running. You
+   For <a href="/toolbox/overview/" target="_blank">Docker Toolbox</a> users, use `docker-machine status your_vm_name` to make sure your VM is running. You
    may need to run `eval "$(docker-machine env your_vm_name)"` to initialize your
    shell environment.
 


### PR DESCRIPTION
Originally the step mentioned Mac in general but the step is actually just for Docker Toolbox users.  So I just updated to reference Docker Toolbox specifically with a link to the Docker Toolbox doc page.

This closes #974.