### PR TITLE
centos/rhel/oracle/fedora install: fixes

### DIFF
--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -138,8 +138,8 @@ You can install Docker EE in different ways, depending on your needs:
     $ sudo yum -y install docker-ee
     ```
 
-    If this is the first time you have refreshed the package index since adding
-    the Docker repositories, you will be prompted to accept the GPG key, and
+    If this is the first time you are installing a package from a recently added
+    repository, you will be prompted to accept the GPG key, and
     the key's fingerprint will be shown. Verify that the fingerprint matches
     `{{ gpg-fingerprint }}` and if so, accept the key.
 
@@ -148,11 +148,8 @@ You can install Docker EE in different ways, depending on your needs:
     This example uses the `sort -r` command to sort the results by version
     number, highest to lowest, and is truncated.
 
-    > **Note**: This `yum list` command only shows binary packages. To show
-    > source packages as well, omit the `.x86_64` from the package name.
-
     ```bash
-    $ sudo yum list docker-ee.x86_64  --showduplicates | sort -r
+    $ sudo yum list docker-ee  --showduplicates | sort -r
 
     docker-ee.x86_64         {{ minor-version }}.ee.2-1.el7.{{ linux-dist }}          docker-ee-stable-17.06
     ```
@@ -223,9 +220,7 @@ To upgrade Docker EE:
     Docker 17.03.x to Docker 17.06.x),
     [add the new repository](#set-up-the-repository){: target="_blank" class="_" }.
 
-2.  Run `sudo yum makecache fast`.
-
-3.  Follow the
+2.  Follow the
     [installation instructions](#install-docker), choosing the new version you
     want to install.
 

--- a/engine/installation/linux/docker-ce/centos.md
+++ b/engine/installation/linux/docker-ce/centos.md
@@ -136,8 +136,8 @@ from the repository.
     > which may not be appropriate for your stability needs.
     {:.warning}
 
-    If this is the first time you have refreshed the package index since adding
-    the Docker repositories, you will be prompted to accept the GPG key, and
+    If this is the first time you are installing a package from a recently added
+    repository, you will be prompted to accept the GPG key, and
     the key's fingerprint will be shown. Verify that the fingerprint is
     correct, and if so, accept the key. The fingerprint should match
     `060A 61C5 1B55 8A7F 742B  77AA C52F EB6B 621E 9F35`.
@@ -150,11 +150,8 @@ from the repository.
     example uses the `sort -r` command to sort the results by version number,
     highest to lowest, and is truncated.
 
-    > **Note**: This `yum list` command only shows binary packages. To show
-    > source packages as well, omit the `.x86_64` from the package name.
-
     ```bash
-    $ yum list docker-ce.x86_64  --showduplicates | sort -r
+    $ yum list docker-ce --showduplicates | sort -r
 
     docker-ce.x86_64            {{ minor-version }}.ce-1.el7.centos             docker-ce-stable
     ```
@@ -199,7 +196,7 @@ steps.
 
 #### Upgrade Docker CE
 
-To upgrade Docker CE, first run `sudo yum makecache fast`, then follow the
+To upgrade Docker CE, follow the
 [installation instructions](#install-docker), choosing the new version you want
 to install.
 
@@ -214,7 +211,7 @@ a new file each time you want to upgrade Docker.
     and download the `.rpm` file for the Docker version you want to install.
 
     > **Note**: To install an **edge**  package, change the word
-    > `stable` in the > URL to `edge`.
+    > `stable` in the above URL to `edge`.
     > [Learn about **stable** and **edge** channels](/engine/installation/).
 
 2.  Install Docker CE, changing the path below to the path where you downloaded

--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -117,24 +117,18 @@ from the repository.
 
 #### Install Docker CE
 
-1.  Update the `dnf` package index.
-
-    ```bash
-    $ sudo dnf makecache fast
-    ```
-
-    If this is the first time you have refreshed the package index since adding
-    the Docker repositories, you will be prompted to accept the GPG key, and
-    the key's fingerprint will be shown. Verify that the fingerprint matches
-    `060A 61C5 1B55 8A7F 742B  77AA C52F EB6B 621E 9F35` and if so, accept the
-    key.
-
-2.  Install the latest version of Docker CE, or go to the next step to install a
+1.  Install the latest version of Docker CE, or go to the next step to install a
     specific version.
 
     ```bash
     $ sudo dnf install docker-ce
     ```
+
+    If this is the first time you are installing a package from a recently added
+    repository, you will be prompted to accept the GPG key, and
+    the key's fingerprint will be shown. Verify that the fingerprint matches
+    `060A 61C5 1B55 8A7F 742B  77AA C52F EB6B 621E 9F35` and if so, accept the
+    key.
 
     > Got multiple Docker repositories?
     >
@@ -144,16 +138,13 @@ from the repository.
     > which may not be appropriate for your stability needs.
     {:.warning-vanilla}
 
-3.  On production systems, you should install a specific version of Docker CE
+2.  On production systems, you should install a specific version of Docker CE
     instead of always using the latest. List the available versions. This
     example uses the `sort -r` command to sort the results by version number,
     highest to lowest, and is truncated.
 
-    > **Note**: This `dnf list` command only shows binary packages. To show
-    > source packages as well, omit the `.x86_64` from the package name.
-
     ```bash
-    $ dnf list docker-ce.x86_64  --showduplicates | sort -r
+    $ dnf list docker-ce  --showduplicates | sort -r
 
     docker-ce.x86_64  {{ minor-version }}.0.fc24                               docker-ce-stable  
     ```
@@ -194,7 +185,7 @@ steps.
 
 #### Upgrade Docker CE
 
-To upgrade Docker CE, first run `sudo dnf makecache fast`, then follow the
+To upgrade Docker CE, follow the
 [installation instructions](#install-docker), choosing the new version you want
 to install.
 
@@ -209,7 +200,7 @@ a new file each time you want to upgrade Docker CE.
     and download the `.rpm` file for the Docker version you want to install.
 
     > **Note**: To install an **edge**  package, change the word
-    > `stable` in the URL to `edge`.
+    > `stable` in the above URL to `edge`.
 
 2.  Install Docker CE, changing the path below to the path where you downloaded
     the Docker package.


### PR DESCRIPTION
This commit improves engine installation documentation for CentOS,
RHEL, Fedora and Oracle Linux. There are a few fixes and
simplifications. In particular:

1. ~~Fixed incorrect GPG key fingerprint for docker-ee centos and rhel repos.
I have verified keys for Fedora (they are correct) but not Oracle Linux
-- can someone please check it?~~ v2: no longer required.

2. ~~`yum makecache` does not lead to gpg keys installation -- move the
text telling about gpg key to after 'yum install' and modify it
accordingly.~~  Fix a statement about when GPG keys are presented for verification
    (when you install a package from a recently added repo).

3. Unlike for Debian/Ubuntu, which require `apt update`, with both yum
and dnf, `yum makecache` is not required as it is performed
automatically, so remove this step for the sake of simplicity.
Removing this step also fixes the following problem on Fedora 26:
```
	# dnf makecache fast
	...
	dnf makecache: error: argument timer: invalid choice: 'fast' (choose from 'timer')
```
4. As source repos are disabled by default, there is no need to specify
the architecture when running `yum list docker-[ce]e`. The comment
explaining it is also removed.

5. In Docker EE installation instructions, user is required to input
 `$DOCKERURL` twice. Use `$(cat /etc/yum/vars/dockerurl)`
for the second time to avoid it and simplify the process.

6. An extra `>` character in the middle of the line was removed.