### PR TITLE
Don't run bundle update in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM starefossen/github-pages:137
 
-COPY . /usr/src/app/
+COPY . /usr/src/app
 
-CMD jekyll serve -H 0.0.0.0
+CMD bundle exec jekyll serve -d /_site --watch -H 0.0.0.0 -P 4000


### PR DESCRIPTION
This avoids the US-ASCII bug in jekyll-redirect plugin