### PR TITLE
17.06: improve the Docker for Mac networking workaround

### DIFF
--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -78,11 +78,10 @@ There are two scenarios that the above limitations will affect:
 
 #### I want to connect from a container to a service on the host
 
-The Mac has a changing IP address (or none if you have no network access). Our
-current recommendation is to attach an unused IP to the `lo0` interface on the
-Mac; for example: `sudo ifconfig lo0 alias 10.200.10.1/24`, and make sure that
-your service is listening on this address or `0.0.0.0` (ie not `127.0.0.1`).
-Then containers can connect to this address.
+The Mac has a changing IP address (or none if you have no network access). From
+17.06 onwards our recommendation is to connect to the special Mac-only DNS
+name `docker.for.mac.localhost` which will resolve to the internal IP address
+used by the host.
 
 #### I want to connect to a container from the Mac
 


### PR DESCRIPTION
### Proposed changes

In Docker for Mac 17.05 and earlier, there is no easy way for a container to contact a service running on the host (such as a local HTTP proxy) without knowing the host's IP addresses. The workaround in the docs is to add a new IP alias and use that.

In the upcoming 17.06 release of Docker for Mac, there is a special internal DNS name `docker.for.mac.localhost`. This patch replaces the IP alias workaround with a note about the new DNS name.

### Unreleased project version (optional)

This only applies to Docker for Mac 17.06.
