### PR TITLE
Distinguish tasks from containers

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -155,12 +155,15 @@ Get the service ID for the one service in our application:
 docker service ls
 ```
 
-Swarm runs tasks that, in this case, spawn containers. Tasks have state and
-their own IDs:
+Swarm for Docker runs tasks that spawn containers. Tasks have state and their
+own IDs:
 
 ```shell
 docker service ps <service>
 ```
+
+>**Note**: SwarmKit tasks do not need to be containers (you can redefine them),
+> but for Docker they are.
 
 Let's inspect one task and limit the ouput to container ID:
 
@@ -203,7 +206,8 @@ Docker will do an in-place update, no need to tear the stack down first or kill
 any containers.
 
 Now, re-run `docker container ls -q` to see the deployed instances reconfigured.
-For example, if you scaled up the replicas, more containers are started.
+If you scaled up the replicas, more tasks, and hence, more containers, are
+started.
 
 ### Take down the app and the swarm
 

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -155,15 +155,14 @@ Get the service ID for the one service in our application:
 docker service ls
 ```
 
-Swarm for Docker runs tasks that spawn containers. Tasks have state and their
-own IDs:
+Docker Swarm runs tasks that spawn containers. Tasks have state and their own
+IDs:
 
 ```shell
 docker service ps <service>
 ```
 
->**Note**: SwarmKit tasks do not need to be containers (you can redefine them),
-> but for Docker they are.
+>**Note**: Docker Swarm is built using a project called SwarmKit. SwarmKit tasks do not need to be containers, but Docker Swarm tasks are defined to spawn them. 
 
 Let's inspect one task and limit the ouput to container ID:
 

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -146,10 +146,36 @@ Now let's run it. You have to give your app a name. Here, it is set to
 docker stack deploy -c docker-compose.yml getstartedlab
 ```
 
-See a list of the 5 containers you just launched:
+Our single service stack is running 5 container instances of our deployed image on one host. Let's investigate.
+
+Get the service ID for the one service in our application:
 
 ```shell
-docker stack ps getstartedlab
+docker service ls
+```
+
+Swarm runs tasks that, in this case, spawn containers. Tasks have state and their own IDs:
+
+```shell
+docker service ps <service>
+```
+
+Let's inspect one task and limit the ouput to container ID:
+
+```shell
+docker inspect --format='{{.Status.ContainerStatus.ContainerID}}' <task>
+```
+
+Vice versa, inspect the container ID, and extract the task ID:
+
+```shell
+docker inspect --format="{{index .Config.Labels \"com.docker.swarm.task.id\"}}" <container>
+```
+
+Now list all 5 containers:
+
+```shell
+docker container ls -q
 ```
 
 You can run `curl http://localhost` several times in a row, or go to that URL in
@@ -174,8 +200,7 @@ docker stack deploy -c docker-compose.yml getstartedlab
 Docker will do an in-place update, no need to tear the stack down first or kill
 any containers.
 
-Now, re-run the `docker stack ps` command to see the deployed instances reconfigured. For example, if you scaled up the replicas, there will be more
-running containers.
+Now, re-run `docker container ls -q` to see the deployed instances reconfigured. For example, if you scaled up the replicas, there will be more running containers.
 
 ### Take down the app and the swarm
 
@@ -215,9 +240,11 @@ it runs, using the same command that launched the service:
 Some commands to explore at this stage:
 
 ```shell
-docker stack ls              # List all running applications on this Docker host
+docker stack ls                                            # List stacks or apps
 docker stack deploy -c <composefile> <appname>  # Run the specified Compose file
-docker stack services <appname>       # List the services associated with an app
-docker stack ps <appname>   # List the running containers associated with an app
+docker service ls                 # List running services associated with an app
+docker service ps <service>                  # List tasks associated with an app
+docker inspect <task or container>                   # Inspect task or container
+docker container ls -q                                      # List container IDs
 docker stack rm <appname>                             # Tear down an application
 ```

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -146,7 +146,8 @@ Now let's run it. You have to give your app a name. Here, it is set to
 docker stack deploy -c docker-compose.yml getstartedlab
 ```
 
-Our single service stack is running 5 container instances of our deployed image on one host. Let's investigate.
+Our single service stack is running 5 container instances of our deployed image
+on one host. Let's investigate.
 
 Get the service ID for the one service in our application:
 
@@ -154,7 +155,8 @@ Get the service ID for the one service in our application:
 docker service ls
 ```
 
-Swarm runs tasks that, in this case, spawn containers. Tasks have state and their own IDs:
+Swarm runs tasks that, in this case, spawn containers. Tasks have state and
+their own IDs:
 
 ```shell
 docker service ps <service>
@@ -200,7 +202,8 @@ docker stack deploy -c docker-compose.yml getstartedlab
 Docker will do an in-place update, no need to tear the stack down first or kill
 any containers.
 
-Now, re-run `docker container ls -q` to see the deployed instances reconfigured. For example, if you scaled up the replicas, there will be more running containers.
+Now, re-run `docker container ls -q` to see the deployed instances reconfigured.
+For example, if you scaled up the replicas, more containers are started.
 
 ### Take down the app and the swarm
 

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -162,18 +162,18 @@ IDs:
 docker service ps <service>
 ```
 
->**Note**: Docker's support for swarms is built using a project called SwarmKit. SwarmKit tasks do not need to be containers, but Docker swarm tasks are defined to spawn them. 
+>**Note**: Docker's support for swarms is built using a project called SwarmKit. SwarmKit tasks do not need to be containers, but Docker swarm tasks are defined to spawn them.
 
 Let's inspect one task and limit the ouput to container ID:
 
 ```shell
-docker inspect --format='{{.Status.ContainerStatus.ContainerID}}' <task>
+docker inspect --format='{% raw %}{{.Status.ContainerStatus.ContainerID}}{% endraw %}' <task>
 ```
 
 Vice versa, inspect the container ID, and extract the task ID:
 
 ```shell
-docker inspect --format="{{index .Config.Labels \"com.docker.swarm.task.id\"}}" <container>
+docker inspect --format="{% raw %}{{index .Config.Labels \"com.docker.swarm.task.id\"}}{% endraw %}" <container>
 ```
 
 Now list all 5 containers:

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -155,14 +155,14 @@ Get the service ID for the one service in our application:
 docker service ls
 ```
 
-Docker Swarm runs tasks that spawn containers. Tasks have state and their own
+Docker swarms run tasks that spawn containers. Tasks have state and their own
 IDs:
 
 ```shell
 docker service ps <service>
 ```
 
->**Note**: Docker Swarm is built using a project called SwarmKit. SwarmKit tasks do not need to be containers, but Docker Swarm tasks are defined to spawn them. 
+>**Note**: Docker's support for swarms is built using a project called SwarmKit. SwarmKit tasks do not need to be containers, but Docker swarm tasks are defined to spawn them. 
 
 Let's inspect one task and limit the ouput to container ID:
 


### PR DESCRIPTION
The command, `docker stack ps getstartedlab`, does not list containers but tasks. I added a flow that helps the user understand tasks and find associated containers so that running `curl http://localhost` makes sense. 
