### PR TITLE
Docker for Mac and Windows relnotes 17.06.0-rc4-ce

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -355,6 +355,14 @@ events or unexpected unmounts.
 
 ## Edge Release Notes
 
+### Docker Community Edition 17.06.0-rc4-ce-mac15, 2017-06-16 (edge)
+
+**Upgrades**
+
+- [Docker 17.06.0-rc4-ce](https://github.com/docker/docker-ce/releases/tag/v17.06.0-ce-rc4)
+- [Docker Credential Helpers 0.5.2](https://github.com/docker/docker-credential-helpers/releases/tag/v0.5.2)
+- Linux Kernel 4.9.31
+
 ### Docker Community Edition 17.06.0-rc2-ce-mac14, 2017-06-08 (edge)
 
 **Upgrades**

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -309,6 +309,15 @@ We did not distribute a 1.12.4 stable release
 
 ## Edge Release Notes
 
+### Docker Community Edition 17.06.0-win15 Release Notes (2017-06-16 17.06.0-rc4-ce-win15) (edge)
+
+**Upgrades**
+
+- [Docker 17.06.0-rc4-ce](https://github.com/docker/docker-ce/releases/tag/v17.06.0-ce-rc4)
+- [Docker Credential Helpers 0.5.2](https://github.com/docker/docker-credential-helpers/releases/tag/v0.5.2)
+- Linux Kernel 4.9.31
+
+
 ### Docker Community Edition 17.06.0-win14 Release Notes (2017-06-08 17.06.0-rc2-ce-win14) (edge)
 
 **Upgrades**


### PR DESCRIPTION
### What's new

- Docker for Mac and Windows Edge release notes 17.06.0-rc4-ce-mac15, 17.06.0-rc4-ce-win15, respectively


### Reviewers, fyi

@gtardif @friism @jeanlaurent 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>