### PR TITLE
Updated the URL for docker-credential-helper (#3814)

### DIFF
--- a/docker-id/index.md
+++ b/docker-id/index.md
@@ -51,5 +51,5 @@ You can also log in using the `docker login` command. (You can read more about `
 > When you use the `docker login` command, your credentials are
 stored in your home directory in `.docker/config.json`. The password is base64
 encoded in this file. If you require secure storage for this password, use the
-[Docker credential helpers](https://github.com/moby/moby-credential-helpers).
+[Docker credential helpers](https://github.com/docker/docker-credential-helpers).
 {:.warning}


### PR DESCRIPTION
Incorrect URL for docker-credential-helper
repo. It is pointing to
moby/moby-credential-helper which is
not present.

Signed-off-by: Swapnil Kulkarni <me@coolsvap.net>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
