### PR TITLE
Add --log-driver option to UCP/DTR backup commands

### DIFF
--- a/datacenter/dtr/2.3/guides/admin/backups-and-disaster-recovery.md
+++ b/datacenter/dtr/2.3/guides/admin/backups-and-disaster-recovery.md
@@ -83,7 +83,7 @@ command, replacing the placeholders for the real values:
 
 ```none
 read -sp 'ucp password: ' UCP_PASSWORD; \
-docker run -i --rm \
+docker run --log-driver none -i --rm \
   --env UCP_PASSWORD=$UCP_PASSWORD \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} backup \
   --ucp-url <ucp-url> \

--- a/datacenter/dtr/2.3/reference/cli/backup.md
+++ b/datacenter/dtr/2.3/reference/cli/backup.md
@@ -9,7 +9,7 @@ Create a backup of DTR
 ## Usage
 
 ```bash
-docker run -i --rm docker/dtr \
+docker run --log-driver none -i --rm docker/dtr \
     backup [command options] > backup.tar
 ```
 

--- a/datacenter/ucp/2.2/guides/admin/backups-and-disaster-recovery.md
+++ b/datacenter/ucp/2.2/guides/admin/backups-and-disaster-recovery.md
@@ -50,7 +50,7 @@ verify its contents:
 
 ```none
 # Create a backup, encrypt it, and store it on /tmp/backup.tar
-$ docker container run --rm -i --name ucp \
+$ docker container run --log-driver none --rm -i --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} backup --interactive > /tmp/backup.tar
 
@@ -65,7 +65,7 @@ following example:
 
 ```none
 # Create a backup, encrypt it, and store it on /tmp/backup.tar
-$ docker container run --rm -i --name ucp \
+$ docker container run --log-driver none --rm -i --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} backup --interactive \
   --passphrase "secret" > /tmp/backup.tar

--- a/datacenter/ucp/2.2/reference/cli/backup.md
+++ b/datacenter/ucp/2.2/reference/cli/backup.md
@@ -9,7 +9,7 @@ Create a backup of a UCP manager node
 ## Usage
 
 ```bash
-docker container run --rm -i \
+docker container run --log-driver none --rm -i \
     --name ucp \
     -v /var/run/docker.sock:/var/run/docker.sock \
     docker/ucp \


### PR DESCRIPTION
The command lines look like:

```
$ docker container run --log-driver none --rm -i --name ucp -v /var/run/docker.sock:/var/run/docker.sock docker/ucp:latest backup --interactive > /tmp/backup.tar
```

@yongshin PTAL