### PR TITLE
Fixing documentation for v2 `links`

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -551,13 +551,13 @@ It's recommended that you use reverse-DNS notation to prevent your labels from c
 ### links
 
 Link to containers in another service. Either specify both the service name and
-a link alias (`SERVICE:ALIAS`), or just the service name.
+a link alias (`"SERVICE:ALIAS"`), or just the service name.
 
     web:
       links:
-       - db
-       - db:database
-       - redis
+       - "db"
+       - "db:database"
+       - "redis"
 
 Containers for the linked service will be reachable at a hostname identical to
 the alias, or the service name if no alias was specified.


### PR DESCRIPTION
wrapping array values in quotes is required.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Updating v2 compose file docs to reflect `docker-compose` behavior.

#### `dockerfile.yml`

```yml
version: '2'
 
services:

  webapp:
    image: 34ks/webapp
    restart: always
    env_file:
      - monolith/.env

  auth:
    image: 34ks/books-auth
    restart: always
    env_file:
      - auth/.env

  reverseproxy:
    image: 34ks/reverseproxy
    ports:
      - "8080:8080"
    restart: always
    links: 
      - webapp
      - auth
```

#### Problem

```
$ docker-compose config
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.reverseproxy.links contains an invalid type, it should be an array
```

#### Solution: wrap values in quotes

```yml
# ....
    links: 
      - "webapp"
      - "auth"
```

```
$ docker-compose config
networks: {}
services:
  auth:
    environment:
# ...
    image: 34ks/books-auth
    restart: always
  reverseproxy:
    image: 34ks/reverseproxy
    links:
    - webapp
    - auth
    ports:
    - 8080:8080
    restart: always
  webapp:
    environment:
# ...
    image: 34ks/webapp
    restart: always
version: '2.0'
volumes: {}
```

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
