### PR TITLE
Remove unimplemented bullet

### DIFF
--- a/docker-hub/official_repos.md
+++ b/docker-hub/official_repos.md
@@ -21,10 +21,6 @@ designed to:
   and provide clear documentation to serve as a reference for other `Dockerfile`
   authors.
 
-* Ensure that security updates are applied in a timely manner. This is
-  particularly important as many Official Repositories are some of the most
-  popular on Docker Hub.
-
 * Provide a channel for software vendors to redistribute up-to-date and
   supported versions of their products. Organization accounts on Docker Hub can
   also serve this purpose, without the careful review or restrictions on what


### PR DESCRIPTION
Since there are "Deprecated" images on docker hub with the "Official Repository" flag, this bullet might should be removed. 

Django was not patched for more than a year: 
"This image is officially deprecated in favor of the standard python image, and will receive no further updates after 2016-12-31 (Dec 31, 2016). Please adjust your usage accordingly"

https://hub.docker.com/r/library/django/

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
