### PR TITLE
Cleanup editions

### DIFF
--- a/_includes/d4a_buttons.md
+++ b/_includes/d4a_buttons.md
@@ -5,46 +5,31 @@
 
 
 {% capture aws_blue_latest %}
-<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)</a>
-<div class="clearfix"></div>
+<a class="button outline-btn min-hgt aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)</a>
+{% endcapture %}
+
+{% capture aws_blue_vpc_latest %}
+<a class="button outline-btn min-hgt aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker-no-vpc.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)<br/><small>uses your existing VPC</small></a>
 {% endcapture %}
 
 {% capture aws_blue_edge %}
-<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)</a>
-<div class="clearfix"></div>
+<a class="button outline-btn min-hgt aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)</a>
+{% endcapture %}
+
+{% capture aws_blue_vpc_edge %}
+<a class="button outline-btn min-hgt aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker-no-vpc.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)<br/><small>uses your existing VPC</small></a>
 {% endcapture %}
 
 {% capture aws_blue_test %}
 <a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/test/Docker.tmpl" data-rel="{{ d4a_test }}" target="blank">Deploy Docker Community Edition (CE) for AWS (test)</a>
 {% endcapture %}
 
-{% capture aws_blue_vpc_latest %}
-<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker-no-vpc.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)<br/><small>uses your existing VPC</small></a>
-<div class="clearfix"></div>
-{% endcapture %}
-
-{% capture aws_blue_vpc_edge %}
-<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker-no-vpc.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for AWS (edge)<br/><small>uses your existing VPC</small></a>
-<div class="clearfix"></div>
-{% endcapture %}
-
-{% capture aws_blue_vpc_test %}
-<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/test/Docker-no-vpc.tmpl" data-rel="{{ d4a_test }}" target="blank">Deploy Docker Community Edition (CE) for AWS (test)<br/><small>uses your existing VPC</small></a>
-{% endcapture %}
-
-{% capture aws_blue_vpc_latest %}
-<a class="button outline-btn aws-deploy" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Docker&templateURL=https://editions-us-east-1.s3.amazonaws.com/aws/stable/Docker-no-vpc.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for AWS (stable)<br/><small>uses your existing VPC</small></a>
-<div class="clearfix"></div>
-{% endcapture %}
-
 {% capture azure_blue_latest %}
 <a class="button outline-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fstable%2FDocker.tmpl" data-rel="{{ d4a_stable }}" target="blank">Deploy Docker Community Edition (CE) for Azure (stable)</a>
-<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture azure_blue_edge %}
 <a class="button outline-btn azure-deploy" href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdownload.docker.com%2Fazure%2Fedge%2FDocker.tmpl" data-rel="{{ d4a_edge }}" target="blank">Deploy Docker Community Edition (CE) for Azure (edge)</a>
-<div class="clearfix"></div>
 {% endcapture %}
 
 {% capture azure_button_latest %}

--- a/_scss/_buttons.scss
+++ b/_scss/_buttons.scss
@@ -21,6 +21,10 @@ a.button.outline-btn {
     display: inline-block;
 }
 
