### PR TITLE
Document need for --recursive when cloning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You have three options:
 1.  On your local machine, clone this repo and run our staging container:
 
     ```bash
-    git clone https://github.com/docker/docker.github.io.git
+    git clone --recursive https://github.com/docker/docker.github.io.git
     cd docker.github.io
     docker-compose up
     ```
@@ -134,7 +134,7 @@ You have three options:
     a. Clone this repo by running:
 
        ```bash
-       git clone https://github.com/docker/docker.github.io.git
+       git clone --recursive https://github.com/docker/docker.github.io.git
        ```
 
     b. Install Ruby 2.3 or later as described in [Installing Ruby](https://www.ruby-lang.org/en/documentation/installation/).

--- a/apidocs/cloud-api-source/README.md
+++ b/apidocs/cloud-api-source/README.md
@@ -11,7 +11,7 @@ If you find a typo or mismatch between the API and this documentation, please se
 To run it locally:
 
 ```none
-$ git clone https://github.com/docker/docker.github.io.git
+$ git clone --recursive https://github.com/docker/docker.github.io.git
 $ make release
 ```
 


### PR DESCRIPTION
Docker docs use git submodules.  Docs on how to clone and then serve
using Jekyll should recommend `--recursive`.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>