### PR TITLE
reduce padding in nav, space items, remove font weight

### DIFF
--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -198,6 +198,34 @@
     }
 }
 
+@media only screen
+  and (min-device-width: 320px)
+  and (max-device-width: 372px)
+  and (orientation: portrait) {
+    .nav-secondary-tabs {
+      > .container-fluid {
+        padding-left: 5px;
+        padding-right: 5px;
+      }
+    }
+    .tabs {
+      display: -webkit-box;
+      display: -moz-box;
+      display: -ms-flexbox;
+      display: -webkit-flex;
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+      padding: 5px 0 0 0;
+    }
+    .tabs li a {
+      padding: 15px 0 10px 0;
+      margin-left: 0;
+      font-weight: normal;
+    }
+
+}
+
 /* Landscape */
 @media only screen 
   and (min-device-width: 320px) 


### PR DESCRIPTION
This adds a custom break point for small mobile devices and fixes the nav so the last menu item does not wrap to a new line. Viewing the nav on a Samsung Galaxy S5 the `Samples` menu item wraps to a new line and isn't visible. The font weight was changed so the menu would fit in Firefox without changing the font size.