### PR TITLE
syntax: docker config create for ucp

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/configure/ucp-configuration-file.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/ucp-configuration-file.md
@@ -52,7 +52,7 @@ Use the `docker config create` command to read the settings that are specified
 in a TOML file and create a new configuration.   
 
 ```bash
-$ docker config create --name ...  <ucp-config.toml>
+$ docker config create <name>  <ucp-config.toml>
 ```
 
 ## Configuration file and web UI


### PR DESCRIPTION
`--name` is not a valid argument on `docker config create`

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>