### PR TITLE
Update references to moby/moby and 17.03.x branch

### DIFF
--- a/_data/not_edited_here.yaml
+++ b/_data/not_edited_here.yaml
@@ -16,15 +16,15 @@ overrides:
 
 - path: /engine/deprecated.md
   description: Docker Engine deprecation reference
-  source: https://github.com/docker/docker/tree/17.03.x/docs/deprecated.md
+  source: https://github.com/docker/cli/tree/master/docs/deprecated.md
 
 - path: /engine/extend/
   description: References for Docker Engine plugin system
-  source: https://github.com/docker/docker/tree/17.03.x/docs/extend/
+  source: https://github.com/docker/cli/tree/master/docs/extend/
 
 - path: /engine/reference/
   description: Docker Engine CLI and API references
-  source: https://github.com/docker/docker/tree/17.03.x/docs/reference/
+  source: https://github.com/docker/cli/tree/master/docs/reference/
 
 - path: /notary/reference/
   description: Reference docs for Docker Notary

--- a/engine/reference/commandline/README.md
+++ b/engine/reference/commandline/README.md
@@ -2,7 +2,7 @@
 
 The files in this directory are stub files which include the file
 `/_includes/cli.md`, which parses YAML files generated from the
-[`moby/moby`](https://github.com/moby/moby) repository. The YAML files
+[`docker/cli`](https://github.com/docker/cli) repository. The YAML files
 are parsed into output files like
 [https://docs.docker.com/engine/reference/commandline/build/](https://docs.docker.com/engine/reference/commandline/build/).
 
@@ -14,7 +14,7 @@ The output files are composed from two sources:
   the CLI source code in that repository.
 
 - The **Extended Description** and **Examples** sections are pulled into the
-  YAML from the files in [https://github.com/moby/moby/tree/master/docs/reference/commandline](https://github.com/moby/moby/tree/master/docs/reference/commandline)
+  YAML from the files in [https://github.com/docker/cli/tree/master/docs/reference/commandline](https://github.com/docker/cli/tree/master/docs/reference/commandline)
   Specifically, the Markdown inside the `## Description` and `## Examples`
   headings are parsed. Please submit corrections to the text in that repository.
 

--- a/engine/reference/commandline/attach.md
+++ b/engine/reference/commandline/attach.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/build.md
+++ b/engine/reference/commandline/build.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint.md
+++ b/engine/reference/commandline/checkpoint.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint_create.md
+++ b/engine/reference/commandline/checkpoint_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint_ls.md
+++ b/engine/reference/commandline/checkpoint_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/checkpoint_rm.md
+++ b/engine/reference/commandline/checkpoint_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/commit.md
+++ b/engine/reference/commandline/commit.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/config.md
+++ b/engine/reference/commandline/config.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/config_create.md
+++ b/engine/reference/commandline/config_create.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/config_inspect.md
+++ b/engine/reference/commandline/config_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/config_ls.md
+++ b/engine/reference/commandline/config_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/config_rm.md
+++ b/engine/reference/commandline/config_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container.md
+++ b/engine/reference/commandline/container.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_attach.md
+++ b/engine/reference/commandline/container_attach.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_commit.md
+++ b/engine/reference/commandline/container_commit.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_cp.md
+++ b/engine/reference/commandline/container_cp.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_create.md
+++ b/engine/reference/commandline/container_create.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_diff.md
+++ b/engine/reference/commandline/container_diff.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_exec.md
+++ b/engine/reference/commandline/container_exec.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_export.md
+++ b/engine/reference/commandline/container_export.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_inspect.md
+++ b/engine/reference/commandline/container_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_kill.md
+++ b/engine/reference/commandline/container_kill.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_logs.md
+++ b/engine/reference/commandline/container_logs.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_ls.md
+++ b/engine/reference/commandline/container_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_pause.md
+++ b/engine/reference/commandline/container_pause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_port.md
+++ b/engine/reference/commandline/container_port.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_prune.md
+++ b/engine/reference/commandline/container_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_rename.md
+++ b/engine/reference/commandline/container_rename.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_restart.md
+++ b/engine/reference/commandline/container_restart.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_rm.md
+++ b/engine/reference/commandline/container_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_run.md
+++ b/engine/reference/commandline/container_run.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_start.md
+++ b/engine/reference/commandline/container_start.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_stats.md
+++ b/engine/reference/commandline/container_stats.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_stop.md
+++ b/engine/reference/commandline/container_stop.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_top.md
+++ b/engine/reference/commandline/container_top.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_unpause.md
+++ b/engine/reference/commandline/container_unpause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_update.md
+++ b/engine/reference/commandline/container_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/container_wait.md
+++ b/engine/reference/commandline/container_wait.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/cp.md
+++ b/engine/reference/commandline/cp.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/create.md
+++ b/engine/reference/commandline/create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/deploy.md
+++ b/engine/reference/commandline/deploy.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/diff.md
+++ b/engine/reference/commandline/diff.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/docker.md
+++ b/engine/reference/commandline/docker.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/dockerd.md
+++ b/engine/reference/commandline/dockerd.md
@@ -15,7 +15,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/events.md
+++ b/engine/reference/commandline/events.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/exec.md
+++ b/engine/reference/commandline/exec.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/export.md
+++ b/engine/reference/commandline/export.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/history.md
+++ b/engine/reference/commandline/history.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/image.md
+++ b/engine/reference/commandline/image.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_build.md
+++ b/engine/reference/commandline/image_build.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_history.md
+++ b/engine/reference/commandline/image_history.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_import.md
+++ b/engine/reference/commandline/image_import.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_inspect.md
+++ b/engine/reference/commandline/image_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_load.md
+++ b/engine/reference/commandline/image_load.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_ls.md
+++ b/engine/reference/commandline/image_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_prune.md
+++ b/engine/reference/commandline/image_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_pull.md
+++ b/engine/reference/commandline/image_pull.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_push.md
+++ b/engine/reference/commandline/image_push.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_rm.md
+++ b/engine/reference/commandline/image_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_save.md
+++ b/engine/reference/commandline/image_save.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/image_tag.md
+++ b/engine/reference/commandline/image_tag.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/images.md
+++ b/engine/reference/commandline/images.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/import.md
+++ b/engine/reference/commandline/import.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/info.md
+++ b/engine/reference/commandline/info.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/inspect.md
+++ b/engine/reference/commandline/inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/kill.md
+++ b/engine/reference/commandline/kill.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/load.md
+++ b/engine/reference/commandline/load.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/login.md
+++ b/engine/reference/commandline/login.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/logout.md
+++ b/engine/reference/commandline/logout.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/logs.md
+++ b/engine/reference/commandline/logs.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network.md
+++ b/engine/reference/commandline/network.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_connect.md
+++ b/engine/reference/commandline/network_connect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_create.md
+++ b/engine/reference/commandline/network_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_disconnect.md
+++ b/engine/reference/commandline/network_disconnect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_inspect.md
+++ b/engine/reference/commandline/network_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_ls.md
+++ b/engine/reference/commandline/network_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_prune.md
+++ b/engine/reference/commandline/network_prune.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/network_rm.md
+++ b/engine/reference/commandline/network_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node.md
+++ b/engine/reference/commandline/node.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_demote.md
+++ b/engine/reference/commandline/node_demote.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_inspect.md
+++ b/engine/reference/commandline/node_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_ls.md
+++ b/engine/reference/commandline/node_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_promote.md
+++ b/engine/reference/commandline/node_promote.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_ps.md
+++ b/engine/reference/commandline/node_ps.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_rm.md
+++ b/engine/reference/commandline/node_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/node_update.md
+++ b/engine/reference/commandline/node_update.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/pause.md
+++ b/engine/reference/commandline/pause.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin.md
+++ b/engine/reference/commandline/plugin.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_create.md
+++ b/engine/reference/commandline/plugin_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_disable.md
+++ b/engine/reference/commandline/plugin_disable.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_enable.md
+++ b/engine/reference/commandline/plugin_enable.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_inspect.md
+++ b/engine/reference/commandline/plugin_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_install.md
+++ b/engine/reference/commandline/plugin_install.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_ls.md
+++ b/engine/reference/commandline/plugin_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_push.md
+++ b/engine/reference/commandline/plugin_push.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_rm.md
+++ b/engine/reference/commandline/plugin_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_set.md
+++ b/engine/reference/commandline/plugin_set.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/plugin_upgrade.md
+++ b/engine/reference/commandline/plugin_upgrade.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/port.md
+++ b/engine/reference/commandline/port.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/ps.md
+++ b/engine/reference/commandline/ps.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/pull.md
+++ b/engine/reference/commandline/pull.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/push.md
+++ b/engine/reference/commandline/push.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/rename.md
+++ b/engine/reference/commandline/rename.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/restart.md
+++ b/engine/reference/commandline/restart.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/rm.md
+++ b/engine/reference/commandline/rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/rmi.md
+++ b/engine/reference/commandline/rmi.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/run.md
+++ b/engine/reference/commandline/run.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/save.md
+++ b/engine/reference/commandline/save.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/search.md
+++ b/engine/reference/commandline/search.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret.md
+++ b/engine/reference/commandline/secret.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_create.md
+++ b/engine/reference/commandline/secret_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_inspect.md
+++ b/engine/reference/commandline/secret_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_ls.md
+++ b/engine/reference/commandline/secret_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/secret_rm.md
+++ b/engine/reference/commandline/secret_rm.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service.md
+++ b/engine/reference/commandline/service.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_create.md
+++ b/engine/reference/commandline/service_create.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service_inspect.md
+++ b/engine/reference/commandline/service_inspect.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service_logs.md
+++ b/engine/reference/commandline/service_logs.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_ls.md
+++ b/engine/reference/commandline/service_ls.md
@@ -8,7 +8,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 {% if page.datafolder contains '-edge' %}
   {% include edge_only.md section="cliref" %}

--- a/engine/reference/commandline/service_ps.md
+++ b/engine/reference/commandline/service_ps.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_rm.md
+++ b/engine/reference/commandline/service_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_scale.md
+++ b/engine/reference/commandline/service_scale.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/service_update.md
+++ b/engine/reference/commandline/service_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack.md
+++ b/engine/reference/commandline/stack.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_deploy.md
+++ b/engine/reference/commandline/stack_deploy.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_ls.md
+++ b/engine/reference/commandline/stack_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_ps.md
+++ b/engine/reference/commandline/stack_ps.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_rm.md
+++ b/engine/reference/commandline/stack_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stack_services.md
+++ b/engine/reference/commandline/stack_services.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/start.md
+++ b/engine/reference/commandline/start.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stats.md
+++ b/engine/reference/commandline/stats.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/stop.md
+++ b/engine/reference/commandline/stop.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm.md
+++ b/engine/reference/commandline/swarm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_ca.md
+++ b/engine/reference/commandline/swarm_ca.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_init.md
+++ b/engine/reference/commandline/swarm_init.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_join-token.md
+++ b/engine/reference/commandline/swarm_join-token.md
@@ -11,7 +11,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_join.md
+++ b/engine/reference/commandline/swarm_join.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_leave.md
+++ b/engine/reference/commandline/swarm_leave.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_unlock-key.md
+++ b/engine/reference/commandline/swarm_unlock-key.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_unlock.md
+++ b/engine/reference/commandline/swarm_unlock.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/swarm_update.md
+++ b/engine/reference/commandline/swarm_update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system.md
+++ b/engine/reference/commandline/system.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_df.md
+++ b/engine/reference/commandline/system_df.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_events.md
+++ b/engine/reference/commandline/system_events.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_info.md
+++ b/engine/reference/commandline/system_info.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/system_prune.md
+++ b/engine/reference/commandline/system_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/tag.md
+++ b/engine/reference/commandline/tag.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/top.md
+++ b/engine/reference/commandline/top.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/unpause.md
+++ b/engine/reference/commandline/unpause.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/update.md
+++ b/engine/reference/commandline/update.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/version.md
+++ b/engine/reference/commandline/version.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume.md
+++ b/engine/reference/commandline/volume.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_create.md
+++ b/engine/reference/commandline/volume_create.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_inspect.md
+++ b/engine/reference/commandline/volume_inspect.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_ls.md
+++ b/engine/reference/commandline/volume_ls.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_prune.md
+++ b/engine/reference/commandline/volume_prune.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/volume_rm.md
+++ b/engine/reference/commandline/volume_rm.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}

--- a/engine/reference/commandline/wait.md
+++ b/engine/reference/commandline/wait.md
@@ -9,7 +9,7 @@ Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
 
-https://www.github.com/moby/moby
+https://www.github.com/docker/cli
 -->
 
 {% if page.datafolder contains '-edge' %}


### PR DESCRIPTION
The "not_edited_here" YAML was referring to the 17.03.x branch in moby/moby (docker/docker), however, the reference docs moved to the docker/cli repository.

Worth noting that the docs specific to a release are (should be) taken from the https://github.com/docker/docker-ce repository, but we only _cherry-pick_ changes into that repository, so edits are best made in the https://github.com/docker/cli repository first.

Also updated the comment in the CLI reference boiler plating to refer to https://www.github.com/docker/cli

ping @johndmulhausen @mstanleyjones PTAL