### PR TITLE
Replace Rails with Ruby in the examples list

### DIFF
--- a/engine/userguide/eng-image/dockerfile_best-practices.md
+++ b/engine/userguide/eng-image/dockerfile_best-practices.md
@@ -569,7 +569,7 @@ These Official Repositories have exemplary `Dockerfile`s:
 * [Go](https://hub.docker.com/_/golang/)
 * [Perl](https://hub.docker.com/_/perl/)
 * [Hy](https://hub.docker.com/_/hylang/)
-* [Rails](https://hub.docker.com/_/rails)
+* [Ruby](https://hub.docker.com/_/ruby/)
 
 ## Additional resources:
 


### PR DESCRIPTION
The official Rails image was deprecated at the beginning of the year, and it probably shouldn't be referenced in the docs anymore.

### Proposed changes

Replace the link to the official Rails image on Docker Hub with a link to the official Ruby image.