### PR TITLE
Explaining the default iptables FORWARD DROP policy

### DIFF
--- a/engine/userguide/networking/default_network/container-communication.md
+++ b/engine/userguide/networking/default_network/container-communication.md
@@ -127,3 +127,28 @@ ACCEPT     tcp  --  172.17.0.3           172.17.0.2           tcp dpt:80
 containers to each other's raw IP addresses, so connections from one container
 to another should always appear to be originating from the first container's own
 IP address.
+
+## Container communication between hosts
+
+For security reasons Docker configures the `iptables` rules to make sure Docker containers aren't forwarded traffic from outside their host. This is done by setting the `FORWARD` chain default policy to `DROP`.
+
+To change this default behavior you can manually type:
+
+```bash
+$ sudo iptables -P FORWARD ACCEPT
+```
+
+Remember `iptables` settings will be lost on restart so configure your hosts accordingly. 
+
+> **Note**: In versions pre 1.13 the default `FORWARD` chain behavior was `ACCEPT`, this was automatically changed to `DROP` upon upgrading. If you had a previously working configuration with multiple containers spanned over multiple hosts, this change could cause it to suddenly stop working if your setup relied on forwarded packets.
+
+### Why would you need to change the default `DROP` to `ACCEPT`?
+
+Suppose you have two hosts and each has the following configuration
+
+```
+host1: eth0/192.168.7.1, docker0/172.17.0.0/16
+host2: eth0/192.168.8.1, docker0/172.18.0.0/16
+```
+
+If you were on host1 and wanted to ping a Docker container on host2, you have to go setup a route to host2. Once a route is setup host2 would have to accept forwarded packets so that it could forward them to it's containers. This would be a reason for host2 to `ACCEPT` instead of `DROP` forwarded packets.


### PR DESCRIPTION
### Proposed changes
Basically explains the default FORWARD DROP policy in iptables, how to change it and a reason you might need to do this. Also explains how a pre1.13  versions might get caught off guard with the setting changed once upgrading.

### Related issues (optional)
Fixes: #1978 