### PR TITLE
Update part4

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -8,6 +8,7 @@ description: Learn how to create clusters of Dockerized machines.
 ## Prerequisites
 
 - [Install Docker version 1.13 or higher](/engine/installation/).
+- [Install VirtualBox](https://www.virtualbox.org/wiki/Downloads) for your host.
 - Read the orientation in [Part 1](index.md).
 - Learn how to create containers in [Part 2](part2.md).
 - Make sure you have pushed the container you created to a registry, as

--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -8,7 +8,7 @@ description: Learn how to create clusters of Dockerized machines.
 ## Prerequisites
 
 - [Install Docker version 1.13 or higher](/engine/installation/).
-- [Install VirtualBox](https://www.virtualbox.org/wiki/Downloads) for your host.
+- Unless you're on a Windows system that has Hyper-V, such as Windows 10, [install VirtualBox](https://www.virtualbox.org/wiki/Downloads) for your host
 - Read the orientation in [Part 1](index.md).
 - Learn how to create containers in [Part 2](part2.md).
 - Make sure you have pushed the container you created to a registry, as


### PR DESCRIPTION
Installation of VirtualBox should be in the requirements.

### Proposed changes

Following the tutorial, a user may hit an error by easily overlooking need to have VirtualBox installed.

```
docker-machine create --driver virtualbox myvm1
Creating CA: /Users/joeabbey/.docker/machine/certs/ca.pem
Creating client certificate: /Users/joeabbey/.docker/machine/certs/cert.pem
Running pre-create checks...
Error with pre-create check: "VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path"
```

Adding an explicit requirement for VirtualBox in the "Requirements" section will help a first-time user avoid the error.