### PR TITLE
Fixes incorrect link to SDK Installation

### DIFF
--- a/develop/sdk/examples.md
+++ b/develop/sdk/examples.md
@@ -11,7 +11,7 @@ redirect_from:
 
 After you
 [install Docker](/engine/installation.md), you can
-[install the Go and Python SDKs](/develop/api/index.md#install-the-sdks) and
+[install the Go and Python SDKs](/develop/sdk/index.md#install-the-sdks) and
 also try out the Docker Engine API.
 
 Each of these examples show how to perform a given Docker operation using the Go


### PR DESCRIPTION
This fixes a broken link to the SDK installers. Currently, it points /develop/api, which doesn't exist.

### Proposed changes

This changes a broken link to the SDK installation guides.
