### PR TITLE
add two little auth docs blurbs

### DIFF
--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -82,12 +82,25 @@ using `10.10.10.20` and `127.0.0.1`:
 
     $ echo subjectAltName = DNS:$HOST,IP:10.10.10.20,IP:127.0.0.1 > extfile.cnf
 
+Set the Docker daemon key's extended usage attributes to only be used for
+server authentication:
+
+    $ echo extendedKeyUsage = serverAuth > extfile.cnf
+
+Now, generate the key:
+
     $ openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem \
       -CAcreateserial -out server-cert.pem -extfile extfile.cnf
     Signature ok
     subject=/CN=your.host.com
     Getting CA Private Key
     Enter pass phrase for ca-key.pem:
+
+[Authorization plugins](../extend/plugins_authorization) offer more
+fine-grained control to supplement authentication from mutual TLS. In addition
+to other information described in the above document, authorization plugins
+running on a Docker daemon receive the certificate information for connecting
+Docker clients.
 
 For client authentication, create a client key and certificate signing
 request:

--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -76,13 +76,13 @@ name) matches the hostname you will use to connect to Docker:
 
 Next, we're going to sign the public key with our CA:
 
-Since TLS connections can be made via IP address as well as DNS name, they need
-to be specified when creating the certificate. For example, to allow connections
+Since TLS connections can be made via IP address as well as DNS name, the IP addresses
+need to be specified when creating the certificate. For example, to allow connections
 using `10.10.10.20` and `127.0.0.1`:
 
     $ echo subjectAltName = DNS:$HOST,IP:10.10.10.20,IP:127.0.0.1 > extfile.cnf
 
-Set the Docker daemon key's extended usage attributes to only be used for
+Set the Docker daemon key's extended usage attributes to be used only for
 server authentication:
 
     $ echo extendedKeyUsage = serverAuth > extfile.cnf


### PR DESCRIPTION
* one blurb adding serverAuth to extendedKeyUsage for server keys
* another one linking to AuthZ plugins for more advanced authentication
  mechanisms

Signed-off-by: Tycho Andersen <tycho@docker.com>