### PR TITLE
Add example for `preferences` under deploy `placement`

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -629,6 +629,8 @@ documentation.
             constraints:
               - node.role == manager
               - engine.labels.operatingsystem == ubuntu 14.04
+            preferences:
+              - spread: node.labels.zone
 
 #### replicas
 


### PR DESCRIPTION
### Proposed changes

Adding an example for a placement preference in the `deploy/placement` section. Right now, the docs refer back to the `service create` docs.

`preferences` can take a strategy (`spread`) and then a key to distribute work across (like a node label).
