### PR TITLE
Update dockerurl config file URL

### DIFF
--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -89,7 +89,7 @@ the repository.
       [prerequisites](#prerequisites).
 
       ```bash
-      $ sudo sh -c 'echo "<DOCKER-EE-URL>" > /etc/yum/vars/dockerurl'
+      $ sudo sh -c 'echo "<DOCKER-EE-URL>/rhel" > /etc/yum/vars/dockerurl'
       ```
 
     - Store your RHEL version string in `/etc/yum/vars/dockerosversion`.


### PR DESCRIPTION
The instructions as followed result in an incorrect URL because the platform is not inserted. Update docs to add platform into the URL as required

### Proposed changes

The <DOCKER-EE-URL> does not specify platform so needs it appended to match how the repositories are laid out in Docker's yum repositories

