### PR TITLE
Add changelog links to API version matrix

### DIFF
--- a/_includes/api-version-matrix.md
+++ b/_includes/api-version-matrix.md
@@ -1,18 +1,20 @@
 
-| Docker version | Maximum API version       |
------------------|---------------------------|
-| 17.10          | [1.33](/engine/api/v1.33/)|
-| 17.09          | [1.32](/engine/api/v1.32/)|
-| 17.07          | [1.31](/engine/api/v1.31/)|
-| 17.06          | [1.30](/engine/api/v1.30/)|
-| 17.05          | [1.29](/engine/api/v1.29/)|
-| 17.04          | [1.28](/engine/api/v1.28/)|
-| 17.03          | [1.27](/engine/api/v1.27/)|
-| 1.13           | [1.26](/engine/api/v1.26/)|
-| 1.12           | [1.24](/engine/api/v1.24/)|
-| 1.11           | [1.23](/engine/api/v1.23/)|
-| 1.10           | [1.22](/engine/api/v1.22/)|
-| 1.9            | [1.21](/engine/api/v1.21/)|
-| 1.8            | [1.20](/engine/api/v1.20/)|
-| 1.7            | [1.19](/engine/api/v1.19/)|
-| 1.6            | [1.18](/engine/api/v1.18/)|
+| Docker version | Maximum API version       | Change log                                                |
+-----------------|---------------------------|-----------------------------------------------------------|
+| 17.10          | [1.33](/engine/api/v1.33/)| [changes](/engine/api/version-history/#v1-33-api-changes) |
+| 17.09          | [1.32](/engine/api/v1.32/)| [changes](/engine/api/version-history/#v1-32-api-changes) |
+| 17.07          | [1.31](/engine/api/v1.31/)| [changes](/engine/api/version-history/#v1-31-api-changes) |
+| 17.06          | [1.30](/engine/api/v1.30/)| [changes](/engine/api/version-history/#v1-30-api-changes) |
+| 17.05          | [1.29](/engine/api/v1.29/)| [changes](/engine/api/version-history/#v1-29-api-changes) |
+| 17.04          | [1.28](/engine/api/v1.28/)| [changes](/engine/api/version-history/#v1-28-api-changes) |
+| 17.03.1        | [1.27](/engine/api/v1.27/)| [changes](/engine/api/version-history/#v1-27-api-changes) |
+| 17.03          | [1.26](/engine/api/v1.27/)| [changes](/engine/api/version-history/#v1-26-api-changes) |
+| 1.13.1         | [1.26](/engine/api/v1.26/)| [changes](/engine/api/version-history/#v1-26-api-changes) |
+| 1.13           | [1.25](/engine/api/v1.26/)| [changes](/engine/api/version-history/#v1-25-api-changes) |
+| 1.12           | [1.24](/engine/api/v1.24/)| [changes](/engine/api/version-history/#v1-24-api-changes) |
+| 1.11           | [1.23](/engine/api/v1.23/)| [changes](/engine/api/version-history/#v1-23-api-changes) |
+| 1.10           | [1.22](/engine/api/v1.22/)| [changes](/engine/api/version-history/#v1-22-api-changes) |
+| 1.9            | [1.21](/engine/api/v1.21/)| [changes](/engine/api/version-history/#v1-21-api-changes) |
+| 1.8            | [1.20](/engine/api/v1.20/)| [changes](/engine/api/version-history/#v1-20-api-changes) |
+| 1.7            | [1.19](/engine/api/v1.19/)| [changes](/engine/api/version-history/#v1-19-api-changes) |
+| 1.6            | [1.18](/engine/api/v1.18/)| [changes](/engine/api/version-history/#v1-18-api-changes) |


### PR DESCRIPTION
This adds a link to the API change-log to the version matrix. Also adds some patch-releases that had an API version bump.

@mistyhacks I wasn't sure if these versions were deliberately left out (also re: links to change-log)
