### PR TITLE
Add script to wget multiple docker-machine bash completion scripts

### DIFF
--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -71,7 +71,7 @@ as:
 Confirm the version and save scripts to `/etc/bash_completion.d` or
 `/usr/local/etc/bash_completion.d`:
 
-```
+```bash
 scripts=( docker-machine-prompt.bash docker-machine-wrapper.bash docker-machine.bash ); for i in "${scripts[@]}"; do sudo wget https://raw.githubusercontent.com/docker/machine/v{{machineversion}}/contrib/completion/bash/${i} -P /etc/bash_completion.d; done
 ```
 

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -69,7 +69,13 @@ as:
     active machine
 
 To install the scripts, copy or link them into your `/etc/bash_completion.d` or
-`/usr/local/etc/bash_completion.d` directory. To enable the `docker-machine` shell
+`/usr/local/etc/bash_completion.d` directory.
+
+```
+scripts=( docker-machine-prompt.bash docker-machine-wrapper.bash docker-machine.bash ); for i in "${scripts[@]}"; do wget https://raw.githubusercontent.com/docker/machine/v0.12.2/contrib/completion/bash/${i}; done
+```
+
+To enable the `docker-machine` shell
 prompt, add `$(__docker_machine_ps1)` to your `PS1` setting in `~/.bashrc`.
 
 ```

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -68,11 +68,11 @@ as:
 -   a function wrapper that adds a `docker-machine use` subcommand to switch the
     active machine
 
-To install the scripts, copy or link them into your `/etc/bash_completion.d` or
-`/usr/local/etc/bash_completion.d` directory.
+Confirm the version and save scripts to `/etc/bash_completion.d` or
+`/usr/local/etc/bash_completion.d`:
 
 ```
-scripts=( docker-machine-prompt.bash docker-machine-wrapper.bash docker-machine.bash ); for i in "${scripts[@]}"; do wget https://raw.githubusercontent.com/docker/machine/v0.12.2/contrib/completion/bash/${i}; done
+scripts=( docker-machine-prompt.bash docker-machine-wrapper.bash docker-machine.bash ); for i in "${scripts[@]}"; do sudo wget https://raw.githubusercontent.com/docker/machine/v0.12.2/contrib/completion/bash/${i} -P /etc/bash_completion.d; done
 ```
 
 To enable the `docker-machine` shell

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -72,7 +72,7 @@ Confirm the version and save scripts to `/etc/bash_completion.d` or
 `/usr/local/etc/bash_completion.d`:
 
 ```
-scripts=( docker-machine-prompt.bash docker-machine-wrapper.bash docker-machine.bash ); for i in "${scripts[@]}"; do sudo wget https://raw.githubusercontent.com/docker/machine/v0.12.2/contrib/completion/bash/${i} -P /etc/bash_completion.d; done
+scripts=( docker-machine-prompt.bash docker-machine-wrapper.bash docker-machine.bash ); for i in "${scripts[@]}"; do sudo wget https://raw.githubusercontent.com/docker/machine/v{{machineversion}}/contrib/completion/bash/${i} -P /etc/bash_completion.d; done
 ```
 
 To enable the `docker-machine` shell


### PR DESCRIPTION
Add script to download the 3 bash completion scripts for docker:
https://github.com/docker/machine/tree/v0.12.2/contrib/completion/bash

Would prefer to use a variable in the URL. How can I do that here? 
https://raw.githubusercontent.com/docker/machine/**v0.12.2**/contrib/completion/bash/docker-machine-wrapper.bash

Fixes #4499 