### PR TITLE
Run only signed images change

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/configure/run-only-the-images-you-trust.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/run-only-the-images-you-trust.md
@@ -44,14 +44,18 @@ been signed. It doesn't matter who signed the image.
 
 To enforce that the image needs to be signed by specific teams, click the
 dropdown and select those teams from the list. 
-**Note**: You MUST select teams that are a part of the `docker-datacenter` org in 
-order to make use of this feature.
+
+> Team must be in docker-datacenter
+>
+> You need to select a team that's part of the `docker-datacenter` organization
+> in order to use this feature.
+{: .important}
 
 ![UCP settings](../../images/run-only-the-images-you-trust-3.png){: .with-border}
 
 If you specify multiple teams, the image needs to be signed by a member of each
 team, or someone that is a member of all those teams, again which must be a part
-of the `docker-datacenter` org.
+of the `docker-datacenter` organization.
 
 Click **Save** for UCP to start enforcing the policy. From now on, existing
 services will continue running and can be restarted if needed, but UCP will only

--- a/datacenter/ucp/2.2/guides/admin/configure/run-only-the-images-you-trust.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/run-only-the-images-you-trust.md
@@ -43,12 +43,15 @@ With this setting, UCP allows deploying any image as long as the image has
 been signed. It doesn't matter who signed the image.
 
 To enforce that the image needs to be signed by specific teams, click the
-dropdown and select those teams from the list.
+dropdown and select those teams from the list. 
+**Note**: You MUST select teams that are a part of the `docker-datacenter` org in 
+order to make use of this feature.
 
 ![UCP settings](../../images/run-only-the-images-you-trust-3.png){: .with-border}
 
 If you specify multiple teams, the image needs to be signed by a member of each
-team, or someone that is a member of all those teams.
+team, or someone that is a member of all those teams, again which must be a part
+of the `docker-datacenter` org.
 
 Click **Save** for UCP to start enforcing the policy. From now on, existing
 services will continue running and can be restarted if needed, but UCP will only


### PR DESCRIPTION
From https://github.com/docker/orca/issues/10298#issuecomment-340592917 it turns out the "run only signed images" feature only works by selecting teams in the `docker-datacenter` org.  This became an issue in UCP 2.2 which has multiple org support.

Fixing this is very unlikely in a patch release, so we should doc in the UI immediately.

@joaofnfernandes 
