### PR TITLE
Added Kitematic uninstall details, updated d4mac/win install list

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -125,7 +125,7 @@ explanation and list of prerequisites.
 
 * **What the install includes**: The installation provides
   [Docker Engine](/engine/userguide/), Docker CLI client,
-  [Docker Compose](/compose/overview/), and [Docker Machine](/machine/overview/).
+  [Docker Compose](/compose/overview/), [Docker Machine](/machine/overview/), and [Kitematic](/kitematic/userguide.md).
 
 ## Install and Run Docker for Mac
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -115,7 +115,7 @@ on a VMWare or Parallels instance, might work, but come with no
 guarantees (i.e., not officially supported). For more information, see
 [Running Docker for Windows in nested virtualization scenarios](troubleshoot.md#running-docker-for-windows-in-nested-virtualization-scenarios)
 <p />
-* **What the Docker for Windows install includes**: The installation provides [Docker Engine](/engine/userguide/), Docker CLI client, [Docker Compose](/compose/overview.md), and [Docker Machine](/machine/overview.md).
+* **What the Docker for Windows install includes**: The installation provides [Docker Engine](/engine/userguide/), Docker CLI client, [Docker Compose](/compose/overview.md), [Docker Machine](/machine/overview.md), and [Kitematic](/kitematic/userguide.md).
 
 ### About Windows containers and Windows Server 2016
 

--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -224,7 +224,13 @@ To uninstall Toolbox on a Mac, do the following:
 
 3.  Remove the Docker Quickstart Terminal and Kitematic from your "Applications" folder.
 
-4.  Remove the `docker`, `docker-compose`, and `docker-machine` commands from the `/usr/local/bin` folder.
+4.  Run the following in a command shell to fully remove Kitematic:
+
+    ```
+    rm -fr ~/Library/Application\ Support/Kitematic
+    ```
+
+5.  Remove the `docker`, `docker-compose`, and `docker-machine` commands from the `/usr/local/bin` folder.
 
     ```
     $ rm /usr/local/bin/docker
@@ -232,7 +238,7 @@ To uninstall Toolbox on a Mac, do the following:
     $ rm /usr/local/bin/docker-machine
     ```
 
-5. Optionally, remove the `~/.docker` directory.
+6. Optionally, remove the `~/.docker` directory.
 
     If you want to remove Docker entirely, you
     can remove the `~/.docker` directory
@@ -242,7 +248,8 @@ To uninstall Toolbox on a Mac, do the following:
     as certificates). Removing this directory
     is typically not necessary.
 
-6. Uninstall Oracle VirtualBox, which is
+
+7. Uninstall Oracle VirtualBox, which is
 installed as a part of the Toolbox install.
 
 ## Next Steps

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -223,7 +223,7 @@ To uninstall Toolbox on Windows, do the following:
     continue to manage those machines
     through Docker.
 
-3. Uninstall Docker Toolbox using Window's standard process for uninstalling programs through the control panel.
+3. Uninstall Docker Toolbox using Window's standard process for uninstalling programs through the control panel (programs and features).
 
     >**Note**: This process does not remove the `docker-install.exe` file. You must delete that file yourself.
 


### PR DESCRIPTION
### What's changed

- Added extra step for full Kitematic uninstall as part of Toolbox uninstall on Docker for Mac
- Slight clarification on Toolbox uninstall on Windows
- Added Kitematic as a component on the Docker for Mac / Win install lists

### Related

Fixes #988

### Reviewers, fyi

@cognish, @jeffdm, @JimGalasyn 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
