### PR TITLE
release-notes/docker-engine: add missing closing curly dude

### DIFF
--- a/release-notes/docker-engine.md
+++ b/release-notes/docker-engine.md
@@ -827,7 +827,7 @@ installing docker, please make sure to update them accordingly.
 * Add container's short-id as default network alias [#21901](https://github.com/docker/docker/pull/21901)
 * `run` options `--dns` and `--net=host` are no longer mutually exclusive [#22408](https://github.com/docker/docker/pull/22408)
 - Fix DNS issue when renaming containers with generated names [#22716](https://github.com/docker/docker/pull/22716)
-- Allow both `{% raw %network inspect -f {{.Id}}` and `network inspect -f {{.ID}}{% endraw %}` to address inconsistency with inspect output [#23226](https://github.com/docker/docker/pull/23226)
+- Allow both `{% raw %}network inspect -f {{.Id}}` and `network inspect -f {{.ID}}{% endraw %}` to address inconsistency with inspect output [#23226](https://github.com/docker/docker/pull/23226)
 
 ### Plugins (experimental)
 


### PR DESCRIPTION
### Proposed changes

I fixed the syntax of a `{% raw %}` tag so the site would build. 

Without this, you get `Syntax Error in 'raw' - Valid syntax: raw in release-notes/docker-engine.md`

### Unreleased project version (optional)

I think this applies to any ref which has this line!

### Related issues (optional)

Just passing by... 😄 
