### PR TITLE
contraint instead of label to create Registry on node1

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -318,7 +318,7 @@ $ docker service create \
   --name registry \
   --secret domain.crt \
   --secret domain.key \
-  --label registry=true \
+  --constraint 'node.labels.registry==true' \
   --mount src=/mnt/registry,dst=/var/lib/registry \
   -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
   -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/secrets/domain.crt \


### PR DESCRIPTION
As the `--label` option is used before in `docker node update --label-add registry=true node1`, the Docker registry should be restricted to only run on `node1` - and nowhere else. So the `docker service create` command has to use the option `--constraint 'node.labels.registry==true` instead of `--label registry=true`- because it is a contraint, where to run the Registry - we don´t just want to set a label again.

### Proposed changes

Without the correct constraint set, the Registry is able to run somewhere else in the cluster - and not on the desired `node1`
