### PR TITLE
Used proper CSS tag for accordion background color

### DIFF
--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -85,7 +85,7 @@ img.inline {
 }
 
 .panel-heading:hover{
-    background: #fafdfe;
+    background-color: #fafdfe;
 }
 
 


### PR DESCRIPTION
### What's changed

- Changed `background` to `background-color` on hover used for accordions

### Related

#3967

### Reviewers

@mstanleyjones 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
