### PR TITLE
Fix invalid config file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ permalink: pretty
 safe: false
 lsi: false
 url: https://docs.docker.com
-keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13" "v17.03"]
+keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13", "v17.03"]
 compose_current: 1.14.0
 
 gems:


### PR DESCRIPTION
Fixes invalid config file introduced on #3753, that was breaking the build with
```
2017-06-30 00:12:43 (35.0 MB/s) - 'md_source/registry/configuration.md' saved [44432/44432]
jekyll 3.4.3 | Error: (md_source/_config.yml): did not find expected ',' or ']' while parsing a flow sequence at line 14 column 13
```