### PR TITLE
Change Debian Stretch to stable from testing

### DIFF
--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -27,7 +27,7 @@ and distributions for different Docker editions, see
 To install Docker CE, you need the 64-bit version of one of these Debian or
 Raspbian versions:
 
-- Stretch (testing)
+- Stretch (stable)
 - Jessie 8.0 (LTS) / Raspbian Jessie
 - Wheezy 7.7 (LTS)
 


### PR DESCRIPTION
### Proposed changes

This is just a documentation change to update Debian Stretch to stable since it was [released recently](https://www.debian.org/News/2017/20170617) and is now the stable version of Debian. Thanks for supporting Stretch even when it was in testing!