### PR TITLE
Add link from config ref to config docs

### DIFF
--- a/engine/reference/commandline/config.md
+++ b/engine/reference/commandline/config.md
@@ -16,3 +16,7 @@ https://www.github.com/docker/cli
   {% include edge_only.md section="cliref" %}
 {% endif %}
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}
+
+## More info
+
+[Store configuration data using Docker Configs](/engine/swarm/configs.md)


### PR DESCRIPTION
Fixes #3997 

I'm not 100% convinced this is the right way to do this. The config reference is actually in `docker/cli`. Usually I'd put this link there. But this whole "top level" topic is a stub that is created automatically (other ones exist, like the one for [docker service](https://docs.docker.com/engine/reference/commandline/service/)). This seemed like the most expedient way to get this done for now. @johndmulhausen WDYT?

cc/ @mbentley 