### PR TITLE
Clarify that amd64 is x86_64

### DIFF
--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -31,7 +31,7 @@ Raspbian versions:
 - Jessie 8.0 (LTS) / Raspbian Jessie
 - Wheezy 7.7 (LTS)
 
-Docker CE is supported on both `amd64` (`x86_64`) and `armhf` architectures for Jessie and
+Docker CE is supported on both `x86_64`  (`amd64`)  and `armhf` architectures for Jessie and
 Stretch.
 
 ### Uninstall old versions
@@ -147,7 +147,7 @@ from the repository.
     To also add the **edge** repository, add `edge` after `stable` on the last
     line of the command.
 
-    **amd64 (x86_64)**:
+    **x86_64 (amd64)**:
 
     ```bash
     $ sudo add-apt-repository \
@@ -232,7 +232,7 @@ from the repository.
 4.  Verify that Docker CE is installed correctly by running the `hello-world`
     image.
 
-    **amd64 (x86_64)**:
+    **x86_64 (amd64)**:
 
     ```bash
     $ sudo docker run hello-world

--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -31,7 +31,7 @@ Raspbian versions:
 - Jessie 8.0 (LTS) / Raspbian Jessie
 - Wheezy 7.7 (LTS)
 
-Docker CE is supported on both `x86_64` and `armhf` architectures for Jessie and
+Docker CE is supported on both `amd64` (`x86_64`) and `armhf` architectures for Jessie and
 Stretch.
 
 ### Uninstall old versions
@@ -147,7 +147,7 @@ from the repository.
     To also add the **edge** repository, add `edge` after `stable` on the last
     line of the command.
 
-    **amd64**:
+    **amd64 (x86_64)**:
 
     ```bash
     $ sudo add-apt-repository \
@@ -232,7 +232,7 @@ from the repository.
 4.  Verify that Docker CE is installed correctly by running the `hello-world`
     image.
 
-    **amd64**:
+    **amd64 (x86_64)**:
 
     ```bash
     $ sudo docker run hello-world

--- a/engine/installation/linux/docker-ce/debian.md
+++ b/engine/installation/linux/docker-ce/debian.md
@@ -31,7 +31,7 @@ Raspbian versions:
 - Jessie 8.0 (LTS) / Raspbian Jessie
 - Wheezy 7.7 (LTS)
 
-Docker CE is supported on both `x86_64`  (`amd64`)  and `armhf` architectures for Jessie and
+Docker CE is supported on both `x86_64` (or `amd64`)  and `armhf` architectures for Jessie and
 Stretch.
 
 ### Uninstall old versions
@@ -147,7 +147,7 @@ from the repository.
     To also add the **edge** repository, add `edge` after `stable` on the last
     line of the command.
 
-    **x86_64 (amd64)**:
+    **x86_64**:
 
     ```bash
     $ sudo add-apt-repository \
@@ -232,7 +232,7 @@ from the repository.
 4.  Verify that Docker CE is installed correctly by running the `hello-world`
     image.
 
-    **x86_64 (amd64)**:
+    **x86_64**:
 
     ```bash
     $ sudo docker run hello-world

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -34,7 +34,7 @@ versions:
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker CE is supported on Ubuntu on `amd64` (`x86_64`), `armhf`, and `s390x` (IBM Z) architectures.
+Docker CE is supported on Ubuntu on `x86_64` (`amd64`), `armhf`, and `s390x` (IBM Z) architectures.
 
 > **`s390x` limitations**: IBM Z is only supported on Ubuntu Xenial and Zesty.
 
@@ -141,7 +141,7 @@ the repository.
     > to your parent Ubuntu distribution. For example, if you are using
     >  `Linux Mint Rafaela`, you could use `trusty`.
 
