### PR TITLE
Typo correction "mages" -> "images"

### DIFF
--- a/engine/userguide/storagedriver/index.md
+++ b/engine/userguide/storagedriver/index.md
@@ -18,7 +18,7 @@ Docker relies on driver technology to manage the storage and interactions
 associated with images and the containers that run them. This section contains
 the following pages:
 
-* [About mages, containers, and storage drivers](imagesandcontainers.md)
+* [About images, containers, and storage drivers](imagesandcontainers.md)
 * [Select a storage driver](selectadriver.md)
 * [AUFS storage driver in practice](aufs-driver.md)
 * [Btrfs storage driver in practice](btrfs-driver.md)


### PR DESCRIPTION
### Proposed changes

This is a simple spelling fix, `mages` -> `images` in the text but of a link.