### PR TITLE
Fix indentation of Python example

### DIFF
--- a/engine/admin/logging/journald.md
+++ b/engine/admin/logging/journald.md
@@ -111,6 +111,6 @@ import systemd.journal
 reader = systemd.journal.Reader()
 reader.add_match('CONTAINER_NAME=web')
 
-    for msg in reader:
-      print '{CONTAINER_ID_FULL}: {MESSAGE}'.format(**msg)
+for msg in reader:
+    print '{CONTAINER_ID_FULL}: {MESSAGE}'.format(**msg)
 ```


### PR DESCRIPTION
### Proposed changes

Updated the Python example code for retrieving log entries from `journald` via the Python API. The previous example code was incorrectly indented.
