### PR TITLE
Fix broken links on UCP links and TOC on 2.1

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1572,6 +1572,8 @@ manuals:
               title: Use domain names to access services
             - path: /datacenter/ucp/2.1/guides/admin/configure/run-only-the-images-you-trust/
               title: Run only the images you trust
+            - path: /datacenter/ucp/2.1/guides/admin/configure/integrate-with-dtr/
+              title: Integrate with Docker Trusted Registry
             - path: /datacenter/ucp/2.1/guides/admin/configure/external-auth/
               title: Integrate with LDAP
           - sectiontitle: Manage users

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1552,8 +1552,6 @@ manuals:
             section:
             - path: /datacenter/ucp/2.1/guides/admin/configure/license-your-installation/
               title: License your installation
-            - path: /datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates/
-              title: Use your own TLS certificates
             - path: /datacenter/ucp/2.1/guides/admin/configure/scale-your-cluster/
               title: Scale your cluster
             - path: /datacenter/ucp/2.1/guides/admin/configure/set-up-high-availability/
@@ -1576,6 +1574,8 @@ manuals:
               title: Integrate with Docker Trusted Registry
             - path: /datacenter/ucp/2.1/guides/admin/configure/external-auth/
               title: Integrate with LDAP
+            - path: /datacenter/ucp/2.1/guides/admin/configure/use-your-own-tls-certificates/
+              title: Use your own TLS certificates
           - sectiontitle: Manage users
             section:
             - path: /datacenter/ucp/2.1/guides/admin/manage-users/

--- a/datacenter/ucp/2.0/guides/configuration/integrate-with-dtr.md
+++ b/datacenter/ucp/2.0/guides/configuration/integrate-with-dtr.md
@@ -139,4 +139,4 @@ steps as you used to configure your local computer.
 
 ## Where to go next
 
-* [Use externally-signed certificates](index.md)
+* [use your own externally-signed TLS certificates](index.md#customize-the-ucp-tls-certificates)

--- a/datacenter/ucp/2.1/guides/admin/configure/integrate-with-dtr.md
+++ b/datacenter/ucp/2.1/guides/admin/configure/integrate-with-dtr.md
@@ -139,4 +139,4 @@ steps as you used to configure your local computer.
 
 ## Where to go next
 
-* [Use externally-signed certificates](index.md)
+* [Use your own TLS certificates](use-your-own-tls-certificates/.md)

--- a/datacenter/ucp/2.1/guides/admin/configure/integrate-with-dtr.md
+++ b/datacenter/ucp/2.1/guides/admin/configure/integrate-with-dtr.md
@@ -139,4 +139,4 @@ steps as you used to configure your local computer.
 
 ## Where to go next
 
-* [Use your own TLS certificates](use-your-own-tls-certificates/.md)
+* [Use your own TLS certificates](use-your-own-tls-certificates.md)

--- a/datacenter/ucp/2.2/guides/admin/configure/integrate-with-dtr.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/integrate-with-dtr.md
@@ -140,4 +140,4 @@ steps as you used to configure your local computer.
 
 ## Where to go next
 
-* [Use your own TLS certificates](use-your-own-tls-certificates/.md)
+* [Use your own TLS certificates](use-your-own-tls-certificates.md)

--- a/datacenter/ucp/2.2/guides/admin/configure/integrate-with-dtr.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/integrate-with-dtr.md
@@ -140,4 +140,4 @@ steps as you used to configure your local computer.
 
 ## Where to go next
 
-* [Use externally-signed certificates](index.md)
+* [Use your own TLS certificates](use-your-own-tls-certificates/.md)


### PR DESCRIPTION
I haven't got this working yet, but stay tuned, almost there.

### What's changed

- Fixed broken links in "what's next" sections
- Added missing topic to TOC on v2.1

### Related

Fixes #3533

### Reviewers

@grahamnscp


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>

