### PR TITLE
Refer to the 'test' repo, not 'testing'

### DIFF
--- a/engine/installation/linux/docker-ce/centos.md
+++ b/engine/installation/linux/docker-ce/centos.md
@@ -81,7 +81,7 @@ from the repository.
 
 2.  Use the following command to set up the **stable** repository. You always
     need the **stable** repository, even if you want to install builds from the
-    **edge** or **testing** repositories as well.
+    **edge** or **test** repositories as well.
 
     ```bash
     $ sudo yum-config-manager \
@@ -89,7 +89,7 @@ from the repository.
         {{ download-url-base }}/docker-ce.repo
     ```
 
-3.  **Optional**: Enable the **edge** and **testing** repositories. These
+3.  **Optional**: Enable the **edge** and **test** repositories. These
     repositories are included in the `docker.repo` file above but are disabled
     by default. You can enable them alongside the stable repository.
 
@@ -98,10 +98,10 @@ from the repository.
     ```
 
     ```bash
-    $ sudo yum-config-manager --enable docker-ce-testing
+    $ sudo yum-config-manager --enable docker-ce-test
     ```
 
-    You can disable the **edge** or **testing** repository by running the
+    You can disable the **edge** or **test** repository by running the
     `yum-config-manager` command with the `--disable` flag. To re-enable it, use
     the `--enable` flag. The following command disables the **edge** repository.
 
@@ -110,7 +110,7 @@ from the repository.
     ```
 
     > **Note**: Starting with Docker 17.06, stable releases are also pushed to
-    > the **edge** and **testing** repositories.
+    > the **edge** and **test** repositories.
 
     [Learn about **stable** and **edge** builds](/engine/installation/).
 

--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -137,8 +137,8 @@ from the repository.
 
 4.  Use the following command to set up the **stable** repository. You always
     need the **stable** repository, even if you want to install builds from the
-    **edge** or **testing** repositories as well. To add the **edge** or
-    **testing** repository, add the word `edge` or `testing` (or both) after the
+    **edge** or **test** repositories as well. To add the **edge** or
+    **test** repository, add the word `edge` or `test` (or both) after the
     word `stable` in the commands below.
 
     > **Note**: The `lsb_release -cs` sub-command below returns the name of your
@@ -176,7 +176,7 @@ from the repository.
     Save and exit the file.
 
     > **Note**: Starting with Docker 17.06, stable releases are also pushed to
-    > the **edge** and **testing** repositories.
+    > the **edge** and **test** repositories.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
 

--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -82,7 +82,7 @@ from the repository.
 
 2.  Use the following command to set up the **stable** repository. You always
     need the **stable** repository, even if you want to install builds from the
-    **edge** or **testing** repositories as well.
+    **edge** or **test** repositories as well.
 
     ```bash
     $ sudo dnf config-manager \
@@ -90,7 +90,7 @@ from the repository.
         {{ download-url-base }}/docker-ce.repo
     ```
 
-3.  **Optional**: Enable the **edge** and **testing** repositories. These
+3.  **Optional**: Enable the **edge** and **test** repositories. These
     repositories are included in the `docker.repo` file above but are disabled
     by default. You can enable them alongside the stable repository.
 
@@ -99,10 +99,10 @@ from the repository.
     ```
 
     ```bash
-    $ sudo dnf config-manager --set-enabled docker-ce-testing
+    $ sudo dnf config-manager --set-enabled docker-ce-test
     ```
 
-    You can disable the **edge** or **testing** repository by running the
+    You can disable the **edge** or **test** repository by running the
     `dnf config-manager` command with the `--disable` flag. To re-enable it, use
     the `--enable` flag. The following command disables the **edge** repository.
 
@@ -111,7 +111,7 @@ from the repository.
     ```
 
     > **Note**: Starting with Docker 17.06, stable releases are also pushed to
-    > the **edge** and **testing** repositories.
+    > the **edge** and **test** repositories.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
 

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -132,8 +132,8 @@ the repository.
 
 4.  Use the following command to set up the **stable** repository. You always
     need the **stable** repository, even if you want to install builds from the
-    **edge** or **testing** repositories as well. To add the **edge** or
-    **testing** repository, add the word `edge` or `testing` (or both) after the
+    **edge** or **test** repositories as well. To add the **edge** or
+    **test** repository, add the word `edge` or `test` (or both) after the
     word `stable` in the commands below.
 
     > **Note**: The `lsb_release -cs` sub-command below returns the name of your
@@ -170,7 +170,7 @@ the repository.
     ```
 
     > **Note**: Starting with Docker 17.06, stable releases are also pushed to
-    > the **edge** and **testing** repositories.
+    > the **edge** and **test** repositories.
 
     [Learn about **stable** and **edge** channels](/engine/installation/).
 
@@ -227,9 +227,9 @@ the repository.
     ```bash
     $ sudo docker run hello-world
     ```
-    
+
     or if you run on armhf:
-    
+
     ```bash
     $ sudo docker run armhf/hello-world
     ```


### PR DESCRIPTION
Fixes #4075 

The CE docs refer to the `testing` repository when it is actually `test`.