### PR TITLE
Fix file version in volumes long syntax example to 3.2

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1581,7 +1581,7 @@ expressed in the short form.
 
 
 ```none
-version: "3"
+version: "3.2"
 services:
   web:
     image: nginx:alpine


### PR DESCRIPTION
### Proposed changes
Fix docker-compose file version in the example given for the new volumes "long syntax", available from version 3.2.
Currently the example contains version 3 which does not support this syntax.
