### PR TITLE
Raspbian install corrections

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -256,8 +256,33 @@ to install.
 
 
 ### Install on Raspian (Raspberry Pi)
->**Warning**: This isn't necessary if you used the recommended
->```bash $ curl -sSL https://get.docker.com | sh ``` command!
+
+You can choose between two methods for `armhf`. You can use the same method
+as Debian, setting up the repository and using `apt-get install`, or you can
+use a convenience script, which requires privileged access, but sets up the
+repository for you and installs the packages for Bash auto-completion.
+
+- Setting up the repository directly:
+
+  ```bash
+  $ echo "deb [arch=armhf] https://apt.dockerproject.org/repo \
+      raspbian-jessie main" | \
+      sudo tee /etc/apt/sources.list.d/docker.list
+  ```
+
+- Using the convenience script:
+
+  ```bash
+  $ curl -sSL https://get.docker.com > install.sh
+
+  $ sudo bash ./install.sh
+  ```
+
+  > **Warning**: Always audit scripts downloaded from the internet before
+  > running them locally.
+      
+  If you use this method, Docker is installed and starts automatically.
+  Skip the rest of this step.
 
 Once you have added the Docker repo to `/etc/apt/sources.list.d/`, you should
 see `docker.list` if you:

--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -260,9 +260,9 @@ to install.
 You can choose between two methods for `armhf`. You can use the same method
 as Debian, setting up the repository and using `apt-get install`, or you can
 use a convenience script, which requires privileged access, but sets up the
-repository for you and installs the packages for Bash auto-completion.
+repository for you and start automatically the daemon.
 
-- Setting up the repository directly:
+- Setting up the repository directly (recommended):
 
   ```bash
   $ echo "deb [arch=armhf] https://apt.dockerproject.org/repo \
@@ -312,13 +312,13 @@ installing Docker.
     Use this command to install the latest version of Docker:
 
     ```bash
-    $ sudo apt-get install docker
+    $ sudo apt-get install docker-engine
     ```
-    > **NOTE**: By default, Docker on Raspian is Docker Community Edition, so
-    > there is no need to specify docker-ce.
-
-    > **NOTE**: If ```bash $ curl -sSL https://get.docker.com | sh ``` isn't used,
-    > then docker won't have auto-completion! You'll have to add it manually.
+    > **NOTE**: Currently Docker on Raspian is Docker Community Edition Edge.
+    > The URL is still the same as prior to the introduction of the CE and EE edition.
+    > It is possible that in the future this URL does not work anymore,
+    > then please use the Debian URL. Use also that URL if you want to use the stable
+    > edition.
 
 3.  Verify that Docker is installed correctly by running the `hello-world`
     image.

--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -260,9 +260,9 @@ to install.
 You can choose between two methods for Raspbian on `armhf`. You can use the
 same method as Debian, setting up the repository and using `apt-get install`,
 or you can use a convenience script, which requires privileged access, but
-sets up the repository for you and start automatically the daemon.
+sets up the repository for you and automatically start Docker.
 
-- Setting up the repository directly:
+- Set up the repository directly:
 
   ```bash
   $ echo "deb [arch=armhf] https://apt.dockerproject.org/repo \
@@ -270,7 +270,7 @@ sets up the repository for you and start automatically the daemon.
       sudo tee /etc/apt/sources.list.d/docker.list
   ```
 
-- Using the convenience script:
+- Use the convenience script:
 
   ```bash
   $ curl -sSL https://get.docker.com > install.sh

--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -255,14 +255,14 @@ To upgrade Docker, first run `sudo apt-get update`, then follow the
 to install.
 
 
-### Install on Raspian (Raspberry Pi)
+### Install on Raspbian (Raspberry Pi)
 
-You can choose between two methods for `armhf`. You can use the same method
-as Debian, setting up the repository and using `apt-get install`, or you can
-use a convenience script, which requires privileged access, but sets up the
-repository for you and start automatically the daemon.
+You can choose between two methods for Raspbian on `armhf`. You can use the
+same method as Debian, setting up the repository and using `apt-get install`,
+or you can use a convenience script, which requires privileged access, but
+sets up the repository for you and start automatically the daemon.
 
-- Setting up the repository directly (recommended):
+- Setting up the repository directly:
 
   ```bash
   $ echo "deb [arch=armhf] https://apt.dockerproject.org/repo \
@@ -284,8 +284,8 @@ repository for you and start automatically the daemon.
   If you use this method, Docker is installed and starts automatically.
   Skip the rest of this step.
 
-Once you have added the Docker repo to `/etc/apt/sources.list.d/`, you should
-see `docker.list` if you:
+Once you have added the Docker repository to `/etc/apt/sources.list.d/`,
+you should see `docker.list` if you:
 
 ```bash
 $ ls /etc/apt/sources.list.d/
@@ -314,11 +314,12 @@ installing Docker.
     ```bash
     $ sudo apt-get install docker-engine
     ```
-    > **NOTE**: Currently Docker on Raspian is Docker Community Edition Edge.
-    > The URL is still the same as prior to the introduction of the CE and EE edition.
-    > It is possible that in the future this URL does not work anymore,
-    > then please use the Debian URL. Use also that URL if you want to use the stable
-    > edition.
+    > **NOTE**: Currently Docker on Raspbian is Docker Community Edition from
+    > the edge channel. If you want to use the stable channel, then you need
+    > to use the same URL as for Debian on `armhf`. The URL for Raspbian is still
+    > the same as prior to the introduction of the CE and EE edition but it is
+    > still working.
+
 
 3.  Verify that Docker is installed correctly by running the `hello-world`
     image.


### PR DESCRIPTION
### Proposed changes

After implementing Pull Request #2965 the Raspbian section was inconsistent.

In addition the Raspbian section had several errors:

- The given URL would install the Edge version of Docker
- The package to install was incorrect (`docker` installs a KDE package, one needs to use `docker-engine`)
- The `docker-engine` package contains the Bash completion setup, so the script installation does not bring any advantages. So I remove any mention of "recommendation" for the script as for Debian and Ubuntu this is also not the recommended installation.

These errors were corrected.

### Related issues

Fixes #2098

Related PR #2965 

It completes the related PR by correcting and making consistent the Raspbian section of the Debian installation instructions.