### PR TITLE
Add instructions to remove also proxy_set_header Host

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -55,9 +55,10 @@ So if you have an nginx sitting behind it, should remove these lines from the
 example config below:
 
 ```
-X-Real-IP         $remote_addr; # pass on real client's IP
-X-Forwarded-For   $proxy_add_x_forwarded_for;
-X-Forwarded-Proto $scheme;
+      proxy_set_header  Host              $http_host;   # required for docker client's sake
+      proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+      proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
 ```
 
 Otherwise nginx will reset the ELB's values, and the requests will not be routed

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -51,17 +51,17 @@ X-Forwarded-For
 X-Forwarded-Proto
 ```
 
-So if you have an nginx sitting behind it, should remove these lines from the
+So if you have an Nginx instance sitting behind it, remove these lines from the
 example config below:
 
-```
-      proxy_set_header  Host              $http_host;   # required for docker client's sake
-      proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
-      proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
-      proxy_set_header  X-Forwarded-Proto $scheme;
+```none
+proxy_set_header  Host              $http_host;   # required for docker client's sake
+proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header  X-Forwarded-Proto $scheme;
 ```
 
-Otherwise nginx will reset the ELB's values, and the requests will not be routed
+Otherwise Nginx will reset the ELB's values, and the requests will not be routed
 properly. For more information, see
 [#970](https://github.com/docker/distribution/issues/970).
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
Add instructions to remove also proxy_set_header Host when using ELB.
In my case I only had commented out X-Real-IP, X-Forwarded-For, X-Forwarded-Proto, but not Host, and I was getting lots of retrys in Docker. Commenting the proxy_set_header Host fixed the issue, as recommended in https://github.com/moby/moby/issues/16949

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

https://github.com/moby/moby/issues/16949
