### PR TITLE
mention about `log` metadata for fluentd-log driver

### DIFF
--- a/engine/admin/logging/fluentd.md
+++ b/engine/admin/logging/fluentd.md
@@ -21,6 +21,7 @@ driver sends the following metadata in the structured log message:
 | `container_id`   | The full 64-character container ID.                                                                                                                    |
 | `container_name` | The container name at the time it was started. If you use `docker rename` to rename a container, the new name is not reflected in the journal entries. |
 | `source`         | `stdout` or `stderr`                                                                                                                                   |
+| `log`            | The container log                                                                                                                                      |
 
 The `docker logs` command is not available for this logging driver.
 


### PR DESCRIPTION
I was looking into the main log content the driver send to fluentd but I could not find any in the doc.

There were no mention in the doc. I do a quick check by outputting whatever fluentd send:

```
<match **>
  @type stdout
</match>
```

the output shows `log` key

This PR is to document this metadata

File: [engine/admin/logging/fluentd.md](https://docs.docker.com/engine/admin/logging/fluentd/), CC @mistyhacks