### PR TITLE
Try to update gitmodules to not fail gh-pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	path = tests/src/gopkg.in/yaml.v2
 	url = https://github.com/go-yaml/yaml.git
 	branch = a5b47d31c556af34a302ce5d659e6fea44d90de0
-
 [submodule "samples/library"]
 	path = samples/library
 	url = https://github.com/docker-library/docs.git
+	branch = master


### PR DESCRIPTION
Github Pages is supposed to work with submodules: https://help.github.com/articles/using-submodules-with-pages/

I wonder if maybe we were missing the branch, so this tries to fix that. Let's see.