### PR TITLE
Update mongodb.md

### DIFF
--- a/engine/examples/mongodb.md
+++ b/engine/examples/mongodb.md
@@ -156,7 +156,12 @@ $ docker run -p 27017:27017 --name mongo_instance_001 -d my/repo
 # Dockerized MongoDB, lean and mean!
 # Usage: docker run --name <name for container> -d <user-name>/<repository> --noprealloc --smallfiles
 $ docker run -p 27017:27017 --name mongo_instance_001 -d my/repo --smallfiles
+```
+> **Warning!**: This can expose the mongo instance to all interfaces even when ufw is active and the net.ip binding for the mongodb instance is set to 127.0.0.1 which is the default.
 
+> `$ docker run -p 127.0.0.1:27017:27017 --name mongo_instance_001 -d my/repo` is one workaround. See [this askubuntu post](https://askubuntu.com/a/652572/323247).
+
+```
 # Checking out the logs of a MongoDB container
 # Usage: docker logs <name for container>
 $ docker logs mongo_instance_001


### PR DESCRIPTION
### Proposed changes

I was double-checking that a mongodb instance running in a Docker container was not exposed to the outside. Even with ufw not allowing port 27017 and with the default net.ip binding for mongodb set to 127.0.0.1 the database was still exposed.

When I started the container with `docker run -p 27017:27017 --name mongo_instance_001 -d my/repo` I was still able to access the database from the outside.

I could no longer access the database from the outside when I started the database with  `docker run -p 127.0.0.1:27017:27017 --name mongo_instance_001 -d my/repo`