### PR TITLE
Fix markdown for Docker Machine overview

### DIFF
--- a/machine/overview.md
+++ b/machine/overview.md
@@ -75,9 +75,9 @@ When people say "Docker" they typically mean **Docker Engine**, the
 client-server application made up of the Docker daemon, a REST API that
 specifies interfaces for interacting with the daemon, and a command line
 interface (CLI) client that talks to the daemon (through the REST API wrapper).
-Docker Engine accepts `docker` commands from the CLI, such as `docker run
-<image>`, `docker ps` to list running containers, `docker images` to list
-images, and so on.
+Docker Engine accepts `docker` commands from the CLI, such as
+`docker run <image>`, `docker ps` to list running containers, `docker images`
+to list images, and so on.
 
 ![Docker Engine](img/engine.png)
 


### PR DESCRIPTION
Currently, the formatting for https://docs.docker.com/machine/overview
is broken due to a hanging inline code block.

Fix it by moving the inline code block to a new line.

Signed-off-by: Chandan Singh <csingh43@bloomberg.net>