### PR TITLE
updates to version variables for compose and machine

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,6 @@ safe: false
 lsi: false
 url: https://docs.docker.com
 keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13", "v17.03"]
-compose_current: 1.14.0
 
 collections:
   samples:

--- a/compose/install.md
+++ b/compose/install.md
@@ -5,6 +5,8 @@ title: Install Docker Compose
 toc_max: 2
 ---
 
+{% assign composeversion = '0.15.0' %}
+
 You can run Compose on macOS, Windows and 64-bit Linux.
 
 ## Prerequisites
@@ -72,11 +74,11 @@ Docker Compose. To do so, follow these steps:
     Invoke-WebRequest "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
     ```
 
-    For example, to download Compose version {{ site.compose_current }},
+    For example, to download Compose version {{composeversion}},
     the command is:
 
     ```none
-    Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_current}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
+    Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{composeversion}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
     ```
     >  Use the latest Compose release number in the download command.
     >
@@ -110,11 +112,11 @@ https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker
 -s`-`uname -m` -o /usr/local/bin/docker-compose
     ```
 
-    For example, to download Compose version {{site.compose_current}}, the command
+    For example, to download Compose version {{composeversion}}, the command
     is:
 
     ```bash
-    sudo curl -L https://github.com/docker/compose/releases/download/{{site.compose_current}}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+    sudo curl -L https://github.com/docker/compose/releases/download/{{composeversion}}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
     ```
 
     > Use the latest Compose release number in the download command.
@@ -144,7 +146,7 @@ https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker
 
     ```bash
     $ docker-compose --version
-    docker-compose version {{site.compose_current}}, build 1719ceb
+    docker-compose version {{composeversion}}, build 1719ceb
     ```  
 <hr>
 </div>
@@ -183,7 +185,7 @@ install compose as a container run this command. Be sure to replace the version
 number with the one that you want, if this example is out-of-date:
 
 ```bash
-$ sudo curl -L --fail https://github.com/docker/compose/releases/download/{{site.compose_current}}/run.sh -o /usr/local/bin/docker-compose
+$ sudo curl -L --fail https://github.com/docker/compose/releases/download/{{composeversion}}/run.sh -o /usr/local/bin/docker-compose
 $ sudo chmod +x /usr/local/bin/docker-compose
 ```
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -5,7 +5,7 @@ title: Install Docker Compose
 toc_max: 2
 ---
 
-{% assign composeversion = '0.15.0' %}
+{% assign composeversion = '1.15.0' %}
 
 You can run Compose on macOS, Windows and 64-bit Linux.
 

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -4,6 +4,8 @@ keywords: machine, orchestration, install, installation, docker, documentation, 
 title: Install Docker Machine
 ---
 
+{% assign machineversion = '0.12.2' %}
+
 On macOS and Windows, Machine is installed along with other Docker products when
 you install the [Docker for Mac](/docker-for-mac/index.md), [Docker for
 Windows](/docker-for-windows/index.md), or [Docker
@@ -24,14 +26,14 @@ on GitHub.
     If you are running on **macOS**:
 
     ```console
-    $ curl -L https://github.com/docker/machine/releases/download/v0.12.2/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine && \
+    $ curl -L https://github.com/docker/machine/releases/download/v{{machineversion}}/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine && \
   chmod +x /usr/local/bin/docker-machine
     ```
 
     If you are running on **Linux**:
 
     ```console
-    $ curl -L https://github.com/docker/machine/releases/download/v0.12.2/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine &&
+    $ curl -L https://github.com/docker/machine/releases/download/v{{machineversion}}/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine &&
     chmod +x /tmp/docker-machine &&
     sudo cp /tmp/docker-machine /usr/local/bin/docker-machine
     ```
@@ -40,7 +42,7 @@ on GitHub.
 
     ```console
     $ if [[ ! -d "$HOME/bin" ]]; then mkdir -p "$HOME/bin"; fi && \
-curl -L https://github.com/docker/machine/releases/download/v0.12.2/docker-machine-Windows-x86_64.exe > "$HOME/bin/docker-machine.exe" && \
+curl -L https://github.com/docker/machine/releases/download/v{{machineversion}}/docker-machine-Windows-x86_64.exe > "$HOME/bin/docker-machine.exe" && \
 chmod +x "$HOME/bin/docker-machine.exe"
     ```
 
@@ -54,7 +56,7 @@ chmod +x "$HOME/bin/docker-machine.exe"
 3.  Check the installation by displaying the Machine version:
 
         $ docker-machine version
-        docker-machine version 0.12.2, build 9371605
+        docker-machine version {{machineversion}}, build 9371605
 
 ## Installing bash completion scripts
 


### PR DESCRIPTION
### What's changed

- replaced Compose `site: compose_current` site-wide variable in `_config.yml` with `composeversion` on the only page where it's called

- added a page-level variable for `machineversion`

- updated the values for both to match the current released verisons showing on the associated release pages ([Compose releases](https://github.com/docker/compose/releases) currently at `1.15.0` and [Machine releases](https://github.com/docker/machine/releases/) currently at `0.12.2`)

### Reviewers

@shin- @FrenchBen 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

