### PR TITLE
Possible left/right navbar sidebar menu scrollbar not visible fix

### DIFF
--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -234,6 +234,6 @@ section.section {
     overflow-y: auto;
     padding: 20px 10px 100px 0;
     position: fixed;
-    height: 100% !important;
+    height: 100%;
     width: 270px;
 }

--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -165,7 +165,7 @@ section.section {
     right: 250px;
     margin-right: -250px;
     width: 0;
-    transition: all 0.5s ease;
+    //transition: all 0.5s ease;
 }
 
 #sidebar-right {

--- a/js/docs.js
+++ b/js/docs.js
@@ -67,6 +67,7 @@ function checkNavSizes()
     var tocNavHeight = (footerTop < $(window).height()) ? footerTop : $(window).height();
     sidebarObj.style.height = sidebarHeight + "px";
     document.getElementsByClassName("toc-nav")[0].style.height = tocNavHeight + "px";
+    document.getElementsByClassName("col-nav")[0].style.height = tocNavHeight + "px";
     $(sidebarObj).clearQueue().finish();
     setTimeout(highlightRightNav(currentHeading),1);
   }

--- a/js/docs.js
+++ b/js/docs.js
@@ -59,15 +59,27 @@ function checkNavSizes()
   sidebarBottom = sidebarObj.getBoundingClientRect().bottom;
   footerTop = document.getElementsByClassName("footer")[0].getBoundingClientRect().top;
   headerOffset = document.getElementsByClassName("container-fluid")[0].getBoundingClientRect().bottom;
-  if (footerTop < sidebarBottom || (sidebarBottom < footerTop && sidebarBottom < $(window).height()))
+  if(document.getElementsByClassName("header").length != 0){
+    //on home page
+    var screenBottomReal = $(window).scrollTop() + $(window).height();
+    var footerTopReal = $("footer").offset().top;
+    var sideBarHeight = $(window).height();
+    if(screenBottomReal > footerTopReal){
+      var dif = screenBottomReal - footerTopReal;
+      sideBarHeight = sideBarHeight - dif;
+    }
+    document.getElementsByClassName("col-nav")[0].getElementsByTagName('ul')[0].style.height = sideBarHeight +"px"; 
+  }
+  else if (footerTop < sidebarBottom || (sidebarBottom < footerTop && sidebarBottom < $(window).height()))
   {
 
     // the footer is overlapping the sidebar
     var sidebarHeight = (footerTop < $(window).height()) ? footerTop : $(window).height();
     var tocNavHeight = (footerTop < $(window).height()) ? footerTop : $(window).height();
     sidebarObj.style.height = sidebarHeight + "px";
-    document.getElementsByClassName("toc-nav")[0].style.height = tocNavHeight + "px";
+    //document.getElementsByClassName("toc-nav")[0].style.height = tocNavHeight + "px";
     document.getElementsByClassName("col-nav")[0].style.height = tocNavHeight + "px";
+    document.getElementById("sidebar-wrapper").style.height = tocNavHeight + "px";
     $(sidebarObj).clearQueue().finish();
     setTimeout(highlightRightNav(currentHeading),1);
   }


### PR DESCRIPTION
### Proposed changes
The homepage and many other pages have scrolling issues with the left and right scrollbars if content is expanded within them. There is a function called checkNavSizes() in docs.js that tried to fix this issue I believe but was incomplete. Because the homepage is different from the other page, a check is needed and the sidebar height to set it accordingly. The other pages just needed to set the correct tags with the correct height when the footer comes into view as was previously attempted.

layout.scss "sidebar-wrapper" needed the transition style removed or setting the height would not be instant on the right side menu. Also "sidebar" the "height: 100% !important" had to be changed to just "height: 100%" to allow the height to be set.

### Related issues (optional)
Fixes: #2232 
