### PR TITLE
Change EXPOSEd to published

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -172,7 +172,7 @@ friendlyhello         latest              326387cea398
 
 ## Run the app
 
-Run the app, mapping your machine's port 4000 to the container's `EXPOSE`d port
+Run the app, mapping your machine's port 4000 to the container's published port
 80 using `-p`:
 
 ```shell


### PR DESCRIPTION
Constructing the word, "exposed," by concatenating EXPOSE + d, is awkward. Also, the port is not really being exposed _because of_ the keyword, EXPOSE, as implied. The keyword is a convention in the Dockerfile for clarity.  
