### PR TITLE
#1168: Incorrect TLS cert instructions for Intermediate CA

### DIFF
--- a/datacenter/ucp/2.0/guides/configuration/index.md
+++ b/datacenter/ucp/2.0/guides/configuration/index.md
@@ -39,11 +39,9 @@ and click **Certificates**.
 
 Upload your certificates and keys:
 
-* A `ca.pem` file with the root CA public certificate followed by any intermediate CA public 
-certificates.
-* A `cert.pem` file with the TLS certificate and any intermediate public
-certificates. This certificate should also have SANs for all addresses used to
-access UCP, including load balancers.
+* A `ca.pem` file with the root CA public certificate.
+* A `cert.pem` file with the TLS certificate for your domain and any intermediate public
+certificates, in this order.
 * A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. 
 Encrypted keys should have `ENCRYPTED` in the first line.
 

--- a/datacenter/ucp/2.0/guides/configuration/index.md
+++ b/datacenter/ucp/2.0/guides/configuration/index.md
@@ -44,7 +44,8 @@ certificates.
 * A `cert.pem` file with the TLS certificate and any intermediate public
 certificates. This certificate should also have SANs for all addresses used to
 access UCP, including load balancers.
-* A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. Encrypted keys should have `ENCRYPTED` in the first line.
+* A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. 
+Encrypted keys should have `ENCRYPTED` in the first line.
 
 Finally, click **Update** for the changes to take effect.
 

--- a/datacenter/ucp/2.0/guides/configuration/index.md
+++ b/datacenter/ucp/2.0/guides/configuration/index.md
@@ -39,11 +39,12 @@ and click **Certificates**.
 
 Upload your certificates and keys:
 
-* A ca.pem file with the root CA public certificate.
-* A cert.pem file with the TLS certificate and any intermediate CA public
+* A `ca.pem` file with the root CA public certificate followed by any intermediate CA public 
+certificates.
+* A `cert.pem` file with the TLS certificate and any intermediate public
 certificates. This certificate should also have SANs for all addresses used to
 access UCP, including load balancers.
-* A key.pem file with TLS private key.
+* A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. Encrypted keys should have `ENCRYPTED` in the first line.
 
 Finally, click **Update** for the changes to take effect.
 

--- a/datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates.md
+++ b/datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates.md
@@ -39,11 +39,9 @@ and click **Certificates**.
 
 Upload your certificates and keys:
 
-* A `ca.pem` file with the root CA public certificate followed by any intermediate CA public 
-certificates.
-* A `cert.pem` file with the TLS certificate and any intermediate public
-certificates. This certificate should also have SANs for all addresses used to
-access UCP, including load balancers.
+* A `ca.pem` file with the root CA public certificate.
+* A `cert.pem` file with the TLS certificate for your domain and any intermediate public
+certificates, in this order.
 * A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. 
 Encrypted keys should have `ENCRYPTED` in the first line.
 

--- a/datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates.md
+++ b/datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates.md
@@ -44,7 +44,8 @@ certificates.
 * A `cert.pem` file with the TLS certificate and any intermediate public
 certificates. This certificate should also have SANs for all addresses used to
 access UCP, including load balancers.
-* A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. Encrypted keys should have `ENCRYPTED` in the first line.
+* A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. 
+Encrypted keys should have `ENCRYPTED` in the first line.
 
 Finally, click **Update** for the changes to take effect.
 

--- a/datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates.md
+++ b/datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates.md
@@ -39,11 +39,12 @@ and click **Certificates**.
 
 Upload your certificates and keys:
 
-* A ca.pem file with the root CA public certificate.
-* A cert.pem file with the TLS certificate and any intermediate CA public
+* A `ca.pem` file with the root CA public certificate followed by any intermediate CA public 
+certificates.
+* A `cert.pem` file with the TLS certificate and any intermediate public
 certificates. This certificate should also have SANs for all addresses used to
 access UCP, including load balancers.
-* A key.pem file with TLS private key.
+* A `key.pem` file with TLS private key. Make sure it is not encrypted with a password. Encrypted keys should have `ENCRYPTED` in the first line.
 
 Finally, click **Update** for the changes to take effect.
 


### PR DESCRIPTION
### Proposed changes

Fixed incorrect TLS cert configuration instructions for Intermediate CA on UCP versions 2.0 and 2.1

### Related issues (optional)

Fixes #1168 
