### PR TITLE
d4mac, d4win 17.06.1 stable, 17.07.0 edge release

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -398,6 +398,35 @@ events or unexpected unmounts.
 
 ## Edge Release Notes
 
+### Docker Community Edition 17.07.0-ce-rc1-mac21, 2017-07-31 (edge)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc1)
+- [Docker compose 1.15.0](https://github.com/docker/compose/releases/tag/1.15.0)
+- [Docker Machine 0.12.2](https://github.com/docker/machine/releases/tag/v0.12.2)  
+- Linux Kernel 4.9.38
+
+  **New**
+
+- Transparent proxy using macOS system proxies (if defined) directly
+- GUI settings are now stored in `~/Library/Group\ Containers/group.com.docker/settings.json`. `daemon.json` in now a file in `~/.docker/`
+- You can now change the default IP address used by Hyperkit if it collides with your network
+
+**Bug fixes and minor changes**
+
+- Add daemon options validation
+- Diagnose can be cancelled & Improved help information. Fixes [docker/for-mac#1134](https://github.com/docker/for-mac/issues/1134), [docker/for-mac#1474](https://github.com/docker/for-mac/issues/1474)
+- Support paging of Docker Cloud [repositories](/docker-cloud/builds/repos.md) and [organizations](/docker-cloud/orgs.md). Fixes [docker/for-mac#1538](https://github.com/docker/for-mac/issues/1538)
+
+### Docker Community Edition 17.06.1-ce-mac20, 2017-07-18 (edge)
+
+**Upgrades**
+
+- [Docker 17.06.1-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce-rc1)
+- Linux Kernel 4.9.36
+- AUFS 20170703
+
 ### Docker Community Edition 17.06.0-ce-mac17, 2017-06-28 (edge)
 
 **Upgrades**

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -445,7 +445,7 @@ events or unexpected unmounts.
 - [Docker Machine 0.12.2](https://github.com/docker/machine/releases/tag/v0.12.2)  
 - Linux Kernel 4.9.38
 
-  **New**
+**New**
 
 - Transparent proxy using macOS system proxies (if defined) directly
 - GUI settings are now stored in `~/Library/Group\ Containers/group.com.docker/settings.json`. `daemon.json` in now a file in `~/.docker/`

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -1,6 +1,6 @@
 ---
 description: Change log / release notes per release
-keywords: pinata, alpha, tutorial
+keywords: Docker for Mac, edge, stable, release notes
 redirect_from:
 - /mackit/release-notes/
 title: Docker for Mac release notes

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -19,6 +19,64 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
+### Docker Community Edition 17.07.0-ce-rc3-mac23, 2017-08-21 (stable)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc3](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc3)
+
+**New**
+
+- VPNKit: Added support for ping!
+- VPNKit: Added slirp/port-max-idle-timeout to allow the timeout to be adjusted or even disabled
+- VPNKit: Bridge mode is default everywhere now
+
+**Bug fixes and minor changes**
+
+- VPNKit: Improved the logging around the Unix domain socket connections
+- VPNKit: Automatically trim whitespace from int or bool database keys
+
+### Docker Community Edition 17.07.0-ce-rc2-mac22, 2017-08-11 (stable)
+
+* Upgrades
+  - [Docker 17.07.0-ce-rc2](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc2)
+  - Linux Kernel 4.9.41
+
+### Docker Community Edition 17.07.0-ce-rc1-mac21, 2017-07-31 (stable)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc1)
+- [Docker compose 1.15.0](https://github.com/docker/compose/releases/tag/1.15.0)
+- [Docker Machine 0.12.2](https://github.com/docker/machine/releases/tag/v0.12.2)  
+- Linux Kernel 4.9.38
+
+**New**
+
+- Transparent proxy using macOS system proxies (if defined) directly
+- GUI settings are now stored in `~/Library/Group\ Containers/group.com.docker/settings.json`. `daemon.json` in now a file in `~/.docker/`
+- You can now change the default IP address used by Hyperkit if it collides with your network
+
+**Bug fixes and minor changes**
+
+- Add daemon options validation
+- Diagnose can be cancelled & Improved help information. Fixes [docker/for-mac#1134](https://github.com/docker/for-mac/issues/1134), [docker/for-mac#1474](https://github.com/docker/for-mac/issues/1474)
+- Support paging of docker-cloud repositories & orgs. Fixes [docker/for-mac#1538](https://github.com/docker/for-mac/issues/1538)
+
+### Docker Community Edition 17.06.1-ce-mac20, 2017-07-18 (stable)
+
+**Upgrades**
+
+- [Docker 17.06.1-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce-rc1)
+- Linux Kernel 4.9.36
+- AUFS 20170703
+
+**Bug fixes and minor changes**
+
+- DNS Fixes. Fixes [docker/for-mac#1763](https://github.com/docker/for-mac/issues/176), [docker/for-mac#1811](https://github.com/docker/for-mac/issues/1811), [docker/for-mac#1803](https://github.com/docker/for-mac/issues/1803)
+
+- Avoid unnecessary VM reboot (when changing proxy exclude, but no proxy set). Fixes [docker/for-mac#1809](https://github.com/docker/for-mac/issues/1809), [docker/for-mac#1801](https://github.com/docker/for-mac/issues/1801)
+
 ### Docker Community Edition 17.06.0-ce-mac18, 2017-06-28 (stable)
 
 **Upgrades**
@@ -397,6 +455,30 @@ events or unexpected unmounts.
 * Docker Compose 1.8.0
 
 ## Edge Release Notes
+
+### Docker Community Edition 17.07.0-ce-rc3-mac23, 2017-08-21 (edge)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc3](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc3)
+
+**New**
+
+- VPNKit: Added support for ping!
+- VPNKit: Added `slirp/port-max-idle-timeout` to allow the timeout to be adjusted or even disabled
+- VPNKit: Bridge mode is default everywhere now
+
+**Bug fixes and minor changes**
+
+- VPNKit: Improved the logging around the Unix domain socket connections
+- VPNKit: Automatically trim whitespace from int or bool database keys
+
+### Docker Community Edition 17.07.0-ce-rc2-mac22, 2017-08-11 (edge)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc2](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc2)
+- Linux Kernel 4.9.41
 
 ### Docker Community Edition 17.07.0-ce-rc1-mac21, 2017-07-31 (edge)
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -19,51 +19,7 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
-### Docker Community Edition 17.07.0-ce-rc3-mac23, 2017-08-21 (stable)
-
-**Upgrades**
-
-- [Docker 17.07.0-ce-rc3](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc3)
-
-**New**
-
-- VPNKit: Added support for ping!
-- VPNKit: Added slirp/port-max-idle-timeout to allow the timeout to be adjusted or even disabled
-- VPNKit: Bridge mode is default everywhere now
-
-**Bug fixes and minor changes**
-
-- VPNKit: Improved the logging around the Unix domain socket connections
-- VPNKit: Automatically trim whitespace from int or bool database keys
-
-### Docker Community Edition 17.07.0-ce-rc2-mac22, 2017-08-11 (stable)
-
-* Upgrades
-  - [Docker 17.07.0-ce-rc2](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc2)
-  - Linux Kernel 4.9.41
-
-### Docker Community Edition 17.07.0-ce-rc1-mac21, 2017-07-31 (stable)
-
-**Upgrades**
-
-- [Docker 17.07.0-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc1)
-- [Docker compose 1.15.0](https://github.com/docker/compose/releases/tag/1.15.0)
-- [Docker Machine 0.12.2](https://github.com/docker/machine/releases/tag/v0.12.2)  
-- Linux Kernel 4.9.38
-
-**New**
-
-- Transparent proxy using macOS system proxies (if defined) directly
-- GUI settings are now stored in `~/Library/Group\ Containers/group.com.docker/settings.json`. `daemon.json` in now a file in `~/.docker/`
-- You can now change the default IP address used by Hyperkit if it collides with your network
-
-**Bug fixes and minor changes**
-
-- Add daemon options validation
-- Diagnose can be cancelled & Improved help information. Fixes [docker/for-mac#1134](https://github.com/docker/for-mac/issues/1134), [docker/for-mac#1474](https://github.com/docker/for-mac/issues/1474)
-- Support paging of docker-cloud repositories & orgs. Fixes [docker/for-mac#1538](https://github.com/docker/for-mac/issues/1538)
-
-### Docker Community Edition 17.06.1-ce-mac20, 2017-07-18 (stable)
+### Docker Community Edition 17.06.1-ce-mac20, 2017-08-21 (stable)
 
 **Upgrades**
 
@@ -471,7 +427,7 @@ events or unexpected unmounts.
 **Bug fixes and minor changes**
 
 - VPNKit: Improved the logging around the Unix domain socket connections
-- VPNKit: Automatically trim whitespace from int or bool database keys
+- VPNKit: Automatically trim whitespace from `int` or `bool` database keys
 
 ### Docker Community Edition 17.07.0-ce-rc2-mac22, 2017-08-11 (edge)
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -19,7 +19,64 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
-### Docker CommunityEdition 17.06.0-ce-win18 2017-06-28 (stable)
+### Docker Community Edition 17.07.0-ce-rc3-win23 2017-08-21 (stable)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc3](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc3)
+
+**New**
+
+- Store Linux daemon configuration in `~\.docker\daemon.json` instead of settings file
+- Store Windows daemon configuration in C:\ProgramData\Docker\config\daemon.json instead of settings file
+- VPNKit: Added support for ping!
+- VPNKit: Added `slirp/port-max-idle-timeout` to allow the timeout to be adjusted or even disabled
+- VPNKit: Bridge mode is default everywhere now
+
+* Bug fixes and minor changes
+- VPNKit: Improved the logging around the Unix domain socket connections
+- VPNKit: Automatically trim whitespace from int or bool database keys
+
+### Docker Community Edition 17.07.0-ce-rc2-win22 2017-08-11 (stable)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc2](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc2)
+- Linux Kernel 4.9.41
+
+### Docker Community Edition 17.07.0-ce-rc1-win21 2017-07-31 (stable)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc1)
+- [Docker compose 1.15.0](https://github.com/docker/compose/releases/tag/1.15.0)
+- [Docker Machine 0.12.2](https://github.com/docker/machine/releases/tag/v0.12.2)
+- Linux Kernel 4.9.38
+
+**New**
+
+- Windows Docker daemon is now started as service for better lifecycle management
+
+**Bug fixes and minor**
+
+- Keep Docker info in the same place as before in the registry, used by Visual Studio 2017 (Fixes [docker/for-win#939](https://github.com/docker/for-win/issues/939))
+- Fixed `config.json` not being released properly (Fixes [docker/for-win#867](https://github.com/docker/for-win/issues/867))
+- Do not move credentials in credential store at startup
+
+### Docker Community Edition 17.06.1-ce-rc1-win20 2017-07-18 (stable)
+
+**Upgrades**
+
+- [Docker 17.06.1-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce-rc1)
+- Linux Kernel 4.9.36
+- AUFS 20170703
+
+**Bug fixes and minor**
+
+- Fix locked container id file (Fixes [docker/for-win#818](https://github.com/docker/for-win/issues/818))
+- Avoid expanding variables in PATH env variable (Fixes [docker/for-win#859](https://github.com/docker/for-win/issues/859)))
+
+### Docker Community Edition 17.06.0-ce-win18 2017-06-28 (stable)
 
 **Upgrades**
 
@@ -347,7 +404,33 @@ We did not distribute a 1.12.4 stable release
 
 ## Edge Release Notes
 
-### Docker Community Edition 17.06.0-win17 Release Notes (2017-07-31 17.06.0-win17) (edge)
+### Docker Community Edition 17.06.0-rc3-win23 Release Notes (2017-08-21 17.07.0-win23) (edge)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc3](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc3)
+
+**New**
+
+- Store Linux daemon configuration in ~\.docker\daemon.json instead of settings file
+- Store Windows daemon configuration in C:\ProgramData\Docker\config\daemon.json instead of settings file
+- VPNKit: Added support for ping!
+- VPNKit: Added slirp/port-max-idle-timeout to allow the timeout to be adjusted or even disabled
+- VPNKit: Bridge mode is default everywhere now
+
+* Bug fixes and minor changes
+- VPNKit: Improved the logging around the Unix domain socket connections
+- VPNKit: Automatically trim whitespace from int or bool database keys
+
+### Docker Community Edition 17.07.0-ce-rc2-win22 Release Notes (2017-08-11 17.06.0-win22) (edge)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc2](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc2)
+- Linux Kernel 4.9.41
+
+
+### Docker Community Edition 17.07.0-ce-rc1-win21 Release Notes (2017-07-31 17.07.0-win21) (edge)
 
 **Upgrades**
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -19,51 +19,7 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
-### Docker Community Edition 17.07.0-ce-rc3-win23 2017-08-21 (stable)
-
-**Upgrades**
-
-- [Docker 17.07.0-ce-rc3](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc3)
-
-**New**
-
-- Store Linux daemon configuration in `~\.docker\daemon.json` instead of settings file
-- Store Windows daemon configuration in C:\ProgramData\Docker\config\daemon.json instead of settings file
-- VPNKit: Added support for ping!
-- VPNKit: Added `slirp/port-max-idle-timeout` to allow the timeout to be adjusted or even disabled
-- VPNKit: Bridge mode is default everywhere now
-
-* Bug fixes and minor changes
-- VPNKit: Improved the logging around the Unix domain socket connections
-- VPNKit: Automatically trim whitespace from int or bool database keys
-
-### Docker Community Edition 17.07.0-ce-rc2-win22 2017-08-11 (stable)
-
-**Upgrades**
-
-- [Docker 17.07.0-ce-rc2](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc2)
-- Linux Kernel 4.9.41
-
-### Docker Community Edition 17.07.0-ce-rc1-win21 2017-07-31 (stable)
-
-**Upgrades**
-
-- [Docker 17.07.0-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc1)
-- [Docker compose 1.15.0](https://github.com/docker/compose/releases/tag/1.15.0)
-- [Docker Machine 0.12.2](https://github.com/docker/machine/releases/tag/v0.12.2)
-- Linux Kernel 4.9.38
-
-**New**
-
-- Windows Docker daemon is now started as service for better lifecycle management
-
-**Bug fixes and minor**
-
-- Keep Docker info in the same place as before in the registry, used by Visual Studio 2017 (Fixes [docker/for-win#939](https://github.com/docker/for-win/issues/939))
-- Fixed `config.json` not being released properly (Fixes [docker/for-win#867](https://github.com/docker/for-win/issues/867))
-- Do not move credentials in credential store at startup
-
-### Docker Community Edition 17.06.1-ce-rc1-win20 2017-07-18 (stable)
+### Docker Community Edition 17.06.1-ce-rc1-win20 2017-08-21 (stable)
 
 **Upgrades**
 
@@ -404,7 +360,7 @@ We did not distribute a 1.12.4 stable release
 
 ## Edge Release Notes
 
-### Docker Community Edition 17.06.0-rc3-win23 Release Notes (2017-08-21 17.07.0-win23) (edge)
+### Docker Community Edition 17.07.0-rc3-win23 Release Notes (2017-08-21 17.07.0-win23) (edge)
 
 **Upgrades**
 
@@ -412,15 +368,16 @@ We did not distribute a 1.12.4 stable release
 
 **New**
 
-- Store Linux daemon configuration in ~\.docker\daemon.json instead of settings file
-- Store Windows daemon configuration in C:\ProgramData\Docker\config\daemon.json instead of settings file
+- Store Linux daemon configuration in `~\.docker\daemon.json` instead of settings file
+- Store Windows daemon configuration in `C:\ProgramData\Docker\config\daemon.json` instead of settings file
 - VPNKit: Added support for ping!
-- VPNKit: Added slirp/port-max-idle-timeout to allow the timeout to be adjusted or even disabled
+- VPNKit: Added `slirp/port-max-idle-timeout` to allow the timeout to be adjusted or even disabled
 - VPNKit: Bridge mode is default everywhere now
 
-* Bug fixes and minor changes
+**Bug fixes and minor changes**
+
 - VPNKit: Improved the logging around the Unix domain socket connections
-- VPNKit: Automatically trim whitespace from int or bool database keys
+- VPNKit: Automatically trim whitespace from `int` or `bool` database keys
 
 ### Docker Community Edition 17.07.0-ce-rc2-win22 Release Notes (2017-08-11 17.06.0-win22) (edge)
 
@@ -428,7 +385,6 @@ We did not distribute a 1.12.4 stable release
 
 - [Docker 17.07.0-ce-rc2](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc2)
 - Linux Kernel 4.9.41
-
 
 ### Docker Community Edition 17.07.0-ce-rc1-win21 Release Notes (2017-07-31 17.07.0-win21) (edge)
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -1,6 +1,6 @@
 ---
 description: Change log / release notes per release
-keywords: pinata, alpha, tutorial
+keywords: Docker for Windows, edge, stable, release notes
 redirect_from:
 - /winkit/release-notes/
 title: Docker for Windows Release notes

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -347,6 +347,38 @@ We did not distribute a 1.12.4 stable release
 
 ## Edge Release Notes
 
+### Docker Community Edition 17.06.0-win17 Release Notes (2017-07-31 17.06.0-win17) (edge)
+
+**Upgrades**
+
+- [Docker 17.07.0-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.07.0-ce-rc1)
+- [Docker compose 1.15.0](https://github.com/docker/compose/releases/tag/1.15.0)
+- [Docker Machine 0.12.2](https://github.com/docker/machine/releases/tag/v0.12.2)
+- Linux Kernel 4.9.38
+
+**New**
+
+- Windows Docker daemon is now started as service for better lifecycle management
+
+**Bug fixes and minor changes**
+
+- Keep Docker info in the same place as before in the registry, used by Visual Studio 2017 (Fixes [docker/for-win#939](https://github.com/docker/for-win/issues/939))
+- Fix `config.json` not being released properly (Fixes [docker/for-win#867](https://github.com/docker/for-win/issues/867))
+- Do not anymore move credentials in credential store at startup
+
+### Docker Community Edition 17.06.1-ce-rc1-win20 Release Notes (2017-07-18 17.06.1-win20) (edge)
+
+**Upgrades**
+
+- [Docker 17.06.1-ce-rc1](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce-rc1)
+- Linux Kernel 4.9.36
+- AUFS 20170703
+
+**Bug fixes and minor changes**
+
+- Fix locked container id file (Fixes [docker/for-win#818](https://github.com/docker/for-win/issues/818))
+- Avoid expanding variables in PATH env variable (Fixes [docker/for-win#859](https://github.com/docker/for-win/issues/859))
+
 ### Docker Community Edition 17.06.0-win17 Release Notes (2017-06-28 17.06.0-win17) (edge)
 
 **Upgrades**


### PR DESCRIPTION
### What's changed

- added edge release notes for d4mac 17.07.0 
- added edge release notes for d4win 17.07.0
- added stable release notes for d4mac 17.06.1 
- added stable release notes for d4win 17.06.1

### Reviewers

@jeanlaurent @friism @ebriney @djs55 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

