### PR TITLE
remove the recommendation of 7 nodes.

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/configure/set-up-high-availability.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/set-up-high-availability.md
@@ -23,8 +23,6 @@ your swarm.
 |       1       |         0          |
 |       3       |         1          |
 |       5       |         2          |
-|       7       |         3          |
-
 
 For production-grade deployments, follow these rules of thumb:
 


### PR DESCRIPTION
removing the recommendation of 7 managers nodes based guidance from engineering. they claimed 7 manager nodes was less performative then 5.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Guidance that came out from a customer issue. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
