### PR TITLE
Update glossary with amd64 and x86_64

### DIFF
--- a/_data/glossary.yaml
+++ b/_data/glossary.yaml
@@ -1,3 +1,6 @@
+amd64: |
+  AMD64 is AMD's 64-bit extension of Intel's x86 architecture, and is also
+  referred to as x86_64 (or x86-64).
 aufs: |
   aufs (advanced multi layered unification filesystem) is a Linux [filesystem](#filesystem) that
   Docker supports as a storage backend. It implements the
@@ -356,3 +359,7 @@ volume: |
 
   - An **anonymous volume** is similar to a named volume, however, it can be difficult, to refer to
     the same volume over time when it is an anonymous volumes. Docker handle where the files are stored.
+x86_64: |
+  x86_64 (or x86-64) refers to a 64-bit instruction set invented by AMD as an
+  extension of Intel's x86 architecture. AMD calls its x86_64 architecture,
+  AMD64, and Intel calls its implementation, Intel 64.


### PR DESCRIPTION
Added entries for amd64 and x86_64 to address reader concerns in #4295 

Some references: 
- https://en.wikipedia.org/wiki/X86-64#History_2
- https://support.amd.com/TechDocs/24592.pdf