### PR TITLE
Add current_issues table to DTR troubleshooting

### DIFF
--- a/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -92,6 +92,10 @@ queries such as:
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
 ...
+
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
 ```
 
 Indvidual DBs and tables are a private implementation detail and may change in DTR

--- a/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -92,6 +92,10 @@ queries such as:
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
 ...
+
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
 ```
 
 Indvidual DBs and tables are a private implementation detail and may change in DTR


### PR DESCRIPTION
rethinkdb `current_issues` table is relevant in troubleshooting rethinkdb
issues.

Ref: https://www.rethinkdb.com/docs/system-issues/

DON'T MERGE until rebased after pull request #4495 is merged