### PR TITLE
Update syslog documentation for typo

### DIFF
--- a/engine/admin/logging/syslog.md
+++ b/engine/admin/logging/syslog.md
@@ -40,7 +40,7 @@ dockerd \
   --log-opt syslog-address=udp://1.2.3.4:1111
 ```
 
-> **Note**: The syslog-address supports both UP and TCP.
+> **Note**: The syslog-address supports both UDP and TCP.
 
 To make the changes persistent, add the toptions to `/etc/docker/daemon.json`:
 


### PR DESCRIPTION
There is a typo of UDP which is spelled as UP.
Corrected it.

Signed-off-by: Swapnil Kulkarni <me@coolsvap.net>

Fixes #3501 
