### PR TITLE
Fix problems in the SDK examples

### DIFF
--- a/develop/sdk/examples.md
+++ b/develop/sdk/examples.md
@@ -550,7 +550,7 @@ func main() {
 
 </div>
 
-<div id="tab-pullimages-python" class="tab-pane fadee" markdown="1">
+<div id="tab-pullimages-python" class="tab-pane fade" markdown="1">
 
 ```python
 import docker

--- a/develop/sdk/index.md
+++ b/develop/sdk/index.md
@@ -142,7 +142,7 @@ Docker API directly, or using the Python or Go SDK.
 </ul>
 <div class="tab-content">
 
-  <div id="go" class="tab-pane fade" markdown="1">
+  <div id="go" class="tab-pane fade in active" markdown="1">
 
 ```go
 package main
@@ -200,7 +200,7 @@ func main() {
 ```
 
   </div>
-  <div id="python" class="tab-pane fade in active" markdown="1">
+  <div id="python" class="tab-pane fade" markdown="1">
 
 ```python
 import docker


### PR DESCRIPTION
cc/ @tiborvass 

Without this fix, the Python example in the Overview is still shown even though the Go tab is active, and there is another small mistake in one of the examples in the Examples page.