### PR TITLE
centos Uninstall lost a dependency

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -50,7 +50,8 @@ $ sudo yum remove docker \
                   docker-common \
                   container-selinux \
                   docker-selinux \
-                  docker-engine
+                  docker-engine \
+                  docker-engine-selinux
 ```
 
 It's OK if `yum` reports that none of these packages are installed.


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
When I degrade to lower docker version in centos7.3,
I found that docker-engine-selinux dependency need to remove.
<!--Tell us what you did and why-->

