### PR TITLE
Get started part 2: How to access app in container on Windows 7 Docker Toolbox

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -207,7 +207,9 @@ message.
 
 ![Hello World in browser](images/app-in-browser.png)
 
-> **Note**: If you are using Docker Toolbox on Windows 7, use the Docker Machine IP instead of localhost, e.g. http://192.168.99.100:4000/. You can find out the address with `docker-machine ip`.
+> **Note**: If you are using Docker Toolbox on Windows 7, use the Docker Machine IP
+> instead of `localhost`. For example, http://192.168.99.100:4000/. To find the IP
+> address, use the command `docker-machine ip`.
 
 You can also use the `curl` command in a shell to view the same content.
 

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -207,6 +207,8 @@ message.
 
 ![Hello World in browser](images/app-in-browser.png)
 
+> **Note**: If you are using Docker Toolbox on Windows 7, use the Docker Machine IP instead of localhost, e.g. http://192.168.99.100:4000/. You can find out the address with `docker-machine ip`.
+
 You can also use the `curl` command in a shell to view the same content.
 
 ```shell


### PR DESCRIPTION
Instructions how to access application in container on Windows due to https://github.com/docker/for-win/issues/458. See also https://stackoverflow.com/questions/41208782/docker-localhost-process-not-working-on-windows.

### Proposed changes

I added a small note to explain how to access the application running in container on Windows environment. The reason for this is I spent 2 hours finding out why I can't access the tutorial application, I hope to save this time from other newcomers.

### Related issues (optional)

Documents https://github.com/docker/for-win/issues/458