### PR TITLE
Fix typo in docker-machine completion setup for zsh

### DIFF
--- a/machine/completion.md
+++ b/machine/completion.md
@@ -39,7 +39,7 @@ Place the completion script in your `/path/to/zsh/completion`, using e.g. `~/.zs
 
 ```shell
 mkdir -p ~/.zsh/completion
-curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/zsh/_docker > ~/.zsh/completion/_docker-machine
+curl -L https://raw.githubusercontent.com/docker/machine/master/contrib/completion/zsh/_docker-machine > ~/.zsh/completion/_docker-machine
 ```
 
 Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`:


### PR DESCRIPTION
The file that was downloaded was actually the autocompletion for `docker` and **not** `docker-machine`

I tested the "fix" on my local installation: It's working ;)