### PR TITLE
Typo in redis port on docker-compose.yml example

### DIFF
--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -162,7 +162,7 @@ services:
   redis:
     image: redis
     ports:
-      - "6379:6739"
+      - "6379:6379"
     volumes:
       - ./data:/data
     deploy:


### PR DESCRIPTION
### Proposed changes

Redis service is forwarding to the wrong port, i believe it was a typo.