### PR TITLE
Avoid Liquid warning

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/install/architecture-specific-images.md
+++ b/datacenter/ucp/2.2/guides/admin/install/architecture-specific-images.md
@@ -16,6 +16,7 @@ image for IBM z Systems. For example, you can modify the CLI command for getting
 a [UCP support dump](..\..\get-support.md) to use an environment variable
 that indicates the current architecture:
 
+{% raw %}
 ```bash
 [[ $(docker info --format='{{.Architecture}}') == s390x ]] && export _ARCH='-s390x' || export _ARCH=''
 
@@ -26,6 +27,7 @@ docker container run --rm \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }}${_ARCH} \
   support > docker-support.tgz
 ```
+{% endraw %}
 
 In this example, the environment variable is named `_ARCH`, but you can use any 
 valid shell name.


### PR DESCRIPTION
This page contains curly braces and Liquid interpreter generates a warning at build:

```
Liquid Warning: Liquid syntax error (line 14): [:dot, "."] is not a valid expression in "{{.Architecture}}" in datacenter/ucp/2.2/guides/admin/install/architecture-specific-images.md
```

> Jekyll processes all Liquid filters in code blocks
> If you are using a language that contains curly braces, you will likely need to place {% raw %} and {% endraw %} tags around your code.


