### PR TITLE
Fixed wrong link to linux-postinstall.md

### DIFF
--- a/engine/installation/linux/docker-ee/ubuntu.md
+++ b/engine/installation/linux/docker-ee/ubuntu.md
@@ -262,7 +262,7 @@ a new file each time you want to upgrade Docker EE.
     container runs, it prints an informational message and exits.
 
 Docker EE is installed and running. You need to use `sudo` to run Docker
-commands. Continue to [Post-installation steps for Linux](linux-postinstall.md)
+commands. Continue to [Post-installation steps for Linux](/engine/installation/linux/linux-postinstall.md)
 to allow non-privileged users to run Docker commands and for other optional
 configuration steps.
 


### PR DESCRIPTION
Link after install previously gave 404

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
