### PR TITLE
Fixing syntax for DTR upgrade command in docs

### DIFF
--- a/datacenter/dtr/2.3/guides/admin/upgrade.md
+++ b/datacenter/dtr/2.3/guides/admin/upgrade.md
@@ -66,7 +66,7 @@ nodes if upgrading offline), run the upgrade command:
 
 ```none
 $ docker run -it --rm \
-  {{ page.dtr_org }}/{{ page.dtr_repo }}{{ page.dtr_version }} upgrade \
+  {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} upgrade \
   --ucp-insecure-tls
 ```
 


### PR DESCRIPTION
## Proposed changes
Added missing colon between `dtr_repo` and `dtr_version`, which is required for the command to function as written.