### PR TITLE
added Compose topics on caching options for performance

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1431,7 +1431,8 @@ services:
 On Docker 17.04 CE Edge and up, including 17.06 CE Edge and Stable, you can
 configure container-and-host consistency requirements for bind-mounted
 directories in Compose files to allow for better performance on read/write of
-volume mounts. These options address issues specific to `osxfs` file sharing, and therefore are only applicable on Docker for Mac.
+volume mounts. These options address issues specific to `osxfs` file sharing,
+and therefore are only applicable on Docker for Mac.
 
 The flags are:
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1426,9 +1426,49 @@ services:
         constraints: [node.role == manager]
 ```
 
+#### Performance tuning for volume mounts (Docker for Mac)
+
+On Docker 17.04 CE Edge and up, including 17.06 CE Edge and Stable, you can
+configure container-and-host consistency requirements for bind-mounted
+directories in Compose files to allow for better performance on read/write of
+volume mounts. These options address issues specific to `osxfs` file sharing, and therefore are only applicable on Docker for Mac.
+
+The flags are:
+
+* `consistent`: Full consistency. The container runtime and the
+host maintain an identical view of the mount at all times.  This is the default.
+
+* `cached`: The host's view of the mount is authoritative. There may be
+delays before updates made on the host are visible within a container.
+
+* `delegated`: The container runtime's view of the mount is
+authoritative. There may be delays before updates made in a container
+are visible on the host.
+
+Here is an example of configuring a volume as `cached`:
+
+```
+version: '3'
+services:
+  php:
+    image: php:7.1-fpm
+    ports:
+      - 9000
+    volumes:
+      - .:/var/www/project:cached
+```
+
+Full detail on these flags, the problems they solve, and their
+`docker run` counterparts is in the Docker for Mac topic [Performance tuning for
+volume mounts (shared filesystems)](/docker-for-mac/osxfs-caching.md).
+
+
 ### restart
 
-`no` is the default restart policy, and it will not restart a container under any circumstance. When `always` is specified, the container always restarts. The `on-failure` policy restarts a container if the exit code indicates an on-failure error.
+`no` is the default restart policy, and it will not restart a container under
+any circumstance. When `always` is specified, the container always restarts. The
+`on-failure` policy restarts a container if the exit code indicates an
+on-failure error.
 
     restart: "no"
     restart: always

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1426,7 +1426,7 @@ services:
         constraints: [node.role == manager]
 ```
 
-#### Performance tuning for volume mounts (Docker for Mac)
+#### Caching options for volume mounts (Docker for Mac)
 
 On Docker 17.04 CE Edge and up, including 17.06 CE Edge and Stable, you can
 configure container-and-host consistency requirements for bind-mounted

--- a/docker-for-mac/osxfs-caching.md
+++ b/docker-for-mac/osxfs-caching.md
@@ -15,7 +15,22 @@ of mounted volume access on Docker for Mac. These options begin to solve some of
 the challenges discussed in [Performance issues, solutions, and
 roadmap](/docker-for-mac/osxfs.md#performance-issues-solutions-and-roadmap).
 
-> **Tip:** Release notes for Docker CE Edge 17.04 are [here](https://github.com/moby/moby/releases/tag/v17.04.0-ce), and the associated pull request for the additional `docker run -v` flags is [here](https://github.com/moby/moby/pull/31047).
+> **Tip:** Release notes for Docker CE Edge 17.04 are
+[here](https://github.com/moby/moby/releases/tag/v17.04.0-ce), and the
+associated pull request for the additional `docker run -v` flags is
+[here](https://github.com/moby/moby/pull/31047).
+
+The following topics describe the challenges of bind-mounted volumes on `osxfs`,
+and the caching options provided to optimize performance.
+
+This blog post on  [Docker on Mac
+Performance](https://stories.amazee.io/docker-on-mac-performance-docker-machine-vs-docker-for-mac-4c64c0afdf99)
+gives a nice, quick summary.
+
+For information on how to configure these options in a Compose file, see
+[Performance tuning for volume
+mounts](/compose/compose-file.md#performance-tuning-for-volume-mounts-docker-for-mac)
+the Docker Compose topics.
 
 ## Performance implications of host-container file system consistency
 
@@ -67,9 +82,10 @@ there is no need for writes to build artifacts within the container to
 be immediately reflected on the host file system.  Distinguishing between
 these two cases makes it possible to significantly improve performance.
 
-There are three broad scenarios to consider, based on which you can dial in the level of consistency you need.  In each case, the container
-has an internally-consistent view of bind-mounted directories, but in
-two cases temporary discrepancies are allowed between container and host.
+There are three broad scenarios to consider, based on which you can dial in the
+level of consistency you need.  In each case, the container has an
+internally-consistent view of bind-mounted directories, but in two cases
+temporary discrepancies are allowed between container and host.
 
  * `consistent`: perfect consistency  
    (host and container have an identical view of the mount at all times)
@@ -82,10 +98,12 @@ two cases temporary discrepancies are allowed between container and host.
 
 ## Examples
 
-Each of these configurations (`consistent`, `cached`, `delegated`) can be specified as a suffix to the [`-v`](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems)
-option of [`docker run`](https://docs.docker.com/engine/reference/run.md).
-For example, to bind-mount `/Users/yallop/project` in a container under
-the path `/project`, you might run the following command:
+Each of these configurations (`consistent`, `cached`, `delegated`) can be
+specified as a suffix to the
+[`-v`](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems)
+option of [`docker run`](https://docs.docker.com/engine/reference/run.md). For
+example, to bind-mount `/Users/yallop/project` in a container under the path
+`/project`, you might run the following command:
 
 ```
 docker run -v /Users/yallop/project:/project:cached alpine command

--- a/docker-for-mac/osxfs-caching.md
+++ b/docker-for-mac/osxfs-caching.md
@@ -28,8 +28,8 @@ Performance](https://stories.amazee.io/docker-on-mac-performance-docker-machine-
 gives a nice, quick summary.
 
 For information on how to configure these options in a Compose file, see
-[Performance tuning for volume
-mounts](/compose/compose-file.md#performance-tuning-for-volume-mounts-docker-for-mac)
+[Caching options for volume
+mounts](/compose/compose-file.md#caching-options-for-volume-mounts-docker-for-mac)
 the Docker Compose topics.
 
 ## Performance implications of host-container file system consistency


### PR DESCRIPTION
### What's changed

- Added topic with example on caching options to Compose version 3 file reference
- Cross referenced it with the details on these options in the Docker for Mac topic on performance tuning

### Questions for Reviewers

@shin- @dnephin @dsheets @kkrauth @yallop Please let me know if these additions to the docs make sense, and are in the right place. Also, I assume that if one of these options is specified on a volume (`consistent`, `cached`, or `delegated`) and the platform is _*not*_ Mac, the option is ignored. Is that true? If so, we should probably add that here, right?

Also let me know If you want me to add this to Compose version 2 file reference.

### Related

Fixes #3921 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>


