### PR TITLE
Change ifconfig to ip addr show on Networking w/hints for Docker for Mac, Windows

### DIFF
--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -56,7 +56,7 @@ docker0   Link encap:Ethernet  HWaddr 02:42:47:bc:3a:eb
 
 > Running on Docker for Mac or Docker for Windows?
 >
-> If you are using Docker for Mac (or runnin Linux containers on Docker for Windows), the
+> If you are using Docker for Mac (or running Linux containers on Docker for Windows), the
 `docker network ls` command will work as described above, but the
 `ip addr show` and `ifconfig` commands may be present, but will give you information about
 the IP addresses for your local host, not Docker container networks.

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -35,12 +35,12 @@ your container should connect to.
 
 The `bridge` network represents the `docker0` network present in all Docker
 installations. Unless you specify otherwise with the `docker run
---network=<NETWORK>` option, the Docker daemon connects containers to this network
-by default. You can see this bridge as part of a host's network stack by using
-the `ifconfig` command on the host.
+--network=<NETWORK>` option, the Docker daemon connects containers to this
+network by default. You can see this bridge as part of a host's network stack by
+using the `ip addr show` command (or short form, `ip a`) on the host. The `ifconfig` command is deprecated, but may also work, depending on your system.
 
 ```bash
-$ ifconfig
+$ ip addr show
 
 docker0   Link encap:Ethernet  HWaddr 02:42:47:bc:3a:eb
           inet addr:172.17.0.1  Bcast:0.0.0.0  Mask:255.255.0.0
@@ -51,6 +51,16 @@ docker0   Link encap:Ethernet  HWaddr 02:42:47:bc:3a:eb
           collisions:0 txqueuelen:0
           RX bytes:1100 (1.1 KB)  TX bytes:648 (648.0 B)
 ```
+> Running on Docker for Mac or Docker for Windows?
+>
+> If you are using Docker for Mac or Docker for Windows, the
+`docker network ls` command will work as described above, but the
+`ifconfig` and `ip addr show` commands will give you information
+about the IP addresses for your local host, not Docker node networks. 
+To use these commands to browse Docker networks, log on to a
+[Docker machine](/machine/overview.md) such as a local VM or
+cloud provider such as a [Docker machine on AWS](/machine/examples/aws.md)
+or a  [Docker machine on Digital Ocean](/machine/examples/ocean.md).
 
 The `none` network adds a container to a container-specific network stack. That
 container lacks a network interface. Attaching to such a container and looking

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -53,12 +53,15 @@ docker0   Link encap:Ethernet  HWaddr 02:42:47:bc:3a:eb
           collisions:0 txqueuelen:0
           RX bytes:1100 (1.1 KB)  TX bytes:648 (648.0 B)
 ```
+
 > Running on Docker for Mac or Docker for Windows?
 >
-> If you are using Docker for Mac or Docker for Windows, the
+> If you are using Docker for Mac (or runnin Linux containers on Docker for Windows), the
 `docker network ls` command will work as described above, but the
-`ip addr show` and `ifconfig` commands will give you information about
+`ip addr show` and `ifconfig` commands may be present, but will give you information about
 the IP addresses for your local host, not Docker container networks.
+This is because Docker uses network interfaces running inside a thin VM,
+instead of on the host machine itself.
 >
 > To use the `ip addr show` or `ifconfig` commands to browse Docker
 networks, log on to a [Docker machine](/machine/overview.md) such as a

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -37,7 +37,9 @@ The `bridge` network represents the `docker0` network present in all Docker
 installations. Unless you specify otherwise with the `docker run
 --network=<NETWORK>` option, the Docker daemon connects containers to this
 network by default. You can see this bridge as part of a host's network stack by
-using the `ip addr show` command (or short form, `ip a`) on the host. The `ifconfig` command is deprecated, but may also work, depending on your system.
+using the `ip addr show` command (or short form, `ip a`) on the host. (The
+`ifconfig` command is deprecated. It may also work or give you a `command not
+found` error, depending on your system.)
 
 ```bash
 $ ip addr show
@@ -55,12 +57,17 @@ docker0   Link encap:Ethernet  HWaddr 02:42:47:bc:3a:eb
 >
 > If you are using Docker for Mac or Docker for Windows, the
 `docker network ls` command will work as described above, but the
-`ifconfig` and `ip addr show` commands will give you information
-about the IP addresses for your local host, not Docker node networks. 
-To use these commands to browse Docker networks, log on to a
-[Docker machine](/machine/overview.md) such as a local VM or
-cloud provider such as a [Docker machine on AWS](/machine/examples/aws.md)
-or a  [Docker machine on Digital Ocean](/machine/examples/ocean.md).
+`ip addr show` and `ifconfig` commands will give you information about
+the IP addresses for your local host, not Docker container networks.
+>
+> To use the `ip addr show` or `ifconfig` commands to browse Docker
+networks, log on to a [Docker machine](/machine/overview.md) such as a
+local VM or on a cloud provider like a
+[Docker machine on AWS](/machine/examples/aws.md) or a
+[Docker machine on Digital Ocean](/machine/examples/ocean.md).
+You can use `docker-machine ssh <machine-name>` to log on to your
+local or cloud hosted machines, or a direct `ssh` as described
+on the cloud provider site.
 
 The `none` network adds a container to a container-specific network stack. That
 container lacks a network interface. Attaching to such a container and looking


### PR DESCRIPTION
### What's changed

- updated Networking topic to refer to `ip addr show` and short for `ip a`, mention that `ifconfig` is deprecated 

- changed example to reflect new commands

- added a note and links for Docker for Mac and Windows users, for whom neither `ifconfig` or `ip a` will give the expected output until they log into a Dockerized node

- searched the docs for other instances of `ifconfig`, after this hit, the next several pages were all in Forums, so this may do it for now ..?

### Related 

Fixes #4559 

### Reviewers

@dlaptin

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>