### PR TITLE
Update host_integration.md

### DIFF
--- a/engine/admin/host_integration.md
+++ b/engine/admin/host_integration.md
@@ -73,7 +73,7 @@ a new service that will be started after the docker daemon service has started.
 
 If you intend to use this as a system service, put the above contents in a file
 in the `/etc/systemd/system` directory, e.g.
-`/etc/systemd/system/docker-container@.service`.
+`/etc/systemd/system/docker-container@redis_server.service`.
 
 If you need to pass options to the redis container (such as `--env`),
 then you'll need to use `docker run` rather than `docker start`. This will


### PR DESCRIPTION
### Proposed changes

The page seems to refer to a docker-container@redis_server.service file in the systemd section. There was one instance that left out the "redis_server" part. To remove ambiguity, I changed "docker-container@.service " to be "docker-container@redis_server.service" to be consistent.
