### PR TITLE
Documentation typo fix

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -67,7 +67,7 @@ properly. For more information, see
 
 ## Setting things up
 
-Review the [requirements](/registry/recipes/index.md#requirements), then follow ese steps.
+Review the [requirements](/registry/recipes/index.md#requirements), then follow these steps.
 
 1.  Create the required directories
 


### PR DESCRIPTION
Fixed a typo in the "Setting things up" section to correct "ese" to "these"

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

I noticed a typo in the "Setting things up" section of the nginx recipes page when using this recipe. This PR fixes the typo by correcting "ese" to "these".

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
