### PR TITLE
Only `sut` service and its dependents are started

### DIFF
--- a/docker-cloud/builds/automated-testing.md
+++ b/docker-cloud/builds/automated-testing.md
@@ -35,16 +35,19 @@ The example above builds the repository, and runs the `run_tests.sh` file inside
 a container using the built image.
 
 You can define any number of linked services in this file. The only requirement
-is that `sut` is defined. Its return code determines if tests passed or not:
-tests **pass** if the `sut` service returns `0`, and **fail** otherwise.
+is that `sut` is defined. Its return code determines if tests passed or not.
+Tests **pass** if the `sut` service returns `0`, and **fail** otherwise.
 
 > **Note**: Only the `sut` service and all other services listed in `depends_on`
-are started. For instance, if you have services that poll for changes in other 
+are started. For instance, if you have services that poll for changes in other
 services, be sure to include the polling services in the `depends_on` list to
-ensure it is started. 
+make sure all of your services start.
 
 You can define more than one `docker-compose.test.yml` file if needed. Any file
-that ends in `.test.yml` is used for testing, and the tests run sequentially. You can also use [custom build hooks](advanced.md#override-build-test-or-push-commands) to further customize your test behavior.
+that ends in `.test.yml` is used for testing, and the tests run sequentially.
+You can also use [custom build
+hooks](advanced.md#override-build-test-or-push-commands) to further customize
+your test behavior.
 
 > **Note**: If you enable Automated builds, they will also run any tests defined
 in the `test.yml` files.

--- a/docker-cloud/builds/automated-testing.md
+++ b/docker-cloud/builds/automated-testing.md
@@ -38,6 +38,11 @@ You can define any number of linked services in this file. The only requirement
 is that `sut` is defined. Its return code determines if tests passed or not:
 tests **pass** if the `sut` service returns `0`, and **fail** otherwise.
 
+> **Note**: Only the `sut` service and all other services listed in `depends_on`
+are started. For instance, if you have services that poll for changes in other 
+services, be sure to include the polling services in the `depends_on` list to
+ensure it is started. 
+
 You can define more than one `docker-compose.test.yml` file if needed. Any file
 that ends in `.test.yml` is used for testing, and the tests run sequentially. You can also use [custom build hooks](advanced.md#override-build-test-or-push-commands) to further customize your test behavior.
 


### PR DESCRIPTION
### Proposed changes

Documentation update to prevent others from trying to diagnose failing tests for hours, like we did
