### PR TITLE
Note on mixing network_mode with links in Docker compose file

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -824,6 +824,8 @@ the special form `service:[service name]`.
 > [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
 > with a (version 3) Compose file.
 
+> **Note**: `network_mode: "host"` cannot be mixed with [links](#links).
+
 ### networks
 
 Networks to join, referencing entries under the


### PR DESCRIPTION
I just encountered this little gotcha today coming from https://github.com/moby/moby/issues/15086 :)
This might save other people some time :tada: 