### PR TITLE
standalone swarm: consul listen on public ip

### DIFF
--- a/engine/userguide/networking/overlay-standalone-swarm.md
+++ b/engine/userguide/networking/overlay-standalone-swarm.md
@@ -88,7 +88,7 @@ key-value stores. This example uses Consul.
       --name consul
       -p "8500:8500" \
       -h "consul" \
-      consul agent -server -bootstrap
+      consul agent -server -bootstrap -client "0.0.0.0"
     ```
 
     The client starts a `consul` image running in the


### PR DESCRIPTION
consul (maybe caused by latest changes) default listens on 127.0.0.1, so can't access by outside.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