-    **amd64 (x86_64)**:
+    **x86_64 (amd64)**:
 
     ```bash
     $ sudo add-apt-repository \

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -34,7 +34,7 @@ versions:
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker CE is supported on Ubuntu on `x86_64` (`amd64`), `armhf`, and `s390x` (IBM Z) architectures.
+Docker CE is supported on Ubuntu on `amd64` (`x86_64`), `armhf`, and `s390x` (IBM Z) architectures.
 
 > **`s390x` limitations**: IBM Z is only supported on Ubuntu Xenial and Zesty.
 

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -34,7 +34,7 @@ versions:
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker CE is supported on Ubuntu on `x86_64`, `armhf`, and `s390x` (IBM Z) architectures.
+Docker CE is supported on Ubuntu on `x86_64` (`amd64`), `armhf`, and `s390x` (IBM Z) architectures.
 
 > **`s390x` limitations**: IBM Z is only supported on Ubuntu Xenial and Zesty.
 

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -34,7 +34,7 @@ versions:
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker CE is supported on Ubuntu on `x86_64` (`amd64`), `armhf`, and `s390x` (IBM Z) architectures.
+Docker CE is supported on Ubuntu on `x86_64` (or `amd64`), `armhf`, and `s390x` (IBM Z) architectures.
 
 > **`s390x` limitations**: IBM Z is only supported on Ubuntu Xenial and Zesty.
 
@@ -141,7 +141,7 @@ the repository.
     > to your parent Ubuntu distribution. For example, if you are using
     >  `Linux Mint Rafaela`, you could use `trusty`.
 
-    **x86_64 (amd64)**:
+    **x86_64**:
 
     ```bash
     $ sudo add-apt-repository \

--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -141,7 +141,7 @@ the repository.
     > to your parent Ubuntu distribution. For example, if you are using
     >  `Linux Mint Rafaela`, you could use `trusty`.
 
-    **amd64**:
+    **amd64 (x86_64)**:
 
     ```bash
     $ sudo add-apt-repository \

--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -43,7 +43,7 @@ To install Docker EE, you need the 64-bit version of one of these Ubuntu version
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker EE is supported on `amd64` (`x86_64`) and `s390x` (IBM Z) architectures.
+Docker EE is supported on `x86_64` (`amd64`) and `s390x` (IBM Z) architectures.
 
 The only supported storage driver for Docker EE on Ubuntu is `aufs`.
 
@@ -137,7 +137,7 @@ from the repository.
     > Ubuntu distribution, such as `xenial`.
     >
 
-    **amd64 (x86_64)**:
+    **x86_64 (amd64)**:
 
     ```bash
     $ sudo add-apt-repository \

--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -43,7 +43,7 @@ To install Docker EE, you need the 64-bit version of one of these Ubuntu version
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker EE is supported on `x86_64` (`amd64`) and `s390x` (IBM Z) architectures.
+Docker EE is supported on `x86_64` (or `amd64`) and `s390x` (IBM Z) architectures.
 
 The only supported storage driver for Docker EE on Ubuntu is `aufs`.
 
@@ -137,7 +137,7 @@ from the repository.
     > Ubuntu distribution, such as `xenial`.
     >
 
-    **x86_64 (amd64)**:
+    **x86_64**:
 
     ```bash
     $ sudo add-apt-repository \

--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -43,7 +43,7 @@ To install Docker EE, you need the 64-bit version of one of these Ubuntu version
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker EE is supported on `x86_64` and `s390x` (IBM Z) architectures.
+Docker EE is supported on `amd64` (`x86_64`) and `s390x` (IBM Z) architectures.
 
 The only supported storage driver for Docker EE on Ubuntu is `aufs`.
 
@@ -137,7 +137,7 @@ from the repository.
     > Ubuntu distribution, such as `xenial`.
     >
 
-    **amd64**:
+    **amd64 (x86_64)**:
 
     ```bash
     $ sudo add-apt-repository \


### PR DESCRIPTION
Clarified the equivalence of amd64 and x84_64. Made amd64 primary and put x86_64 in parens to fit our naming pattern, e.g.,: https://download.docker.com/linux/ubuntu/dists/xenial/stable/binary-amd64/

#4295 