### PR TITLE
fixed bash completion link in Machine docs

### DIFF
--- a/machine/completion.md
+++ b/machine/completion.md
@@ -21,13 +21,13 @@ Place the completion script in `/etc/bash_completion.d/` as follows:
 *   On a Mac:
 
     ```shell
-    curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/engine/contrib/completion/bash/docker > `brew --prefix`/etc/bash_completion.d/docker
+    curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker > `brew --prefix`/etc/bash_completion.d/docker
     ```
 
 *   On a standard Linux installation:
 
     ```shell
-    curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/engine/contrib/completion/bash/docker > /etc/bash_completion.d/docker
+    curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker > /etc/bash_completion.d/docker
     ```
 
 Completion will be available upon next login.


### PR DESCRIPTION
### What's changed

- Fixed links to `bash` completion script shown with `curl` calls in CLI examples (the links changed)

### Related 

Fixes #3739

### Reviewers

@FrenchBen @shin- @Cellebyte @mstanleyjones 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
