### PR TITLE
Fix linux-postinstall.md

### DIFF
--- a/engine/installation/linux/linux-postinstall.md
+++ b/engine/installation/linux/linux-postinstall.md
@@ -55,6 +55,16 @@ To create the `docker` group and add your user:
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
+    If you see the below warning while running an image,
+    ```none
+    WARNING: Error loading config file: /home/user/.docker/config.json - stat /home/user/.docker/config.json: permission denied
+    ```
+    change the permissions of your `~/.docker` folder as follows:
+    ```bash
+    $ sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
+    $ sudo chmod g+rwx "/home/$USER/.docker" -R
+    ```
+
 ## Configure Docker to start on boot
 
 Most current Linux distributions (RHEL, CentOS, Fedora, Ubuntu 16.04 and higher)

--- a/engine/installation/linux/linux-postinstall.md
+++ b/engine/installation/linux/linux-postinstall.md
@@ -55,11 +55,21 @@ To create the `docker` group and add your user:
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-    If you see the below warning while running an image,
+    If you initially ran Docker CLI commands using `sudo` before adding
+    your user to the `docker` group, you may see the following error,
+    which indicates that your `~/.docker/` directory was created with
+    incorrect permissions due to the `sudo` commands.
+    
     ```none
-    WARNING: Error loading config file: /home/user/.docker/config.json - stat /home/user/.docker/config.json: permission denied
+    WARNING: Error loading config file: /home/user/.docker/config.json -
+    stat /home/user/.docker/config.json: permission denied
     ```
-    change the permissions of your `~/.docker` folder as follows:
+    
+    To fix this problem, either remove the `~/.docker/` directory
+    (it will be recreated automatically, but any custom settings
+    will be lost), or change its ownership and pemissions using the
+    following commands:
+    
     ```bash
     $ sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
     $ sudo chmod g+rwx "/home/$USER/.docker" -R


### PR DESCRIPTION
Suggestion to fix warnings when docker is configured to be used by non-root user.

### Proposed changes
On following the instructions under **Manage Docker as a non-root user** subheading, we face a warning every time we run an image. To fix the warning, the documentation should suggest correcting the permissions to the `~/.docker` folder. Thus this PR contains a note to fix the warning.

### Unreleased project version (optional)

### Related issues (optional)
Fixes #5326 
