### PR TITLE
Add release notes for 1.13-cs4 1.12-cs12 1.11-cs8

### DIFF
--- a/cs-engine/1.12/release-notes/release-notes.md
+++ b/cs-engine/1.12/release-notes/release-notes.md
@@ -22,6 +22,13 @@ cannot be adopted as quickly for consistency and compatibility reasons.
 These notes refer to the current and immediately prior releases of the
 CS Engine. For notes on older versions, see the [CS Engine prior release notes archive](prior-release-notes.md).
 
+## CS Engine 1.12.6-cs12
+(01 Jun 2017)
+
+* Fix an issue where if a volume using the local volume driver which has
+mount options fails to unmount on container exit, the data in the mount may be
+lost if the user attempts to subsequently remove the volume. [#32327](https://github.com/docker/docker/pulls/32327)
+
 ## CS Engine 1.12.6-cs11
 (11 May 2017)
 
@@ -120,6 +127,13 @@ This release addresses the following issues:
 * [#25962](https://github.com/docker/docker/pull/25962) Allow normal containers
 to connect to swarm-mode overlay network
 * Various bug fixes in swarm mode networking
+
+## CS Engine 1.11.2-cs8
+(01 Jun 2017)
+
+* Fix an issue where if a volume using the local volume driver which has
+mount options fails to unmount on container exit, the data in the mount may be
+lost if the user attempts to subsequently remove the volume. [#32327](https://github.com/docker/docker/pulls/32327)
 
 ## CS Engine 1.11.2-cs7
 (24 Jan 2017)

--- a/cs-engine/1.13/release-notes.md
+++ b/cs-engine/1.13/release-notes.md
@@ -18,6 +18,14 @@ cannot be adopted as quickly for consistency and compatibility reasons.
 
 [Looking for the release notes for Docker CS Engine 1.12?](/cs-engine/1.12/release-notes/index.md)
 
+## CS Engine 1.13.1-cs4
+(01 Jun 2017)
+
+Backports all fixes from [17.03.2](https://github.com/moby/moby/releases/tag/v17.03.2-ce)
+
+*Note*: This release includes a fix for potential data loss under certain
+circumstances with the local (built-in) volume driver.
+
 ## CS Engine 1.13.1-cs3
 (23 Feb 2017)
 


### PR DESCRIPTION
Note the link to the 17.03 release notes is not yet active.