### PR TITLE
fix default secrets path in container

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -311,7 +311,7 @@ you are also specifying that only a single replica should run at a time. The
 example bind-mounts `/mnt/registry` on the swarm node to `/var/lib/registry/`
 within the container.
 
-By default, secrets are mounted into a service at `/run/<secret-name>`.
+By default, secrets are mounted into a service at `/run/secrets/<secret-name>`.
 
 ```bash
 $ docker service create \
@@ -321,8 +321,8 @@ $ docker service create \
   --label registry=true \
   -v /mnt/registry:/var/lib/registry \
   -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
-  -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/domain.crt \
-  -e REGISTRY_HTTP_TLS_KEY=/run/domain.key \
+  -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/secrets/domain.crt \
+  -e REGISTRY_HTTP_TLS_KEY=/run/secrets/domain.key \
   -p 80:80 \
   --replicas 1 \
   registry:2


### PR DESCRIPTION
### Proposed changes
Run swarm mode error as default secrets path in containers is error.
```
$ docker service create \
  --name registry \
  --secret domain.crt \
  --secret domain.key \
  --label registry=true \
  -v /mnt/registry:/var/lib/registry \
  -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
  -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/domain.crt \
  -e REGISTRY_HTTP_TLS_KEY=/run/domain.key \
  -p 80:80 \
  --replicas 1 \
  registry:2
```
Please refer to [secrets](https://github.com/docker/docker.github.io/blob/master/engine/swarm/secrets.md)

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
