### PR TITLE
clarify Compose install prerequisites

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -32,35 +32,40 @@ Server 2016** (with [Docker EE for Windows Server
 2016](/engine/installation/windows/docker-ee.md), you _do_ need to install
 Docker Compose.
 
-To do this, start an "elevated" PowerShell (run it as administrator). Search
-for PowerShell, right-click, and choose **Run as administrator**. When asked
-if you want to allow this app to make changes to your device, click **Yes**.
+To do this, follow these steps:
 
-Run the following command to download Docker Compose, replacing
-`$dockerComposeVersion` with the specific version of Compose you want to use:
+1.  Start an "elevated" PowerShell (run it as administrator).
 
-```none
-Invoke-WebRequest "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
-```
+    Search for PowerShell, right-click, and choose
+    **Run as administrator**. When asked if you want to allow this app
+    to make changes to your device, click **Yes**.
 
-For example, to download Compose version {{ site.compose_current }}, the command
-is:
+    In PowerShell, run the following command to download
+    Docker Compose, replacing `$dockerComposeVersion` with the specific
+    version of Compose you want to use:
 
-```none
-Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_current}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
-```
->  Use the latest Compose release number in the download command.
->
-> As already mentioned, the above command is an _example_, and
-it may become out-of-date once in a while. Always follow the
-command pattern shown above it. If you cut-and-paste an example,
-check which release it specifies and, if needed,
-replace `$dockerComposeVersion` with the release number that
-you want. Compose releases are also available for direct download
-on the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" class="_"}.
-{: .important}
+    ```none
+    Invoke-WebRequest "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
+    ```
 
-Now, run the executable to install Compose.
+    For example, to download Compose version {{ site.compose_current }},
+    the command is:
+
+    ```none
+    Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_current}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
+    ```
+    >  Use the latest Compose release number in the download command.
+    >
+    > As already mentioned, the above command is an _example_, and
+    it may become out-of-date once in a while. Always follow the
+    command pattern shown above it. If you cut-and-paste an example,
+    check which release it specifies and, if needed,
+    replace `$dockerComposeVersion` with the release number that
+    you want. Compose releases are also available for direct download
+    on the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" class="_"}.
+    {: .important}
+
+3.  Run the executable to install Compose.
 
 ## Install Compose on Linux systems
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -14,7 +14,7 @@ You need to install Docker first, before you install and run Docker Compose.
 included as part of those desktop installs. Skip down to [Install Compose on Linux systems](#install-compose-on-linux-systems).
 
 - On Linux systems, first install the
-[Docker server](/engine/installation/index.md#server){: target="_blank" class="_"}
+[Docker](/engine/installation/index.md#server){: target="_blank" class="_"}
 for your OS as described on the Get Docker page, then come back here for
 instructions on installing [installing Compose on
 Linux](#install-compose-on-linux-systems).

--- a/compose/install.md
+++ b/compose/install.md
@@ -8,7 +8,8 @@ You can run Compose on macOS, Windows and 64-bit Linux.
 
 ## Prerequisites
 
-You need to install Docker first, before you install and run Docker Compose.
+Docker Compose relies on Docker Engine for any meaningful work, so make sure you
+have Docker Engine installed either locally or remote, depending on your setup.
 
 - On desktop systems like Docker for Mac and Windows, Docker Compose is
 included as part of those desktop installs. Skip down to [Install Compose on Linux systems](#install-compose-on-linux-systems).

--- a/compose/install.md
+++ b/compose/install.md
@@ -4,77 +4,91 @@ keywords: compose, orchestration, install, installation, docker, documentation
 title: Install Docker Compose
 ---
 
-You can run Compose on macOS, Windows and 64-bit Linux. To install it, you'll need to install Docker first.
+You can run Compose on macOS, Windows and 64-bit Linux.
 
-To install Compose, do the following:
+## Prerequisites
 
-1.  Install Docker Engine:
+You need to install Docker first, before you install and run Docker Compose.
 
-    * [Mac installation](/docker-for-mac/index.md){: target="_blank" class="_"}
+- On desktop systems like Docker for Mac and Windows, Docker Compose is
+included as part of those desktop installs. Skip down to [Install Compose on Linux systems](#install-compose-on-linux-systems).
 
-    * [Windows installation](/docker-for-windows/index.md){: target="_blank" class="_"}
+- On Linux systems, first install the
+[Docker server](/engine/installation/index.md#server){: target="_blank" class="_"}
+for your OS as described on the Get Docker page, then come back here for
+instructions on installing [installing Compose on
+Linux](#install-compose-on-linux-systems).
 
-    * [Ubuntu installation](/engine/installation/linux/ubuntu.md){: target="_blank" class="_"}
+## Install Compose on Mac or Windows systems
 
-    * [Other systems](/engine/installation/index.md){: target="_blank" class="_"}
+**[Docker for Mac](/docker-for-mac/install.md)**,
+**[Docker for Windows](/docker-for-windows/install.md)**, and
+**[Docker Toolbox](/toolbox/overview.md)** include Docker Compose,
+so most Mac and Windows users do not need to install Docker Compose
+separately.
 
-2.  **[Docker for Mac](/docker-for-mac/install.md)**, **[Docker for Windows](/docker-for-windows/install.md)**, and **[Docker Toolbox](/toolbox/overview.md)** include Docker Compose, so most Mac and Windows users do not need to install Docker Compose separately.
+If you are running the Docker daemon and client directly on **Microsoft Windows
+Server 2016** (with [Docker EE for Windows Server
+2016](/engine/installation/windows/docker-ee.md), you _do_ need to install
+Docker Compose.
 
-    If you are running the Docker daemon and client directly on
-    **Microsoft Windows Server 2016** (with [Docker EE for Windows Server 2016](/engine/installation/windows/docker-ee.md), you _do_ need to install Docker Compose.
+To do this, start an "elevated" PowerShell (run it as administrator). Search
+for PowerShell, right-click, and choose **Run as administrator**. When asked
+if you want to allow this app to make changes to your device, click **Yes**.
 
-    To do this, start an "elevated" PowerShell (run it as administrator). Search
-    for PowerShell, right-click, and choose **Run as administrator**. When asked
-    if you want to allow this app to make changes to your device, click **Yes**.
-
-    Run the following command to download Docker Compose, replacing
+Run the following command to download Docker Compose, replacing
 `$dockerComposeVersion` with the specific version of Compose you want to use:
 
-    ```none
-    Invoke-WebRequest "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
-    ```
+```none
+Invoke-WebRequest "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
+```
 
-    For example, to download Compose version {{ site.compose_current }}, the command is:
+For example, to download Compose version {{ site.compose_current }}, the command
+is:
 
-    ```none
-    Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_current}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
-    ```
-    >  Use the latest Compose release number in the download command.
-    >
-    > As already mentioned, the above command is an _example_, and
-    it may become out-of-date once in a while. Always follow the
-    command pattern shown above it. If you cut-and-paste an example,
-    check which release it specifies and, if needed,
-    replace `$dockerComposeVersion` with the release number that
-    you want. Compose releases are also available for direct download
-    on the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" class="_"}.
-    {: .important}
+```none
+Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_current}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
+```
+>  Use the latest Compose release number in the download command.
+>
+> As already mentioned, the above command is an _example_, and
+it may become out-of-date once in a while. Always follow the
+command pattern shown above it. If you cut-and-paste an example,
+check which release it specifies and, if needed,
+replace `$dockerComposeVersion` with the release number that
+you want. Compose releases are also available for direct download
+on the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" class="_"}.
+{: .important}
 
-    Now, run the executable to install Compose.
+Now, run the executable to install Compose.
 
-3.  On **Linux**, you can download the Docker Compose binary from the
-    [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank" class="_"}.
-    Follow the instructions from the link, which involve running the `curl` command in your terminal to download the binaries.
+## Install Compose on Linux systems
 
-    >  Got a "Permission denied" error?
-    >
-    If so, your `/usr/local/bin` directory probably isn't writable and
-    you'll need to install Compose as the superuser. Run `sudo -i`, then
-    run the download and install commands below, then `exit`.
+On **Linux**, you can download the Docker Compose binary from  the [Compose
+repository release page on GitHub](https://github.com/docker/compose/releases){:
+target="_blank" class="_"}. Follow the instructions from the link, which involve
+running the `curl` command in your terminal to download the binaries. These step
+by step instructions are also included below.
 
-
-    Run this command to download Docker Compose, replacing
+1.  Run this command to download Docker Compose, replacing
 `$dockerComposeVersion` with the specific version of Compose you want to use:
 
     ```bash
     curl -L https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
     ```
 
-    For example, to download Compose version {{site.compose_current}}, the command is:
+    For example, to download Compose version {{site.compose_current}}, the command
+    is:
 
     ```bash
     curl -L https://github.com/docker/compose/releases/download/{{site.compose_current}}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
     ```
+
+    >  Got a "Permission denied" error?
+    >
+    If so, your `/usr/local/bin` directory probably isn't writable and
+    you'll need to install Compose as the superuser. Run `sudo -i`, then
+    run the download and install commands below, then `exit`.
 
     > Use the latest Compose release number in the download command.
     >
@@ -84,22 +98,22 @@ To install Compose, do the following:
     if needed, replace `$dockerComposeVersion` with the release number that
     you want. Compose releases are also available for direct download on
     the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank"
-class="_"}.
+    class="_"}.
     {: .important}
 
     If you have problems installing with `curl`, see
     [Alternative Install Options](install.md#alternative-install-options).
 
-5.  Apply executable permissions to the binary:
+2.  Apply executable permissions to the binary:
 
     ```bash
     sudo chmod +x /usr/local/bin/docker-compose
     ```
 
-6.  Optionally, install [command completion](completion.md) for the
+3.  Optionally, install [command completion](completion.md) for the
     `bash` and `zsh` shell.
 
-7.  Test the installation.
+4.  Test the installation.
 
     ```bash
     $ docker-compose --version

--- a/compose/install.md
+++ b/compose/install.md
@@ -21,18 +21,18 @@ Linux](#install-compose-on-linux-systems).
 
 ## Install Compose on Mac or Windows systems
 
-**[Docker for Mac](/docker-for-mac/install.md)**,
-**[Docker for Windows](/docker-for-windows/install.md)**, and
-**[Docker Toolbox](/toolbox/overview.md)** include Docker Compose,
-so most Mac and Windows users do not need to install Docker Compose
-separately.
+**Docker for Mac**, **Docker for Windows**, and **Docker Toolbox**
+already include Compose along with other Docker apps, so most Mac
+and Windows users do not need to install Docker Compose separately.
+Docker install instructions for these are here:
 
-If you are running the Docker daemon and client directly on **Microsoft Windows
-Server 2016** (with [Docker EE for Windows Server
-2016](/engine/installation/windows/docker-ee.md), you _do_ need to install
-Docker Compose.
+* [Get Docker for Mac](/docker-for-mac/install.md)
+* [Get Docker for Windows](/docker-for-windows/install.md)
+* [Get Docker Toolbox](/toolbox/overview.md) (for older systems)
 
-To do this, follow these steps:
+**If you are running the Docker daemon and client directly on Microsoft
+Windows Server 2016** (with [Docker EE for Windows Server 2016](/engine/installation/windows/docker-ee.md), you _do_ need to install
+Docker Compose. To do so, follow these steps:
 
 1.  Start an "elevated" PowerShell (run it as administrator).
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -12,7 +12,7 @@ Docker Compose relies on Docker Engine for any meaningful work, so make sure you
 have Docker Engine installed either locally or remote, depending on your setup.
 
 - On desktop systems like Docker for Mac and Windows, Docker Compose is
-included as part of those desktop installs. Skip down to [Install Compose on Linux systems](#install-compose-on-linux-systems).
+included as part of those desktop installs. Skip down to [Install Compose on Mac or Windows systems](#install-compose-on-mac-or-windows-systems).
 
 - On Linux systems, first install the
 [Docker](/engine/installation/index.md#server){: target="_blank" class="_"}
@@ -70,7 +70,7 @@ Docker Compose. To do so, follow these steps:
 
 ## Install Compose on Linux systems
 
-On **Linux**, you can download the Docker Compose binary from  the [Compose
+On **Linux**, you can download the Docker Compose binary from the [Compose
 repository release page on GitHub](https://github.com/docker/compose/releases){:
 target="_blank" class="_"}. Follow the instructions from the link, which involve
 running the `curl` command in your terminal to download the binaries. These step

--- a/compose/install.md
+++ b/compose/install.md
@@ -23,7 +23,7 @@ Linux](#install-compose-on-linux-systems).
 
 **Docker for Mac**, **Docker for Windows**, and **Docker Toolbox**
 already include Compose along with other Docker apps, so most Mac
-and Windows users do not need to install Docker Compose separately.
+and Windows users do not need to install Compose separately.
 Docker install instructions for these are here:
 
 * [Get Docker for Mac](/docker-for-mac/install.md)


### PR DESCRIPTION
### What's changed

- Re-organized topic to highlight that Docker Engine (server) is a prerequisite for Compose install
- Provided more useful links
- Changed from numbered lists to sections that call out Mac and Windows installs vs Linux

### Related

#4126 

### Direct link to updated topic in Netlify preview

https://deploy-preview-4130--docker-docs-vnext-engine.netlify.com/compose/install/

### Reviewers fyi

@mstanleyjones @barrystaes @shin- @dnephin 


Signed-off-by: Victoria Binalas <victoria.bialas@docker.com>

