### PR TITLE
Update cloudstor docs

### DIFF
--- a/docker-for-azure/persistent-data-volumes.md
+++ b/docker-for-azure/persistent-data-volumes.md
@@ -12,6 +12,8 @@ Cloudstor a volume plugin managed by Docker. It comes pre-installed and pre-conf
 
 ## Use Cloudstor
 
+> **Note**: Cloudstor is currently only pre-installed and pre-configured in the edge channel distribution of Docker for Azure v17.03.
+
 After creating a swarm on Docker for Azure and connecting to any manager using SSH, verify that Cloudstor is already installed and configured for the stack/resource group:
 
 ```bash


### PR DESCRIPTION
Update docs to indicate cloudstor plugin is only on the edge channel distro for Docker for Azure.

### Proposed changes
Updated documentation to indicate the cloudstor plugin only comes pre-installed on the edge channel for Docker for Azure (https://forums.docker.com/t/cloudstor-volume-plugin-missing/29080/4)

### Unreleased project version (optional)

### Related issues (optional)

Fixes #2096 
