### PR TITLE
Update part3.md

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -99,7 +99,7 @@ This `docker-compose.yml` file tells Docker to do the following:
   called `web`, limiting each one to use, at most, 10% of the CPU (across all
   cores), and 50MB of RAM.
 
-- Immediately restart containers if one fails.
+- Immediately restart containers which fail.
 
 - Map port 80 on the host to `web`'s port 80.
 


### PR DESCRIPTION
Maybe you can describe it in better words than mine.
Or maybe it is a local or Cmder problem only at my side?

When I "quit" the docker-container with CTRL+C, the container stays alive, which can be controlled with docker ps or with browsing "http://localhost:4000". When I try to do the next command in the documentation ("docker run -d -p 4000:80 friendlyhello"), there will be an error: "Port is already allocated". So additionally to CTRL+C I have to stop the container before I can continue.

( Windows 10 Pro N, Docker version 17.03.1-ce, build c6d412e (Docker for Windows), Terminal: Cmder/ConEmu 161022 [64] {Stable} )

-----------------------------------------

Sorry, it seems that I have to write again in this input form for my second remark ("modification"). I am not really fit with GitHub, I hope I do not annoy somebody; I just want to contribute with my view on the problems I have met here.

Perhaps the explanation of the restart-policy should be explained more detailled? Or linked to the more detailled explanation? I additionally read https://www.getconvey.com/devblog/on-docker-restart-policies/
