### PR TITLE
Docker for AWS - fix broken link to distributed app bundles

### DIFF
--- a/docker-for-aws/deploy.md
+++ b/docker-for-aws/deploy.md
@@ -149,7 +149,7 @@ This tool internally makes use of docker global-mode service that runs a task on
 
 ### Distributed Application Bundles
 
-To deploy complex multi-container apps, you can use [distributed application bundles](https://github.com/moby/moby/blob/master/experimental/docker-stacks-and-bundles.md). You can either run `docker deploy` to deploy a bundle on your machine over an SSH tunnel, or copy the bundle (for example using `scp`) to a manager node, SSH into the manager and then run `docker deploy` (if you have multiple managers, you have to ensure that your session is on one that has the bundle file).
+To deploy complex multi-container apps, you can use [distributed application bundles](/compose/bundles.md). You can either run `docker deploy` to deploy a bundle on your machine over an SSH tunnel, or copy the bundle (for example using `scp`) to a manager node, SSH into the manager and then run `docker deploy` (if you have multiple managers, you have to ensure that your session is on one that has the bundle file).
 
 A good sample app to test application bundles is the [Docker voting app](https://github.com/docker/example-voting-app).
 


### PR DESCRIPTION
### Proposed changes

The "Docker for AWS / Deploy your app" page has a broken link to
distributed application bundles. There now is a dedicated page within
the documentation repo ("Docker Compose / Docker stacks and distributed
application bundles") that we can reference.

### Related issues

https://github.com/docker/docker.github.io/issues/3660
