### PR TITLE
Specify Compose version for Compose file formats

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -171,7 +171,7 @@ between services and startup order.
 ### Version 2.1
 
 An upgrade of [version 2](#version-2) that introduces new parameters only
-available with Docker Engine version **1.12.0+**. Version 2.1 files are 
+available with Docker Engine version **1.12.0+**. Version 2.1 files are
 supported by **Compose 1.9.0+**
 
 Introduces the following additional parameters:
@@ -187,9 +187,9 @@ Introduces the following additional parameters:
 ### Version 2.2
 
 An upgrade of [version 2.1](#version-21) that introduces new parameters only
-available with Docker Engine version **1.13.0+**.  Version 2.1 files are 
-supported by **Compose 1.13.0+**. This version also allows you to specify 
-default scale numbers inside the service's configuration. 
+available with Docker Engine version **1.13.0+**.  Version 2.2 files are 
+supported by **Compose 1.13.0+**. This version also allows you to specify
+default scale numbers inside the service's configuration.
 
 Introduces the following additional parameters:
 

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -171,7 +171,8 @@ between services and startup order.
 ### Version 2.1
 
 An upgrade of [version 2](#version-2) that introduces new parameters only
-available with Docker Engine version **1.12.0+**
+available with Docker Engine version **1.12.0+**. Version 2.1 files are 
+supported by **Compose 1.9.0+**
 
 Introduces the following additional parameters:
 
@@ -186,8 +187,9 @@ Introduces the following additional parameters:
 ### Version 2.2
 
 An upgrade of [version 2.1](#version-21) that introduces new parameters only
-available with Docker Engine version **1.13.0+**. This version also allows
-to specify default scale numbers inside the service's configuration.
+available with Docker Engine version **1.13.0+**.  Version 2.1 files are 
+supported by **Compose 1.13.0+**. This version also allows you to specify 
+default scale numbers inside the service's configuration. 
 
 Introduces the following additional parameters:
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Explicitly specifying Compose versions for file formats 2.1 and 2.2. 

Context: I had Compose v.1.8.1 and was getting a version error when trying to "docker-compose up" on a 2.1 Compose file. This page states "Version 2 files are supported by **Compose 1.6.0+** ", but I didn't immediately realize that this doesn't cover file formats 2.1 and 2.2.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->