### PR TITLE
Fix links to subtopics in index.md files by include full path

### DIFF
--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -375,7 +375,7 @@ Links also express dependency between services in the same way as
 ### log_driver
 
 > [Version 1 file format](compose-versioning#version-1) only. In version 2 and up, use
-> [logging](index.md#logging).
+> [logging](/compose/compose-file/index.md#logging).
 
 Specify a log driver. The default is `json-file`.
 
@@ -384,7 +384,7 @@ Specify a log driver. The default is `json-file`.
 ### log_opt
 
 > [Version 1 file format](compose-versioning#version-1) only. In version 2 and up, use
-> [logging](index.md#logging).
+> [logging](/compose/compose-file/index.md#logging).
 
 Specify logging options as key-value pairs. An example of `syslog` options:
 
@@ -394,7 +394,7 @@ Specify logging options as key-value pairs. An example of `syslog` options:
 ### net
 
 > [Version 1 file format](compose-versioning.md#version-1) only. In version 2 and up, use
-> [network_mode](index.md#networkmode) and [networks](index.md#networks).
+> [network_mode](/compose/compose-file/index.md#networkmode) and [networks](/compose/compose-file/index.md#networks).
 
 Network mode. Use the same values as the docker client `--net` parameter.
 The `container:...` form can take a service name instead of a container name or

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -75,18 +75,18 @@ These differences are explained below.
 ### Version 1
 
 Compose files that do not declare a version are considered "version 1". In those
-files, all the [services](index.md#service-configuration-reference) are
+files, all the [services](/compose/compose-file/index.md#service-configuration-reference) are
 declared at the root of the document.
 
 Version 1 is supported by **Compose up to 1.6.x**. It will be deprecated in a
 future Compose release.
 
 Version 1 files cannot declare named
-[volumes](index.md#volume-configuration-reference), [networks](index.md#network-configuration-reference) or
-[build arguments](index.md#args).
+[volumes](/compose/compose-file/index.md#volume-configuration-reference), [networks](/compose/compose-file/index.md#network-configuration-reference) or
+[build arguments](/compose/compose-file/index.md#args).
 
-Compose does not take advantage of [networking](index.md#networking.md) when you use
-version 1: every container is placed on the default `bridge` network and is
+Compose does not take advantage of [networking](/compose/networking.md) when you
+use version 1: every container is placed on the default `bridge` network and is
 reachable from every other container at its IP address. You will need to use
 [links](compose-file-v1.md#links) to enable discovery between containers.
 
@@ -225,7 +225,7 @@ several more.
 the [upgrading](#upgrading) guide for how to migrate away from these.
 (For more information on `extends`, please see [Extending services](/compose/extends.md#extending-services).)
 
-- Added: [deploy](index.md#deploy)
+- Added: [deploy](/compose/compose-file/index.md#deploy)
 
 ### Version 3.3
 
@@ -234,10 +234,10 @@ available with Docker Engine version **17.06.0+**, and higher.
 
 Introduces the following additional parameters:
 
-- [build `labels`](index.md#build)
-- [`credential_spec`](index.md#credentialspec)
-- [`configs`](index.md#configs)
-- [deploy `endpoint_mode`](index.md#endpointmode)
+- [build `labels`](/compose/compose-file/index.md#build)
+- [`credential_spec`](/compose/compose-file/index.md#credentialspec)
+- [`configs`](/compose/compose-file/index.md#configs)
+- [deploy `endpoint_mode`](/compose/compose-file/index.md#endpointmode)
 
 ## Upgrading
 
@@ -248,7 +248,7 @@ several options have been removed:
 
 -   `volume_driver`: Instead of setting the volume driver on the service, define
     a volume using the
-    [top-level `volumes` option](index.md#volume-configuration-reference)
+    [top-level `volumes` option](/compose/compose-file/index.md#volume-configuration-reference)
     and specify the driver there.
 
         version: "3"
@@ -262,12 +262,12 @@ several options have been removed:
             driver: mydriver
 
 -   `volumes_from`: To share a volume between services, define it using the
-    [top-level `volumes` option](index.md#volume-configuration-reference)
+    [top-level `volumes` option](/compose/compose-file/index.md#volume-configuration-reference)
     and reference it from each service that shares it using the
-    [service-level `volumes` option](index.md#volumes-volumedriver).
+    [service-level `volumes` option](/compose/compose-file/index.md#volumes-volumedriver).
 
 -   `cpu_shares`, `cpu_quota`, `cpuset`, `mem_limit`, `memswap_limit`: These
-    have been replaced by the [resources](index.md#resources) key under
+    have been replaced by the [resources](/compose/compose-file/index.md#resources) key under
     `deploy`. Note that `deploy` configuration only takes effect when using
     `docker stack deploy`, and is ignored by `docker-compose`.
 

--- a/docker-for-aws/faqs.md
+++ b/docker-for-aws/faqs.md
@@ -46,7 +46,7 @@ This AWS documentation page will describe how you can tell if you have EC2-Class
 ### Possible fixes to the EC2-Classic region issue:
 There are a few workarounds that you can try to get Docker for AWS up and running for you.
 
-1. Create your own VPC, then [install Docker for AWS with a pre-existing VPC](index.md#install-with-an-existing-vpc).
+1. Create your own VPC, then [install Docker for AWS with a pre-existing VPC](/docker-for-aws/index.md#install-with-an-existing-vpc).
 2. Use a region that doesn't have **EC2-Classic**. The most common region with this issue is `us-east-1`. So try another region, `us-west-1`, `us-west-2`, or the new `us-east-2`. These regions will more then likely be setup with **EC2-VPC** and you will not longer have this issue.
 3. Create an new AWS account, all new accounts will be setup using **EC2-VPC** and will not have this problem.
 4. Contact AWS support to convert your **EC2-Classic** account to a **EC2-VPC** account. For more information checkout the following answer for **"Q. I really want a default VPC for my existing EC2 account. Is that possible?"** on https://aws.amazon.com/vpc/faqs/#Default_VPCs
@@ -61,7 +61,7 @@ There are a few workarounds that you can try to get Docker for AWS up and runnin
 
 ## Can I use my existing VPC?
 
-Yes, see [install Docker for AWS with a pre-existing VPC](index.md#install-with-an-existing-vpc) for more info.
+Yes, see [install Docker for AWS with a pre-existing VPC](/docker-for-aws/index.md#install-with-an-existing-vpc) for more info.
 
 ## Recommended VPC and subnet setup
 

--- a/docker-for-aws/release-notes.md
+++ b/docker-for-aws/release-notes.md
@@ -123,7 +123,7 @@ Release date: 02/16/2017
 **New**
 
 - Docker Engine upgraded to [Docker 1.13.1](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- Added a second CloudFormation template that allows you to [install Docker for AWS into a pre-existing VPC](index.md#install-into-an-existing-vpc).
+- Added a second CloudFormation template that allows you to [install Docker for AWS into a pre-existing VPC](/docker-for-aws/index.md#install-into-an-existing-vpc).
 - Added Swarm wide support for [persistent storage volumes](persistent-data-volumes.md)
 - Added the following engine labels
     - **os** (linux)

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -24,7 +24,7 @@ installers from the Stable or beta channel.
 Both Stable and Edge installers come with <a
 href="https://github.com/moby/moby/blob/master/experimental/README.md">
 experimental features in Docker Engine</a> enabled by default and configurable
-on [Docker Daemon preferences](index.md#daemon-experimental-mode) for
+on [Docker Daemon preferences](/docker-for-mac/index.md#daemon-experimental-mode) for
 experimental mode. We recommend that you disable experimental features for
 apps in production.
 

--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -93,7 +93,7 @@ container. Note that this is what you have to do even on Linux if the container
 is on an overlay network, not a bridge network, as these are not routed.
 
 The command to run the `nginx` webserver shown in [Getting
-Started](index.md#explore-the-application-and-run-examples) is an example of this.
+Started](/docker-for-mac/index.md#explore-the-application-and-run-examples) is an example of this.
 
 ```bash
 $ docker run -d -p 80:80 --name webserver nginx

--- a/docker-for-mac/osxfs.md
+++ b/docker-for-mac/osxfs.md
@@ -59,7 +59,7 @@ By default, you can share files in `/Users/`, `/Volumes/`, `/private/`, and
 `/tmp` directly. To add or remove directory trees that are exported to Docker,
 use the **File sharing** tab in Docker preferences ![whale
 menu](/docker-for-mac/images/whale-x.png){: .inline} -> **Preferences** ->
-**File sharing**. (See [Preferences](index.md#preferences).)
+**File sharing**. (See [Preferences](/docker-for-mac/index.md#preferences).)
 
 All other paths
 used in `-v` bind mounts are sourced from the Moby Linux VM running the Docker

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -637,7 +637,7 @@ events or unexpected unmounts.
 
 **New**
 
-- More options when moving disk image (see [Storage location](index.md#storage-location) under Advanced preference settings)
+- More options when moving disk image (see [Storage location](/docker-for-mac/index.md#storage-location) under Advanced preference settings)
 - Filesharing and daemon table empty fields are editable
 - DNS forwarder ignores responses from malfunctioning servers ([docker/for-mac#1025](https://github.com/docker/for-mac/issues/1025))
 - DNS forwarder send all queries in parallel, process results in order
@@ -820,9 +820,9 @@ events or unexpected unmounts.
 
 **New**
 
-- Dedicated preference pane for advanced configuration of the docker daemon (edit daemon.json). See [[Daemon Advanced (JSON configuration file)](index.md#daemon-advanced-json-configuration-file).
+- Dedicated preference pane for advanced configuration of the docker daemon (edit daemon.json). See [[Daemon Advanced (JSON configuration file)](/docker-for-mac/index.md#daemon-advanced-json-configuration-file).
 
-- Docker Experimental mode can be toggled. See [Daemon Basic (experimental mode and registries)](index.md#daemon-basic-experimental-mode-and-registries).
+- Docker Experimental mode can be toggled. See [Daemon Basic (experimental mode and registries)](/docker-for-mac/index.md#daemon-basic-experimental-mode-and-registries).
 
 **Upgrades**
 
@@ -1116,7 +1116,7 @@ events or unexpected unmounts.
 
 **New**
 
-* Docker for Mac is now available from 2 channels: **stable** and **beta**. New features and bug fixes will go out first in auto-updates to users in the beta channel. Updates to the stable channel are much less frequent and happen in sync with major and minor releases of the Docker engine. Only features that are well-tested and ready for production are added to the stable channel releases. For downloads of both and more information, see the [Getting Started](index.md#download-docker-for-mac).
+* Docker for Mac is now available from 2 channels: **stable** and **beta**. New features and bug fixes will go out first in auto-updates to users in the beta channel. Updates to the stable channel are much less frequent and happen in sync with major and minor releases of the Docker engine. Only features that are well-tested and ready for production are added to the stable channel releases. For downloads of both and more information, see the [Getting Started](/docker-for-mac/index.md#download-docker-for-mac).
 
 **Upgrades**
 

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -153,7 +153,7 @@ See also, the discussion on the issue [docker/for-mac#1209](https://github.com/d
 If you are using mounted volumes and get runtime errors indicating an
 application file is not found, a volume mount is denied, or a service cannot
 start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might
-need to enable [file sharing](index.md#file-sharing).
+need to enable [file sharing](/docker-for-mac/index.md#file-sharing).
 
 Volume mounting requires shared drives for projects that live outside of the
 `/Users` directory. Go to ![whale menu](/docker-for-mac/images/whale-x.png){:
@@ -257,7 +257,7 @@ know before you install](install.md#what-to-know-before-you-install).
         Pulling repository docker.io/library/busybox
         Network timed out while trying to connect to https://index.docker.io/v1/repositories/library/busybox/images. You may want to check your internet connection or if you are behind a proxy.
 
-    Starting with v1.12.1, 2016-09016 on the stable channel, and Beta 24 on the beta channel, a workaround is provided that auto-filters out the IPv6 addresses in DNS server lists and enables successful network accesss. For example, `2001:4860:4860::8888` would become `8.8.8.8`. So, the only workaround action needed for users is to [upgrade to Docker for Mac stable v1.12.1 or newer, or Beta 24 or newer](index.md#download-docker-for-mac).
+    Starting with v1.12.1, 2016-09016 on the stable channel, and Beta 24 on the beta channel, a workaround is provided that auto-filters out the IPv6 addresses in DNS server lists and enables successful network accesss. For example, `2001:4860:4860::8888` would become `8.8.8.8`. So, the only workaround action needed for users is to [upgrade to Docker for Mac stable v1.12.1 or newer, or Beta 24 or newer](/docker-for-mac/install.md#download-docker-for-mac).
 
     On releases with the workaround included to filter out / truncate IPv6 addresses from the DNS list, the above command should run properly:
 

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -228,7 +228,7 @@ To learn more about using Docker for Windows and Docker Machine, see
 ### How do I run Windows containers on Docker on Windows Server 2016?
 
 See [About Windows containers and Windows Server
-2016](index.md#about-windows-containers-and-windows-server-2016).
+2016](/docker-for-windows/index.md#about-windows-containers-and-windows-server-2016).
 
 A full tutorial is available in [docker/labs](https://github.com/docker/labs) at
 [Getting Started with Windows

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -26,10 +26,10 @@ download installers from the **Stable** or **Edge** channel.
 
 Both Stable and Edge installers come with <a
 href="https://github.com/moby/moby/blob/master/experimental/README.md">
-experimental features in Docker Engine</a> enabled by default. Experimental mode can be toggled on and off in [preferences](index.md#daemon-experimental-mode).
+experimental features in Docker Engine</a> enabled by default. Experimental mode can be toggled on and off in [preferences](/docker-for-windows/index.md#daemon-experimental-mode).
 
 We welcome your
-[feedback](index.md#giving-feedback-and-getting-help) to help us improve Docker for Windows.
+[feedback](/docker-for-windows/index.md#giving-feedback-and-getting-help) to help us improve Docker for Windows.
 
 For more about Stable and Edge channels, see the
 [FAQs](/docker-for-windows/faqs.md#questions-about-stable-and-edge-channels).

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -731,9 +731,9 @@ registry access (fixes [docker/for-win#569](https://github.com/docker/for-win/is
 **New**
 
 - Windows containers settings panel and options are working. In previous releases, settings were not implemented for [Windows containers
-mode](index.md#switch-between-windows-and-linux-containers-beta-feature). (See
+mode](/docker-for-windows/index.md#switch-between-windows-and-linux-containers-beta-feature). (See
 [About the Docker Windows containers specific
-dialogs](index.md#about-the-docker-windows-containers-specific-dialogs).)
+dialogs](/docker-for-windows/index.md#about-the-docker-windows-containers-specific-dialogs).)
 - Windows containers: Restart from the settings panel works
 - Windows containers: Factory default
 - Windows containers: `Daemon.json` can be modified
@@ -1071,7 +1071,7 @@ Unreleased. See Beta 23 for changes.
 
 **New**
 
-* Docker for Windows is now available from 2 channels: **stable** and **beta**. New features and bug fixes will go out first in auto-updates to users in the beta channel. Updates to the stable channel are much less frequent and happen in sync with major and minor releases of the Docker engine. Only features that are well-tested and ready for production are added to the stable channel releases. For downloads of both and more information, see the [Getting Started](index.md#download-docker-for-windows).
+* Docker for Windows is now available from 2 channels: **stable** and **beta**. New features and bug fixes will go out first in auto-updates to users in the beta channel. Updates to the stable channel are much less frequent and happen in sync with major and minor releases of the Docker engine. Only features that are well-tested and ready for production are added to the stable channel releases. For downloads of both and more information, see the [Getting Started](/docker-for-windows/index.md#download-docker-for-windows).
 
 * Removed the docker host name. Containers with exported ports are reachable via localhost.
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -23,7 +23,7 @@ documentation, on [Docker for Windows issues on
 GitHub](https://github.com/docker/for-win/issues), or the [Docker for Windows
 forum](https://forums.docker.com/c/docker-for-windows), we can help you
 troubleshoot the log data. See [Diagnose and
-Feedback](index.md#diagnose-and-feedback) to learn about diagnostics and how to
+Feedback](/docker-for-windows/index.md#diagnose-and-feedback) to learn about diagnostics and how to
 create new issues on GitHub.
 
 ## Checking the Logs
@@ -118,7 +118,7 @@ applications](https://github.com/remy/nodemon#application-isnt-restarting)
 If you are using mounted volumes and get runtime errors indicating an
 application file is not found, a volume mount is denied, or a service cannot
 start (e.g., with [Docker Compose](/compose/gettingstarted.md)), you might need
-to enable [shared drives](index.md#shared-drives).
+to enable [shared drives](/docker-for-windows/index.md#shared-drives).
 
 Volume mounting requires shared drives for Linux containers
 (not for Windows containers). Go to
@@ -129,11 +129,11 @@ contains the Dockerfile and volume.
 ### Verify domain user has permissions for shared drives (volumes)
 
 >**Tip**: Shared drives are only required for volume mounting [Linux
-containers](index.md#switch-between-windows-and-linux-containers),
+containers](/docker-for-windows/index.md#switch-between-windows-and-linux-containers),
 not Windows containers.
 
 Permissions to access shared drives are tied to the username and password you
-use to set up [shared drives](index.md#shared-drives). If you run `docker`
+use to set up [shared drives](/docker-for-windows/index.md#shared-drives). If you run `docker`
 commands and tasks under a different username than the one used to set up shared
 drives, your containers will not have permissions to access the mounted volumes.
 The volumes will show as empty.
@@ -162,7 +162,7 @@ local user is `samstevens` and the domain user is `merlin`.
 
 		net share c /delete
 
-4. Re-share the drive via the [Shared Drives dialog](index.md#shared-drives), and provide the Windows domain user account credentials.
+4. Re-share the drive via the [Shared Drives dialog](/docker-for-windows/index.md#shared-drives), and provide the Windows domain user account credentials.
 
 5. Re-run `net share c`.
 
@@ -207,7 +207,7 @@ Compose file documentation.
 ### Local security policies can block shared drives and cause login errors
 
 You need permissions to mount shared drives in order to use the Docker for
-Windows [shared drives](index.md#shared-drives) feature.
+Windows [shared drives](/docker-for-windows/index.md#shared-drives) feature.
 
 If local policy prevents this, you will get errors when you attempt to enable
 shared drives on Docker. This is not something Docker can resolve, you do need
@@ -388,7 +388,7 @@ this switch.
 
 If you have questions about how to set up and run Windows containers on Windows
 Server 2016 or Windows 10, see [About Windows containers and Windows Server
-2016](index.md#about-windows-containers-and-windows-server-2016).
+2016](/docker-for-windows/index.md#about-windows-containers-and-windows-server-2016).
 
 A full tutorial is available in [docker/labs](https://github.com/docker/labs) at
 [Getting Started with Windows
@@ -527,7 +527,7 @@ Here is an example command and error message:
 	C:\Program Files\Docker\Docker\Resources\bin\docker.exe: Error while pulling image: Get https://index.docker.io/v1/repositories/library/hello-world/images: dial tcp: lookup index.docker.io on 10.0.75.1:53: no such host.
 	See 'C:\Program Files\Docker\Docker\Resources\bin\docker.exe run --help'.
 
-As an immediate workaround to this problem, reset the DNS server to use the Google DNS fixed address: `8.8.8.8`. You can configure this via the **Settings** -> **Network** dialog, as described in the topic [Network](index.md#network). Docker will automatically restart when you apply this setting, which could take some time.
+As an immediate workaround to this problem, reset the DNS server to use the Google DNS fixed address: `8.8.8.8`. You can configure this via the **Settings** -> **Network** dialog, as described in the topic [Network](/docker-for-windows/index.md#network). Docker will automatically restart when you apply this setting, which could take some time.
 
 We are currently investigating this issue.
 
@@ -574,8 +574,8 @@ the adapter.
 
 By default, Docker for Windows uses an internal network prefix of
 `10.0.75.0/24`. Should this clash with your normal network setup, you can change
-the prefix from the **Settings** menu. See the [Network](index.md#network) topic
-under [Settings](index.md#docker-settings).
+the prefix from the **Settings** menu. See the [Network](/docker-for-windows/index.md#network) topic
+under [Settings](/docker-for-windows/index.md#docker-settings).
 
 #### NAT/IP configuration issues on pre Beta 15 versions
 
@@ -583,13 +583,13 @@ As of Beta 15, Docker for Windows is no longer using a switch with a NAT
 configuration. The notes below are left here only for older Beta versions.
 
 As of Beta14, networking for Docker for Windows is configurable through the UI.
-See the [Network](index.md#network) topic under
-[Settings](index.md#docker-settings).
+See the [Network](/docker-for-windows/index.md#network) topic under
+[Settings](/docker-for-windows/index.md#docker-settings).
 
 By default, Docker for Windows uses an internal Hyper-V switch with a NAT
 configuration with a `10.0.75.0/24` prefix. You can change the prefix used (as
 well as the DNS server) via the **Settings** menu as described in the
-[Network](index.md#network) topic.
+[Network](/docker-for-windows/index.md#network) topic.
 
 If you have additional Hyper-V VMs and they are attached to their own NAT
 prefixes, the prefixes need to be managed carefully, due to limitation of the

--- a/engine/swarm/swarm-tutorial/create-swarm.md
+++ b/engine/swarm/swarm-tutorial/create-swarm.md
@@ -27,7 +27,7 @@ machines.
 single-node swarm, simply run `docker swarm init` with no arguments. There is no
 need to specify `--advertise-addr` in this case. To learn more, see the topic
 on how to [Use Docker for Mac or Docker for
-Windows](index.md#use-docker-for-mac-or-docker-for-windows) with Swarm.
+Windows](/swarm/swarm-tutorial/index.md#use-docker-for-mac-or-docker-for-windows) with Swarm.
 
     In the tutorial, the following command creates a swarm on the `manager1`
     machine:

--- a/engine/swarm/swarm-tutorial/create-swarm.md
+++ b/engine/swarm/swarm-tutorial/create-swarm.md
@@ -27,7 +27,7 @@ machines.
 single-node swarm, simply run `docker swarm init` with no arguments. There is no
 need to specify `--advertise-addr` in this case. To learn more, see the topic
 on how to [Use Docker for Mac or Docker for
-Windows](/swarm/swarm-tutorial/index.md#use-docker-for-mac-or-docker-for-windows) with Swarm.
+Windows](/engine/swarm/swarm-tutorial/index.md#use-docker-for-mac-or-docker-for-windows) with Swarm.
 
     In the tutorial, the following command creates a swarm on the `manager1`
     machine:

--- a/registry/recipes/apache.md
+++ b/registry/recipes/apache.md
@@ -30,7 +30,7 @@ Furthermore, introducing an extra http layer in your communication pipeline will
 
 ## Setting things up
 
-Read again [the requirements](../index.md#requirements).
+Read again [the requirements](/registry/recipes/index.md#requirements).
 
 Ready?
 

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -67,7 +67,7 @@ properly. For more information, see
 
 ## Setting things up
 
-Review the [requirements](../index.md#requirements), then follow ese steps.
+Review the [requirements](/registry/recipes/index.md#requirements), then follow ese steps.
 
 1.  Create the required directories
 


### PR DESCRIPTION
### What changed

- Changed all links to `index.md` subtopics to include full path to the target topic instead of relative path to `index.md#<some-topic>. These links will now work with the Javascript that was reverted (re-included) in #4051

### Related

- PR #4051

- Marginally related to to issue #4044


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
