### PR TITLE
Add '-RequiredVersion' flag option for "Installing a specific version"

### DIFF
--- a/engine/installation/windows/docker-ee.md
+++ b/engine/installation/windows/docker-ee.md
@@ -129,10 +129,10 @@ installs, or install on air-gapped systems.
 
 ## Install a specific version
 
-To install a specific Docker version, you can use the `MaximumVersion` and `MinimumVersion` flags. For example:
+To install a specific Docker version, you can use the `MaximumVersion`,`MinimumVersion` or 'RequiredVersion' flags. For example:
 
 ```PowerShell
-Install-Package -Name docker -ProviderName DockerProvider -Force -MaximumVersion 17.03
+Install-Package -Name docker -ProviderName DockerProvider -Force -RequiredVersion 17.06.2-ee-5
 ...
 Name                           Version          Source           Summary
 ----                           -------          ------           -------


### PR DESCRIPTION
If your wanting to installed a specific version of Docker EE on Windows 2016 the -RequiredVersion flag works better than the `MaximumVersion`,`MinimumVersion`.


### Problem description
I was trying to install a specific version of Docker EE on Windows 2016 using the -MaximumVersion flag below.

**Install-Package -Name docker -ProviderName DockerProvider -Force -MaximumVersion 17.06.2-ee-5**

Results - Instead of EE-5 being installed, 17.06.1-ee-1-rc4 was installed
Docker                         17.06.1-ee-1-rc4 Docker           Docker for Windows Server 2016


### Proposed changes
To install a specific version it is better to use the -RequiredVersion flag
 Add '-RequiredVersion' flag in documentation under "Install a specific version" section

https://docs.docker.com/engine/installation/windows/docker-ee/#use-a-script-to-install-docker-ee

