### PR TITLE
Editing typo in 'docker machine ls' command

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -65,7 +65,7 @@ machine a swarm manager. From then on, Docker will run the commands you execute
 on the swarm you're managing, rather than just on the current machine.
 
 {% capture local-instructions %}
-You now have two VMs created, named `myvm1` and `myvm2` (as `docker machine ls`
+You now have two VMs created, named `myvm1` and `myvm2` (as `docker-machine ls`
 shows). The first one will act as the manager, which executes `docker` commands
 and authenticates workers to join the swarm, and the second will be a worker.
 


### PR DESCRIPTION
The command is 'docker-machine ls'. Current version has a typo and is missing the dash '-'

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
