### PR TITLE
Fix "virtual" explanation for "docker ps -s"

### DIFF
--- a/engine/userguide/storagedriver/imagesandcontainers.md
+++ b/engine/userguide/storagedriver/imagesandcontainers.md
@@ -81,7 +81,8 @@ command. Two different columns relate to size.
   each container
 
 - `virtual size`: the amount of data used for the read-only image data
-  used by the container. Multiple containers may share some or all read-only
+  used by the container plus the container's writable layer `size`. 
+  Multiple containers may share some or all read-only
   image data. Two containers started from the same image share 100% of the
   read-only data, while two containers with different images which have layers
   in common share those common layers. Therefore, you can't just total the
@@ -90,8 +91,9 @@ command. Two different columns relate to size.
 
 The total disk space used by all of the running containers on disk is some
 combination of each container's `size` and the `virtual size` values. If
-multiple containers have exactly the same `virtual size`, they are likely
-started from the same exact image.
+multiple containers started from the same exact image, the total size on disk for 
+these containers would be SUM (`size` of containers) plus one container's 
+(`virtual size`- `size`).
 
 This also does not count the following additional ways a container can take up
 disk space:


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Copy from Slack #docs conversation:

Xinfeng Liu [16:35] 
Hi, 
from https://github.com/moby/moby/blob/master/daemon/getsize_unix.go#L39   
and https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/#container-size-on-disk  `virtual size: the amount of data used for the read-only image data used by the container. `  The source codes and docs are not consistent,  I want to confirm which is correct?
Also please see new issue for this: https://github.com/docker/docker.github.io/issues/5270 (edited)

Sebastiaan van Stijn [17:19] 
@xinfeng was just reading it this morning (didn't reply on that issue yet); yes, I think an error slipped into the docs: `size:` is the size used by the writable layer of the container, and `virtual size` is "writable layer + read-only layers (AKA "the image")". To get the size of "the image" on disk, you'd have to do "`virtual size - size`". To calculate the total size on disk for `N` containers running `image:foo`; the size would be: `SUM(size of containers)` + `1 x "virtual size - size"`

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
Fixes #5270
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
