### PR TITLE
Fixes #1683.  Correct misleading information around ports 4789 & 7946

### DIFF
--- a/datacenter/ucp/2.0/guides/installation/system-requirements.md
+++ b/datacenter/ucp/2.0/guides/installation/system-requirements.md
@@ -31,7 +31,7 @@ When installing UCP on a host, make sure the following ports are open:
 | managers, workers |    in     | TCP 443  (configurable) | Port for the UCP web UI and API                                                   |
 | managers          |    in     | TCP 2376 (configurable) | Port for the Docker Swarm manager. Used for backwards compatibility               |
 | managers, workers |    in     | TCP 2377 (configurable) | Port for communication between swarm nodes                                        |
-| managers, workers |  in, out  | TCP, UDP 4789           | Port for overlay networking                                                       |
+| managers, workers |  in, out  | UDP 4789                | Port for overlay networking                                                       |
 | managers, workers |  in, out  | TCP, UDP 7946           | Port for gossip-based clustering                                                  |
 | managers, workers |    in     | TCP 12376               | Port for a TLS proxy that provides access to UCP, Docker Engine, and Docker Swarm |
 | managers          |    in     | TCP 12379               | Port for internal node configuration, cluster configuration, and HA               |

--- a/datacenter/ucp/2.0/guides/installation/system-requirements.md
+++ b/datacenter/ucp/2.0/guides/installation/system-requirements.md
@@ -31,8 +31,8 @@ When installing UCP on a host, make sure the following ports are open:
 | managers, workers |    in     | TCP 443  (configurable) | Port for the UCP web UI and API                                                   |
 | managers          |    in     | TCP 2376 (configurable) | Port for the Docker Swarm manager. Used for backwards compatibility               |
 | managers, workers |    in     | TCP 2377 (configurable) | Port for communication between swarm nodes                                        |
-| managers, workers |  in, out  | UDP 4789                | Port for overlay networking                                                       |
-| managers, workers |  in, out  | TCP, UDP 7946           | Port  for overlay networking                                                      |
+| managers, workers |  in, out  | TCP, UDP 4789           | Port for overlay networking                                                       |
+| managers, workers |  in, out  | TCP, UDP 7946           | Port for gossip-based clustering                                                  |
 | managers, workers |    in     | TCP 12376               | Port for a TLS proxy that provides access to UCP, Docker Engine, and Docker Swarm |
 | managers          |    in     | TCP 12379               | Port for internal node configuration, cluster configuration, and HA               |
 | managers          |    in     | TCP 12380               | Port for internal node configuration, cluster configuration, and HA               |

--- a/datacenter/ucp/2.0/reference/cli/install.md
+++ b/datacenter/ucp/2.0/reference/cli/install.md
@@ -45,8 +45,8 @@ firewall:
 
 * 443 or the '--controller-port'
 * 2376 or the '--swarm-port'
-* 12376, 4789, 12379, 12380, 12381, 12382, 12383, 12384, 12385, 12386
-* 4789(tcp/udp) and 7946(tcp/udp) for overlay networking
+* 12376, 12379, 12380, 12381, 12382, 12383, 12384, 12385, 12386
+* 4789 (udp) and 7946 (tcp/udp) for overlay networking
 
 
 ## Options

--- a/datacenter/ucp/2.0/reference/cli/install.md
+++ b/datacenter/ucp/2.0/reference/cli/install.md
@@ -46,7 +46,7 @@ firewall:
 * 443 or the '--controller-port'
 * 2376 or the '--swarm-port'
 * 12376, 4789, 12379, 12380, 12381, 12382, 12383, 12384, 12385, 12386
-* 4789(udp) and 7946(tcp/udp) for overlay networking
+* 4789(tcp/udp) and 7946(tcp/udp) for overlay networking
 
 
 ## Options

--- a/datacenter/ucp/2.1/guides/admin/install/system-requirements.md
+++ b/datacenter/ucp/2.1/guides/admin/install/system-requirements.md
@@ -32,7 +32,7 @@ When installing UCP on a host, make sure the following ports are open:
 | managers          |    in     | TCP 2376 (configurable) | Port for the Docker Swarm manager. Used for backwards compatibility               |
 | managers, workers |    in     | TCP 2377 (configurable) | Port for communication between swarm nodes                                        |
 | managers, workers |  in, out  | TCP, UDP 4789           | Port for overlay networking                                                       |
-| managers, workers |  in, out  | TCP, UDP 7946           | Port  for overlay networking                                                      |
+| managers, workers |  in, out  | TCP, UDP 7946           | Port for gossip-based clustering                                                  |
 | managers, workers |    in     | TCP 12376               | Port for a TLS proxy that provides access to UCP, Docker Engine, and Docker Swarm |
 | managers          |    in     | TCP 12379               | Port for internal node configuration, cluster configuration, and HA               |
 | managers          |    in     | TCP 12380               | Port for internal node configuration, cluster configuration, and HA               |

--- a/datacenter/ucp/2.1/guides/admin/install/system-requirements.md
+++ b/datacenter/ucp/2.1/guides/admin/install/system-requirements.md
@@ -31,7 +31,7 @@ When installing UCP on a host, make sure the following ports are open:
 | managers, workers |    in     | TCP 443  (configurable) | Port for the UCP web UI and API                                                   |
 | managers          |    in     | TCP 2376 (configurable) | Port for the Docker Swarm manager. Used for backwards compatibility               |
 | managers, workers |    in     | TCP 2377 (configurable) | Port for communication between swarm nodes                                        |
-| managers, workers |  in, out  | TCP, UDP 4789           | Port for overlay networking                                                       |
+| managers, workers |  in, out  | UDP 4789                | Port for overlay networking                                                       |
 | managers, workers |  in, out  | TCP, UDP 7946           | Port for gossip-based clustering                                                  |
 | managers, workers |    in     | TCP 12376               | Port for a TLS proxy that provides access to UCP, Docker Engine, and Docker Swarm |
 | managers          |    in     | TCP 12379               | Port for internal node configuration, cluster configuration, and HA               |

--- a/datacenter/ucp/2.1/reference/cli/install.md
+++ b/datacenter/ucp/2.1/reference/cli/install.md
@@ -27,8 +27,8 @@ firewall:
 
   * 443 or the '--controller-port'
   * 2376 or the '--swarm-port'
-  * 12376, 4789, 12379, 12380, 12381, 12382, 12383, 12384, 12385, 12386, 12387
-  * 4789(tcp/udp) and 7946(tcp/udp) for overlay networking
+  * 12376, 12379, 12380, 12381, 12382, 12383, 12384, 12385, 12386, 12387
+  * 4789 (udp) and 7946 (tcp/udp) for overlay networking
 
 
 ## Options

--- a/datacenter/ucp/2.1/reference/cli/install.md
+++ b/datacenter/ucp/2.1/reference/cli/install.md
@@ -28,7 +28,7 @@ firewall:
   * 443 or the '--controller-port'
   * 2376 or the '--swarm-port'
   * 12376, 4789, 12379, 12380, 12381, 12382, 12383, 12384, 12385, 12386, 12387
-  * 4789(udp) and 7946(tcp/udp) for overlay networking
+  * 4789(tcp/udp) and 7946(tcp/udp) for overlay networking
 
 
 ## Options


### PR DESCRIPTION
### Proposed changes

Fixed incorrect information around ports 4789 and 7946 in UCP 2.0 / 2.1 documentation

### Related issues (optional)

Fixes #1683 