### PR TITLE
Fixed grammar

### DIFF
--- a/_data/engine-cli-edge/docker_build.yaml
+++ b/_data/engine-cli-edge/docker_build.yaml
@@ -16,7 +16,7 @@ long: |-
   repository acts as the build context. The system recursively fetches the
   repository and its submodules. The commit history is not preserved. A
   repository is first pulled into a temporary directory on your local host. After
-  the that succeeds, the directory is sent to the Docker daemon as the context.
+  that succeeds, the directory is sent to the Docker daemon as the context.
   Local copy gives you the ability to access private repositories using local
   user credentials, VPN's, and so forth.
 

--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -16,7 +16,7 @@ long: |-
   repository acts as the build context. The system recursively fetches the
   repository and its submodules. The commit history is not preserved. A
   repository is first pulled into a temporary directory on your local host. After
-  the that succeeds, the directory is sent to the Docker daemon as the context.
+  that succeeds, the directory is sent to the Docker daemon as the context.
   Local copy gives you the ability to access private repositories using local
   user credentials, VPN's, and so forth.
 


### PR DESCRIPTION
### Proposed changes

Wrong grammar is used on the official doc site: `After the that succeeds, ...`, which is corrected to `After that succeeds, ...` in this PR.
