### PR TITLE
dtr: operationalize rethinkcli docs

### DIFF
--- a/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -47,15 +47,19 @@ DTR replica to check the DTR internal state.
 {: .warning }
 
 Use SSH to log into a node that is running a DTR replica, and run the following
-command, replacing `$REPLICA_ID` with the ID of the DTR replica running on that
-node:
+commands:
 
-```none
+```bash
+{% raw %}
+# REPLICA_ID will be the replica ID for the current node.
+REPLICA_ID=$(docker ps -lf name='^/dtr-rethinkdb-.{12}$' --format '{{.Names}}' | cut -d- -f3)
+# This command will start a RethinkDB client attached to the database
+# on the current node.
 docker run -it --rm \
   --net dtr-ol \
   -v dtr-ca-$REPLICA_ID:/ca dockerhubenterprise/rethinkcli:v2.2.0 \
   $REPLICA_ID
->
+{% endraw %}
 ```
 
 This container connects to the local DTR replica and launches a RethinkDB client 

--- a/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -47,15 +47,19 @@ DTR replica to check the DTR internal state.
 {: .warning }
 
 Use SSH to log into a node that is running a DTR replica, and run the following
-command, replacing `$REPLICA_ID` with the ID of the DTR replica running on that
-node:
+commands:
 
-```none
+```bash
+{% raw %}
+# REPLICA_ID will be the replica ID for the current node.
+REPLICA_ID=$(docker ps -lf name='^/dtr-rethinkdb-.{12}$' --format '{{.Names}}' | cut -d- -f3)
+# This command will start a RethinkDB client attached to the database
+# on the current node.
 docker run -it --rm \
   --net dtr-ol \
   -v dtr-ca-$REPLICA_ID:/ca dockerhubenterprise/rethinkcli:v2.2.0 \
   $REPLICA_ID
->
+{% endraw %}
 ```
 
 This container connects to the local DTR replica and launches a RethinkDB client 


### PR DESCRIPTION
populate REPLICA_ID variable to cut down on copy-paste while
troubleshooting.

Fixes docker/dhe-deploy#6506