### PR TITLE
Fix download url for Compose's command completion

### DIFF
--- a/compose/completion.md
+++ b/compose/completion.md
@@ -4,6 +4,8 @@ keywords: fig, composition, compose, docker, orchestration, cli, reference
 title: Command-line completion
 ---
 
+{% assign composeversion = '1.15.0' %}
+
 Compose comes with [command completion](http://en.wikipedia.org/wiki/Command-line_completion)
 for the bash and zsh shell.
 
@@ -22,7 +24,7 @@ Place the completion script in `/etc/bash_completion.d/`
 (or `/usr/local/etc/bash_completion.d/` on a Mac):
 
 ```shell
-curl -L https://raw.githubusercontent.com/docker/compose/master/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+curl -L https://raw.githubusercontent.com/docker/compose/{{composeversion}}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
 ```
 
 On a Mac, add the following to your `~/.bash_profile`:
@@ -59,7 +61,7 @@ Place the completion script in your `/path/to/zsh/completion`, using e.g. `~/.zs
 
 ```shell
 $ mkdir -p ~/.zsh/completion
-$ curl -L https://raw.githubusercontent.com/docker/compose/master/contrib/completion/zsh/_docker-compose > ~/.zsh/completion/_docker-compose
+$ curl -L https://raw.githubusercontent.com/docker/compose/{{composeversion}}/contrib/completion/zsh/_docker-compose > ~/.zsh/completion/_docker-compose
 ```
 
 Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`:

--- a/compose/completion.md
+++ b/compose/completion.md
@@ -24,7 +24,7 @@ Place the completion script in `/etc/bash_completion.d/`
 (or `/usr/local/etc/bash_completion.d/` on a Mac):
 
 ```shell
-curl -L https://raw.githubusercontent.com/docker/compose/{{composeversion}}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+sudo curl -L https://raw.githubusercontent.com/docker/compose/{{composeversion}}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
 ```
 
 On a Mac, add the following to your `~/.bash_profile`:


### PR DESCRIPTION
Fixes #4137 

This PR changes the urls from `master` to the tag specified in the template variable `{{composeversion}}`. This notion is also used in the install instructions of Compose and Machine, so it will look familiar to users.

See also #4419 for the corresponding fix for Machine.