### PR TITLE
fixed instances where docker was changed to moby and broke links

### DIFF
--- a/docker-cloud/apps/deploy-to-cloud-btn.md
+++ b/docker-cloud/apps/deploy-to-cloud-btn.md
@@ -16,7 +16,7 @@ be used anywhere else.
 
 This is an example button to deploy our [python quickstart](https://github.com/docker/dockercloud-quickstart-python){: target="_blank" class="_"}:
 
-<a href="https://cloud.docker.com/stack/deploy/?repo=https://github.com/moby/mobycloud-quickstart-python" target="_blank" class="_"><img src="https://files.cloud.docker.com/images/deploy-to-dockercloud.svg"></a>
+<a href="https://cloud.docker.com/stack/deploy/?repo=https://github.com/docker/dockercloud-quickstart-python" target="_blank" class="_"><img src="https://files.cloud.docker.com/images/deploy-to-dockercloud.svg"></a>
 
 The button redirects the user to the **Launch new Stack** wizard, with the stack
 definition already filled with the contents of any of the following files (which
@@ -61,9 +61,9 @@ https://cloud.docker.com/stack/deploy/?repo=<repo_url>
 
 where `<repo_url>` is the path to your GitHub repository. For example:
 
-* `https://github.com/moby/mobycloud-quickstart-python`
-* `https://github.com/moby/mobycloud-quickstart-python/tree/staging` to use branch `staging` instead of the default branch
-* `https://github.com/moby/mobycloud-quickstart-python/tree/master/example` to use branch `master` and the relative path `/example` inside the repository
+* `https://github.com/docker/dockercloud-quickstart-python`
+* `https://github.com/docker/dockercloud-quickstart-python/tree/staging` to use branch `staging` instead of the default branch
+* `https://github.com/docker/dockercloud-quickstart-python/tree/master/example` to use branch `master` and the relative path `/example` inside the repository
 
 You can use your own image for the link (or no image). Our **Deploy to Docker Cloud** image is available at the following URL:
 

--- a/docker-cloud/getting-started/deploy-app/2_set_up.md
+++ b/docker-cloud/getting-started/deploy-app/2_set_up.md
@@ -24,7 +24,7 @@ docker run dockercloud/cli -h
 
 This command runs the `docker-cloud` CLI image in a container for you. Learn
 more about how to use this container
-[here](https://github.com/moby/mobycloud-cli#docker-image).
+[here](https://github.com/docker/dockercloud-cli#docker-image).
 
 #### Install for Linux or Windows
 

--- a/docker-cloud/getting-started/deploy-app/3_prepare_the_app.md
+++ b/docker-cloud/getting-started/deploy-app/3_prepare_the_app.md
@@ -16,14 +16,14 @@ install Python or Go to follow the tutorial.
 **Python quickstart**
 
 ```bash
-$ git clone https://github.com/moby/mobycloud-quickstart-python.git
+$ git clone https://github.com/docker/dockercloud-quickstart-python.git
 $ cd dockercloud-quickstart-python
 ```
 
 **Go quickstart**
 
 ```bash
-$ git clone https://github.com/moby/mobycloud-quickstart-go.git
+$ git clone https://github.com/docker/dockercloud-quickstart-go.git
 $ cd dockercloud-quickstart-go
 ```
 

--- a/docker-cloud/infrastructure/link-aws.md
+++ b/docker-cloud/infrastructure/link-aws.md
@@ -111,7 +111,7 @@ You can use the following `dockercloud-policy` to limit Docker Cloud to a specif
 
 7. Give the new role a name, such as `dockercloud-role`.
 
-    > **Note**: You must use one role per Docker Cloud account namespace, so if you will be using nodes from a single AWS account for multiple Docker Cloud accounts, you should add an identifying the namespace to the end of the name. For example, you might have `dockercloud-role-moby` and `dockercloud-role-teamawesome`.
+    > **Note**: You must use one role per Docker Cloud account namespace, so if you will be using nodes from a single AWS account for multiple Docker Cloud accounts, you should add an identifying the namespace to the end of the name. For example, you might have `dockercloud-role-docker` and `dockercloud-role-teamawesome`.
 
 8.  Click **Create Role**.
 


### PR DESCRIPTION
### What's changed

- Fixed several instances where `docker` was incorrectly changed to `moby` 

- It looks like there was a brute search-and-replace for this on all docs (i.e., for future reference, paths with `docker/dockercloud` in them should not be changed to `moby/mobycloud`; paths with `docker/docker/` should be changed to `moby/moby/`)

### Related

#3592

### Netlify preview

This is the topic on which the user reported the broken link, but there were several others fixed as a part of this PR (see Files changed in the PR): https://deploy-preview-3593--docker-docs.netlify.com/docker-cloud/getting-started/deploy-app/3_prepare_the_app/

### Reviewers

@shotokai @pkennedyr @KickingTheTV @mstanleyjones @thaJeztah 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
