### PR TITLE
Update documentation of proxy server configuration

### DIFF
--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -614,12 +614,12 @@ value. This method makes the image less portable, so if you have Docker 17.07
 or higher, you should [configure the Docker client](#configure-the-docker-client)
 instead.
 
-| Variable      | Dockerfile example                               | `docker run` Example                                |
-|:--------------|:-------------------------------------------------|:----------------------------------------------------|
-| `HTTP_PROXY`  | `ENV HTTP_PROXY "http://127.0.0.1:3001"`         | `--env HTTP_PROXY "http://127.0.0.1:3001"`          |
-| `HTTPS_PROXY` | `ENV HTTPS_PROXY "https://127.0.0.1:3001"`       | `--env HTTPS_PROXY "https://127.0.0.1:3001"`        |
-| `FTP_PROXY`   | `ENV FTP_PROXY "ftp://127.0.0.1:3001"`           | `--env FTP_PROXY "ftp://127.0.0.1:3001"`            |
-| `NO_PROXY`    | `ENV NO_PROXY "*.test.example.com,.example2.com" | `--env NO_PROXY "*.test.example.com,.example2.com"` |
+| Variable      | Dockerfile example                                | `docker run` Example                                |
+|:--------------|:--------------------------------------------------|:----------------------------------------------------|
+| `HTTP_PROXY`  | `ENV HTTP_PROXY "http://127.0.0.1:3001"`          | `--env HTTP_PROXY "http://127.0.0.1:3001"`          |
+| `HTTPS_PROXY` | `ENV HTTPS_PROXY "https://127.0.0.1:3001"`        | `--env HTTPS_PROXY "https://127.0.0.1:3001"`        |
+| `FTP_PROXY`   | `ENV FTP_PROXY "ftp://127.0.0.1:3001"`            | `--env FTP_PROXY "ftp://127.0.0.1:3001"`            |
+| `NO_PROXY`    | `ENV NO_PROXY "*.test.example.com,.example2.com"` | `--env NO_PROXY "*.test.example.com,.example2.com"` |
 
 ## Links
 

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -579,7 +579,7 @@ configure it in different ways:
 
 1.  On the Docker client, create or edit the file `~/.config.json` in the
     home directory of the user which starts containers. Add JSON such as the
-    following, substituting the type of proxy with `httpsproxy` or `ftpproxy` if
+    following, substituting the type of proxy with `httpsProxy` or `ftpProxy` if
     necessary, and substituting the address and port of the proxy server. You
     can configure multiple proxy servers at the same time.
 
@@ -592,8 +592,11 @@ configure it in different ways:
     {
       "proxies":
       {
-        "httpProxy": "http://127.0.0.1:3001",
-        "noProxy": "*.test.example.com,.example2.com"
+        "default":
+        {
+          "httpProxy": "http://127.0.0.1:3001",
+          "noProxy": "*.test.example.com,.example2.com"
+        }
       }
     }
     ```


### PR DESCRIPTION
### Proposed changes

As per the implementation in docker/cli#93 the proxy server addresses
are specified per docker daemon or as defaults.  Updated the example to
show the default option.

### Related issues (optional)

Fixes #4686
