### PR TITLE
Specify tagging behaviour when running docker-compose build command.

### DIFF
--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -17,7 +17,8 @@ Options:
 ```
 
 Services are built once and then tagged, by default as `project_service`, e.g.,
-`composetest_db`. If the compose file specify an image name, the image will be
+`composetest_db`. If the compose file specify an
+[image](/compose/compose-file/index.md#image) name, the image will be
 tagged with that name, substituting any variables beforehand. See [variable
 substitution](#variable-substitution)
 

--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -16,6 +16,10 @@ Options:
     --build-arg key=val     Set build-time variables for one service.
 ```
 
-Services are built once and then tagged as `project_service`, e.g.,
-`composetest_db`. If you change a service's Dockerfile or the contents of its
+Services are built once and then tagged, by default as `project_service`, e.g.,
+`composetest_db`. If the compose file specify an image name, the image will be
+tagged with that name, substituting any variables beforehand. See [variable
+substitution](#variable-substitution)
+
+If you change a service's Dockerfile or the contents of its
 build directory, run `docker-compose build` to rebuild it.


### PR DESCRIPTION
### Proposed changes

I clarified the way the images will be tagged when using docker-compose build. I just learned about the variable substitution after a while of searching and having this made clear in this section would have helped me a lot discover the feature.