### PR TITLE
explain why `init` is not (yet) supported in v3

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -274,6 +274,8 @@ several options have been removed:
 -   `pids_limit`: This option has not been introduced in `version: "3.x"` Compose files.
 -   `link_local_ips` in `networks`: This option has not been introduced in
     `version: "3.x"` Compose files.
+-   `init`: This option has not been added for `version: "3.x"` Compose files because Swarm services do not support custom init yet.
+
 
 ### Version 1 to 2.x
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add a single line to explain why `init` is not supported for version 3 in the upgrading from 2.x to 3.x section.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
Fixes https://github.com/docker/compose/issues/5049



