### PR TITLE
Fix typo in "link-aws.md"

### DIFF
--- a/docker-cloud/infrastructure/link-aws.md
+++ b/docker-cloud/infrastructure/link-aws.md
@@ -12,7 +12,7 @@ Docker Cloud can provision and manage swarms on your behalf.
 
 ## How to create the link
 
-For instructions on how to link your Microsoft Azure account to Docker Cloud,
+For instructions on how to link your AWS account to Docker Cloud,
 see [the AWS instructions that enable swarm
 mode](/docker-cloud/cloud-swarm/link-aws-swarm.md).
 


### PR DESCRIPTION

### Proposed changes

Fix typo in introduction for the guide about how to link the AWS account to Docker Cloud. It was confusing for me that it said "Microsoft Azure account" 😄 
