### PR TITLE
fixed link which for some reason was changed to Moby

### DIFF
--- a/docker-cloud/installing-cli.md
+++ b/docker-cloud/installing-cli.md
@@ -29,7 +29,7 @@ docker run dockercloud/cli -h
 
 This command runs the `docker-cloud` CLI image in a container for you. Learn
 more about how to use this container
-[here](https://github.com/moby/mobycloud-cli#docker-image).
+[here](https://github.com/docker/dockercloud-cli#docker-image).
 
 #### Install for Linux or Windows
 


### PR DESCRIPTION
### what's changed

- Fixed link per user feedback (for some reason `docker` was changed to `moby` in the URL (maybe as part of a broad search-and-replace, which wasn't appropriate in this case.)

### Related issues

Fixes #3222 

### Reviewers, fyi

@mmorejon @KickingTheTV @pkennedyr 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

