### PR TITLE
notary: fix trust pinning diagram path

### DIFF
--- a/notary/reference/client-config.md
+++ b/notary/reference/client-config.md
@@ -126,7 +126,7 @@ by the pinned CA, followed by TOFUS (TOFU over HTTPS).  The diagram below
 describes this validation flow:
 
 <center>
-![Trust pinning flow](../images/trust-pinning-flow.png)
+<img src="https://cdn.rawgit.com/docker/notary/27469f01fe244bdf70f34219616657b336724bc3/docs/images/trust-pinning-flow.png"></img>
 </center>
 
 Only one trust pinning option will be used to validate a GUN even if multiple


### PR DESCRIPTION
Carry https://github.com/docker/notary/pull/1172 to fix trust-pinning image, but use html instead
<img src="https://scopicimpulse.files.wordpress.com/2017/05/comedy-wildlife-photo-awards-shortlist-57fb453b11c53__880.jpg" width="400"></img>
Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
