### PR TITLE
Indent services in compose file

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -55,63 +55,65 @@ services:
     deploy:
       placement:
         constraints: [node.role == manager]
-vote:
-  image: dockersamples/examplevotingapp_vote:before
-  ports:
-    - 5000:80
-  networks:
-    - frontend
-  depends_on:
-    - redis
-  deploy:
-    replicas: 2
-    update_config:
-      parallelism: 2
-    restart_policy:
-      condition: on-failure
-result:
-  image: dockersamples/examplevotingapp_result:before
-  ports:
-    - 5001:80
-  networks:
-    - backend
-  depends_on:
-    - db
-  deploy:
-    replicas: 1
-    update_config:
-      parallelism: 2
-      delay: 10s
-    restart_policy:
-      condition: on-failure
 
-worker:
-  image: dockersamples/examplevotingapp_worker
-  networks:
-    - frontend
-    - backend
-  deploy:
-    mode: replicated
-    replicas: 1
-    labels: [APP=VOTING]
-    restart_policy:
-      condition: on-failure
-      delay: 10s
-      max_attempts: 3
-      window: 120s
-    placement:
-      constraints: [node.role == manager]
+  vote:
+    image: dockersamples/examplevotingapp_vote:before
+    ports:
+      - 5000:80
+    networks:
+      - frontend
+    depends_on:
+      - redis
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 2
+      restart_policy:
+        condition: on-failure
 
-visualizer:
-  image: dockersamples/visualizer:stable
-  ports:
-    - "8080:8080"
-  stop_grace_period: 1m30s
-  volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock"
-  deploy:
-    placement:
-      constraints: [node.role == manager]
+  result:
+    image: dockersamples/examplevotingapp_result:before
+    ports:
+      - 5001:80
+    networks:
+      - backend
+    depends_on:
+      - db
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 2
+        delay: 10s
+      restart_policy:
+        condition: on-failure
+
+  worker:
+    image: dockersamples/examplevotingapp_worker
+    networks:
+      - frontend
+      - backend
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels: [APP=VOTING]
+      restart_policy:
+        condition: on-failure
+        delay: 10s
+        max_attempts: 3
+        window: 120s
+      placement:
+        constraints: [node.role == manager]
+
+  visualizer:
+    image: dockersamples/visualizer:stable
+    ports:
+      - "8080:8080"
+    stop_grace_period: 1m30s
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    deploy:
+      placement:
+        constraints: [node.role == manager]
 
 networks:
   frontend:

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -33,28 +33,28 @@ how to upgrade, see **[About versions and upgrading](compose-versioning.md)**.
 version: "3"
 services:
 
-redis:
-  image: redis:alpine
-  ports:
-    - "6379"
-  networks:
-    - frontend
-  deploy:
-    replicas: 2
-    update_config:
-      parallelism: 2
-      delay: 10s
-    restart_policy:
-      condition: on-failure
-db:
-  image: postgres:9.4
-  volumes:
-    - db-data:/var/lib/postgresql/data
-  networks:
-    - backend
-  deploy:
-    placement:
-      constraints: [node.role == manager]
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379"
+    networks:
+      - frontend
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 2
+        delay: 10s
+      restart_policy:
+        condition: on-failure
+  db:
+    image: postgres:9.4
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    deploy:
+      placement:
+        constraints: [node.role == manager]
 vote:
   image: dockersamples/examplevotingapp_vote:before
   ports:
@@ -561,7 +561,7 @@ networks:
 The options for `endpoint_mode` also work as flags on the swarm mode CLI command
 [docker service create](/engine/reference/commandline/service_create.md). For a
 quick list of all swarm related `docker` commands, see [Swarm mode CLI
-commands](/engine/swarm.md#swarm-mode-key-concepts-and-tutorial).  
+commands](/engine/swarm.md#swarm-mode-key-concepts-and-tutorial).
 
 To learn more about service discovery and networking in swarm mode, see
 [Configure service

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -46,6 +46,7 @@ services:
         delay: 10s
       restart_policy:
         condition: on-failure
+        
   db:
     image: postgres:9.4
     volumes:


### PR DESCRIPTION
Indent services, redis and db, in docker-compose.yml file, so that they are children of "services" rather than siblings. 

Fixes #4610 