### PR TITLE
4098 devicemapper bullet appears twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docs @ Docker
+# Docs @ Docker 
 
 Welcome to the repo for our documentation. This is the source for
 [https://docs.docker.com/](https://docs.docker.com/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docs @ Docker 
+# Docs @ Docker
 
 Welcome to the repo for our documentation. This is the source for
 [https://docs.docker.com/](https://docs.docker.com/).

--- a/engine/userguide/storagedriver/selectadriver.md
+++ b/engine/userguide/storagedriver/selectadriver.md
@@ -223,4 +223,3 @@ Restart Docker for the changes to take effect. After restarting, run
 * [`overlay` and `overlay2` storage drivers in practice](overlayfs-driver.md)
 * [`btrfs` storage driver in practice](btrfs-driver.md)
 * [`zfs` storage driver in practice](zfs-driver.md)
-* [Device Mapper storage driver in practice](device-mapper-driver.md)


### PR DESCRIPTION
File: engine/userguide/storagedriver/selectadriver.md

In section Related information at the bottom of the page item devicemapper storage driver in practice appears twice with two different styles. The one is correct so I deleted the second one. Fixes #4098.