### PR TITLE
Added notes and troubleshooting topic on volume mounts from host

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1359,12 +1359,16 @@ The supported units are `us`, `ms`, `s`, `m` and `h`.
 
 ## Volume configuration reference
 
-While it is possible to declare volumes on the fly as part of the service
-declaration, this section allows you to create named volumes that can be
-reused across multiple services (without relying on `volumes_from`), and are
-easily retrieved and inspected using the docker command line or API.
-See the [docker volume](/engine/reference/commandline/volume_create.md)
-subcommand documentation for more information.
+While it is possible to declare volumes on the file as part of the service
+declaration, this section allows you to create named volumes that can be reused
+across multiple services (without relying on
+[`volumes_from`](/compose/compose-file/compose-file-v2#volumes_from)), and are
+easily retrieved and inspected using the docker command line or API. See the
+[docker volume](/engine/reference/commandline/volume_create.md) subcommand
+documentation for more information.
+
+See [Docker Volumes](/engine/userguide/dockervolumes.md) and [Volume
+Plugins](/engine/extend/plugins_volume.md) for general information on volumes.
 
 Here's an example of a two-service setup where a database's data directory is
 shared with another service as a volume so that it can be periodically backed

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1210,9 +1210,9 @@ more information.
 ### volumes
 
 > **Note**: The top-level
-> [`volumes` option](#volume-configuration-reference) defines
-> a named volume and references it from each service's `volumes` list. This replaces `volumes_from` in earlier versions of the Compose file format. See [Docker Volumes](/engine/userguide/dockervolumes.md) and
-[Volume Plugins](/engine/extend/plugins_volume.md) for general information on volumes.
+> [volumes](#volume-configuration-reference) option defines
+> a named volume and references it from each service's `volumes` list. This replaces `volumes_from` in earlier versions of the Compose file format. (See [Docker Volumes](/engine/userguide/dockervolumes.md) and
+[Volume Plugins](/engine/extend/plugins_volume.md) for general information on volumes.)
 
 Mount host paths or named volumes. Named volumes must be defined in the
 [top-level `volumes` key](#volume-configuration-reference). Use named volumes with [services, swarms, and stack files](#volumes-for-services-swarms-and-stack-files).
@@ -1359,10 +1359,9 @@ The supported units are `us`, `ms`, `s`, `m` and `h`.
 
 ## Volume configuration reference
 
-While it is possible to declare volumes on the file as part of the service
-declaration, this section allows you to create named volumes that can be reused
-across multiple services (without relying on
-[`volumes_from`](/compose/compose-file/compose-file-v2#volumes_from)), and are
+While it is possible to declare [volumes](#volumes) on the file as part of the
+service declaration, this section allows you to create named volumes (without
+relying on `volumes_from`) that can be reused across multiple services, and are
 easily retrieved and inspected using the docker command line or API. See the
 [docker volume](/engine/reference/commandline/volume_create.md) subcommand
 documentation for more information.

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -196,7 +196,7 @@ Started topic.
 
 To learn more about using Docker for Windows and Docker Machine, see
 [What to know before you install](install.md#what-to-know-before-you-install) in the Getting Started topic. For more about Docker Machine itself, see
-[What is Docker Machine?](/machine/overview.md#what-is-docker-machine)
+[What is Docker Machine?](/machine/overview.md#what-is-docker-machine), and the [Hyper-V driver](/machine/drivers/hyper-v.md) for Docker Machine.
 
 ### How do I run Windows containers on Docker on Windows Server 2016?
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -394,6 +394,16 @@ volumes](troubleshoot.md#permissions-errors-on-data-directories-for-shared-volum
 > Docker Machine nodes. See
 > [Can I share local drives and filesystem with my Docker Machine VMs?](faqs.md#can-i-share-local-drives-and-filesystem-with-my-docker-machine-vms)
 > in the FAQs.
+>
+> * We recommend that you do not mount databases on the Windows host,
+but rather define and use a [data
+volume](https://docs.docker.com/engine/tutorials/dockervolumes.md#data-volumes)
+(named volume) or [data
+container](/engine/tutorials/dockervolumes.md#creating-and-mounting-a-data-volume-container).
+There are a number of issues with using host-mounted volumes and network paths
+for database files. See the troubleshooting topic, [Volume mounts from host
+paths use a `nobrl` option to override database
+locking](/docker-for-windows/troubleshoot.md#volume-mounts-from-host-paths-use-a-nobrl-option-to-override-database-locking).
 {: .note-vanilla}
 
 See also [Verify domain user has permissions for shared

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -372,17 +372,27 @@ here. If you run `docker` commands and tasks under a different username than the
 one used here to set up sharing, your containers will not have permissions to
 access the mounted volumes.
 
-> Tips on shared drives and permissions
+> Tips on shared drives, permissions, and volume mounts
 >
-> * Shared drives are only required for volume mounting
-> [Linux containers](#switch-between-windows-and-linux-containers), and not for
-> Windows containers. For Linux containers, you need to share the drive where
-> your project is located (i.e., where the Dockerfile and volume are located).
-> Runtime errors such as file not found or cannot start service may indicate
-> shared drives are needed. (See also
-> [Volume mounting requires shared drives for Linux containers](troubleshoot.md#volume-mounting-requires-shared-drives-for-linux-containers).)
+ * Shared drives are only required for volume mounting
+ [Linux containers](#switch-between-windows-and-linux-containers), not for
+ Windows containers. For Linux containers, you need to share the drive where
+ your project is located (i.e., where the Dockerfile and volume are located).
+ Runtime errors such as file not found or cannot start service may indicate
+ shared drives are needed. (See also
+ [Volume mounting requires shared drives for Linux containers](troubleshoot.md#volume-mounting-requires-shared-drives-for-linux-containers).)
 >
-> * You cannot control (`chmod`) permissions on shared volumes for
+* If possible, avoid volume mounts from the Windows host, and instead  mount on
+the MobyVM, or use a [data
+volume](https://docs.docker.com/engine/tutorials/dockervolumes.md#data-volumes)
+(named volume) or [data
+container](/engine/tutorials/dockervolumes.md#creating-and-mounting-a-data-volume-container).
+There are a number of issues with using host-mounted volumes and network paths
+for database files. Please see the troubleshooting topic on [Volume mounts from
+host paths use a nobrl option to override database
+locking](/docker-for-windows/troubleshoot.md#volume-mounts-from-host-paths-use-a-nobrl-option-to-override-database-locking).
+>
+ * You cannot control (`chmod`) permissions on shared volumes for
 deployed containers. Docker for Windows sets permissions to a default value of
 [0755](http://permissions-calculator.org/decode/0755/) (`read`, `write`,
 `execute` permissions for `user`, `read` and `execute` for `group`). This is not
@@ -390,25 +400,14 @@ configurable. See the troubleshooting topic [Permissions errors on data
 directories for shared
 volumes](troubleshoot.md#permissions-errors-on-data-directories-for-shared-volumes) for workarounds and more detail.
 >
-> * You can share local drives with your _containers_ but not with
-> Docker Machine nodes. See
-> [Can I share local drives and filesystem with my Docker Machine VMs?](faqs.md#can-i-share-local-drives-and-filesystem-with-my-docker-machine-vms)
-> in the FAQs.
+ * Make sure that the domain user has permissions to shared drives,
+ as described in the troubleshooting topic ([Verify domain user has permissions for shared drives](troubleshoot.md#verify-domain-user-has-permissions-for-shared-drives-volumes)).
 >
-> * We recommend that you do not mount databases on the Windows host,
-but rather define and use a [data
-volume](https://docs.docker.com/engine/tutorials/dockervolumes.md#data-volumes)
-(named volume) or [data
-container](/engine/tutorials/dockervolumes.md#creating-and-mounting-a-data-volume-container).
-There are a number of issues with using host-mounted volumes and network paths
-for database files. See the troubleshooting topic, [Volume mounts from host
-paths use a `nobrl` option to override database
-locking](/docker-for-windows/troubleshoot.md#volume-mounts-from-host-paths-use-a-nobrl-option-to-override-database-locking).
+ * You can share local drives with your _containers_ but not with Docker Machine
+nodes. See [Can I share local drives and filesystem with my Docker Machine
+VMs?](faqs.md#can-i-share-local-drives-and-filesystem-with-my-docker-machine-vms) in the FAQs.
+>
 {: .note-vanilla}
-
-See also [Verify domain user has permissions for shared
-drives](troubleshoot.md#verify-domain-user-has-permissions-for-shared-drives-volumes)
-in Troubleshooting.
 
 #### Firewall rules for shared drives
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -55,7 +55,7 @@ volumes](/docker-for-windows/index.md#shared-drives) to a default value of
 working with applications that require permissions different than this default,
 you will likely get errors similar to the following.
 
-```
+```none
 Data directory (/var/www/html/data) is readable by other users. Please change the permissions to 0755 so that the directory cannot be listed by other users.
 ```
 
@@ -107,10 +107,10 @@ containers](index.md#switch-between-windows-and-linux-containers),
 not Windows containers.
 
 Permissions to access shared drives are tied to the username and password you
-use to set up shared drives. (See [Shared Drives](index.md#shared-drives).) If
-you run `docker` commands and tasks under a different username than the one used
-to set up shared drives, your containers will not have permissions to access the
-mounted volumes. The volumes will show as empty.
+use to set up [shared drives](index.md#shared-drives). If you run `docker`
+commands and tasks under a different username than the one used to set up shared
+drives, your containers will not have permissions to access the mounted volumes.
+The volumes will show as empty.
 
 The solution to this is to switch to the domain user account and reset
 credentials on shared drives.
@@ -159,18 +159,24 @@ database software and which options are enabled. Docker for Windows uses
 protocols](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365233(v=vs.85).aspx)
 to mount host paths, and mounts them with the `nobrl` option, which prevents
 lock requests from being sent to the database server
-([docker/for-win#11](https://github.com/docker/for-win/issues/11)). This is done
-to ensure container access to database files shared from the host. Although it
-solves the over-the-network database access problem, this "unlocked" strategy
+([docker/for-win#11](https://github.com/docker/for-win/issues/11),
+[docker/for-win#694](https://github.com/docker/for-win/issues/694)). This is
+done to ensure container access to database files shared from the host. Although
+it solves the over-the-network database access problem, this "unlocked" strategy
 can interfere with other aspects of database functionality (for example,
 write-ahead logging (WAL) with SQLite, as described in
 [docker/for-win#1886](https://github.com/Sonarr/Sonarr/issues/1886)).
 
-We recommend that you avoid using shared drives for volume mounts from the host
-if possible, and instead create a [data
+If possible, avoid using shared drives for volume mounts on the host with network paths, and
+instead mount on the MobyVM, or create a [data
 volume](https://docs.docker.com/engine/tutorials/dockervolumes.md#data-volumes)
 (named volume) or [data
 container](/engine/tutorials/dockervolumes.md#creating-and-mounting-a-data-volume-container).
+See also, the [volumes key under service
+configuration](/compose/compose-file/index.md#volumes) and the [volume
+configuration
+reference](/compose/compose-file/index.md#volume-configuration-reference) in the
+Compose file documentation.
 
 ### Local security policies can block shared drives and cause login errors
 
@@ -183,7 +189,7 @@ these permissions to use the feature.
 
 Here are snip-its from example error messages:
 
-```
+```none
 Logon failure: the user has not been granted the requested logon type at
 this computer.
 
@@ -212,7 +218,9 @@ commands ultimately get passed to Unix commands inside a Unix based container
 (for example, a shell script passed to `/bin/sh`). If Windows style line endings
 are used, `docker run` will fail with syntax errors.
 
-For an example of this issue and the resolution, see this issue on GitHub: <a href="https://github.com/moby/moby/issues/24388">Docker RUN fails to execute shell script (https://github.com/moby/moby/issues/24388)</a>.
+For an example of this issue and the resolution, see this issue on GitHub:
+[Docker RUN fails to execute shell
+script](https://github.com/moby/moby/issues/24388).
 
 ### Recreate or update your containers after Beta 18 upgrade
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -151,6 +151,27 @@ local user is `samstevens` and the domain user is `merlin`.
 
 See also, the related issue on GitHub, [Mounted volumes are empty in the container](https://github.com/docker/for-win/issues/25).
 
+### Volume mounts from host paths use a `nobrl` option to override database locking  
+
+You may encounter problems using volume mounts on the host, depending on the
+database software and which options are enabled. Docker for Windows uses
+[SMB/CIFS
+protocols](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365233(v=vs.85).aspx)
+to mount host paths, and mounts them with the `nobrl` option, which prevents
+lock requests from being sent to the database server
+([docker/for-win#11](https://github.com/docker/for-win/issues/11)). This is done
+to ensure container access to database files shared from the host. Although it
+solves the over-the-network database access problem, this "unlocked" strategy
+can interfere with other aspects of database functionality (for example,
+write-ahead logging (WAL) with SQLite, as described in
+[docker/for-win#1886](https://github.com/Sonarr/Sonarr/issues/1886)).
+
+We recommend that you avoid using shared drives for volume mounts from the host
+if possible, and instead create a [data
+volume](https://docs.docker.com/engine/tutorials/dockervolumes.md#data-volumes)
+(named volume) or [data
+container](/engine/tutorials/dockervolumes.md#creating-and-mounting-a-data-volume-container).
+
 ### Local security policies can block shared drives and cause login errors
 
 You need permissions to mount shared drives in order to use the Docker for


### PR DESCRIPTION
### What's new

- Added a note under Docker for Windows "Shared Drives" topic re: caveats for volume mounts from host

- Added a troubleshooting topic on effect of `nobrl` flag on volume mounts from host (prevents database locking), w/rationale,  implications, recommendations, and links to relevant issues

- **Note:** What I _did not do_ is add anything to the Docker for Mac docs, even though if you read all the discussion threads on the listed bugs, it sounds like there might be similar but slightly different problems or stumbling blocks with `osxfs`. Let me know if we need to tackle that too, or not.

### Reviewers

@friism @dgageot @Taloth @lokkju @mstanleyjones @JimGalasyn @thaJeztah 

### Direct links to relevant topics in Netlify preview

* Getting Started, Shared Drives topic: [Second tip re: shared drivers, permissions and volume mounts](https://deploy-preview-3556--docker-docs.netlify.com/docker-for-windows/#shared-drives)

* Troubleshooting topic: [Volume mounts from host paths use a nobrl option to override database locking](https://deploy-preview-3556--docker-docs.netlify.com/docker-for-windows/troubleshoot/#volume-mounts-from-host-paths-use-a-nobrl-option-to-override-database-locking) 

### Related

Fixes #3147 (docs issue)

[docker/for-win/issues/11](https://github.com/docker/for-win/issues/11)

[docker/for-win/issues/694](https://github.com/docker/for-win/issues/694)

[docker/for-win/issues/1886](https://github.com/Sonarr/Sonarr/issues/1886)

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>