### PR TITLE
command spelling mistake

### DIFF
--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -200,7 +200,7 @@ assumes that the Docker daemon is in the `stopped` state.
     ```
 
 7.  Convert the volumes to a thin pool and a storage location for metadata for
-    the thin pool, using the `lgconvert` command.
+    the thin pool, using the `lvconvert` command.
 
     ```none
     $ sudo lvconvert -y \


### PR DESCRIPTION
Convert the volumes to a thin pool and a storage location for metadata for the thin pool, using the lgconvert command.
should be
Convert the volumes to a thin pool and a storage location for metadata for the thin pool, using the lvconvert command.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
