### PR TITLE
Fix section hierarchy in machine install docs

### DIFF
--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -78,7 +78,7 @@ PS1='[\u@\h \W$(__docker_machine_ps1)]\$ '
 
 You can find additional documentation in the comments at the [top of each script](https://github.com/docker/machine/tree/master/contrib/completion/bash){: target="_blank" class="_"}.
 
-### How to uninstall Docker Machine
+## How to uninstall Docker Machine
 
 To uninstall Docker Machine:
 


### PR DESCRIPTION
_How to uninstall Docker Machine_ is not a subsection of _Installing bash completion scripts_.
