### PR TITLE
Fix bad syntax in filesystem.md

### DIFF
--- a/registry/storage-drivers/filesystem.md
+++ b/registry/storage-drivers/filesystem.md
@@ -14,4 +14,4 @@ there is adequate space available. Defaults to `/var/lib/registry`.
 `maxthreads`: (optional) The maximum number of simultaneous blocking filesystem
 operations permitted within the registry. Each operation spawns a new thread and
 may cause thread exhaustion issues if many are done in parallel. Defaults to
-`100`, and can be no lower than `25`.
+`100`, and cannot be lower than `25`.


### PR DESCRIPTION
### Proposed changes

I've modified the sentence about the maximum and minimum maxthreads in the filesystem page

-`100`, and can be no lower than `25`.
+`100`, and cannot be lower than `25`.

The sentence was strange, and was actually misunderstood by Google Translate, which is bad if a non english person tries to translate the documentation. This modification will add clarity and is correctly translated by Google Translate.
