### PR TITLE
Tweak formatting of options tables

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -12,9 +12,10 @@
 
 {% if site.data[include.datafolder][include.datafile].min_api_version %}
 
-**The client and daemon API must both be at least
+<span class="badge badge-info">API {{ site.data[include.datafolder][include.datafile].min_api_version }}+</span>&nbsp;
+The client and daemon API must both be at least
 {{ site.data[include.datafolder][include.datafile].min_api_version }}
-to use this command.** Use the `docker version` command on the client to check
+to use this command. Use the `docker version` command on the client to check
 your client and daemon API versions.
 
 {% endif %}
@@ -55,28 +56,22 @@ your client and daemon API versions.
   <tr>
     <td>Name, shorthand</td>
     <td>Default</td>
-    <td>Stability</td>
     <td>Description</td>
   </tr>
 </thead>
 <tbody>
 {% for option in site.data[include.datafolder][include.datafile].options %}
+
+  {% capture min-api %}{% if option.min_api_version %}<span class="badge badge-info">API {{ option.min_api_version }}+</span>&nbsp;{% endif %}{%endcapture%}
+  {% capture stability-string %}{% if option.deprecated and option.experimental %}<span class="badge badge-danger">deprecated</span>&nbsp;<span class="badge badge-warning">experimental</span>&nbsp;{% elsif option.deprecated %}<span class="badge badge-danger">deprecated</span>&nbsp;{% elsif option.experimental %}<span class="badge badge-warning">experimental</span>&nbsp;{% endif %}{% endcapture %}
+  {% capture all-badges %}{% unless min-api == '' and stability-string == '' %}{{ min-api }}{{ stability-string }}<br />{% endunless %}{% endcapture %}
+
   <tr>
     <td markdown="span">`--{{ option.option }}{% if option.shorthand %} , -{{ option.shorthand }}{% endif %}`</td>
     <td markdown="span">{% if option.default_value and option.default_value != "[]" %}`{{ option.default_value }}`{% endif %}</td>
-    <td markdown="span">
-    {% if option.deprecated and option.experimental %}
-      <span style="color: #ce4844">deprecated</span><span>,&nbsp;</span><span style="color: #aa6708">experimental</span>
-    {% elsif option.deprecated %}
-      <span style="color: #ce4844">deprecated</span>
-    {% elsif option.experimental %}
-      <span style="color: #aa6708">experimental</span>
-    {% else %}
-      <span>stable</span>
-    {% endif %}
-    </td>
-    <td markdown="span">{{ option.description | replace: "|","&#124;" | strip }}</td>
+    <td markdown="span">{{ all-badges | strip }}{{ option.description | strip }}</td>
   </tr>
+
 {% endfor %} <!-- end for option -->
 </tbody>
 </table>

--- a/_scss/_notes.scss
+++ b/_scss/_notes.scss
@@ -77,3 +77,30 @@ blockquote > p:only-child {
 blockquote > p:only-child::before {
   content: none;
 }
+
+/* For Bootstrap badges */
+
+span.badge {
+  display: inline-block;
+  padding: .25em .4em;
+  font-size: 75%;
+  font-weight: bold;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25rem;
+}
+
+span.badge.badge-info {
+  background-color: $note-color;
+}
+
+span.badge.badge-danger {
+  background-color: $warning-color;
+}
+
+span.badge.badge-warning {
+  background-color: $important-color;
+}

--- a/test.md
+++ b/test.md
@@ -472,6 +472,12 @@ break the Markdown block up. This example does it with Markdown. You can't have 
 break the Markdown block up.
 {: style="column-count: 3 "}
 
+### Badges
+
+You can have <span class="badge badge-info">badges</span>. You can also have
+<span class="badge badge-warning">yellow badges</span> or
+<span class="badge badge-danger">red badges</span>.
+
 ## Running in-page Javascript
 
 If you need to run custom Javascript within a page, and it depends upon JQuery


### PR DESCRIPTION
Move the `deprecated` or `experimental` info from its own column (which is usually redundant) to the flag description. Make the word bold as well.

cc/ @tiborvass who also asked for this.