### PR TITLE
fix link to Dockerfile in Engine FAQs

### DIFF
--- a/engine/faq.md
+++ b/engine/faq.md
@@ -43,7 +43,7 @@ offers a high-level tool with several powerful functionalities:
 
  - *Automatic build.* Docker includes [*a tool for developers to automatically
  assemble a container from their source
- code*](/engine/reference/commandline/build.md), with full control over application
+ code*](/engine/reference/builder/), with full control over application
  dependencies, build tools, packaging etc. They are free to use `make`, `maven`,
  `chef`, `puppet`, `salt,` Debian packages, RPMs, source tarballs, or any
  combination of the above, regardless of the configuration of the machines.


### PR DESCRIPTION
### What's changed

- fixed link

### Related

- PR #4447

### Reviewers, FYI

@friism 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
