### PR TITLE
Update "docker-compose up" doc to explain logging

### DIFF
--- a/compose/reference/up.md
+++ b/compose/reference/up.md
@@ -38,7 +38,7 @@ Builds, (re)creates, starts, and attaches to containers for a service.
 
 Unless they are already running, this command also starts any linked services.
 
-The `docker-compose up` command aggregates the output of each container. When
+The `docker-compose up` command aggregates the output of each container (essentially running `docker-compose logs -f`). When
 the command exits, all containers are stopped. Running `docker-compose up -d`
 starts the containers in the background and leaves them running.
 


### PR DESCRIPTION
### Proposed changes

After running "docker-compose up", the console shows a nice aggregated output of each container. When running this in detached mode, it's not clear how to later view this aggregated output again. Added a quick note on how this is done.

### Unreleased project version (optional)
### Related issues (optional)