### PR TITLE
Make 'use a process manager' clearer

### DIFF
--- a/engine/admin/start-containers-automatically.md
+++ b/engine/admin/start-containers-automatically.md
@@ -74,9 +74,9 @@ process manager for more details.
 ### Using a process manager inside containers
 
 Process managers can also run within the container to check whether a process is
-running and starts/restart it if not. These are not Docker-aware and just monitor
-operating system processes within the container.
+running and starts/restart it if not. 
 
-Docker does not recommend this approach, because it is platform-dependent
-and even differs within different versions of a given Linux distribution.
+> **Warning**: These are not Docker-aware and just monitor operating system processes within the container.
+>
+> Docker does not recommend this approach, because it is platform-dependent and even differs within different versions of a given Linux distribution.
 

--- a/engine/admin/start-containers-automatically.md
+++ b/engine/admin/start-containers-automatically.md
@@ -63,13 +63,6 @@ Docker depend on Docker containers, you can use a process manager such as
 [systemd](http://freedesktop.org/wiki/Software/systemd/), or
 [supervisor](http://supervisord.org/) instead.
 
-A process manager runs within the container and checks whether a process is
-running and starts it if not. It is not Docker-aware, but just monitors
-operating system processes within the container.
-
-Docker does not recommend this approach, because it is platform-dependent
-and even differs within different versions of a given Linux distribution.
-
 > **Warning**: Do not try to combine Docker restart policies with host-level
 > process managers, because the two will conflict.
 
@@ -77,4 +70,13 @@ To use a process manager, configure it to start your container or service using
 the same `docker start` or `docker service` command you would normally use to
 start the container manually. Consult the documentation for the specific
 process manager for more details.
+
+### Using a process manager inside containers
+
+Process managers can also run within the container to check whether a process is
+running and starts/restart it if not. These are not Docker-aware and just monitor
+operating system processes within the container.
+
+Docker does not recommend this approach, because it is platform-dependent
+and even differs within different versions of a given Linux distribution.
 


### PR DESCRIPTION
The "Use a process manager" section appears to mix use of process manager on host with using process managers within a container.

The essence of the section appears to suggest that host-level process managers are ok as long as you don't combine them with docker restart policies.  But paragraphs 2 & 3 (in the original) seem to actively discourage the use of process managers within containers. Putting paragraphs 2 & 3 under an explicit heading would be clearer.

Should a section on process mangers within containers be expanded? There are lots of articles on the internet that relate to using process managers to start multiple processor in containers or to manage zombie pid 1 processes.  Are there official recommendations on what to do in these situations — whether to use a process manager or is a recommended 'docker native' way to achieve the same results?

### Proposed changes

Put paragraphs 2 & 3 under a sub-heading of 'Using a process manager inside containers' to make it distinction between process managers on the host and within a container clearer.


