### PR TITLE
Fix install DDC on Linux

### DIFF
--- a/datacenter/install/linux.md
+++ b/datacenter/install/linux.md
@@ -94,7 +94,7 @@ Use ssh to log in to the host where you already installed UCP, and run:
 
 ```bash
 $ docker container run -it --rm \
-  {{ page.ucp_latest_image }} install \
+  {{ page.dtr_latest_image }} install \
   --ucp-node <node-hostname> \
   --ucp-insecure-tls
 ```


### PR DESCRIPTION
Right now, the docs tell you to install UCP twice, and that’s not what we want.
We want it to make it that you install UCP and then DTR