### PR TITLE
Clarified links and services communication in Compose

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1088,6 +1088,10 @@ a link alias (`SERVICE:ALIAS`), or just the service name.
 Containers for the linked service will be reachable at a hostname identical to
 the alias, or the service name if no alias was specified.
 
+Links are not required to enable services to communicate - by default,
+any service can reach any other service at that service’s name. (See also, the
+[Links topic in Networking in Compose](/compose/networking.md#links).)
+
 Links also express dependency between services in the same way as
 [depends_on](#dependson), so they determine the order of service startup.
 


### PR DESCRIPTION
### What's changed

- Clarified how links work with regard to service-to-service communication per user comments on the docs

### Related

Fixes #4388 

### Relevant topic on the Netlify preview

https://deploy-preview-4416--docker-docs.netlify.com/compose/compose-file/#links

### Reviewers

@dgroomes @shin- 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
