### PR TITLE
added Machine overview to left-side toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -2319,6 +2319,8 @@ manuals:
       title: url
   - sectiontitle: Machine drivers
     section:
+    - path: /machine/drivers/
+      title: Drivers overview
     - path: /machine/drivers/os-base/
       title: Driver options and operating system defaults
     - path: /machine/drivers/aws/

--- a/machine/drivers/index.md
+++ b/machine/drivers/index.md
@@ -1,7 +1,7 @@
 ---
 description: Reference for drivers Docker Machine supports
 keywords: machine, drivers, supports
-title: Drivers
+title: Machine drivers
 ---
 
 -   [Amazon Web Services](aws.md)


### PR DESCRIPTION
### what's new 

- Added Machine drivers overview to left side toc nav to surface full list

### Related

Issue #3512

PR #3542

### Reviewers

@cwon7609 @dnephin @shin- @dmp42 @mstanleyjones



Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
