### PR TITLE
Fix wrong format in sample daemon.json for devicemapper config

### DIFF
--- a/engine/userguide/storagedriver/device-mapper-driver.md
+++ b/engine/userguide/storagedriver/device-mapper-driver.md
@@ -163,12 +163,12 @@ options in the table above.
 {
   "storage-driver": "devicemapper",
   "storage-opts": [
-    "dm.directlvm_device": "/dev/xdf",
-    "dm.thinp_percent": 95,
-    "dm.thinp_metapercent": 1,
-    "dm.thinp_autoextend_threshold": 80,
-    "dm.thinp_autoextend_percent": 20,
-    "dm.directlvm_device_force": false 
+    "dm.directlvm_device=/dev/xdf",
+    "dm.thinp_percent=95",
+    "dm.thinp_metapercent=1",
+    "dm.thinp_autoextend_threshold=80",
+    "dm.thinp_autoextend_percent=20",
+    "dm.directlvm_device_force=false" 
   ]
 }
 ```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
The first example daemon.json in the devicemapper section seems to be incorrect - at least on Docker 17.05, trying to use it raises an 

FATA[0000] unable to configure the Docker daemon with file /etc/docker/daemon.json: invalid character ':' after array element 

on starting the Docker daemon. The root cause is that it uses key-value pairs inside the array, whereas it should use strings (the second example daemon.json on the same page uses the correct format).

The PR therefore replaces the key-value pairs with strings.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
