### PR TITLE
Indentation fix

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1622,6 +1622,12 @@ services:
       - type: bind
         source: ./static
         target: /opt/app/static
+        
+networks:
+  webnet:
+
+volumes:
+  mydata:
 ```
 
 > **Note:** The long syntax is new in v3.2

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1610,18 +1610,18 @@ services:
     ports:
       - "80:80"
 
-networks:
-  webnet:
+    networks:
+      webnet:
 
-volumes:
-  - type: volume
-    source: mydata
-    target: /data
-    volume:
-      nocopy: true
-  - type: bind
-    source: ./static
-    target: /opt/app/static
+    volumes:
+      - type: volume
+        source: mydata
+        target: /data
+        volume:
+          nocopy: true
+      - type: bind
+        source: ./static
+        target: /opt/app/static
 ```
 
 > **Note:** The long syntax is new in v3.2

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1609,10 +1609,6 @@ services:
     image: nginx:alpine
     ports:
       - "80:80"
-
-    networks:
-      webnet:
-
     volumes:
       - type: volume
         source: mydata


### PR DESCRIPTION
### Proposed changes
Indentation in the code example for Volumes > Long syntax is wrong, those volumes should be part of the services definition, and not as part of top level volumes key
https://docs.docker.com/compose/compose-file/#long-syntax-3