### PR TITLE
"DTR needs that a majority" -> "DTR requires that a majority"

### DIFF
--- a/datacenter/dtr/2.2/guides/admin/backups-and-disaster-recovery.md
+++ b/datacenter/dtr/2.2/guides/admin/backups-and-disaster-recovery.md
@@ -4,7 +4,7 @@ description: Learn how to back up your Docker Trusted Registry cluster, and to r
 keywords: docker, registry, high-availability, backup, recovery
 ---
 
-DTR needs that a majority (n/2 + 1) of its replicas are healthy at all times
+DTR requires that a majority (n/2 + 1) of its replicas are healthy at all times
 for it to work. So if a majority of replicas is unhealthy or lost, the only
 way to restore DTR to a working state, is by recovering from a backup. This
 is why it's important to ensure replicas are healthy and perform frequent

--- a/datacenter/dtr/2.3/guides/admin/backups-and-disaster-recovery.md
+++ b/datacenter/dtr/2.3/guides/admin/backups-and-disaster-recovery.md
@@ -7,7 +7,7 @@ keywords: registry, high-availability, backup, recovery
 {% assign image_backup_file = "backup-images.tar" %}
 {% assign metadata_backup_file = "backup-metadata.tar" %}
 
-DTR needs that a majority (n/2 + 1) of its replicas are healthy at all times
+DTR requires that a majority (n/2 + 1) of its replicas are healthy at all times
 for it to work. So if a majority of replicas is unhealthy or lost, the only
 way to restore DTR to a working state, is by recovering from a backup. This
 is why it's important to ensure replicas are healthy and perform frequent


### PR DESCRIPTION
### Proposed changes

Changed the phrase "needs that a majority" to "requires that a majority" in the docker dtr documentation because the existing wording is unclear. 