### PR TITLE
Fixed text links for Docker for AWS/Azure

### DIFF
--- a/index.md
+++ b/index.md
@@ -300,7 +300,7 @@ channel for more predictability.
                 <div class="component-icon">
                     <a href="docker-for-aws/"> <img src="../images/cloud_48.svg" alt="Docker for AWS"> </a>
                 </div>
-                <h3 id="docker-cloud-providers"><a href="/engine/installation/#platform-support-matrix">Docker for AWS</a></h3>
+                <h3 id="docker-cloud-providers"><a href="docker-for-aws/">Docker for AWS</a></h3>
                 <p>Deploy your Docker apps on AWS.</p>
             </div>
         </div>
@@ -309,7 +309,7 @@ channel for more predictability.
                 <div class="component-icon">
                     <a href="docker-for-azure/"> <img src="../images/cloud_48.svg" alt="Docker for Azure"> </a>
                 </div>
-                <h3 id="docker-cloud-providers"><a href="/engine/installation/#platform-support-matrix">Docker for Azure</a></h3>
+                <h3 id="docker-cloud-providers"><a href="docker-for-azure/">Docker for Azure</a></h3>
                 <p>Deploy your Docker apps on Azure.</p>
             </div>
         </div>


### PR DESCRIPTION
Derp'd and didn't update the text links under the images :-(

