### PR TITLE
Document that overlay2 is now the default for ubuntu

### DIFF
--- a/engine/installation/linux/docker-ce/ubuntu.md
+++ b/engine/installation/linux/docker-ce/ubuntu.md
@@ -51,7 +51,20 @@ It's OK if `apt-get` reports that none of these packages are installed.
 The contents of `/var/lib/docker/`, including images, containers, volumes, and
 networks, are preserved. The Docker CE package is now called `docker-ce`.
 
-### Recommended extra packages for Trusty 14.04
+### If you need to use aufs
+
+Docker CE now uses the `overlay2` storage driver by default, and it is
+recommended that you use it instead of `aufs`. If you need to use `aufs`, you
+will need to do additional preparation.
+
+#### Xenial 16.04 and newer
+
+For Ubuntu 16.04 and higher, the Linux kernel includes support for OverlayFS,
+and Docker CE will use the `overlay2` storage driver by default. If you need
+to use `aufs` instead, you need to configure it manually.
+See [aufs](/engine/userguide/storagedriver/aufs-driver.md)
+
+#### Trusty 14.04
 
 Unless you have a strong reason not to, install the
 `linux-image-extra-*` packages, which allow Docker to use the `aufs` storage
@@ -64,9 +77,6 @@ $ sudo apt-get install \
     linux-image-extra-$(uname -r) \
     linux-image-extra-virtual
 ```
-
-For Ubuntu 16.04 and higher, the Linux kernel includes support for OverlayFS,
-and Docker CE will use the `overlay2` storage driver by default.
 
 ## Install Docker CE
 

--- a/engine/userguide/storagedriver/aufs-driver.md
+++ b/engine/userguide/storagedriver/aufs-driver.md
@@ -4,20 +4,14 @@ keywords: 'container, storage, driver, AUFS '
 title: Use the AUFS storage driver
 ---
 
-AUFS a *union filesystem*. The `aufs` storage driver is the default storage
-driver used for managing images and layers on Docker for Ubuntu, and for
-Debian versions prior to Stretch. For Debian Stretch,
-[overlay2](overlayfs-driver.md) is the default.
+AUFS a *union filesystem*. The `aufs` storage driver was previously the default
+storage driver used for managing images and layers on Docker for Ubuntu, and for
+Debian versions prior to Stretch. If your Linux kernel is version 4.0 or higher,
+and you use Docker CE, consider using the newer
+[overlay2](overlayfs-driver.md){: target="_blank" class="_" }, which has
+potential performance advantages over the `aufs` storage driver.
 
-AUFS is the most mature storage driver used by Docker. It provides fast
-container startup time, as well as efficient usage of memory and storage.
-
-If your Linux kernel is version 4.0 or higher, and you use Docker CE, consider
-using the newer [overlay2](overlayfs-driver.md){: target="_blank" class="_" },
-which has potential performance advantages over the `aufs` storage driver.
-
-> **Note**: Even though AUFS is used by default if it is present in the Linux
-> kernel, it is not supported on some distributions and Docker editions. See
+> **Note**: AUFS is not supported on some distributions and Docker editions. See
 > [Prerequisites](#prerequisites) > for more information about supported
 > platforms, and see also
 > [the order of preferences for storage drivers](selectadriver.md#storage-driver-order).

--- a/engine/userguide/storagedriver/aufs-driver.md
+++ b/engine/userguide/storagedriver/aufs-driver.md
@@ -4,7 +4,7 @@ keywords: 'container, storage, driver, AUFS '
 title: Use the AUFS storage driver
 ---
 
-AUFS a *union filesystem*. The `aufs` storage driver was previously the default
+AUFS is a *union filesystem*. The `aufs` storage driver was previously the default
 storage driver used for managing images and layers on Docker for Ubuntu, and for
 Debian versions prior to Stretch. If your Linux kernel is version 4.0 or higher,
 and you use Docker CE, consider using the newer

--- a/engine/userguide/storagedriver/selectadriver.md
+++ b/engine/userguide/storagedriver/selectadriver.md
@@ -22,9 +22,6 @@ this decision, there are three high-level factors to consider:
   explicitly configured, assuming that the prerequisites for that storage driver
   are met:
 
-  - If `aufs` is available, default to it, because it is the oldest storage
-    driver. However, it is not universally available.
-
   - If possible, the storage driver with the least amount of configuration is
     used, such as `btrfs` or `zfs`. Each of these relies on the backing
     filesystem being configured correctly.
@@ -33,20 +30,22 @@ this decision, there are three high-level factors to consider:
     and stability in the most usual scenarios.
 
     - `overlay2` is preferred, followed by `overlay`. Neither of these requires
-      extra configuration.
+      extra configuration. `overlay2` is the default choice for Docker CE.
 
     - `devicemapper` is next, but requires `direct-lvm` for production
       environments, because `loopback-lvm`, while zero-configuration, has very
       poor performance.
 
-  The selection order is defined in Docker's source code. You can see the order
-  for Docker 17.03 by looking at
-  [the source code](https://github.com/moby/moby/blob/v17.03.1-ce/daemon/graphdriver/driver_linux.go#L54-L63).
-  For a different Docker version, change the URL to that version.
+  The selection order is defined in Moby's source code. You can see the order
+  by looking at
+  [the source code](https://github.com/docker/docker-ce/blob/master/components/engine/daemon/graphdriver/driver_linux.go#L54-L63).
+  The order may vary slightly by version. Select the branch for the version you
+  use to verify the storage driver order.
   {: id="storage-driver-order" }
 
 - Your choice may be limited by your Docker edition, operating system, and
-  distribution. For instance, `aufs` is only supported on Ubuntu and Debian,
+  distribution. For instance, `aufs` is only supported on Ubuntu and Debian, and
+  may require extra packages to be installed,
   while `btrfs` is only supported on SLES, which is only supported with Docker
   EE. See
   [Support storage drivers per Linux distribution](#supported-storage-drivers-per-linux-distribution).

--- a/engine/userguide/storagedriver/selectadriver.md
+++ b/engine/userguide/storagedriver/selectadriver.md
@@ -91,6 +91,15 @@ configurations work on recent versions of the Linux distribution:
 | Docker CE on CentOS | `devicemapper`, `vfs`                                                                                 |
 | Docker CE on Fedora | `devicemapper`, `overlay2` (Fedora 26 or later, experimental), `overlay` (experimental), `vfs`        |
 
+When possible, `overlay2` is the recommended storage driver. When installing
+Docker for the first time, `overlay2` is used by default. Previously, `aufs` was
+used by default when available, but this is no longer the case. If you want to
+use `aufs` on new installations going forward, you need to explicitly configure
+it, and you may need to install extra packages, such as `linux-image-extra`.
+See [aufs](aufs-driver.md).
+
+On existing installations using `aufs`, it will continue to be used.
+
 When in doubt, the best all-around configuration is to use a modern Linux
 distribution with a kernel that supports the `overlay2` storage driver, and to
 use Docker volumes for write-heavy workloads instead of relying on writing data


### PR DESCRIPTION
Fixes #4141 

This will need follow-up to the Ubuntu EE install instructions when the next version of EE comes out. cc/ @JimGalasyn 