### PR TITLE
Get started ver1.13 or higher required

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -133,7 +133,9 @@ entanglement; a containerized app "runs anywhere."
 Before we get started, make sure your system has the latest version of Docker
 installed.
 
-[Install Docker](/engine/installation/index.md){: class="button outline-btn" style="margin-bottom: 30px; margin-right:100%"}
+[Install Docker](/engine/installation/index.md){: class="button outline-btn" style="margin-bottom: 30px; margin-right:100%; clear: left;"}
+<div style="clear:left"></div>
+> **Note** version 1.13 or higher is required
 
 You should be able to run `docker run hello-world` and see a response like this:
 
@@ -147,7 +149,15 @@ To generate this message, Docker took the following steps:
 ...(snipped)...
 ```
 
-If you see a message like the one above, you're ready to begin the journey.
+Now would also be a good time to make sure you are using version 1.13 or higher
+
+```
+$ docker version
+
+Docker version 17.03.1-ce, build c6d412e
+```
+
+If you see a messages like the ones above, you're ready to begin the journey.
 
 ## Conclusion
 

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -8,7 +8,7 @@ description: Learn how to write, build, and run a simple app -- the Docker way.
 
 ## Prerequisites
 
-- [Install Docker](/engine/installation/).
+- [Install Docker version 1.13 or higher](/engine/installation/).
 - Read the orientation in [Part 1](index.md).
 - Give your environment a quick test run to make sure you're all set up:
 

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -7,7 +7,7 @@ description: Learn how to define load-balanced and scalable service that runs co
 
 ## Prerequisites
 
-- [Install Docker](/engine/installation/).
+- [Install Docker version 1.13 or higher](/engine/installation/).
 - Read the orientation in [Part 1](index.md).
 - Learn how to create containers in [Part 2](part2.md).
 - Make sure you have pushed the container you created to a registry, as

--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -7,7 +7,7 @@ description: Learn how to create clusters of Dockerized machines.
 
 ## Prerequisites
 
-- [Install Docker](/engine/installation/).
+- [Install Docker version 1.13 or higher](/engine/installation/).
 - Read the orientation in [Part 1](index.md).
 - Learn how to create containers in [Part 2](part2.md).
 - Make sure you have pushed the container you created to a registry, as

--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -8,7 +8,7 @@ description: Learn how to create a multi-container application that uses all the
 
 ## Prerequisites
 
-- [Install Docker](/engine/installation/).
+- [Install Docker version 1.13 or higher](/engine/installation/).
 - Read the orientation in [Part 1](index.md).
 - Learn how to create containers in [Part 2](part2.md).
 - Make sure you have pushed the container you created to a registry, as

--- a/get-started/part6.md
+++ b/get-started/part6.md
@@ -7,7 +7,7 @@ description: Deploy your app to production using Docker CE or EE.
 
 ## Prerequisites
 
-- [Install Docker](/engine/installation/).
+- [Install Docker version 1.13 or higher](/engine/installation/).
 - Read the orientation in [Part 1](index.md).
 - Learn how to create containers in [Part 2](part2.md).
 - Make sure you have pushed the container you created to a registry, as


### PR DESCRIPTION
### Proposed changes

All get started pages having warning about using 1.13 or higher now.

Had to use a div clear left because I put a note under the install button on the index page

### Related issues (optional)

Fixes: #2981