### PR TITLE
copyedits, link fixes on glossary in test.md

### DIFF
--- a/test.md
+++ b/test.md
@@ -185,11 +185,11 @@ only need to do it on the first one. If you have a `<th>`, set it there.
   </tr>
 </table>
 
-## Glossary
+## Glossary links and content
 
 The glossary source lives in the documentation repository
-https://github.com/docker/docker.github.io in `_data/glossary.yaml`. The
-glossary publishes to
+[docker.github.io](https://github.com/docker/docker.github.io) in
+`_data/glossary.yaml`. The glossary publishes to
 [https://docs.docker.com/glossary/](https://docs.docker.com/glossary/).
 
 To update glossary content, edit `_data/glossary.yaml`.


### PR DESCRIPTION
### what's changed

- improved glossary description
- fixed a weird right-side TOC linking problem to the Glossary heading in `test.md`

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
