### PR TITLE
Documentation: Remove reference to PUBLISH Dockerfile directive in networking docs

### DIFF
--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -525,16 +525,16 @@ network and user-defined bridge networks.
 
 - You expose ports using the `EXPOSE` keyword in the Dockerfile or the
   `--expose` flag to `docker run`. Exposing ports is a way of documenting which
-  ports are used, but does not actually map or open any ports. Exposing ports
+  ports are used, but **does not actually map or open any ports**. Exposing ports
   is optional.
 - You publish ports using the `--publish` or `--publish-all` flag to `docker run`. 
   This tells Docker which ports to open on the container's network interface. 
   When a port is published, it is mapped to an
   available high-order port (higher than `30000`) on the host machine, unless
   you specify the port to map to on the host machine at runtime. You cannot
-  specify the port to map to on the host machine in the Dockerfile, because
-  there is no way to guarantee that the port will be available on the host
-  machine where you run the image.
+  specify the port to map to on the host machine when you build the image (in the
+  Dockerfile), because there is no way to guarantee that the port will be available
+  on the host machine where you run the image.
 
   This example publishes port 80 in the container to a random high
   port (in this case, `32768`) on the host machine. The `-d` flag causes the

--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -527,9 +527,9 @@ network and user-defined bridge networks.
   `--expose` flag to `docker run`. Exposing ports is a way of documenting which
   ports are used, but does not actually map or open any ports. Exposing ports
   is optional.
-- You publish ports using the `PUBLISH` keyword in the Dockerfile or the
-  `--publish` flag to `docker run`. This tells Docker which ports to open on the
-  container's network interface. When a port is published, it is mapped to an
+- You publish ports using the `--publish` or `--publish-all` flag to `docker run`. 
+  This tells Docker which ports to open on the container's network interface. 
+  When a port is published, it is mapped to an
   available high-order port (higher than `30000`) on the host machine, unless
   you specify the port to map to on the host machine at runtime. You cannot
   specify the port to map to on the host machine in the Dockerfile, because


### PR DESCRIPTION
### Proposed changes

Remove reference to PUBLISH Dockerfile directive in networking documentation as PUBLISH does not exist in the Dockerfile reference https://docs.docker.com/engine/reference/builder/
