### PR TITLE
Fix `docker-machine mount` reference page

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -2784,6 +2784,8 @@ manuals:
       title: kill
     - path: /machine/reference/ls/
       title: ls
+    - path: /machine/reference/mount/
+      title: mount
     - path: /machine/reference/provision/
       title: provision
     - path: /machine/reference/regenerate-certs/

--- a/machine/reference/index.md
+++ b/machine/reference/index.md
@@ -13,6 +13,7 @@ title: Docker Machine command-line reference
 -   [ip](ip.md)
 -   [kill](kill.md)
 -   [ls](ls.md)
+-   [mount](mount.md)
 -   [provision](provision.md)
 -   [regenerate-certs](regenerate-certs.md)
 -   [restart](restart.md)

--- a/machine/reference/mount.md
+++ b/machine/reference/mount.md
@@ -26,9 +26,10 @@ Now you can use the directory on the machine, for mounting into containers.
 Any changes done in the local directory, will be reflected in the machine too.
 
 ```none
+$ eval $(docker-machine env dev)
 $ docker run -v /home/docker/foo:/tmp/foo busybox ls /tmp/foo
 bar
-$ docker touch foo/baz
+$ touch foo/baz
 $ docker run -v /home/docker/foo:/tmp/foo busybox ls /tmp/foo
 bar
 baz


### PR DESCRIPTION
This fixes two problems in the example:
- without switching to the `dev` machine, the commands are issued against the local docker instance instead of the `dev` instance managed by `docker-machine`
- there is no `docker touch` command. It should be just `touch`.

Furthermore, the page was not added to the navigation. This means that
- there is no link to the reference page
- the left side bar is broken on https://docs.docker.com/machine/reference/mount/
- in the top navigation, `Product manuals` is not highlighted