### PR TITLE
added note on external volumes with docker stack deploy

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1431,6 +1431,18 @@ refer to it within the Compose file:
         external:
           name: actual-name-of-volume
 
+> External volumes are always created with docker stack deploy
+>
+External volumes that do not exist _will be created_ if you use [docker stack
+deploy](#deploy) to launch the app in [swarm mode](/engine/swarm/index.md)
+(instead of [docker compose up](/compose/reference/up.md)). In swarm mode, a
+volume is automatically created when it is defined by a service. As service
+tasks are scheduled on new nodes,
+[swarmkit](https://github.com/docker/swarmkit/blob/master/README.md) creates the
+volume on the local node. To learn more, see
+[moby/moby#29976](https://github.com/moby/moby/issues/29976).
+{: .note-vanilla}
+
 ### labels
 
 Add metadata to containers using


### PR DESCRIPTION
### What's changed

- added note about the differences in behaviour between `docker stack deploy` and `docker compose up` with regard to external volumes that do not exist

- Note, this solves only the docs issue. Related issues are listed below.

### Related

Fixes #3141 (docs)

Moby: https://github.com/moby/moby/issues/29976
Moby: https://github.com/moby/moby/issues/33181 (duplicate, closed)

### Reviewers, fyi

@briantd @cghislai @dnephin @shin- @justincormack @thaJeztah 

I'm going to merge to get this published, as the docs issue has been sitting a while. Y'all please ping me if you want changes to the docs update on this PR. 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
