### PR TITLE
Update index.md

### DIFF
--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -196,9 +196,9 @@ $ docker network inspect bridge
 ```
 
 Containers connected to the default `bridge` network can communicate with each
-other by IP address. Docker does not support automatic service discovery on the
+other by IP address. **Docker does not support automatic service discovery on the
 default bridge network. If you want containers to be able to resolve IP addresses
-by container name, you should use user-defined networks instead. You can link
+by container name, you should use _user-defined networks_ instead**. You can link
 two containers together using the legacy `docker run --link` option, but this
 is not recommended in most cases.
 


### PR DESCRIPTION
add emphasis about automatic service discovery on the default network and user-defined networks


### Proposed changes

emphasis text in the document, specifically add emphasis about automatic service discovery on the default network and user-defined networks.

I really really think this section should be emphasised, It is very important


### Unreleased project version (optional)


### Related issues (optional)


