### PR TITLE
Fix docker package name for Raspbian Jessie

### DIFF
--- a/engine/installation/linux/debian.md
+++ b/engine/installation/linux/debian.md
@@ -277,7 +277,7 @@ installing Docker.
     Use this command to install the latest version of Docker:
 
     ```bash
-    $ sudo apt-get install docker
+    $ sudo apt-get install docker-engine
     ```
     > **NOTE**: By default, Docker on Raspbian is Docker Community Edition, so
     > there is no need to specify docker-ce.


### PR DESCRIPTION
### Proposed changes

On Raspbian Jessie the docker package is named `docker-engine`, `docker` being another unrelated package. Package details: https://packages.debian.org/jessie/docker


