### PR TITLE
Changed grep flags

### DIFF
--- a/engine/admin/multi-service_container.md
+++ b/engine/admin/multi-service_container.md
@@ -59,9 +59,9 @@ this in a few different ways.
   # Otherwise it will loop forever, waking up every 60 seconds
   
   while /bin/true; do
-    ps aux |grep -q my_first_process |grep -v grep
+    ps aux |grep my_first_process |grep -q -v grep
     PROCESS_1_STATUS=$?
-    ps aux |grep -q my_second_process |grep -v grep
+    ps aux |grep my_second_process |grep -q -v grep
     PROCESS_2_STATUS=$?
     # If the greps above find anything, they will exit with 0 status
     # If they are not both 0, then something is wrong


### PR DESCRIPTION
### Proposed changes

Switch the -q flag from the first grep command to the second.

Reason:
If the first grep is already quiet, the second one will not find anything and exit with error code 1. So the quiet flag has to be on the second grep command to get the script working.