### PR TITLE
fix config management example

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -306,7 +306,7 @@ services:
     image: redis:latest
     deploy:
       replicas: 1
-    secrets:
+    configs:
       - source: my_config
         target: /redis_config
         uid: '103'


### PR DESCRIPTION
Somebody forgot to change "secrets" to "configs" in the Docker Configs example. It was just a copy mistake.