### PR TITLE
Fix missing title in "telemetry" frontmatter

### DIFF
--- a/enterprise/telemetry.md
+++ b/enterprise/telemetry.md
@@ -1,5 +1,6 @@
 ---
 name: Manage usage data collection
+title: Manage usage data collection
 description: Understand and manage usage data collected by Docker EE and sent to Docker.
 keywords: enterprise, telemetry, data collection
 ---


### PR DESCRIPTION
CI was failing because this page was missing a title:

    11:35:10 === RUN   TestFrontMatterTitle
    11:35:10 --- FAIL: TestFrontMatterTitle (0.12s)
    11:35:10 	frontmatter_test.go:27: can't find title in frontmatter - /docs/enterprise/telemetry.md

This was added through https://github.com/docker/docker.github.io/commit/79a134f523e149c2eeb378e3fc838e662b6a7ad6, which is part of https://github.com/docker/docker.github.io/pull/4212

ping @mstanleyjones @joaofnfernandes @JimGalasyn 