### PR TITLE
fixed link to dns section

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -736,7 +736,7 @@ The following sub-options (supported for `docker compose up` and `docker compose
 - [cgroup_parent](#cgroup_parent)
 - [container_name](#container_name)
 - [devices](#devices)
-- [dns](#devices)
+- [dns](#dns)
 - [dns_search](#dns_search)
 - [tmpfs](#tmpfs)
 - [external_links](#external_links)


### PR DESCRIPTION
DNS link was incorrectly pointing to #devices

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I fixed a link to "dns" section, which actually pointed to "devices" section (looks like a failed copy/paste).
