### PR TITLE
Fix port in docker-compose.yml in part5.md

### DIFF
--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -85,7 +85,7 @@ with the following. Be sure to replace `username/repo:tag` with your image detai
       visualizer:
         image: dockersamples/visualizer:stable
         ports:
-          - "8080:8080":
+          - "8080:8080"
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
         deploy:


### PR DESCRIPTION
### Proposed changes

There is a wrong colon in the docker-compose.yml in part5.md, which makes the guide does not work and confuses beginners. So just remove it.