### PR TITLE
Configure curl to use ipv4

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -191,7 +191,7 @@ Now list all 5 containers:
 docker container ls -q
 ```
 
-You can run `curl http://localhost` several times in a row, or go to that URL in
+You can run `curl -4 http://localhost` several times in a row, or go to that URL in
 your browser and hit refresh a few times.
 
 ![Hello World in browser](images/app80-in-browser.png)


### PR DESCRIPTION
Update curl command to use `-4`. 

This option is _necessary_ for ipv6 users (as recommended in #4662) but it doesn't hurt ipv4 users. 

Fixes #4662 