### PR TITLE
Pointing wrong URI to prometheus alert

### DIFF
--- a/engine/admin/prometheus.md
+++ b/engine/admin/prometheus.md
@@ -276,4 +276,4 @@ level.
 ## Next steps
 
 - Read the [Prometheus documentation](https://prometheus.io/docs/introduction/overview/){: target="_blank" class="_" }
-- Set up some [alerts](https://prometheus.io/docs/alerting/rules/){: target="_blank" class="_" }
+- Set up some [alerts](https://prometheus.io/docs/alerting/overview/){: target="_blank" class="_" }


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
It seems to be pointing wrong or legacy URI(https://prometheus.io/docs/alerting/rules/)
The [URI](https://prometheus.io/docs/alerting/rules/) returns "Page Not found".
I have found an alternative URI(https://prometheus.io/docs/alerting/overview/) for Prometheus alert.

I just exchange 'https://prometheus.io/docs/alerting/rules/' to 'https://prometheus.io/docs/alerting/overview/'

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
