### PR TITLE
Fix link to DTR install topic

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/configure/integrate-with-dtr.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/integrate-with-dtr.md
@@ -6,7 +6,7 @@ keywords: trust, registry, integrate, UCP, DTR
 
 Once you deploy Docker Trusted Registry (DTR), you can use it to store your
 Docker images and deploy services to UCP using these images.
-[Learn how to deploy DTR](/datacenter/dtr/2.3/guides/install/index.md).
+[Learn how to deploy DTR](/datacenter/dtr/2.3/guides/admin/install/index.md).
 
 Docker UCP integrates out of the box with Docker Trusted Registry (DTR).
 This means that you can deploy services from the UCP web UI, using Docker


### PR DESCRIPTION
Fixes [UCP docs don't explain how to install DTR #741](https://github.com/docker/docker.github.io/issues/741) by updating the link to [Install Docker Trusted Registry](https://docs.docker.com/datacenter/dtr/2.3/guides/admin/install/).