### PR TITLE
Revert "Document order option in update_config"

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -251,20 +251,6 @@ Introduces the following additional parameters:
 - [`configs`](/compose/compose-file/index.md#configs)
 - [deploy `endpoint_mode`](/compose/compose-file/index.md#endpointmode)
 
-### Version 3.4
-
-An upgrade of [version 3](#version-3) that introduces new parameters only available with Docker version **17.06.0+**, and higher.
-
-Introduces these additional parameters:
-
-- `cache_from`, `network`, and `target` options in [build](/compose/compose-file/index.md#build) configurations
-
-- `order` parameter in the [update_config](/compose/compose-file/index.md#update_config) section
-
-- `name` parameter for setting a custom name in
-[volume](/compose/compose-file/index.md#volume-configuration-reference)
-definitions
-
 ## Upgrading
 
 ### Version 2.x to 3.x

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -739,13 +739,9 @@ updates.
   (default: `pause`).
 - `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
 - `max_failure_ratio`: Failure rate to tolerate during an update.
-- `order`: Order of operations during updates. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks will briefly overlap) (default `stop-first`) **Note**: Only supported for v3.4 and higher.
-
-> **Note**: `order` is only supported for v3.4 and higher of the compose
-file format.
 
 ```none
-version: '3.4'
+version: '3'
 services:
   vote:
     image: dockersamples/examplevotingapp_vote:before
@@ -756,7 +752,6 @@ services:
       update_config:
         parallelism: 2
         delay: 10s
-        order: stop-first
 ```
 
 #### Not supported for `docker stack deploy`


### PR DESCRIPTION
Reverts docker/docker.github.io#5089