### PR TITLE
Machine bash completion

### DIFF
--- a/compose/completion.md
+++ b/compose/completion.md
@@ -11,54 +11,72 @@ for the bash and zsh shell.
 
 ### Bash
 
-Make sure bash completion is installed. If you use a current Linux in a non-minimal installation, bash completion should be available.
-On a Mac, install with `brew install bash-completion`
+Make sure bash completion is installed. If you use a current Linux in a
+non-minimal installation, bash completion should be available. On a Mac, install
+with `brew install bash-completion`.
 
-Place the completion script in `/etc/bash_completion.d/` (`/usr/local/etc/bash_completion.d/` on a Mac), using e.g.
+Place the completion script in `/etc/bash_completion.d/`
+(`/usr/local/etc/bash_completion.d/` on a Mac):
 
-    curl -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+```shell
+curl -L https://raw.githubusercontent.com/docker/compose/master/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+```
 
-Then add the following to your `~/.bash_profile`
+Then add the following to your `~/.bash_profile`:
 
-	if [ -f $(brew --prefix)/etc/bash_completion ]; then
-	. $(brew --prefix)/etc/bash_completion
-	fi
- 
-You can source your `~/.bash_profile` or launch a new terminal to utilize completion.
+```shell
+if [ -f $(brew --prefix)/etc/bash_completion ]; then
+. $(brew --prefix)/etc/bash_completion
+fi
+```
+
+You can source your `~/.bash_profile` or launch a new terminal to utilize
+completion.
 
 ## MacPorts Bash Completion
 
-If you're using MacPorts you'll need to slightly modify your steps to the following
-Run `sudo port install bash-completion` to install bash completion
+If you're using MacPorts you'll need to slightly modify your steps to the
+following Run `sudo port install bash-completion` to install bash completion.
 
-	if [ -f /opt/local/etc/profile.d/bash_completion.sh ]; then
-	    . /opt/local/etc/profile.d/bash_completion.sh
-	fi
+```shell
+if [ -f /opt/local/etc/profile.d/bash_completion.sh ]; then
+    . /opt/local/etc/profile.d/bash_completion.sh
+fi
+```
 
- You can source your `~/.bash_profile` or launch a new terminal to utilize completion.
+You can source your `~/.bash_profile` or launch a new terminal to utilize
+completion.
 
 ### Zsh
 
-Place the completion script in your `/path/to/zsh/completion`, using e.g. `~/.zsh/completion/`
+Place the completion script in your `/path/to/zsh/completion`, using e.g. `~/.zsh/completion/`:
 
-    $ mkdir -p ~/.zsh/completion
-    $ curl -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/zsh/_docker-compose > ~/.zsh/completion/_docker-compose
+```shell
+$ mkdir -p ~/.zsh/completion
+$ curl -L https://raw.githubusercontent.com/docker/compose/master/contrib/completion/zsh/_docker-compose > ~/.zsh/completion/_docker-compose
+```
 
-Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`
+Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`:
 
-    fpath=(~/.zsh/completion $fpath)
+```shell
+fpath=(~/.zsh/completion $fpath)
+```
 
-Make sure `compinit` is loaded or do it by adding in `~/.zshrc`
+Make sure `compinit` is loaded or do it by adding in `~/.zshrc`:
 
-    autoload -Uz compinit && compinit -i
+```shell
+autoload -Uz compinit && compinit -i
+```
 
-Then reload your shell
+Then reload your shell:
 
-    exec $SHELL -l
+```shell
+exec $SHELL -l
+```
 
 ## Available completions
 
