### PR TITLE
Fix brocken link

### DIFF
--- a/engine/userguide/eng-image/dockerfile_best-practices.md
+++ b/engine/userguide/eng-image/dockerfile_best-practices.md
@@ -560,7 +560,7 @@ A Docker build executes `ONBUILD` commands before any command in a child
 `ONBUILD` is useful for images that are going to be built `FROM` a given
 image. For example, you would use `ONBUILD` for a language stack image that
 builds arbitrary user software written in that language within the
-`Dockerfile`, as you can see in [Ruby’s `ONBUILD` variants](https://github.com/docker-library/ruby/blob/master/2.1/onbuild/Dockerfile).
+`Dockerfile`, as you can see in [Ruby’s `ONBUILD` variants](https://github.com/docker-library/ruby/blob/master/2.4/jessie/onbuild/Dockerfile).
 
 Images built from `ONBUILD` should get a separate tag, for example:
 `ruby:1.9-onbuild` or `ruby:2.0-onbuild`.


### PR DESCRIPTION
### Proposed changes

Curren link `https://github.com/docker-library/ruby/blob/master/2.1/onbuild/Dockerfile` brocken, got 404