### PR TITLE
Correct version typo in live-restore doc.

### DIFF
--- a/engine/admin/live-restore.md
+++ b/engine/admin/live-restore.md
@@ -45,7 +45,7 @@ config.json, see [daemon configuration file](../reference/commandline/dockerd.md
 
 The live restore feature supports restoring containers to the daemon for
 upgrades from one minor release to the next. For example from Docker Engine
-1.12.1 to 1.13.2.
+1.12.1 to 1.12.2.
 
 If you skip releases during an upgrade, the daemon may not restore its connection to the containers. If the daemon is unable to restore the connection, it ignores the running containers and you must manage them manually.
 


### PR DESCRIPTION
The paragraph mentions that live restore is only supported for minor
releases (aka patch releases) but goes on to show "1.12.1" updated to
"1.13.2". This is unfortunately a pretty nasty typo and should be
"1.12.2" not "1.13.2".