### PR TITLE
Update "Getting Started with Ubuntu"

### DIFF
--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -141,7 +141,7 @@ the repository.
     > to your parent Ubuntu distribution. For example, if you are using
     >  `Linux Mint Rafaela`, you could use `trusty`.
 
-    **amd64**:
+    **amd64 / x86_64**:
 
     ```bash
     $ sudo add-apt-repository \


### PR DESCRIPTION



### Proposed changes

Clarifies the repository to add for the "x86_64" architecture. This improves the experience for users know they have a "x86_64" system but do not know which repository to pick.

### Related issues (optional)

Closes #4295