-Depending on what you typed on the command line so far, it will complete
+Depending on what you typed on the command line so far, it will complete:
 
  - available docker-compose commands
  - options that are available for a particular command

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -364,8 +364,8 @@ To report bugs or problems, log on to [Docker for Mac issues on
 GitHub](https://github.com/docker/for-mac/issues), where you can review
 community reported issues, and file new ones. See [Diagnose problems, send
 feedback, and create GitHub
-issues](troubleshoot.md#diagnose-problems-send-feedback-and-create-github-issues).
-As a part of reporting issues on GitHub, we can help you troubleshoot the log
+issues](troubleshoot.md#diagnose-problems-send-feedback-and-create-github-issues). As a part of reporting issues on GitHub, we can help you troubleshoot
+the log
 data.
 
 To give us feedback on the documentation or update it yourself, use the Feedback
@@ -384,9 +384,13 @@ distributed as Docker Images.
 
 ## Docker Cloud (Edge feature)
 
->**Note:** Integrated Docker Cloud access is currently available only on the [Edge channel](install.md#download-docker-for-mac). On stable, you'll need to log onto [Docker Cloud](https://cloud.docker.com/) independently for now.
+>**Note:** Integrated Docker Cloud access is currently available only on
+the [Edge channel](install.md#download-docker-for-mac). On stable, you'll
+need to log onto [Docker Cloud](https://cloud.docker.com/) independently
+for now.
 
-You can access your [Docker Cloud](https://cloud.docker.com/) account from within Docker for Mac.
+You can access your [Docker Cloud](/docker-cloud/index.md) account from within
+Docker for Mac.
 
 ![Docker Cloud](images/docker-cloud.png)
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -672,19 +672,24 @@ distributed as Docker Images.
 
 ### Docker Cloud (Edge feature)
 
-You can access your [Docker Cloud](https://cloud.docker.com/) account from within Docker for Windows.
+>**Note:** Integrated Docker Cloud access is currently available only on
+the [Edge channel](install.md#download-docker-for-windows).  On stable,
+you'll need to log onto [Docker Cloud](https://cloud.docker.com/)
+independently for now.
+
+You can access your [Docker Cloud](/docker-cloud/index.md) account from
+within Docker for Windows.
 
 ![Docker Cloud](images/docker-cloud.png)
-
->**Note:** Integrated Docker Cloud access is currently available only on the [Edge channel](install.md#download-docker-for-windows).  On stable, you'll need to log onto [Docker Cloud](https://cloud.docker.com/) independently for now.
 
 From the Docker for Windows menu, sign in to Docker Cloud with your Docker ID,
 or create one.
 
 ![Docker Cloud sign-in](images/docker-cloud-menu.png)
 
-Then use the Docker for Windows menu to create, view, or navigate directly to your
-Cloud resources, including **organizations**, **repositories**, and **swarms**.
+Then use the Docker for Windows menu to create, view, or navigate directly to
+your Cloud resources, including **organizations**, **repositories**, and
+**swarms**.
 
 Check out these [Docker Cloud topics](/docker-cloud/index.md) to learn more:
 

--- a/machine/completion.md
+++ b/machine/completion.md
@@ -11,7 +11,8 @@ for the bash and zsh shell.
 
 ### Bash
 
-Make sure bash completion is installed. If you are using a current version of Linux in a non-minimal installation, bash completion should be available.
+Make sure bash completion is installed. If you are using a current version of
+Linux in a non-minimal installation, bash completion should be available.
 
 On a Mac, install with `brew install bash-completion`.
 
@@ -19,14 +20,14 @@ Place the completion script in `/etc/bash_completion.d/` as follows:
 
 *   On a Mac:
 
-    ```none
-    curl -L https://raw.githubusercontent.com/docker/docker/master/contrib/completion/bash/docker > `brew --prefix`/etc/bash_completion.d/docker
+    ```shell
+    curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/engine/contrib/completion/bash/docker > `brew --prefix`/etc/bash_completion.d/docker
     ```
 
 *   On a standard Linux installation:
 
-    ```none
-    curl -L https://raw.githubusercontent.com/docker/docker/master/contrib/completion/bash/docker > /etc/bash_completion.d/docker
+    ```shell
+    curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/engine/contrib/completion/bash/docker > /etc/bash_completion.d/docker
     ```
 
 Completion will be available upon next login.
@@ -34,26 +35,43 @@ Completion will be available upon next login.
 
 ### Zsh
 
-Place the completion script in your `/path/to/zsh/completion`, using e.g. `~/.zsh/completion/`
+Place the completion script in your `/path/to/zsh/completion`, using e.g. `~/.zsh/completion/`:
 
-    mkdir -p ~/.zsh/completion
-    curl -L https://raw.githubusercontent.com/docker/docker/master/contrib/completion/zsh/_docker > ~/.zsh/completion/_docker-machine
+```shell
+mkdir -p ~/.zsh/completion
+curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/zsh/_docker > ~/.zsh/completion/_docker-machine
+```
 
-Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`
+Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`:
 
-    fpath=(~/.zsh/completion $fpath)
+```shell
+fpath=(~/.zsh/completion $fpath)
+```
 
-Make sure `compinit` is loaded or do it by adding in `~/.zshrc`
+Make sure `compinit` is loaded or do it by adding in `~/.zshrc`:
 
-    autoload -Uz compinit && compinit -i
+```shell
+autoload -Uz compinit && compinit -i
+```
 
-Then reload your shell
+Then reload your shell:
 
-    exec $SHELL -l
+```shell
+exec $SHELL -l
+```
 
-
-<!--[metadata]>
 ## Available completions
 
-**TODO**
-<![end-metadata]-->
+Depending on what you typed on the command line so far, it will complete:
+
+- commands and their options
+- container IDs and names
+- image repositories and image tags
+- file paths
+
+## Where to go next
+
+* [Get started with a local VM](/machine/get-started.md)
+* [Machine command-line reference](/machine/reference/index.md)
+* [Machine drivers](/machine/drivers/index.md)
+* [Machine concepts and help](/machine/concepts.md)

--- a/machine/examples/aws.md
+++ b/machine/examples/aws.md
@@ -19,7 +19,7 @@ from those Docker desktop applications. See Docker Cloud (Edge feature) on
 >
 > Docker Machine will still work as described here, but Docker Cloud
 supercedes Machine for this purpose.
-{: .important}
+{: .important-vanilla}
 
 Follow along with this example to create a Dockerized [Amazon Web Services (AWS)](https://aws.amazon.com/) EC2 instance.
 

--- a/machine/examples/aws.md
+++ b/machine/examples/aws.md
@@ -4,6 +4,23 @@ keywords: docker, machine, cloud, aws
 title: Amazon Web Services (AWS) EC2 example
 ---
 
+> Try out Docker Cloud!
+>
+> We suggest using [Docker Cloud](https://cloud.docker.com/) as the
+most up-to-date way to run Docker on your cloud providers. To get started, see
+[Docker Cloud docs home page](/docker-cloud/index.md), [Docker Cloud Settings
+and Docker ID](/docker-cloud/dockerid.md), [Swarms in Docker Cloud
+(Beta)](/docker-cloud/cloud-swarm/index.md), and [Link Amazon Web Services to
+Docker Cloud](/docker-cloud/cloud-swarm/link-aws-swarm.md). If you are running
+Edge channel Docker for Mac or Windows, you can access your Docker Cloud account
+from those Docker desktop applications. See Docker Cloud (Edge feature) on
+[Mac](/docker-for-mac/index.md#docker-cloud-edge-feature) or
+[Windows](/docker-for-windows/index.md#docker-cloud-edge-feature).
+>
+> Docker Machine will still work as described here, but Docker Cloud
+supercedes Machine for this purpose.
+{: .important}
+
 Follow along with this example to create a Dockerized [Amazon Web Services (AWS)](https://aws.amazon.com/) EC2 instance.
 
 ### Step 1. Sign up for AWS and configure credentials

--- a/machine/examples/index.md
+++ b/machine/examples/index.md
@@ -4,5 +4,21 @@ keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, ra
 title: Learn by example
 ---
 
+> Try out Docker Cloud!
+>
+> We suggest using [Docker Cloud](https://cloud.docker.com/) as the
+most up-to-date way to run Docker on your cloud providers. To get started, see
+[Docker Cloud docs home page](/docker-cloud/index.md), [Docker Cloud Settings
+and Docker ID](/docker-cloud/dockerid.md) and [Swarms in Docker Cloud
+(Beta)](/docker-cloud/cloud-swarm/index.md). If you are running Edge channel
+Docker for Mac or Windows, you can access your Docker Cloud account from those
+Docker desktop applications. See Docker Cloud (Edge feature) on
+[Mac](/docker-for-mac/index.md#docker-cloud-edge-feature) or
+[Windows](/docker-for-windows/index.md#docker-cloud-edge-feature).
+>
+> Docker Machine will still work as described here, but Docker Cloud
+supercedes Machine for this purpose.
+{: .important}
+
 -   [Digital Ocean Example](ocean.md)
 -   [AWS Example](aws.md)

--- a/machine/examples/index.md
+++ b/machine/examples/index.md
@@ -18,7 +18,7 @@ Docker desktop applications. See Docker Cloud (Edge feature) on
 >
 > Docker Machine will still work as described here, but Docker Cloud
 supercedes Machine for this purpose.
-{: .important}
+{: .important-vanilla}
 
 -   [Digital Ocean Example](ocean.md)
 -   [AWS Example](aws.md)

--- a/machine/examples/ocean.md
+++ b/machine/examples/ocean.md
@@ -4,6 +4,22 @@ keywords: docker, machine, cloud, digital ocean
 title: Digital Ocean example
 ---
 
+> Try out Docker Cloud!
+>
+> We suggest using [Docker Cloud](https://cloud.docker.com/) as the
+most up-to-date way to run Docker on your cloud providers. To get started, see
+[Docker Cloud docs home page](/docker-cloud/index.md), [Docker Cloud Settings
+and Docker ID](/docker-cloud/dockerid.md), and [Link a DigitalOcean account to
+Docker Cloud](/docker-cloud/infrastructure/link-do.md). If you are running Edge
+channel Docker for Mac or Windows, you can access your Docker Cloud account from
+those Docker desktop applications. See Docker Cloud (Edge feature) on
+[Mac](/docker-for-mac/index.md#docker-cloud-edge-feature) or
+[Windows](/docker-for-windows/index.md#docker-cloud-edge-feature).
+>
+> Docker Machine will still work as described below, but Docker Cloud
+supercedes Machine for this purpose.
+{: .important}
+
 Follow along with this example to create a Dockerized [Digital Ocean](https://digitalocean.com) Droplet (cloud host).
 
 ### Step 1. Create a Digital Ocean account

--- a/machine/examples/ocean.md
+++ b/machine/examples/ocean.md
@@ -18,7 +18,7 @@ those Docker desktop applications. See Docker Cloud (Edge feature) on
 >
 > Docker Machine will still work as described below, but Docker Cloud
 supercedes Machine for this purpose.
-{: .important}
+{: .important-vanilla}
 
 Follow along with this example to create a Dockerized [Digital Ocean](https://digitalocean.com) Droplet (cloud host).
 

--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -118,7 +118,7 @@ You can register an already existing docker host by passing the daemon url. With
 > Swarm mode supercedes Docker Machine provisioning of swarm clusters
 >
 > In previous releases, Docker Machine was used to provision swarm
-clusters, but this is legacy&#8212;[swarm mode](/engine/swarm/index.md), built
+clusters, but this is legacy. [Swarm mode](/engine/swarm/index.md), built
 into Docker Engine, supercedes Machine provisioning of swarm clusters. The
 topics below show you how to get started with the new swarm mode.
 {: .important-vanilla}

--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -4,7 +4,7 @@ keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, ra
 title: Use Docker Machine to provision hosts on cloud providers
 ---
 
-> Try out Docker Cloud
+> Try out Docker Cloud!
 >
 > We suggest using [Docker Cloud](https://cloud.docker.com/) as the
 most up-to-date way to run Docker on your cloud providers. To get started, see
@@ -15,6 +15,9 @@ Docker for Mac or Windows, you can access your Docker Cloud account from those
 Docker desktop applications. See Docker Cloud (Edge feature) on
 [Mac](/docker-for-mac/index.md#docker-cloud-edge-feature) or
 [Windows](/docker-for-windows/index.md#docker-cloud-edge-feature).
+>
+> Docker Machine will still work as described here, but Docker Cloud supercedes Machine for this purpose.
+{: .important}
 
 Docker Machine driver plugins are available for many cloud platforms, so you can use Machine to provision cloud hosts. When you use Docker Machine for provisioning, you create cloud hosts with Docker Engine installed on them.
 

--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -17,57 +17,92 @@ Docker desktop applications. See Docker Cloud (Edge feature) on
 [Windows](/docker-for-windows/index.md#docker-cloud-edge-feature).
 >
 > Docker Machine will still work as described here, but Docker Cloud supercedes Machine for this purpose.
-{: .important}
+{: .important-vanilla}
 
-Docker Machine driver plugins are available for many cloud platforms, so you can use Machine to provision cloud hosts. When you use Docker Machine for provisioning, you create cloud hosts with Docker Engine installed on them.
+Docker Machine driver plugins are available for many cloud platforms, so you can
+use Machine to provision cloud hosts. When you use Docker Machine for
+provisioning, you create cloud hosts with Docker Engine installed on them.
 
-You'll need to install and run Docker Machine, and create an account with the cloud provider.
+You'll need to install and run Docker Machine, and create an account with the
+cloud provider.
 
-Then you provide account verification, security credentials, and configuration options for the providers as flags to `docker-machine create`. The flags are unique for each cloud-specific driver.  For instance, to pass a Digital Ocean access token you use the `--digitalocean-access-token` flag. Take a look at the examples below for Digital Ocean and AWS.
+Then you provide account verification, security credentials, and configuration
+options for the providers as flags to `docker-machine create`. The flags are
+unique for each cloud-specific driver.  For instance, to pass a Digital Ocean
+access token you use the `--digitalocean-access-token` flag. Take a look at the
+examples below for Digital Ocean and AWS.
 
 ## Examples
 
 ### Digital Ocean
 
-For Digital Ocean, this command creates a Droplet (cloud host) called "docker-sandbox".
+For Digital Ocean, this command creates a Droplet (cloud host) called
+"docker-sandbox".
 
-      $ docker-machine create --driver digitalocean --digitalocean-access-token xxxxx docker-sandbox
+```shell
+$ docker-machine create --driver digitalocean --digitalocean-access-token xxxxx docker-sandbox
+```
 
-For a step-by-step guide on using Machine to create Docker hosts on Digital Ocean, see the [Digital Ocean Example](examples/ocean.md).
+For a step-by-step guide on using Machine to create Docker hosts on Digital
+Ocean, see the [Digital Ocean Example](examples/ocean.md).
 
 ### Amazon Web Services (AWS)
 
 For AWS EC2, this command creates an instance called "aws-sandbox":
 
-      $ docker-machine create --driver amazonec2 --amazonec2-access-key AKI******* --amazonec2-secret-key 8T93C*******  aws-sandbox
+```shell
+$ docker-machine create --driver amazonec2 --amazonec2-access-key AKI******* --amazonec2-secret-key 8T93C*******  aws-sandbox
+```
 
-For a step-by-step guide on using Machine to create Dockerized AWS instances, see the [Amazon Web Services (AWS) example](examples/aws.md).
+For a step-by-step guide on using Machine to create Dockerized AWS instances,
+see the [Amazon Web Services (AWS) example](examples/aws.md).
 
 ## The docker-machine create command
 
-The `docker-machine create` command typically requires that you specify, at a minimum:
+The `docker-machine create` command typically requires that you specify, at a
+minimum:
 
-* `--driver` - to indicate the provider on which to create the machine  (VirtualBox, DigitalOcean, AWS, and so on)
+* `--driver` - to indicate the provider on which to create the
+machine  (VirtualBox, DigitalOcean, AWS, and so on)
 
-* Account verification and security credentials (for cloud providers), specific to the cloud service you are using
+* Account verification and security credentials (for cloud providers),
+specific to the cloud service you are using
 
 * `<machine>` - name of the host you want to create
 
-For convenience, `docker-machine` will use sensible defaults for choosing settings such as the image that the server is based on, but you override the defaults using the respective flags (e.g. `--digitalocean-image`). This is useful if, for example, you want to create a cloud server with a lot of memory and CPUs (by default `docker-machine` creates a small server).
+For convenience, `docker-machine` will use sensible defaults for choosing
+settings such as the image that the server is based on, but you override the
+defaults using the respective flags (e.g. `--digitalocean-image`). This is
+useful if, for example, you want to create a cloud server with a lot of memory
+and CPUs (by default `docker-machine` creates a small server).
 
-For a full list of the flags/settings available and their defaults, see the output of `docker-machine create -h` at the command line, the <a href="../machine/reference/create/" target="_blank">create</a> command in the Machine <a href="../machine/reference/" target="_blank">command line reference</a>, and <a href="/machine/drivers/os-base/" target="_blank">driver options and operating system defaults</a> in the Machine driver reference.
+For a full list of the flags/settings available and their defaults, see the
+output of `docker-machine create -h` at the command line, the
+[create](/machine/reference/create/){: target="_blank" class="_" } command in
+the Machine [command line reference](/machine/reference/index.md){:
+target="_blank" class="_" }, and [driver options and operating system
+defaults](/machine/drivers/os-base/){: target="_blank" class="_" } in the
+Machine driver reference.
 
 ## Drivers for cloud providers
 
-When you install Docker Machine, you get a set of drivers for various cloud providers (like Amazon Web Services, Digital Ocean, or Microsoft Azure) and local providers (like Oracle VirtualBox, VMWare Fusion, or Microsoft Hyper-V).
+When you install Docker Machine, you get a set of drivers for various cloud
+providers (like Amazon Web Services, Digital Ocean, or Microsoft Azure) and
+local providers (like Oracle VirtualBox, VMWare Fusion, or Microsoft Hyper-V).
 
-See <a href="../machine/drivers/" target="_blank">Docker Machine driver reference</a> for details on the drivers, including required flags and configuration options (which vary by provider).
+See [Docker Machine driver reference](/machine/drivers/index.md){:
+target="_blank" class="_"} for details on the drivers, including required flags
+and configuration options (which vary by provider).
 
 ## 3rd-party driver plugins
 
-  Several Docker Machine driver plugins for use with other cloud platforms are available from 3rd party contributors. These are use-at-your-own-risk plugins, not maintained by or formally associated with Docker.
+Several Docker Machine driver plugins for use with other cloud platforms are
+available from 3rd party contributors. These are use-at-your-own-risk plugins,
+not maintained by or formally associated with Docker.
 
-  See <a href="https://github.com/docker/docker.github.io/blob/master/machine/AVAILABLE_DRIVER_PLUGINS.md" target="_blank">Available driver plugins</a>.
+See [Available driver
+plugins](https://github.com/docker/docker.github.io/blob/master/machine/AVAILABLE_DRIVER_PLUGINS.md){:
+target="_blank" class="_"}.
 
 ## Adding a host without a driver
 
@@ -80,11 +115,24 @@ You can register an already existing docker host by passing the daemon url. With
 
 ## Using Machine to provision Docker Swarm clusters
 
-Docker Machine can also provision <a href="/swarm/overview/" target="_blank">Docker Swarm</a> clusters. This can be used with any driver and will be secured with TLS.
+> Swarm mode supercedes Docker Machine provisioning of swarm clusters
+>
+> In previous releases, Docker Machine was used to provision swarm
+clusters, but this is legacy&#8212;[swarm mode](/engine/swarm/index.md), built
+into Docker Engine, supercedes Machine provisioning of swarm clusters. The
+topics below show you how to get started with the new swarm mode.
+{: .important-vanilla}
 
-* To get started with Swarm, see <a href="/swarm/get-swarm/" target="_blank">How to get Docker Swarm</a>.
+You can use Docker Machine to create local virtual hosts on which to deploy
+and test [swarm mode](/engine/swarm/index.md) clusters.
 
-* To learn how to use Machine to provision a Swarm cluster, see <a href="/swarm/provision-with-machine/" target="_blank">Provision a Swarm cluster with Docker Machine</a>.
+Good places to start working with Docker Machine and swarm mode are these
+tutorials:
+
+* [Get started with Docker](/get-started/index.md)
+
+* [Getting started with swarm mode](/engine/swarm/swarm-tutorial/index.md)
+
 
 ## Where to go next
 -   Example: Provision Dockerized [Digital Ocean Droplets](examples/ocean.md)

--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -4,6 +4,18 @@ keywords: docker, machine, amazonec2, azure, digitalocean, google, openstack, ra
 title: Use Docker Machine to provision hosts on cloud providers
 ---
 
+> Try out Docker Cloud
+>
+> We suggest using [Docker Cloud](https://cloud.docker.com/) as the
+most up-to-date way to run Docker on your cloud providers. To get started, see
+[Docker Cloud docs home page](/docker-cloud/index.md), [Docker Cloud Settings
+and Docker ID](/docker-cloud/dockerid.md) and [Swarms in Docker Cloud
+(Beta)](/docker-cloud/cloud-swarm/index.md). If you are running Edge channel
+Docker for Mac or Windows, you can access your Docker Cloud account from those
+Docker desktop applications. See Docker Cloud (Edge feature) on
+[Mac](/docker-for-mac/index.md#docker-cloud-edge-feature) or
+[Windows](/docker-for-windows/index.md#docker-cloud-edge-feature).
+
 Docker Machine driver plugins are available for many cloud platforms, so you can use Machine to provision cloud hosts. When you use Docker Machine for provisioning, you create cloud hosts with Docker Engine installed on them.
 
 You'll need to install and run Docker Machine, and create an account with the cloud provider.


### PR DESCRIPTION
### What's changed

#### Machine topics

- replaced incorrect bash and zsh completion URLs with correct ones per user feedback
- added list of available options once completion is installed, and a "What's next" section
- added links to Docker Cloud docs from Machine cloud topics in a note ("Try out Docker Cloud")

#### Compose topics

- replaced incorrect bash and zsh completion URLs with correct ones per user feedback
- added links to Docker Cloud docs from Machine cloud topics in a note ("Try out Docker Cloud")

#### Cloud and Mac/Windows topics

- Improved Cloud / Mac/ Windows cross referencing.

### Related

Fixes #3620 for Machine
Fixes #3621 for Compose

### Reviewers

@trestini @shin- @ManoMarks @mstanleyjones 





Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
