### PR TITLE
Fix `depends_on` links for compose file across documents.

### DIFF
--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -365,7 +365,7 @@ Containers for the linked service will be reachable at a hostname identical to
 the alias, or the service name if no alias was specified.
 
 Links also express dependency between services in the same way as
-[depends_on](#dependson), so they determine the order of service startup.
+[depends_on](#depends_on), so they determine the order of service startup.
 
 > **Note**: If you define both links and [networks](#networks), services with
 > links between them must share at least one network in common in order to

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -638,7 +638,7 @@ Containers for the linked service will be reachable at a hostname identical to
 the alias, or the service name if no alias was specified.
 
 Links also express dependency between services in the same way as
-[depends_on](#dependson), so they determine the order of service startup.
+[depends_on](#depends_on), so they determine the order of service startup.
 
 > **Note**: If you define both links and [networks](#networks), services with
 > links between them must share at least one network in common in order to

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -166,7 +166,7 @@ Several other options were added to support networking, such as:
 
 * [`aliases`](compose-file-v2.md#aliases)
 
-* The [`depends_on`](compose-file-v2.md#dependson) option can be used in place of links to indicate dependencies
+* The [`depends_on`](compose-file-v2.md#depends_on) option can be used in place of links to indicate dependencies
 between services and startup order.
 
       version: '2'

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1089,7 +1089,7 @@ Containers for the linked service will be reachable at a hostname identical to
 the alias, or the service name if no alias was specified.
 
 Links also express dependency between services in the same way as
-[depends_on](#dependson), so they determine the order of service startup.
+[depends_on](#depends_on), so they determine the order of service startup.
 
 > **Notes**
 >


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

This fixes most broken links for compose file `depends_on` across documents.

NOTE: compose file v1 doesn't support `depends_on`, thus it's still a broken link (which should be fixed either by removing it or linking to `...-v2.md#depends_on`).

Signed-off-by: Wenxuan Zhao <viz@linux.com>