### PR TITLE
Add CSS for option to create inline images (like whale menu)

### DIFF
--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -58,7 +58,7 @@ i.fa.fa-outdent {
     padding: 0px 15px 10px 15px;
 }
 
-.image-inline img {
+img.inline {
     display: inline;
 }
 

--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -58,6 +58,9 @@ i.fa.fa-outdent {
     padding: 0px 15px 10px 15px;
 }
 
+.image-inline img {
+    display: inline;
+}
 
 /*
 * Search *********************************************************************
@@ -259,4 +262,3 @@ div#autocompleteResults span {
 input.gsc-search-button, input.gsc-search-button:hover, input.gsc-search-button:focus {
     display: none!important;
 }
-

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -100,10 +100,6 @@ docker-machine version 0.10.0, build 76ed2a6
 
 ## Preferences
 
-This is test calling the class from the `scss` file in the `img` tag (instead of
-embedding the style directly like the previous tests) here, ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} but it does not
-work. This file does not seem to be reading the `scss` file.
-
 Choose ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} ->
 **Preferences** from the menu bar.
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -100,8 +100,36 @@ docker-machine version 0.10.0, build 76ed2a6
 
 ## Preferences
 
-Choose ![whale-x](/docker-for-mac/images/whale-x.png) --> **Preferences** from
-the menu bar.
+### Josh look here
+
+<div style="background: red;">
+    The inline styles for this div should make it red. Just testing inline styles.
+</div>
+
+This is a test for an inline image using `div` and embedded CSS for `display:
+auto;">` <div style="display: auto;"> <img
+src="/docker-for-mac/images/whale-x.png" /> and now the sentence ends. The
+div's show up, so not good.
+
+This is a test for an inline image using just the `img` tag instead of `div` and
+embedded CSS for `display: auto;` <img
+src="/docker-for-mac/images/whale-x.png" style="display: inline;" /> and now the
+sentence ends. This works!
+
+This is a test for an inline image using just the `img` tag instead of `div` and
+embedded CSS for `display: inline;` <img
+src="/docker-for-mac/images/whale-x.png" style="display: inline;" /> and now the
+sentence ends. This also works!
+
+This is test calling the class from the `scss` file in the `img` tag (instead of
+embedding the style directly like the previous tests) here: <img
+src="/docker-for-mac/images/whale-x.png" class="image-inline" /> but it does not
+work. This file does not seem to be reading the `scss` file.
+
+**END OF IMG AND CSS TESTS**
+
+Choose <img src="/docker-for-mac/images/whale-x.png" class="image-inline" /> ->
+**Preferences** from the menu bar.
 
 ![Docker context menu](images/menu-prefs-selected.png)
 
@@ -122,10 +150,10 @@ see [Docker Cloud](#docker-cloud).
   open your session.
 
 * Docker for Mac is set to **automatically check for updates**  and notify
-  you when an update is available. If an update is found, click **OK** to
-  accept and install it (or cancel to keep the current version). If you
-  disable the check for updates, you can still find out about updates manually
-  by choosing ![whale-x](/docker-for-mac/images/whale-x.png) -> **Check for Updates**
+  you when an update is available. If an update is found, click **OK** to accept
+and install it (or cancel to keep the current version). If you disable the check
+for updates, you can still find out about updates manually by choosing <img src="/docker-for-mac/images/whale-x.png" class="image-inline" /> ->
+**Check for Updates**
 
 * Check **Include VM in Time Machine backups** to back up the Docker for Mac virtual machine. (By default, this is unchecked.)
 
@@ -294,7 +322,8 @@ choose to discard or not apply changes when asked.
 ![Docker Daemon](/docker-for-mac/images/settings-daemon-beta.png)
 
 ## Uninstall or reset
-Choose ![whale-x](/docker-for-mac/images/whale-x.png) --> **Preferences** from
+Choose <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
+/></div> --> **Preferences** from
 the menu bar, then click **Uninstall / Reset** on the Preferences dialog.
 
 ![Uninstall or reset Docker](images/settings-uninstall.png)

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -100,35 +100,11 @@ docker-machine version 0.10.0, build 76ed2a6
 
 ## Preferences
 
-### Josh look here
-
-<div style="background: red;">
-    The inline styles for this div should make it red. Just testing inline styles.
-</div>
-
-This is a test for an inline image using `div` and embedded CSS for `display:
-auto;">` <div style="display: auto;"> <img
-src="/docker-for-mac/images/whale-x.png" /> and now the sentence ends. The
-div's show up, so not good.
-
-This is a test for an inline image using just the `img` tag instead of `div` and
-embedded CSS for `display: auto;` <img
-src="/docker-for-mac/images/whale-x.png" style="display: inline;" /> and now the
-sentence ends. This works!
-
-This is a test for an inline image using just the `img` tag instead of `div` and
-embedded CSS for `display: inline;` <img
-src="/docker-for-mac/images/whale-x.png" style="display: inline;" /> and now the
-sentence ends. This also works!
-
 This is test calling the class from the `scss` file in the `img` tag (instead of
-embedding the style directly like the previous tests) here: <img
-src="/docker-for-mac/images/whale-x.png" class="image-inline" /> but it does not
+embedding the style directly like the previous tests) here, ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} but it does not
 work. This file does not seem to be reading the `scss` file.
 
-**END OF IMG AND CSS TESTS**
-
-Choose <img src="/docker-for-mac/images/whale-x.png" class="image-inline" /> ->
+Choose ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} ->
 **Preferences** from the menu bar.
 
 ![Docker context menu](images/menu-prefs-selected.png)
@@ -152,8 +128,8 @@ see [Docker Cloud](#docker-cloud).
 * Docker for Mac is set to **automatically check for updates**  and notify
   you when an update is available. If an update is found, click **OK** to accept
 and install it (or cancel to keep the current version). If you disable the check
-for updates, you can still find out about updates manually by choosing <img src="/docker-for-mac/images/whale-x.png" class="image-inline" /> ->
-**Check for Updates**
+for updates, you can still find out about updates manually by choosing ![whale
+menu](/docker-for-mac/images/whale-x.png){: .inline} -> **Check for Updates**
 
 * Check **Include VM in Time Machine backups** to back up the Docker for Mac virtual machine. (By default, this is unchecked.)
 
@@ -322,9 +298,9 @@ choose to discard or not apply changes when asked.
 ![Docker Daemon](/docker-for-mac/images/settings-daemon-beta.png)
 
 ## Uninstall or reset
-Choose <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
-/></div> --> **Preferences** from
-the menu bar, then click **Uninstall / Reset** on the Preferences dialog.
+Choose ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} ->
+**Preferences** from the menu bar, then click **Uninstall / Reset** on the
+Preferences dialog.
 
 ![Uninstall or reset Docker](images/settings-uninstall.png)
 

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -145,16 +145,14 @@ explanation and list of prerequisites.
 
 	  ![Whale in menu bar](/docker-for-mac/images/whale-in-menu-bar.png)
 
-	  If you just installed the app, you also get a success message with suggested
-next steps and a link to this documentation. Click the whale (<div
-class="image-inline"><img src="/docker-for-mac/images/whale-x.png" /></div>) in
-the status bar to dismiss this popup.
+    If you just installed the app, you also get a success message with suggested
+    next steps and a link to this documentation. Click the whale (![whale
+    menu](/docker-for-mac/images/whale-x.png){: .inline}) in the status bar to
+    dismiss this popup.
 
 	  ![Startup information](/docker-for-mac/images/mac-install-success-docker-cloud.png)
 
-3.  Click the whale (<div class="image-inline"><img
-src="/docker-for-mac/images/whale-x.png" /></div>) to get Preferences and other
-options.
+3.  Click the whale (![whale menu](/docker-for-mac/images/whale-x.png){: .inline}) to get Preferences and other options.
 
 	  ![Docker context menu](images/menu.png)
 

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -146,13 +146,15 @@ explanation and list of prerequisites.
 	  ![Whale in menu bar](/docker-for-mac/images/whale-in-menu-bar.png)
 
 	  If you just installed the app, you also get a success message with suggested
-    next steps and a link to this documentation. Click the whale (![whale](/docker-for-mac/images/whale-x.png))
-    in the status bar to dismiss this popup.
+next steps and a link to this documentation. Click the whale (<div
+class="image-inline"><img src="/docker-for-mac/images/whale-x.png" /></div>) in
+the status bar to dismiss this popup.
 
 	  ![Startup information](/docker-for-mac/images/mac-install-success-docker-cloud.png)
 
-3.  Click the whale (![whale-x](images/whale-x.png)) to get Preferences and
-    other options.
+3.  Click the whale (<div class="image-inline"><img
+src="/docker-for-mac/images/whale-x.png" /></div>) to get Preferences and other
+options.
 
 	  ![Docker context menu](images/menu.png)
 

--- a/docker-for-mac/opensource.md
+++ b/docker-for-mac/opensource.md
@@ -5,10 +5,10 @@ title: Open source components and licensing
 notoc: true
 ---
 
-Docker Desktop Editions are built using open source software. For
-details on the licensing, choose <img src="../images/whale-x.png"> -->
-**About Docker** from within the application, then click
-**Acknowledgements**.
+Docker Desktop Editions are built using open source software. For details on the
+licensing, choose <div class="image-inline"><img
+src="/docker-for-mac/images/whale-x.png" /></div> --> **About Docker** from
+within the application, then click **Acknowledgements**.
 
 Docker Desktop Editions distribute some components that are licensed under the
 GNU General Public License. You can download the source for these components

--- a/docker-for-mac/opensource.md
+++ b/docker-for-mac/opensource.md
@@ -5,10 +5,10 @@ title: Open source components and licensing
 notoc: true
 ---
 
-Docker Desktop Editions are built using open source software. For details on the
-licensing, choose <div class="image-inline"><img
-src="/docker-for-mac/images/whale-x.png" /></div> --> **About Docker** from
-within the application, then click **Acknowledgements**.
+Docker Desktop Editions are built using open source software.
+For details on the licensing, choose
+![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -->
+**About Docker** from within the application, then click **Acknowledgements**.
 
 Docker Desktop Editions distribute some components that are licensed under the
 GNU General Public License. You can download the source for these components

--- a/docker-for-mac/osxfs.md
+++ b/docker-for-mac/osxfs.md
@@ -55,11 +55,11 @@ Desktop	boot	etc	lib	lib64	media	opt	root	sbin	sys	usr
 bin	dev	home	lib32	libx32	mnt	proc	run	srv	tmp	var
 ```
 
-By default, you can share files in `/Users/`, `/Volumes/`, `/private/`, and `/tmp`
-directly.
-To add or remove directory trees that are exported to Docker, use the
-**File sharing** tab in Docker preferences ![Docker Preferences](images/whale-x.png) -> **Preferences** ->
-**File sharing**. (See [Preferences](index.md#preferences).)
+By default, you can share files in `/Users/`, `/Volumes/`, `/private/`, and
+`/tmp` directly. To add or remove directory trees that are exported to Docker,
+use the **File sharing** tab in Docker preferences <div
+class="image-inline"><img src="/docker-for-mac/images/whale-x.png" /></div> ->
+**Preferences** -> **File sharing**. (See [Preferences](index.md#preferences).)
 
 All other paths
 used in `-v` bind mounts are sourced from the Moby Linux VM running the Docker

--- a/docker-for-mac/osxfs.md
+++ b/docker-for-mac/osxfs.md
@@ -57,9 +57,9 @@ bin	dev	home	lib32	libx32	mnt	proc	run	srv	tmp	var
 
 By default, you can share files in `/Users/`, `/Volumes/`, `/private/`, and
 `/tmp` directly. To add or remove directory trees that are exported to Docker,
-use the **File sharing** tab in Docker preferences <div
-class="image-inline"><img src="/docker-for-mac/images/whale-x.png" /></div> ->
-**Preferences** -> **File sharing**. (See [Preferences](index.md#preferences).)
+use the **File sharing** tab in Docker preferences ![whale
+menu](/docker-for-mac/images/whale-x.png){: .inline} -> **Preferences** ->
+**File sharing**. (See [Preferences](index.md#preferences).)
 
 All other paths
 used in `-v` bind mounts are sourced from the Moby Linux VM running the Docker

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -22,7 +22,8 @@ GitHub](https://github.com/docker/for-mac/issues) already filed by other users,
 or on the [Docker for Mac forum](https://forums.docker.com/c/docker-for-mac), we
 can help you troubleshoot the log data.
 
-Choose <img src="../images/whale-x.png"> --> **Diagnose & Feedback** from the
+Choose <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
+/></div> --> **Diagnose & Feedback** from the
 menu bar.
 
 ![Diagnose problems](images/settings-diagnose.png)
@@ -156,8 +157,9 @@ start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might
 need to enable [file sharing](index.md#file-sharing).
 
 Volume mounting requires shared drives for projects that live outside of the
-`/Users` directory. Go to <img src="images/whale-x.png"> --> **Preferences** -->
-**File sharing** and share the drive that contains the Dockerfile and volume.
+`/Users` directory. Go to <div class="image-inline"><img
+src="/docker-for-mac/images/whale-x.png" /></div> --> **Preferences** --> **File
+sharing** and share the drive that contains the Dockerfile and volume.
 
 ### Recreate or update your containers after Beta 18 upgrade
 
@@ -278,7 +280,11 @@ know before you install](install.md#what-to-know-before-you-install).
 
 * If Docker for Mac fails to install or start properly:
 
-  * Make sure you quit Docker for Mac before installing a new version of the application ( <img src="../images/whale-x.png"> --> **Quit Docker**). Otherwise, you will get an "application in use" error when you try to copy the new app from the `.dmg` to `/Applications`.
+  * Make sure you quit Docker for Mac before installing a new version
+  of the application ( <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
+  /></div> --> **Quit Docker**). Otherwise, you will get an
+  "application in use" error when you try to copy the new app
+  from the `.dmg` to `/Applications`.
 
   * Restart your Mac to stop / discard any vestige of the daemon running from the previously installed version.
 
@@ -337,11 +343,19 @@ Docker for Mac does not yet support IPv6. See "IPv6 workaround to auto-filter DN
 
 <p></p>
 
-* Docker does not auto-start on login even when it is enabled in <img src="../images/whale-x.png"> --> **Preferences**. This is related to a set of issues with Docker helper, registration, and versioning.
+* Docker does not auto-start on login even when it is enabled in <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
+/></div> --> **Preferences**. This is related to a set of issues with Docker helper, registration, and versioning.
 
 <p></p>
 
-* Docker for Mac uses the `HyperKit` hypervisor (https://github.com/docker/hyperkit) in macOS 10.10 Yosemite and higher. If you are developing with tools that have conflicts with `HyperKit`, such as [Intel Hardware Accelerated Execution Manager (HAXM)](https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager/), the current workaround is not to run them at the same time. You can pause `HyperKit` by quitting Docker for Mac temporarily while you work with HAXM. This will allow you to continue work with the other tools and prevent `HyperKit` from interfering.
+* Docker for Mac uses the `HyperKit` hypervisor (https://github.com/docker/hyperkit) in macOS 10.10 Yosemite and higher. If you
+are developing with tools that have conflicts with `HyperKit`, such as [Intel
+Hardware Accelerated Execution Manager
+(HAXM)](https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager/),
+the current workaround is not to run them at the same time. You can pause
+`HyperKit` by quitting Docker for Mac temporarily while you work with HAXM. This
+will allow you to continue work with the other tools and prevent `HyperKit` from
+interfering.
 
 <p></p>
 

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -22,9 +22,8 @@ GitHub](https://github.com/docker/for-mac/issues) already filed by other users,
 or on the [Docker for Mac forum](https://forums.docker.com/c/docker-for-mac), we
 can help you troubleshoot the log data.
 
-Choose <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
-/></div> --> **Diagnose & Feedback** from the
-menu bar.
+Choose ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -->
+**Diagnose & Feedback** from the menu bar.
 
 ![Diagnose problems](images/settings-diagnose.png)
 
@@ -157,9 +156,9 @@ start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might
 need to enable [file sharing](index.md#file-sharing).
 
 Volume mounting requires shared drives for projects that live outside of the
-`/Users` directory. Go to <div class="image-inline"><img
-src="/docker-for-mac/images/whale-x.png" /></div> --> **Preferences** --> **File
-sharing** and share the drive that contains the Dockerfile and volume.
+`/Users` directory. Go to ![whale menu](/docker-for-mac/images/whale-x.png){:
+.inline} --> **Preferences** --> **File sharing** and share the drive that
+contains the Dockerfile and volume.
 
 ### Recreate or update your containers after Beta 18 upgrade
 
@@ -281,8 +280,7 @@ know before you install](install.md#what-to-know-before-you-install).
 * If Docker for Mac fails to install or start properly:
 
   * Make sure you quit Docker for Mac before installing a new version
-  of the application ( <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
-  /></div> --> **Quit Docker**). Otherwise, you will get an
+  of the application ( ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} --> **Quit Docker**). Otherwise, you will get an
   "application in use" error when you try to copy the new app
   from the `.dmg` to `/Applications`.
 
@@ -343,8 +341,9 @@ Docker for Mac does not yet support IPv6. See "IPv6 workaround to auto-filter DN
 
 <p></p>
 
-* Docker does not auto-start on login even when it is enabled in <div class="image-inline"><img src="/docker-for-mac/images/whale-x.png"
-/></div> --> **Preferences**. This is related to a set of issues with Docker helper, registration, and versioning.
+* Docker does not auto-start on login even when it is enabled in
+![whale menu](/docker-for-mac/images/whale-x.png){: .inline} --> **Preferences**. This is related to a set of issues with Docker
+helper, registration, and versioning.
 
 <p></p>
 

--- a/docker-for-windows/opensource.md
+++ b/docker-for-windows/opensource.md
@@ -6,9 +6,8 @@ notoc: true
 ---
 
 Docker Desktop Editions are built using open source software. For details on the
-licensing, choose <div class="image-inline"><img
-src="/docker-for-mac/images/whale-x.png" /></div> -->&nbsp;**About** from within
-the application, then click **Acknowledgements**.
+licensing, choose ![whale menu](/docker-for-mac/images/whale-x.png){: .inline}
+-->&nbsp;**About** from within the application, then click **Acknowledgements**.
 
 Docker Desktop Editions distribute some components that are licensed under the
 GNU General Public License. You can download the source for these components

--- a/docker-for-windows/opensource.md
+++ b/docker-for-windows/opensource.md
@@ -5,9 +5,10 @@ title: Open source components and licensing
 notoc: true
 ---
 
-Docker Desktop Editions are built using open source software. For
-details on the licensing, choose <img src="../images/whale-x.png">
--->&nbsp;**About** from within the application, then click **Acknowledgements**.
+Docker Desktop Editions are built using open source software. For details on the
+licensing, choose <div class="image-inline"><img
+src="/docker-for-mac/images/whale-x.png" /></div> -->&nbsp;**About** from within
+the application, then click **Acknowledgements**.
 
 Docker Desktop Editions distribute some components that are licensed under the
 GNU General Public License. You can download the source for these components

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -120,10 +120,11 @@ application file is not found, a volume mount is denied, or a service cannot
 start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might need
 to enable [shared drives](index.md#shared-drives).
 
-Volume mounting requires shared drives for Linux containers (not for Windows
-containers). Go to <div class="image-inline"><img
-src="/docker-for-mac/images/whale-x.png" /></div> --> **Settings** --> **Shared
-Drives** and share the drive that contains the Dockerfile and volume.
+Volume mounting requires shared drives for Linux containers
+(not for Windows containers). Go to
+![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -->
+**Settings** --> **Shared Drives** and share the drive that
+contains the Dockerfile and volume.
 
 ### Verify domain user has permissions for shared drives (volumes)
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -121,7 +121,8 @@ start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might need
 to enable [shared drives](index.md#shared-drives).
 
 Volume mounting requires shared drives for Linux containers (not for Windows
-containers). Go to <img src="images/whale-x.png"> --> **Settings** --> **Shared
+containers). Go to <div class="image-inline"><img
+src="/docker-for-mac/images/whale-x.png" /></div> --> **Settings** --> **Shared
 Drives** and share the drive that contains the Dockerfile and volume.
 
 ### Verify domain user has permissions for shared drives (volumes)


### PR DESCRIPTION
### What's changed

- added CSS class for an inline image

- added tests in Docker for Mac

- updated all occurrences of references to Moby whale in menu to use the new class, but we'll have to change these because the tests show that using the `div` tags inline doesn't work (`div` tags show up in rendered HTML). Using an embedded style directly from within the `img` tag does work, but there is a disconnect when trying to use the class in the `scss` file instead.

### Here's what works, and what doesn't work

Here’s what works:

- Calling the image like this directly as an embedded style: `<img
src=“/docker-for-mac/images/whale-x.png” style=“display: inline;” /> `

- Both `display: inline` and `display: auto` work

Here is what doesn’t work:

- When you flip it to call the class from the `scss`, that does not work. It’s just not reading that file, because I tried other tags in there too for the `img` and it doesn't read the values for any of them, but they work if I embed them directly in the file we are testing in.

### Reviewers

@jsouth , run the build locally then go to: http://localhost:4000/docker-for-mac/#preferences and look at the tests under the subhead "**Josh look here**"

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
