### PR TITLE
Using a process manager is platform-dependent

### DIFF
--- a/engine/admin/start-containers-automatically.md
+++ b/engine/admin/start-containers-automatically.md
@@ -67,7 +67,7 @@ A process manager runs within the container and checks whether a process is
 running and starts it if not. It is not Docker-aware, but just monitors
 operating system processes within the container.
 
-Docker does not recommend this approach, because it is not platform-dependent
+Docker does not recommend this approach, because it is platform-dependent
 and even differs within different versions of a given Linux distribution.
 
 > **Warning**: Do not try to combine Docker restart policies with host-level


### PR DESCRIPTION
### Proposed changes

The docs explaining why [using a process manager](https://docs.docker.com/engine/admin/start-containers-automatically/#use-a-process-manager) isn't recommended should either read "because it is platform-dependent" or "because it is not platform-independent". I more or less chose the former at random.