### PR TITLE
clarified Compose resource options for v2, v3

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -646,9 +646,12 @@ containers that should be running at any given time.
 
 #### resources
 
-Configures resource constraints. This replaces the older resource constraint
-options in Compose files prior to version 3 (`cpu_shares`, `cpu_quota`,
-`cpuset`, `mem_limit`, `memswap_limit`, `mem_swappiness`).
+Configures resource constraints.
+
+> **Note**: This replaces the [older resource constraint options](compose-file-v2.md#cpu-and-other-resources) for non swarm mode in
+Compose files prior to version 3 (`cpu_shares`, `cpu_quota`, `cpuset`,
+`mem_limit`, `memswap_limit`, `mem_swappiness`), as described in [Upgrading
+version 2.x to 3.x](/compose/compose-file/compose-versioning.md#upgrading).
 
 Each of these is a single value, analogous to its [docker service
 create](/engine/reference/commandline/service_create.md) counterpart.
@@ -1638,7 +1641,7 @@ services:
       - type: bind
         source: ./static
         target: /opt/app/static
-        
+
 networks:
   webnet:
 

--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -185,7 +185,7 @@ To add a manager to this swarm, run 'docker swarm join-token manager' and follow
 >
 > The machine IP addresses returned by `docker-machine ls` include port 2376,
 > which is the Docker daemon port. Do not use this port or
-> [you may experience errors](https://forums.docker.com/t/docker-swarm-join-with-virtualbox-connection-error-13-bad-certificate/31392/2).
+> [you may experience errors](https://forums.docker.com/t/docker-swarm-join-with-virtualbox-connection-error-13-bad-certificate/31392/2){: target="_blank" class="_"}.
 
 
 As you can see, the response to `docker swarm init` contains a pre-configured


### PR DESCRIPTION
### What's changed

- Clarified options for setting resource constraints on Compose reference file v3 vs. v2
- Modified a link on Getting Started tutorial to open on a new tab

### Related 

#4451 

### Reviewers

@shin- 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
