### PR TITLE
Fix Liquid Exception (#3316)

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ page.redirect.to }}">
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+  <script>location="{{ page.redirect.to }}"</script>
+</html>


### PR DESCRIPTION
jekyll-redirect-from v0.12.1 causes "Liquid Exception: invalid byte sequence in US-ASCII in _layouts/redirect.html"

-override default built-in redirect.html with a custom "_layouts/redirect.html" that has the ellipsis HTML fix encoded locally

fixes: #3316