### PR TITLE
Update admonitions CSS for consistency and better writer workflow

### DIFF
--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -29,9 +29,11 @@ install the latest stable release of Docker CE on Linux. To install the latest
 testing version, use [test.docker.com](https://test.docker.com/) instead. In
 each of the commands below, replace each occurrence of `get` with `test`.
 
-> **Warning**: Always examine scripts downloaded from the internet  before
+> **Warning**:
+>
+Always examine scripts downloaded from the internet before
 > running them locally.
-{:.warning-vanilla}
+{:.warning}
 
 ```bash
 $ curl -fsSL get.docker.com -o get-docker.sh

--- a/_scss/_notes.scss
+++ b/_scss/_notes.scss
@@ -6,43 +6,82 @@ $note-color: #1488C6;
 $important-color: #aa6708;
 $warning-color: #ce4844;
 
+
+/*** Blocquotes with no Liquid tag get $note-color sidebar
+***/
 blockquote {
   border-left-color: $note-color;
 }
 
+/*** First paragraph of a multi-paragraph blockquote is bold and defaults to $note-color if not tagged differently
+***/
 blockquote > p:first-child {
   margin-top: 0;
   font-weight: 700;
   color: $note-color;
 }
 
+/*** This used to prepend "Note" to title of any multi-paragraph blockquote, now it adds the note icon instead
+***/
 blockquote > p:first-child::before {
-  content: 'Note: ';
-}
-
-blockquote.note-vanilla > p:first-child::before {
   content: '\f058 \00a0';
   font-family: FontAwesome;
 }
 
-blockquote.note {
-  border-left-color: $note-color;
-  content: '\f058 \00a0';
-  font-family: FontAwesome;
-}
-
+/*** Blockquotes with important tag get $important-color sidebar
+***/
 blockquote.important {
   border-left-color: $important-color;
-  content: '\f06a  \00a0';
-  font-family: FontAwesome;
 }
 
+/*** First paragraph of a multi-paragraph .important blockquote inherits bold, and is $important-color
+***/
 blockquote.important > p:first-child {
   color: $important-color;
 }
 
+/*** This used to prepend "Important" to important admonitions, now it adds the important icon instead
+***/
 blockquote.important > p:first-child::before {
-  content: 'Important: ';
+  content: '\f06a  \00a0';
+  font-family: FontAwesome;
+}
+
+/*** Blockquotes with warning tag get $warning-color sidebar
+***/
+blockquote.warning {
+  border-left-color: $warning-color;
+}
+
+
+/*** First paragraph of a multi-paragraph .warning blockquote inherits bold, and is $warning-color
+***/
+blockquote.warning > p:first-child {
+  color: $warning-color;
+}
+
+/*** This used to prepend the "Warning" text as content, now it adds the warning icon instead
+***/
+blockquote.warning > p:first-child::before {
+  content: '\f057  \00a0';
+  font-family: FontAwesome;
+}
+
+/* Maintain backwards compatibility with old
+*  note style
+*/
+blockquote > p:only-child {
+  font-weight: inherit;
+  color: inherit;
+}
+blockquote > p:only-child::before {
+  content: none;
+}
+
+/*** Vanilla styles, soon to be removed when it's clear there is no impact to current docset***/
+blockquote.note-vanilla > p:first-child::before {
+  content: '\f058 \00a0';
+  font-family: FontAwesome;
 }
 
 blockquote.important-vanilla {
@@ -58,23 +97,6 @@ blockquote.important-vanilla > p:first-child::before {
   font-family: FontAwesome;
 }
 
-/***
-blockquote.warning {
-  border-left-color: $warning-color;
-}
-***/
-
-blockquote.warning > p:first-child {
-  color: $warning-color;
-  border-left-color: $warning-color;
-  content: '\f057  \00a0';
-  font-family: FontAwesome;
-}
-
-blockquote.warning > p:first-child::before {
-  content: 'Warning: ';
-}
-
 blockquote.warning-vanilla {
   border-left-color: $warning-color;
 }
@@ -87,15 +109,4 @@ blockquote.warning-vanilla > p:first-child::before {
   content: '\f057  \00a0';
   font-family: FontAwesome;
 
-}
-
-/* Maintain backwards compatibility with old
-*  note style
-*/
-blockquote > p:only-child {
-  font-weight: inherit;
-  color: inherit;
-}
-blockquote > p:only-child::before {
-  content: none;
 }

--- a/_scss/_notes.scss
+++ b/_scss/_notes.scss
@@ -25,8 +25,16 @@ blockquote.note-vanilla > p:first-child::before {
   font-family: FontAwesome;
 }
 
+blockquote.note {
+  border-left-color: $note-color;
+  content: '\f058 \00a0';
+  font-family: FontAwesome;
+}
+
 blockquote.important {
   border-left-color: $important-color;
+  content: '\f06a  \00a0';
+  font-family: FontAwesome;
 }
 
 blockquote.important > p:first-child {
@@ -50,12 +58,17 @@ blockquote.important-vanilla > p:first-child::before {
   font-family: FontAwesome;
 }
 
+/***
 blockquote.warning {
   border-left-color: $warning-color;
 }
+***/
 
 blockquote.warning > p:first-child {
   color: $warning-color;
+  border-left-color: $warning-color;
+  content: '\f057  \00a0';
+  font-family: FontAwesome;
 }
 
 blockquote.warning > p:first-child::before {

--- a/_scss/_notes.scss
+++ b/_scss/_notes.scss
@@ -77,36 +77,3 @@ blockquote > p:only-child {
 blockquote > p:only-child::before {
   content: none;
 }
-
-/*** Vanilla styles, soon to be removed when it's clear there is no impact to current docset***/
-blockquote.note-vanilla > p:first-child::before {
-  content: '\f058 \00a0';
-  font-family: FontAwesome;
-}
-
-blockquote.important-vanilla {
-  border-left-color: $important-color;
-}
-
-blockquote.important-vanilla > p:first-child {
-  color: $important-color;
-}
-
-blockquote.important-vanilla > p:first-child::before {
-  content: '\f06a  \00a0';
-  font-family: FontAwesome;
-}
-
-blockquote.warning-vanilla {
-  border-left-color: $warning-color;
-}
-
-blockquote.warning-vanilla > p:first-child {
-  color: $warning-color;
-}
-
-blockquote.warning-vanilla > p:first-child::before {
-  content: '\f057  \00a0';
-  font-family: FontAwesome;
-
-}

--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -58,7 +58,6 @@ context.
 >   form that is allowed in Version 2 and up.
 > * Using `build` together with [`image`](#image) is not allowed.
 Attempting to do so results in an error.
-{: .note}
 
 #### dockerfile
 

--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -49,7 +49,7 @@ context.
 
     build: ./dir
 
-> **Notes**
+> **Note**
 >
 > In [version 1 file format](compose-versioning.md#version-1),
 `build` is  different in two ways:
@@ -58,7 +58,7 @@ context.
 >   form that is allowed in Version 2 and up.
 > * Using `build` together with [`image`](#image) is not allowed.
 Attempting to do so results in an error.
-{: .note-vanilla}
+{: .note}
 
 #### dockerfile
 

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1004,7 +1004,6 @@ then read-write will be used.
 >     - `service_name:ro`
 >     - `container_name`
 >     - `container_name:rw`
-{: .note-vanilla}
 
 ### restart
 

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -33,7 +33,7 @@ notes](https://github.com/docker/compose/releases/). Each set of release notes
 gives details on which versions of Docker Engine are supported, along
 with compatible Compose file format versions. (See also, the discussion in
 [issue #3404](https://github.com/docker/docker.github.io/issues/3404).)
-{: .note-vanilla}
+
 
 For details on versions and how to upgrade, see
 [Versioning](compose-versioning.md#versioning) and

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -788,7 +788,6 @@ Simple example:
 > - The `depends_on` option is ignored when
 >   [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
 >   with a version 3 Compose file.
-{: .note-vanilla}
 
 
 ### dns
@@ -971,7 +970,6 @@ legacy option. We recommend using [networks](#networks) instead.
 >
 > This option is ignored when [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
 with a (version 3) Compose file.
-{: .note-vanilla}
 
 ### extra_hosts
 
@@ -1086,7 +1084,6 @@ Links also express dependency between services in the same way as
 > *  This option is ignored when
 > [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
 > with a (version 3) Compose file.
-{: .note-vanilla}
 
 ### logging
 
@@ -1148,7 +1145,6 @@ specific to the [json-file driver](/engine/admin/logging/overview.md#json-file).
 These particular options are not available on other logging drivers.
 For a full list of supported logging drivers and their options, see
 [logging drivers](/engine/admin/logging/overview.md).
-{: .note-vanilla}
 
 ### network_mode
 
@@ -1169,7 +1165,6 @@ the special form `service:[service name]`.
  file.
 >
 >* `network_mode: "host"` cannot be mixed with [links](#links).
-{: .note-vanilla}
 
 ### networks
 
@@ -1344,7 +1339,7 @@ to the secret name.
 > the short syntax are unreadable within the container if the command does not
 > run as the `root` user. The workaround is to use the long syntax instead if
 > you use Docker 1.13.1 and the secret must be read by a non-`root` user.
-{: .warning-vanilla}
+{: .warning}
 
 The following example uses the short syntax to grant the `redis` service
 access to the `my_secret` and `my_other_secret` secrets. The value of
@@ -1835,7 +1830,6 @@ tasks are scheduled on new nodes,
 [swarmkit](https://github.com/docker/swarmkit/blob/master/README.md) creates the
 volume on the local node. To learn more, see
 [moby/moby#29976](https://github.com/moby/moby/issues/29976).
-{: .note-vanilla}
 
 ### labels
 

--- a/compose/django.md
+++ b/compose/django.md
@@ -199,7 +199,6 @@ In this section, you set up the database connection for Django.
     >
     > Please note this value is **not** safe for production usage.  Refer to the
      [Django documentation](https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts)  for more information.
-     {: .note-vanilla}
 
 5.  List running containers.
 

--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -46,7 +46,6 @@ environment variables, follow the guidelines in the topic [Environment variables
 in Compose](/compose/environment-variables.md), which describes how to pass
 shell environment variables through to containers, define environment variables
 in Compose files, and more.
-{: .note-vanilla}
 
 ## More Compose documentation
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -48,7 +48,7 @@ To install Compose, do the following:
     replace `$dockerComposeVersion` with the release number that
     you want. Compose releases are also available for direct download
     on the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" class="_"}.
-    {: .important-vanilla}
+    {: .important}
 
     Now, run the executable to install Compose.
 
@@ -61,7 +61,6 @@ To install Compose, do the following:
     If so, your `/usr/local/bin` directory probably isn't writable and
     you'll need to install Compose as the superuser. Run `sudo -i`, then
     run the download and install commands below, then `exit`.
-    {: .note-vanilla}
 
 
     Run this command to download Docker Compose, replacing
@@ -86,7 +85,7 @@ To install Compose, do the following:
     you want. Compose releases are also available for direct download on
     the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank"
 class="_"}.
-    {: .important-vanilla}
+    {: .important}
 
     If you have problems installing with `curl`, see
     [Alternative Install Options](install.md#alternative-install-options).
@@ -147,7 +146,7 @@ release number with the one that you want. Compose releases are also listed and
 available for direct download on the [Compose repository release page on
 GitHub](https://github.com/docker/compose/releases){: target="_blank"
 class="_"}.
-{: .important-vanilla}
+{: .important}
 
 ## Master builds
 
@@ -201,7 +200,6 @@ pip uninstall docker-compose
 > methods, you probably do not have the proper permissions to remove
 > `docker-compose`. To force the removal, prepend `sudo` to either of the above
 > commands and run again.
-{: .note-vanilla}
 
 
 ## Where to go next

--- a/docker-cloud/getting-started/deploy-app/2_set_up.md
+++ b/docker-cloud/getting-started/deploy-app/2_set_up.md
@@ -41,7 +41,6 @@ package manager, which is a package manager for
   > We recommend using Python 2.x with Docker Cloud. To learn more,
   see the Python and CLI issues described in
   [Known issues in Docker Cloud](/docker-cloud/docker-errors-faq.md).
-  {: .note-vanilla}
 
 * If you do not have Python or `pip` installed, you can either [install
 Python](https://wiki.python.org/moin/BeginnersGuide/Download) or use this

--- a/docker-cloud/infrastructure/link-aws.md
+++ b/docker-cloud/infrastructure/link-aws.md
@@ -10,7 +10,6 @@ title: Link an Amazon Web Services account
 > **Legacy instructions**:
 >
 > This topic has been superseded by [the AWS instructions that enable swarm mode](/docker-cloud/cloud-swarm/link-aws-swarm.md).
-{: .note-vanilla}
 
 You can create a role with AWS IAM (Identity and Access Management) so that
 Docker Cloud can provision and manage **node clusters** and **nodes** on your

--- a/docker-cloud/infrastructure/link-azure.md
+++ b/docker-cloud/infrastructure/link-azure.md
@@ -11,7 +11,6 @@ notoc: true
 > **Legacy instructions**:
 >
 > This topic has been superseded by [the Azure instructions that enable swarm mode](/docker-cloud/cloud-swarm/link-azure-swarm.md).
-{: .note-vanilla}
 
 You can link your Microsoft Azure account to your Docker Cloud account to deploy
 **nodes** and **node clusters** using Docker Cloud's Dashboard, API, or CLI. You

--- a/docker-cloud/installing-cli.md
+++ b/docker-cloud/installing-cli.md
@@ -46,7 +46,6 @@ package manager, which is a package manager for
 > we recommend using Python 2.x. To learn more,
 see the Python and CLI issues described in
 [Known issues in Docker Cloud](/docker-cloud/docker-errors-faq.md).
-{: .note-vanilla}
 
 * If you do not have Python or `pip` installed, you can either [install
 Python](https://wiki.python.org/moin/BeginnersGuide/Download) or use this
@@ -61,7 +60,7 @@ $ pip install docker-cloud
 ```
 
 If you encounter errors on Linux machines, make sure that `python-dev` is
-installed. For example, on Ubuntu, run the following command: 
+installed. For example, on Ubuntu, run the following command:
 
 ```
 $ apt-get install python-dev

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -242,7 +242,6 @@ PowerShell Module as follows.
 > * Depending on your setup, you might need the [NuGet package manager](https://www.nuget.org/){: target="_blank" class="_" } so you might get a prompt to install it.
 >
 > * Make sure you have administrator permissions to run an elevated PowerShell.
-{: .note-vanilla}
 
 1.  Start an "elevated" PowerShell (i.e., run it as administrator).
 
@@ -326,7 +325,6 @@ arrow on the taskbar to show it.
   display options through taskbar settings for notifications.
 >
 > ![whale pinned to taskbar](/docker-for-windows/images/whale-taskbar.png)
-{: .note-vanilla}
 
 ![Showing hidden apps in the taskbar](/docker-for-windows/images/whale-systray.png)
 
@@ -416,7 +414,6 @@ volumes](troubleshoot.md#permissions-errors-on-data-directories-for-shared-volum
 nodes. See [Can I share local drives and filesystem with my Docker Machine
 VMs?](faqs.md#can-i-share-local-drives-and-filesystem-with-my-docker-machine-vms) in the FAQs.
 >
-{: .note-vanilla}
 
 #### Firewall rules for shared drives
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -382,7 +382,7 @@ this switch.
 	 `-ForceDeleteAllSwitches` flag. Be sure to read the whole page
 	 before running any scripts, especially the warnings with regard
 	 to the `-ForceDeleteAllSwitches` option.
-	 {: .warning-vanilla}
+	 {: .warning}
 
 ### Windows containers and Windows Server 2016
 

--- a/engine/installation/linux/docker-ce/binaries.md
+++ b/engine/installation/linux/docker-ce/binaries.md
@@ -60,7 +60,7 @@ instructions for enabling and configuring AppArmor or SELinux.
 > If either of the security mechanisms is enabled, do not disable it as a
 > work-around to make Docker or its containers run. Instead, configure it
 > correctly to fix any problems.
-{:.warning-vanilla}
+{:.warning}
 
 ##### Docker daemon considerations
 

--- a/engine/installation/linux/docker-ce/centos.md
+++ b/engine/installation/linux/docker-ce/centos.md
@@ -139,7 +139,7 @@ from the repository.
     > or updating without specifying a version in the `yum install` or
     > `yum update` command will always install the highest possible version,
     > which may not be appropriate for your stability needs.
-    {:.warning-vanilla}
+    {:.warning}
 
 3.  On production systems, you should install a specific version of Docker CE
     instead of always using the latest. List the available versions. This

--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -204,7 +204,7 @@ from the repository.
     > or updating without specifying a version in the `apt-get install` or
     > `apt-get update` command will always install the highest possible version,
     > which may not be appropriate for your stability needs.
-    {:.warning-vanilla}
+    {:.warning}
 
 3.  On production systems, you should install a specific version of Docker CE
     instead of always using the latest. This output is truncated. List the
@@ -263,7 +263,7 @@ to install.
 
 > **Note**: This isn't necessary if you used the recommended
 >`$ curl -sSL https://get.docker.com | sh` command.
-{: .important-vanilla}
+{: .important}
 
 Once you have added the Docker repo to `/etc/apt/sources.list.d/`, you should
 see `docker.list` if you:

--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -142,7 +142,7 @@ from the repository.
     > or updating without specifying a version in the `dnf install` or
     > `dnf update` command will always install the highest possible version,
     > which may not be appropriate for your stability needs.
-    {:.warning-vanilla}
+    {:.warning}
 
 3.  On production systems, you should install a specific version of Docker CE
     instead of always using the latest. List the available versions. This

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -196,7 +196,7 @@ the repository.
     > or updating without specifying a version in the `apt-get install` or
     > `apt-get update` command will always install the highest possible version,
     > which may not be appropriate for your stability needs.
-    {:.warning-vanilla}
+    {:.warning}
 
 3.  On production systems, you should install a specific version of Docker CE
     instead of always using the latest. This output is truncated. List the

--- a/engine/installation/linux/docker-ee/centos.md
+++ b/engine/installation/linux/docker-ee/centos.md
@@ -134,7 +134,7 @@ EE from the repository.
     > or updating without specifying a version in the `yum install` or
     > `yum update` command will always install the highest possible version,
     > which may not be appropriate for your stability needs.
-    {:.warning-vanilla}
+    {:.warning}
 
 3.  On production systems, you should install a specific version of Docker EE
     instead of always using the latest. List the available versions. This

--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -165,7 +165,7 @@ from the repository.
     > or updating without specifying a version in the `apt-get install` or
     > `apt-get update` command will always install the highest possible version,
     > which may not be appropriate for your stability needs.
-    {:.warning-vanilla}
+    {:.warning}
 
 3.  On production systems, you should install a specific version of Docker EE
     instead of always using the latest. This output is truncated. List the

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -127,7 +127,6 @@ You can name the Compose file anything you want to make it logically meaningful
 to you; `docker-compose.yml` is simply a standard name. We could just as easily
 have called this file `docker-stack.yml` or something more specific to our
 project.
-{: .note-vanilla}
 
 ## Run your new load-balanced app
 

--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -96,7 +96,6 @@ To add a worker to this swarm, run the following command:
 > ```
 > docker-machine ssh myvm1 "docker swarm init --advertise-addr 192.168.99.100:2377"
 > ```
-{: .note-vanilla}
 
 As you can see, the response to `docker swarm init` contains a pre-configured
 `docker swarm join` command for you to run on any nodes you want to add. Copy
@@ -265,7 +264,6 @@ look:
 >
 > - Port 7946 TCP/UDP for container network discovery.
 > - Port 4789 UDP for the container ingress network.
-{: .note-vanilla}
 
 ## Iterating and scaling your app
 
@@ -298,7 +296,6 @@ docker-machine ssh myvm1 "docker stack rm getstartedlab"
 > and `docker-machine ssh myvm1 "docker swarm leave --force"` on the
 > manager, but _you'll need this swarm for part 5, so please keep it
 > around for now_.
-{: .note-vanilla}
 
 [On to Part 5 >>](part5.md){: class="button outline-btn" style="margin-bottom: 30px"}
 

--- a/machine/drivers/hyper-v.md
+++ b/machine/drivers/hyper-v.md
@@ -24,7 +24,6 @@ Hyper-V](https://msdn.microsoft.com/en-us/virtualization/hyperv_on_windows/quick
 > [Internet Connection Sharing](http://www.packet6.com/allowing-windows-8-1-hyper-v-vm-to-work-with-wifi/).
 >
 > * This reference page includes an [example](hyper-v.md#example) that shows how to use an elevated (Administrator-level) PowerShell and how to create and use an external network switch.
-{: .note-vanilla}
 
 ## Usage
 

--- a/machine/examples/aws.md
+++ b/machine/examples/aws.md
@@ -19,7 +19,7 @@ from those Docker desktop applications. See Docker Cloud (Edge feature) on
 >
 > Docker Machine will still work as described here, but Docker Cloud
 supercedes Machine for this purpose.
-{: .important-vanilla}
+{: .important}
 
 Follow along with this example to create a Dockerized [Amazon Web Services (AWS)](https://aws.amazon.com/) EC2 instance.
 

--- a/machine/examples/index.md
+++ b/machine/examples/index.md
@@ -18,7 +18,7 @@ Docker desktop applications. See Docker Cloud (Edge feature) on
 >
 > Docker Machine will still work as described here, but Docker Cloud
 supercedes Machine for this purpose.
-{: .important-vanilla}
+{: .important}
 
 -   [Digital Ocean Example](ocean.md)
 -   [AWS Example](aws.md)

--- a/machine/examples/ocean.md
+++ b/machine/examples/ocean.md
@@ -18,7 +18,7 @@ those Docker desktop applications. See Docker Cloud (Edge feature) on
 >
 > Docker Machine will still work as described below, but Docker Cloud
 supercedes Machine for this purpose.
-{: .important-vanilla}
+{: .important}
 
 Follow along with this example to create a Dockerized [Digital Ocean](https://digitalocean.com) Droplet (cloud host).
 

--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -17,7 +17,7 @@ Docker desktop applications. See Docker Cloud (Edge feature) on
 [Windows](/docker-for-windows/index.md#docker-cloud-edge-feature).
 >
 > Docker Machine will still work as described here, but Docker Cloud supercedes Machine for this purpose.
-{: .important-vanilla}
+{: .important}
 
 Docker Machine driver plugins are available for many cloud platforms, so you can
 use Machine to provision cloud hosts. When you use Docker Machine for
@@ -121,7 +121,7 @@ You can register an already existing docker host by passing the daemon url. With
 clusters, but this is legacy. [Swarm mode](/engine/swarm/index.md), built
 into Docker Engine, supercedes Machine provisioning of swarm clusters. The
 topics below show you how to get started with the new swarm mode.
-{: .important-vanilla}
+{: .important}
 
 You can use Docker Machine to create local virtual hosts on which to deploy
 and test [swarm mode](/engine/swarm/index.md) clusters.

--- a/test.md
+++ b/test.md
@@ -457,18 +457,22 @@ Bootstrap JS are loaded.
 
 Current styles for admonitions in
 [`_scss/_notes.scss`](https://github.com/docker/docker.github.io/blob/master/_scss/_notes.scss)
-support two broad categories of admonitions: those with prefixed text (**Note:**,
-**Important:**, **Warning**) and those with prefixed icons.
+support these broad categories of admonitions:
 
-The new styles (with icons) are defined in a way that will not impact
-admonitions formatted with the original styles (prefixed text), so notes in your
-published documents won't be adversely affected.
+- Notes in the old style (no Liquid tag required)
+- Notes with a prefixed icon (no Liquid tag required)
+- Important and Warning admonitions, which take `{: .important}` and `{: .warning}` tags, respectively
+
+The new styles include prepended icons, color sidebars, and bold color titles
+for multi-paragraph notes, but no auto-prepended text. These are defined in a
+way that will not impact admonitions formatted with the original styles, so
+notes in your published documents won't be adversely affected.
 
 Examples of both styles are shown below.
 
 ### Examples (original styles, prefix words)
 
-Admonitions with prefixed text use the following class tags, as shown in the examples.
+Admonitions with prefixed icons use the following class tags, as shown in the examples.
 
 * **Note:** No class tag is needed for standard notes.
 * **Important:** Use the `important` class.
@@ -476,9 +480,6 @@ Admonitions with prefixed text use the following class tags, as shown in the exa
 
 
 > **Note**: This is a note using the old note style
-
-> **Note**: This is a note using
-> the old style and has multiple lines, but a single paragraph
 
 > Pssst, wanna know something?
 >
@@ -513,39 +514,11 @@ Admonitions with prefixed text use the following class tags, as shown in the exa
 >
 > And another sentence to top it all off.
 
-### Examples with FontAwesome icons
+> **Important**: Single paragraph important note with the prefix word "important" manually typed in as bold at the beginning.
+{: .important}
 
->  Pssst, wanna know something?
->
-> You include a small description here telling users to be on the lookout
->
-> This is an example of a note using the `{: .note-vanilla}` tag to get an icon instead of a "Note" prefix, and write your own note title.
-{: .note-vanilla}
-
-
-> It's not safe out there, take this Moby with you
->
-> Use `{: .important-vanilla}` after your important to get an "important" icon.
-{: .important-vanilla}
-
-> Ouch, don't touch that hot Docker engine!
->
-> Use `{: .warning-vanilla}` after your warning to get an icon instead of a "Warning" prefix.
->
-> You can also add more paragraphs here if your explanation is
- super complex.
-{: .warning-vanilla}
-
-### Examples with both prefixed word and icon
-
-The current CSS also supports this kind of of admonition.
-
-> **Notes**
->
-> * This is a note about a thing.
->
-> *  This is another note about the same thing.
-{: .note-vanilla}
+> **Warning**: Single paragraph warning with the prefix word "warning" manually typed in as bold at the beginning.
+{: .warning}
 
 ## Code blocks
 


### PR DESCRIPTION
### What's changed

- Simplify admonitions styles in CSS
-  Updated docset to reflect new styles:
    - removed `vanilla` styles
    - prepend icons but not words (such as warning, important, or note)
   - only warning and important require a Liquid tag (`{: .warning}` and `{: .important)`
   - details are on `test.md` and `notes.css`
 

### Reviewers

@joaofnfernandes @johndmulhausen @mstanleyjones @JimGalasyn 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>