### PR TITLE
Update Docker Compose version to 1.16.1

### DIFF
--- a/compose/completion.md
+++ b/compose/completion.md
@@ -4,7 +4,7 @@ keywords: fig, composition, compose, docker, orchestration, cli, reference
 title: Command-line completion
 ---
 
-{% assign composeversion = '1.15.0' %}
+{% assign composeversion = '1.16.1' %}
 
 Compose comes with [command completion](http://en.wikipedia.org/wiki/Command-line_completion)
 for the bash and zsh shell.

--- a/compose/install.md
+++ b/compose/install.md
@@ -5,7 +5,7 @@ title: Install Docker Compose
 toc_max: 2
 ---
 
-{% assign composeversion = '1.15.0' %}
+{% assign composeversion = '1.16.1' %}
 
 You can run Compose on macOS, Windows and 64-bit Linux.
 


### PR DESCRIPTION
This PR updates the install docs for Compose and its completion to point to the current version.
See https://github.com/docker/compose/releases/