### PR TITLE
update info for older mac users in install.md

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -81,12 +81,13 @@ explanation and list of prerequisites.
 
 ##  What to know before you install
 
-* **README FIRST for Docker Toolbox and Docker Machine users**: If you are
-  already running Docker on your machine, first read
-  [Docker for Mac vs. Docker Toolbox](docker-toolbox.md) to understand the
-  impact of this installation on your existing setup, how to set your environment
-  for Docker for Mac, and how the two products can coexist.
-<p />
+> README FIRST for Docker Toolbox and Docker Machine users
+>
+>If you are already running Docker on your machine, first read
+[Docker for Mac vs. Docker Toolbox](docker-toolbox.md) to understand the
+impact of this installation on your existing setup, how to set your environment
+for Docker for Mac, and how the two products can coexist.
+
 * **Relationship to Docker Machine**: Installing Docker for Mac does not affect
   machines you created with Docker Machine. You'll get the option to copy
   containers and images from your local `default` machine (if one exists) to the
@@ -96,27 +97,27 @@ explanation and list of prerequisites.
   virtualization system running (HyperKit) which takes the place of the
   VirtualBox system. To learn more, see
   [Docker for Mac vs. Docker Toolbox](docker-toolbox.md).
-<p />
+
 * **System Requirements**: Docker for Mac will launch only if all of these
   requirements are met.
-  <p />
-  - Mac must be a 2010 or newer model, with Intel's hardware support for memory
+  
+  - Mac hardware must be a 2010 or newer model, with Intel's hardware support for memory
     management unit (MMU) virtualization; i.e., Extended Page Tables (EPT) and
     Unrestricted Mode. You can check to see if your machine has this support by
-    running the command  sysctl kern.hv_support  in a terminal.
-  <p />
-  - OS X El Capitan 10.11 and newer macOS releases are supported. At a minimum,
+    running the following command  in a terminal: `sysctl kern.hv_support`
+
+  - macOS El Capitan 10.11 and newer macOS releases are supported. At a minimum,
     Docker for Mac requires macOS Yosemite 10.10.3 or newer, with the caveat
     that going forward 10.10.x is a use-at-your-own risk proposition.
-  <p />
-  - Starting with Docker for Mac Stable release 1.13 (upcoming), and concurrent
-    Edge releases, we will no longer address issues specific to OS X Yosemite
-    10.10. In future releases, Docker for Mac could stop working on OS X Yosemite
-    10.10 due to the deprecated status of this OS X version. We recommend
+
+  - Starting with Docker for Mac Stable release 1.13, and concurrent
+    Edge releases, we will no longer address issues specific to macOS Yosemite
+    10.10. In future releases, Docker for Mac could stop working on macOS Yosemite
+    10.10 due to the deprecated status of this macOS version. We recommend
     upgrading to the latest version of macOS.
-  <p />
+
   - At least 4GB of RAM
-  <p />
+
   - VirtualBox prior to version 4.3.30 must NOT be installed (it is incompatible
     with Docker for Mac). If you have a newer version of VirtualBox installed, it's fine.
 

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -102,7 +102,8 @@ explanation and list of prerequisites.
   <p />
   - Mac must be a 2010 or newer model, with Intel's hardware support for memory
     management unit (MMU) virtualization; i.e., Extended Page Tables (EPT) and
-    Unrestricted Mode.
+    Unrestricted Mode. You can check to see if your machine has this support by
+    running the command  sysctl kern.hv_support  in a terminal.
   <p />
   - OS X El Capitan 10.11 and newer macOS releases are supported. At a minimum,
     Docker for Mac requires macOS Yosemite 10.10.3 or newer, with the caveat


### PR DESCRIPTION
Add the command to run which lets you know whether Docker for Mac will work on a machine. The previous instructions said that it would work on machines from 2010 on ... if they had the ability to do hardware virtualization. Unfortunately mid-2010 mackbooks do not have this ability and plenty of people waste their time downloading docker for mac when it won't run on their machine. 
By adding the terminal command people can tell if their machine will work with docker for mac or if they have to install Docker toolbox / Docker machine.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
