### PR TITLE
Add missing Docker edition names  to content table

### DIFF
--- a/docker-store/publish.md
+++ b/docker-store/publish.md
@@ -20,8 +20,8 @@ published in the Store.
 
 | If your content: | Can publish on Store  | Can be certified and supported by Docker | Supported by publisher |
 |:-----|:--------|:------|:-----|
-| Works on Docker Edition  | YES | YES |  Required |                                                
-| Works on Docker Edition  | YES | NO  |  Optional |  
+| Works on Docker Enterprise Edition  | YES | YES |  Required |                                                
+| Works on Docker Community Edition  | YES | NO  |  Optional |  
 | Does not work on Docker Certified Infrastructure | NO                       |   N/A       |    N/A     |
 
 


### PR DESCRIPTION
Closes #5329

The table displayed for [Publish content on Docker Store](https://docs.docker.com/docker-store/publish/) is missing the names of the Docker editions that the qualifications apply to.

![missing-edition-name](https://user-images.githubusercontent.com/159738/32942939-5c499472-cb3f-11e7-8b80-6525f9b073de.png)


### Proposed changes

The names in the table have been updated to reflect either the *Enterprise* or *Community* edition, as appropriate. The table looks like this:

![missing-edition-name-fixed](https://user-images.githubusercontent.com/159738/32968146-02e97720-cb95-11e7-8463-cae160b2947e.png)

