### PR TITLE
Revert "Convert Library references from submodule to upstream"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ _site/**
 .sass-cache/**
 CNAME
 Gemfile.lock
-_samples/library/**

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = tests/src/gopkg.in/yaml.v2
 	url = https://github.com/go-yaml/yaml.git
 	branch = a5b47d31c556af34a302ce5d659e6fea44d90de0
+[submodule "samples/library"]
+	path = samples/library
+	url = https://github.com/docker-library/docs.git
+	branch = master

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,25 @@
+# Migration
+
+This branch is the result of a migration of documentation from several public and
+private repositories. Every attempt has been made to preserve the history of all
+content which was migrated from public repositories, so that all public
+contributors retain credit for their work, and so that `git log` and
+`git blame` commands will work on historical files. At the time of the migration,
+over 42,000 public commits already exist in these files, which shows what a
+vibrant community the Docker documentation attracts. Thanks to everyone for their
+contributions.
+
+The following is a list of each public repository we imported from, the SHA
+reference we imported, and its tag if relevant.
+
+| Repository                             | SHA             | Tag                    |
+|----------------------------------------|-----------------|------------------------|
+| https://github.com/docker/distribution | a9b1322edf48b1f | docs-v2.5.0-2016-07-28 |
+| https://github.com/docker/compose      | 429320a4f8f4040 | docs-v1.8.0-2016-08-03 |
+| https://github.com/docker/swarm        | 27968edd8a160f6 | v1.2.5                 |
+| https://github.com/docker/notary       | a6fda67663e158d | docs-v0.3-2016-08-03   |
+| https://github.com/docker/toolbox      | c6457341499a196 | docs-v1.12.0-2016-09-16a |
+| https://github.com/docker/opensource   | b9b87bed67f4289 | docs-2016-08-03        |
+| https://github.com/docker/kitematic    | 02c9f9607128802 | v0.12.0                |
+| https://github.com/docker/machine      | 95041b4cfe2e8b2 | docs-v0.8.2-2016-09-28 |
+| https://github.com/moby/moby       | 3134c23b55eb100 | n/a                    |

--- a/_config.yml
+++ b/_config.yml
@@ -14,10 +14,6 @@ url: https://docs.docker.com
 keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13", "v17.03"]
 compose_current: 1.14.0
 
-collections:
-  samples:
-    output: true
-
 gems:
   - jekyll-redirect-from
   - jekyll-seo-tag

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1260,16 +1260,28 @@ samples:
     title: ASP.NET Core + SQL Server on Linux
   - path: /engine/examples/couchdb_data_volumes/
     title: CouchDB
+  - path: /samples/couchbase/
+    title: Couchbase
+    nosync: true
   - path: /compose/django/
     title: Django and PostgreSQL
+  - path: /samples/mongo/
+    nosync: true
+    title: MongoDB
   - path: /engine/examples/postgresql_service/
     title: PostgreSQL
   - path: /compose/rails/
     title: Rails and PostgreSQL
+  - path: /samples/redis/
+    title: Redis
+    nosync: true
   - path: /engine/examples/running_riak_service/
     title: Riak
   - path: /engine/examples/running_ssh_service/
     title: SSHd
+  - path: /samples/wordpress/
+    title: WordPress
+    nosync: true
 
 manuals:
 - sectiontitle: Docker Enterprise Edition

--- a/_includes/generateTOC.html
+++ b/_includes/generateTOC.html
@@ -1,3 +1,3 @@
-{% if include.tocToGenerate=="library"%}{% for thisPage in site.samples %}
+{% if include.tocToGenerate=="library"%}{% for thisPage in site.pages %}{% if thisPage.url contains "/samples/" and thisPage.url != "/samples/" %}
 <li><a href="{{ thisPage.url}}"{% if page.url==thisPage.url %}{% assign topicFound="true" %} class="active currentPage"{% endif %}>{{ thisPage.title }}</a></li>
-{% endfor %}{% endif %}
+{% endif %}{% endfor %}{% endif %}

--- a/_layouts/library.html
+++ b/_layouts/library.html
@@ -1,0 +1,22 @@
+---
+layout: docs
+toc_min: 1
+noratings: true
+---
+{% capture fileToUse %}{% if page.file %}{{ page.file }}{% else %}README.md{% endif %}{% endcapture %}
+{% capture ghrepo %}{% include_relative library/{{ page.repo }}/github-repo %}{% endcapture %}
+{% capture markdowncontent %}
+{% include_relative library/{{ page.repo }}/README-short.txt %}
+
+GitHub repo: [{{ ghrepo | strip }}]({{ ghrepo | strip}}){: target="_blank"}
+
+> **Library reference**
+>
+> This content is imported from
+> [the official Docker Library docs](https://github.com/docker-library/docs/tree/master/{{ page.repo}}/),
+> and is provided by the original uploader. You can view the Docker Store page for this repo at
+> [https://store.docker.com/images/{{ page.repo }}](https://store.docker.com/images/{{ page.repo }}).
+
+{% include_relative library/{{ page.repo }}/{{ fileToUse }} %}
+{% endcapture %}
+{{ markdowncontent | markdownify }}

--- a/_samples/boilerplate.txt
+++ b/_samples/boilerplate.txt
@@ -1,8 +1,0 @@
-> **Library reference**
->
-> This content is imported from
-> [the official Docker Library docs](https://github.com/docker-library/docs/tree/master/{{ page.repo}}/),
-> and is provided by the original uploader. You can view the Docker Store page for this image at
-> [https://store.docker.com/images/{{ page.repo }}](https://store.docker.com/images/{{ page.repo }})
-
-<!-- content begin -->

--- a/_scripts/fetch-upstream-resources.sh
+++ b/_scripts/fetch-upstream-resources.sh
@@ -18,49 +18,6 @@ svn co https://github.com/docker/docker-ce/"$ENGINE_SVN_BRANCH"/components/cli/d
 svn co https://github.com/docker/docker-ce/"$ENGINE_SVN_BRANCH"/components/engine/docs/api md_source/engine/api || (echo "Failed engine/api download" && exit -1) # This will only get you the old API MD files 1.18 through 1.24
 svn co https://github.com/docker/distribution/"$DISTRIBUTION_SVN_BRANCH"/docs/spec md_source/registry/spec || (echo "Failed registry/spec download" && exit -1)
 
-# Get the Library docs
-svn co https://github.com/docker-library/docs/trunk md_source/_samples/library || (echo "Failed library download" && exit -1)
-# Remove symlinks to maintainer.md because they break jekyll and we don't use em
-find md_source/_samples/library -maxdepth 9  -type l -delete
-# Loop through the README.md files, turn them into rich index.md files
-FILES=$(find md_source/_samples/library -type f -name 'README.md')
-for f in $FILES
-do
-  curdir=$(dirname "${f}")
-  justcurdir="${curdir##*/}"
-  if [ -e ${curdir}/README-short.txt ]
-  then
-    # shortrm=$(<${curdir}/README-short.txt)
-    shortrm=$(cat ${curdir}/README-short.txt)
-  fi
-  echo "Adding front-matter to ${f} ..."
-  echo --- >> ${curdir}/front-matter.txt
-  echo title: "${justcurdir}" >> ${curdir}/front-matter.txt
-  echo keywords: library, sample, ${justcurdir} >> ${curdir}/front-matter.txt
-  echo repo: "${justcurdir}" >> ${curdir}/front-matter.txt
-  echo layout: docs >> ${curdir}/front-matter.txt
-  echo permalink: /samples/library/${justcurdir}/ >> ${curdir}/front-matter.txt
-  echo description: \| >> ${curdir}/front-matter.txt
-  echo \ \ ${shortrm} >> ${curdir}/front-matter.txt
-  echo --- >> ${curdir}/front-matter.txt
-  echo >> ${curdir}/front-matter.txt
-  echo ${shortrm} >> ${curdir}/front-matter.txt
-  echo >> ${curdir}/front-matter.txt
-  if [ -e ${curdir}/github-repo ]
-  then
-    # gitrepo=$(<${curdir}/github-repo)
-    gitrepo=$(cat ${curdir}/github-repo)
-    echo >> ${curdir}/front-matter.txt
-    echo GitHub repo: \["${gitrepo}"\]\("${gitrepo}"\)\{: target="_blank"\} >> ${curdir}/front-matter.txt
-    echo >> ${curdir}/front-matter.txt
-  fi
-  cat ${curdir}/front-matter.txt md_source/_samples/boilerplate.txt > ${curdir}/header.txt
-  echo {% raw %} >> ${curdir}/header.txt
-  cat ${curdir}/header.txt ${curdir}/README.md > ${curdir}/index.md
-  echo {% endraw %} >> ${curdir}/index.md
-  rm -rf ${curdir}/front-matter.txt
-  rm -rf ${curdir}/header.txt
-done
 
 # Get the Engine APIs that are in Swagger
 # Be careful with the locations on Github for these
