### PR TITLE
Remove delayed features from 1.16.0, fixed changelog

### DIFF
--- a/_includes/content/compose-matrix.md
+++ b/_includes/content/compose-matrix.md
@@ -2,7 +2,6 @@ This table shows which Compose file versions support specific Docker releases.
 
 | **Compose file format** | **Docker Engine release** |
 |  -------------------    |    ------------------     |
-|      3.4                |       17.07.0+            |
 |      3.3                |       17.06.0+            |
 |      3.2                |       17.04.0+            |
 |      3.1                |       1.13.1+             |

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -251,16 +251,6 @@ Introduces the following additional parameters:
 - [`configs`](/compose/compose-file/index.md#configs)
 - [deploy `endpoint_mode`](/compose/compose-file/index.md#endpointmode)
 
-### Version 3.4
-
-An upgrade of [version 3](#version-3).
-
-Introduces the following additional parameters:
-
-- [build `target` and `network`](/compose/compose-file/index.md#build)
-- `name` for [volumes](compose-file-v2.md#volume-configuration-reference)
-- `order` for [`update_config`](/compose/compose-file/index.md#updateconfig) in `deploy`.
-
 ## Upgrading
 
 ### Version 2.x to 3.x

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -311,34 +311,6 @@ those used by other software.
         - "com.example.department=Finance"
         - "com.example.label-with-empty-value"
 
-#### network
-
-> **Note:** This option is new in v3.4
-
-Set the network containers will connect to for the `RUN` instructions during
-build.
-
-    build:
-      context: .
-      network: host
-
-
-    build:
-      context: .
-      network: custom_network_1
-
-#### target
-
-> **Note:** This option is new in v3.4
-
-Build the specified target as defined inside the `Dockerfile`. See the
-[multi-stage build docs](engine/userguide/eng-image/multistage-build.md) for
-details.
-
-      build:
-        context: .
-        target: prod
-
 ### cap_add, cap_drop
 
 Add or drop container capabilities.
@@ -1888,25 +1860,6 @@ conflicting with those used by other software.
       - "com.example.description=Database volume"
       - "com.example.department=IT/Ops"
       - "com.example.label-with-empty-value"
-
-### name
-
-> [Added in version 3.4 file format](compose-versioning.md#version-34)
-
-Set a custom name for this volume.
-
-    version: '3.4'
-    volumes:
-      data:
-        name: my-app-data
-
-It can also be used in conjuction with the `external` property:
-
-    version: '3.4'
-    volumes:
-      data:
-        external: true
-        name: my-app-data
 
 ## Network configuration reference
 

--- a/release-notes/docker-compose.md
+++ b/release-notes/docker-compose.md
@@ -4,122 +4,17 @@ description: Release notes for Docker Compose
 keywords: release notes, compose
 toc_max: 2
 ---
-## 1.15.0 (2017-07-26)
-
-### New features
-
-#### Compose file version 2.2
-
-- Added support for the `network` parameter in build configurations.
-
-#### Compose file version 2.1 and up
-
-- The `pid` option in a service's definition now supports a `service:<name>`
-  value.
-
-- Added support for the `storage_opt` parameter in in service definitions.
-  This option is not available for the v3 format
-
-#### All formats
-
-- Added `--quiet` flag to `docker-compose pull`, suppressing progress output
-
-- Some improvements to CLI output
-
-### Bugfixes
-
-- Volumes specified through the `--volume` flag of `docker-compose run` now
-  complement volumes declared in the service's defintion instead of replacing
-  them
-
-- Fixed a bug where using multiple Compose files would unset the scale value
-  defined inside the Compose file.
-
-- Fixed an issue where the `credHelpers` entries in the `config.json` file
-  were not being honored by Compose
-
-- Fixed a bug where using multiple Compose files with port declarations
-  would cause failures in Python 3 environments
-
-- Fixed a bug where some proxy-related options present in the user's
-  environment would prevent Compose from running
-
-- Fixed an issue where the output of `docker-compose config` would be invalid
-  if the original file used `Y` or `N` values
-
-- Fixed an issue preventing `up` operations on a previously created stack on
-  Windows Engine.
-
-## 1.14.0 (2017-06-19)
-
-### New features
-
-#### Compose file version 3.3
-
-- Introduced version 3.3 of the `docker-compose.yml` specification.
-  This version requires to be used with Docker Engine 17.06.0 or above.
-  Note: the `credential_spec` and `configs` keys only apply to Swarm services
-  and will be ignored by Compose
-
-#### Compose file version 2.2
-
-- Added the following parameters in service definitions: `cpu_count`,
-  `cpu_percent`, `cpus`
-
-#### Compose file version 2.1
-
-- Added support for build labels. This feature is also available in the
-  2.2 and 3.3 formats.
-
-#### All formats
-
-- Added shorthand `-u` for `--user` flag in `docker-compose exec`
-
-- Differences in labels between the Compose file and remote network
-  will now print a warning instead of preventing redeployment.
-
-### Bugfixes
-
-- Fixed a bug where service's dependencies were being rescaled to their
-  default scale when running a `docker-compose run` command
-
-- Fixed a bug where `docker-compose rm` with the `--stop` flag was not
-  behaving properly when provided with a list of services to remove
-
-- Fixed a bug where `cache_from` in the build section would be ignored when
-  using more than one Compose file.
-
-- Fixed a bug that prevented binding the same port to different IPs when
-  using more than one Compose file.
-
-- Fixed a bug where override files would not be picked up by Compose if they
-  had the `.yaml` extension
-
-- Fixed a bug on Windows Engine where networks would be incorrectly flagged
-  for recreation
-
-- Fixed a bug where services declaring ports would cause crashes on some
-  versions of Python 3
-
-- Fixed a bug where the output of `docker-compose config` would sometimes
-  contain invalid port definitions
 
 ## 1.16.0 (2017-08-31)
 
 ### New features
-
-#### Compose file version 3.4
-
-- Introduced version 3.4 of the `docker-compose.yml` specification.
-  This version requires to be used with Docker Engine 17.06.0 or above.
 
 #### Compose file version 2.3
 
 - Introduced version 2.3 of the `docker-compose.yml` specification.
   This version requires to be used with Docker Engine 17.06.0 or above.
 
-- Added support for the `target` parameter in network configurations
-  (also available in 3.4)
+- Added support for the `target` parameter in build configurations
 
 - Added support for the `start_period` parameter in healthcheck
   configurations
@@ -146,6 +41,9 @@ toc_max: 2
 - Fixed issues where logs of TTY-enabled services were being printed
   incorrectly and causing `MemoryError` exceptions
 
+- Fixed a bug where printing application logs would sometimes be interrupted
+  by a `UnicodeEncodeError` exception on Python 3
+
 - The `$` character in the output of `docker-compose config` is now
   properly escaped
 
@@ -159,6 +57,9 @@ toc_max: 2
 
 - Fixed an issue where the `logging` options in the output of
   `docker-compose config` would be set to `null`, an invalid value
+
+- Fixed the output of the `docker-compose images` command when an image
+  would come from a private repository using an explicit port number
 
 - Fixed the output of `docker-compose config` when a port definition used
   `0` as the value for the published port


### PR DESCRIPTION
### Proposed changes

Follow-up to #4293 to account for RC2 changes.
Also fixes bad merge in Compose changelog

### Unreleased project version (optional)

Compose 1.16.0

### Related issues (optional)

https://github.com/docker/compose/pull/5139
