### PR TITLE
Fix link to requirements in Apache recipe

### DIFF
--- a/registry/recipes/apache.md
+++ b/registry/recipes/apache.md
@@ -30,7 +30,7 @@ Furthermore, introducing an extra http layer in your communication pipeline will
 
 ## Setting things up
 
-Read again [the requirements](index.md#requirements).
+Read again [the requirements](../index.md#requirements).
 
 Ready?
 


### PR DESCRIPTION
### Proposed changes

This patch fixes link to Docker registry requirements from the Apache recipe.