### PR TITLE
Code example in "mode" section is messed up

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -253,7 +253,6 @@ see [Replicated and global
 services](/engine/swarm/how-swarm-mode-works/services/#replicated-and-global-services)
 in the [swarm](/engine/swarm/) topics.)
 
-
     version: '3'
     services:
       worker:


### PR DESCRIPTION
For some reason example in "mode" section doesn't render as code. Only difference that I've noticed from other code blocks is 2 newlines between it and preceding text, so probably this should fix formatting. See https://docs.docker.com/compose/compose-file/#mode