### PR TITLE
Linked `docker build` in a Caution note

### DIFF
--- a/docker-cloud/builds/advanced.md
+++ b/docker-cloud/builds/advanced.md
@@ -83,7 +83,7 @@ In the following example, we define a build hook that uses `docker build` argume
 docker build --build-arg CUSTOM=$VAR -t $IMAGE_NAME
 ```
 
-> **Caution**: A `hooks/build` file overrides the basic `docker build` command
+> **Caution**: A `hooks/build` file overrides the basic [docker build](/engine/reference/commandline/build.md) command
 used by the builder, so you must include a similar build command in the hook or
 the automated build will fail.
 


### PR DESCRIPTION
### What's changed

- Added an additional link to the `docker build` command topics per user feedback

### Related

Fixes #3103

### Reviewers

@brianbolt @alberto @pkennedyr 

### Netlify preview

https://deploy-preview-3165--docker-docs.netlify.com/docker-cloud/builds/advanced/#build-hook-examples
