### PR TITLE
Stop gap measure to fix data persistence part of the tutorial

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -372,7 +372,7 @@ more, see the [Docker Machine getting started topics](/machine/get-started.md#cr
 the VM but doesn't give you immediate access to files on your local host.
 >
 > * On Mac and Linux, you can use `docker-machine scp <file> <machine>:~`
-to copy files across machines, but Windows users need a terminal emulator
+to copy files across machines, but Windows users need a Linux terminal emulator
 like [Git Bash](https://git-for-windows.github.io/){: target="_blank" class="_"} in order for this to work.
 >
 > This tutorial demos both `docker-machine ssh` and

--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -232,10 +232,7 @@ Redis service. Be sure to replace `username/repo:tag` with your image details.
 
     - The placement constraint you put on the Redis service, ensuring that it
       always uses the same host.
-    - The volume you created that lets the container access `./data` (on the host)
-      as `/data` (inside the Redis container). While containers come and go, the
-      files stored on `./data` on the specified host will persist, enabling
-      continuity.
+    - The volume you created that lets the container access `./data` (on the host) as `/data` (inside the Redis container). While containers come and go, the files stored on `./data` on the specified host will persist, enabling continuity.
 
     You are ready to deploy your new Redis-using stack.
 
@@ -251,8 +248,12 @@ Redis service. Be sure to replace `username/repo:tag` with your image details.
     $ docker-machine scp docker-compose.yml myvm1:~
     ```
 
-    > **Note**: For now, Windows users will need a Linux terminal emulator
-    like [Git Bash](https://git-for-windows.github.io/){: target="_blank" class="_"} in order for `docker-machine scp` to work. We are researching a better solution here, but right now it looks like the Compose file needs to be located on the VM so that it looks for `~/.data/` in the right place.
+    > **Note**: Windows users will need a Linux terminal emulator like [Git
+Bash](https://git-for-windows.github.io/){: target="_blank" class="_"} in order
+for `docker-machine scp` to work. We are researching a better solution here, one
+without the need to copy files over to the VM, but for now it seems that the
+Compose file needs to be located on the VM so that it looks for `./data` in the
+right place.
 
 4.  Run `docker stack deploy` one more time, this time wrapped in  `docker-machine ssh myvm1` to specifically send it to the Compose file we just placed on the manager.
 

--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -85,7 +85,7 @@ with the following. Be sure to replace `username/repo:tag` with your image detai
       visualizer:
         image: dockersamples/visualizer:stable
         ports:
-          - "8080:8080"
+          - "8080:8080":
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
         deploy:
@@ -107,11 +107,23 @@ with the following. Be sure to replace `username/repo:tag` with your image detai
 
     We'll talk more about placement constraints and volumes in a moment.
 
-2.  Make sure your shell is configured to talk to `myvm1` (examples are [here](part4.md#configure-a-docker-machine-shell-to-the-swarm-manager)).
+2.  Make sure your shell is configured to talk to `myvm1` (full examples are [here](part4.md#configure-a-docker-machine-shell-to-the-swarm-manager)).
 
     * Run `docker-machine ls` to list machines and make sure you are connected to `myvm1`, as indicated by an asterisk next it.
 
     * If needed, re-run `docker-machine env myvm1`, then run the given command to configure the shell.
+
+      On **Mac or Linux** the command is:
+
+      ```shell
+      eval $(docker-machine env myvm1)
+      ```
+
+      On **Windows** the command is:
+
+      ```shell
+      & "C:\Program Files\Docker\Docker\Resources\bin\docker-machine.exe" env myvm1 | Invoke-Expression
+      ```
 
 3.  Re-run the `docker stack deploy` command on the manager, and
 whatever services need updating will be updated:
@@ -189,6 +201,7 @@ Redis service. Be sure to replace `username/repo:tag` with your image details.
         deploy:
           placement:
             constraints: [node.role == manager]
+        command: redis-server --appendonly yes
         networks:
           - webnet
     networks:
@@ -232,16 +245,19 @@ Redis service. Be sure to replace `username/repo:tag` with your image details.
     docker-machine ssh myvm1 "mkdir ./data"
     ```
 
-3.  Make sure your shell is configured to talk to `myvm1` (examples are [here](part4.md#configure-a-docker-machine-shell-to-the-swarm-manager)).
-
-    * Run `docker-machine ls` to list machines and make sure you are connected to `myvm1`, as indicated by an asterisk next it.
-
-    * If needed, re-run `docker-machine env myvm1`, then run the given command to configure the shell.
-
-4.  Run `docker stack deploy` one more time.
+3.  This time, we need to copy over the new `docker-compose.yml` file with `docker-machine scp`:
 
     ```shell
-    docker stack deploy -c docker-compose.yml getstartedlab
+    $ docker-machine scp docker-compose.yml myvm1:~
+    ```
+
+    > **Note**: For now, Windows users will need a Linux terminal emulator
+    like [Git Bash](https://git-for-windows.github.io/){: target="_blank" class="_"} in order for `docker-machine scp` to work. We are researching a better solution here, but right now it looks like the Compose file needs to be located on the VM so that it looks for `~/.data/` in the right place.
+
+4.  Run `docker stack deploy` one more time, this time wrapped in  `docker-machine ssh myvm1` to specifically send it to the Compose file we just placed on the manager.
+
+    ```shell
+    $ docker-machine ssh myvm1 "docker stack deploy -c docker-compose.yml getstartedlab"
     ```
 
 5.  Check the web page at one of your nodes (e.g. `http://192.168.99.101`) and you'll see the results of the visitor counter, which is now live and storing information on Redis.


### PR DESCRIPTION
### What's changed

- Added back in `docker-machine scp` and `docker-machine ssh` commands in part 5 to get the the data persistence step with the `redis` service to work. With the current Compose file, when you run  the `docker stack deploy` command on the local host with `myvm1` active, Docker looks for the `~./data` directory on the local host, not on the remote machine, `myvm1`.

- Added an override to the `redis` command in the Compose file to get the data to persist.

### Related 

Addresses #4723, but we will leave the issue open to further research getting this to work without `scp` if possible.

Related PR is #4675

### Reviewers

@shin- @friism @johndmulhausen @jasonmevans @mstanleyjones

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
