### PR TITLE
Update b.o. Error while creating Registry Service

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -319,7 +319,7 @@ $ docker service create \
   --secret domain.crt \
   --secret domain.key \
   --label registry=true \
-  -v /mnt/registry:/var/lib/registry \
+  --mount src=/mnt/registry,dst=/var/lib/registry \
   -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
   -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/secrets/domain.crt \
   -e REGISTRY_HTTP_TLS_KEY=/run/secrets/domain.key \


### PR DESCRIPTION
As one can find in the Docker Swarm docs (https://docs.docker.com/engine/swarm/services/#give-a-service-access-to-volumes-or-bind-mounts), there´s is no CLI option like '-v' (anymore?). But if you use `--mount src=/mnt/registry,dst=/var/lib/registry`, everything works fine.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
