### PR TITLE
Added reference to the proxy setup in part 2 to part 1 of tutorial

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -139,6 +139,7 @@ installed.
 
 You should be able to run `docker run hello-world` and see a response like this:
 > **Note**: You may need to add your user to the `docker` group in order to call this command without sudo. [Read more](https://docs.docker.com/engine/installation/linux/linux-postinstall/)
+> **Note**: If there are networking issues in your setup, `docker run hello-world` may fail to execute successfully. In case you are behind a proxy server and you suspect that it blocks the connection, check the [next part] (https://docs.docker.com/get-started/part2/) of the tutorial.
 
 ```shell
 $ docker run hello-world

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -139,6 +139,7 @@ installed.
 
 You should be able to run `docker run hello-world` and see a response like this:
 > **Note**: You may need to add your user to the `docker` group in order to call this command without sudo. [Read more](https://docs.docker.com/engine/installation/linux/linux-postinstall/)
+
 > **Note**: If there are networking issues in your setup, `docker run hello-world` may fail to execute successfully. In case you are behind a proxy server and you suspect that it blocks the connection, check the [next part] (https://docs.docker.com/get-started/part2/) of the tutorial.
 
 ```shell

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -140,7 +140,7 @@ installed.
 You should be able to run `docker run hello-world` and see a response like this:
 > **Note**: You may need to add your user to the `docker` group in order to call this command without sudo. [Read more](https://docs.docker.com/engine/installation/linux/linux-postinstall/)
 
-> **Note**: If there are networking issues in your setup, `docker run hello-world` may fail to execute successfully. In case you are behind a proxy server and you suspect that it blocks the connection, check the [next part] (https://docs.docker.com/get-started/part2/) of the tutorial.
+> **Note**: If there are networking issues in your setup, `docker run hello-world` may fail to execute successfully. In case you are behind a proxy server and you suspect that it blocks the connection, check the [next part](https://docs.docker.com/get-started/part2/) of the tutorial.
 
 ```shell
 $ docker run hello-world


### PR DESCRIPTION
### Proposed changes

Added reference to the next part of the tutorial in case there is an issue running `docker run hello-world`. This was an issue for me. As soon as I couldn't run the command successfully I went on searching what might cause the problem. Would have saved me quite some time if I knew that the next part contains info on proxy settings.