### PR TITLE
Fix --filter option for docker stack ps

### DIFF
--- a/engine/reference/commandline/README.md
+++ b/engine/reference/commandline/README.md
@@ -2,7 +2,7 @@
 
 The files in this directory are stub files which include the file
 `/_includes/cli.md`, which parses YAML files generated from the
-[`docker/docker`](https://github.com/moby/moby) repository. The YAML files
+[`moby/moby`](https://github.com/moby/moby) repository. The YAML files
 are parsed into output files like
 [https://docs.docker.com/engine/reference/commandline/build/](https://docs.docker.com/engine/reference/commandline/build/).
 
@@ -22,7 +22,7 @@ The output files are composed from two sources:
 
 The process for generating the YAML files is still in flux. Check with
 @thajestah or @frenchben. Be sure to generate the YAML files with the correct
-branch of `docker/docker` checked out (probably not `master`).
+branch of `moby/moby` checked out (probably not `master`).
 
 After generating the YAML files, replace the YAML files in
 [https://github.com/docker/docker.github.io/tree/master/_data/engine-cli](https://github.com/docker/docker.github.io/tree/master/_data/engine-cli)


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

### Proposed changes
1.  docker stack ps --filter option should be "desired-state" and not "desired-stat" as in documentation
2.  modify from "docker/docker" to "moby/moby"


### Related issues (optional)

Fixes #33720
