### PR TITLE
update re:container_name not supported in v3 Compose

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -190,7 +190,7 @@ Designed to be cross-compatible between Compose and the Docker Engine's
 several more.
 
 - Removed: `volume_driver`, `volumes_from`, `cpu_shares`, `cpu_quota`, `cpuset`,
-  `mem_limit`, `memswap_limit`, `extends`, `group_add`. See the [upgrading](#upgrading)
+  `mem_limit`, `memswap_limit`, `extends`, `group_add`, `container_name`. See the [upgrading](#upgrading)
   guide for how to migrate away from these.
 
 - Added: [deploy](index.md#deploy)

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -227,6 +227,7 @@ several options have been removed:
     `deploy`. Note that `deploy` configuration only takes effect when using
     `docker stack deploy`, and is ignored by `docker-compose`.
 
+-   `container_name`: This option has been removed for `version: "3.x"` Compose files.
 -   `extends`: This option has been removed for `version: "3.x"` Compose files.
 -   `group_add`: This option has been removed for `version: "3.x"` Compose files.
 

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -190,7 +190,7 @@ Designed to be cross-compatible between Compose and the Docker Engine's
 several more.
 
 - Removed: `volume_driver`, `volumes_from`, `cpu_shares`, `cpu_quota`, `cpuset`,
-  `mem_limit`, `memswap_limit`, `extends`, `group_add`, `container_name`. See the [upgrading](#upgrading)
+  `mem_limit`, `memswap_limit`, `extends`, `group_add`. See the [upgrading](#upgrading)
   guide for how to migrate away from these.
 
 - Added: [deploy](index.md#deploy)
@@ -227,7 +227,6 @@ several options have been removed:
     `deploy`. Note that `deploy` configuration only takes effect when using
     `docker stack deploy`, and is ignored by `docker-compose`.
 
--   `container_name`: This option has been removed for `version: "3.x"` Compose files.
 -   `extends`: This option has been removed for `version: "3.x"` Compose files.
 -   `group_add`: This option has been removed for `version: "3.x"` Compose files.
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -304,16 +304,6 @@ Specify an optional parent cgroup for the container.
 > [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
 > with a (version 3) Compose file.
 
-### container_name
-
-Specify a custom container name, rather than a generated default name.
-
-    container_name: my-web-container
-
-Because Docker container names must be unique, you cannot scale a service
-beyond 1 container if you have specified a custom name. Attempting to do so
-results in an error.
-
 ### deploy
 
 > **[Version 3](compose-versioning.md#version-3) only.**
@@ -1212,7 +1202,7 @@ volumes:
 
 ### restart
 
-`no` is the default restart policy, and it will not restart a container under any circumstance. When `always` is specified, the container always restarts. The `on-failure` policy restarts a container if the exit code indicates an on-failure error. 
+`no` is the default restart policy, and it will not restart a container under any circumstance. When `always` is specified, the container always restarts. The `on-failure` policy restarts a container if the exit code indicates an on-failure error.
 
       - restart: no
       - restart: always

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -445,6 +445,25 @@ To set labels on containers instead, use the `labels` key outside of `deploy`:
         labels:
           com.example.description: "This label will appear on all containers for the web service"
 
+#### Not supported for `docker stack deploy`
+
+The following sub-options (supported for `docker compose up` and `docker compose run`) are _not supported_ for `docker stack deploy` or the `deploy` key.
+
+- [build](#build)
+- [cgroup_parent](#cgroup-parent)
+- [container_name](#containername)
+- [devices](#devices)
+- [dns](#devices)
+- [dns_search](#dnssearch)
+- [tmpfs](#tmpfs)
+- [external_links](#externallinks)
+- [links](#links)
+- [network_mode](#networkmode)
+- [security_opt](#securityopt)
+- [stop_signal](#stopsignal)
+- [sysctls](#sysctls)
+- [userns_mode](#usernsmode)
+
 ### devices
 
 List of device mappings.  Uses the same format as the `--device` docker

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -304,6 +304,20 @@ Specify an optional parent cgroup for the container.
 > [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
 > with a (version 3) Compose file.
 
+### container_name
+
+Specify a custom container name, rather than a generated default name.
+
+    container_name: my-web-container
+
+Because Docker container names must be unique, you cannot scale a service beyond
+1 container if you have specified a custom name. Attempting to do so results in
+an error.
+
+> **Note**: This option is ignored when
+> [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
+> with a (version 3) Compose file.
+
 ### deploy
 
 > **[Version 3](compose-versioning.md#version-3) only.**


### PR DESCRIPTION
### What's changed

- Removed `container_name` option from Compose v3 file reference
- Added mention of `container_name` as one of the options no longer supported v3 under "Upgrading Version 2.x to 3.x"

### Reviewers

@dnephin @shin- Can you verify that this is correct?
@joaofnfernandes pointed to this `.go` file: https://github.com/moby/moby/blob/master/cli/compose/types/types.go#L34. Definitely looks unsupported, but we missed this one in previous iterations of the Compose v3 update.

@joaofnfernandes, per your comments in the issue, the other keywords/options deprecated in v3 or already covered in the [upgrading topic](http://localhost:4000/compose/compose-file/compose-versioning/#version-2x-to-3x), are not in the v3 reference file. 

### Related 

Issue #2950 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
