### PR TITLE
Update docker machine binary URL to reflect latest release

### DIFF
--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -25,14 +25,14 @@ docker/machine release page</a> on GitHub.
     If you are running on **macOS**:
 
     ```console
-    $ curl -L https://github.com/docker/machine/releases/download/v0.12.1/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine && \
+    $ curl -L https://github.com/docker/machine/releases/download/v0.12.2/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine && \
   chmod +x /usr/local/bin/docker-machine
     ```
 
     If you are running on **Linux**:
 
     ```console
-    $ curl -L https://github.com/docker/machine/releases/download/v0.12.1/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine &&
+    $ curl -L https://github.com/docker/machine/releases/download/v0.12.2/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine &&
     chmod +x /tmp/docker-machine &&
     sudo cp /tmp/docker-machine /usr/local/bin/docker-machine
     ```
@@ -41,7 +41,7 @@ docker/machine release page</a> on GitHub.
 
     ```console
     $ if [[ ! -d "$HOME/bin" ]]; then mkdir -p "$HOME/bin"; fi && \
-curl -L https://github.com/docker/machine/releases/download/v0.12.1/docker-machine-Windows-x86_64.exe > "$HOME/bin/docker-machine.exe" && \
+curl -L https://github.com/docker/machine/releases/download/v0.12.2/docker-machine-Windows-x86_64.exe > "$HOME/bin/docker-machine.exe" && \
 chmod +x "$HOME/bin/docker-machine.exe"
     ```
 
@@ -50,7 +50,7 @@ chmod +x "$HOME/bin/docker-machine.exe"
 3.  Check the installation by displaying the Machine version:
 
         $ docker-machine version
-        docker-machine version 0.12.1, build c8b17e8
+        docker-machine version 0.12.2, build 9371605
 
 ## Installing bash completion scripts
 


### PR DESCRIPTION
### Proposed changes
Modify the URL of the docker-machine binary on the "Install Docker Machine" page to reflect the latest release (0.12.2).

### Related issues

[Docker Machine Issue #4198](https://github.com/docker/machine/issues/4198) and related [issue closure with release of v0.12.2](https://github.com/docker/machine/issues/4198#issuecomment-315847971).
