### PR TITLE
Renamed gems to plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Update me once in a while: https://github.com/github/pages-gem/releases
 # Please ensure, before upgrading, that this version exists as a tag in starefossen/github-pages here:
 # https://hub.docker.com/r/starefossen/github-pages/tags/
-gem "github-pages", "147"
+gem "github-pages", "147", group: :jekyll_plugins
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Update me once in a while: https://github.com/github/pages-gem/releases
 # Please ensure, before upgrading, that this version exists as a tag in starefossen/github-pages here:
 # https://hub.docker.com/r/starefossen/github-pages/tags/
-gem "github-pages", "137"
+gem "github-pages", "147"
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ collections:
   samples:
     output: true
 
-gems:
+plugins:
   - jekyll-redirect-from
   - jekyll-seo-tag
   - jekyll-relative-links


### PR DESCRIPTION
`gems` config key has been defaulted to `plugins` since Jekyll 3.5, this PR intend to avoid the following deprecation warning at build time:

```
 Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```