### PR TITLE
Improvements to Getting Started content for Compose

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -131,12 +131,13 @@ Hub registry.
 
 2.  Enter `http://0.0.0.0:5000/` in a browser to see the application running.
 
-    If you're using Docker natively on Linux, Docker for Mac, or Docker
-    for Windows, then the web app should now be listening on port 5000
-    on your Docker daemon host. Point your web browser to `http://localhost:5000` to find the `Hello World` message. If this
-    doesn't resolve, you can also try `http://0.0.0.0:5000`.
+    If you're using Docker natively on Linux, Docker for Mac, or Docker for
+    Windows, then the web app should now be listening on port 5000 on your
+    Docker daemon host. Point your web browser to `http://localhost:5000` to
+    find the `Hello World` message. If this doesn't resolve, you can also try
+    `http://0.0.0.0:5000`.
 
-    If you're using Docker Machine on a Mac, use `docker-machine ip
+    If you're using Docker Machine on a Mac or Windows, use `docker-machine ip
     MACHINE_VM` to get the IP address of your Docker host. Then, open
     `http://MACHINE_VM_IP:5000` in a browser.
 

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -17,6 +17,8 @@ provided by Docker images.
 
 ## Step 1: Setup
 
+Define the application dependencies.
+
 1.  Create a directory for the project:
 
         $ mkdir composetest
@@ -45,9 +47,6 @@ provided by Docker images.
 
         flask
         redis
-
-   These define the application's dependencies.
-
 
 ## Step 2: Create a Dockerfile
 
@@ -167,7 +166,7 @@ Hub registry.
     ```
     $ docker image ls
     REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
-    composetest_web   latest              e2c21aa48cc1        4 minutes ago       93.8MB
+    composetest_web         latest              e2c21aa48cc1        4 minutes ago       93.8MB
     python                  3.4-alpine          84e6077c7ab6        7 days ago          82.5MB
     redis                   alpine              9d8fa9aa0e5b        3 weeks ago         27.5MB
     ```

--- a/compose/install.md
+++ b/compose/install.md
@@ -5,7 +5,7 @@ title: Install Docker Compose
 toc_max: 2
 ---
 
-{% assign composeversion = '1.15.0' %}
+{% assign composeversion = '1.16.0' %}
 
 You can run Compose on macOS, Windows and 64-bit Linux.
 
@@ -103,33 +103,15 @@ target="_blank" class="_"}. Follow the instructions from the link, which involve
 running the `curl` command in your terminal to download the binaries. These step
 by step instructions are also included below.
 
-1.  Run this command to download Docker Compose, replacing
-`$dockerComposeVersion` with the specific version of Compose you want to use:
+1.  Run this command to download the latest version of Docker Compose:
 
     ```bash
-    sudo -i
-    curl -L
-https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-`uname
--s`-`uname -m` -o /usr/local/bin/docker-compose
-    ```
-
-    For example, to download Compose version {{composeversion}}, the command
-    is:
-
-    ```bash
-    sudo -i
-    curl -L https://github.com/docker/compose/releases/download/{{composeversion}}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+    sudo curl -L https://github.com/docker/compose/releases/download/{{composeversion}}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
     ```
 
     > Use the latest Compose release number in the download command.
     >
-    The above command is an _example_, and it may become out-of-date once
-    in a while. Always follow the command pattern shown above it. If
-    you cut-and-paste an example, check which release it specifies and,
-    if needed, replace `$dockerComposeVersion` with the release number that
-    you want. Compose releases are also available for direct download on
-    the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank"
-    class="_"}.
+    The above command is an _example_, and it may become out-of-date. To ensure you have the latest version, check the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank" class="_"}.
     {: .important}
 
     If you have problems installing with `curl`, see
@@ -149,7 +131,7 @@ https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker
     ```bash
     $ docker-compose --version
     docker-compose version {{composeversion}}, build 1719ceb
-    ```  
+    ```
 <hr>
 </div>
 <div id="alternatives" class="tab-pane fade" markdown="1">


### PR DESCRIPTION
Included "Windows" in the the paragraph on having to point a browser to `http://<docker-machine ip>:5000`. 

I cannot reproduce the user's volume issue and suspect it relates to the note on [Shared folders, volumes, and bind mounts](https://docs.docker.com/compose/gettingstarted/#step-6-re-build-and-run-the-app-with-compose). 

I successfully tested all of [Getting Started with Docker Compose](https://docs.docker.com/compose/gettingstarted/) on Windows 7 (with Docker Toolbox: docker 17.07.0-ce, docker-compose 1.15.0, and docker-machine 0.12.2). 

Steps:

1. Configure, build, and run:
```
mkdir ~/composetest
cd ~/composetest
vi app.py
vi requirements.txt
vi Dockerfile
vi docker-compose.yml   ## with volumes
docker-machine ip <machine>
docker-compose up -d
```

2. Point browser to: http://<docker-machine ip>:5000

Fixes #2963 