### PR TITLE
Fixed bug: 1809: Different compose file versions are confusing in Ver…

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -20,8 +20,7 @@ identical to the container name.
 
 For example, suppose your app is in a directory called `myapp`, and your `docker-compose.yml` looks like this:
 
-    version: '2'
-
+    version: "3"
     services:
       web:
         build: .
@@ -55,8 +54,9 @@ If any containers have connections open to the old container, they will be close
 
 Links allow you to define extra aliases by which a service is reachable from another service. They are not required to enable services to communicate - by default, any service can reach any other service at that service's name. In the following example, `db` is reachable from `web` at the hostnames `db` and `database`:
 
-    version: '2'
+    version: "3"
     services:
+      
       web:
         build: .
         links:
@@ -80,33 +80,33 @@ Each service can specify what networks to connect to with the *service-level* `n
 
 Here's an example Compose file defining two custom networks. The `proxy` service is isolated from the `db` service, because they do not share a network in common - only `app` can talk to both.
 
-    version: '2'
-
+    version: "3"
     services:
+      
       proxy:
         build: ./proxy
         networks:
-          - front
+          - frontend
       app:
         build: ./app
         networks:
-          - front
-          - back
+          - frontend
+          - backend
       db:
         image: postgres
         networks:
-          - back
+          - backend
 
-    networks:
-      front:
-        # Use a custom driver
-        driver: custom-driver-1
-      back:
-        # Use a custom driver which takes special options
-        driver: custom-driver-2
-        driver_opts:
-          foo: "1"
-          bar: "2"
+     networks:
+       frontend:
+         # Use a custom driver
+         driver: custom-driver-1
+       backend:
+         # Use a custom driver which takes special options
+         driver: custom-driver-2
+         driver_opts:
+           foo: "1"
+           bar: "2"
 
 Networks can be configured with static IP addresses by setting the [ipv4_address and/or ipv6_address](compose-file.md#ipv4-address-ipv6-address) for each attached network.
 
@@ -119,9 +119,9 @@ For full details of the network configuration options available, see the followi
 
 Instead of (or as well as) specifying your own networks, you can also change the settings of the app-wide default network by defining an entry under `networks` named `default`:
 
-    version: '2'
-
+    version: "3"
     services:
+    
       web:
         build: .
         ports:
@@ -129,8 +129,8 @@ Instead of (or as well as) specifying your own networks, you can also change the
       db:
         image: postgres
 
-    networks:
-      default:
+      networks:
+        default:
         # Use a custom driver
         driver: custom-driver-1
 


### PR DESCRIPTION
…sion 3 reference #1809

Changed version from 2 to 3, updated quotation marks to match example, changed front and back to frontend and backend.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
