### PR TITLE
Fix service name

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -148,7 +148,7 @@ IDs that numerically increment, up to the number of `replicas` you defined in
 `docker-compose.yml`. List the tasks for your service:
 
 ```shell
-docker service ps getstartedlab
+docker service ps getstartedlab_web
 ```
 
 Tasks also show up if you just list all the containers on your system, though that


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Updated to correct service name when attempting to list tasks.
`docker service ps getstartedlab` returns `no such service: getstartedlab`
`docker service ps getstartedlab_web` has the expected behaviour of listing all tasks.

<img width="1473" alt="screenshot 2017-11-02 00 00 16" src="https://user-images.githubusercontent.com/1697001/32313865-188455d0-bf62-11e7-836d-cb0f47cde06e.png">

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
