### PR TITLE
Typo in example command

### DIFF
--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -85,7 +85,7 @@ using `10.10.10.20` and `127.0.0.1`:
 Set the Docker daemon key's extended usage attributes to be used only for
 server authentication:
 
-    $ echo extendedKeyUsage = serverAuth > extfile.cnf
+    $ echo extendedKeyUsage = serverAuth >> extfile.cnf
 
 Now, generate the key:
 


### PR DESCRIPTION
Configuration file should be extended with new key-valye instead of overwritten by it
