### PR TITLE
Removes Ubuntu Yakkety mentions for docker-ce

### DIFF
--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -31,15 +31,13 @@ To install Docker CE, you need the 64-bit version of one of these Ubuntu
 versions:
 
 - Zesty 17.04
-- Yakkety 16.10
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
 Docker CE is supported on Ubuntu on `x86_64`, `armhf`, and `s390x` (IBM z
 Systems) architectures.
 
-> **`s390x` limitations**: System Z is only supported on Ubuntu Xenial,
-> Yakkety, and Zesty.
+> **`s390x` limitations**: System Z is only supported on Ubuntu Xenial and Zesty.
 
 ### Uninstall old versions
 


### PR DESCRIPTION
Ubuntu 16.10 (Yakkety) reached its end of life on July 20, 2017:
http://fridge.ubuntu.com/2017/07/20/ubuntu-16-10-yakkety-yak-end-of-life-reached-on-july-20-2017/

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
Remove Ubuntu Yakkety from the ubuntu page
<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

docker/docker-ce-packaging#38
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
