### PR TITLE
Fix section hierarchy in Compose's completion page

### DIFF
--- a/compose/completion.md
+++ b/compose/completion.md
@@ -36,9 +36,7 @@ fi
 You can source your `~/.bash_profile` or launch a new terminal to utilize
 completion.
 
-## MacPorts Bash Completion
-
-If you're using MacPorts you'll need to slightly modify your steps to the
+If you're using MacPorts instead of brew you'll need to slightly modify your steps to the
 following:
 
 Run `sudo port install bash-completion` to install bash completion.


### PR DESCRIPTION
The hierarchy here is

    Installing Command Completion
      Bash completion
        install on Linux
        install on a Mac
          using brew
          using MacPorts
      zsh completion

So there should not be a _MacPorts Bash Completion_ heading. This information definitely is not a `##` section.