### PR TITLE
Correct the command prompt hash

### DIFF
--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -209,7 +209,7 @@ a `#` character.
 ```none
 $ docker attach container1
 
-root@0cb243cd1293:/# ifconfig
+root@3386a527aa08:/# ifconfig
 
 eth0      Link encap:Ethernet  HWaddr 02:42:AC:11:00:02
           inet addr:172.17.0.2  Bcast:0.0.0.0  Mask:255.255.0.0
@@ -234,7 +234,7 @@ From inside the container, use the `ping` command to test the network connection
 to the IP address of the other container.
 
 ```none
-root@0cb243cd1293:/# ping -w3 172.17.0.3
+root@3386a527aa08:/# ping -w3 172.17.0.3
 
 PING 172.17.0.3 (172.17.0.3): 56 data bytes
 64 bytes from 172.17.0.3: seq=0 ttl=64 time=0.096 ms
@@ -250,7 +250,7 @@ Use the `cat` command to view the `/etc/hosts` file on the container. This shows
 the hostnames and IP addresses the container recognizes.
 
 ```
-root@0cb243cd1293:/# cat /etc/hosts
+root@3386a527aa08:/# cat /etc/hosts
 
 172.17.0.2	3386a527aa08
 127.0.0.1	localhost


### PR DESCRIPTION
The command prompt after attaching on this command:
```
$ docker attach container1
root@0cb243cd1293:/# ifconfig
```
Should be:
```
root@3386a527aa08:/# ifconfig
```
The previous one looks like it was a copy/paste from an earlier example of attaching to a container:

```
$ docker attach nonenetcontainer
root@0cb243cd1293:/# cat /etc/hosts
```

The same copy/paste prompt continues down to other examples:
```
root@0cb243cd1293:/# ping -w3 172.17.0.3
...
root@0cb243cd1293:/# cat /etc/hosts
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
