### PR TITLE
Fix example of "configs"

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -306,7 +306,7 @@ services:
     image: redis:latest
     deploy:
       replicas: 1
-    secrets:
+    configs:
       - source: my_config
         target: /redis_config
         uid: '103'


### PR DESCRIPTION
This should be "configs" not "secrets" as it's an example of the new "configs" option.

## Proposed changes

The example was incorrect.
