### PR TITLE
Wrong syntax for configs

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -306,7 +306,7 @@ services:
     image: redis:latest
     deploy:
       replicas: 1
-    secrets:
+    configs:
       - source: my_config
         target: /redis_config
         uid: '103'


### PR DESCRIPTION
### Proposed changes

Probably a copy paste error from secrets. Updated the long syntax with the correct configs syntax.
