### PR TITLE
Update automated repository tests docs

### DIFF
--- a/docker-cloud/builds/automated-testing.md
+++ b/docker-cloud/builds/automated-testing.md
@@ -19,8 +19,9 @@ built images to your Docker Cloud repository, enable [Automated Builds](automate
 ## Set up automated test files
 
 To set up your automated tests, create a `docker-compose.test.yml` file which
-defines a `sut` service that lists the tests to be run. The
-`docker-compose.test.yml` file should be located in the same directory that
+defines a `sut` service that lists the tests to be run. This file has a structure 
+similar to the [docker-cloud.yml](https://docs.docker.com/docker-cloud/apps/stack-yaml-reference/).
+The `docker-compose.test.yml` file should be located in the same directory that
 contains the Dockerfile used to build the image.
 
 For example:


### PR DESCRIPTION
Specify that `docker-compose.test.yml` file structure is similar to `docker-cloud.yml`.

It seems unclear from documentation what format and other options the `docker-compose.test.yml` may have. By specifying that its structure is similar to [docker-cloud.yml](https://docs.docker.com/docker-cloud/apps/stack-yaml-reference/) developers will get a hint of where to search for further `docker-compose.test.yml` specification.
