### PR TITLE
Fix Windows support dump to use version number

### DIFF
--- a/datacenter/ucp/2.2/guides/get-support.md
+++ b/datacenter/ucp/2.2/guides/get-support.md
@@ -46,7 +46,7 @@ from all of the manager nodes.
 On Windows worker nodes, run the following command to generate a local support dump:
 
 ```ps
-PS> docker run --name windowssupport -v 'C:\ProgramData\docker\daemoncerts:C:\ProgramData\docker\daemoncerts' -v 'C:\Windows\system32\winevt\logs:C:\eventlogs:ro' docker/ucp-dsinfo-win; docker cp windowssupport:'C:\dsinfo' .; docker rm -f windowssupport
+PS> docker run --name windowssupport -v 'C:\ProgramData\docker\daemoncerts:C:\ProgramData\docker\daemoncerts' -v 'C:\Windows\system32\winevt\logs:C:\eventlogs:ro' docker/ucp-dsinfo-win:2.2.2; docker cp windowssupport:'C:\dsinfo' .; docker rm -f windowssupport
 ```
 
 This command creates a directory named `dsinfo` in your current directory.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Change the docker support dump to use ucp-dsinfo-win:2.2.2
vs
ucp-dsoinfo-win

as the latter uses the latest tag which doesn't exist.

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
