### PR TITLE
Fix typo in compose/samples-for-compose TOC entry

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1499,7 +1499,7 @@ manuals:
   - path: /compose/startup-order/
     title: Control startup order
   - path: /compose/samples-for-compose/
-    title: Samples apps with Compose
+    title: Sample apps with Compose
 - sectiontitle: Docker Datacenter
   section:
   - path: /datacenter/install/aws/


### PR DESCRIPTION
### Proposed changes

Change the TOC entry from "Samples apps with Compose" to "Sample apps with Compose".