### PR TITLE
Add info about adding shared folders to Toolbox

### DIFF
--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -118,33 +118,35 @@ Virtual Box VM, it maintains its configuration between uses.
 
     The terminal does a number of things to set up Docker Quickstart Terminal for you.
 
-        Last login: Sat Jul 11 20:09:45 on ttys002
-        bash '/Applications/Docker Quickstart Terminal.app/Contents/Resources/Scripts/start.sh'
-        Get http:///var/run/docker.sock/v1.19/images/json?all=1&filters=%7B%22dangling%22%3A%5B%22true%22%5D%7D: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
-        Get http:///var/run/docker.sock/v1.19/images/json?all=1: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
-        -bash: lolcat: command not found
+    ```
+    Last login: Sat Jul 11 20:09:45 on ttys002
+    bash '/Applications/Docker Quickstart Terminal.app/Contents/Resources/Scripts/start.sh'
+    Get http:///var/run/docker.sock/v1.19/images/json?all=1&filters=%7B%22dangling%22%3A%5B%22true%22%5D%7D: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
+    Get http:///var/run/docker.sock/v1.19/images/json?all=1: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
+    -bash: lolcat: command not found
 
-        mary at meepers in ~
-        $ bash '/Applications/Docker Quickstart Terminal.app/Contents/Resources/Scripts/start.sh'
-        Creating Machine dev...
-        Creating VirtualBox VM...
-        Creating SSH key...
-        Starting VirtualBox VM...
-        Starting VM...
-        To see how to connect Docker to this machine, run: docker-machine env dev
-        Starting machine dev...
-        Setting environment variables for machine dev...
+    mary at meepers in ~
+    $ bash '/Applications/Docker Quickstart Terminal.app/Contents/Resources/Scripts/start.sh'
+    Creating Machine dev...
+    Creating VirtualBox VM...
+    Creating SSH key...
+    Starting VirtualBox VM...
+    Starting VM...
+    To see how to connect Docker to this machine, run: docker-machine env dev
+    Starting machine dev...
+    Setting environment variables for machine dev...
 
-                                ##         .
-                          ## ## ##        ==
-                       ## ## ## ## ##    ===
-                   /"""""""""""""""""\___/ ===
-              ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
-                   \______ o           __/
-                     \    \         __/
-                      \____\_______/
+                            ##         .
+                      ## ## ##        ==
+                   ## ## ## ## ##    ===
+               /"""""""""""""""""\___/ ===
+          ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
+               \______ o           __/
+                 \    \         __/
+                  \____\_______/
 
-        The Docker Quick Start Terminal is configured to use Docker with the "default" VM.
+    The Docker Quick Start Terminal is configured to use Docker with the "default" VM.
+    ```
 
 3.  Click your mouse in the terminal window to make it active.
 
@@ -189,6 +191,39 @@ Virtual Box VM, it maintains its configuration between uses.
 
         For more examples and ideas, visit:
         https://docs.docker.com/userguide/
+
+## Optional: Add shared directories
+
+By default, Toolbox only has access to the `/Users` directory and mounts it into
+the VMs at `/Users`. If your project lives elsewhere or needs access to other
+directories on the host filesystem, you can add them.
+
+### Use the VirtualBox GUI
+
+You can configure shared folders in the VirtualBox UI.
+
+1.  Open the VirtualBox UI.
+2.  Click the **Settings** gear, then go to **Shared Folders**.
+3.  Click any existing listing under **Machine Folders** and click the **+**
+    icon. Choose the **Folder Path** on the host, the **Folder Name** for within the
+    VM, and configure any additional options you need. Chooose **Automount** if you want
+    the folder to automatically be mounted into the VM, and choose
+    **Make Permanent** for it to be considered a permanently shared folder.
+4.  Click **OK**. Click **OK** again to exit the Settings dialog.
+
+### Use the command line
+
+You can configure shared folders using a command like the following:
+
+```bash
+$ mount -t vboxsf -o uid=1000,gid=50 your-other-share-name /some/mount/location
+```
+
+This command mounts `/some/mount/location` into the VM at `/your-other-share-hame`,
+owned by UID 1000 and GID 50.
+
+> **Note**: The autommount and permanent mount options are not supported using
+> the command line.
 
 ## How to uninstall Toolbox
 

--- a/toolbox/toolbox_install_mac.md
+++ b/toolbox/toolbox_install_mac.md
@@ -203,13 +203,23 @@ directories on the host filesystem, you can add them.
 You can configure shared folders in the VirtualBox UI.
 
 1.  Open the VirtualBox UI.
+
 2.  Click the **Settings** gear, then go to **Shared Folders**.
