### PR TITLE
removed quotes from --fixed-cidr-v6 assignment

### DIFF
--- a/engine/userguide/networking/default_network/ipv6.md
+++ b/engine/userguide/networking/default_network/ipv6.md
@@ -28,7 +28,7 @@ specify an IPv6 subnet to pick the addresses from. Set the IPv6 subnet via the
 `--fixed-cidr-v6` parameter when starting Docker daemon:
 
 ```
-dockerd --ipv6 --fixed-cidr-v6="2001:db8:1::/64"
+dockerd --ipv6 --fixed-cidr-v6=2001:db8:1::/64
 ```
 
 The subnet for Docker containers should at least have a size of `/80`. This way


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Doc edit to prevent others from trying the --fixed-cidr-v6= dockerd option with quotes as that causes a 
Error starting daemon: Error initializing network controller: invalid CIDR address: foobar

... also discussed here - https://github.com/moby/moby/issues/30315

### Unreleased project version (optional)
n/a

### Related issues (optional)
n/s
