### PR TITLE
Update install to ensure extras repo is enabled

### DIFF
--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -96,12 +96,12 @@ Repository set-up instructions are different for [Docker CE](#docker-ce) and
     $ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
     ```
 
-2. Enable the `extras` CentOS repository. This ensures access to the
-   `container-selinux` package which is required by `docker-ce`.
+2.  Enable the `extras` CentOS repository. This ensures access to the
+    `container-selinux` package which is required by `docker-ce`.
 
-   ```bash
-   $ sudo yum-config-manager --enable extras
-   ```
+    ```bash
+    $ sudo yum-config-manager --enable extras
+    ```
 
 3.  Use the following command to set up the **stable** repository. You always
     need the **stable** repository, even if you want to install **edge** builds
@@ -143,12 +143,12 @@ Repository set-up instructions are different for [Docker CE](#docker-ce) and
     $ sudo sh -c 'echo "<DOCKER-EE-URL>" > /etc/yum/vars/dockerurl'
     ```
 
-3. Enable the `extras` CentOS repository. This ensures access to the
-   `container-selinux` package which is required by `docker-ee`.
+3.  Enable the `extras` CentOS repository. This ensures access to the
+    `container-selinux` package which is required by `docker-ee`.
 
-   ```bash
-   $ sudo yum-config-manager --enable extras
-   ```
+    ```bash
+    $ sudo yum-config-manager --enable extras
+    ```
 
 4.  Install required packages. `yum-utils` provides the `yum-config-manager`
     utility, and `device-mapper-persistent-data` and `lvm2` are required by the

--- a/engine/installation/linux/centos.md
+++ b/engine/installation/linux/centos.md
@@ -96,7 +96,14 @@ Repository set-up instructions are different for [Docker CE](#docker-ce) and
     $ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
     ```
 
-2.  Use the following command to set up the **stable** repository. You always
+2. Enable the `extras` CentOS repository. This ensures access to the
+   `container-selinux` package which is required by `docker-ce`.
+
+   ```bash
+   $ sudo yum-config-manager --enable extras
+   ```
+
+3.  Use the following command to set up the **stable** repository. You always
     need the **stable** repository, even if you want to install **edge** builds
     as well.
 
@@ -106,7 +113,7 @@ Repository set-up instructions are different for [Docker CE](#docker-ce) and
         {{ download-url-base }}/docker-ce.repo
     ```
 
-3.  **Optional**: Enable the **edge** repository. This repository is included
+4.  **Optional**: Enable the **edge** repository. This repository is included
     in the `docker.repo` file above but is disabled by default. You can enable
     it alongside the stable repository.
 
@@ -136,7 +143,14 @@ Repository set-up instructions are different for [Docker CE](#docker-ce) and
     $ sudo sh -c 'echo "<DOCKER-EE-URL>" > /etc/yum/vars/dockerurl'
     ```
 
-3.  Install required packages. `yum-utils` provides the `yum-config-manager`
+3. Enable the `extras` CentOS repository. This ensures access to the
+   `container-selinux` package which is required by `docker-ee`.
+
+   ```bash
+   $ sudo yum-config-manager --enable extras
+   ```
+
+4.  Install required packages. `yum-utils` provides the `yum-config-manager`
     utility, and `device-mapper-persistent-data` and `lvm2` are required by the
     `devicemapper` storage driver.
 
@@ -144,7 +158,7 @@ Repository set-up instructions are different for [Docker CE](#docker-ce) and
     $ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
     ```
 
-4.  Use the following command to add the **stable** repository:
+5.  Use the following command to add the **stable** repository:
 
     ```bash
     $ sudo yum-config-manager \

--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -114,7 +114,31 @@ the repository.
     $ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
     ```
 
-4.  Use the following command to add the **stable** repository:
+4. Enable the `extras` RHEL repository. This ensures access to the
+   `container-selinux` package which is required by `docker-ee`.
+
+   ```bash
+   $ sudo yum-config-manager --enable rhel-7-server-extras-rpms
+   ```
+
+   Depending on cloud provider, you may also need to enable another repository.
+
+   For AWS:
+
+   ```bash
+   $ sudo yum-config-manager --enable rhui-REGION-rhel-server-extras
+   ```
+
+   >> **Note**: `REGION` here is literal, and does *not* represent the region
+   >> your machine is running in.
+
+   For Azure:
+
+   ```bash
+   $ sudo yum-config-manager --enable rhui-rhel-7-server-rhui-extras-rpms
+   ```
+
+5.  Use the following command to add the **stable** repository:
 
     ```bash
     $ sudo yum-config-manager \

--- a/engine/installation/linux/rhel.md
+++ b/engine/installation/linux/rhel.md
@@ -114,29 +114,29 @@ the repository.
     $ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
     ```
 
-4. Enable the `extras` RHEL repository. This ensures access to the
-   `container-selinux` package which is required by `docker-ee`.
+4.  Enable the `extras` RHEL repository. This ensures access to the
+    `container-selinux` package which is required by `docker-ee`.
 
-   ```bash
-   $ sudo yum-config-manager --enable rhel-7-server-extras-rpms
-   ```
+    ```bash
+    $ sudo yum-config-manager --enable rhel-7-server-extras-rpms
+    ```
 
-   Depending on cloud provider, you may also need to enable another repository.
+    Depending on cloud provider, you may also need to enable another repository.
 
-   For AWS:
+    For AWS:
 
-   ```bash
-   $ sudo yum-config-manager --enable rhui-REGION-rhel-server-extras
-   ```
+    ```bash
+    $ sudo yum-config-manager --enable rhui-REGION-rhel-server-extras
+    ```
 
-   >> **Note**: `REGION` here is literal, and does *not* represent the region
-   >> your machine is running in.
+    > **Note**: `REGION` here is literal, and does *not* represent the region
+    > your machine is running in.
 
-   For Azure:
+    For Azure:
 
-   ```bash
-   $ sudo yum-config-manager --enable rhui-rhel-7-server-rhui-extras-rpms
-   ```
+    ```bash
+    $ sudo yum-config-manager --enable rhui-rhel-7-server-rhui-extras-rpms
+    ```
 
 5.  Use the following command to add the **stable** repository:
 
@@ -242,14 +242,14 @@ If you cannot use the official Docker repository to install Docker, you can
 download the `.rpm` file for your release and install it manually. You will
 need to download a new file each time you want to upgrade Docker.
 
-1. Go to the Docker EE repository URL associated with your
-   trial or subscription in your browser. Go to
-   `7/x86_64/stable-{{ minor-version }}/Packages` and download the `.rpm` file
-   for the Docker version you want to install.
+1.  Go to the Docker EE repository URL associated with your
+    trial or subscription in your browser. Go to
+    `7/x86_64/stable-{{ minor-version }}/Packages` and download the `.rpm` file
+    for the Docker version you want to install.
 
-   > **Note**: If you have trouble with `selinux` using the packages under the
-   > `7` directory, try choosing the version-specific directory instead, such
-   > as `7.3`.
+    > **Note**: If you have trouble with `selinux` using the packages under the
+    > `7` directory, try choosing the version-specific directory instead, such
+    > as `7.3`.
 
 2.  Install Docker EE, changing the path below to the path where you downloaded
     the Docker package.


### PR DESCRIPTION
The `extras` repos are required for 17.06 which depends on the
`container-selinux` package.

CentOS typically has the repo enabled by default, but in some cases may
be disabled, and RHEL never has it enabled by default.

This is provided by the main Fedora repos and does not require any extra
setting.

ping @mstanleyjones 