### PR TITLE
Fix whitespace issues for compose/startup-order.md

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -34,7 +34,7 @@ script:
     wrapper scripts which you can include in your application's image and will
     poll a given host and port until it's accepting TCP connections.
 
-    For example, to use `wait-for-it.sh` or `wait-for` to wrap your service's command:
+    For example, to use `wait-for-it.sh` or `wait-for` to wrap your service's command:
 
         version: "2"
         services:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

* Indent the `compose.yml` code snippet.
* Fix display of the "**Tip**..." blockquote.

Before:
<img width="957" alt="screen shot 2017-05-16 at 16 40 01" src="https://cloud.githubusercontent.com/assets/1370047/26108883/6f54dd08-3a56-11e7-988c-675b7fed1ac9.png">

After:

<img width="956" alt="screen shot 2017-05-16 at 16 41 37" src="https://cloud.githubusercontent.com/assets/1370047/26108944/9ea0fe5c-3a56-11e7-8429-7bfa164e70a6.png">






