### PR TITLE
added link to vmwareworkstation driver

### DIFF
--- a/machine/drivers/index.md
+++ b/machine/drivers/index.md
@@ -18,4 +18,4 @@ title: Drivers
 -   [VMware vCloud Air](vm-cloud.md)
 -   [VMware Fusion](vm-fusion.md)
 -   [VMware vSphere](vsphere.md)
--   [vmwareworkstation](https://github.com/pecigonzalo/docker-machine-vmwareworkstation) (unofficial, not supported by Docker)
+-   [VMware Workstation](https://github.com/pecigonzalo/docker-machine-vmwareworkstation) (unofficial plugin, not supported by Docker)

--- a/machine/drivers/index.md
+++ b/machine/drivers/index.md
@@ -18,3 +18,4 @@ title: Drivers
 -   [VMware vCloud Air](vm-cloud.md)
 -   [VMware Fusion](vm-fusion.md)
 -   [VMware vSphere](vsphere.md)
+-   [vmwareworkstation](https://github.com/pecigonzalo/docker-machine-vmwareworkstation) (unofficial, not supported by Docker)


### PR DESCRIPTION
### What's changed

- added a link to a [Docker Machine driver for vmwareworkstation](https://github.com/pecigonzalo/docker-machine-vmwareworkstation)

### Related

Fixes #3512 

### Reviewers, fyi

@cwon7609 @dnephin @shin- @dmp42 @mstanleyjones 

Chris, I'll see if there are no objections.



Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
