### PR TITLE
nginx does not support bcrypt when using auth_basic

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -146,7 +146,7 @@ Review the [requirements](/registry/recipes/index.md#requirements), then follow 
 3.  Create a password file `auth/nginx.htpasswd` for "testuser" and "testpassword".
 
     ```bash
-    $ docker run --rm --entrypoint htpasswd registry:2 -Bbn testuser testpassword > auth/nginx.htpasswd
+    $ docker run --rm --entrypoint htpasswd registry:2 -bn testuser testpassword > auth/nginx.htpasswd
     ```
 
 4.  Copy your certificate files to the `auth/` directory.


### PR DESCRIPTION
Registry only support bcrypt when using basic auth.
However, nginx does *not* support bcrypt, only md5....

Without this change you'll get error in the nginx log like
```[crit] 5#5: *1 crypt_r() failed (22: Invalid argument)```

Ref. https://stackoverflow.com/questions/31833583/nginx-gives-an-internal-server-error-500-after-i-have-configured-basic-auth