### PR TITLE
Added better links to Compose overview docs

### DIFF
--- a/compose/index.md
+++ b/compose/index.md
@@ -13,7 +13,7 @@ Compose is a tool for defining and running multi-container Docker applications. 
 - [Get started with Django](django.md)
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
-- [Get started with Drupal](https://docs.docker.com/samples/drupal/)
+- [Get started with Drupal](/samples/drupal/)
 - [Frequently asked questions](faq.md)
 - [Command-line reference](./reference/index.md)
 - [Compose file reference](/compose/compose-file/index.md)

--- a/compose/index.md
+++ b/compose/index.md
@@ -10,13 +10,13 @@ Compose is a tool for defining and running multi-container Docker applications. 
 - [Compose Overview](overview.md)
 - [Install Compose](install.md)
 - [Getting Started](gettingstarted.md)
-- [Get started with Drupal](http://docker4drupal.org/)
 - [Get started with Django](django.md)
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
+- [Get started with Drupal](https://docs.docker.com/samples/drupal/)
 - [Frequently asked questions](faq.md)
 - [Command-line reference](./reference/index.md)
-- [Compose file reference](compose-file.md)
+- [Compose file reference](/compose/compose-file/index.md)
 - [Environment file](env-file.md)
 
 To see a detailed list of changes for past and current releases of Docker

--- a/compose/overview.md
+++ b/compose/overview.md
@@ -4,6 +4,8 @@ keywords: documentation, docs, docker, compose, orchestration, containers
 title: Overview of Docker Compose
 ---
 
+>**Looking for Compose file reference?** [Find the latest version here](/compose/compose-file/index.md).
+
 Compose is a tool for defining and running multi-container Docker applications.
 With Compose, you use a Compose file to configure your application's services.
 Then, using a single command, you create and start all the services


### PR DESCRIPTION
### What's changed

- Compose overview now provides obvious link to Compose file reference at top
- Updated some links on the Compose home page (`index.md`)


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

