### PR TITLE
Updated CLI command for telemetry.md

### DIFF
--- a/enterprise/telemetry.md
+++ b/enterprise/telemetry.md
@@ -22,18 +22,26 @@ either using the Docker CLI or using Universal Control Plane.
 
 ### Use the Docker CLI
 
-To disable the telemetry plugin, use the `docker plugin disable` command:
+To disable the telemetry plugin, use the `docker plugin disable` with either the plugin NAME or ID:
 
 ```bash
-$ docker plugin disable telemetry
+$ docker plugin ls
+ID                  NAME                                           [..]
+114dbeaa400c        docker/telemetry:1.0.0.linux-x86_64-stable     [..]
+
+$ docker plugin disable docker/telemetry:1.0.0.linux-x86_64-stable
 ```
 
 This command must be run on each Docker host.
 
-To re-enable the telemetry plugin, you can use `docker plugin enable`.
+To re-enable the telemetry plugin, you can use `docker plugin enable` with either the plugin NAME or ID:
 
 ```bash
-$ docker plugin enable telemetry
+$ docker plugin ls
+ID                  NAME                                           [..]
+114dbeaa400c        docker/telemetry:1.0.0.linux-x86_64-stable     [..]
+
+$ docker plugin enable docker/telemetry:1.0.0.linux-x86_64-stable
 ```
 
 ### Use Universal Control Plane


### PR DESCRIPTION
Using `docker plugin enable telemetry` or `docker plugin enable telemetry` throws an error-message. Either the full plugin name or ID needs to be supplied:
* `docker plugin enable docker/telemetry:1.0.0.linux-x86_64-stable`
* `docker plugin enable 114dbeaa400c`

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Update the commands to reflect how-to resolve the full plugin name or ID:

```bash
$ docker plugin ls
 ID                  NAME                                           [..]
 114dbeaa400c        docker/telemetry:1.0.0.linux-x86_64-stable     [..]
 
 $ docker plugin disable docker/telemetry:1.0.0.linux-x86_64-stable
```

.. and the same for enabling the plugin

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
