### PR TITLE
Fixed CSS padding on search autocompleteList

### DIFF
--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -258,7 +258,8 @@ div#autocompleteResults span {
 {
   list-style-type: none;
   width: 400px;
-  padding:0px;
+/* commented out 0px padding to allow inherit padding, search results on autocompleteList were getting smashed up against left margin due to this */
+/*  padding:0px; */
   margin-bottom: 0px;
 }
 .autoCompleteResult {


### PR DESCRIPTION
### What's new

- Fixed padding on search `autocompleteList` which was causing inline search results to get smashed up against left side of list menu

#### Before

![search-before](https://user-images.githubusercontent.com/11660803/28805230-54991a80-761d-11e7-9c7b-750dab4bf1f4.png)

#### After
![search-list-after](https://user-images.githubusercontent.com/11660803/28805285-c46c6236-761d-11e7-97e5-b0a4635bd260.png)


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

