### PR TITLE
Removed incorrect encrypt comment text

### DIFF
--- a/datacenter/ucp/2.1/guides/admin/backups-and-disaster-recovery.md
+++ b/datacenter/ucp/2.1/guides/admin/backups-and-disaster-recovery.md
@@ -49,7 +49,7 @@ The example below shows how to create a backup of a UCP manager node and
 verify its contents:
 
 ```none
-# Create a backup, encrypt it, and store it on /tmp/backup.tar
+# Create a backup and store it on /tmp/backup.tar
 $ docker run --rm -i --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   {{ page.docker_image }} backup --interactive > /tmp/backup.tar


### PR DESCRIPTION
Removed ", encrypt it," from comment in non-encrypted code block

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
