### PR TITLE
updated Docker version information for Cloud

### DIFF
--- a/docker-cloud/cloud-swarm/index.md
+++ b/docker-cloud/cloud-swarm/index.md
@@ -8,15 +8,12 @@ title: Swarms in Docker Cloud (Beta)
 notoc: true
 ---
 
-Docker Cloud now allows you to connect to clusters
-of Docker Engines running in v1.13
-[swarm mode](/engine/swarm/).
+Docker Cloud now allows you to connect to clusters of Docker Engines running on
+v17.06 [swarm mode](/engine/swarm/).
 
-With Beta Swarm Mode in Docker Cloud, you can
-provision swarms to popular cloud providers, or
-register existing swarms to Docker Cloud.
-Use your Docker ID to authenticate and securely access
-personal or team swarms.
+With Beta Swarm Mode in Docker Cloud, you can provision swarms to popular cloud
+providers, or register existing swarms to Docker Cloud. Use your Docker ID to
+authenticate and securely access personal or team swarms.
 
 * [Using Swarm Mode with Docker Cloud](using-swarm-mode.md)
 

--- a/docker-cloud/cloud-swarm/index.md
+++ b/docker-cloud/cloud-swarm/index.md
@@ -8,8 +8,7 @@ title: Swarms in Docker Cloud (Beta)
 notoc: true
 ---
 
-Docker Cloud now allows you to connect to clusters of Docker Engines running on
-Docker 17.06 [swarm mode](/engine/swarm/).
+Docker Cloud now allows you to connect to clusters of Docker Engines in [swarm mode](/engine/swarm/).
 
 With Beta Swarm Mode in Docker Cloud, you can provision swarms to popular cloud
 providers, or register existing swarms to Docker Cloud. Use your Docker ID to

--- a/docker-cloud/cloud-swarm/index.md
+++ b/docker-cloud/cloud-swarm/index.md
@@ -9,7 +9,7 @@ notoc: true
 ---
 
 Docker Cloud now allows you to connect to clusters of Docker Engines running on
-v17.06 [swarm mode](/engine/swarm/).
+Docker 17.06 [swarm mode](/engine/swarm/).
 
 With Beta Swarm Mode in Docker Cloud, you can provision swarms to popular cloud
 providers, or register existing swarms to Docker Cloud. Use your Docker ID to

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -4,17 +4,16 @@ keywords: docker, container, cluster, swarm
 title: Swarm mode overview
 ---
 
-To use Docker in swarm mode, install Docker `1.12.0` or later. Alternatively,
-install the latest Docker for Mac or Docker for Windows. Install instructions
-for all platforms are [here](https://docs.docker.com/engine/installation/). The
-most recent version is Docker 17.06.
+To use Docker in swarm mode, install Docker `1.12.0` or later. Install
+instructions for all platforms are
+[here](https://docs.docker.com/engine/installation/).
 
-Current versions of Docker include swarm mode for natively managing a cluster of
-Docker Engines called a *swarm*. Use the Docker CLI to create a swarm, deploy
+Current versions of Docker include *swarm mode* for natively managing a cluster
+of Docker Engines called a *swarm*. Use the Docker CLI to create a swarm, deploy
 application services to a swarm, and manage swarm behavior.
 
-If you’re using a Docker version prior to `1.12.0`, see [Docker
-Swarm](/swarm).
+If you are using a Docker version prior to `1.12.0`, you can use [standalone
+swarm](/swarm/index.md), but we recommend a updating.
 
 ## Feature highlights
 

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -5,14 +5,14 @@ title: Swarm mode overview
 ---
 
 To use Docker Engine in swarm mode, install the Docker Engine `v1.12.0` or
-later from the [Docker releases GitHub
-repository](https://github.com/moby/moby/releases). Alternatively, install
-the latest Docker for Mac or Docker for Windows Beta.
+later. Alternatively, install the latest Docker for Mac or Docker for Windows
+Beta. Install instructions for all platforms are
+[here](https://docs.docker.com/engine/installation/). The current version of
+Docker Engine is v17.06.
 
-Docker Engine 1.12 includes swarm mode for natively managing a cluster of
-Docker Engines called a *swarm*. Use the Docker CLI to create a swarm, deploy
-application services to a swarm, and manage swarm behavior.
-
+Current versions of Docker Engine include swarm mode for natively managing a
+cluster of Docker Engines called a *swarm*. Use the Docker CLI to create a
+swarm, deploy application services to a swarm, and manage swarm behavior.
 
 If you’re using a Docker version prior to `v1.12.0`, see [Docker
 Swarm](/swarm).

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -4,17 +4,16 @@ keywords: docker, container, cluster, swarm
 title: Swarm mode overview
 ---
 
-To use Docker Engine in swarm mode, install the Docker Engine `v1.12.0` or
-later. Alternatively, install the latest Docker for Mac or Docker for Windows
-Beta. Install instructions for all platforms are
-[here](https://docs.docker.com/engine/installation/). The current version of
-Docker Engine is v17.06.
+To use Docker in swarm mode, install Docker `1.12.0` or later. Alternatively,
+install the latest Docker for Mac or Docker for Windows. Install instructions
+for all platforms are [here](https://docs.docker.com/engine/installation/). The
+most recent version is Docker 17.06.
 
-Current versions of Docker Engine include swarm mode for natively managing a
-cluster of Docker Engines called a *swarm*. Use the Docker CLI to create a
-swarm, deploy application services to a swarm, and manage swarm behavior.
+Current versions of Docker include swarm mode for natively managing a cluster of
+Docker Engines called a *swarm*. Use the Docker CLI to create a swarm, deploy
+application services to a swarm, and manage swarm behavior.
 
-If you’re using a Docker version prior to `v1.12.0`, see [Docker
+If you’re using a Docker version prior to `1.12.0`, see [Docker
 Swarm](/swarm).
 
 ## Feature highlights

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -13,7 +13,7 @@ of Docker Engines called a *swarm*. Use the Docker CLI to create a swarm, deploy
 application services to a swarm, and manage swarm behavior.
 
 If you are using a Docker version prior to `1.12.0`, you can use [standalone
-swarm](/swarm/index.md), but we recommend a updating.
+swarm](/swarm/index.md), but we recommend updating.
 
 ## Feature highlights
 


### PR DESCRIPTION
### What's changed

- updated the Docker version referenced in Cloud swarm docs

### Reviewers

@ManoMarks @mstanleyjones @johndmulhausen 

### Related

Fixes #3895

### Notes

- I added an explicit reference to the current Docker version. We should automate this somehow so that as the version updates, the text changes. 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
