### PR TITLE
Hide things for archives

### DIFF
--- a/_includes/archive-list.html
+++ b/_includes/archive-list.html
@@ -1,4 +1,4 @@
-<div class="btn-group">
+<div class="btn-group" style="visibility: hidden">
   <button type="button" class="btn btn-default dropdown-btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {% for item in site.data.docsarchive.archives %}{% if item.current == true %}Docker {{ item.name }} (current) {% endif %} {% endfor %}<span class="caret"></span>
   </button>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,4 +1,4 @@
-<div class="search-form" id="search-div">
+<div class="search-form" id="search-div" style="visibility: hidden">
     <form class="search-form form-inline ng-pristine ng-valid" id="searchForm" action="/search/">
         <input class="search-field form-control ds-input" id="st-search-input" value="" name="q" placeholder="Search the docs" type="search" autocomplete="off" spellcheck="false" dir="auto" style="position: relative; vertical-align: top;">
         <div id="autocompleteContainer">

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -121,7 +121,7 @@ else %}{% assign edit_url = "" %}{% endif %} {% break %} {% endif %} {% endfor %
 							}
 							</script>
 							{% if page.noratings != true %}
-						  <div style="color:#b9c2cc; text-align: center; margin-top: 150px">
+						  <div id="ratings-div" style="color:#b9c2cc; text-align: center; margin-top: 150px; visibility: hidden">
 								<div id="pd_rating_holder_8453675"></div>
 								<script type="text/javascript">
 									PDRTJS_settings_8453675 = {
@@ -156,7 +156,7 @@ else %}{% assign edit_url = "" %}{% endif %} {% break %} {% endif %} {% endfor %
 								<div class="feedback-links">
 									<ul>
 										{% if edit_url != "" %}
-										<li><a href="{{ edit_url }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit this page</a></li>{% endif %}
+										<li style="visibility: hidden"><a href="{{ edit_url }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit this page</a></li>{% endif %}
 										<li><a href="https://github.com/docker/docker.github.io/issues/new?assignee={% if page.assignee %}{{ page.assignee }}{% else %}{{ page.defaultassignee }}{% endif %}&body=File: [{{ page.path }}](https://docs.docker.com{{ page.url }}), CC @{{ assignee }}"
 															class="nomunge"><i class="fa fa-check" aria-hidden="true"></i> Request docs changes</a></li>
 										<li><a href="https://www.docker.com/docker-support-services"><i class="fa fa-question" aria-hidden="true"></i> Get support</a></li>
@@ -216,6 +216,12 @@ else %}{% assign edit_url = "" %}{% endif %} {% break %} {% endif %} {% endfor %
 	<script src="/js/jquery.js"></script>
 	<script src="/js/bootstrap.min.js"></script>
 	<!-- Always include the archive.js, but it doesn't do much unless we are an archive -->
+	<script language="javascript">
+	// Default to assuming this is an archive and hiding some stuff
+	// See js/archive.js and js/docs.js for logic relating to this
+	var isArchive = true;
+	var dockerVersion = 'v{{ site.engine_version }}';
+	</script>
 	<script src="/js/archive.js"></script>
 	<script src="/js/stickyfill.min.js"></script>
 	<script defer src="/js/docs.js"></script>

--- a/js/archive.js
+++ b/js/archive.js
@@ -4,7 +4,6 @@ layout: null
 
 /* Only run this if we are online*/
 if (window.navigator.onLine) {
-  var dockerVersion = 'v{{ site.engine_version }}';
   var suppressButterBar = false;
   /* This JSON file contains a current list of all docs versions of Docker */
   $.getJSON("/js/archives.json", function(result){
@@ -33,10 +32,16 @@ if (window.navigator.onLine) {
       }
     });
     // only append the butterbar if we are NOT the current version
+    // Also set the isArchive variable to true if it's an archive. It defaults
+    // to true, set in _layouts/docs.html. We default to true because it looks
+    // better in CSS to show stuff than to hide stuff onLoad.
     if ( suppressButterBar == false ) {
       $( 'body' ).prepend(outerDivStart + buttonCode + listStart + listItems.join("") + listEnd + outerDivEnd);
+      isArchive = true;
+      console.log("Detected that this is an archive.");
     } else {
-      console.log("Suppressing the archive versions bar");
+      isArchive = false;
+      console.log("This is not an archive. Suppressing the archive versions bar");
     }
   });
 }

--- a/js/docs.js
+++ b/js/docs.js
@@ -292,6 +292,26 @@ window.onload = function() {
     var group = $(this).attr('data-group');
     $('.nav-tabs > li > a[data-group="'+ group +'"]').tab('show');
   })
+
+  // isArchive is set by logic in archive.js
+  if ( isArchive == false ) {
+    console.log("Showing content that should only be in the current version.");
+    // Hide elements that are not appropriate for archives
+    // PollDaddy
+    $('#ratings-div').css("visibility","visible");
+    console.log("Ratings widget shown.");
+    // Archive drop-down
+    $('.ctrl-right .btn-group').css("visibility","visible");
+    console.log("Archive widget shown.");
+    // Swarch
+    $('.search-form').css("visibility","visible");
+    console.log("Search widget shown.");
+    // Page edit link
+    $('.feedback-links li').first().css("visibility","visible");
+    console.log("Page edit link shown.");
+  } else {
+    console.log("Keeping non-applicable elements hidden.");
+  }
 };
 
 $('.glossLink').popover();


### PR DESCRIPTION
Relies on and augments #4790. Logical changes:

- Default to assuming it's an archive
- If it's an archive, hide the search div, the normal archive drop-down (because we have the butterbar one), the "Edit this page" link, and the ratings widget.
- If it's not an archive, show the above things.

The reason we default to it being an archive is that it's less visually flickery to hide elements by default and then show them, than to show them and then hide them. I tested both ways. I think this is pretty clean.

Of course it breaks if JS is disabled, but so does the whole site.

To test what happens if it's an archive, set `isArchive = true` in line 296 of `js/docs.js` and do `jekyll serve`.