### PR TITLE
Do not split the content inside backticks

### DIFF
--- a/machine/examples/aws.md
+++ b/machine/examples/aws.md
@@ -182,7 +182,7 @@ other machine):
     eval $(docker-machine env -u)
     docker container ls -a
     ```
-    
+
 3. Reset aws-sandbox as the active docker machine:
 
     ```bash
@@ -196,7 +196,7 @@ other machine):
     > container on another port, update the security group to reflect that.
 
     In this example, the `-p` option is used to expose port 80 from the `nginx`
-    container and make it accessible on port `8000` of the `aws-sandbox` host.
+    container and make it accessible on port `8000` of the `aws-sandbox` host:
 
     ```bash
     $ docker run -d -p 8000:80 --name webserver kitematic/hello-world-nginx
@@ -211,9 +211,9 @@ other machine):
     ```
 
     In a web browser, go to `http://<host_ip>:8000` to bring up the webserver
-    home page. You got the `<host_ip>` from the output of the `docker-machine ip
-    <machine>` command you ran in a previous step. Use the port you exposed in
-    the `docker run` command.
+    home page. You got the `<host_ip>` from the output of the `docker-machine ip <machine>`
+    command you ran in a previous step. Use the port you exposed in the
+    `docker run` command.
 
     ![nginx webserver](../img/nginx-webserver.png)
 


### PR DESCRIPTION
Adding newlines inside backticks breaks Markdown. Page affected: https://docs.docker.com/machine/examples/aws/#step-3-run-docker-commands-on-the-new-instance.

| **Before** | **After** |
| :----: | :-----: |
| ![screenshot-docs docker com-2017-11-10-15-16-35](https://user-images.githubusercontent.com/340023/32662257-2efab740-c62a-11e7-86f4-b62297632dea.png)  | ![screenshot-localhost 4000-2017-11-10-15-16-06](https://user-images.githubusercontent.com/340023/32662266-33fc22a6-c62a-11e7-9c8a-f49cbe71e206.png) |