### PR TITLE
Fix offline install links for DTR 2.3.5 and 2.2.10

### DIFF
--- a/_data/ddc_offline_files.yaml
+++ b/_data/ddc_offline_files.yaml
@@ -19,7 +19,7 @@
     - description: "UCP 2.1.0"
       url: https://packages.docker.com/caas/ucp_images_2.1.0.tar.gz
     - description: "DTR 2.2.10"
-      url: https://packages.docker.com/caas/dtr-2.2.10.tar.gz
+      url: https://packages.docker.com/caas/dtr_images_2.2.10.tar.gz
     - description: "DTR 2.2.9"
       url: https://packages.docker.com/caas/dtr-2.2.9.tar.gz
     - description: "DTR 2.2.8"

--- a/_data/ddc_offline_files_2.yaml
+++ b/_data/ddc_offline_files_2.yaml
@@ -45,7 +45,7 @@
   version: "2.3"
   tar-files:
     - description: "DTR 2.3.5"
-      url: https://packages.docker.com/caas/dtr-2.3.5.tar.gz
+      url: https://packages.docker.com/caas/dtr_images_2.3.5.tar.gz
     - description: "DTR 2.3.4"
       url: https://packages.docker.com/caas/dtr-2.3.4.tar.gz
     - description: "DTR 2.3.3"


### PR DESCRIPTION
### Proposed changes

Fix offline install links for DTR 2.3.5 and 2.2.10