### PR TITLE
Add more info re: Hyper-V driver for Docker Machine on Windows, cleanup, link topics together

### DIFF
--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -328,15 +328,16 @@ off".
 #### Hyper-V driver for Docker Machine
 
 Docker for Windows comes with the legacy tool Docker Machine which uses the old
-[`boot2docker.iso`](https://github.com/boot2docker/boot2docker), and the
-[Microsoft Hyper-V driver](/machine/drivers/hyper-v.md) to create local virtual
-machines. _This is tangential to using Docker for Windows_, but if you want to
-use Docker Machine to create multiple local VMs, or to provision remote
-machines, see the [Docker Machine](/machine/index.md) topics. We mention only
-mention this here in case someone is looking for information about Docker
-Machine on Windows, which requires that Hyper-V is enabled, an external network
-switch is active, and these are referenced in the flags for the `docker-machine
-create` command [as described in the Docker Machine driver
+[`boot2docker.iso`](https://github.com/boot2docker/boot2docker){:
+target="_blank" class="_"}, and the [Microsoft Hyper-V
+driver](/machine/drivers/hyper-v.md) to create local virtual machines. _This is
+tangential to using Docker for Windows_, but if you want to use Docker Machine
+to create multiple local VMs, or to provision remote machines, see the [Docker
+Machine](/machine/index.md) topics. We mention only mention this here in case
+someone is looking for information about Docker Machine on Windows, which
+requires that Hyper-V is enabled, an external network switch is active, and
+these are referenced in the flags for the `docker-machine create` command [as
+described in the Docker Machine driver
 example](/machine/drivers/hyper-v.md#example).
 
 ### Virtualization must be enabled

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -334,8 +334,9 @@ machines. _This is tangential to using Docker for Windows_, but if you want to
 use Docker Machine to create multiple local VMs, or to provision remote
 machines, see the [Docker Machine](/machine/index.md) topics. We mention only
 mention this here in case someone is looking for information about Docker
-Machine on Windows, which requires that Hyper-V is enabled and an external
-network switch is active [as described in the Docker Macihne driver
+Machine on Windows, which requires that Hyper-V is enabled, an external network
+switch is active, and these are referenced in the flags for the `docker-machine
+create` command [as described in the Docker Machine driver
 example](/machine/drivers/hyper-v.md#example).
 
 ### Virtualization must be enabled

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -333,12 +333,11 @@ target="_blank" class="_"}, and the [Microsoft Hyper-V
 driver](/machine/drivers/hyper-v.md) to create local virtual machines. _This is
 tangential to using Docker for Windows_, but if you want to use Docker Machine
 to create multiple local VMs, or to provision remote machines, see the [Docker
-Machine](/machine/index.md) topics. We mention only mention this here in case
-someone is looking for information about Docker Machine on Windows, which
-requires that Hyper-V is enabled, an external network switch is active, and
-these are referenced in the flags for the `docker-machine create` command [as
-described in the Docker Machine driver
-example](/machine/drivers/hyper-v.md#example).
+Machine](/machine/index.md) topics. We mention this here only in case someone is
+looking for information about Docker Machine on Windows, which requires that
+Hyper-V is enabled, an external network switch is active, and referenced in the
+flags for the `docker-machine create` command [as described in the Docker
+Machine driver example](/machine/drivers/hyper-v.md#example).
 
 ### Virtualization must be enabled
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -325,6 +325,19 @@ off".
 
 ![Hyper-V on Windows features](images/hyper-v-enable-status.png )
 
+#### Hyper-V driver for Docker Machine
+
+Docker for Windows comes with the legacy tool Docker Machine which uses the old
+[`boot2docker.iso`](https://github.com/boot2docker/boot2docker), and the
+[Microsoft Hyper-V driver](/machine/drivers/hyper-v.md) to create local virtual
+machines. _This is tangential to using Docker for Windows_, but if you want to
+use Docker Machine to create multiple local VMs, or to provision remote
+machines, see the [Docker Machine](/machine/index.md) topics. We mention only
+mention this here in case someone is looking for information about Docker
+Machine on Windows, which requires that Hyper-V is enabled and an external
+network switch is active [as described in the Docker Macihne driver
+example](/machine/drivers/hyper-v.md#example).
+
 ### Virtualization must be enabled
 
 In addition to [Hyper-V](#hyper-v), virtualization must be enabled.

--- a/machine/drivers/hyper-v.md
+++ b/machine/drivers/hyper-v.md
@@ -147,4 +147,4 @@ To get started using `docker-machine` commands, see these topics:
 
 *  [Run containers and experiment with Machine commands](/machine/get-started.md#run-containers-and-experiment-with-machine-commands) and the introductory topics that follow
 
-* [Docker Machine commmand line reference](/machine/reference/index.md).
+* [Docker Machine commmand line reference](/machine/reference/index.md)

--- a/machine/drivers/hyper-v.md
+++ b/machine/drivers/hyper-v.md
@@ -137,12 +137,14 @@ you can create these swarm nodes: `manager1`, `worker1`, `worker2`.
 
 ## Where to go next
 
-As a point of interest, virtual machines you create with `docker-machine create`
-show up in the Hyper-V Manager under "Virtual Machines", but you need to manage
-them with `docker-machine` commands not through the Hyper-V Manager.
+As a point of interest, the virtual machines you create with the
+[`docker-machine create`](/machine/reference/create.md) command show up in the
+Hyper-V Manager under "Virtual Machines", but you need to manage them with
+[`docker-machine`](/machine/reference/index.md) commands not through the Hyper-V
+Manager.
 
 To get started using `docker-machine` commands, see these topics:
 
 *  [Run containers and experiment with Machine commands](/machine/get-started.md#run-containers-and-experiment-with-machine-commands) and the introductory topics that follow
 
-* [Docker Machine commmand line reference](/machine/reference/).
+* [Docker Machine commmand line reference](/machine/reference/index.md).

--- a/machine/drivers/hyper-v.md
+++ b/machine/drivers/hyper-v.md
@@ -134,3 +134,15 @@ you can create these swarm nodes: `manager1`, `worker1`, `worker2`.
     docker-machine create -d hyperv --hyperv-virtual-switch "Primary Virtual Switch" worker1
     docker-machine create -d hyperv --hyperv-virtual-switch "Primary Virtual Switch" worker2
     ```
+
+## Where to go next
+
+As a point of interest, virtual machines you create with `docker-machine create`
+show up in the Hyper-V Manager under "Virtual Machines", but you need to manage
+them with `docker-machine` commands not through the Hyper-V Manager.
+
+To get started using `docker-machine` commands, see these topics:
+
+*  [Run containers and experiment with Machine commands](/machine/get-started.md#run-containers-and-experiment-with-machine-commands) and the introductory topics that follow
+
+* [Docker Machine commmand line reference](/machine/reference/).

--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -126,7 +126,7 @@ choose another name for this new machine.
 
     * If you are using Toolbox on Mac, Toolbox on older Windows systems without Hyper-V, or Docker for Mac, use `virtualbox` as the driver, as shown in this example. (The Docker Machine VirtualBox driver reference is [here](drivers/virtualbox.md).) (See [prerequisites](get-started.md#prerequisite-information) above to learn more.)
 
-    * On Docker for Windows systems that support Hyper-V, use the `hyperv` driver as shown in the [Docker Machine Microsoft Hyper-V driver reference](drivers/hyper-v.md). (See [prerequisites](get-started.md#prerequisite-information) above to learn more.)
+    * On Docker for Windows systems that support Hyper-V, use the `hyperv` driver as shown in the [Docker Machine Microsoft Hyper-V driver reference](drivers/hyper-v.md) and follow the [example](/machine/drivers/hyper-v.md#example), which shows how to use an external network switch and provides the flags for the full command. (See [prerequisites](get-started.md#prerequisite-information) above to learn more.)
 
             $ docker-machine create --driver virtualbox default
             Running pre-create checks...

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -94,12 +94,20 @@ To uninstall Docker Machine:
 
     To remove each machine individually: `docker-machine rm <machine-name>`
 
-    To remove all machines: `docker-machine rm -f $(docker-machine ls -q)`
+    To remove all machines: `docker-machine rm -f $(docker-machine ls -q)` (you might need to use `-force` on Windows)
 
   Removing machines is an optional step because there are cases where you might
   want to save and migrate existing machines to a [Docker for
   Mac](/docker-for-mac/index.md) or [Docker for
   Windows](/docker-for-windows/index.md) environment, for example.
+
+>**Note**: As a point of information, the `config.json`, certificates,
+and other data related to each virtual machine created by `docker-machine`
+is stored in `~/.docker/machine/machines/` on Mac and Linux and in
+`~\.docker\machine\machines\` on Windows. We recommend that you do not edit or
+remove those files directly as this will only affect information for the Docker
+CLI, not the actual VMs, regardless of whether they are local or on remote
+servers.
 
 ## Where to go next
 

--- a/machine/reference/create.md
+++ b/machine/reference/create.md
@@ -15,6 +15,10 @@ information on how to use them, see [Machine
 drivers](/machine/drivers/index.md).
 {: .important}
 
+## Example
+
+Here is an example of using the `--virtualbox` driver to create a machine.
+
 ```none
 $ docker-machine create --driver virtualbox dev
 Creating CA: /home/username/.docker/machine/certs/ca.pem

--- a/machine/reference/create.md
+++ b/machine/reference/create.md
@@ -17,7 +17,7 @@ drivers](/machine/drivers/index.md).
 
 ## Example
 
-Here is an example of using the `--virtualbox` driver to create a machine.
+Here is an example of using the `--virtualbox` driver to create a machine called `dev`.
 
 ```none
 $ docker-machine create --driver virtualbox dev

--- a/machine/reference/create.md
+++ b/machine/reference/create.md
@@ -8,6 +8,13 @@ Create a machine.  Requires the `--driver` flag to indicate which provider
 (VirtualBox, DigitalOcean, AWS, etc.) the machine should be created on, and an
 argument to indicate the name of the created machine.
 
+> Looking for the full list of available drivers?
+>
+>For a full list of drivers that work with `docker-machine create` and
+information on how to use them, see [Machine
+drivers](/machine/drivers/index.md).
+{: .important}
+
 ```none
 $ docker-machine create --driver virtualbox dev
 Creating CA: /home/username/.docker/machine/certs/ca.pem


### PR DESCRIPTION
### What's changed

- Just filling in some gaps in Docker for Windows docs troubleshooting where people might be looking for info on working with the Hyper-V manager, external networks switches, and `docker-machine` commands

- In Docker Machine docs, clarified info on viewing machines in the Hyper-V manager, and where Docker machine data lives

### Reviewers

@friism I couldn't help but add this in a gentle way, you can nix it if you want, just seems like useful stuff to know where things live and how they work together

@JimGalasyn 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
