### PR TITLE
part3: `docker stack ps` needs the stack name

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -175,7 +175,7 @@ docker stack deploy -c docker-compose.yml getstartedlab
 Docker will do an in-place update, no need to tear the stack down first or kill
 any containers.
 
-Now, re-run the `docker stack ps` command to see the deployed instances reconfigured. For example, if you scaled up the replicas, there will be more
+Now, re-run the `docker stack ps getstartedlab` command to see the deployed instances reconfigured. For example, if you scaled up the replicas, there will be more
 running containers.
 
 ### Take down the app and the swarm


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Adding stack name to the `docker stack ps` command.

When following along the steps at part3, I got stock when trying to do `docker stack ps`. It outputs the following:
```
"docker stack ps" requires exactly 1 argument(s).
See 'docker stack ps --help'.

Usage:  docker stack ps [OPTIONS] STACK

List the tasks in the stack
```