### PR TITLE
add detail on redis default port

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -38,6 +38,8 @@ provided by Docker images.
         if __name__ == "__main__":
             app.run(host="0.0.0.0", debug=True)
 
+      In this example, `redis` is the hostname of the redis container on the application's network. We use the default port for Redis, `6379`.
+
 3.  Create another file called `requirements.txt` in your project directory and
     paste this in:
 


### PR DESCRIPTION
### What's changed

Added some clarification around the `redis` settings for this example, per user feedback.

### Related Issues

Fixes #3128

## Direct link to page on Netlify preview

https://deploy-preview-3136--docker-docs.netlify.com/compose/gettingstarted/

LGTM

### Reviewers

@shin- @robertf224

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>


