### PR TITLE
docs change for compose/networking

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -28,6 +28,8 @@ For example, suppose your app is in a directory called `myapp`, and your `docker
           - "8000:8000"
       db:
         image: postgres
+        ports:
+          - "8001:5432"
 
 When you run `docker-compose up`, the following happens:
 
@@ -42,7 +44,15 @@ get back the appropriate container's IP address. For example, `web`'s
 application code could connect to the URL `postgres://db:5432` and start
 using the Postgres database.
 
-Because `web` explicitly maps a port, it's also accessible from the outside world via port 8000 on your Docker host's network interface.
+It is important to note the distinction between `HOST_PORT` and `CONTAINER_PORT`.
+In the above example, for `db`, the `HOST_PORT` would be `8001`,
+and the container port would be `5432` (postgres default). Networked service-to-service
+communication happens on the `CONTAINER_PORT`, and when `HOST_PORT` is defined,
+the service is accessible externally as well.
+
+Within the `web` container, your connection string to `db` would look like
+`postgres://db:5432`, and from the host machine, the connection string would
+look like `postgres://{DOCKER_IP}:8001`.
 
 ## Updating containers
 

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -45,10 +45,10 @@ application code could connect to the URL `postgres://db:5432` and start
 using the Postgres database.
 
 It is important to note the distinction between `HOST_PORT` and `CONTAINER_PORT`.
-In the above example, for `db`, the `HOST_PORT` would be `8001`,
-and the container port would be `5432` (postgres default). Networked service-to-service
-communication happens on the `CONTAINER_PORT`, and when `HOST_PORT` is defined,
-the service is accessible externally as well.
+In the above example, for `db`, the `HOST_PORT` is `8001` and the container port is
+`5432` (postgres default). Networked service-to-service
+communication use the `CONTAINER_PORT`. When `HOST_PORT` is defined,
+the service is accessible outside the swarm as well.
 
 Within the `web` container, your connection string to `db` would look like
 `postgres://db:5432`, and from the host machine, the connection string would


### PR DESCRIPTION
### Proposed changes

In the current version, it wasn't made explicitly clear that containers talk to each other within the network via the container port, and not the host port (if defined).

Since the example was using `8000:8000` and a `postgres` default, it's easy to miss the important distinction, and purposes, of both ports. Both `{DOCKER_IP}:8000` and `web:8000` would result in a successful call to `web`, but if you were to do something like `4000:80`, it isn't super clear that the new strings are `{DOCKER_IP}:4000` and `web:80`. Since `{DOCKER_IP}:4000` would actually work for another service that was communicating with `web`, it becomes very easy to use that string in your apps instead. Since the `DOCKER_IP` is never truly static, it's good practice to use `web:80` inside your containers.

I've added some clearer and more defined sentences, plus a `HOST_PORT` to `CONTAINER_PORT` mapping to help illustrate the communication differences between external and internally-networked service communications.

### Unreleased project version (optional)

### Related issues (optional)
