### PR TITLE
updating docker version command

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -152,9 +152,8 @@ To generate this message, Docker took the following steps:
 Now would also be a good time to make sure you are using version 1.13 or higher
 
 ```
-$ docker version
-
-Docker version 17.03.1-ce, build c6d412e
+$ docker --version
+Docker version 17.05.0-ce-rc1, build 2878a85
 ```
 
 If you see a messages like the ones above, you're ready to begin the journey.


### PR DESCRIPTION
To get the output shown in the example, you need to run `docker --version` (`docker version` gives  you the long form version output)

cc: @johndmulhausen 
