### PR TITLE
WIP: Consistent device usage in devicemapper examples

### DIFF
--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -401,14 +401,16 @@ NAME			   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
 xvda			   202:0	0	 8G  0 disk
 └─xvda1			   202:1	0	 8G  0 part /
 xvdf			   202:80	0	10G  0 disk
-├─docker-thinpool_tmeta		   253:0	0	90G  0 lvm
-│ └─docker-202:1-1032-pool 253:2	0	10G  0 dm
+├─docker-thinpool_tmeta	   253:0	0	90G  0 lvm
+│ └─docker-thinpool        253:2	0	10G  0 lvm
 └─docker-thinpool_tdata	   253:1	0	 4G  0 lvm
-  └─docker-202:1-1032-pool 253:2	0	10G  0 dm
+  └─docker-thinpool        253:2	0	10G  0 lvm
 ```
 
 The diagram below shows the image from prior examples updated with the detail
-from the `lsblk` command above.
+from the `lsblk` command above when no containers are running.
+
+
 
 ![](images/lsblk-diagram.jpg)
 

--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -401,9 +401,9 @@ NAME			   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
 xvda			   202:0	0	 8G  0 disk
 └─xvda1			   202:1	0	 8G  0 part /
 xvdf			   202:80	0	10G  0 disk
-├─vg--docker-data		   253:0	0	90G  0 lvm
+├─docker-thinpool_tmeta		   253:0	0	90G  0 lvm
 │ └─docker-202:1-1032-pool 253:2	0	10G  0 dm
-└─vg--docker-metadata	   253:1	0	 4G  0 lvm
+└─docker-thinpool_tdata	   253:1	0	 4G  0 lvm
   └─docker-202:1-1032-pool 253:2	0	10G  0 dm
 ```
 
@@ -576,17 +576,17 @@ disk partition.
 1.  Extend the volume group (VG) `vg-docker`.
 
     ```bash
-    $ sudo vgextend vg-docker /dev/sdh1
+    $ sudo vgextend docker /dev/sdh1
 
-    Volume group "vg-docker" successfully extended
+    Volume group "docker" successfully extended
     ```
 
     Your volume group may use a different name.
 
-2.  Extend the `data` logical volume (LV) `vg-docker/data`
+2.  Extend the `data` logical volume (LV) `docker/thinpool`
 
     ```bash
-    $ sudo lvextend  -l+100%FREE -n vg-docker/data
+    $ sudo lvextend  -l+100%FREE -n docker/thinpool
 
     Extending logical volume data to 200 GiB
     Logical volume data successfully resized
@@ -621,7 +621,7 @@ disk partition.
     `515883008`.
 
     ```bash
-    $ sudo blockdev --getsize64 /dev/vg-docker/data
+    $ sudo blockdev --getsize64 /dev/docker/thinpool
 
     264132100096
     ```

--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -331,7 +331,7 @@ assumes that the Docker daemon is in the `stopped` state.
 
     ```none
     --storage-driver=devicemapper \
-    --storage-opt=dm.thinpooldev=/dev/mapper/docker-thinpool \
+    --storage-opt=dm.thinpooldev=docker-thinpool \
     --storage-opt=dm.use_deferred_removal=true \
     --storage-opt=dm.use_deferred_deletion=true
     ```


### PR DESCRIPTION
### Proposed changes

The existing docs use inconsistent names for the docker volume, and the thinpool logical volume names.  I've updated the docs to use `docker` consistently as the volume group name, and `docker/thinpool` as the logical volume in all examples.

this makes the docs easier to comprehend, since users don't have to go through multiple times to realize the names of volumes keep switching halfway through the example.