### PR TITLE
Add a note regarding retrieving log messages when tty is enabled

### DIFF
--- a/engine/admin/logging/journald.md
+++ b/engine/admin/logging/journald.md
@@ -100,6 +100,17 @@ to return the log messages in JSON format.
 $ sudo journalctl -o json CONTAINER_NAME=webserver
 ```
 
+### View logs for a container with a TTY enabled
+
+If TTY is enabled on a container you may see `[10B blob data]` in the output
+when retrieving log messages.
+The reason for that is that `\r` is appended to the end of the line and
+`journalctl` doesn't strip it automatically unless `--all` is set:
+
+```bash
+$ sudo journalctl -b CONTAINER_NAME=webserver --all
+```
+
 ## Retrieve log messages with the `journal` API
 
 This example uses the `systemd` Python module to retrieve container


### PR DESCRIPTION
### Proposed changes

When running a container with tty enabled and setting the journald
logging driver, you may see "blob data" instead of the real log
message.

That's because tty appends "\r" to the end of the log line,
which isn't stripped by jorunald unless you specify the "--all" flag.


### Related issues (optional)
related to https://github.com/moby/moby/pull/35416 and https://github.com/moby/moby/pull/22450