### PR TITLE
Remove unsupported link_local_ips param from v3 doc

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -242,6 +242,8 @@ several options have been removed:
 -   `extends`: This option has been removed for `version: "3.x"` Compose files.
 -   `group_add`: This option has been removed for `version: "3.x"` Compose files.
 -   `pids_limit`: This option has not been introduced in `version: "3.x"` Compose files.
+-   `link_local_ips` in `networks`: This option has not been introduced in
+    `version: "3.x"` Compose files.
 
 ### Version 1 to 2.x
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -912,29 +912,6 @@ An example:
           -
             subnet: 2001:3984:3989::/64
 
-#### link_local_ips
-
-Specify a list of link-local IPs. Link-local IPs are special IPs which belong
-to a well known subnet and are purely managed by the operator, usually
-dependent on the architecture where they are deployed. Therefore they are not
-managed by docker (IPAM driver).
-
-Example usage:
-
-    version: '2.1'
-    services:
-      app:
-        image: busybox
-        command: top
-        networks:
-          app_net:
-            link_local_ips:
-              - 57.123.22.11
-              - 57.123.22.13
-    networks:
-      app_net:
-        driver: bridge
-
 ### pid
 
     pid: "host"


### PR DESCRIPTION
### Proposed changes

This option is not available in the v3 format

### Related issues (optional)

https://github.com/docker/compose/issues/4897