@@ -90,4 +47,3 @@ wget -O md_source/registry/configuration.md https://raw.githubusercontent.com/do
 rm md_source/registry/spec/api.md.tmpl
 rm -rf md_source/apidocs/cloud-api-source
 rm -rf md_source/tests
-rm md_source/_samples/library/index.md

--- a/metadata.txt
+++ b/metadata.txt
@@ -9,12 +9,4 @@ layout: null
 "description":{{ page.description | jsonify }},
 "keywords":{{ page.keywords | jsonify }}
 }
-{% endif %}{% endfor %}
-{% for page in site.samples %},
-{
-"url":{{ page.url | jsonify }},
-"title":{{ page.title | jsonify }},
-"description":{{ page.description | strip | jsonify }},
-"keywords":{{ page.keywords | jsonify }}
-}
-{% endfor %}]}
+{% endif %}{% endfor %}]}

--- a/redirect_from.csv
+++ b/redirect_from.csv
@@ -1,0 +1,5 @@
+---
+layout: null
+---
+{% for page in site.pages %}{% for redirect in page.redirect_from %}{{ redirect }},{{ page.url }}
+{% endfor %}{% endfor %}

--- a/samples/adminer.md
+++ b/samples/adminer.md
@@ -1,0 +1,6 @@
+---
+title: Adminer
+keywords: library, sample, Adminer
+layout: library
+repo: adminer
+---

--- a/samples/aerospike.md
+++ b/samples/aerospike.md
@@ -1,0 +1,6 @@
+---
+title: Aerospike
+keywords: library, sample, Aerospike
+layout: library
+repo: aerospike
+---

--- a/samples/alpine.md
+++ b/samples/alpine.md
@@ -1,0 +1,6 @@
+---
+title: Alpine
+keywords: library, sample, Alpine
+layout: library
+repo: alpine
+---

