### PR TITLE
Clarify --replica-id format

### DIFF
--- a/datacenter/dtr/2.1/reference/cli/install.md
+++ b/datacenter/dtr/2.1/reference/cli/install.md
@@ -52,6 +52,6 @@ the 'join' command.
 |`--ucp-ca`|Use a PEM-encoded TLS CA certificate for UCP|
 |`--nfs-storage-url`|URL (with IP address or hostname) of the NFS mount if using NFS (e.g. nfs://<ip address>/<mount point>)|
 |`--ucp-node`|Specify the host to install Docker Trusted Registry|
-|`--replica-id`|Specify the replica ID. Must be unique per replica, leave blank for random|
+|`--replica-id`|Specify the replica ID. Must be unique per replica and formatted as a 12-character hexadecimal string. Leave blank for random.|
 |`--unsafe`|Enable this flag to skip safety checks when installing or joining|
 |`--extra-envs`|List of extra environment variables to use for deploying the DTR containers for the replica. This can be used to specify swarm constraints. Separate the environment variables with ampersands (&). You can escape actual ampersands with backslashes (\). Can't be used in combination with --ucp-node|


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The DTR replica ID must be in hexadecimal format, and must be 12 characters long.  Update documentation to reflect this limitation.
