### PR TITLE
Be clear on Fedora 26 package repos

### DIFF
--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -94,6 +94,10 @@ from the repository.
 3.  **Optional**: Enable the **edge** and **test** repositories. These
     repositories are included in the `docker.repo` file above but are disabled
     by default. You can enable them alongside the stable repository.
+    
+    <!---TODO: Remove below note once 17.09.0 GA for Fedora 26--->
+    > **Note**: Fedora 26 packages are currently only available in the **edge** 
+    > and **test** repositories
 
     ```bash
     $ sudo dnf config-manager --set-enabled docker-ce-edge

--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -29,6 +29,10 @@ To install Docker, you need the 64-bit version of one of these Fedora versions:
 - 25
 - 26
 
+<!---TODO: Remove below note once 17.09.0 GA for Fedora 26--->
+> **Note**: Fedora 26 packages are currently only available in the **edge** 
+> and **test** repositories.
+
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. If these are
@@ -97,7 +101,7 @@ from the repository.
     
     <!---TODO: Remove below note once 17.09.0 GA for Fedora 26--->
     > **Note**: Fedora 26 packages are currently only available in the **edge** 
-    > and **test** repositories
+    > and **test** repositories.
 
     ```bash
     $ sudo dnf config-manager --set-enabled docker-ce-edge


### PR DESCRIPTION
### Proposed changes
Fedora 26 will not have any _stable_ packages until 17.09.0 GA is released for Fedora 26, this adds a note for those trying to install Docker CE for Fedora 26 to enable the _edge_ or _test_ repo in order to be able to continue successfully.

### Related issues (optional)
* Relates to docker/for-linux#35

ping @andrewhsu @mstanleyjones 