### PR TITLE
Use nginx image which supports bcrypt

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -176,7 +176,7 @@ Review the [requirements](/registry/recipes/index.md#requirements), then follow 
       ports:
         - 127.0.0.1:5000:5000
       volumes:
-        - `pwd`./data:/var/lib/registry
+        - ./data:/var/lib/registry
     ```
 
 ## Starting and stopping

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -146,7 +146,7 @@ Review the [requirements](/registry/recipes/index.md#requirements), then follow 
 3.  Create a password file `auth/nginx.htpasswd` for "testuser" and "testpassword".
 
     ```bash
-    $ docker run --rm --entrypoint htpasswd registry:2 -bn testuser testpassword > auth/nginx.htpasswd
+    $ docker run --rm --entrypoint htpasswd registry:2 -Bbn testuser testpassword > auth/nginx.htpasswd
     ```
 
 4.  Copy your certificate files to the `auth/` directory.

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -160,7 +160,9 @@ Review the [requirements](/registry/recipes/index.md#requirements), then follow 
 
     ```yaml
     nginx:
-      image: "nginx:1.9"
+      # Note : Only the alpine flavour supports bcrypt
+      # Ref. https://github.com/nginxinc/docker-nginx/issues/29
+      image: "nginx:alpine"
       ports:
         - 5043:443
       links:

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -148,6 +148,8 @@ Review the [requirements](/registry/recipes/index.md#requirements), then follow 
     ```bash
     $ docker run --rm --entrypoint htpasswd registry:2 -Bbn testuser testpassword > auth/nginx.htpasswd
     ```
+    
+    > **Note**: If you do not want to use `bcrypt`, you can omit the `-B` parameter.
 
 4.  Copy your certificate files to the `auth/` directory.
 
@@ -160,7 +162,8 @@ Review the [requirements](/registry/recipes/index.md#requirements), then follow 
 
     ```yaml
     nginx:
-      # Note : Only the alpine flavour supports bcrypt
+      # Note : Only nginx:alpine supports bcrypt.
+      # If you don't need to use bcrypt, you can use a different tag.
       # Ref. https://github.com/nginxinc/docker-nginx/issues/29
       image: "nginx:alpine"
       ports:


### PR DESCRIPTION
This is a follow-up to #4332 which was not fixed in the correct way

The problem is basically that the example uses htpasswd file with bcrypt hashes while the nginx image in question do not support bcrypt