### PR TITLE
Fix some links that pointed at the wrong repo

### DIFF
--- a/compose/bundles.md
+++ b/compose/bundles.md
@@ -7,7 +7,7 @@ title: Docker stacks and distributed application bundles (experimental)
 
 > **Note**: This is a modified copy of the [Docker Stacks and Distributed Application
 > Bundles](https://github.com/moby/moby/blob/v1.12.0-rc4/experimental/docker-stacks-and-bundles.md)
-> document in the [docker/docker repo](https://github.com/moby/moby). It's been updated to accurately reflect newer releases.
+> document in the [docker/docker-ce repo](https://github.com/docker/docker-ce). It's been updated to accurately reflect newer releases.
 
 ## Overview
 
@@ -59,7 +59,7 @@ Wrote bundle to vossibility-stack.dab
 > [Docker for Mac](/docker-for-mac/) or
 > [Docker for Windows](/docker-for-windows/) to install
 > it. If you're on Linux, follow the instructions in the
-> [experimental build README](https://github.com/moby/moby/blob/master/experimental/README.md).
+> [experimental build README](https://github.com/docker/cli/blob/master/experimental/README.md).
 
 A stack is created using the `docker deploy` command:
 

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -522,7 +522,7 @@ some of the common settings to make it easier to configure them.
 
 Both Docker for Windows Stable and Edge releases have the experimental version
 of Docker Engine enabled, described in the [Docker Experimental Features
-README](https://github.com/moby/moby/blob/master/experimental/README.md) on
+README](https://github.com/docker/cli/blob/master/experimental/README.md) on
 GitHub.
 
 Experimental features are not appropriate for production environments or

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -25,7 +25,7 @@ If you have not already done so, please install Docker for Windows. You can
 download installers from the **Stable** or **Edge** channel.
 
 Both Stable and Edge installers come with <a
-href="https://github.com/moby/moby/blob/master/experimental/README.md">
+href="https://github.com/docker/cli/blob/master/experimental/README.md">
 experimental features in Docker Engine</a> enabled by default. Experimental mode can be toggled on and off in [preferences](/docker-for-windows/index.md#daemon-experimental-mode).
 
 We welcome your


### PR DESCRIPTION
Fixes https://github.com/docker/cli/issues/473 

experimental docs are in docker/cli now.

For most things we probably want to point at `docker/docker-ce` not `moby/moby`. I fixed one instance of that. The only exception would be links to previous release tags.