### PR TITLE
Dynamically display latest Docker EE version

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -99,6 +99,12 @@
 	<link rel="stylesheet" href="/css/temp.css">
 	{% seo %}
 	{% if page.hide_from_sitemap %}<meta name="robots" content="noindex" />{% endif %}
+	<script language="javascript">
+	// Default to assuming this is an archive and hiding some stuff
+	// See js/archive.js and js/docs.js for logic relating to this
+	var isArchive = true;
+	var dockerVersion = 'v{{ site.docker_ce_stable_version }}';
+	</script>
 </head>
 <body ng-app="Docker" ng-controller="DockerController" class="colums">
 	<header>
@@ -290,12 +296,6 @@
 	<script src="/js/jquery.js"></script>
 	<script src="/js/bootstrap.min.js"></script>
 	<!-- Always include the archive.js, but it doesn't do much unless we are an archive -->
-	<script language="javascript">
-	// Default to assuming this is an archive and hiding some stuff
-	// See js/archive.js and js/docs.js for logic relating to this
-	var isArchive = true;
-	var dockerVersion = 'v{{ site.docker_ce_stable_version }}';
-	</script>
 	<script src="/js/archive.js"></script>
 	<script src="/js/stickyfill.min.js"></script>
 	<script defer src="/js/docs.js"></script>

--- a/enterprise/index.md
+++ b/enterprise/index.md
@@ -11,6 +11,9 @@ and supported to provide enterprises with the most secure container platform
 in the industry. For more info about Docker EE, including purchasing
 options, see [Docker Enterprise Edition](https://www.docker.com/enterprise-edition/).
 
+<!-- This is populated by logic in js/archive.js -->
+<p id="ee-version-div"></p>
+
 The free Docker products continue to be available as the Docker Community
 Edition (*Docker CE*).
 

--- a/js/archive.js
+++ b/js/archive.js
@@ -38,10 +38,12 @@ if (window.navigator.onLine) {
     if ( suppressButterBar == false ) {
       $( 'body' ).prepend(outerDivStart + buttonCode + listStart + listItems.join("") + listEnd + outerDivEnd);
       isArchive = true;
-      console.log("Detected that this is an archive.");
     } else {
       isArchive = false;
-      console.log("This is not an archive. Suppressing the archive versions bar");
+      /* This is only relevant to /enterprise/index.md */
+      if (document.getElementById('ee-version-div')) {
+        document.getElementById('ee-version-div').textContent += "The latest version of Docker EE is {{ site.docker_ee_version }}.";
+      }
     }
   });
 }


### PR DESCRIPTION
Fixes #5324 

cc/ @friism

We have to do this in JS because the archive-detecting logic is all in JS, and we don't want to display the "latest" version of EE in an archive, where it will always be wrong.

This introduces a tiny bit of page flicker as the JS appends text into a paragraph in the DOM. Not sure if this is acceptable long-term, but it should work for now.

To test, view `/enterprise/` in the Netlify output.