### PR TITLE
Suggest passing --no-log-init to adduser

### DIFF
--- a/engine/userguide/eng-image/dockerfile_best-practices.md
+++ b/engine/userguide/eng-image/dockerfile_best-practices.md
@@ -513,11 +513,19 @@ parts of your image.
 
 If a service can run without privileges, use `USER` to change to a non-root
 user. Start by creating the user and group in the `Dockerfile` with something
-like `RUN groupadd -r postgres && useradd -r -g postgres postgres`.
+like `RUN groupadd -r postgres && useradd --no-log-init -r -g postgres postgres`.
 
 > **Note**: Users and groups in an image get a non-deterministic
 > UID/GID in that the “next” UID/GID gets assigned regardless of image
 > rebuilds. So, if it’s critical, you should assign an explicit UID/GID.
+
+> **Note**: Due to an [unresolved bug](https://github.com/golang/go/issues/13548)
+> in the Go archive/tar package's handling of sparse files, attempting to
+> create a user with a sufficiently large UID inside a Docker container can
+> lead to disk exhaustion as `/var/log/faillog` in the container layer is
+> filled with NUL (\0) characters.  Passing the `--no-log-init` flag to
+> useradd works around this issue.  The Debian/Ubuntu `adduser` wrapper
+> does not support the `--no-log-init` flag and should be avoided.
 
 You should avoid installing or using `sudo` since it has unpredictable TTY and
 signal-forwarding behavior that can cause more problems than it solves. If


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Running `useradd` without `--no-log-init` risks triggering a resource exhaustion issue.  So, the "best practices" guide should probably make note of that.

### Unreleased project version (optional)

n/a

### Related issues (optional)

https://github.com/moby/moby/issues/15585
https://github.com/moby/moby/issues/5419
https://github.com/golang/go/issues/13548