### PR TITLE
Fixed broken link - #5024

### DIFF
--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -163,8 +163,7 @@ contains the Dockerfile and volume.
 ### Recreate or update your containers after Beta 18 upgrade
 
 Docker 1.12.0 RC3 release introduces a backward incompatible change from RC2 to
-RC3. (For more information, see [https://github.com/moby/moby/issues/24343#issuecomment-230623542]
-(https://github.com/moby/moby/issues/24343#issuecomment-230623542).)
+RC3. (For more information, see (For more information, see [moby/moby#24343 (comment)](https://github.com/moby/moby/issues/24343#issuecomment-230623542).)
 
 You may get the following error when you try to start a container created with
 pre-Beta 18 Docker for Mac applications.


### PR DESCRIPTION
### Proposed changes

There was a rogue space in between [text] (url), breaking the markdown syntax, which is now removed. 

The resulting link text is now shortened for readability, as before it was just the full URL.

### Related issues (optional)

Fixes #5024 
