### PR TITLE
Add NTT Communications Enterprise Cloud machine driver to the list of 3rd-party docker machine drivers

### DIFF
--- a/machine/AVAILABLE_DRIVER_PLUGINS.md
+++ b/machine/AVAILABLE_DRIVER_PLUGINS.md
@@ -153,6 +153,20 @@ with Docker Inc.  Use 3rd party plugins at your own risk.
       </td>
     </tr>
     <tr>
+      <td>NTT Communications Enterprise Cloud</td>
+      <td>
+        <a href="https://github.com/mittz/docker-machine-driver-ecl">
+          https://github.com/mittz/docker-machine-driver-ecl
+        </a>
+      </td>
+      <td>
+        <a href="https://github.com/mittz">Hayahito Kawamitsu</a>
+      </td>
+      <td>
+        <a href="mailto:halation3@gmail.com">halation3@gmail.com</a>
+      </td>
+    </tr>
+    <tr>
       <td>GleSYS Internet Services</td>
       <td>
         <a href="https://github.com/glesys/docker-machine-driver-glesys">

--- a/machine/AVAILABLE_DRIVER_PLUGINS.md
+++ b/machine/AVAILABLE_DRIVER_PLUGINS.md
@@ -153,20 +153,6 @@ with Docker Inc.  Use 3rd party plugins at your own risk.
       </td>
     </tr>
     <tr>
-      <td>NTT Communications Enterprise Cloud</td>
-      <td>
-        <a href="https://github.com/mittz/docker-machine-driver-ecl">
-          https://github.com/mittz/docker-machine-driver-ecl
-        </a>
-      </td>
-      <td>
-        <a href="https://github.com/mittz">Hayahito Kawamitsu</a>
-      </td>
-      <td>
-        <a href="mailto:halation3@gmail.com">halation3@gmail.com</a>
-      </td>
-    </tr>
-    <tr>
       <td>GleSYS Internet Services</td>
       <td>
         <a href="https://github.com/glesys/docker-machine-driver-glesys">
@@ -220,6 +206,20 @@ with Docker Inc.  Use 3rd party plugins at your own risk.
       <td>
         <a href=
         "mailto:daniel.hiltgen@docker.com">daniel.hiltgen@docker.com</a>
+      </td>
+    </tr>
+    <tr>
+      <td>NTT Communications Enterprise Cloud</td>
+      <td>
+        <a href="https://github.com/mittz/docker-machine-driver-ecl">
+          https://github.com/mittz/docker-machine-driver-ecl
+        </a>
+      </td>
+      <td>
+        <a href="https://github.com/mittz">Hayahito Kawamitsu</a>
+      </td>
+      <td>
+        <a href="mailto:halation3@gmail.com">halation3@gmail.com</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Added [NTT Communications Enterprise Cloud](https://ecl.ntt.com/en/) driver to the list of 3rd-party docker machine drivers.