### PR TITLE
security: remove blurb about userns conflicting with r/o (#4396)

### DIFF
--- a/engine/security/userns-remap.md
+++ b/engine/security/userns-remap.md
@@ -251,9 +251,6 @@ The following standard Docker features are incompatible with running a Docker
 daemon with user namespaces enabled:
 
 - sharing PID or NET namespaces with the host (`--pid=host` or `--network=host`).
-- A `--read-only` container filesystem. This is a Linux kernel restriction
-  against remounting an already-mounted filesystem with modified flags when
-  inside a user namespace.
 - external (volume or storage) drivers which are unaware or incapable of using
   daemon user mappings.
 - Using the `--privileged` mode flag on `docker run` without also specifying


### PR DESCRIPTION
As of
https://github.com/opencontainers/runc/commit/66eb2a3e8fc930e1bb6703561152edf5ab550bff
in runc, this is no longer true (in fact, it was never true; the problem
was a bug in runc, not a kernel check). Let's remove it.

Signed-off-by: Tycho Andersen <tycho@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
