### PR TITLE
fix registry template plist location for launchctl

### DIFF
--- a/registry/recipes/osx-setup-guide.md
+++ b/registry/recipes/osx-setup-guide.md
@@ -57,8 +57,8 @@ Copy the registry configuration file in place:
 
 Copy the Docker registry plist into place:
 
-    plutil -lint docs/osx/com.docker.registry.plist
-    cp docs/osx/com.docker.registry.plist ~/Library/LaunchAgents/
+    plutil -lint registry/recipes/osx/com.docker.registry.plist
+    cp registry/recipes/osx/com.docker.registry.plist ~/Library/LaunchAgents/
     chmod 644 ~/Library/LaunchAgents/com.docker.registry.plist
 
 Start the Docker registry:

--- a/registry/recipes/osx-setup-guide.md
+++ b/registry/recipes/osx-setup-guide.md
@@ -44,6 +44,7 @@ If you want to understand, you should read [How to Write Go Code](https://golang
 ## Build the binary
 
     GOPATH=$(PWD)/Godeps/_workspace:$GOPATH make binaries
+    sudo mkdir -p /usr/local/libexec
     sudo cp bin/registry /usr/local/libexec/registry
 
 ## Setup


### PR DESCRIPTION
Signed-off-by: ebriney <emmanuel.briney@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

This is a fix to setup native registry on mac (at least you can use it) 

### Related issues (optional)

Related to https://github.com/docker/docker.github.io/issues/2767 but need more changes to close the issue

