### PR TITLE
Update part5.md

### DIFF
--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -231,6 +231,8 @@ Redis service. Be sure to replace `username/repo:tag` with your image details.
     ```shell
     docker-machine ssh myvm1 "mkdir ./data"
     ```
+    
+    You should also create the `data` folder in the folder containing your `docker-compose` file.
 
 3.  Make sure your shell is configured to talk to `myvm1` (examples are [here](part4.md#configure-a-docker-machine-shell-to-the-swarm-manager)).
 


### PR DESCRIPTION
I couldn't start redis and was getting the following error message `invalid mount config for type "bind": bind source path does not exist"`.
Using docker-compose config I got the full path that docker was expecting, created the folder and could finally start the redis service.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
