### PR TITLE
ucp: indicate how to validate client bundle communication

### DIFF
--- a/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
@@ -52,6 +52,15 @@ local Docker CLI communicate with UCP. It also updates the `DOCKER_CERT_PATH`
 environment variables to use the client certificates that are included in the
 client bundle you downloaded.
 
+To verify a client certificate bundle has been loaded and the client is
+successfully communicating with UCP, look for `ucp` in the `Server Version`
+returned by `docker version`.
+
+```bash
+$ docker version --format '{{.Server.Version}}'
+ucp/2.0.0
+```
+
 From now on, when you use the Docker CLI client, it includes your client
 certificates as part of the request to the Docker Engine.
 You can now use the Docker CLI to create services, networks, volumes and other

--- a/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
@@ -57,7 +57,9 @@ successfully communicating with UCP, look for `ucp` in the `Server Version`
 returned by `docker version`.
 
 ```bash
+{% raw %}
 $ docker version --format '{{.Server.Version}}'
+{% endraw %}
 ucp/2.0.0
 ```
 

--- a/datacenter/ucp/2.1/guides/user/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.1/guides/user/access-ucp/cli-based-access.md
@@ -52,6 +52,15 @@ local Docker CLI communicate with UCP. It also updates the `DOCKER_CERT_PATH`
 environment variable to use the client certificates that are included in the
 client bundle you downloaded.
 
+To verify a client certificate bundle has been loaded and the client is
+successfully communicating with UCP, look for `ucp` in the `Server Version`
+returned by `docker version`.
+
+```bash
+$ docker version --format '{{.Server.Version}}'
+ucp/2.1.0
+```
+
 From now on, when you use the Docker CLI client, it includes your client
 certificates as part of the request to the Docker Engine.
 You can now use the Docker CLI to create services, networks, volumes, and other

--- a/datacenter/ucp/2.1/guides/user/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.1/guides/user/access-ucp/cli-based-access.md
@@ -57,7 +57,9 @@ successfully communicating with UCP, look for `ucp` in the `Server Version`
 returned by `docker version`.
 
 ```bash
+{% raw %}
 $ docker version --format '{{.Server.Version}}'
+{% endraw %}
 ucp/2.1.0
 ```
 

--- a/datacenter/ucp/2.2/guides/user/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.2/guides/user/access-ucp/cli-based-access.md
@@ -61,8 +61,10 @@ successfully communicating with UCP, look for `ucp` in the `Server Version`
 returned by `docker version`.
 
 ```bash
+{% raw %}
 $ docker version --format '{{.Server.Version}}'
-ucp/2.2.0
+{% endraw %}
+{{ page.ucp_repo }}/{{ page.ucp_version }}
 ```
 
 From now on, when you use the Docker CLI client, it includes your client

--- a/datacenter/ucp/2.2/guides/user/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.2/guides/user/access-ucp/cli-based-access.md
@@ -56,6 +56,15 @@ client bundle you downloaded.
 > Windows environment, run `env.cmd` in an elevated command prompt, or run
 > `env.ps1` in an elevated PowerShell prompt.
 
+To verify a client certificate bundle has been loaded and the client is
+successfully communicating with UCP, look for `ucp` in the `Server Version`
+returned by `docker version`.
+
+```bash
+$ docker version --format '{{.Server.Version}}'
+ucp/2.2.0
+```
+
 From now on, when you use the Docker CLI client, it includes your client
 certificates as part of the request to the Docker Engine. You can now use the
 Docker CLI to create services, networks, volumes, and other resources on a swarm


### PR DESCRIPTION
Recommends using `docker version` to confirm UCP client certificate
bundle has been sourced and the client is successfully able to reach UCP.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>