--- a/samples/amazonlinux.md
+++ b/samples/amazonlinux.md
@@ -1,0 +1,6 @@
+---
+title: Amazon Linux
+keywords: library, sample, Amazon Linux
+layout: library
+repo: amazonlinux
+---

--- a/samples/arangodb.md
+++ b/samples/arangodb.md
@@ -1,0 +1,6 @@
+---
+title: ArangoDB
+keywords: library, sample, ArangoDB
+layout: library
+repo: arangodb
+---

--- a/samples/backdrop.md
+++ b/samples/backdrop.md
@@ -1,0 +1,6 @@
+---
+title: Backdrop
+keywords: library, sample, Backdrop
+layout: library
+repo: backdrop
+---

--- a/samples/bash.md
+++ b/samples/bash.md
@@ -1,0 +1,6 @@
+---
+title: Bash
+keywords: library, sample, Bash
+layout: library
+repo: bash
+---

--- a/samples/bonita.md
+++ b/samples/bonita.md
@@ -1,0 +1,6 @@
+---
+title: Bonita
+keywords: library, sample, Bonita
+layout: library
+repo: bonita
+---

--- a/samples/buildpack-deps.md
+++ b/samples/buildpack-deps.md
@@ -1,0 +1,6 @@
+---
+title: buildpack-deps
+keywords: library, sample, buildpack-deps
+layout: library
+repo: buildpack-deps
+---

--- a/samples/busybox.md
+++ b/samples/busybox.md
@@ -1,0 +1,6 @@
+---
+title: BusyBox
+keywords: library, sample, BusyBox
+layout: library
+repo: busybox
+---

--- a/samples/cassandra.md
+++ b/samples/cassandra.md
@@ -1,0 +1,6 @@
+---
+title: Cassandra
+keywords: library, sample, Cassandra
+layout: library
+repo: cassandra
+---

--- a/samples/celery.md
+++ b/samples/celery.md
@@ -1,0 +1,6 @@
+---
+title: Celery
+keywords: library, sample, Celery
+layout: library
+repo: celery
+---

--- a/samples/centos.md
+++ b/samples/centos.md
@@ -1,0 +1,6 @@
+---
+title: CentOS
+keywords: library, sample, CentOS
+layout: library
+repo: centos
+---

--- a/samples/chronograf.md
+++ b/samples/chronograf.md
@@ -1,0 +1,6 @@
+---
+title: Chronograf
+keywords: library, sample, Chronograf
+layout: library
+repo: chronograf
+---

--- a/samples/cirros.md
+++ b/samples/cirros.md
@@ -1,0 +1,6 @@
+---
+title: CirrOS
+keywords: library, sample, CirrOS
+layout: library
+repo: cirros
+---

--- a/samples/clearlinux.md
+++ b/samples/clearlinux.md
@@ -1,0 +1,6 @@
+---
+title: Clear Linux
+keywords: library, sample, Clear Linux
+layout: library
+repo: clearlinux
+---

--- a/samples/clojure.md
+++ b/samples/clojure.md
@@ -1,0 +1,6 @@
+---
+title: Clojure
+keywords: library, sample, Clojure
+layout: library
+repo: clojure
+---

--- a/samples/composer.md
+++ b/samples/composer.md
@@ -1,0 +1,6 @@
+---
+title: Composer
+keywords: library, sample, Composer
+layout: library
+repo: composer
+---

--- a/samples/consul.md
+++ b/samples/consul.md
@@ -1,0 +1,6 @@
+---
+title: Consul
+keywords: library, sample, Consul
+layout: library
+repo: consul
+---

--- a/samples/convertigo.md
+++ b/samples/convertigo.md
@@ -1,0 +1,6 @@
+---
+title: Convertigo
+keywords: library, sample, Convertigo
+layout: library
+repo: convertigo
+---

--- a/samples/couchbase.md
+++ b/samples/couchbase.md
@@ -1,0 +1,8 @@
+---
+title: Couchbase
+keywords: library, sample, Couchbase
+layout: library
+repo: couchbase
+redirect_from:
+- /engine/examples/couchbase/
+---

--- a/samples/couchdb.md
+++ b/samples/couchdb.md
@@ -1,0 +1,6 @@
+---
+title: CouchDB
+keywords: library, sample, CouchDB
+layout: library
+repo: couchdb
+---

--- a/samples/crate.md
+++ b/samples/crate.md
@@ -1,0 +1,6 @@
+---
+title: Crate
+keywords: library, sample, Crate
+layout: library
+repo: crate
+---

--- a/samples/crux.md
+++ b/samples/crux.md
@@ -1,0 +1,6 @@
+---
+title: CRUX
+keywords: library, sample, CRUX
+layout: library
+repo: crux
+---

--- a/samples/debian.md
+++ b/samples/debian.md
@@ -1,0 +1,6 @@
+---
+title: Debian
+keywords: library, sample, Debian
+layout: library
+repo: debian
+---

--- a/samples/django.md
+++ b/samples/django.md
@@ -1,0 +1,6 @@
+---
+title: Django
+keywords: library, sample, Django
+layout: library
+repo: django
+---

--- a/samples/docker.md
+++ b/samples/docker.md
@@ -1,0 +1,6 @@
+---
+title: Docker in Docker
+keywords: library, sample, Docker in Docker
+layout: library
+repo: docker
+---

