### PR TITLE
fixed links to on-page installs

### DIFF
--- a/engine/installation/linux/docker-ce/centos.md
+++ b/engine/installation/linux/docker-ce/centos.md
@@ -114,7 +114,7 @@ from the repository.
 
     [Learn about **stable** and **edge** builds](/engine/installation/).
 
-#### Install Docker
+#### Install Docker CE
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ce/centos.md
+++ b/engine/installation/linux/docker-ce/centos.md
@@ -10,7 +10,7 @@ title: Get Docker CE for CentOS
 
 To get started with Docker CE on CentOS, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ce).
 
 ## Prerequisites
 
@@ -114,7 +114,7 @@ from the repository.
 
     [Learn about **stable** and **edge** builds](/engine/installation/).
 
-#### Install Docker CE
+#### Install Docker
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -180,7 +180,7 @@ from the repository.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
 
-#### Install Docker
+#### Install Docker CE
 
 > **Note**: On Debian for ARM you can continue following this step. For Raspbian,
 > scroll down to follow its specific steps.

--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -12,7 +12,7 @@ title: Get Docker CE for Debian
 
 To get started with Docker CE on Debian, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ce).
 
 ## Prerequisites
 
@@ -180,7 +180,7 @@ from the repository.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
 
-#### Install Docker CE
+#### Install Docker
 
 > **Note**: On Debian for ARM you can continue following this step. For Raspbian,
 > scroll down to follow its specific steps.

--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -11,7 +11,7 @@ title: Get Docker CE for Fedora
 
 To get started with Docker CE on Fedora, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ce).
 
 ## Prerequisites
 
@@ -115,7 +115,7 @@ from the repository.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
 
-#### Install Docker CE
+#### Install Docker
 
 1.  Update the `dnf` package index.
 

--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -115,7 +115,7 @@ from the repository.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
 
-#### Install Docker
+#### Install Docker CE
 
 1.  Update the `dnf` package index.
 

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -175,7 +175,7 @@ the repository.
     [Learn about **stable** and **edge** channels](/engine/installation/).
 
 
-#### Install Docker
+#### Install Docker CE
 
 1.  Update the `apt` package index.
 

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -12,7 +12,7 @@ title: Get Docker CE for Ubuntu
 
 To get started with Docker CE on Ubuntu, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ce).
 
 ## Prerequisites
 
@@ -175,7 +175,7 @@ the repository.
     [Learn about **stable** and **edge** channels](/engine/installation/).
 
 
-#### Install Docker CE
+#### Install Docker
 
 1.  Update the `apt` package index.
 
@@ -231,8 +231,8 @@ the repository.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker CE is installed and running. You need to use `sudo` to run Docker commands.
-Continue to [Linux postinstall](../linux-postinstall.md) to allow
+Docker CE is installed and running. You need to use `sudo` to run Docker
+commands. Continue to [Linux postinstall](../linux-postinstall.md) to allow
 non-privileged users to run Docker commands and for other optional configuration
 steps.
 

--- a/engine/installation/linux/docker-ee/centos.md
+++ b/engine/installation/linux/docker-ee/centos.md
@@ -109,7 +109,7 @@ EE from the repository.
         <DOCKER-EE-URL>/centos/docker-ee.repo
     ```
 
-#### Install Docker EE
+#### Install Docker
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ee/centos.md
+++ b/engine/installation/linux/docker-ee/centos.md
@@ -109,7 +109,7 @@ EE from the repository.
         <DOCKER-EE-URL>/centos/docker-ee.repo
     ```
 
-#### Install Docker
+#### Install Docker EE
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ee/oracle.md
+++ b/engine/installation/linux/docker-ee/oracle.md
@@ -9,7 +9,7 @@ title: Get Docker EE for Oracle Linux
 
 To get started with Docker EE on Oracle Linux, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ee).
 
 ## Prerequisites
 
@@ -107,7 +107,7 @@ from the repository.
         <DOCKER-EE-URL>/oraclelinux/docker-ee.repo
     ```
 
-#### Install Docker EE
+#### Install Docker
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ee/oracle.md
+++ b/engine/installation/linux/docker-ee/oracle.md
@@ -107,7 +107,7 @@ from the repository.
         <DOCKER-EE-URL>/oraclelinux/docker-ee.repo
     ```
 
-#### Install Docker
+#### Install Docker EE
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ee/rhel.md
+++ b/engine/installation/linux/docker-ee/rhel.md
@@ -148,7 +148,7 @@ from the repository.
         <DOCKER-EE-URL>/rhel/docker-ee.repo
     ```
 
-#### Install Docker
+#### Install Docker EE
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ee/rhel.md
+++ b/engine/installation/linux/docker-ee/rhel.md
@@ -10,7 +10,7 @@ title: Get Docker EE for Red Hat Enterprise Linux
 
 To get started with Docker EE on Red Hat Enterprise Linux (RHEL), make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ee).
 
 ## Prerequisites
 
@@ -148,7 +148,7 @@ from the repository.
         <DOCKER-EE-URL>/rhel/docker-ee.repo
     ```
 
-#### Install Docker EE
+#### Install Docker
 
 1.  Update the `yum` package index.
 

--- a/engine/installation/linux/docker-ee/suse.md
+++ b/engine/installation/linux/docker-ee/suse.md
@@ -11,7 +11,7 @@ title: Get Docker EE for SLES
 
 To get started with Docker on SUSE Linux Enterprise Server (SLES), make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ee).
 
 ## Prerequisites
 
@@ -130,7 +130,7 @@ from the repository.
     $ sudo rpm --import <DOCKER-EE-URL/sles/gpg
     ```
 
-#### Install Docker EE
+#### Install Docker
 
 1.  Update the `zypper` package index.
 

--- a/engine/installation/linux/docker-ee/suse.md
+++ b/engine/installation/linux/docker-ee/suse.md
@@ -130,7 +130,7 @@ from the repository.
     $ sudo rpm --import <DOCKER-EE-URL/sles/gpg
     ```
 
-#### Install Docker
+#### Install Docker EE
 
 1.  Update the `zypper` package index.
 

--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -144,7 +144,7 @@ from the repository.
        stable-{{ minor-version }}"
     ```
 
-#### Install Docker
+#### Install Docker EE
 
 1.  Update the `apt` package index.
 

--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -12,7 +12,7 @@ title: Get Docker EE for Ubuntu
 
 To get started with Docker EE on Ubuntu, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker).
+[install Docker](#install-docker-ee).
 
 ## Prerequisites
 
@@ -144,7 +144,7 @@ from the repository.
        stable-{{ minor-version }}"
     ```
 
-#### Install Docker EE
+#### Install Docker
 
 1.  Update the `apt` package index.
 


### PR DESCRIPTION
### What's changed

In Get Docker install topics, fixed links to on-page install instructions for CE and EE, which required two things:

- match link path to target topic name (e.g., `install-docker-ce` or `install-docker-ee`,  instead of `install-docker`)

- rename duplicate named lower level subtopic, which was causing conflict and breaking the links even when they had the right target topic name (e.g., `Install Docker` instead of `Install Docker CE` or `Install Docker EE`)

### Related

- Marginally related to #4044



Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
