### PR TITLE
driver exoscale: update default value for affinity group

### DIFF
--- a/machine/drivers/exoscale.md
+++ b/machine/drivers/exoscale.md
@@ -44,4 +44,4 @@ There is a limit to the number of docker machines that an anti-affinity group ca
 | `--exoscale-availability-zone`  | `EXOSCALE_AVAILABILITY_ZONE` | `ch-dk-2`                         |
 | `--exoscale-ssh-user`           | `EXOSCALE_SSH_USER`          | `ubuntu`                          |
 | `--exoscale-userdata`           | `EXOSCALE_USERDATA`          | -                                 |
-| `--exoscale-affinity-group`     | `EXOSCALE_AFFINITY_GROUP`    | `docker-machine`                  |
+| `--exoscale-affinity-group`     | `EXOSCALE_AFFINITY_GROUP`    | -                                 |


### PR DESCRIPTION
Referring change in docker-machine
https://github.com/docker/machine/pull/4255

Signed-off-by: Marc-Aurèle Brothier <m@brothier.org>

### Proposed changes
Documentation change for Exoscale driver which remove the default value for `--exoscale-affinity-group` parameter.

### Related issues (optional)
https://github.com/docker/machine/pull/4255