--- a/samples/drupal.md
+++ b/samples/drupal.md
@@ -1,0 +1,6 @@
+---
+title: Drupal
+keywords: library, sample, Drupal
+layout: library
+repo: drupal
+---

--- a/samples/eclipse-mosquitto.md
+++ b/samples/eclipse-mosquitto.md
@@ -1,0 +1,6 @@
+---
+title: Eclipse Mosquitto
+keywords: library, sample, Eclipse Mosquitto
+layout: library
+repo: eclipse-mosquitto
+---

--- a/samples/eggdrop.md
+++ b/samples/eggdrop.md
@@ -1,0 +1,6 @@
+---
+title: Eggdrop
+keywords: library, sample, Eggdrop
+layout: library
+repo: eggdrop
+---

--- a/samples/elasticsearch.md
+++ b/samples/elasticsearch.md
@@ -1,0 +1,6 @@
+---
+title: Elasticsearch
+keywords: library, sample, Elasticsearch
+layout: library
+repo: elasticsearch
+---

--- a/samples/elixir.md
+++ b/samples/elixir.md
@@ -1,0 +1,6 @@
+---
+title: Elixir
+keywords: library, sample, Elixir
+layout: library
+repo: elixir
+---

--- a/samples/erlang.md
+++ b/samples/erlang.md
@@ -1,0 +1,6 @@
+---
+title: Erlang
+keywords: library, sample, Erlang
+layout: library
+repo: erlang
+---

--- a/samples/fedora.md
+++ b/samples/fedora.md
@@ -1,0 +1,6 @@
+---
+title: Fedora
+keywords: library, sample, Fedora
+layout: library
+repo: fedora
+---

--- a/samples/fsharp.md
+++ b/samples/fsharp.md
@@ -1,0 +1,6 @@
+---
+title: F#
+keywords: library, sample, F#
+layout: library
+repo: fsharp
+---

--- a/samples/gazebo.md
+++ b/samples/gazebo.md
@@ -1,0 +1,6 @@
+---
+title: Gazebo
+keywords: library, sample, Gazebo
+layout: library
+repo: gazebo
+---

--- a/samples/gcc.md
+++ b/samples/gcc.md
@@ -1,0 +1,6 @@
+---
+title: The GNU Compiler Collection (GCC)
+keywords: library, sample, GNU Compiler Collection, GCC
+layout: library
+repo: gcc
+---

--- a/samples/geonetwork.md
+++ b/samples/geonetwork.md
@@ -1,0 +1,6 @@
+---
+title: GeoNetwork
+keywords: library, sample, GeoNetwork
+layout: library
+repo: geonetwork
+---

--- a/samples/ghost.md
+++ b/samples/ghost.md
@@ -1,0 +1,6 @@
+---
+title: Ghost
+keywords: library, sample, Ghost
+layout: library
+repo: ghost
+---

--- a/samples/golang.md
+++ b/samples/golang.md
@@ -1,0 +1,6 @@
+---
+title: Go (a.k.a., Golang)
+keywords: library, sample, Go, Golang
+layout: library
+repo: golang
+---

--- a/samples/gradle.md
+++ b/samples/gradle.md
@@ -1,0 +1,6 @@
+---
+title: Gradle
+keywords: library, sample, Gradle
+layout: library
+repo: gradle
+---

--- a/samples/groovy.md
+++ b/samples/groovy.md
@@ -1,0 +1,6 @@
+---
+title: Groovy
+keywords: library, sample, Groovy
+layout: library
+repo: groovy
+---

--- a/samples/haproxy.md
+++ b/samples/haproxy.md
@@ -1,0 +1,6 @@
+---
+title: HAProxy
+keywords: library, sample, HAProxy
+layout: library
+repo: haproxy
+---

--- a/samples/haskell.md
+++ b/samples/haskell.md
@@ -1,0 +1,6 @@
+---
+title: Haskell
+keywords: library, sample, Haskell
+layout: library
+repo: haskell
+---

--- a/samples/haxe.md
+++ b/samples/haxe.md
@@ -1,0 +1,6 @@
+---
+title: Haxe
+keywords: library, sample, Haxe
+layout: library
+repo: haxe
+---

--- a/samples/httpd.md
+++ b/samples/httpd.md
@@ -1,0 +1,6 @@
+---
+title: Apache httpd
+keywords: library, sample, httpd, Apache
+layout: library
+repo: httpd
+---

--- a/samples/hylang.md
+++ b/samples/hylang.md
@@ -1,0 +1,6 @@
+---
+title: Hy (a.k.a., Hylang)
+keywords: library, sample, Hy, Hylang
+layout: library
+repo: hylang
+---

--- a/samples/ibmjava.md
+++ b/samples/ibmjava.md
@@ -1,0 +1,6 @@
+---
+title: IBM® SDK, Java™ Technology Edition
+keywords: library, sample, IBM Java, Java, IBM
+layout: library
+repo: ibmjava
+---

