### PR TITLE
Adds note about passing boolean arguments

### DIFF
--- a/machine/drivers/digital-ocean.md
+++ b/machine/drivers/digital-ocean.md
@@ -12,6 +12,11 @@ Control Panel and pass that to `docker-machine create` with the `--digitalocean-
 ## Usage
 
     $ docker-machine create --driver digitalocean --digitalocean-access-token=aa9399a2175a93b17b1c86c807e08d3fc4b79876545432a629602f61cf6ccd6b test-this
+    
+When passing a boolean value to any option, the argument requires a slightly different format.
+
+    $ docker-machine create --driver digitalocean --digitalocean-access-token=aa9399a2175a93b17b1c86c807e08d3fc4b79876545432a629602f61cf6ccd6b --digitalocean-size 1gb --digitalocean-backups=true test-this
+    
 
 ## Options
 


### PR DESCRIPTION
### Proposed changes

Adds a sentence and example on how to use boolean arguments. I attempted to create a machine on Digital Ocean and the CLI returned:

```
Invalid command line. Found extra arguments [--digitalocean-private-networking true --digitalocean-backups true]
```

### Unreleased project version (optional)

Not sure if this applies to only edge or if stable is affected as well. I assume it is both as the CLI library you are using specifies this as normal behavior.