### PR TITLE
Add a quick link for getting to the .deb packages

### DIFF
--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -41,6 +41,9 @@ Systems) architectures.
 > **`s390x` limitations**: System Z is only supported on Ubuntu Xenial,
 > Yakkety, and Zesty.
 
+### Location of .deb files
+Go here for the .deb files: `http://apt.dockerproject.org/repo/pool/main/d/docker-engine/` and download the appropriate package for your OS version.
+
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. If these are

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -41,8 +41,8 @@ Systems) architectures.
 > **`s390x` limitations**: System Z is only supported on Ubuntu Xenial,
 > Yakkety, and Zesty.
 
-### Location of .deb files
-Go here for the .deb files: `http://apt.dockerproject.org/repo/pool/main/d/docker-engine/` and download the appropriate package for your OS version.
+### Locating the .deb files
+If you need to download the **.deb** packages manually go to `https://download.docker.com/linux/ubuntu/dists`, select your target distribution, and then go to the **pool** directory to find the packages needed for your architecture. For example, For stable build of Ubuntu Trusty amd64 the URL would be `https://download.docker.com/linux/ubuntu/dists/trusty/pool/stable/amd64/`.
 
 ### Uninstall old versions
 


### PR DESCRIPTION
Going to the stated location of https://download.docker.com/linux/ubuntu/dists/trusty/stable/ does not give an easy link to the .deb files. This addition gives such a link.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
