### PR TITLE
Remove ro userns restriction

### DIFF
--- a/engine/security/userns-remap.md
+++ b/engine/security/userns-remap.md
@@ -251,9 +251,6 @@ The following standard Docker features are incompatible with running a Docker
 daemon with user namespaces enabled:
 
 - sharing PID or NET namespaces with the host (`--pid=host` or `--network=host`).
-- A `--read-only` container filesystem. This is a Linux kernel restriction
-  against remounting an already-mounted filesystem with modified flags when
-  inside a user namespace.
 - external (volume or storage) drivers which are unaware or incapable of using
   daemon user mappings.
 - Using the `--privileged` mode flag on `docker run` without also specifying


### PR DESCRIPTION
As of
https://github.com/opencontainers/runc/commit/66eb2a3e8fc930e1bb6703561152edf5ab550bff
in runc, this is no longer true (in fact, it was never true; the problem
was a bug in runc, not a kernel check). Let's remove it.

Signed-off-by: Tycho Andersen <tycho@docker.com>