### PR TITLE
state default is not permitted driver for network

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1083,6 +1083,9 @@ The default driver depends on how the Docker Engine you're using is configured,
 but in most instances it will be `bridge` on a single host and `overlay` on a
 Swarm.
 
+**Note:** although `driver` can be left blank to use the default, explicitly
+settings `driver: default` is invalid.
+
 The Docker Engine will return an error if the driver is not available.
 
     driver: overlay


### PR DESCRIPTION
### Proposed changes

Explicitly state that `default` is not a valid driver for compose networks.

### Related issues 

https://github.com/docker/compose/issues/4905