### PR TITLE
add placement pref note about null labels

### DIFF
--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -642,7 +642,7 @@ $ docker service create \
   --placement-pref 'spread=node.labels.datacenter' \
   redis:3.0.6
 ```
-Note that nodes that are missing the label used to spread, will still receive 
+Note that nodes which are missing the label used to spread, will still receive 
 task assignments. As a group, they will receive tasks in equal proportion to 
 any of the other groups identified by a specific label value. In a sense, a 
 missing label is the same as having the label with a null value attached to it. 

--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -642,6 +642,12 @@ $ docker service create \
   --placement-pref 'spread=node.labels.datacenter' \
   redis:3.0.6
 ```
+Note that nodes that are missing the label used to spread, will still receive 
+task assignments. As a group, they will receive tasks in equal proportion to 
+any of the other groups identified by a specific label value. In a sense, a 
+missing label is the same as having the label with a null value attached to it. 
+If the service should only run on nodes with the label being used for the the 
+spread preference, the preference should be combined with a constraint.
 
 You can specify multiple placement preferences, and they are processed in the
 order they are encountered. The following example sets up a service with

--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -642,12 +642,16 @@ $ docker service create \
   --placement-pref 'spread=node.labels.datacenter' \
   redis:3.0.6
 ```
-Note that nodes which are missing the label used to spread, will still receive 
-task assignments. As a group, they will receive tasks in equal proportion to 
-any of the other groups identified by a specific label value. In a sense, a 
-missing label is the same as having the label with a null value attached to it. 
-If the service should only run on nodes with the label being used for the the 
-spread preference, the preference should be combined with a constraint.
+
+> Missing or null labels
+>
+> Nodes which are missing the label used to spread will still receive 
+> task assignments. As a group, these nodes will receive tasks in equal
+> proportion to  any of the other groups identified by a specific label
+> value. In a sense, a missing label is the same as having the label with
+> a null value attached to it. If the service should **only** run on
+> nodes with the label being used for the the spread preference, the
+> preference should be combined with a constraint.
 
 You can specify multiple placement preferences, and they are processed in the
 order they are encountered. The following example sets up a service with


### PR DESCRIPTION

### Proposed changes

Nearly a cut and paste from SwarmKit topology.md to prevent confusion about missing labels on nodes when setting placement preferences for spread.

### Related issues (optional)

https://github.com/moby/moby/issues/35433#issuecomment-342862546
