### PR TITLE
Updated links to more info on stack files

### DIFF
--- a/docker-cloud/apps/stack-yaml-reference.md
+++ b/docker-cloud/apps/stack-yaml-reference.md
@@ -8,7 +8,7 @@ title: Docker Cloud stack file YAML reference
 
 A stack is a collection of services that make up an application in a specific environment. Learn more about stacks for Docker Cloud [here](stacks.md). A **stack file** is a file in YAML format that defines one or more services, similar to a `docker-compose.yml` file for Docker Compose but with a few extensions. The default name for this file is `docker-cloud.yml`.
 
-**Looking for information on stack files for Swarm?** A good place to start is the [Compose reference file](/compose/compose-file/index.md), particularly the section on [deploy](/compose/compose-file/index.md#deploy] key. Also, the new [Getting Started tutorial](/get-started/index.md) demos use of a stack file to deploy an application to a swarm.
+**Looking for information on stack files for Swarm?** A good place to start is the [Compose reference file](/compose/compose-file/index.md), particularly the section on deploy key, and the reference on [Docker stacks](/compose/bundles.md). Also, the new [Getting Started tutorial](/get-started/index.md) demos use of a stack file to deploy an application to a swarm.
 
 ## Stack file example
 

--- a/docker-cloud/apps/stack-yaml-reference.md
+++ b/docker-cloud/apps/stack-yaml-reference.md
@@ -8,7 +8,7 @@ title: Docker Cloud stack file YAML reference
 
 A stack is a collection of services that make up an application in a specific environment. Learn more about stacks for Docker Cloud [here](stacks.md). A **stack file** is a file in YAML format that defines one or more services, similar to a `docker-compose.yml` file for Docker Compose but with a few extensions. The default name for this file is `docker-cloud.yml`.
 
-**Looking for information on stack files for Swarm?** A good place to start is the [Compose reference file](/compose/compose-file/index.md), particularly the section on deploy key, and the reference on [Docker stacks](/compose/bundles.md). Also, the new [Getting Started tutorial](/get-started/index.md) demos use of a stack file to deploy an application to a swarm.
+**Looking for information on stack files for Swarm?** A good place to start is the [Compose reference file](/compose/compose-file/index.md), particularly the section on `deploy` key and its sub-options, and the reference on [Docker stacks](/compose/bundles.md). Also, the new [Getting Started tutorial](/get-started/index.md) demos use of a stack file to deploy an application to a swarm.
 
 ## Stack file example
 

--- a/docker-cloud/apps/stack-yaml-reference.md
+++ b/docker-cloud/apps/stack-yaml-reference.md
@@ -8,7 +8,7 @@ title: Docker Cloud stack file YAML reference
 
 A stack is a collection of services that make up an application in a specific environment. Learn more about stacks for Docker Cloud [here](stacks.md). A **stack file** is a file in YAML format that defines one or more services, similar to a `docker-compose.yml` file for Docker Compose but with a few extensions. The default name for this file is `docker-cloud.yml`.
 
-**Looking for information on stack files for Swarm?** A good place to start is the [Compose reference file](/compose/compose-file/index.md), particularly the section on [deploy](/compose/compose-file.md#deploy] key. Also, the new [Getting Started tutorial](/get-started/index.md) demos use of a stack file to deploy an application to a swarm.
+**Looking for information on stack files for Swarm?** A good place to start is the [Compose reference file](/compose/compose-file/index.md), particularly the section on [deploy](/compose/compose-file/index.md#deploy] key. Also, the new [Getting Started tutorial](/get-started/index.md) demos use of a stack file to deploy an application to a swarm.
 
 ## Stack file example
 

--- a/docker-cloud/apps/stack-yaml-reference.md
+++ b/docker-cloud/apps/stack-yaml-reference.md
@@ -8,7 +8,7 @@ title: Docker Cloud stack file YAML reference
 
 A stack is a collection of services that make up an application in a specific environment. Learn more about stacks for Docker Cloud [here](stacks.md). A **stack file** is a file in YAML format that defines one or more services, similar to a `docker-compose.yml` file for Docker Compose but with a few extensions. The default name for this file is `docker-cloud.yml`.
 
-[Looking for information on stack files for Swarm?](/compose/compose-files/index.md).
+**Looking for information on stack files for Swarm?** A good place to start is the [Compose reference file](/compose/compose-file/index.md), particularly the section on [deploy](/compose/compose-file.md#deploy] key. Also, the new [Getting Started tutorial](/get-started/index.md) demos use of a stack file to deploy an application to a swarm.
 
 ## Stack file example
 


### PR DESCRIPTION
### what's changed

- Updated x-refs to more info on `docker stack deploy` and stack files (to disambiguate from Docker Cloud stack files)

- I'll also add `stack file` and `Docker Cloud stack file` to the Glossary in another PR. I should probably also add a link to this topic: https://docs.docker.com/compose/bundles/. 

- The file to review is: https://deploy-preview-3104--docker-docs.netlify.com/docker-cloud/apps/stack-yaml-reference/

### Related

Fixes #3079
Fixes #3117 

### Reviewers

@alberto @caylorme @stevvooe
