### PR TITLE
Add code to enable keeping archive.js in master

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,13 @@ permalink: pretty
 safe: false
 lsi: false
 url: https://docs.docker.com
-keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13", "v17.03","v17.06"]
+keep_files: ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11", "v1.12", "v1.13", "v17.03", "v17.06"]
+
+# Component versions -- address like site.data.engine_version
+engine_version: "17.09"
+#compose_version: ""
+#machine_version: ""
+#registry_version: ""
 
 collections:
   samples:
@@ -30,7 +36,6 @@ defaults:
     values:
       layout: docs
       defaultassignee: johndmulhausen
-      enginebranch: 1.13.x
       toc_min: 2
       toc_max: 3
       tree: true

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -215,6 +215,8 @@ else %}{% assign edit_url = "" %}{% endif %} {% break %} {% endif %} {% endfor %
 	<script defer src="/js/menu.js"></script>
 	<script src="/js/jquery.js"></script>
 	<script src="/js/bootstrap.min.js"></script>
+	<!-- Always include the archive.js, but it doesn't do much unless we are an archive -->
+	<script src="/js/archive.js"></script>
 	<script src="/js/stickyfill.min.js"></script>
 	<script defer src="/js/docs.js"></script>
 	<script language="javascript">

--- a/js/archive.js
+++ b/js/archive.js
@@ -1,0 +1,42 @@
+---
+layout: null
+---
+
+/* Only run this if we are online*/
+if (window.navigator.onLine) {
+  var dockerVersion = 'v{{ site.engine_version }}';
+  var suppressButterBar = false;
+  /* This JSON file contains a current list of all docs versions of Docker */
+  $.getJSON("/js/archives.json", function(result){
+    var outerDivStart = '<div style="padding-top: 10px; padding-bottom: 10px; min-height: 34px; border: 1px solid #254356; background-color: #FFE1C0; color: #254356"><div class="container"><div style="text-align: center"><span id="archive-list">This is <b><a href="https://docs.docker.com/docsarchive/" style="color: #254356; text-decoration: underline !important">archived documentation</a></b> for Docker&nbsp;' + dockerVersion + '. Go to the <a style="color: #254356; text-decoration: underline !important" href="https://docs.docker.com/">latest docs</a> or a different version:&nbsp;&nbsp;</span>' +
+                               '<span style="z-index: 1001" class="dropdown">';
+    var listStart = '<ul class="dropdown-menu" role="menu" aria-labelledby="archive-menu">';
+    var listEnd = '</ul>';
+    var outerDivEnd = '</span></div></div></div>';
+    var buttonCode = null;
+    var listItems = new Array();
+    $.each(result, function(i, field){
+      if ( field.name == dockerVersion && field.current ) {
+        // We are the current version so we don't need a butterbar
+        suppressButterBar = true;
+      } else {
+        var prettyName = 'Docker ' + field.name.replace("v", "");
+        // If this archive has current = true, and we don't already have a button
+        if ( field.current && buttonCode == null ) {
+          // Get the button code
+          buttonCode = '<button id="archive-menu" data-toggle="dropdown" class="btn dropdown-toggle" style="border: 1px solid #254356; background-color: #fff; color: #254356;">' + prettyName + '&nbsp;(current) &nbsp;<span class="caret"></span></button>';
+          // The link is different for the current release
+          listItems.push('<li role="presentation"><a role="menuitem" tabindex="-1" href="https://docs.docker.com/">' + prettyName + '</a></li>');
+        } else {
+          listItems.push('<li role="presentation"><a role="menuitem" tabindex="-1" href="https://docs.docker.com/' + field.name + '/">' + prettyName + '</a></li>');
+        }
+      }
+    });
+    // only append the butterbar if we are NOT the current version
+    if ( suppressButterBar == false ) {
+      $( 'body' ).prepend(outerDivStart + buttonCode + listStart + listItems.join("") + listEnd + outerDivEnd);
+    } else {
+      console.log("Suppressing the archive versions bar");
+    }
+  });
+}


### PR DESCRIPTION
Follow-up to #4787

This adds logic in `archive.js` that suppresses the butterbar if we are actually in the current version, as opposed by the canonical `archives.json` file in the online published docs. This means we don't have to have a commit like #4787 every time we add a new archive.

It also adds a `site.engine_version` variable to `_config.yml`. I needed it for my logic, but we can rationalize use of version variables and have them all in the top-level file if we want. I'll do that for Engine in a follow-up PR.

Testing this is awkward. You need to check out the PR, download the https://docs.docker.com/js/archives.json into the `js/` folder (replacing the other one) and then do a local build. At first, `master` build won't have a butterbar and you can see a console log that it is suppressed. If you then edit the `archives.json` and change which entry is `current` then it will have the butterbar. Please please don't commit this `archives.json` anywhere but just use it for testing.

cc/ @allejo who helped me.