### PR TITLE
Document order option in update_config

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -251,6 +251,20 @@ Introduces the following additional parameters:
 - [`configs`](/compose/compose-file/index.md#configs)
 - [deploy `endpoint_mode`](/compose/compose-file/index.md#endpointmode)
 
+### Version 3.4
+
+An upgrade of [version 3](#version-3) that introduces new parameters only available with Docker version **17.06.0+**, and higher.
+
+Introduces these additional parameters:
+
+- `cache_from`, `network`, and `target` options in [build](/compose/compose-file/index.md#build) configurations
+
+- `order` parameter in the [update_config](/compose/compose-file/index.md#update_config) section
+
+- `name` parameter for setting a custom name in
+[volume](/compose/compose-file/index.md#volume-configuration-reference)
+definitions
+
 ## Upgrading
 
 ### Version 2.x to 3.x

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -739,9 +739,10 @@ updates.
   (default: `pause`).
 - `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
 - `max_failure_ratio`: Failure rate to tolerate during an update.
+- `order`: Order of operations during updates. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks will briefly overlap) (default `stop-first`) **Note**: Only supported for v3.4 and higher.
 
 ```none
-version: '3'
+version: '3.4'
 services:
   vote:
     image: dockersamples/examplevotingapp_vote:before
@@ -752,6 +753,7 @@ services:
       update_config:
         parallelism: 2
         delay: 10s
+        order: stop-first
 ```
 
 #### Not supported for `docker stack deploy`

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -741,6 +741,9 @@ updates.
 - `max_failure_ratio`: Failure rate to tolerate during an update.
 - `order`: Order of operations during updates. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks will briefly overlap) (default `stop-first`) **Note**: Only supported for v3.4 and higher.
 
+> **Note**: `order` is only supported for v3.4 and higher of the compose
+file format.
+
 ```none
 version: '3.4'
 services:


### PR DESCRIPTION
### Proposed changes

Adding some documentation for the `order` option in `update_config` in the Docker Compose v3.4 format - new in Docker CE 17.09.

### Related issues (optional)

Fixes #5088

Signed-off-by: Dave Henderson <dhenderson@gmail.com>