### PR TITLE
Add documentation for new mount command

### DIFF
--- a/machine/reference/mount.md
+++ b/machine/reference/mount.md
@@ -1,0 +1,49 @@
+---
+description: Mount directory from machine
+keywords: machine, mount, subcommand
+title: docker-machine mount
+---
+
+Mount directories from a machine to your local host, using `sshfs`.
+
+The notation is `machinename:/path/to/dir` for the argument; you can also supply an alternative mount point (default is the same dir path).
+
+## Example
+
+Consider the following example:
+
+```none
+$ mkdir foo
+$ docker-machine ssh dev mkdir foo
+$ docker-machine mount dev:/home/docker/foo foo
+$ touch foo/bar
+$ docker-machine ssh dev ls foo
+bar
+```
+
+
+Now you can use the directory on the machine, for mounting into containers.
+Any changes done in the local directory, will be reflected in the machine too.
+
+```none
+$ docker run -v /home/docker/foo:/tmp/foo busybox ls /tmp/foo
+bar
+$ docker touch foo/baz
+$ docker run -v /home/docker/foo:/tmp/foo busybox ls /tmp/foo
+bar
+baz
+```
+
+The files are actually being transferred using `sftp` (over an ssh connection),
+so this program ("sftp") needs to be present on the machine - but it usually is.
+
+
+To unmount the directory again, you can use the same options but the  `-u` flag.
+You can also call `fuserunmount` (or `fusermount -u`) commands directly.
+
+```none
+$ docker-machine mount -u dev:/home/docker/foo foo
+$ rmdir foo
+```
+**Note that files are actually being stored on the machine, *not* on the host.**
+So make sure to make a copy of any files you want to keep, before removing it!


### PR DESCRIPTION
The currently implementation uses sshfs (and FUSE) to mount.
It would be possible to make a Windows version, using Dokan.

Signed-off-by: Anders F Björklund <anders.f.bjorklund@gmail.com>

### Proposed changes

Add documentation for mount command

### Unreleased project version (optional)

machine 0.11.0

### Related issues (optional)

https://github.com/docker/machine/pull/4018