### PR TITLE
Added note on tag formatting of docker image

### DIFF
--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -74,7 +74,7 @@ $ docker run --log-driver=awslogs \
              ...
 ```
 
-> **Note:**
+> **Note**:
 > Your AWS IAM policy must include the `logs:CreateLogGroup` permission before you attempt to use `awslogs-create-group`.
 
 
@@ -87,11 +87,13 @@ When both `awslogs-stream` and `tag` are specified, the value supplied for `awsl
 
 If not specified, the container ID is used as the log stream.
 
-> **Note:**
+{% raw %}
+> **Note**:
 > The CloudWatch log API doesn't support `:` in the log name. This can cause some issues when using the `{{ .ImageName }}` as a tag, since a docker image has a format of `IMAGE:TAG`, such as `alpine:latest`.
-> To remedy the above, one can use some template markup to get the proper format. 
-> e.g. to get the image name and the first 12 characters of the container id, you can use: `--log-opt tag='{{ with split .ImageName ":" }}{{join . "_"}}{{end}}-{{.ID}}'`
+> Template markup can be used to get the proper format. 
+> To get the image name and the first 12 characters of the container id, you can use: `--log-opt tag='{{ with split .ImageName ":" }}{{join . "_"}}{{end}}-{{.ID}}'`
 > the output will be something like: `alpine_latest-bf0072049c76` 
+{% endraw %}
 
 
 ## Credentials

--- a/engine/admin/logging/awslogs.md
+++ b/engine/admin/logging/awslogs.md
@@ -87,6 +87,12 @@ When both `awslogs-stream` and `tag` are specified, the value supplied for `awsl
 
 If not specified, the container ID is used as the log stream.
 
+> **Note:**
+> The CloudWatch log API doesn't support `:` in the log name. This can cause some issues when using the `{{ .ImageName }}` as a tag, since a docker image has a format of `IMAGE:TAG`, such as `alpine:latest`.
+> To remedy the above, one can use some template markup to get the proper format. 
+> e.g. to get the image name and the first 12 characters of the container id, you can use: `--log-opt tag='{{ with split .ImageName ":" }}{{join . "_"}}{{end}}-{{.ID}}'`
+> the output will be something like: `alpine_latest-bf0072049c76` 
+
 
 ## Credentials
 


### PR DESCRIPTION
### Proposed changes

Update the AWS log driver documentation to provide an example on template usage for docker images

### Related issues (optional)

Fixes the confusion found in this issue: https://github.com/moby/moby/issues/30518

/cc @johndmulhausen @mstanleyjones @thaJeztah 
