### PR TITLE
Make the link in wordpress.md point to the right engine doc

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -66,7 +66,7 @@ Compose to set up and run WordPress. Before starting, you'll need to have
    > **Notes**:
    >
    * The docker volume `db_data` persists any updates made by Wordpress
-   to the database. [Learn more about docker volumes](/engine/tutorials/dockervolumes.md)
+   to the database. [Learn more about docker volumes](/engine/admin/volumes/volumes/)
    >
    * WordPress Multisite works only on ports `80` and `443`.
    {: .note-vanilla}


### PR DESCRIPTION
### Proposed changes

Change to the correct link. Although there's a redirect, it's better to link to to the right place.
