### PR TITLE
Add redirect for old logging landing page

### DIFF
--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -8,9 +8,9 @@ redirect_from:
 title: Configure logging drivers
 ---
 
-Docker includes multiple logging mechanisms to help you get information from
-running containers and services. These mechanisms are called logging
-drivers.
+Docker includes multiple logging mechanisms to help you
+[get information from running containers and services](/engine/admin/logging/view_container_logs.md).
+These mechanisms are called logging drivers.
 
 Each Docker daemon has a default logging driver, which each container uses
 unless you configure it to use a different logging driver.

--- a/engine/admin/logging/view_container_logs.md
+++ b/engine/admin/logging/view_container_logs.md
@@ -1,21 +1,24 @@
 ---
 description: How to write to and view a container's logs
 keywords: docker, logging
-title: View a container's logs
+title: View logs for a container or service
+redirect_from:
+- /engine/admin/logging/
 ---
 
 The `docker logs` command shows information logged by a running container. The
-information that is logged and the format of the log depends almost entirely on
-the container's endpoint command.
+`docker service logs` command shows information logged by all containers
+participating in a service. The information that is logged and the format of the
+log depends almost entirely on the container's endpoint command.
 
-By default, `docker logs` shows the command's output just as it would appear if
-you ran the command interactively in a terminal. UNIX and Linux commands
-typically open three I/O streams when they run, called `STDIN`, `STDOUT`, and
-`STDERR`. `STDIN` is the commmand's input stream, which may include input from
-the keyboard or input from another command. `STDOUT` is usually a command's
-normal output, and `STDERR` is typically used to output error messages. By
-default, `docker logs` shows the command's `STDOUT` and `STDERR`. To read more
-about I/O and Linux, see the
+By default, `docker logs` or `docker service logs` shows the command's output
+just as it would appear if you ran the command interactively in a terminal. UNIX
+and Linux commands typically open three I/O streams when they run, called
+`STDIN`, `STDOUT`, and `STDERR`. `STDIN` is the commmand's input stream, which
+may include input from the keyboard or input from another command. `STDOUT` is
+usually a command's normal output, and `STDERR` is typically used to output
+error messages. By default, `docker logs` shows the command's `STDOUT` and
+`STDERR`. To read more about I/O and Linux, see the
 [Linux Documentation Project article on I/O redirection](http://www.tldp.org/LDP/abs/html/io-redirection.html).
 
 In some cases, `docker logs` may not show useful information unless you take


### PR DESCRIPTION
#3440 removed a landing page. Add a redirect from that old landing page to an appropriate page. Add a little cross-linking between the topics about viewing logs and configuring logging drivers. Add mention of `docker service logs` to the topic about viewing logs.