-3.  Click any existing listing under **Machine Folders** and click the **+**
-    icon. Choose the **Folder Path** on the host, the **Folder Name** for within the
-    VM, and configure any additional options you need. Chooose **Automount** if you want
-    the folder to automatically be mounted into the VM, and choose
-    **Make Permanent** for it to be considered a permanently shared folder.
-4.  Click **OK**. Click **OK** again to exit the Settings dialog.
+
+3.  Select any existing listing under **Machine Folders**, then
+    click the **+** icon.
+
+    * Choose the **Folder Path** on the host, enter the **Folder Name**
+      for within the VM (or take the default, which is the same name
+      as on the host), and configure any additional options you need.
+
+    * Choose **Auto-mount** if you want the folder to automatically
+      be mounted into the VM, and choose **Make Permanent** for it
+      to be considered a permanently shared folder.
+
+4.  Click **OK** to add the new folder to the Shared Folders list.
+
+5.  Click **OK** again to save your changes and exit the Settings dialog.
 
 ### Use the command line
 

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -73,7 +73,7 @@ To verify your machine meets these requirements, do the following:
     <br>
     **For Windows 7**
 
-    Run the [Microsoft® Hardware-Assisted Virtualization Detection Tool](http://www.microsoft.com/en-us/download/details.aspx?id=592) and follow the on-screen instructions.
+    Run a tool like the [Microsoft® Hardware-Assisted Virtualization Detection Tool](http://www.microsoft.com/en-us/download/details.aspx?id=592){: target="_blank" class="_"} or [Speccy](https://www.piriform.com/speccy){: target="_blank" class="_"}, and follow the on-screen instructions.
     <br><br>
 3. Verify your Windows OS is 64-bit (x64)
 
@@ -201,13 +201,23 @@ If your project lives elsewhere or needs access to other
 directories on the host filesystem, you can add them, using the VirtualBox UI.
 
 1.  Open the VirtualBox UI.
+
 2.  Click the **Settings** gear, then go to **Shared Folders**.
-3.  Click any existing listing under **Machine Folders** and click the **+**
-    icon. Choose the **Folder Path** on the host, the **Folder Name** for within the
-    VM, and configure any additional options you need. Chooose **Automount** if you want
-    the folder to automatically be mounted into the VM, and choose
-    **Make Permanent** for it to be considered a permanently shared folder.
-4.  Click **OK**. Click **OK** again to exit the Settings dialog.
+
+3.  Select any existing listing under **Machine Folders**, then
+    click the **+** icon.
+
+    * Choose the **Folder Path** on the host, enter the **Folder Name**
+      for within the VM (or take the default, which is the same name
+      as on the host), and configure any additional options you need.
+
+    * Choose **Auto-mount** if you want the folder to automatically
+      be mounted into the VM, and choose **Make Permanent** for it
+      to be considered a permanently shared folder.
+
+4.  Click **OK** to add the new folder to the Shared Folders list.
+
+5.  Click **OK** again to save your changes and exit the Settings dialog.
 
 
 ## How to uninstall Toolbox

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -219,7 +219,6 @@ directories on the host filesystem, you can add them, using the VirtualBox UI.
 
 5.  Click **OK** again to save your changes and exit the Settings dialog.
 
-
 ## How to uninstall Toolbox
 
 Removing Toolbox involves removing all the Docker components it includes.

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -190,6 +190,25 @@ Typically, the above steps work out-of-the-box, but some scenarios can cause pro
 A Windows specific problem you might encounter has to do with the NDIS6 host network filter driver, which is known to cause issues on some Windows
 versions. For Windows Vista systems and newer, VirtualBox installs NDIS6 driver by default. Issues can range from system slowdowns to networking problems for the virtual machine (VM). If you notice problems, **re-run the Docker Toolbox installer**, and select the option to _**install VirtualBox with the NDIS5 driver**_.
 
+## Optional: Add shared directories
+
+By default, Toolbox only has access to the `C:\Users` directory and mounts it into
+the VMs at `/c/Users`.
+
+> **Note**: Within the VM path, `c` is lowercase and the `Users` is capitalized.
+
+If your project lives elsewhere or needs access to other
+directories on the host filesystem, you can add them, using the VirtualBox UI.
+
+1.  Open the VirtualBox UI.
+2.  Click the **Settings** gear, then go to **Shared Folders**.
+3.  Click any existing listing under **Machine Folders** and click the **+**
+    icon. Choose the **Folder Path** on the host, the **Folder Name** for within the
+    VM, and configure any additional options you need. Chooose **Automount** if you want
+    the folder to automatically be mounted into the VM, and choose
+    **Make Permanent** for it to be considered a permanently shared folder.
+4.  Click **OK**. Click **OK** again to exit the Settings dialog.
+
 
 ## How to uninstall Toolbox
 


### PR DESCRIPTION
Fixes #4334 

cc/ @FrenchBen for technical review

Specifically, I only included the command-line method on Mac, and I almost feel like I should remove it there too since it's limited, compared to adding the shared folder within VirtualBox.