--- a/samples/index.md
+++ b/samples/index.md
@@ -29,12 +29,11 @@ repository]({{ labsbase }}).
 These docs are imported from
 [the official Docker Library docs](https://github.com/docker-library/docs/),
 and help you use some of the most popular software that has been
-"Dockerized" into Docker images.
+"Dockerized."
 
-| Image name | Description |
-| ---------- | ----------- |
-{% for page in site.samples %}| [{{ page.title }}]({{ page.url }}) | {{ page.description | strip }} |
-{% endfor %}
+| Software | Description |
+{% for thisPage in site.pages %}{% if thisPage.url contains "/samples/" and thisPage.url != "/samples/" %}| [{{ thisPage.title }}]({{ thisPage.url }}) | {% capture shortxt %}{% include_relative library/{{ thisPage.repo }}/README-short.txt %}{% endcapture %}{{ shortxt | strip }} |
+{% endif %}{% endfor %}
 
 ## Sample applications
 
@@ -45,8 +44,12 @@ Run popular software using Docker.
 | [apt-cacher-ng](/engine/examples/apt-cacher-ng) | Run a Dockerized apt-cacher-ng instance. |
 | [ASP.NET Core + SQL Server on Linux](/compose/aspnet-mssql-compose) | Run a Dockerized ASP.NET Core + SQL Server environment. |
 | [CouchDB](/engine/examples/couchdb_data_volumes) | Run a Dockerized CouchDB instance. |
+| [Couchbase](/engine/examples/couchbase) | Run a Dockerized Couchbase instance. |
 | [Django + PostgreSQL](/compose/django/) | Run a Dockerized Django + PostgreSQL environment. |
+| [MongoDB](/engine/examples/mongodb) | Run a Dockerized MongoDB instance. |
 | [PostgreSQL](/engine/examples/postgresql_service) | Run a Dockerized PosgreSQL instance. |
 | [Rails + PostgreSQL](/compose/rails/) | Run a Dockerized Rails + PostgreSQL environment. |
+| [Redis](/engine/examples/running_redis_service) | Run a Dockerized Redis instance. |
 | [Riak](/engine/examples/running_riak_service) | Run a Dockerized Riak instance. |
 | [SSHd](/engine/examples/running_ssh_service) | Run a Dockerized SSHd instance. |
+| [WordPress](/compose/wordpress/) | Run a Dockerized WordPress instance. |

--- a/samples/influxdb.md
+++ b/samples/influxdb.md
@@ -1,0 +1,6 @@
+---
+title: InfluxDB
+keywords: library, sample, InfluxDB
+layout: library
+repo: influxdb
+---

--- a/samples/iojs.md
+++ b/samples/iojs.md
@@ -1,0 +1,6 @@
+---
+title: io.js
+keywords: library, sample, io.js, npm
+layout: library
+repo: iojs
+---

--- a/samples/irssi.md
+++ b/samples/irssi.md
@@ -1,0 +1,6 @@
+---
+title: Irssi
+keywords: library, sample, Irssi
+layout: library
+repo: irssi
+---

--- a/samples/java.md
+++ b/samples/java.md
@@ -1,0 +1,6 @@
+---
+title: Java
+keywords: library, sample, Java
+layout: library
+repo: java
+---

--- a/samples/jenkins.md
+++ b/samples/jenkins.md
@@ -1,0 +1,6 @@
+---
+title: Jenkins
+keywords: library, sample, Jenkins
+layout: library
+repo: jenkins
+---

--- a/samples/jetty.md
+++ b/samples/jetty.md
@@ -1,0 +1,6 @@
+---
+title: Jetty
+keywords: library, sample, Java, Jetty
+layout: library
+repo: jetty
+---

--- a/samples/joomla.md
+++ b/samples/joomla.md
@@ -1,0 +1,6 @@
+---
+title: Joomla
+keywords: library, sample, Joomla
+layout: library
+repo: joomla
+---

--- a/samples/jruby.md
+++ b/samples/jruby.md
@@ -1,0 +1,6 @@
+---
+title: JRuby
+keywords: library, sample, JRuby
+layout: library
+repo: jruby
+---

--- a/samples/julia.md
+++ b/samples/julia.md
@@ -1,0 +1,6 @@
+---
+title: Julia
+keywords: library, sample, Julia
+layout: library
+repo: julia
+---

--- a/samples/kaazing-gateway.md
+++ b/samples/kaazing-gateway.md
@@ -1,0 +1,6 @@
+---
+title: Kaazing Gateway
+keywords: library, sample, Kaazing Gateway
+layout: library
+repo: kaazing-gateway
+---

--- a/samples/kapacitor.md
+++ b/samples/kapacitor.md
@@ -1,0 +1,6 @@
+---
+title: Kapacitor
+keywords: library, sample, Kapacitor
+layout: library
+repo: kapacitor
+---

--- a/samples/kibana.md
+++ b/samples/kibana.md
@@ -1,0 +1,6 @@
+---
+title: Kibana
+keywords: library, sample, Kibana, Elasticsearch
+layout: library
+repo: kibana
+---

--- a/samples/known.md
+++ b/samples/known.md
@@ -1,0 +1,6 @@
+---
+title: Known
+keywords: library, sample, Known
+layout: library
+repo: known
+---

--- a/samples/kong.md
+++ b/samples/kong.md
@@ -1,0 +1,6 @@
+---
+title: Kong
+keywords: library, sample, Kong
+layout: library
+repo: kong
+---

--- a/samples/lightstreamer.md
+++ b/samples/lightstreamer.md
@@ -1,0 +1,6 @@
+---
+title: Lightstreamer
+keywords: library, sample, Lightstreamer
+layout: library
+repo: lightstreamer
+---

--- a/samples/logstash.md
+++ b/samples/logstash.md
@@ -1,0 +1,6 @@
+---
+title: Logstash
+keywords: library, sample, Logstash
+layout: library
+repo: logstash
+---

--- a/samples/mageia.md
+++ b/samples/mageia.md
@@ -1,0 +1,6 @@
+---
+title: Mageia
+keywords: library, sample, Mageia
+layout: library
+repo: mageia
+---

--- a/samples/mariadb.md
+++ b/samples/mariadb.md
@@ -1,0 +1,6 @@
+---
+title: MariaDB
+keywords: library, sample, MariaDB
+layout: library
+repo: mariadb
+---

--- a/samples/maven.md
+++ b/samples/maven.md
@@ -1,0 +1,6 @@
+---
+title: Maven
+keywords: library, sample, Maven
+layout: library
+repo: maven
+---

--- a/samples/memcached.md
+++ b/samples/memcached.md
@@ -1,0 +1,6 @@
+---
+title: Memcached
+keywords: library, sample, Memcached
+layout: library
+repo: memcached
+---

--- a/samples/mongo-express.md
+++ b/samples/mongo-express.md
@@ -1,0 +1,6 @@
+---
+title: mongo-express
+keywords: library, sample, mongo-express
+layout: library
+repo: mongo-express
+---

--- a/samples/mongo.md
+++ b/samples/mongo.md
@@ -1,0 +1,8 @@
+---
+title: MongoDB
+keywords: library, sample, MongoDB
+layout: library
+repo: mongo
+redirect_from:
+- /engine/examples/mongodb/
+---

--- a/samples/mono.md
+++ b/samples/mono.md
@@ -1,0 +1,6 @@
+---
+title: Mono
+keywords: library, sample, Mono
+layout: library
+repo: mono
+---

--- a/samples/mysql.md
+++ b/samples/mysql.md
@@ -1,0 +1,6 @@
+---
+title: MySQL
+keywords: library, sample, MySQL
+layout: library
+repo: mysql
+---

--- a/samples/nats-streaming.md
+++ b/samples/nats-streaming.md
@@ -1,0 +1,6 @@
+---
+title: nats-streaming
+keywords: library, sample, nats-streaming
+layout: library
+repo: nats-streaming
+---

--- a/samples/nats.md
+++ b/samples/nats.md
@@ -1,0 +1,6 @@
+---
+title: nats
+keywords: library, sample, nats
+layout: library
+repo: nats
+---

--- a/samples/neo4j.md
+++ b/samples/neo4j.md
@@ -1,0 +1,6 @@
+---
+title: Neo4j
+keywords: library, sample, Neo4j
+layout: library
+repo: neo4j
+---

--- a/samples/neurodebian.md
+++ b/samples/neurodebian.md
@@ -1,0 +1,6 @@
+---
+title: NeuroDebian
+keywords: library, sample, NeuroDebian
+layout: library
+repo: neurodebian
+---

--- a/samples/nextcloud.md
+++ b/samples/nextcloud.md
@@ -1,0 +1,6 @@
+---
+title: Nextcloud
+keywords: library, sample, Nextcloud
+layout: library
+repo: nextcloud
+---

--- a/samples/nginx.md
+++ b/samples/nginx.md
@@ -1,0 +1,6 @@
+---
+title: Nginx
+keywords: library, sample, Nginx
+layout: library
+repo: nginx
+---

--- a/samples/node.md
+++ b/samples/node.md
@@ -1,0 +1,6 @@
+---
+title: Node.js
+keywords: library, sample, Node.js
+layout: library
+repo: node
+---

--- a/samples/notary.md
+++ b/samples/notary.md
@@ -1,0 +1,6 @@
+---
+title: Notary
+keywords: library, sample, Notary
+layout: library
+repo: notary
+---

--- a/samples/nuxeo.md
+++ b/samples/nuxeo.md
@@ -1,0 +1,6 @@
+---
+title: Nuxeo
+keywords: library, sample, Nuxeo
+layout: library
+repo: nuxeo
+---

--- a/samples/odoo.md
+++ b/samples/odoo.md
@@ -1,0 +1,6 @@
+---
+title: Odoo
+keywords: library, sample, Odoo
+layout: library
+repo: odoo
+---

--- a/samples/openjdk.md
+++ b/samples/openjdk.md
@@ -1,0 +1,6 @@
+---
+title: OpenJDK
+keywords: library, sample, OpenJDK
+layout: library
+repo: openjdk
+---

--- a/samples/opensuse.md
+++ b/samples/opensuse.md
@@ -1,0 +1,6 @@
+---
+title: openSUSE
+keywords: library, sample, openSUSE
+layout: library
+repo: opensuse
+---

--- a/samples/oraclelinux.md
+++ b/samples/oraclelinux.md
@@ -1,0 +1,6 @@
+---
+title: Oracle Linux
+keywords: library, sample, Oracle Linux
+layout: library
+repo: oraclelinux
+---

--- a/samples/orientdb.md
+++ b/samples/orientdb.md
@@ -1,0 +1,6 @@
+---
+title: OrientDB
+keywords: library, sample, OrientDB
+layout: library
+repo: orientdb
+---

--- a/samples/owncloud.md
+++ b/samples/owncloud.md
@@ -1,0 +1,6 @@
+---
+title: ownCloud
+keywords: library, sample, ownCloud
+layout: library
+repo: owncloud
+---

--- a/samples/percona.md
+++ b/samples/percona.md
@@ -1,0 +1,6 @@
+---
+title: Percona
+keywords: library, sample, Percona
+layout: library
+repo: percona
+---

--- a/samples/perl.md
+++ b/samples/perl.md
@@ -1,0 +1,6 @@
+---
+title: Perl
+keywords: library, sample, Perl
+layout: library
+repo: perl
+---

--- a/samples/photon.md
+++ b/samples/photon.md
@@ -1,0 +1,6 @@
+---
+title: Photon
+keywords: library, sample, Photon
+layout: library
+repo: photon
+---

--- a/samples/php-zendserver.md
+++ b/samples/php-zendserver.md
@@ -1,0 +1,6 @@
+---
+title: Zend Server
+keywords: library, sample, Zend Server
+layout: library
+repo: php-zendserver
+---

--- a/samples/php.md
+++ b/samples/php.md
@@ -1,0 +1,6 @@
+---
+title: PHP
+keywords: library, sample, PHP
+layout: library
+repo: php
+---

--- a/samples/piwik.md
+++ b/samples/piwik.md
@@ -1,0 +1,6 @@
+---
+title: Piwik
+keywords: library, sample, Piwik
+layout: library
+repo: piwik
+---

--- a/samples/plone.md
+++ b/samples/plone.md
@@ -1,0 +1,6 @@
+---
+title: Plone
+keywords: library, sample, Plone
+layout: library
+repo: plone
+---

--- a/samples/postgres.md
+++ b/samples/postgres.md
@@ -1,0 +1,6 @@
+---
+title: PostgreSQL
+keywords: library, sample, PostgreSQL
+layout: library
+repo: postgres
+---

--- a/samples/pypy.md
+++ b/samples/pypy.md
@@ -1,0 +1,6 @@
+---
+title: PyPy
+keywords: library, sample, PyPy, Python
+layout: library
+repo: pypy
+---

--- a/samples/python.md
+++ b/samples/python.md
@@ -1,0 +1,6 @@
+---
+title: Python
+keywords: library, sample, Python
+layout: library
+repo: python
+---

--- a/samples/r-base.md
+++ b/samples/r-base.md
@@ -1,0 +1,6 @@
+---
+title: R (a.k.a., Rlang)
+keywords: library, sample, R, Rlang
+layout: library
+repo: r-base
+---

--- a/samples/rabbitmq.md
+++ b/samples/rabbitmq.md
@@ -1,0 +1,6 @@
+---
+title: RabbitMQ
+keywords: library, sample, RabbitMQ
+layout: library
+repo: rabbitmq
+---

--- a/samples/rails.md
+++ b/samples/rails.md
@@ -1,0 +1,6 @@
+---
+title: Ruby on Rails
+keywords: library, sample, Ruby on Rails, Ruby, Rails
+layout: library
+repo: rails
+---

--- a/samples/rakudo-star.md
+++ b/samples/rakudo-star.md
@@ -1,0 +1,6 @@
+---
+title: Rakudo Star
+keywords: library, sample, Rakudo Star
+layout: library
+repo: rakudo-star
+---

--- a/samples/rapidoid.md
+++ b/samples/rapidoid.md
@@ -1,0 +1,6 @@
+---
+title: Rapidoid
+keywords: library, sample, Rapidoid
+layout: library
+repo: rapidoid
+---

--- a/samples/redis.md
+++ b/samples/redis.md
@@ -1,0 +1,8 @@
+---
+title: Redis
+keywords: library, sample, Redis
+layout: library
+repo: redis
+redirect_from:
+- /engine/examples/running_redis_service/
+---

--- a/samples/redmine.md
+++ b/samples/redmine.md
@@ -1,0 +1,6 @@
+---
+title: Redmine
+keywords: library, sample, Redmine
+layout: library
+repo: redmine
+---

--- a/samples/registry.md
+++ b/samples/registry.md
@@ -1,0 +1,6 @@
+---
+title: Docker Registry
+keywords: library, sample, registry, Docker Registry
+layout: library
+repo: registry
+---

--- a/samples/rethinkdb.md
+++ b/samples/rethinkdb.md
@@ -1,0 +1,6 @@
+---
+title: RethinkDB
+keywords: library, sample, RethinkDB
+layout: library
+repo: rethinkdb
+---

--- a/samples/rocket.chat.md
+++ b/samples/rocket.chat.md
@@ -1,0 +1,6 @@
+---
+title: Rocket.Chat
+keywords: library, sample, Rocket.Chat
+layout: library
+repo: rocket.chat
+---

--- a/samples/ros.md
+++ b/samples/ros.md
@@ -1,0 +1,6 @@
+---
+title: Robot Operating System (ROS)
+keywords: library, sample, Robot Operating System, ROS
+layout: library
+repo: ros
+---

--- a/samples/ruby.md
+++ b/samples/ruby.md
@@ -1,0 +1,6 @@
+---
+title: Ruby
+keywords: library, sample, Ruby
+layout: library
+repo: ruby
+---

--- a/samples/scratch.md
+++ b/samples/scratch.md
@@ -1,0 +1,6 @@
+---
+title: scratch
+keywords: library, sample, scratch
+layout: library
+repo: scratch
+---

--- a/samples/sentry.md
+++ b/samples/sentry.md
@@ -1,0 +1,6 @@
+---
+title: Sentry
+keywords: library, sample, Sentry
+layout: library
+repo: sentry
+---

--- a/samples/silverpeas.md
+++ b/samples/silverpeas.md
@@ -1,0 +1,6 @@
+---
+title: Silverpeas
+keywords: library, sample, Silverpeas
+layout: library
+repo: silverpeas
+---

--- a/samples/solr.md
+++ b/samples/solr.md
@@ -1,0 +1,6 @@
+---
+title: Solr
+keywords: library, sample, Solr
+layout: library
+repo: solr
+---

--- a/samples/sonarqube.md
+++ b/samples/sonarqube.md
@@ -1,0 +1,6 @@
+---
+title: SonarQube
+keywords: library, sample, SonarQube
+layout: library
+repo: sonarqube
+---

--- a/samples/sourcemage.md
+++ b/samples/sourcemage.md
@@ -1,0 +1,6 @@
+---
+title: Source Mage
+keywords: library, sample, Source Mage
+layout: library
+repo: sourcemage
+---

--- a/samples/spiped.md
+++ b/samples/spiped.md
@@ -1,0 +1,6 @@
+---
+title: Spiped
+keywords: library, sample, Spiped
+layout: library
+repo: spiped
+---

--- a/samples/storm.md
+++ b/samples/storm.md
@@ -1,0 +1,6 @@
+---
+title: Storm
+keywords: library, sample, Storm
+layout: library
+repo: storm
+---

--- a/samples/swarm.md
+++ b/samples/swarm.md
@@ -1,0 +1,6 @@
+---
+title: swarm
+keywords: library, sample, swarm
+layout: library
+repo: swarm
+---

--- a/samples/swift.md
+++ b/samples/swift.md
@@ -1,0 +1,6 @@
+---
+title: Swift
+keywords: library, sample, Swift
+layout: library
+repo: swift
+---

--- a/samples/telegraf.md
+++ b/samples/telegraf.md
@@ -1,0 +1,6 @@
+---
+title: Telegraf
+keywords: library, sample, Telegraf
+layout: library
+repo: telegraf
+---

--- a/samples/thrift.md
+++ b/samples/thrift.md
@@ -1,0 +1,6 @@
+---
+title: Thrift
+keywords: library, sample, Thrift
+layout: library
+repo: thrift
+---

--- a/samples/tomcat.md
+++ b/samples/tomcat.md
@@ -1,0 +1,6 @@
+---
+title: Tomcat
+keywords: library, sample, Tomcat
+layout: library
+repo: tomcat
+---

--- a/samples/tomee.md
+++ b/samples/tomee.md
@@ -1,0 +1,6 @@
+---
+title: TomEE
+keywords: library, sample, TomEE
+layout: library
+repo: tomee
+---

--- a/samples/traefik.md
+++ b/samples/traefik.md
@@ -1,0 +1,6 @@
+---
+title: Træfɪk
+keywords: library, sample, Træfɪk, traefik
+layout: library
+repo: traefik
+---

--- a/samples/ubuntu.md
+++ b/samples/ubuntu.md
@@ -1,0 +1,6 @@
+---
+title: Ubuntu
+keywords: library, sample, Ubuntu
+layout: library
+repo: ubuntu
+---

--- a/samples/vault.md
+++ b/samples/vault.md
@@ -1,0 +1,6 @@
+---
+title: Vault
+keywords: library, sample, Vault
+layout: library
+repo: vault
+---

--- a/samples/websphere-liberty.md
+++ b/samples/websphere-liberty.md
@@ -1,0 +1,6 @@
+---
+title: IBM WebSphere Application Server Liberty
+keywords: library, sample, WebSphere Liberty, WebSphere, Liberty
+layout: library
+repo: websphere-liberty
+---

--- a/samples/wordpress.md
+++ b/samples/wordpress.md
@@ -1,0 +1,8 @@
+---
+title: WordPress
+keywords: library, sample, WordPress
+layout: library
+repo: wordpress
+redirect_from:
+- /compose/wordpress/
+---

--- a/samples/xwiki.md
+++ b/samples/xwiki.md
@@ -1,0 +1,6 @@
+---
+title: XWiki
+keywords: library, sample, XWiki
+layout: library
+repo: xwiki
+---

--- a/samples/znc.md
+++ b/samples/znc.md
@@ -1,0 +1,6 @@
+---
+title: ZNC
+keywords: library, sample, ZNC
+layout: library
+repo: znc
+---

--- a/samples/zookeeper.md
+++ b/samples/zookeeper.md
@@ -1,0 +1,6 @@
+---
+title: ZooKeeper
+keywords: library, sample, ZooKeeper
+layout: library
+repo: zookeeper
+---

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,10 +12,6 @@ layout: null
   <loc>https://docs.docker.com/</loc>
   <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
 </url>
-{% for page in site.samples %}<url>
-  <loc>https://docs.docker.com{{ page.url }}</loc>
-  <lastmod>{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}</lastmod>
-</url>{% endfor %}
 {% for page in site.pages %}{% unless page.hide_from_sitemap %}<url>
   <loc>https://docs.docker.com{{ page.url }}</loc>
   <lastmod>{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}</lastmod>


### PR DESCRIPTION
Reverts docker/docker.github.io#4102

Due to error:

```
jekyll 3.4.3 | Error: Could not locate the included file 'library/adminer/github-repo' in any of ["/usr/src/app/md_source/samples"]. Ensure it exists in one of those directories and, if it is a symlink, does not point outside your site source.
Removing intermediate container e0d5fda0cb6f

```

cc/ @johndmulhausen 