### PR TITLE
Remove sentence about super old Docker

### DIFF
--- a/registry/index.md
+++ b/registry/index.md
@@ -32,9 +32,7 @@ into [Docker Trusted Registry](/datacenter/dtr/2.1/guides/index.md).
 
 ## Requirements
 
-The Registry is compatible with Docker engine **version 1.6.0 or higher**. If
-you really need to work with older Docker versions, you should look into the
-[old python registry](https://github.com/moby/moby-registry).
+The Registry is compatible with Docker engine **version 1.6.0 or higher**.
 
 ## TL;DR
 


### PR DESCRIPTION
Remove sentence about super-old versions of Docker, which also contains a non-working link.

cc/ @kizbitz 