### PR TITLE
Don't remove `container-selinux` when removing old Docker version

### DIFF
--- a/engine/installation/linux/docker-ce/centos.md
+++ b/engine/installation/linux/docker-ce/centos.md
@@ -35,7 +35,6 @@ installed, uninstall them, along with associated dependencies.
 ```bash
 $ sudo yum remove docker \
                   docker-common \
-                  container-selinux \
                   docker-selinux \
                   docker-engine
 ```


### PR DESCRIPTION
Unless I'm missing something, `container-selinux` is still a dependency of `docker-ce` so it doesn't make sense to remove it when removing old versions of `docker` when switching to `docker-ce`.

<img width="403" src="https://user-images.githubusercontent.com/5820654/27761021-39a1fe94-5e09-11e7-8169-9945621b6060.png">
