### PR TITLE
added missing stable release notes for mac and win

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -23,7 +23,7 @@ about both kinds of releases, and download stable and edge product installers at
 
 **Upgrades**
 
-- security fix for CVE-2017-7308
+- Security fix for CVE-2017-7308
 
 ### Docker Community Edition 17.03.1-ce-mac5, 2017-03-29 (stable)
 
@@ -359,7 +359,7 @@ events or unexpected unmounts.
 
 **Upgrades**
 
-- security fix for CVE-2017-7308
+- Security fix for CVE-2017-7308
 
 ### Docker Community Edition 17.05.0-ce-mac9, 2017-05-09 (edge)
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -19,6 +19,26 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
+### Docker Community Edition 17.03.1-ce-mac12, 2017-05-12 (stable)
+
+**Upgrades**
+
+- security fix for CVE-2017-7308
+
+### Docker Community Edition 17.03.1-ce-mac5, 2017-03-29 (stable)
+
+**Upgrades**
+
+- [Docker Credential Helpers 0.4.2](https://github.com/docker/docker-credential-helpers/releases/tag/v0.4.2)
+
+
+### Docker Community Edition 17.03.1-ce-mac4, 2017-03-28 (stable)
+
+**Hotfixes**
+
+- Set the ethernet MTU to 1500 to prevent a hyperkit crash
+- Fix docker build on private images
+
 ### Docker Community Edition 17.03.0-ce-mac2, 2017-03-06 (stable)
 
 **Hotfixes**

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -23,7 +23,7 @@ about both kinds of releases, and download stable and edge product installers at
 
 **Upgrades**
 
-- security fix for CVE-2017-7308  
+- Security fix for CVE-2017-7308  
 
 ### Docker Community Edition 17.03.0, 2017-03-02 (stable)
 
@@ -313,7 +313,7 @@ We did not distribute a 1.12.4 stable release
 
 **Upgrades**
 
-- security fix for CVE-2017-7308  
+- Security fix for CVE-2017-7308  
 
 ### Docker Community Edition 17.0.5c-win9 Release Notes (2017-05-09 17.05.0-ce-win9) (edge)
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -19,6 +19,12 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
+### Docker Community Edition 17.03.1-ce-win12  2017-05-12 (stable)
+
+**Upgrades**
+
+- security fix for CVE-2017-7308  
+
 ### Docker Community Edition 17.03.0, 2017-03-02 (stable)
 
 **New**


### PR DESCRIPTION
### What's changed

- added `stable` releases for Docker for Mac: `mac4`, `mac5` and `mac12`
- added `stable` release for Docker for Windows: `win12`

### Questions

1. How do I read the [releases spreadsheet](https://docs.google.com/spreadsheets/d/1HEgpHvHZrWG2T5Kq_VAwf39N3NjhN3cagVlH6w77_3M/edit#gid=0)?

2. How do I get the updates, features, and bug lists for each release?

Here is my understanding I derived to make these latest updates to the docs release notes. _**Please tell me if this is correct**_:

- For **edge** releases, updates, features and bug lists are shown in the [Mac changelog](https://github.com/docker/pinata/blob/master/mac/CHANGELOG) and [Windows changelog](https://github.com/docker/pinata/blob/master/win/CHANGELOG)

- For **stable** releases, you use the [spreadsheet](https://docs.google.com/spreadsheets/d/1HEgpHvHZrWG2T5Kq_VAwf39N3NjhN3cagVlH6w77_3M/edit#gid=0). The "**Released from**" column shows which `edge` release each `stable` release is based on. For any given `stable` release, you use the feature list for the `edge` release listed in the "Released from" column. (You have those lists because they are in the Mac and Windows changelogs mentioned in the first bullet ^^)

- Once in a while, a `stable` release is based on another `stable` release, for instance in the case of Friday, May 12, 2017 Stable release  17.03.1-ce-mac5, which was based on stable 17.03.1-ce-mac4 from the day before, plus Credentials Helper added in. (17.03.1-ce-mac4 was originally based on Edge 17.03.0-ce-mac2, as you can see in the column above.)

### Reviewers

@gtardif @dsheets @jeanlaurent @friism @mstanleyjones 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