+a.button.outline-btn.min-hgt {
+    min-height: 85px;
+}
+
 .button {
     margin: 10px 10px 10px 0;
     font-family: Geomanist Book;

--- a/_scss/_buttons.scss
+++ b/_scss/_buttons.scss
@@ -18,6 +18,7 @@ a.button.outline-btn {
     color: #0087C8;
     float: none;
     margin-bottom: 30px;
+    display: inline-block;
 }
 
 .button {

--- a/_scss/_buttons.scss
+++ b/_scss/_buttons.scss
@@ -16,6 +16,8 @@ a.button {
 
 a.button.outline-btn {
     color: #0087C8;
+    float: none;
+    margin-bottom: 30px;
 }
 
 .button {

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -140,6 +140,7 @@ body.night {
         color: #a7e2ff;
         float: none;
         margin-bottom: 30px;
+        display: inline-block;
     }
     .component img, .component-full-icon img {
         opacity: 1;

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -138,6 +138,8 @@ body.night {
     }
     a.button.outline-btn {
         color: #a7e2ff;
+        float: none;
+        margin-bottom: 30px;
     }
     .component img, .component-full-icon img {
         opacity: 1;

--- a/docker-for-aws/archive.md
+++ b/docker-for-aws/archive.md
@@ -22,6 +22,11 @@ http://editions-us-east-1.s3.amazonaws.com/aws/stable/17.03.0/Docker.tmpl
 
 ## EE
 
+### 17.06.1
+
+https://editions-us-east-1.s3.amazonaws.com/aws/17.06/17.06.1/Docker.tmpl
+https://editions-us-east-1.s3.amazonaws.com/aws/17.06/17.06.1/Docker-DDC.tmpl
+
 ### 17.03.1
 
 https://editions-us-east-1.s3.amazonaws.com/aws/17.03/17.03.1/Docker.tmpl

--- a/docker-for-aws/archive.md
+++ b/docker-for-aws/archive.md
@@ -12,24 +12,16 @@ CloudFormation templates for past releases. If starting out, please use the late
 
 http://editions-us-east-1.s3.amazonaws.com/aws/stable/17.03.1/Docker.tmpl
 
+### 17.03.1
+
+http://editions-us-east-1.s3.amazonaws.com/aws/stable/17.03.1/Docker.tmpl
+
 ### 17.03.0
 
 http://editions-us-east-1.s3.amazonaws.com/aws/stable/17.03.0/Docker.tmpl
-
-### 1.13.1
-
-http://editions-us-east-1.s3.amazonaws.com/aws/stable/2017-02-09/Docker.tmpl
-
-### 1.13.0
-
-http://editions-us-east-1.s3.amazonaws.com/aws/stable/2017-01-18/Docker.tmpl
 
 ## EE
 
 ### 17.03.1
 
 https://editions-us-east-1.s3.amazonaws.com/aws/17.03/17.03.1/Docker.tmpl
-
-### 17.03
-
-https://editions-us-east-1.s3.amazonaws.com/aws/17.03/17.03.0/Docker.tmpl

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -13,7 +13,7 @@ redirect_from:
 ## Docker Enterprise Edition (EE) for AWS
 This deployment is fully baked and tested, and comes with the latest Enterprise Edition version of Docker. <br/>This release is maintained and receives <strong>security and critical bugfixes for one year</strong>.
 
-<a class="button outline-btn" href="https://store.docker.com/editions/enterprise/docker-ee-aws?tab=description" target="_blank">Deploy Docker Enterprise Edition (EE) for AWS</a>
+[Deploy Docker Enterprise Edition (EE) for AWS](https://store.docker.com/editions/enterprise/docker-ee-aws?tab=description){: target="_blank" class="button outline-btn"}
 
 
 ## Docker Community Edition (CE) for AWS

--- a/docker-for-aws/index.md
+++ b/docker-for-aws/index.md
@@ -30,12 +30,10 @@ using CloudFormation. For more about stable and edge channels, see the
   <tr>
     <th style="font-size: x-large; font-family: arial">Stable channel</th>
     <th style="font-size: x-large; font-family: arial">Edge channel</th>
-    <th style="font-size: x-large; font-family: arial">Test channel</th>
   </tr>
   <tr valign="top">
     <td width="33%">This deployment is fully baked and tested, and comes with the latest CE version of Docker. <br><br>This is the best channel to use if you want a reliable platform to work with. <br><br>Stable is released quarterly and is for users that want an easier-to-maintain release pace.</td>
     <td width="34%">This deployment offers cutting edge features of the CE version of Docker and comes with experimental features turned on, described in the <a href="https://github.com/docker/docker-ce/blob/master/components/cli/experimental/README.md">Docker Experimental Features README</a> on GitHub. (Adjust the branch or tag in the URL to match your version.)<br><br>This is the best channel to use if you want to experiment with features under development, and can weather some instability and bugs. Edge is for users wanting a drop of the latest and greatest features every month. <br><br>We collect usage data on edges across the board.</td>
-    <td width="33%">This is the test channel. It is used for testing release candidates for upcoming releases. Use this channel if you want to test out the new releases before they are available.</td>
   </tr>
   <tr valign="top">
   <td width="33%">
@@ -46,12 +44,13 @@ using CloudFormation. For more about stable and edge channels, see the
   {{aws_blue_edge}}
   {{aws_blue_vpc_edge}}
   </td>
-  <td width="34%">
-  {{aws_blue_test}}
-  {{aws_blue_vpc_test}}
-  </td>
   </tr>
 </table>
+
+
+#### Test Channel
+<p>This is the test channel. It is used for testing release candidates for upcoming releases. Use this channel if you want to test out the new releases before they are available.</p>
+{{aws_blue_test}}
 
 ### Deployment options
 

--- a/docker-for-aws/release-notes.md
+++ b/docker-for-aws/release-notes.md
@@ -23,11 +23,19 @@ title: Docker for AWS release notes
 
 ## Stable channel
 
+### 17.06.1 CE
+
+Release date: 08/17/2017
+
+{{aws_blue_latest}}
+
+**New**
+
+- Docker Engine upgraded to [Docker 17.06.1 CE](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce){: target="_blank"}
+
 ### 17.06.0 CE
 
 Release date: 06/28/2017
-
-{{aws_blue_latest}}
 
 **New**
 

--- a/docker-for-aws/release-notes.md
+++ b/docker-for-aws/release-notes.md
@@ -6,6 +6,21 @@ title: Docker for AWS release notes
 
 {% include d4a_buttons.md %}
 
+## Enterprise Edition
+[Docker Enterprise Edition Lifecycle](https://success.docker.com/Policies/Maintenance_Lifecycle){: target="_blank"}
+
+[Deploy Docker Enterprise Edition (EE) for AWS](https://store.docker.com/editions/enterprise/docker-ee-aws?tab=description){: target="_blank" class="button outline-btn"}
+
+### 17.06 EE
+
+- Docker engine 17.06 EE
+- For Std/Adv external logging has been removed, as it is now handled by [UCP](https://docs.docker.com/datacenter/ucp/2.0/guides/configuration/configure-logs/){: target="_blank"}
+
+### 17.03 EE
+
+- Docker engine 17.03 EE
+
+
 ## Stable channel
 
 ### 17.06.0 CE
@@ -16,7 +31,7 @@ Release date: 06/28/2017
 
 **New**
 
-- Docker Engine upgraded to [Docker 17.06.0 CE](https://github.com/docker/docker-ce/releases/tag/v17.06.0-ce)
+- Docker Engine upgraded to [Docker 17.06.0 CE](https://github.com/docker/docker-ce/releases/tag/v17.06.0-ce){: target="_blank"}
 - Fixed an issue with load balancer controller that caused the ELB health check to fail.
 - Added VPCID output when a VPC is created
 - Added CloudStor support (EFS (in regions that support EFS), and EBS) for [persistent storage volumes](persistent-data-volumes.md)
@@ -33,7 +48,7 @@ Release date: 03/30/2017
 
 **New**
 
-- Docker Engine upgraded to [Docker 17.03.1 CE](https://github.com/docker/docker/blob/master/CHANGELOG.md)
+- Docker Engine upgraded to [Docker 17.03.1 CE](https://github.com/docker/docker/blob/master/CHANGELOG.md){: target="_blank"}
 - Updated AZ for Sao Paulo
 
 ### 17.03.0 CE
@@ -42,293 +57,10 @@ Release date: 03/01/2017
 
 **New**
 
-- Docker Engine upgraded to [Docker 17.03.0 CE](https://github.com/docker/docker/blob/master/CHANGELOG.md)
+- Docker Engine upgraded to [Docker 17.03.0 CE](https://github.com/docker/docker/blob/master/CHANGELOG.md){: target="_blank"}
 - Added r4 EC2 instance types
 - Added `ELBDNSZoneID` output to make it easier to interact with Route53
 
-### 1.13.1-2
-
-Release date: 02/08/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.1](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-
-### 1.13.0-1
-
-Release date: 01/18/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.0](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- Change ELB health check from TCP to HTTP
-
-## Edge channel
-
-### 17.06.0-edge CE
-
-Release date: 06/28/2017
-
-{{aws_blue_latest}}
-
-**New**
-
-- Docker Engine upgraded to [Docker 17.06.0 CE](https://github.com/docker/docker-ce/releases/tag/v17.06.0-ce)
-- Fixed an issue with load balancer controller that caused the ELB health check to fail.
-- Changed the AutoScaleGroup Manager max size to 6, so that it correctly upgrades with 5 managers
-- Added Beta support for [adding AWS ACM certificates to the ELB to support SSL/TLS traffic](load-balancer.md)
-
-
-### 17.05.0-edge CE
-
-Release date: 05/08/2017
-
-{{aws_blue_edge}}
-
-**New**
-
-- Docker Engine upgraded to [Docker 17.05.0 CE](https://github.com/moby/moby/releases/tag/v17.05.0-ce)
-- Added VPCID output when a VPC is created
-- Added CloudFormation parameter to enable/disable CloudStor
-
-### 17.04.0-edge CE
-
-Release date: 04/06/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 17.04.0 CE](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- Added lambda support for Mumbai
-- Removed the ELB Name to allow for longer stack names
-- Added i3 EC2 instance types
-- Added CloudStor support to the Sydney region
-- Updated AZ for Sao Paulo
-- [Bring your own VPC] Added a VPC CIDR Parameter
-
-### 17.03.0-edge CE
-
-Release date: 03/01/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 17.03.0 CE](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- Added r4 EC2 instance types
-- Added `ELBDNSZoneID` output to make it easier to interact with Route53
-- Added alias to `Cloudstor` plugin to make it easier on upgrades.
-
-### 1.13.1-beta18
-
-Release date: 02/16/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.1](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- Added a second CloudFormation template that allows you to [install Docker for AWS into a pre-existing VPC](/docker-for-aws/index.md#install-into-an-existing-vpc).
-- Added Swarm wide support for [persistent storage volumes](persistent-data-volumes.md)
-- Added the following engine labels
-    - **os** (linux)
-    - **region** (us-east-1, etc)
-    - **availability_zone** (us-east-1a, etc)
-    - **instance_type** (t2.micro, etc)
-    - **node_type** (worker, manager)
-
-### 1.13.1-rc2-beta17
-
-Release date: 02/07/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.1-rc2](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-
-### 1.13.1-rc1-beta16
-
-Release date: 02/01/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.1-rc1](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-
-### 1.13.0-rc5-beta15
-
-Release date: 01/10/2017
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.0-rc5](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-
-### 1.13.0-rc4-beta14
-
-Release date: 12/21/2016
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.0-rc4](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- Previously we always only used 2 Availability Zones per region, even if the region had more. We now dynamically pick the best number of Availability Zones to use based on the region. If a region only has two AZs it will only use 2. If it has three or more, it will use 3
-- Changed the AutoScaleGroup HealthCheck from an EC2 check to an ELB check
-- Removed password prompt when ssh key is invalid
-- Added new Canada Central region `ca-central-1`
-- Added new London region `eu-west-2`
-- Made recovery improvements when primary swarm node crashes
-
-### 1.13.0-rc3-beta13
-
-Release date: 12/06/2016
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.0-rc3](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- New option to decide if you want to send container logs to CloudWatch. (previously it was always on)
-- SSH access has been added to the worker nodes
-- The Docker daemon no longer listens on port 2375
-- Added a `swarm-exec` to execute a docker command across all of the swarm nodes. See [Executing Docker commands in all swarm nodes](/docker-for-aws/deploy.md#execute-docker-commands-in-all-swarm-nodes) for more details.
-
-### 1.13.0-rc2-beta12
-
-Release date: 11/23/2016
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.0-rc2](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- New option to cleanup unused resources on your Swarm using new Docker prune command available in 1.13
-- New option to pick the size of the ephemeral storage volume size on workers and managers
-- New option to pick the disk type for the ephemeral storage on workers and managers
-- Changed the Cloud Watch container log name from container "ID" to "Container Name-ID"
-
-
-### 1.13.0-rc1-beta11
-
-Release date: 11/17/2016
-
-**New**
-
-- Docker Engine upgraded to [Docker 1.13.0-rc1](https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- Changes to port 2375 access. For security reasons we locked down access to port 2375 in the following ways.
-    - You can't connect to port 2375 on managers from workers (changed)
-    - You can't connect to port 2375 on workers from other workers (changed)
-    - You can't connect to port 2375 on managers and workers from the public internet (no change)
-    - You can connect to port 2375 on workers from managers (no change)
-    - You can connect to port 2375 on managers from other managers (no change)
-- Added changes to the way we manage swarm tokens to make it more secure.
-
-**Important**
-
-- Due to some changes with the IP ranges in the subnets in Beta10, it will not be possible to upgrade from beta 10 to beta 11. You will need to start from scratch using beta11. We are sorry for any issues this might cause. We needed to make the change, and it was decided it was best to do it now, while still in private beta to limit the impact.
-
-### 1.12.3-beta10
-
-Release date: 10/27/2016
-
-**New**
-
-- Docker Engine upgraded to Docker 1.12.3
-- Fixed the shell container that runs on the managers, to remove a ssh host key that was accidentally added to the image.
-This could have led to a potential man in the middle (MITM) attack. The ssh host key is now generated on host startup, so that each host has its own key.
-- The SSH ELB for connecting to the managers by SSH has been removed because it is no longer possible to SSH into the managers without getting a security warning
-- You can connect to each manager using SSH by following our deploy [guide](/docker-for-aws/deploy.md)
-- Added new region us-east-2 (Ohio)
-- Fixed some bugs related to upgrading the swarm
-- SSH keypair is now a required field in CloudFormation
-- Fixed networking dependency issues in CloudFormation template that could result in a stack failure.
-
-### 1.12.2-beta9
-
-Release date: 10/12/2016
-
-**New**
-
-- Docker Engine upgraded to Docker 1.12.2
-- Can better handle scaling swarm nodes down and back up again
-- Container logs are now sent to CloudWatch
-- Added a diagnostic command (docker-diagnose), to more easily send us diagnostic information in case of errors for troubleshooting
-- Added sudo support to the shell container on manager nodes
-- Change SQS default message timeout to 12 hours from 4 days
-- Added support for region 'ap-south-1': Asia Pacific (Mumbai)
-
-**Deprecated:**
-
-- Port 2375 will be closed in next release. If you relay on this being open, please plan accordingly.
-
-### 1.12.2-RC3-beta8
-
-Release date: 10/06/2016
-
-**New**
-
- * Docker Engine upgraded to 1.12.2-RC3
-
-### 1.12.2-RC2-beta7
-
-Release date: 10/04/2016
-
-**New**
-
- * Docker Engine upgraded to 1.12.2-RC2
-
-### 1.12.2-RC1-beta6
-
-Release date: 9/29/2016
-
-**New**
-
- * Docker Engine upgraded to 1.12.2-RC1
-
-
-### 1.12.1-beta5
-
-Release date: 8/18/2016
-
-**New**
-
- * Docker Engine upgraded to 1.12.1
-
-**Errata**
-
- * Upgrading from previous Docker for AWS versions to 1.12.0-beta4 is not possible because of RC-incompatibilities between Docker 1.12.0 release candidate 5 and previous release candidates.
-
-### 1.12.0-beta4
-
-Release date: 7/28/2016
-
-**New**
-
- * Docker Engine upgraded to 1.12.0
-
-**Errata**
-
- * Upgrading from previous Docker for AWS versions to 1.12.0-beta4 is not possible because of RC-incompatibilities between Docker 1.12.0 release candidate 5 and previous release candidates.
-
-### 1.12.0-rc5-beta3
-
-(internal release)
-
-### 1.12.0-rc4-beta2
-
-Release date: 7/13/2016
-
-**New**
-
- * Docker Engine upgraded to 1.12.0-rc4
- * EC2 instance tags
- * Beta Docker for AWS sends anonymous analytics
-
-**Errata**
-
- * When upgrading, old Docker nodes may not be removed from the swarm and show up when running `docker node ls`. Marooned nodes can be removed with `docker node rm`
-
-### 1.12.0-rc3-beta1
-
-**New**
-
- * First release of Docker for AWS!
- * CloudFormation based installer
- * ELB integration for running public-facing services
- * Swarm access with SSH
- * Worker scaling using AWS ASG
-
-**Errata**
-
- * To assist with debugging, the Docker Engine API is available internally in the AWS VPC on TCP port 2375. These ports cannot be accessed from outside the cluster, but could be used from within the cluster to obtain privileged access on other cluster nodes. In future releases, direct remote access to the Docker API will not be available.
- * Likewise, swarm-mode is configured to auto-accept both manager and worker nodes inside the VPC. This policy will be changed to be more restrictive by default in the future.
 
 ## Test channel
 

--- a/docker-for-aws/release-notes.md
+++ b/docker-for-aws/release-notes.md
@@ -15,10 +15,14 @@ title: Docker for AWS release notes
 
 - Docker engine 17.06 EE
 - For Std/Adv external logging has been removed, as it is now handled by [UCP](https://docs.docker.com/datacenter/ucp/2.0/guides/configuration/configure-logs/){: target="_blank"}
+- UCP 2.2.0 
+- DTR 2.3.0
 
 ### 17.03 EE
 
 - Docker engine 17.03 EE
+- UCP 2.1.5
+- DTR 2.2.7
 
 
 ## Stable channel
@@ -32,6 +36,8 @@ Release date: 08/17/2017
 **New**
 
 - Docker Engine upgraded to [Docker 17.06.1 CE](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce){: target="_blank"}
+- Improvements to CloudStor support
+- Added SSL support at the LB level
 
 ### 17.06.0 CE
 

--- a/docker-for-azure/archive.md
+++ b/docker-for-azure/archive.md
@@ -15,21 +15,3 @@ https://download.docker.com/azure/stable/17.03.1/Docker.tmpl
 ### 17.03.0
 
 https://download.docker.com/azure/stable/17.03.0/Docker.tmpl
-
-### 1.13.1
-
-https://download.docker.com/azure/stable/2017-02-16/Docker.tmpl
-
-### 1.13.0
-
-https://download.docker.com/azure/stable/2017-01-18/Docker.tmpl
-
-## EE
-
-### 17.03.1
-
-https://download.docker.com/azure/17.03/17.03.1/Docker.tmpl
-
-### 17.03.0
-
-https://download.docker.com/azure/17.03/17.03.0/Docker.tmpl

--- a/docker-for-azure/index.md
+++ b/docker-for-azure/index.md
@@ -12,7 +12,7 @@ redirect_from:
 ## Docker Enterprise Edition (EE) for Azure
 This deployment is fully baked and tested, and comes with the latest Enterprise Edition version of Docker. <br/>This release is maintained and receives <strong>security and critical bugfixes for one year</strong>.
 
-<a class="button outline-btn" href="https://store.docker.com/editions/enterprise/docker-ee-azure?tab=description" target="_blank">Deploy Docker Enterprise Edition (EE) for Azure</a>
+[Deploy Docker Enterprise Edition (EE) for Azure](https://store.docker.com/editions/enterprise/docker-ee-azure?tab=description){: target=“_blank” class=“button outline-btn”}
 
 
 ## Docker Community Edition (CE) for Azure

--- a/docker-for-azure/release-notes.md
+++ b/docker-for-azure/release-notes.md
@@ -22,6 +22,16 @@ title: Docker for Azure Release Notes
 
 ## Stable channel
 
+### 17.06.1 CE
+
+Release date: 08/17/2017
+
+{{aws_blue_latest}}
+
+**New**
+
+- Docker Engine upgraded to [Docker 17.06.1 CE](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce){: target="_blank"}
+
 ### 17.06.0 CE
 
 Release date: 06/28/2017

--- a/docker-for-azure/release-notes.md
+++ b/docker-for-azure/release-notes.md
@@ -15,10 +15,14 @@ title: Docker for Azure Release Notes
 
 - Docker engine 17.06 EE
 - For Std/Adv external logging has been removed, as it is now handled by [UCP](https://docs.docker.com/datacenter/ucp/2.0/guides/configuration/configure-logs/){: target="_blank"}
+- UCP 2.2.0 
+- DTR 2.3.0
 
 ### 17.03 EE
 
 - Docker engine 17.03 EE
+- UCP 2.1.5
+- DTR 2.2.7
 
 ## Stable channel
 
@@ -31,6 +35,8 @@ Release date: 08/17/2017
 **New**
 
 - Docker Engine upgraded to [Docker 17.06.1 CE](https://github.com/docker/docker-ce/releases/tag/v17.06.1-ce){: target="_blank"}
+- Improvements to CloudStor support
+- Azure agent logs are limited to 50mb with proper logrotation
 
 ### 17.06.0 CE
 

--- a/docker-for-azure/release-notes.md
+++ b/docker-for-azure/release-notes.md
@@ -6,6 +6,20 @@ title: Docker for Azure Release Notes
 
 {% include d4a_buttons.md %}
 
+## Enterprise Edition
+[Docker Enterprise Edition Lifecycle](https://success.docker.com/Policies/Maintenance_Lifecycle){: target="_blank"}
+
+[Deploy Docker Enterprise Edition (EE) for AWS](https://store.docker.com/editions/enterprise/docker-ee-aws?tab=description){: target="_blank" class="button outline-btn"}
+
+### 17.06 EE
+
+- Docker engine 17.06 EE
+- For Std/Adv external logging has been removed, as it is now handled by [UCP](https://docs.docker.com/datacenter/ucp/2.0/guides/configuration/configure-logs/){: target="_blank"}
+
+### 17.03 EE
+
+- Docker engine 17.03 EE
+
 ## Stable channel
 
 ### 17.06.0 CE

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -133,7 +133,7 @@ entanglement; a containerized app "runs anywhere."
 Before we get started, make sure your system has the latest version of Docker
 installed.
 
-[Install Docker](/engine/installation/index.md){: class="button outline-btn" style="margin-bottom: 30px; margin-right:100%; clear: left;"}
+[Install Docker](/engine/installation/index.md){: class="button outline-btn"}
 <div style="clear:left"></div>
 > **Note**: version 1.13 or higher is required
 

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -351,8 +351,7 @@ install anything but Docker to run it.
 That's all for this page. In the next section, we will learn how to scale our
 application by running this container in a **service**.
 
-[Continue to Part 3 >>](part3.md){: class="button outline-btn"
-style="margin-bottom: 30px"}
+[Continue to Part 3 >>](part3.md){: class="button outline-btn"}
 
 
 ## Recap and cheat sheet (optional)

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -197,7 +197,7 @@ machines.
 Cloud](/docker-cloud/), or on any hardware or cloud provider you choose with
 [Docker Enterprise Edition](https://www.docker.com/enterprise-edition).
 
-[On to "Part 4" >>](part4.md){: class="button outline-btn" style="margin-bottom: 30px"}
+[On to "Part 4" >>](part4.md){: class="button outline-btn"}
 
 ## Recap and cheat sheet (optional)
 

--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -297,7 +297,7 @@ docker-machine ssh myvm1 "docker stack rm getstartedlab"
 > manager, but _you'll need this swarm for part 5, so please keep it
 > around for now_.
 
-[On to Part 5 >>](part5.md){: class="button outline-btn" style="margin-bottom: 30px"}
+[On to Part 5 >>](part5.md){: class="button outline-btn"}
 
 ## Recap and cheat sheet (optional)
 

--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -253,7 +253,7 @@ Redis service. Be sure to replace `username/repo:tag` with your image details.
     ![Visualizer with redis screenshot](images/visualizer-with-redis.png)
 
 
-[On to Part 6 >>](part6.md){: class="button outline-btn" style="margin-bottom: 30px"}
+[On to Part 6 >>](part6.md){: class="button outline-btn"}
 
 ## Recap (optional)
 

--- a/get-started/part6.md
+++ b/get-started/part6.md
@@ -119,7 +119,7 @@ via UI using Universal Control Plane, run a private image registry with Docker
 Trusted Registry, integrate with your LDAP provider, sign production images with
 Docker Content Trust, and many other features.
 
-[Take a tour of Docker Enterprise Edition](https://www.docker.com/enterprise-edition){: class="button outline-btn" onclick="ga('send', 'event', 'Get Started Referral', 'Enterprise', 'Take tour');" style="margin-bottom: 30px; margin-right:58%"}
+[Take a tour of Docker Enterprise Edition](https://www.docker.com/enterprise-edition){: class="button outline-btn" onclick="ga('send', 'event', 'Get Started Referral', 'Enterprise', 'Take tour');"}
 {% endcapture %}
 {% capture enterprisedeployapp %}
 Once you're all set up and Datacenter is running, you can [deploy your Compose

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ Try our new multi-part walkthrough that goes from writing your first app,
 data storage, networking, and swarms, ending with your app running on
 production servers in the cloud. Total reading time is less than an hour!
 
-[Get started with Docker](/get-started/){: class="button outline-btn" style="margin-bottom:30px"}
+[Get started with Docker](/get-started/){: class="button outline-btn"}
 
 {% if site.edge == true %}
 {% capture ce-edge-section %}


### PR DESCRIPTION
### Proposed changes

Update our current edition docs to have the beginning of a release notes for EE and remove old notes. There is only a need to have 1 stable version referenced in EE, as we usually do not make any major changes to the template when going through patch releases.

Additionally some styling fixes were applied. 

### Related issues (optional)
Fixes #3086

/cc @johndmulhausen @mstanleyjones 