### PR TITLE
updated syntax for command in Compose files

### DIFF
--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -97,7 +97,7 @@ Override the default command.
 The command can also be a list, in a manner similar to
 [dockerfile](/engine/reference/builder.md#cmd):
 
-    command: [bundle, exec, thin, -p, 3000]
+    command: ["bundle", "exec", "thin", "-p", "3000"]
 
 ### cgroup_parent
 

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -152,7 +152,7 @@ Override the default command.
 The command can also be a list, in a manner similar to
 [dockerfile](/engine/reference/builder.md#cmd):
 
-    command: [bundle, exec, thin, -p, 3000]
+    command: ["bundle", "exec", "thin", "-p", "3000"]
 
 ### cgroup_parent
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -196,7 +196,7 @@ Override the default command.
 The command can also be a list, in a manner similar to
 [dockerfile](/engine/reference/builder.md#cmd):
 
-    command: [bundle, exec, thin, -p, 3000]
+    command: ["bundle", "exec", "thin", "-p", "3000"]
 
 ### cgroup_parent
 


### PR DESCRIPTION
### What's changed

- modified the syntax for `command` in v1, v2, and v3 Compose file references, per @gdevillele 's comment

Please let me know if this is comprehensive enough, or if we need more examples

### Related

#3491

### Reviewers 

@gdevillele @shin- @dnephin 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
