### PR TITLE
Add overlay2 support for Docker EE 17.06.2-ee-5 on RHEL

### DIFF
--- a/engine/installation/linux/docker-ee/rhel.md
+++ b/engine/installation/linux/docker-ee/rhel.md
@@ -30,9 +30,11 @@ Docker Community Edition (Docker CE) is not supported on {{ linux-dist-long }}.
 To install Docker EE, you need the 64-bit version of {{ linux-dist-long }}
 running on `x86_64`, `s390x` (IBM Z), or `ppc64le` (IBM Power) architectures.
 
-In addition, you must use the `overlay2` or `devicemapper` storage driver. The
-`overlay2` driver is preferred for ease of configuration, if you are able to
-use it. The following limitations apply:
+In addition, you must use the `overlay2` or `devicemapper` storage driver.
+Beginning with Docker EE 17.06.2-ee-5 the `overlay2` storage driver is the
+recommended storage driver.
+
+The following limitations apply:
 
 **OverlayFS**:
 


### PR DESCRIPTION
Since https://success.docker.com/Policies/Compatibility_Matrix has added statement:
`Beginning with Docker EE daemon version 17.06.2-ee-5 the overlay2 storage driver is supported, and is the recommended storage driver.`
Propose to add it to docker ee installation guide as well to make the information consistent.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
