### PR TITLE
Example overlay IPs consistency

### DIFF
--- a/engine/userguide/networking/overlay-standalone-swarm.md
+++ b/engine/userguide/networking/overlay-standalone-swarm.md
@@ -307,7 +307,7 @@ it automatically is part of the network.
     2c5ac3f849df: Pull complete
     Digest: sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
     Status: Downloaded newer image for busybox:latest
-    Connecting to web (10.0.0.2:80)
+    Connecting to web (10.0.9.2:80)
     <!DOCTYPE html>
     <html>
     <head>
@@ -391,7 +391,7 @@ to have external connectivity outside of their cluster.
         valid_lft forever preferred_lft forever
     22: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
     link/ether 02:42:0a:00:09:03 brd ff:ff:ff:ff:ff:ff
-    inet 10.0.9.3/24 scope global eth0
+    inet 10.0.9.2/24 scope global eth0
         valid_lft forever preferred_lft forever
     inet6 fe80::42:aff:fe00:903/64 scope link
         valid_lft forever preferred_lft forever


### PR DESCRIPTION
For consistency:

1. change) in line 214 if the overlay network was created with

```bash
    $ docker network create --driver overlay --subnet=10.0.9.0/24 my-net
```

then the curl example to a nginx container on such overlay network (my-net) should be in that range, e.g. 10.0.9.2 instead of the current 10.0.0.2 in line 310

2. change) if the first change gets accepted then (to neat-pick even more) in line 384

```bash
    $ docker exec web ip addr
```

shows container "web" with eth0 IP `10.0.9.3` in line 394 instead of `10.0.9.2` like when it got hit in the curl example.