### PR TITLE
Improve script to reset user password

### DIFF
--- a/datacenter/ucp/2.2/guides/access-control/recover-a-user-password.md
+++ b/datacenter/ucp/2.2/guides/access-control/recover-a-user-password.md
@@ -26,7 +26,7 @@ node managed by UCP, and run:
 ```none
 {% raw %}
 docker exec -it ucp-auth-api enzi \
-  "$(docker inspect --format '{{ .Args}}' ucp-auth-api | perl -ne 'print "$1\n" if /(--db-addr=(\d+[.:]?)+)/')" \
+  $(docker inspect --format '{{range .Args}}{{if eq "--db-addr=" (printf "%.10s" .)}}{{.}}{{end}}{{end}}' ucp-auth-api) \
   passwd -i
 {% endraw %}  
 ```

--- a/datacenter/ucp/2.2/guides/access-control/recover-a-user-password.md
+++ b/datacenter/ucp/2.2/guides/access-control/recover-a-user-password.md
@@ -26,7 +26,7 @@ node managed by UCP, and run:
 ```none
 {% raw %}
 docker exec -it ucp-auth-api enzi \
-  "$(docker inspect --format '{{ index .Args 0 }}' ucp-auth-api)" \
+  "$(docker inspect --format '{{ .Args}}' ucp-auth-api | perl -ne 'print "$1\n" if /(--db-addr=(\d+[.:]?)+)/')" \
   passwd -i
 {% endraw %}  
 ```


### PR DESCRIPTION
Updates the script to reset a UCP admin password so that it works independently of the environment setup. I could not get a solution with Grep that was portable between OSX and Ubuntu, that's why I ended up with this small perl script.
/cc @trapier for a review.

Fixes #5237