### PR TITLE
Fix typos in https://docs.docker.com/get-started/part4/

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -224,7 +224,7 @@ like `myvm1` execute Docker commands; workers are just for capacity.
 
 ### Configure a `docker-machine` shell to the swarm manager
 
-So far, you've been wrapping Docker commmands in `docker-machine ssh` to talk to
+So far, you've been wrapping Docker commands in `docker-machine ssh` to talk to
 the VMs. Another option is to run `docker-machine env <machine>` to get
 and run a command that configures your current shell to talk to the Docker
 daemon on the VM. This method works better for the next step because it allows


### PR DESCRIPTION
### Proposed changes

Today I read this article: https://docs.docker.com/get-started/part4/ and notice that there is a typo in ```commands``` text.
![image](https://user-images.githubusercontent.com/20354417/33601844-09b7b306-d9e0-11e7-9869-fb436154fad0.png)

Anyway, thanks for all these awesome articles on https://docs.docker.com.

