### PR TITLE
Correct wording

### DIFF
--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -56,7 +56,7 @@ See <a href="../machine/drivers/" target="_blank">Docker Machine driver referenc
 
 ## Adding a host without a driver
 
-You can register an already existing docker host by passing the daemon url. With that, you can have the same workflow than an host provisioned by docker-machine
+You can register an already existing docker host by passing the daemon url. With that, you can have the same workflow as on a host provisioned by docker-machine
 
     $ docker-machine create --driver none --url=tcp://50.134.234.20:2376 custombox
     $ docker-machine ls


### PR DESCRIPTION
### Proposed changes

This file change adjusts the wording in the section "Adding a host without a driver". The word "as" seems more appropriate here in order to indicate that working with a host created by machine vs working with a host provisioned by other means results in a comparable situation. The word "than", on the other hand, is used in comparisons to indicate a difference.
Besides "than" vs "as", this change exchanges "an" for "a" as this is more appropriate, given the next word starts with a vowel sound.
