### PR TITLE
Change refs to `docker/docker` to `moby/moby`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ work will be visible on docs.docker.com.
 The following `vnext` branches currently exist:
 
 - **[vnext-engine](https://github.com/docker/docker.github.io/tree/vnext-engine):**
-  docs for upcoming features in the [docker/docker](https://github.com/docker/docker/)
+  docs for upcoming features in the [moby/moby](https://github.com/moby/moby/)
   project
 
 - **[vnext-compose](https://github.com/docker/docker.github.io/tree/vnext-compose):**

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,4 +22,4 @@ reference we imported, and its tag if relevant.
 | https://github.com/docker/opensource   | b9b87bed67f4289 | docs-2016-08-03        |
 | https://github.com/docker/kitematic    | 02c9f9607128802 | v0.12.0                |
 | https://github.com/docker/machine      | 95041b4cfe2e8b2 | docs-v0.8.2-2016-09-28 |
-| https://github.com/docker/docker       | 3134c23b55eb100 | n/a                    |
+| https://github.com/moby/moby       | 3134c23b55eb100 | n/a                    |

--- a/_includes/github-pr.md
+++ b/_includes/github-pr.md
@@ -8,5 +8,5 @@
     If you omit the pr, it defaults to NULL.
 
   Output:
-    [#12345](https://github.com/docker/docker/pull/12345)
+    [#12345](https://github.com/moby/moby/pull/12345)
 {% endcomment %}{% assign org = include.org | default: "docker" %}{% assign repo = include.repo | default: "docker" %}{% assign pr = include.pr | default: NULL %}{% assign github-url="https://github.com" %}{% capture pr-link %}[#{{ pr }}]({{ github-url }}/{{ org }}/{{ repo }}/pull/{{ pr }}){% endcapture %}{{ pr-link | strip_newlines }}

--- a/compose/bundles.md
+++ b/compose/bundles.md
@@ -6,8 +6,8 @@ title: Docker stacks and distributed application bundles (experimental)
 ---
 
 > **Note**: This is a modified copy of the [Docker Stacks and Distributed Application
-> Bundles](https://github.com/docker/docker/blob/v1.12.0-rc4/experimental/docker-stacks-and-bundles.md)
-> document in the [docker/docker repo](https://github.com/docker/docker). It's been updated to accurately reflect newer releases.
+> Bundles](https://github.com/moby/moby/blob/v1.12.0-rc4/experimental/docker-stacks-and-bundles.md)
+> document in the [moby/moby repo](https://github.com/moby/moby). It's been updated to accurately reflect newer releases.
 
 ## Overview
 
@@ -59,7 +59,7 @@ Wrote bundle to vossibility-stack.dab
 > [Docker for Mac](/docker-for-mac/) or
 > [Docker for Windows](/docker-for-windows/) to install
 > it. If you're on Linux, follow the instructions in the
-> [experimental build README](https://github.com/docker/docker/blob/master/experimental/README.md).
+> [experimental build README](https://github.com/moby/moby/blob/master/experimental/README.md).
 
 A stack is created using the `docker deploy` command:
 

--- a/datacenter/dtr/2.0/release-notes/index.md
+++ b/datacenter/dtr/2.0/release-notes/index.md
@@ -210,7 +210,7 @@ future release. Configure user authentication in UCP.
 * Misc
   * When using Docker Engine 1.11 and DTR and UCP are running on the same host,
   restarting the host might cause the DTR containers not start. This is caused
-  by a [bug in Docker Engine](https://github.com/docker/docker/issues/22486).
+  by a [bug in Docker Engine](https://github.com/moby/moby/issues/22486).
   You can restart the DTR containers from the UCP UI.
   * When the DTR proxy container stops, it may seem that the DTR UI is
   responding but it shows an "empty" notification when saving settings.

--- a/datacenter/ucp/2.1/guides/release-notes/index.md
+++ b/datacenter/ucp/2.1/guides/release-notes/index.md
@@ -259,7 +259,7 @@ Docker Engine 1.13 in the nodes that you plan to manage with UCP.
 
 The `docker stats` command is sometimes wrongly reporting high CPU usage.
 Use the `top` command to confirm the real CPU usage of your node.
-[Learn more](https://github.com/docker/docker/issues/28941).
+[Learn more](https://github.com/moby/moby/issues/28941).
 
 
 **Version compatibility**

--- a/docker-cloud/docker-errors-faq.md
+++ b/docker-cloud/docker-errors-faq.md
@@ -97,7 +97,7 @@ Timeouts occur when pulling the image takes more than 10 minutes. This can somet
 
 #### GitHub link
 
-<a href="https://github.com/docker/docker/issues/12823" target="_blank">docker/docker#12823</a>
+<a href="https://github.com/moby/moby/issues/12823" target="_blank">moby/moby#12823</a>
 
 #### Workaround
 

--- a/docker-for-aws/deploy.md
+++ b/docker-for-aws/deploy.md
@@ -149,7 +149,7 @@ This tool internally makes use of docker global-mode service that runs a task on
 
 ### Distributed Application Bundles
 
-To deploy complex multi-container apps, you can use [distributed application bundles](https://github.com/docker/docker/blob/master/experimental/docker-stacks-and-bundles.md). You can either run `docker deploy` to deploy a bundle on your machine over an SSH tunnel, or copy the bundle (for example using `scp`) to a manager node, SSH into the manager and then run `docker deploy` (if you have multiple managers, you have to ensure that your session is on one that has the bundle file).
+To deploy complex multi-container apps, you can use [distributed application bundles](https://github.com/moby/moby/blob/master/experimental/docker-stacks-and-bundles.md). You can either run `docker deploy` to deploy a bundle on your machine over an SSH tunnel, or copy the bundle (for example using `scp`) to a manager node, SSH into the manager and then run `docker deploy` (if you have multiple managers, you have to ensure that your session is on one that has the bundle file).
 
 A good sample app to test application bundles is the [Docker voting app](https://github.com/docker/example-voting-app).
 

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -32,7 +32,7 @@ using CloudFormation. For more about stable and edge channels, see the
   </tr>
   <tr valign="top">
     <td width="50%">This deployment is fully baked and tested, and comes with the latest CE version of Docker. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>Stable is released quarterly and is for users that want an easier-to-maintain release pace.</td>
-    <td width="50%">This deployment offers cutting edge features of the CE version of Docker and comes with experimental features turned on, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. Edge is for users wanting a drop of the latest and greatest features every month <br><br>We collect usage data on edges across the board.</td>
+    <td width="50%">This deployment offers cutting edge features of the CE version of Docker and comes with experimental features turned on, described in the <a href="https://github.com/moby/moby/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. Edge is for users wanting a drop of the latest and greatest features every month <br><br>We collect usage data on edges across the board.</td>
   </tr>
   <tr valign="top">
   <td width="50%">

--- a/docker-for-azure/deploy.md
+++ b/docker-for-azure/deploy.md
@@ -158,7 +158,7 @@ This tool internally makes use of docker global-mode service that runs a task on
 
 ### Distributed Application Bundles
 
-To deploy complex multi-container apps, you can use [distributed application bundles](https://github.com/docker/docker/blob/master/experimental/docker-stacks-and-bundles.md). You can either run `docker deploy` to deploy a bundle on your machine over an SSH tunnel, or copy the bundle (for example using `scp`) to a manager node, SSH into the manager and then run `docker deploy` (if you have multiple managers, you have to ensure that your session is on one that has the bundle file).
+To deploy complex multi-container apps, you can use [distributed application bundles](https://github.com/moby/moby/blob/master/experimental/docker-stacks-and-bundles.md). You can either run `docker deploy` to deploy a bundle on your machine over an SSH tunnel, or copy the bundle (for example using `scp`) to a manager node, SSH into the manager and then run `docker deploy` (if you have multiple managers, you have to ensure that your session is on one that has the bundle file).
 
 A good sample app to test application bundles is the [Docker voting app](https://github.com/docker/example-voting-app).
 

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -28,7 +28,7 @@ For more about stable and edge channels, see the [FAQs](/docker-for-azure/faqs.m
   </tr>
   <tr valign="top">
     <td width="50%">This deployment is fully baked and tested, and comes with the latest CE version of Docker. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>Stable is released quarterly and is for users that want an easier-to-maintain release pace.</td>
-    <td width="50%">This deployment offers cutting edge features of the CE version of Docker and comes with experimental features turned on, described in the <a href="https://github.com/docker/docker/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. Edge is for users wanting a drop of the latest and greatest features every month <br><br>We collect usage data on edges across the board.</td>
+    <td width="50%">This deployment offers cutting edge features of the CE version of Docker and comes with experimental features turned on, described in the <a href="https://github.com/moby/moby/tree/master/experimental">Docker Experimental Features README</a> on GitHub.<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. Edge is for users wanting a drop of the latest and greatest features every month <br><br>We collect usage data on edges across the board.</td>
   </tr>
   <tr valign="top">
   <td width="50%">

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -222,7 +222,7 @@ some of the commmon settings to make it easier to configure them.
 Starting with Stable 1.13.0 and Beta 31, both Docker for Mac Stable and Beta
 releases have experimental features enabled on Docker Engine, as described in
 the [Docker Experimental Features
-README](https://github.com/docker/docker/blob/master/experimental/README.md) on GitHub.
+README](https://github.com/moby/moby/blob/master/experimental/README.md) on GitHub.
 
 Experimental features are not appropriate for production environments or
 workloads. They are meant to be sandbox experiments for new ideas. Some

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -22,7 +22,7 @@ If you have not already done so, please install Docker for Mac. You can download
 installers from the Stable or beta channel.
 
 Both Stable and Edge installers come with <a
-href="https://github.com/docker/docker/blob/master/experimental/README.md">
+href="https://github.com/moby/moby/blob/master/experimental/README.md">
 experimental features in Docker Engine</a> enabled by default and configurable
 on [Docker Daemon preferences](index.md#daemon-experimental-mode) for
 experimental mode. We recommend that you disable experimental features for

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -141,7 +141,7 @@ Volume mounting requires shared drives for projects that live outside of the
 
 Docker 1.12.0 RC3 release introduces a backward incompatible change from RC2 to
 RC3. (For more information, see
-https://github.com/docker/docker/issues/24343#issuecomment-230623542.)
+https://github.com/moby/moby/issues/24343#issuecomment-230623542.)
 
 You may get the following error when you try to start a container created with
 pre-Beta 18 Docker for Mac applications.

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -469,7 +469,7 @@ some of the commmon settings to make it easier to configure them.
 
 Starting with Stable 1.13.0 and Beta 34, both Docker for Windows Stable and Beta
 releases have the experimental version of Docker Engine enabled, described
-in the [Docker Experimental Features README](https://github.com/docker/docker/blob/master/experimental/README.md) on GitHub.
+in the [Docker Experimental Features README](https://github.com/moby/moby/blob/master/experimental/README.md) on GitHub.
 
 Experimental features are not appropriate for production environments or
 workloads. They are meant to be sandbox experiments for new ideas. Some

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -24,7 +24,7 @@ If you have not already done so, please install Docker for Windows. You can
 download installers from the **Stable** or **Edge** channel.
 
 Both Stable and Edge installers come with <a
-href="https://github.com/docker/docker/blob/master/experimental/README.md">
+href="https://github.com/moby/moby/blob/master/experimental/README.md">
 experimental features in Docker Engine</a> enabled by default and configurable
 on [Docker Daemon preferences](index.md#daemon-experimental-mode) for
 experimental mode. We recommend that you disable experimental features for

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -160,11 +160,11 @@ commands ultimately get passed to Unix commands inside a Unix based container
 (for example, a shell script passed to `/bin/sh`). If Windows style line endings
 are used, `docker run` will fail with syntax errors.
 
-For an example of this issue and the resolution, see this issue on GitHub: <a href="https://github.com/docker/docker/issues/24388">Docker RUN fails to execute shell script (https://github.com/docker/docker/issues/24388)</a>.
+For an example of this issue and the resolution, see this issue on GitHub: <a href="https://github.com/moby/moby/issues/24388">Docker RUN fails to execute shell script (https://github.com/moby/moby/issues/24388)</a>.
 
 ### Recreate or update your containers after Beta 18 upgrade
 
-Docker 1.12.0 RC3 release introduces a backward incompatible change from RC2 to RC3. (For more information, see https://github.com/docker/docker/issues/24343#issuecomment-230623542.)
+Docker 1.12.0 RC3 release introduces a backward incompatible change from RC2 to RC3. (For more information, see https://github.com/moby/moby/issues/24343#issuecomment-230623542.)
 
 You may get the following error when you try to start a container created with pre-Beta 18 Docker for Windows applications.
 
@@ -380,7 +380,7 @@ Discussion thread on GitHub at [Docker for Windows issue 267](https://github.com
 
 ### Networking issues
 
-Some users have reported problems connecting to Docker Hub on the Docker for Windows stable version. (See GitHub issue [22567](https://github.com/docker/docker/issues/22567).)
+Some users have reported problems connecting to Docker Hub on the Docker for Windows stable version. (See GitHub issue [22567](https://github.com/moby/moby/issues/22567).)
 
 Here is an example command and error message:
 

--- a/edge/engine/reference/commandline/README.md
+++ b/edge/engine/reference/commandline/README.md
@@ -2,7 +2,7 @@
 
 The files in this directory are stub files which include the file
 `/_includes/cli.md`, which parses YAML files generated from the
-[`docker/docker`](https://github.com/docker/docker) repository. The YAML files
+[`moby/moby`](https://github.com/moby/moby) repository. The YAML files
 are parsed into output files like
 [https://docs.docker.com/engine/reference/commandline/build/](https://docs.docker.com/engine/reference/commandline/build/).
 
@@ -14,7 +14,7 @@ The output files are composed from two sources:
   the CLI source code in that repository.
 
 - The **Extended Description** and **Examples** sections are pulled into the
-  YAML from the files in [https://github.com/docker/docker/tree/master/docs/reference/commandline](https://github.com/docker/docker/tree/master/docs/reference/commandline)
+  YAML from the files in [https://github.com/moby/moby/tree/master/docs/reference/commandline](https://github.com/moby/moby/tree/master/docs/reference/commandline)
   Specifically, the Markdown inside the `## Description` and `## Examples`
   headings are parsed. Please submit corrections to the text in that repository.
 
@@ -22,7 +22,7 @@ The output files are composed from two sources:
 
 The process for generating the YAML files is still in flux. Check with
 @thajestah or @frenchben. Be sure to generate the YAML files with the correct
-branch of `docker/docker` checked out (probably not `master`).
+branch of `moby/moby` checked out (probably not `master`).
 
 After generating the YAML files, replace the YAML files in
 [https://github.com/docker/docker.github.io/tree/master/_data/engine-cli](https://github.com/docker/docker.github.io/tree/master/_data/engine-cli)

--- a/edge/engine/reference/commandline/attach.md
+++ b/edge/engine/reference/commandline/attach.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/build.md
+++ b/edge/engine/reference/commandline/build.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/checkpoint.md
+++ b/edge/engine/reference/commandline/checkpoint.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/checkpoint_create.md
+++ b/edge/engine/reference/commandline/checkpoint_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/checkpoint_ls.md
+++ b/edge/engine/reference/commandline/checkpoint_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/checkpoint_rm.md
+++ b/edge/engine/reference/commandline/checkpoint_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/commit.md
+++ b/edge/engine/reference/commandline/commit.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/container.md
+++ b/edge/engine/reference/commandline/container.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/s
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_attach.md
+++ b/edge/engine/reference/commandline/container_attach.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_commit.md
+++ b/edge/engine/reference/commandline/container_commit.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_cp.md
+++ b/edge/engine/reference/commandline/container_cp.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/s
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_create.md
+++ b/edge/engine/reference/commandline/container_create.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_diff.md
+++ b/edge/engine/reference/commandline/container_diff.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_exec.md
+++ b/edge/engine/reference/commandline/container_exec.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_export.md
+++ b/edge/engine/reference/commandline/container_export.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_inspect.md
+++ b/edge/engine/reference/commandline/container_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_kill.md
+++ b/edge/engine/reference/commandline/container_kill.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_logs.md
+++ b/edge/engine/reference/commandline/container_logs.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_ls.md
+++ b/edge/engine/reference/commandline/container_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_pause.md
+++ b/edge/engine/reference/commandline/container_pause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_port.md
+++ b/edge/engine/reference/commandline/container_port.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_prune.md
+++ b/edge/engine/reference/commandline/container_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_rename.md
+++ b/edge/engine/reference/commandline/container_rename.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_restart.md
+++ b/edge/engine/reference/commandline/container_restart.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_rm.md
+++ b/edge/engine/reference/commandline/container_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_run.md
+++ b/edge/engine/reference/commandline/container_run.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/s
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_start.md
+++ b/edge/engine/reference/commandline/container_start.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_stats.md
+++ b/edge/engine/reference/commandline/container_stats.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_stop.md
+++ b/edge/engine/reference/commandline/container_stop.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_top.md
+++ b/edge/engine/reference/commandline/container_top.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_unpause.md
+++ b/edge/engine/reference/commandline/container_unpause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/s
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_update.md
+++ b/edge/engine/reference/commandline/container_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/container_wait.md
+++ b/edge/engine/reference/commandline/container_wait.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/cp.md
+++ b/edge/engine/reference/commandline/cp.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/create.md
+++ b/edge/engine/reference/commandline/create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/deploy.md
+++ b/edge/engine/reference/commandline/deploy.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/diff.md
+++ b/edge/engine/reference/commandline/diff.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/docker.md
+++ b/edge/engine/reference/commandline/docker.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/dockerd.md
+++ b/edge/engine/reference/commandline/dockerd.md
@@ -15,7 +15,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/events.md
+++ b/edge/engine/reference/commandline/events.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/exec.md
+++ b/edge/engine/reference/commandline/exec.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/export.md
+++ b/edge/engine/reference/commandline/export.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/history.md
+++ b/edge/engine/reference/commandline/history.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/image.md
+++ b/edge/engine/reference/commandline/image.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_build.md
+++ b/edge/engine/reference/commandline/image_build.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_history.md
+++ b/edge/engine/reference/commandline/image_history.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_import.md
+++ b/edge/engine/reference/commandline/image_import.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_inspect.md
+++ b/edge/engine/reference/commandline/image_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_load.md
+++ b/edge/engine/reference/commandline/image_load.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_ls.md
+++ b/edge/engine/reference/commandline/image_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_prune.md
+++ b/edge/engine/reference/commandline/image_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_pull.md
+++ b/edge/engine/reference/commandline/image_pull.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_push.md
+++ b/edge/engine/reference/commandline/image_push.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_rm.md
+++ b/edge/engine/reference/commandline/image_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_save.md
+++ b/edge/engine/reference/commandline/image_save.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/image_tag.md
+++ b/edge/engine/reference/commandline/image_tag.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/images.md
+++ b/edge/engine/reference/commandline/images.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/import.md
+++ b/edge/engine/reference/commandline/import.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/s
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/info.md
+++ b/edge/engine/reference/commandline/info.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/inspect.md
+++ b/edge/engine/reference/commandline/inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/kill.md
+++ b/edge/engine/reference/commandline/kill.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/load.md
+++ b/edge/engine/reference/commandline/load.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/login.md
+++ b/edge/engine/reference/commandline/login.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/logout.md
+++ b/edge/engine/reference/commandline/logout.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/logs.md
+++ b/edge/engine/reference/commandline/logs.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/s
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network.md
+++ b/edge/engine/reference/commandline/network.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network_connect.md
+++ b/edge/engine/reference/commandline/network_connect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network_create.md
+++ b/edge/engine/reference/commandline/network_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network_disconnect.md
+++ b/edge/engine/reference/commandline/network_disconnect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network_inspect.md
+++ b/edge/engine/reference/commandline/network_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network_ls.md
+++ b/edge/engine/reference/commandline/network_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network_prune.md
+++ b/edge/engine/reference/commandline/network_prune.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/network_rm.md
+++ b/edge/engine/reference/commandline/network_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node.md
+++ b/edge/engine/reference/commandline/node.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node_demote.md
+++ b/edge/engine/reference/commandline/node_demote.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node_inspect.md
+++ b/edge/engine/reference/commandline/node_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node_ls.md
+++ b/edge/engine/reference/commandline/node_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node_promote.md
+++ b/edge/engine/reference/commandline/node_promote.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node_ps.md
+++ b/edge/engine/reference/commandline/node_ps.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node_rm.md
+++ b/edge/engine/reference/commandline/node_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/node_update.md
+++ b/edge/engine/reference/commandline/node_update.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/pause.md
+++ b/edge/engine/reference/commandline/pause.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin.md
+++ b/edge/engine/reference/commandline/plugin.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_create.md
+++ b/edge/engine/reference/commandline/plugin_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_disable.md
+++ b/edge/engine/reference/commandline/plugin_disable.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_enable.md
+++ b/edge/engine/reference/commandline/plugin_enable.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_inspect.md
+++ b/edge/engine/reference/commandline/plugin_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_install.md
+++ b/edge/engine/reference/commandline/plugin_install.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_ls.md
+++ b/edge/engine/reference/commandline/plugin_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_push.md
+++ b/edge/engine/reference/commandline/plugin_push.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_rm.md
+++ b/edge/engine/reference/commandline/plugin_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_set.md
+++ b/edge/engine/reference/commandline/plugin_set.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/plugin_upgrade.md
+++ b/edge/engine/reference/commandline/plugin_upgrade.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/port.md
+++ b/edge/engine/reference/commandline/port.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/ps.md
+++ b/edge/engine/reference/commandline/ps.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/pull.md
+++ b/edge/engine/reference/commandline/pull.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/push.md
+++ b/edge/engine/reference/commandline/push.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/rename.md
+++ b/edge/engine/reference/commandline/rename.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/restart.md
+++ b/edge/engine/reference/commandline/restart.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/rm.md
+++ b/edge/engine/reference/commandline/rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/rmi.md
+++ b/edge/engine/reference/commandline/rmi.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/run.md
+++ b/edge/engine/reference/commandline/run.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/save.md
+++ b/edge/engine/reference/commandline/save.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/search.md
+++ b/edge/engine/reference/commandline/search.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/secret.md
+++ b/edge/engine/reference/commandline/secret.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/secret_create.md
+++ b/edge/engine/reference/commandline/secret_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/secret_inspect.md
+++ b/edge/engine/reference/commandline/secret_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/secret_ls.md
+++ b/edge/engine/reference/commandline/secret_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/secret_rm.md
+++ b/edge/engine/reference/commandline/secret_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/service.md
+++ b/edge/engine/reference/commandline/service.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/service_create.md
+++ b/edge/engine/reference/commandline/service_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/service_inspect.md
+++ b/edge/engine/reference/commandline/service_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/service_logs.md
+++ b/edge/engine/reference/commandline/service_logs.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/service_ls.md
+++ b/edge/engine/reference/commandline/service_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/edge/engine/reference/commandline/service_ps.md
+++ b/edge/engine/reference/commandline/service_ps.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/service_rm.md
+++ b/edge/engine/reference/commandline/service_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/service_scale.md
+++ b/edge/engine/reference/commandline/service_scale.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/service_update.md
+++ b/edge/engine/reference/commandline/service_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stack.md
+++ b/edge/engine/reference/commandline/stack.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stack_deploy.md
+++ b/edge/engine/reference/commandline/stack_deploy.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stack_ls.md
+++ b/edge/engine/reference/commandline/stack_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stack_ps.md
+++ b/edge/engine/reference/commandline/stack_ps.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stack_rm.md
+++ b/edge/engine/reference/commandline/stack_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stack_services.md
+++ b/edge/engine/reference/commandline/stack_services.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/start.md
+++ b/edge/engine/reference/commandline/start.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stats.md
+++ b/edge/engine/reference/commandline/stats.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/stop.md
+++ b/edge/engine/reference/commandline/stop.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm.md
+++ b/edge/engine/reference/commandline/swarm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm_init.md
+++ b/edge/engine/reference/commandline/swarm_init.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm_join-token.md
+++ b/edge/engine/reference/commandline/swarm_join-token.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm_join.md
+++ b/edge/engine/reference/commandline/swarm_join.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm_leave.md
+++ b/edge/engine/reference/commandline/swarm_leave.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm_unlock-key.md
+++ b/edge/engine/reference/commandline/swarm_unlock-key.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm_unlock.md
+++ b/edge/engine/reference/commandline/swarm_unlock.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/swarm_update.md
+++ b/edge/engine/reference/commandline/swarm_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/system.md
+++ b/edge/engine/reference/commandline/system.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/system_df.md
+++ b/edge/engine/reference/commandline/system_df.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/system_events.md
+++ b/edge/engine/reference/commandline/system_events.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/system_info.md
+++ b/edge/engine/reference/commandline/system_info.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/system_prune.md
+++ b/edge/engine/reference/commandline/system_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/tag.md
+++ b/edge/engine/reference/commandline/tag.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/top.md
+++ b/edge/engine/reference/commandline/top.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/unpause.md
+++ b/edge/engine/reference/commandline/unpause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/update.md
+++ b/edge/engine/reference/commandline/update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/version.md
+++ b/edge/engine/reference/commandline/version.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/volume.md
+++ b/edge/engine/reference/commandline/volume.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/volume_create.md
+++ b/edge/engine/reference/commandline/volume_create.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/volume_inspect.md
+++ b/edge/engine/reference/commandline/volume_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/volume_ls.md
+++ b/edge/engine/reference/commandline/volume_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/volume_prune.md
+++ b/edge/engine/reference/commandline/volume_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/volume_rm.md
+++ b/edge/engine/reference/commandline/volume_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/engine/reference/commandline/wait.md
+++ b/edge/engine/reference/commandline/wait.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/edge/index.md
+++ b/edge/index.md
@@ -40,7 +40,7 @@ Continue reading, or go straight to [API and CLI](#api-and-cli),
 [Daemon](#daemon), [Dockerfile](#dockerfile), [Services](#services), or
 [Stacks](#stacks).
 
-[Read the full release notes](https://github.com/docker/docker/releases/tag/v17.04.0-ce){: target="_blank" class="_" }
+[Read the full release notes](https://github.com/moby/moby/releases/tag/v17.04.0-ce){: target="_blank" class="_" }
 
 ##### API and CLI
 

--- a/engine/admin/logging/log_tags.md
+++ b/engine/admin/logging/log_tags.md
@@ -42,7 +42,7 @@ original container name.
 
 For advanced usage, the generated tag's use
 [go templates](http://golang.org/pkg/text/template/) and the container's
-[logging context](https://github.com/docker/docker/blob/17.05.x/daemon/logger/loginfo.go).
+[logging context](https://github.com/moby/moby/blob/17.05.x/daemon/logger/loginfo.go).
 
 As an example of what is possible with the syslog logger, if you use the following
 command, you get the output that follows:

--- a/engine/admin/systemd.md
+++ b/engine/admin/systemd.md
@@ -139,5 +139,5 @@ you will need to add this configuration in the Docker systemd service file.
 When installing the binary without a package, you may want
 to integrate Docker with systemd. For this, install the two unit files
 (`service` and `socket`) from [the github
-repository](https://github.com/docker/docker/tree/master/contrib/init/systemd)
+repository](https://github.com/moby/moby/tree/master/contrib/init/systemd)
 to `/etc/systemd/system`.

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -8,7 +8,7 @@ title: Docker Engine frequently asked questions (FAQ)
 
 If you don't see your question here, feel free to submit new ones to
 <docs@docker.com>.  Or, you can fork [the
-repo](https://github.com/docker/docker) and contribute them yourself by editing
+repo](https://github.com/moby/moby) and contribute them yourself by editing
 the documentation sources.
 
 
@@ -19,8 +19,8 @@ Docker Engine is 100% free. It is open source, so you can use it without paying.
 ### What open source license are you using?
 
 We are using the Apache License Version 2.0, see it here:
-[https://github.com/docker/docker/blob/master/LICENSE](
-https://github.com/docker/docker/blob/master/LICENSE)
+[https://github.com/moby/moby/blob/master/LICENSE](
+https://github.com/moby/moby/blob/master/LICENSE)
 
 ### Does Docker run on Linux, macOS, or Windows?
 
@@ -283,7 +283,7 @@ You can find more answers on:
 - [Docker user mailinglist](https://groups.google.com/d/forum/docker-user)
 - [Docker developer mailinglist](https://groups.google.com/d/forum/docker-dev)
 - [IRC, docker on freenode](irc://chat.freenode.net#docker)
-- [GitHub](https://github.com/docker/docker)
+- [GitHub](https://github.com/moby/moby)
 - [Ask questions on Stackoverflow](http://stackoverflow.com/search?q=docker)
 - [Join the conversation on Twitter](http://twitter.com/docker)
 

--- a/engine/index.md
+++ b/engine/index.md
@@ -111,5 +111,5 @@ The complete list of deprecated features can be found on the
 ## Licensing
 
 Docker is licensed under the Apache License, Version 2.0. See
-[LICENSE](https://github.com/docker/docker/blob/master/LICENSE) for the full
+[LICENSE](https://github.com/moby/moby/blob/master/LICENSE) for the full
 license text.

--- a/engine/installation/binaries.md
+++ b/engine/installation/binaries.md
@@ -36,9 +36,9 @@ meets the prerequisites:
   https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount)
   `cgroupfs` hierarchy; a single, all-encompassing `cgroup` mount
   point is not sufficient. See Github issues
-  [#2683](https://github.com/docker/docker/issues/2683),
-  [#3485](https://github.com/docker/docker/issues/3485),
-  [#4568](https://github.com/docker/docker/issues/4568)).
+  [#2683](https://github.com/moby/moby/issues/2683),
+  [#3485](https://github.com/moby/moby/issues/3485),
+  [#4568](https://github.com/moby/moby/issues/4568)).
 
 #### Secure your environment as much as possible
 
@@ -68,7 +68,7 @@ instructions for enabling and configuring AppArmor or SELinux.
 
 1.  Download the static binary archive. You can download either the latest
     release binaries or a specific version. To find the download link, see the
-    [release notes](https://github.com/docker/docker/releases) for the version
+    [release notes](https://github.com/moby/moby/releases) for the version
     of Docker you want to install. You can choose a `tar.gz` archive or `zip`
     archive.
 
@@ -123,7 +123,7 @@ The macOS binary includes the Docker client only. It does not include the
 
 1.  Download the static binary archive. You can download either the latest
     release binaries or a specific version. To find the download link, see the
-    [release notes](https://github.com/docker/docker/releases) for the version
+    [release notes](https://github.com/moby/moby/releases) for the version
     of Docker you want to install. You can choose a `tar.gz` archive or
     `zip` archive.
 

--- a/engine/installation/linux/linux-postinstall.md
+++ b/engine/installation/linux/linux-postinstall.md
@@ -101,11 +101,11 @@ your host's Linux distribution and available kernel drivers.
 
 Docker will not run correctly if your kernel is older than version 3.10 or if it
 is missing some modules. To check kernel compatibility, you can download and
-run the [`check-compatibility.sh`](https://raw.githubusercontent.com/docker/docker/master/contrib/check-config.sh)
+run the [`check-compatibility.sh`](https://raw.githubusercontent.com/moby/moby/master/contrib/check-config.sh)
 script.
 
 ```bash
-$ curl https://raw.githubusercontent.com/docker/docker/master/contrib/check-config.sh > check-config.sh
+$ curl https://raw.githubusercontent.com/moby/moby/master/contrib/check-config.sh > check-config.sh
 
 $ bash ./check-config.sh
 ```

--- a/engine/reference/commandline/README.md
+++ b/engine/reference/commandline/README.md
@@ -2,7 +2,7 @@
 
 The files in this directory are stub files which include the file
 `/_includes/cli.md`, which parses YAML files generated from the
-[`docker/docker`](https://github.com/docker/docker) repository. The YAML files
+[`moby/moby`](https://github.com/moby/moby) repository. The YAML files
 are parsed into output files like
 [https://docs.docker.com/engine/reference/commandline/build/](https://docs.docker.com/engine/reference/commandline/build/).
 
@@ -14,7 +14,7 @@ The output files are composed from two sources:
   the CLI source code in that repository.
 
 - The **Extended Description** and **Examples** sections are pulled into the
-  YAML from the files in [https://github.com/docker/docker/tree/master/docs/reference/commandline](https://github.com/docker/docker/tree/master/docs/reference/commandline)
+  YAML from the files in [https://github.com/moby/moby/tree/master/docs/reference/commandline](https://github.com/moby/moby/tree/master/docs/reference/commandline)
   Specifically, the Markdown inside the `## Description` and `## Examples`
   headings are parsed. Please submit corrections to the text in that repository.
 
@@ -22,7 +22,7 @@ The output files are composed from two sources:
 
 The process for generating the YAML files is still in flux. Check with
 @thajestah or @frenchben. Be sure to generate the YAML files with the correct
-branch of `docker/docker` checked out (probably not `master`).
+branch of `moby/moby` checked out (probably not `master`).
 
 After generating the YAML files, replace the YAML files in
 [https://github.com/docker/docker.github.io/tree/master/_data/engine-cli](https://github.com/docker/docker.github.io/tree/master/_data/engine-cli)

--- a/engine/reference/commandline/attach.md
+++ b/engine/reference/commandline/attach.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/build.md
+++ b/engine/reference/commandline/build.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint.md
+++ b/engine/reference/commandline/checkpoint.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint_create.md
+++ b/engine/reference/commandline/checkpoint_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint_ls.md
+++ b/engine/reference/commandline/checkpoint_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint_rm.md
+++ b/engine/reference/commandline/checkpoint_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/commit.md
+++ b/engine/reference/commandline/commit.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/container.md
+++ b/engine/reference/commandline/container.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_attach.md
+++ b/engine/reference/commandline/container_attach.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_commit.md
+++ b/engine/reference/commandline/container_commit.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_cp.md
+++ b/engine/reference/commandline/container_cp.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_create.md
+++ b/engine/reference/commandline/container_create.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_diff.md
+++ b/engine/reference/commandline/container_diff.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_exec.md
+++ b/engine/reference/commandline/container_exec.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_export.md
+++ b/engine/reference/commandline/container_export.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_inspect.md
+++ b/engine/reference/commandline/container_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_kill.md
+++ b/engine/reference/commandline/container_kill.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_logs.md
+++ b/engine/reference/commandline/container_logs.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_ls.md
+++ b/engine/reference/commandline/container_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_pause.md
+++ b/engine/reference/commandline/container_pause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_port.md
+++ b/engine/reference/commandline/container_port.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_prune.md
+++ b/engine/reference/commandline/container_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_rename.md
+++ b/engine/reference/commandline/container_rename.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_restart.md
+++ b/engine/reference/commandline/container_restart.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_rm.md
+++ b/engine/reference/commandline/container_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_run.md
+++ b/engine/reference/commandline/container_run.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_start.md
+++ b/engine/reference/commandline/container_start.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_stats.md
+++ b/engine/reference/commandline/container_stats.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_stop.md
+++ b/engine/reference/commandline/container_stop.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_top.md
+++ b/engine/reference/commandline/container_top.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_unpause.md
+++ b/engine/reference/commandline/container_unpause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_update.md
+++ b/engine/reference/commandline/container_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_wait.md
+++ b/engine/reference/commandline/container_wait.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/cp.md
+++ b/engine/reference/commandline/cp.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/create.md
+++ b/engine/reference/commandline/create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/deploy.md
+++ b/engine/reference/commandline/deploy.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/diff.md
+++ b/engine/reference/commandline/diff.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/docker.md
+++ b/engine/reference/commandline/docker.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/dockerd.md
+++ b/engine/reference/commandline/dockerd.md
@@ -15,7 +15,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/events.md
+++ b/engine/reference/commandline/events.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/exec.md
+++ b/engine/reference/commandline/exec.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/export.md
+++ b/engine/reference/commandline/export.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/history.md
+++ b/engine/reference/commandline/history.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/image.md
+++ b/engine/reference/commandline/image.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_build.md
+++ b/engine/reference/commandline/image_build.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_history.md
+++ b/engine/reference/commandline/image_history.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_import.md
+++ b/engine/reference/commandline/image_import.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_inspect.md
+++ b/engine/reference/commandline/image_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_load.md
+++ b/engine/reference/commandline/image_load.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_ls.md
+++ b/engine/reference/commandline/image_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_prune.md
+++ b/engine/reference/commandline/image_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_pull.md
+++ b/engine/reference/commandline/image_pull.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_push.md
+++ b/engine/reference/commandline/image_push.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_rm.md
+++ b/engine/reference/commandline/image_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_save.md
+++ b/engine/reference/commandline/image_save.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_tag.md
+++ b/engine/reference/commandline/image_tag.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/images.md
+++ b/engine/reference/commandline/images.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/import.md
+++ b/engine/reference/commandline/import.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/info.md
+++ b/engine/reference/commandline/info.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/inspect.md
+++ b/engine/reference/commandline/inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/kill.md
+++ b/engine/reference/commandline/kill.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/load.md
+++ b/engine/reference/commandline/load.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/login.md
+++ b/engine/reference/commandline/login.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/logout.md
+++ b/engine/reference/commandline/logout.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/logs.md
+++ b/engine/reference/commandline/logs.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network.md
+++ b/engine/reference/commandline/network.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_connect.md
+++ b/engine/reference/commandline/network_connect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_create.md
+++ b/engine/reference/commandline/network_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_disconnect.md
+++ b/engine/reference/commandline/network_disconnect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_inspect.md
+++ b/engine/reference/commandline/network_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_ls.md
+++ b/engine/reference/commandline/network_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_prune.md
+++ b/engine/reference/commandline/network_prune.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_rm.md
+++ b/engine/reference/commandline/network_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node.md
+++ b/engine/reference/commandline/node.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_demote.md
+++ b/engine/reference/commandline/node_demote.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_inspect.md
+++ b/engine/reference/commandline/node_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_ls.md
+++ b/engine/reference/commandline/node_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_promote.md
+++ b/engine/reference/commandline/node_promote.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_ps.md
+++ b/engine/reference/commandline/node_ps.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_rm.md
+++ b/engine/reference/commandline/node_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_update.md
+++ b/engine/reference/commandline/node_update.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/pause.md
+++ b/engine/reference/commandline/pause.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin.md
+++ b/engine/reference/commandline/plugin.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_create.md
+++ b/engine/reference/commandline/plugin_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_disable.md
+++ b/engine/reference/commandline/plugin_disable.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_enable.md
+++ b/engine/reference/commandline/plugin_enable.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_inspect.md
+++ b/engine/reference/commandline/plugin_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_install.md
+++ b/engine/reference/commandline/plugin_install.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_ls.md
+++ b/engine/reference/commandline/plugin_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_push.md
+++ b/engine/reference/commandline/plugin_push.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_rm.md
+++ b/engine/reference/commandline/plugin_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_set.md
+++ b/engine/reference/commandline/plugin_set.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_upgrade.md
+++ b/engine/reference/commandline/plugin_upgrade.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/port.md
+++ b/engine/reference/commandline/port.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/ps.md
+++ b/engine/reference/commandline/ps.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/pull.md
+++ b/engine/reference/commandline/pull.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/push.md
+++ b/engine/reference/commandline/push.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/rename.md
+++ b/engine/reference/commandline/rename.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/restart.md
+++ b/engine/reference/commandline/restart.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/rm.md
+++ b/engine/reference/commandline/rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/rmi.md
+++ b/engine/reference/commandline/rmi.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/run.md
+++ b/engine/reference/commandline/run.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/save.md
+++ b/engine/reference/commandline/save.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/search.md
+++ b/engine/reference/commandline/search.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret.md
+++ b/engine/reference/commandline/secret.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_create.md
+++ b/engine/reference/commandline/secret_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_inspect.md
+++ b/engine/reference/commandline/secret_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_ls.md
+++ b/engine/reference/commandline/secret_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_rm.md
+++ b/engine/reference/commandline/secret_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service.md
+++ b/engine/reference/commandline/service.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_create.md
+++ b/engine/reference/commandline/service_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service_inspect.md
+++ b/engine/reference/commandline/service_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service_logs.md
+++ b/engine/reference/commandline/service_logs.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_ls.md
+++ b/engine/reference/commandline/service_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service_ps.md
+++ b/engine/reference/commandline/service_ps.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_rm.md
+++ b/engine/reference/commandline/service_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_scale.md
+++ b/engine/reference/commandline/service_scale.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_update.md
+++ b/engine/reference/commandline/service_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack.md
+++ b/engine/reference/commandline/stack.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_deploy.md
+++ b/engine/reference/commandline/stack_deploy.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_ls.md
+++ b/engine/reference/commandline/stack_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_ps.md
+++ b/engine/reference/commandline/stack_ps.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_rm.md
+++ b/engine/reference/commandline/stack_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_services.md
+++ b/engine/reference/commandline/stack_services.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/start.md
+++ b/engine/reference/commandline/start.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stats.md
+++ b/engine/reference/commandline/stats.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stop.md
+++ b/engine/reference/commandline/stop.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm.md
+++ b/engine/reference/commandline/swarm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_init.md
+++ b/engine/reference/commandline/swarm_init.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_join-token.md
+++ b/engine/reference/commandline/swarm_join-token.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_join.md
+++ b/engine/reference/commandline/swarm_join.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_leave.md
+++ b/engine/reference/commandline/swarm_leave.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_unlock-key.md
+++ b/engine/reference/commandline/swarm_unlock-key.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_unlock.md
+++ b/engine/reference/commandline/swarm_unlock.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_update.md
+++ b/engine/reference/commandline/swarm_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system.md
+++ b/engine/reference/commandline/system.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_df.md
+++ b/engine/reference/commandline/system_df.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_events.md
+++ b/engine/reference/commandline/system_events.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_info.md
+++ b/engine/reference/commandline/system_info.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_prune.md
+++ b/engine/reference/commandline/system_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/tag.md
+++ b/engine/reference/commandline/tag.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/top.md
+++ b/engine/reference/commandline/top.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/unpause.md
+++ b/engine/reference/commandline/unpause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/update.md
+++ b/engine/reference/commandline/update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/version.md
+++ b/engine/reference/commandline/version.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume.md
+++ b/engine/reference/commandline/volume.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_create.md
+++ b/engine/reference/commandline/volume_create.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_inspect.md
+++ b/engine/reference/commandline/volume_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_ls.md
+++ b/engine/reference/commandline/volume_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_prune.md
+++ b/engine/reference/commandline/volume_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_rm.md
+++ b/engine/reference/commandline/volume_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/wait.md
+++ b/engine/reference/commandline/wait.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/docker/docker
+https://www.github.com/moby/moby
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/security/apparmor.md
+++ b/engine/security/apparmor.md
@@ -20,7 +20,7 @@ instead.
 A profile for the Docker Engine daemon exists but it is not currently installed
 with the `deb` packages. If you are interested in the source for the daemon
 profile, it is located in
-[contrib/apparmor](https://github.com/docker/docker/tree/master/contrib/apparmor)
+[contrib/apparmor](https://github.com/moby/moby/tree/master/contrib/apparmor)
 in the Docker Engine source repository.
 
 ## Understand the policies
@@ -28,7 +28,7 @@ in the Docker Engine source repository.
 The `docker-default` profile is the default for running containers. It is
 moderately protective while providing wide application compatibility. The
 profile is generated from the following
-[template](https://github.com/docker/docker/blob/master/profiles/apparmor/template.go).
+[template](https://github.com/moby/moby/blob/master/profiles/apparmor/template.go).
 
 When you run a container, it uses the `docker-default` policy unless you
 override it with the `security-opt` option. For example, the following
@@ -283,8 +283,8 @@ Trusty, where some interesting behaviors are enforced.)
 
 Advanced users and package managers can find a profile for `/usr/bin/docker`
 (Docker Engine Daemon) underneath
-[contrib/apparmor](https://github.com/docker/docker/tree/master/contrib/apparmor)
+[contrib/apparmor](https://github.com/moby/moby/tree/master/contrib/apparmor)
 in the Docker Engine source repository.
 
 The `docker-default` profile for containers lives in
-[profiles/apparmor](https://github.com/docker/docker/tree/master/profiles/apparmor).
+[profiles/apparmor](https://github.com/moby/moby/tree/master/profiles/apparmor).

--- a/engine/security/https/README.md
+++ b/engine/security/https/README.md
@@ -10,7 +10,7 @@ At this point, it has to be a manual thing, and I've been running it in boot2doc
 My process is as following:
 
     $ boot2docker ssh
-    root@boot2docker:/# git clone https://github.com/docker/docker
+    root@boot2docker:/# git clone https://github.com/moby/moby
     root@boot2docker:/# cd docker/docs/articles/https
     root@boot2docker:/# make cert
 

--- a/engine/security/seccomp.md
+++ b/engine/security/seccomp.md
@@ -31,7 +31,7 @@ The default `seccomp` profile provides a sane default for running containers wit
 seccomp and disables around 44 system calls out of 300+. It is moderately
 protective while providing wide application compatibility. The default Docker
 profile can be found
-[here](https://github.com/docker/docker/blob/master/profiles/seccomp/default.json)).
+[here](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json)).
 
 In effect, the profile is a whitelist which denies access to system calls by
 default, then whitelists specific system calls. The profile works by defining a

--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -191,7 +191,7 @@ to the host.
 This won't affect regular web apps; but malicious users will find that
 the arsenal at their disposal has shrunk considerably! By default Docker
 drops all capabilities except [those
-needed](https://github.com/docker/docker/blob/master/oci/defaults_linux.go#L62-L77),
+needed](https://github.com/moby/moby/blob/master/oci/defaults_linux.go#L62-L77),
 a whitelist instead of a blacklist approach. You can see a full list of
 available capabilities in [Linux
 manpages](http://man7.org/linux/man-pages/man7/capabilities.7.html).

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -6,7 +6,7 @@ title: Swarm mode overview
 
 To use Docker Engine in swarm mode, install the Docker Engine `v1.12.0` or
 later from the [Docker releases GitHub
-repository](https://github.com/docker/docker/releases). Alternatively, install
+repository](https://github.com/moby/moby/releases). Alternatively, install
 the latest Docker for Mac or Docker for Windows Beta.
 
 Docker Engine 1.12 includes swarm mode for natively managing a cluster of

--- a/engine/userguide/eng-image/baseimages.md
+++ b/engine/userguide/eng-image/baseimages.md
@@ -37,13 +37,13 @@ It can be as simple as this to create an Ubuntu base image:
 There are more example scripts for creating base images in the Docker
 GitHub Repo:
 
- - [BusyBox](https://github.com/docker/docker/blob/master/contrib/mkimage-busybox.sh)
+ - [BusyBox](https://github.com/moby/moby/blob/master/contrib/mkimage-busybox.sh)
  - CentOS / Scientific Linux CERN (SLC) [on Debian/Ubuntu](
-   https://github.com/docker/docker/blob/master/contrib/mkimage-rinse.sh) or
+   https://github.com/moby/moby/blob/master/contrib/mkimage-rinse.sh) or
    [on CentOS/RHEL/SLC/etc.](
-   https://github.com/docker/docker/blob/master/contrib/mkimage-yum.sh)
+   https://github.com/moby/moby/blob/master/contrib/mkimage-yum.sh)
  - [Debian / Ubuntu](
-   https://github.com/docker/docker/blob/master/contrib/mkimage-debootstrap.sh)
+   https://github.com/moby/moby/blob/master/contrib/mkimage-debootstrap.sh)
 
 ## Creating a simple base image using scratch
 

--- a/engine/userguide/eng-image/dockerfile_best-practices.md
+++ b/engine/userguide/eng-image/dockerfile_best-practices.md
@@ -280,7 +280,7 @@ reduces the image size, since the apt cache is not stored in a layer. Since the
 `RUN` statement starts with `apt-get update`, the package cache will always be
 refreshed prior to `apt-get install`.
 
-> **Note**: The official Debian and Ubuntu images [automatically run `apt-get clean`](https://github.com/docker/docker/blob/03e2923e42446dbb830c654d0eec323a0b4ef02a/contrib/mkimage/debootstrap#L82-L105),
+> **Note**: The official Debian and Ubuntu images [automatically run `apt-get clean`](https://github.com/moby/moby/blob/03e2923e42446dbb830c654d0eec323a0b4ef02a/contrib/mkimage/debootstrap#L82-L105),
 > so explicit invocation is not required.
 
 #### Using pipes

--- a/index.md
+++ b/index.md
@@ -68,7 +68,7 @@ Continue reading, or go straight to [API and CLI](#api-and-cli),
 [Daemon](#daemon), [Dockerfile](#dockerfile), [Services](#services), or
 [Stacks](#stacks).
 
-[Read the full release notes](https://github.com/docker/docker/releases/tag/v17.04.0-ce){: target="_blank" class="_" }
+[Read the full release notes](https://github.com/moby/moby/releases/tag/v17.04.0-ce){: target="_blank" class="_" }
 
 ##### API and CLI
 

--- a/machine/completion.md
+++ b/machine/completion.md
@@ -20,13 +20,13 @@ Place the completion script in `/etc/bash_completion.d/` as follows:
 *   On a Mac:
 
     ```none
-    curl -L https://raw.githubusercontent.com/docker/docker/master/contrib/completion/bash/docker > `brew --prefix`/etc/bash_completion.d/docker
+    curl -L https://raw.githubusercontent.com/moby/moby/master/contrib/completion/bash/docker > `brew --prefix`/etc/bash_completion.d/docker
     ```
 
 *   On a standard Linux installation:
 
     ```none
-    curl -L https://raw.githubusercontent.com/docker/docker/master/contrib/completion/bash/docker > /etc/bash_completion.d/docker
+    curl -L https://raw.githubusercontent.com/moby/moby/master/contrib/completion/bash/docker > /etc/bash_completion.d/docker
     ```
 
 Completion will be available upon next login.
@@ -37,7 +37,7 @@ Completion will be available upon next login.
 Place the completion scripts in your `/path/to/zsh/completion`, using e.g. `~/.zsh/completion/`
 
     mkdir -p ~/.zsh/completion
-    curl -L https://raw.githubusercontent.com/docker/docker/master/contrib/completion/zsh/_docker > ~/.zsh/completion/_docker-machine
+    curl -L https://raw.githubusercontent.com/moby/moby/master/contrib/completion/zsh/_docker > ~/.zsh/completion/_docker-machine
 
 Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`
 

--- a/opensource/FAQ.md
+++ b/opensource/FAQ.md
@@ -44,10 +44,10 @@ Set your local repo to track changes upstream, on the `docker` repository.
     $ cd docker-fork
     ```
 
-2.  Add a remote called `upstream` that points to `docker/docker`.
+2.  Add a remote called `upstream` that points to `moby/moby`.
 
     ```
-    $ git remote add upstream https://github.com/docker/docker.git
+    $ git remote add upstream https://github.com/moby/moby.git
     ```
 
 ## How do I format my Go code
@@ -90,7 +90,7 @@ leave a blank line to separate paragraphs.
 
 Always rebase and squash your commits before making a pull request.
 
-1.  Fetch any of the last minute changes from `docker/docker`.
+1.  Fetch any of the last minute changes from `moby/moby`.
 
     ```
     $ git fetch upstream master

--- a/opensource/code.md
+++ b/opensource/code.md
@@ -9,7 +9,7 @@ title: Quickstart code or doc contribution
 If you'd like to improve the code of any of Docker's projects, we would love to
 have your contributions. All of our projects' code <a href="https://github.com/docker" target="_blank">repositories are on GitHub</a>.
 
-If you want to contribute to the `docker/docker` repository you should be
+If you want to contribute to the `moby/moby` repository you should be
 familiar with or interested in learning Go or the Markdown language.  If you
 know other languages, investigate our other repositories&mdash;not all of them
 run on Go.

--- a/opensource/doc-style.md
+++ b/opensource/doc-style.md
@@ -15,7 +15,7 @@ If a question about syntactical, grammatical, or lexical practice comes up,
 refer to the AP guide first. If you don’t have a copy of (or online subscription
 to) the AP guide, you can almost always find an answer to a specific question by
 searching the web. If you can’t find an answer, please ask a
-[maintainer](https://github.com/docker/docker/blob/master/MAINTAINERS) and
+[maintainer](https://github.com/moby/moby/blob/master/MAINTAINERS) and
 we will find the answer.
 
 That said, please don't get too hung up on using correct style. We'd rather have

--- a/opensource/kitematic/find_issue.md
+++ b/opensource/kitematic/find_issue.md
@@ -40,4 +40,4 @@ To find and claim an issue you want to work on:
 Go to next section to learn [Set up your Kitematic development
 environment](set_up_dev.md).
 
-(For more about working with open source issues in Docker, see <a href="/opensource/workflow/find-an-issue/" target="_blank">Find an issue</a> and <a href="https://github.com/docker/docker/blob/master/CONTRIBUTING.md" target="_blank"> Docker Contributing Guidelines</a>.)
+(For more about working with open source issues in Docker, see <a href="/opensource/workflow/find-an-issue/" target="_blank">Find an issue</a> and <a href="https://github.com/moby/moby/blob/master/CONTRIBUTING.md" target="_blank"> Docker Contributing Guidelines</a>.)

--- a/opensource/kitematic/work_issue.md
+++ b/opensource/kitematic/work_issue.md
@@ -73,7 +73,7 @@ To do this, edit the container `General Settings` layout.
     $ git commit -s -m "added container ID to show on settings tab, fixes issue #1191"
     ```
 
-    (See <a href="https://github.com/docker/docker/blob/master/CONTRIBUTING.md#coding-style" target="_blank">Coding Style</a> in the general guidelines on <a href="https://github.com/docker/docker/blob/master/CONTRIBUTING.md" target="_blank">Contributing to Docker</a>.)
+    (See <a href="https://github.com/moby/moby/blob/master/CONTRIBUTING.md#coding-style" target="_blank">Coding Style</a> in the general guidelines on <a href="https://github.com/moby/moby/blob/master/CONTRIBUTING.md" target="_blank">Contributing to Docker</a>.)
 
 ## Where to go next
 

--- a/opensource/project/set-up-dev-env.md
+++ b/opensource/project/set-up-dev-env.md
@@ -16,7 +16,7 @@ run a Docker container, and develop code in the container. Docker itself builds,
 tests, and releases new Docker versions using this container.
 
 If you followed the procedures that <a href="/opensource/project/set-up-git/" target="_blank">
-set up Git for contributing</a>, you should have a fork of the `docker/docker`
+set up Git for contributing</a>, you should have a fork of the `moby/moby`
 repository. You also created a branch called `dry-run-test`. In this section,
 you continue working with your fork on this branch.
 

--- a/opensource/project/set-up-git.md
+++ b/opensource/project/set-up-git.md
@@ -23,15 +23,15 @@ To fork and clone Docker:
 
 1. Open a browser and log into GitHub with your account.
 
-2. Go to the <a href="https://github.com/docker/docker"
-target="_blank">docker/docker repository</a>.
+2. Go to the <a href="https://github.com/moby/moby"
+target="_blank">moby/moby repository</a>.
 
 3. Click the "Fork" button in the upper right corner of the GitHub interface.
 
     ![Branch Signature](images/fork_docker.png)
 
     GitHub forks the repository to your GitHub account. The original
-    `docker/docker` repository becomes a new fork `YOUR_ACCOUNT/docker` under
+    `moby/moby` repository becomes a new fork `YOUR_ACCOUNT/docker` under
     your account.
 
 4. Copy your fork's clone URL from GitHub.
@@ -102,8 +102,8 @@ with `git commit -s`. Docker does not accept anonymous contributions or contribu
 through pseudonyms.
 
 As you change code in your fork, you'll want to keep it in sync with the changes
-others make in the `docker/docker` repository. To make syncing easier, you'll
-also add a _remote_ called `upstream` that points to `docker/docker`. A remote
+others make in the `moby/moby` repository. To make syncing easier, you'll
+also add a _remote_ called `upstream` that points to `moby/moby`. A remote
 is just another project version hosted on the internet or network.
 
 To configure your username, email, and add a remote:
@@ -129,7 +129,7 @@ To configure your username, email, and add a remote:
 4. Set your local repo to track changes upstream, on the `docker` repository.
 
    ```bash
-   $ git remote add upstream https://github.com/docker/docker.git
+   $ git remote add upstream https://github.com/moby/moby.git
    ```
 
 5. Check the result in your `git` configuration.
@@ -146,7 +146,7 @@ To configure your username, email, and add a remote:
    branch.master.merge=refs/heads/master
    user.name=Mary Anthony
    user.email=mary@docker.com
-   remote.upstream.url=https://github.com/docker/docker.git
+   remote.upstream.url=https://github.com/moby/moby.git
    remote.upstream.fetch=+refs/heads/*:refs/remotes/upstream/*
    ```
 
@@ -156,8 +156,8 @@ To configure your username, email, and add a remote:
    $ git remote -v
    origin	https://github.com/moxiegirl/docker.git (fetch)
    origin	https://github.com/moxiegirl/docker.git (push)
-   upstream https://github.com/docker/docker.git (fetch)
-   upstream https://github.com/docker/docker.git (push)
+   upstream https://github.com/moby/moby.git (fetch)
+   upstream https://github.com/moby/moby.git (push)
    ```
 
 ## Task 3. Create and push a branch

--- a/opensource/project/software-req-win.md
+++ b/opensource/project/software-req-win.md
@@ -39,10 +39,10 @@ You are now ready clone and build the Docker source code.
 
 In a new (to pick up the path change) PowerShell prompt, run:
 
-    git clone https://github.com/docker/docker
+    git clone https://github.com/moby/moby
     cd docker
 
-This clones the main Docker repository. Check out [Docker on GitHub](https://github.com/docker/docker) to learn about the other software that powers the Docker platform.
+This clones the main Docker repository. Check out [Docker on GitHub](https://github.com/moby/moby) to learn about the other software that powers the Docker platform.
 
 ## 5. Build and run
 

--- a/opensource/project/who-written-for.md
+++ b/opensource/project/who-written-for.md
@@ -9,13 +9,13 @@ title: README first
 This section of the documentation contains a guide for Docker users who want to
 contribute code or documentation to the Docker Engine project. As a community, we
 share rules of behavior and interaction. Make sure you are familiar with the <a
-href="https://github.com/docker/docker/blob/master/CONTRIBUTING.md#docker-community-guidelines"
+href="https://github.com/moby/moby/blob/master/CONTRIBUTING.md#docker-community-guidelines"
 target="_blank">community guidelines</a> before continuing.
 
 ## Where and what you can contribute
 
 The Docker project consists of not just one but several repositories on GitHub.
-So, in addition to the `docker/docker` repository, there is the
+So, in addition to the `moby/moby` repository, there is the
 `docker/compose` repo, the `docker/machine` repo, and several more.
 Contribute to any of these and you contribute to the Docker project.
 
@@ -25,7 +25,7 @@ contributing to a Docker repository that has a language or a focus area you are
 familiar with.
 
 If you are new to the open source community, to Docker, or to formal
-programming, you should start out contributing to the `docker/docker`
+programming, you should start out contributing to the `moby/moby`
 repository. Why? Because this guide is written for that repository specifically.
 
 Finally, code or documentation isn't the only way to contribute. You can report

--- a/opensource/ways/community.md
+++ b/opensource/ways/community.md
@@ -28,7 +28,7 @@ target="_blank">Docker Community Forum</a>
 *  <a href="http://stackoverflow.com/search?tab=newest&q=docker"
 target="_blank">StackOverflow</a>
 
-You can also check the <a href="https://github.com/docker/docker/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fquestion+-label%3Astatus%2Fclaimed+-label%3Astatus%2Fassigned+no%3Aassignee" target="_blank">list of
+You can also check the <a href="https://github.com/moby/moby/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fquestion+-label%3Astatus%2Fclaimed+-label%3Astatus%2Fassigned+no%3Aassignee" target="_blank">list of
 open user questions</a> on the Docker project.
 
 

--- a/opensource/ways/issues.md
+++ b/opensource/ways/issues.md
@@ -34,7 +34,7 @@ Follow these steps:
    notification go to your GitHub or email inbox. Some of repositories you can watch are:
 
    | Repository | Description |
-   | [docker/docker](https://github.com/docker/docker) | Docker the open-source application container engine |
+   | [moby/moby](https://github.com/moby/moby) | Docker the open-source application container engine |
    | [docker/machine](https://github.com/docker/machine) | Software for the easy and quick creation of Docker hosts on your computer, on cloud providers, and inside your own data center. |
    | [kitematic/kitematic](https://github.com/kitematic/kitematic) | Kitematic is a simple application for managing Docker containers on macOS and Windows. |
    | [docker/swarm](https://github.com/docker/swarm) | Native clustering for Docker; manage several Docker hosts as a single, virtual host. |
@@ -42,9 +42,9 @@ Follow these steps:
 
    See <a href="https://github.com/docker" target="_blank">the complete list of Docker repositories</a> on GitHub.
 
-3. Choose an issue from the [list of untriaged issues](https://github.com/docker/docker/issues?q=is%3Aopen+is%3Aissue+-label%3Akind%2Fproposal+-label%3Akind%2Fenhancement+-label%3Akind%2Fbug+-label%3Akind%2Fcleanup+-label%3Akind%2Fgraphics+-label%3Akind%2Fwriting+-label%3Akind%2Fsecurity+-label%3Akind%2Fquestion+-label%3Akind%2Fimprovement+-label%3Akind%2Ffeature).
+3. Choose an issue from the [list of untriaged issues](https://github.com/moby/moby/issues?q=is%3Aopen+is%3Aissue+-label%3Akind%2Fproposal+-label%3Akind%2Fenhancement+-label%3Akind%2Fbug+-label%3Akind%2Fcleanup+-label%3Akind%2Fgraphics+-label%3Akind%2Fwriting+-label%3Akind%2Fsecurity+-label%3Akind%2Fquestion+-label%3Akind%2Fimprovement+-label%3Akind%2Ffeature).
 
-4. Follow <a href="https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md" target="_blank">the triage process</a> to triage the issue.
+4. Follow <a href="https://github.com/moby/moby/blob/master/project/ISSUE-TRIAGE.md" target="_blank">the triage process</a> to triage the issue.
 
    The triage process asks you to add both a `kind/` and a `exp/` label to each
    issue. Because you are not a Docker maintainer, you add these through comments.
@@ -54,6 +54,6 @@ Follow these steps:
 
    For example, the `+exp/beginner` and `+kind/writing` labels would triage an issue as
    beginner writing task. For descriptions of valid labels, see <a
-   href="https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md">the triage process</a>.
+   href="https://github.com/moby/moby/blob/master/project/ISSUE-TRIAGE.md">the triage process</a>.
 
 5. Triage another issue.

--- a/opensource/ways/test.md
+++ b/opensource/ways/test.md
@@ -43,7 +43,7 @@ What to look for:
  * Are the steps in the right order?
  * Did you get the results the procedure or example said you would?
 
-## Step 3.  If you couldn't complete the procedure or example, file <a href="https://github.com/docker/docker/issues/new" target="_blank">an issue in the Docker repo</a>.
+## Step 3.  If you couldn't complete the procedure or example, file <a href="https://github.com/moby/moby/issues/new" target="_blank">an issue in the Docker repo</a>.
 
 # Test code in the Docker
 

--- a/opensource/workflow/advanced-contributing.md
+++ b/opensource/workflow/advanced-contributing.md
@@ -22,7 +22,7 @@ the project contributor guide. You should also have
 A refactor or cleanup proposal changes Docker's internal structure without
 altering the external behavior. To make this type of proposal:
 
-1. Fork `docker/docker`.
+1. Fork `moby/moby`.
 
 2. Make your changes in a feature branch.
 
@@ -74,7 +74,7 @@ The following provides greater detail on the process:
     where you can get feedback on your idea. Float your idea in a forum or two
     to get some commentary going on it.
 
-4. Fork `docker/docker` and clone the repo to your local host.
+4. Fork `moby/moby` and clone the repo to your local host.
 
 5. Create a new Markdown file in the area you wish to change.
 
@@ -96,7 +96,7 @@ The following provides greater detail on the process:
 
     This is your chance to convince people your idea is sound.
 
-8. Submit your proposal in a pull request to `docker/docker`.
+8. Submit your proposal in a pull request to `moby/moby`.
 
     The title should have the format:
 
@@ -120,14 +120,14 @@ The following provides greater detail on the process:
 
     Implementation uses all the standard practices of any contribution.
 
-    * fork `docker/docker`
+    * fork `moby/moby`
     * create a feature branch
     * sync frequently back to master
     * test as you go and full test before a PR
 
     If you run into issues, the community is there to help.
 
-12. When you have a complete implementation, submit a pull request back to `docker/docker`.
+12. When you have a complete implementation, submit a pull request back to `moby/moby`.
 
 13. Review and iterate on your code.
 

--- a/opensource/workflow/coding-style.md
+++ b/opensource/workflow/coding-style.md
@@ -11,7 +11,7 @@ program code and documentation code.
 
 ## Change and commit code
 
-* Fork the `docker/docker` repository.
+* Fork the `moby/moby` repository.
 
 * Make changes on your fork in a feature branch. Name your branch `XXXX-something`
   where `XXXX` is the issue number you are working on.

--- a/opensource/workflow/create-pr.md
+++ b/opensource/workflow/create-pr.md
@@ -6,9 +6,9 @@ title: Create a pull request (PR)
 
 A pull request (PR) sends your changes to the Docker maintainers for review. You
 create a pull request on GitHub. A pull request "pulls" changes from your forked
-repository into the `docker/docker` repository.
+repository into the `moby/moby` repository.
 
-You can see <a href="https://github.com/docker/docker/pulls" target="_blank">the
+You can see <a href="https://github.com/moby/moby/pulls" target="_blank">the
 list of active pull requests to Docker</a> on GitHub.
 
 ## Check your work
@@ -41,10 +41,10 @@ Always rebase and squash your commits before making a pull request.
 
     This is the branch associated with your request.
 
-2. Fetch any last minute changes from `docker/docker`.
+2. Fetch any last minute changes from `moby/moby`.
 
         $ git fetch upstream master
-        From github.com:docker/docker
+        From github.com:moby/moby
          * branch            master     -> FETCH_HEAD
 
 3. Start an interactive rebase.
@@ -97,7 +97,7 @@ You create and manage PRs on GitHub:
     ![PR dialog](images/to_from_pr.png)
 
     The pull request compares your changes to the `master` branch on the
-    `docker/docker` repository.
+    `moby/moby` repository.
 
 3. Edit the dialog's description and add a reference to the issue you are fixing.
 
@@ -114,7 +114,7 @@ You create and manage PRs on GitHub:
 
 5. Press "Create pull request".
 
-    The system creates the request and opens it for you in the `docker/docker`
+    The system creates the request and opens it for you in the `moby/moby`
     repository.
 
     ![Pull request made](images/pull_request_made.png)

--- a/opensource/workflow/find-an-issue.md
+++ b/opensource/workflow/find-an-issue.md
@@ -146,8 +146,8 @@ class="gh-label expert">exp/expert</strong> issue.
 
 To claim an issue:
 
-1. Go to the `docker/docker` <a
-	href="https://github.com/docker/docker" target="_blank">repository</a>.
+1. Go to the `moby/moby` <a
+	href="https://github.com/moby/moby" target="_blank">repository</a>.
 
 2. Click the "Issues" tab.
 
@@ -180,10 +180,10 @@ bot, changes the issue status to claimed. The following example shows issue #110
 
 ## Sync your fork and create a new branch
 
-If you have followed along in this guide, you forked the `docker/docker`
+If you have followed along in this guide, you forked the `moby/moby`
 repository. Maybe that was an hour ago or a few days ago. In any case, before
 you start working on your issue, sync your repository with the upstream
-`docker/docker` master. Syncing ensures your repository has the latest
+`moby/moby` master. Syncing ensures your repository has the latest
 changes.
 
 To sync your repository:
@@ -202,17 +202,17 @@ To sync your repository:
 
     Recall that `origin/master` is a branch on your remote GitHub repository.
 
-4. Make sure you have the upstream remote `docker/docker` by listing them.
+4. Make sure you have the upstream remote `moby/moby` by listing them.
 
         $ git remote -v
         origin	https://github.com/moxiegirl/docker.git (fetch)
         origin	https://github.com/moxiegirl/docker.git (push)
-        upstream	https://github.com/docker/docker.git (fetch)
-        upstream	https://github.com/docker/docker.git (push)
+        upstream	https://github.com/moby/moby.git (fetch)
+        upstream	https://github.com/moby/moby.git (push)
 
     If the `upstream` is missing, add it.
 
-        $ git remote add upstream https://github.com/docker/docker.git
+        $ git remote add upstream https://github.com/moby/moby.git
 
 5. Fetch all the changes from the `upstream master` branch.
 
@@ -222,7 +222,7 @@ To sync your repository:
         remote: Total 141 (delta 52), reused 46 (delta 46), pack-reused 66
         Receiving objects: 100% (141/141), 112.43 KiB | 0 bytes/s, done.
         Resolving deltas: 100% (79/79), done.
-	    From github.com:docker/docker
+	    From github.com:moby/moby
 	     * branch            master     -> FETCH_HEAD
 
 7. Rebase your local master with the `upstream/master`.

--- a/opensource/workflow/make-a-contribution.md
+++ b/opensource/workflow/make-a-contribution.md
@@ -16,7 +16,7 @@ process simple so you'll want to contribute frequently.
 ## The basic contribution workflow
 
 In this guide, you work through Docker's basic contribution workflow by fixing a
-single *beginner* issue in the `docker/docker` repository. The workflow
+single *beginner* issue in the `moby/moby` repository. The workflow
 for fixing simple issues looks like this:
 
 ![Simple process](images/existing_issue.png)

--- a/opensource/workflow/work-issue.md
+++ b/opensource/workflow/work-issue.md
@@ -147,10 +147,10 @@ You should pull and rebase frequently as you work.
 1. Return to the terminal on your local machine and checkout your
     feature branch in your local `docker-fork` repository.
 
-2. Fetch any last minute changes from `docker/docker`.
+2. Fetch any last minute changes from `moby/moby`.
 
         $ git fetch upstream master
-        From github.com:docker/docker
+        From github.com:moby/moby
          * branch            master     -> FETCH_HEAD
 
 3. Start an interactive rebase.

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -120,7 +120,7 @@ http {
     # disable any limits to avoid HTTP 413 for large image uploads
     client_max_body_size 0;
 
-    # required to avoid HTTP 411: see Issue #1486 (https://github.com/docker/docker/issues/1486)
+    # required to avoid HTTP 411: see Issue #1486 (https://github.com/moby/moby/issues/1486)
     chunked_transfer_encoding on;
 
     location /v2/ {

--- a/swarm/discovery.md
+++ b/swarm/discovery.md
@@ -208,8 +208,8 @@ swarm is connected to the public internet. To create your cluster:
 
 You can contribute a new discovery backend to Swarm. For information on how to
 do this, see <a
-href="https://github.com/docker/docker/tree/master/pkg/discovery">
-github.com/docker/docker/pkg/discovery</a>.
+href="https://github.com/moby/moby/tree/master/pkg/discovery">
+github.com/moby/moby/pkg/discovery</a>.
 
 
 ## Docker Swarm documentation index

--- a/swarm/status-code-comparison-to-docker.md
+++ b/swarm/status-code-comparison-to-docker.md
@@ -10,7 +10,7 @@ Docker Engine provides a REST API for making calls to the Engine daemon. Docker 
 
 Four methods are included, and they are GET, POST, PUT and DELETE.
 
-The comparison is based on api v1.22, and all Docker Status Codes in api v1.22 are referenced from [docker-remote-api-v1.22](https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md
+The comparison is based on api v1.22, and all Docker Status Codes in api v1.22 are referenced from [docker-remote-api-v1.22](https://github.com/moby/moby/blob/master/docs/reference/api/docker_remote_api_v1.22.md
 ).
 
 ## GET

--- a/test.md
+++ b/test.md
@@ -75,7 +75,7 @@ culpa qui officia deserunt mollit anim id est laborum.
 
 - <a href="https://docker.com/" target="_blank" class="_">an HTML link that opens in a new window</a>
 
-- A link to a Github PR in `docker/docker`: {% include github-pr.md pr=28199 %}
+- A link to a Github PR in `moby/moby`: {% include github-pr.md pr=28199 %}
 
 - A link to a Github PR in `docker/docker.github.io`: {% include github-pr.md repo=docker.github.io pr=9999 %}
 
@@ -171,7 +171,7 @@ only need to do it on the first one. If you have a `<th>`, set it there.
   <tr>
   <td>This is some test text. <br><br>This is more <b>text</b> on a new line. <br><br>Lorem ipsum dolor <tt>sit amet</tt>, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </td>
-    <td>This is some more text about the right hand side. There is a <a href="https://github.com/docker/docker/tree/master/experimental" target="_blank" class="_">link here to the Docker Experimental Features README</a> on GitHub.<br><br>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</td>
+    <td>This is some more text about the right hand side. There is a <a href="https://github.com/moby/moby/tree/master/experimental" target="_blank" class="_">link here to the Docker Experimental Features README</a> on GitHub.<br><br>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</td>
   </tr>
   <tr>
   <td>


### PR DESCRIPTION
### Related issues (optional)
Fixes #2868 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
