### PR TITLE
Links to compose file information terminates with 404

### DIFF
--- a/compose/overview.md
+++ b/compose/overview.md
@@ -44,7 +44,7 @@ A `docker-compose.yml` looks like this:
       logvolume01: {}
 
 For more information about the Compose file, see the
-[Compose file reference](compose-file.md).
+[Compose file reference](compose-file/index.md).
 
 Compose has commands for managing the whole lifecycle of your application:
 
@@ -62,7 +62,7 @@ Compose has commands for managing the whole lifecycle of your application:
 - [Get started with WordPress](wordpress.md)
 - [Frequently asked questions](faq.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](compose-file.md)
+- [Compose file reference](compose-file/index.md)
 
 ## Features
 


### PR DESCRIPTION
### Proposed changes

Links to compose file information terminates with 404, I have corrected the link in two places to what I expect to be the correct resource.

