### PR TITLE
Fixed the stated clone directory

### DIFF
--- a/opensource/project/software-req-win.md
+++ b/opensource/project/software-req-win.md
@@ -40,7 +40,7 @@ You are now ready clone and build the Docker source code.
 In a new (to pick up the path change) PowerShell prompt, run:
 
     git clone https://github.com/moby/moby
-    cd docker
+    cd moby
 
 This clones the main Docker repository. Check out [Docker on GitHub](https://github.com/moby/moby) to learn about the other software that powers the Docker platform.
 


### PR DESCRIPTION
The **git clone** command given in STEP #4 creates the cloned repository in a local **moby** folder, not **docker**.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
