### PR TITLE
removed old content from liquid admonitions include file

### DIFF
--- a/_includes/content/admonitions/notes.html
+++ b/_includes/content/admonitions/notes.html
@@ -1,12 +1,3 @@
-{% if include.type=="note" %}
-{% assign glyphClass="glyphicon glyphicon-ok-sign" %}
-{% assign blockquoteClass="note-vanilla" %}
-{% else if include.type=="warning"%}
-{% assign glyphClass="glyphicon glyphicon-exclamation-sign" %}
-{% assign blockquoteClass="warning-vanilla" %}
-{% else if include.type=="danger"%}
-{% assign glyphClass="glyphicon glyphicon-ban-circle" %}
-{% assign blockquoteClass="danger-vanilla" %}
-{%endif %}
+# PLACEHOLDER FOR LIQUID VARIABLES SOLUTION FOR ADMONITIONS ICONS
 
-<blockquote class="{{ blockquoteClass }}"><i class="{{ glyphClass }}"></i><b>{{ include.title }}</b><p>{{ include.text | markdownify }}</p></blockquote>
+


### PR DESCRIPTION
### What's changed 

- Removed content from this older version of the admonitions include file because @johndmulhausen since created a more complete version of this solution in #3253. If we decide to use a Liquid solution, or even keep it as an alternative to FontAwesome icons, we should use John's version of the includes file, not mine. So, this will make it easier to merge that newer file, if needed. Otherwise, it's a placeholder which can be used or deleted later. Either way, makes no sense to keep the file as it was with content that didn't fully solve the problem.

### Related

#3253 

### Reviewers fyi

@johndmulhausen @joaofnfernandes @mstanleyjones 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

