### PR TITLE
Fix wrong release date for Docker for Mac / Windows 17.06.2

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -19,7 +19,7 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
-### Docker Community Edition 17.06.2-ce-mac27 2017-08-31 (Stable)
+### Docker Community Edition 17.06.2-ce-mac27 2017-09-06 (Stable)
 
 * Upgrades
   - [Docker 17.06.2-ce](https://github.com/docker/docker-ce/releases/tag/v17.06.2-ce)

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -19,7 +19,7 @@ about both kinds of releases, and download stable and edge product installers at
 
 ## Stable Release Notes
 
-### Docker Community Edition 17.06.2-ce-win27 2017-08-31 (Stable)
+### Docker Community Edition 17.06.2-ce-win27 2017-09-06 (Stable)
 
 * Upgrades
   - [Docker 17.06.2-ce](https://github.com/docker/docker-ce/releases/tag/v17.06.2-ce)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

### Proposed changes

Fix wrong release date (wrong copy/paste) for D4Mac /Windows 17.06.2
