### PR TITLE
Cloud docs: fixed TOC headings to match page titles

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -2498,9 +2498,9 @@ manuals:
     - path: /docker-cloud/infrastructure/byoh/
       title: Use the Docker Cloud agent
     - path: /docker-cloud/infrastructure/cloud-on-packet.net-faq/
-      title: Using Docker Cloud and Packet.net
+      title: Use Docker Cloud and Packet.net
     - path: /docker-cloud/infrastructure/cloud-on-aws-faq/
-      title: Using Docker Cloud on AWS
+      title: Use Docker Cloud on AWS
   - sectiontitle: Manage nodes and apps (standard mode)
     section:
     - path: /docker-cloud/standard/


### PR DESCRIPTION
### What's changed

- Fixed Cloud topic titles in TOC to match page topics

### Related 

Fixes #4938

### Reviewers

@scjane 


Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
