### PR TITLE
update centos step 4 to include correct path

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -144,11 +144,11 @@ Repository set-up instructions are different for [Docker CE](#docker-ce) and
     ```
 
 4.  Use the following command to add the **stable** repository:
-
+       
     ```bash
     $ sudo yum-config-manager \
         --add-repo \
-        <DOCKER-EE-URL>/docker-ee.repo
+        <DOCKER-EE-URL>/centos/docker-ee.repo
     ```
 
 #### Install Docker


### PR DESCRIPTION
The DOCKER-EE-URL contains a distribution directory called centos. The docker-ee.repo is located in that dir. This PR updates that path to the correct EE installation path.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
