### PR TITLE
Correct example of daemon.json log-opts config

### DIFF
--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -42,10 +42,10 @@ example sets two configurable options on the `json-file` logging driver:
 ```json
 {
   "log-driver": "json-file",
-  "log-opts": [
-    "labels=production_status",
-    "env=os,customer"
-  ]
+  "log-opts": {
+    "labels": "production_status",
+    "env": "os,customer"
+  }
 }
 ```
 


### PR DESCRIPTION
* Update docs so that log-opts takes map (`{}`) instead of array (`[]`) 

see #25585

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
