### PR TITLE
fixed linktext

### DIFF
--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -17,7 +17,7 @@ To get started with Docker EE on Ubuntu, make sure you
 ## Prerequisites
 
 Docker CE users should go to
-[Get docker CE for CentOS](/engine/installation/linux/docker-ce/ubuntu.md)
+[Get Docker CE for Ubuntu](/engine/installation/linux/docker-ce/ubuntu.md)
 **instead of this topic**.
 
 To install Docker Enterprise Edition (Docker EE), you need to know the Docker EE


### PR DESCRIPTION
the link to CE instructions said "CE for CentOS" even though the link pointed to the Ubuntu page.  Also "Docker" in that link text was not capitalized.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
