### PR TITLE
Make dockremap and testuser uid/gid match

### DIFF
--- a/engine/security/userns-remap.md
+++ b/engine/security/userns-remap.md
@@ -179,11 +179,11 @@ $ dockerd --userns-remap="testuser:testuser"
     ```bash
     $ grep dockremap /etc/subuid
 
-    dockremap:296608:65536
+    dockremap:231072:65536
 
     $ grep dockremap /etc/subgid
 
-    dockremap:296608:65536
+    dockremap:231072:65536
     ```
 
     If these entries are not present, edit the files as the `root` user and


### PR DESCRIPTION
### Proposed changes

This example is leading to confusion when folks populate /etc/sub{g,u}id with dockremap:296608:65536 (as defined in step 2) instead of testuser:231072:65536.  Step 4 (verification) of "Enable userns-remap on the daemon" doesn't match if the dockremap uid/gid is used. 

I changed the example so that dockremap is defined as "dockremap:231072:65536" so that all the steps lined up.

### Unreleased project version (optional)

### Related issues (optional)
