### PR TITLE
added endpoint_mode topic for Compose file v3.3

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -229,14 +229,15 @@ the [upgrading](#upgrading) guide for how to migrate away from these.
 
 ### Version 3.3
 
-An upgrade of [version 3](#version-3) that introduces new parameters only available
-with Docker Engine version **17.06.0+**
+An upgrade of [version 3](#version-3) that introduces new parameters only
+available with Docker Engine version **17.06.0+**
 
 Introduces the following additional parameters:
 
 - [build `labels`](index.md#build)
-- [`credential_spec`](index.md#credential_spec)
+- [`credential_spec`](index.md#credentialspec)
 - [`configs`](index.md#configs)
+- [deploy `endpoint_mode`](index.md#endpointmode)
 
 ## Upgrading
 

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -189,7 +189,7 @@ between services and startup order.
 
 An upgrade of [version 2](#version-2) that introduces new parameters only
 available with Docker Engine version **1.12.0+**. Version 2.1 files are
-supported by **Compose 1.9.0+**
+supported by **Compose 1.9.0+**.
 
 Introduces the following additional parameters:
 
@@ -230,7 +230,7 @@ the [upgrading](#upgrading) guide for how to migrate away from these.
 ### Version 3.3
 
 An upgrade of [version 3](#version-3) that introduces new parameters only
-available with Docker Engine version **17.06.0+**
+available with Docker Engine version **17.06.0+**, and higher.
 
 Introduces the following additional parameters:
 


### PR DESCRIPTION
### What's changed

- Added subtopic on `deploy` key for new sub-option `endpoint_mode` in Compose file reference
- Added `endpoint_mode` to list of new options added v.3.3 to versioning page
- Provided links to the relevant Swarm CLI command

### Related

Fixes #3676 

### Reviewers

@yongshin @shin- @dnephin @ManoMarks @mstanleyjones 

### Resources I used (record keeping for me)

[DNS based load balancing ](https://sreeninet.wordpress.com/2016/07/29/service-discovery-and-load-balancing-internals-in-docker-1-12/)

[Issue 32575](https://github.com/moby/moby/issues/32575) on Moby
[Issue 32333](https://github.com/moby/moby/pull/32333) on Moby
[Issue 32935](https://github.com/moby/moby/issues/32935) on Moby
[Docker Community Forums question on exposing ports for a service in a swarm](https://forums.docker.com/t/only-the-first-service-port-is-getting-exposed-when-doing-a-stack-deploy-in-docker-swarm/27642)

### Note on links / x-refs

- You might notice links from the Versioning page back into Compose file reference are not working right now. This is a separate docs post-processing issue not specific to these files, @johndmulhausen is in the midst of investigating / fixing it.


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
