### PR TITLE
Added note re: needing to explicitly stop containers on Windows

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -196,7 +196,7 @@ Run the app, mapping your machine's port 4000 to the container's published port
 docker run -p 4000:80 friendlyhello
 ```
 
-You should see a notice that Python is serving your app at `http://0.0.0.0:80`.
+You should see a message that Python is serving your app at `http://0.0.0.0:80`.
 But that message is coming from inside the container, which doesn't know you
 mapped port 80 of that container to 4000, making the correct URL
 `http://localhost:4000`.
@@ -215,12 +215,21 @@ $ curl http://localhost:4000
 <h3>Hello World!</h3><b>Hostname:</b> 8fc990912a14<br/><b>Visits:</b> <i>cannot connect to Redis, counter disabled</i>
 ```
 
-> **Note**: This port remapping of `4000:80` is to demonstrate the difference
+This port remapping of `4000:80` is to demonstrate the difference
 between what you `EXPOSE` within the `Dockerfile`, and what you `publish` using
 `docker run -p`. In later steps, we'll just map port 80 on the host to port 80
 in the container and use `http://localhost`.
 
 Hit `CTRL+C` in your terminal to quit.
+
+ > On Windows, explicitly stop the container
+ >
+ > On Windows systems, `CTRL+C` does not stop the container. So, first
+ type `CTRL+C` to get the prompt back (or open another shell), then type
+ `docker container ls` to list the running containers, followed by
+ `docker container stop <Container NAME or ID>` to stop the
+ container. Otherwise, you'll get an error response from the daemon
+ when you try to re-run the container in the next step.
 
 Now let's run the app in the background, in detached mode:
 
@@ -272,7 +281,7 @@ Make note of your username.
 Log in to the Docker public registry on your local machine.
 
 ```shell
-docker login
+$ docker login
 ```
 
 ### Tag the image


### PR DESCRIPTION
### What's changed

- Added a Windows specific note about how CTRL+C doesn't actually stop containers;  Windows users need to use `docker container stop` instead

### Related

- Fixes #5218 

### Reviewers

@nohwnd

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>
