### PR TITLE
Revert "improve links from v2.1"

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1246,7 +1246,7 @@ refer to it within the Compose file:
 > **Note**: In newer versions of Compose, the `external.name` property is
 > deprecated in favor of simply using the `name` property.
 
-### labels  <a id="volume-labels"></a>
+### labels
 
 > [Added in version 2.1 file format](compose-versioning.md#version-21).
 
@@ -1268,7 +1268,7 @@ conflicting with those used by other software.
       - "com.example.label-with-empty-value"
 
 
-### name <a id="volume-name"></a>
+### name
 
 > [Added in version 2.1 file format](compose-versioning.md#version-21)
 
@@ -1358,7 +1358,7 @@ By default, Docker also connects a bridge network to it to provide external
 connectivity. If you want to create an externally isolated overlay network,
 you can set this option to `true`.
 
-### labels <a id="network-labels"></a>
+### labels
 
 > [Added in version 2.1 file format](compose-versioning.md#version-21).
 

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -193,15 +193,15 @@ supported by **Compose 1.9.0+**.
 
 Introduces the following additional parameters:
 
-- [`link_local_ips`](compose-file-v2.md#link_local_ips)
+- [`link_local_ips`](compose-file-v2.md#linklocalips)
 - [`isolation`](compose-file-v2.md#isolation)
-- `labels` for [volumes](compose-file-v2.md#volume-labels) and
-  [networks](compose-file-v2.md#network-labels)
-- `name` for [volumes](compose-file-v2.md#volume-name)
+- `labels` for [volumes](compose-file-v2.md#volume-configuration-reference) and
+  [networks](compose-file-v2.md#network-configuration-reference)
+- `name` for [volumes](compose-file-v2.md#volume-configuration-reference)
 - [`userns_mode`](compose-file-v2.md#userns_mode)
 - [`healthcheck`](compose-file-v2.md#healthcheck)
 - [`sysctls`](compose-file-v2.md#sysctls)
-- [`pids_limit`](compose-file-v2.md#pids_limit)
+- [`pids_limit`](compose-file-v2.md#pidslimit)
 
 ### Version 2.2
 


### PR DESCRIPTION
Reverts docker/docker.github.io#4991

Let's not override the auto-generated IDs of headings, please.