### PR TITLE
Fix daemon command, and improve order of examples

### DIFF
--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -92,8 +92,8 @@ proxy:
 ### Configure the Docker daemon
 
 Either pass the `--registry-mirror` option when starting `dockerd` manually,
-or edit `/etc/docker/daemon.json` and add the `registry-mirrors` key and value,
-to make the change persistent.
+or edit [`/etc/docker/daemon.json`](/engine/reference/commandline/dockerd.md#daemon-configuration-file)
+and add the `registry-mirrors` key and value, to make the change persistent.
 
 ```json
 {
@@ -101,7 +101,7 @@ to make the change persistent.
 }
 ```
 
-Save the file and restart Docker for the change to take effect.
+Save the file and reload Docker for the change to take effect.
 
 > Some log messages that appear to be errors are actually informational messages.
 >
@@ -110,7 +110,7 @@ Save the file and restart Docker for the change to take effect.
 > For example, this log message is informational:
 >
 > ```conf
-> `time="2017-06-02T15:47:37Z" level=info msg="error statting local store, serving from upstream: unknown blob" go.version=go1.7.4`
+> time="2017-06-02T15:47:37Z" level=info msg="error statting local store, serving from upstream: unknown blob" go.version=go1.7.4
 > ```
 >
 > It's telling you that the file doesn't exist yet in the local cache and is
@@ -128,16 +128,9 @@ command, for example:
 $ docker pull registry.docker-cn.com/library/ubuntu
 ```
 
-You can configure the Docker daemon with the `--registry-mirror` startup
-parameter:
-
-```bash
-$ dockerd --registry-mirror=https://registry.docker-cn.com
-```
-
-Or you can add "https://registry.docker-cn.com" to the `registry-mirrors`
-array in `/etc/docker/daemon.json` to pull from the China registry mirror
-by default.  
+You can add `"https://registry.docker-cn.com"` to the `registry-mirrors` array
+in [`/etc/docker/daemon.json`](/engine/reference/commandline/dockerd.md#daemon-configuration-file)
+to pull from the China registry mirror by default.  
 
 ```json
 {
@@ -145,4 +138,12 @@ by default.
 }
 ```
 
-Save the file and restart Docker for the change to take effect.
+Save the file and reload Docker for the change to take effect.
+
+Or, you can configure the Docker daemon with the `--registry-mirror` startup
+parameter:
+
+```bash
+$ dockerd --registry-mirror=https://registry.docker-cn.com
+```
+

--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -132,7 +132,7 @@ You can configure the Docker daemon with the `--registry-mirror` startup
 parameter:
 
 ```bash
-$ docker --registry-mirror=https://registry.docker-cn.com -d
+$ dockerd --registry-mirror=https://registry.docker-cn.com
 ```
 
 Or you can add "https://registry.docker-cn.com" to the `registry-mirrors`


### PR DESCRIPTION
Spotted this when @jpetazzo linked to this article (I think he's planning to make some improvements to this document 👍 🤗 )

Updated the example to use `dockerd` instead of `docker -d` (which is deprecated, and I think no longer functional).

Also moved the `daemon.json` example before the command-line flag example, because using a daemon.json configuration file is the preferred way to configure the daemon, and allows changing this configuration without _restarting_ the daemon (just `systemctl reload docker` / sending a `SIGHUP` should do)