### PR TITLE
Clarification & expansion of port forwarding

### DIFF
--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -22,7 +22,13 @@ When you run a container with the `-p` argument, for example:
 ```
 $ docker run -p 80:80 -d nginx
 ```
-Docker for Mac will make the container port available at `localhost`.
+Docker for Mac will make whatever is running on port 80 in the container (in this case, `nginx`) available on port 80 of `localhost`. In this example, the host and container ports are the same. What if you need to specify a different host port? If, for example, you already have something running on port 80 of your host machine, you can connect the container to a different port:
+
+```
+$ docker run -p 8081:80 -d nginx
+```
+
+Now, connections to `localhost:8081` will be sent to port 80 in the container. The syntax for `-p` is `HOST_PORT:CLIENT_PORT`.
 
 ### HTTP/HTTPS Proxy Support
 


### PR DESCRIPTION
It seems like another sentence or two of explanation about the `-p` option and its syntax might be helpful, here...

### Proposed changes

I added a little bit more exposition about the `-p` option to `docker run`, which hopefully will make it more clear what's going on with it. I was particularly interested in making the port mapping syntax more explicit- as far as I can tell, the `docker run` man page doesn't actually specify which order the ports are supposed to be in (is it client:host, or host:client?), and giving a more detailed example seemed worthwhile.