### PR TITLE
Bump EE version for Windows Server

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,7 +113,7 @@ defaults:
       path: "engine"
     values:
       assignee: "mstanleyjones"
-      win_latest_build: "docker-17.06.2-ee-4"
+      win_latest_build: "docker-17.06.2-ee-5"
   - scope:
       path: "kitematic"
     values:


### PR DESCRIPTION
New version is `docker-17.06.2-ee-5`.