### PR TITLE
Remove typo in docker-compose.yaml

### DIFF
--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -85,7 +85,7 @@ with the following. Be sure to replace `username/repo:tag` with your image detai
       visualizer:
         image: dockersamples/visualizer:stable
         ports:
-          - "8080:8080":
+          - "8080:8080"
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
         deploy:


### PR DESCRIPTION
### Proposed changes

Removing erroneous semi-colon from `docker-compose.yaml` example that prevents it from working.