### PR TITLE
Fix compose-file compatibility matrix

### DIFF
--- a/_includes/content/compose-matrix.md
+++ b/_includes/content/compose-matrix.md
@@ -3,7 +3,9 @@ This table shows which Compose file versions support specific Docker releases.
 | **Compose file format** | **Docker Engine release** |
 |  -------------------    |    ------------------     |
 |      3.3                |       17.06.0+            |
-|      3.0 - 3.2          |       1.13.0+             |
+|      3.2                |       17.04.0+            |
+|      3.1                |       1.13.1+             |
+|      3.0                |       1.13.0+             |
 |      2.2                |       1.13.0+             |
 |      2.1                |       1.12.0+             |
 |      2.0                |       1.10.0+             |


### PR DESCRIPTION
- support for compose-file schema 3.1 was added in
  docker 1.13.1
- support for compose-file schema 3.2 was added in
  docker 17.04.0

fixes https://github.com/moby/moby/issues/32353


ping @mstanleyjones @londoncalling PTAL