### PR TITLE
Fix unmarshal issue

### DIFF
--- a/engine/userguide/networking/default_network/custom-docker0.md
+++ b/engine/userguide/networking/default_network/custom-docker0.md
@@ -36,7 +36,7 @@ following settings to configure the default bridge network:
   "bip": "192.168.1.5/24",
   "fixed-cidr": "10.20.0.0/16",
   "fixed-cidr-v6": "2001:db8::/64",
-  "mtu": "1500",
+  "mtu": 1500,
   "default-gateway": "10.20.1.1",
   "default-gateway-v6": "2001:db8:abcd::89",
   "dns": ["10.20.1.2","10.20.1.3"]


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

If set to `"mtu": "1500"` will got an error:
```
unable to configure the Docker daemon with file /etc/docker/daemon.json: json: cannot unmarshal string into Go value of type int
```
That code can not unmarshal string into Go value of type int, I changed the type from string to int.

