### PR TITLE
Update networking.md

### DIFF
--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -105,7 +105,7 @@ container to port `8000` on the host:
 ```bash
 $ docker run --publish 8000:80 --name webserver nginx
 
-$ docker run --p 8000:80 --name webserver nginx
+$ docker run -p 8000:80 --name webserver nginx
 ```
 
 To expose all ports, use the `-P` flag. For example, the following command


### PR DESCRIPTION
changed --p to -p

### Proposed changes

Changed the documentation for networking in Docker for Mac, because the --p option resulted in "unknown flag --p". 