### PR TITLE
removed incorrect description of how to link to a service

### DIFF
--- a/docker-cloud/apps/load-balance-hello-world.md
+++ b/docker-cloud/apps/load-balance-hello-world.md
@@ -48,7 +48,7 @@ ready to continue and launch our web service.
 
 1. Click **Services** in the left hand menu, and click **Create**.
 
-3. Click the **rocket icon** and select the **dockercloud/hello-world** image.
+3. Click the **rocket icon** at the top of page, and select the **dockercloud/hello-world** image.
 
     ![](images/lbd-hello-world-jumpstart.png)
 
@@ -96,8 +96,7 @@ browser and view the **dockercloud/hello-world** web page. Note the hostname fo
 
     ![](images/lbd-hostname-1.png)
 
-3. Click other endpoints and check the hostnames. You'll see different hostnames
-which match the container name (web-2, web-3, and so on).
+3. Click other endpoints and check the hostnames. You'll see different hostnames which match the container name (web-2, web-3, and so on).
 
 ## Launch the load balancer
 
@@ -193,7 +192,3 @@ Docker Cloud automatically assigns a DNS endpoint to all services. This endpoint
 routes to all of the containers of that service. You can use the DNS endpoint to
 load balance your load balancer. To learn more, read up on [service
 links](service-links.md).
-
-You can try this by pointing your web browser to
-*servicename.username.svc.dockerapp.io* or using *dig* or *nslookup* to see how
-the service endpoint resolves.


### PR DESCRIPTION
### What's changed

Removed paragraph about linking to a service using username as part of a pretty URL, as it's incorrect. 

Here are some relevant threads in Forums, if we think it's necessary to mention CNAMES at this point (doesn't seem so though in this topic):

- [Using own domain for Docker Cloud stack URL](https://forums.docker.com/t/using-own-domain-for-docker-cloud-stack-url/6519)
- [Assign a custom domain name (nickname, FQDN)](https://forums.docker.com/t/assign-a-custom-domain-name-nickname-fqdn/6911) 
- [How to assign a domain name to a docker cloud service?](https://forums.docker.com/t/how-to-assign-a-domain-name-to-a-docker-cloud-service/7643)

### Related

Fixes #4124 

### Reviewers

@mochawich @fermayo @KickingTheTV @mstanleyjones @JimGalasyn 



Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
