### PR TITLE
Update docs for new publish syntax

### DIFF
--- a/docker-for-aws/deploy.md
+++ b/docker-for-aws/deploy.md
@@ -145,10 +145,10 @@ You can now start creating containers and services.
 
     $ docker run hello-world
 
-You can run websites too. Ports exposed with `-p` are automatically exposed
+You can run websites too. Ports exposed with `--publish` are automatically exposed
 through the platform load balancer:
 
-    $ docker service create --name nginx -p 80:80 nginx
+    $ docker service create --name nginx --publish target=80,port=80 nginx
 
 Once up, find the `DefaultDNSTarget` output in either the AWS or Azure portals
 to access the site.
@@ -184,7 +184,7 @@ A good sample app to test deployment of stacks is the [Docker voting app](https:
 
 By default, apps deployed with stacks do not have ports publicly exposed. Update port mappings for services, and Docker will automatically wire up the underlying platform load balancers:
 
-    docker service update --publish-add 80:80 <example-service>
+    docker service update --publish-add target=80,port=80 <example-service>
 
 ### Images in private repos
 

--- a/docker-for-aws/load-balancer.md
+++ b/docker-for-aws/load-balancer.md
@@ -11,7 +11,7 @@ title: Configure the Docker for AWS load balancer
 When you create a service, any ports that are exposed with `-p` are automatically exposed through the platform load balancer:
 
 ```bash
-$ docker service create --name nginx -p 80:80 nginx
+$ docker service create --name nginx --publish target=80,port=80 nginx
 ```
 
 This opens up port 80 on the Elastic Load Balancer (ELB) and direct any traffic
@@ -36,8 +36,8 @@ described in the service label `com.docker.aws.lb.arn`
 $ docker service create \
   --name demo \
   --detach=true \
-  --publish 80:80 \
-  --publish 443:80 \
+  --publish target=80,port=80 \
+  --publish target=443,port=80 \
   --label com.docker.aws.lb.arn="arn:aws:acm:us-east-1:0123456789:certificate/c02117b6-2b5f-4507-8115-87726f4ab963" \
   yourname/your-image:latest
 ```
@@ -70,8 +70,8 @@ Listen for HTTP on ports 80 and HTTPS on 444
 $ docker service create \
   --name demo \
   --detach=true \
-  --publish 80:80 \
-  --publish 444:80 \
+  --publish target=80,port=80 \
+  --publish target=444,port=80 \
   --label com.docker.aws.lb.arn="arn:aws:acm:us-east-1:0123456789:certificate/c02117b6-2b5f-4507-8115-87726f4ab963@444" \
    yourname/your-image:latest
 ```
@@ -82,8 +82,8 @@ $ docker service create \
 $ docker service create \
   --name demo \
   --detach=true \
-  --publish 80:80 \
-  --publish 444:80 \
+  --publish target=80,port=80 \
+  --publish target=444,port=80 \
   --label com.docker.aws.lb.arn="arn:aws:acm:us-east-1:0123456789:certificate/c02117b6-2b5f-4507-8115-87726f4ab963@443,444" \
    yourname/your-image:latest
 ```
@@ -94,7 +94,7 @@ $ docker service create \
 $ docker service create \
   --name demo \
   --detach=true \
-  --publish 8080:80 \
+  --publish target=8080,port=80 \
   --label com.docker.aws.lb.arn="arn:aws:acm:us-east-1:0123456789:certificate/c02117b6-2b5f-4507-8115-87726f4ab963@8080" \
   yourname/your-image:latest
 ```

--- a/docker-for-azure/deploy.md
+++ b/docker-for-azure/deploy.md
@@ -129,9 +129,9 @@ You can now start creating containers and services.
 
     $ docker run hello-world
 
-You can run websites too. Ports exposed with `-p` are automatically exposed through the platform load balancer:
+You can run websites too. Ports exposed with `--publish` are automatically exposed through the platform load balancer:
 
-    $ docker service create --name nginx -p 80:80 nginx
+    $ docker service create --name nginx --publish target=80,port=80 nginx
 
 Once up, find the `DefaultDNSTarget` output in either the AWS or Azure portals to access the site.
 
@@ -161,7 +161,7 @@ A good sample app to test deployment of stacks is the [Docker voting app](https:
 
 By default, apps deployed with stacks do not have ports publicly exposed. Update port mappings for services, and Docker will automatically wire up the underlying platform load balancers:
 
-    docker service update --publish-add 80:80 <example-service>
+    docker service update --publish-add target=80,port=80 <example-service>
 
 ### Images in private repos
 

--- a/engine/admin/prometheus.md
+++ b/engine/admin/prometheus.md
@@ -200,7 +200,7 @@ Next, start a single-replica Prometheus service using this configuration.
 ```bash
 $ docker service create --replicas 1 --name my-prometheus \
     --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
-    --publish 9090:9090/tcp \
+    --publish target=9090,port=9090,protocol=tcp \
     prom/prometheus
 ```
 
@@ -210,7 +210,7 @@ $ docker service create --replicas 1 --name my-prometheus \
 ```bash
 $ docker service create --replicas 1 --name my-prometheus \
     --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
-    --publish 9090:9090/tcp \
+    --publish target=9090,port=9090,protocol=tcp \
     prom/prometheus
 ```
 
@@ -220,7 +220,7 @@ $ docker service create --replicas 1 --name my-prometheus \
 ```powershell
 PS C:\> docker service create --replicas 1 --name my-prometheus
     --mount type=bind,source=C:/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml
-    --publish 9090:9090/tcp
+    --publish target=9090,port=9090,protocol=tcp
     prom/prometheus
 ```
 

--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -227,7 +227,7 @@ This example assumes that you have PowerShell installed.
     ```powershell
     PS> docker service create
         --name my-iis
-        -p 8000:8000
+        --publish target=8000,port=8000
         --config src=homepage,target="\inetpub\wwwroot\index.html"
         microsoft/iis:nanoserver  
     ```
@@ -399,7 +399,7 @@ generate the site key and certificate, name the files `site.key` and
          --secret site.key \
          --secret site.crt \
          --config source=site.conf,target=/etc/nginx/conf.d/site.conf \
-         --publish 3000:443 \
+         --publish target=3000,port=443 \
          nginx:latest \
          sh -c "exec nginx -g 'daemon off;'"
     ```

--- a/engine/swarm/networking.md
+++ b/engine/swarm/networking.md
@@ -266,7 +266,7 @@ round robin (DNSRR). You can configure this per service.
   addresses, and the client connects directly to one of these.
 
   DNS round-robin is useful in cases where you want to use your own load
-  balancer. To configure a service to use DNSRR, use the flag
+  balancer, such as HAProxy. To configure a service to use DNSRR, use the flag
   `--endpoint-mode dnsrr` when creating a new service or updating an existing
   one.
 

--- a/engine/swarm/secrets.md
+++ b/engine/swarm/secrets.md
@@ -305,7 +305,7 @@ This example assumes that you have PowerShell installed.
     ```powershell
     PS> docker service create
         --name my-iis
-        -p 8000:8000
+        --publish target=8000,port=8000
         --secret src=homepage,target="\inetpub\wwwroot\index.html"
         microsoft/iis:nanoserver  
     ```
@@ -497,7 +497,7 @@ generate the site key and certificate, name the files `site.key` and
            --secret site.key \
            --secret site.crt \
            --secret source=site.conf,target=/etc/nginx/conf.d/site.conf \
-           --publish 3000:443 \
+           --publish target=3000,port=443 \
            nginx:latest \
            sh -c "exec nginx -g 'daemon off;'"
       ```
@@ -510,7 +510,7 @@ generate the site key and certificate, name the files `site.key` and
            --secret site.key \
            --secret site.crt \
            --secret site.conf \
-           --publish 3000:443 \
+           --publish target=3000,port=443 \
            nginx:latest \
            sh -c "ln -s /run/secrets/site.conf /etc/nginx/conf.d/site.conf && exec nginx -g 'daemon off;'"
       ```
@@ -787,7 +787,7 @@ line.
          --name wordpress \
          --replicas 1 \
          --network mysql_private \
-         --publish 30000:80 \
+         --publish target=30000,port=80 \
          --mount type=volume,source=wpdata,destination=/var/www/html \
          --secret source=mysql_password,target=wp_db_password,mode=0400 \
          -e WORDPRESS_DB_USER="wordpress" \

--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -354,7 +354,7 @@ three tasks on a 10-node swarm:
 ```bash
 $ docker service create --name my_web \
                         --replicas 3 \
-                        --publish 8080:80 \
+                        --publish target=8080,port=80 \
                         nginx
 ```
 
@@ -648,7 +648,7 @@ $ docker service create \
 
 > Missing or null labels
 >
-> Nodes which are missing the label used to spread will still receive 
+> Nodes which are missing the label used to spread will still receive
 > task assignments. As a group, these nodes will receive tasks in equal
 > proportion to  any of the other groups identified by a specific label
 > value. In a sense, a missing label is the same as having the label with

--- a/engine/swarm/stack-deploy.md
+++ b/engine/swarm/stack-deploy.md
@@ -40,7 +40,7 @@ a throwaway registry, which you can discard afterward.
 1.  Start the registry as a service on your swarm:
 
     ```bash
-    $ docker service create --name registry --publish 5000:5000 registry:2
+    $ docker service create --name registry --publish target=5000,port=5000 registry:2
     ```
 
 2.  Check its status with `docker service ls`:

--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -127,7 +127,7 @@ $ docker run -d \
   registry:2
 ```
 
-If you want to change the port the registry listens on within the container, you 
+If you want to change the port the registry listens on within the container, you
 can use the environment variable `REGISTRY_HTTP_ADDR` to change it. This command
 causes the registry to listen on port 5001 within the container:
 
@@ -325,7 +325,7 @@ $ docker service create \
   -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
   -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/secrets/domain.crt \
   -e REGISTRY_HTTP_TLS_KEY=/run/secrets/domain.key \
-  -p 80:80 \
+  --publish target=80,port=80 \
   --replicas 1 \
   registry:2
 ```


### PR DESCRIPTION
Fixes #3913 

cc/ @mbentley 
cc/ @joaofnfernandes @JimGalasyn in case UCP / DTR want to use the new syntax, feel free to pile into this PR. I didn't want to change your stuff.

There is a bit of a chicken/egg problem here as the CLI reference doc probably won't be in `docker/docker-ce` (and thus available to us) until the next stable CE release. However, I think we should go ahead and update this, as the "new" syntax has been available since 1.13.

Related: https://github.com/docker/cli/pull/695