### PR TITLE
dtr: promote current_issues in rethinkcli docs

### DIFF
--- a/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -69,6 +69,10 @@ tool launches an interactive prompt where you can run RethinkDB
 queries such as:
 
 ```none
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
+
 # List all the DBs in RethinkDB
 > r.dbList()
 [ 'dtr2',
@@ -95,10 +99,6 @@ queries such as:
     namespaceAccountID: '924bf131-6213-43fa-a5ed-d73c7ccf392e',
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
-...
-
-# List problems detected within the rethinkdb cluster
-> r.db("rethinkdb").table("current_issues")
 ...
 ```
 

--- a/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -69,6 +69,10 @@ tool launches an interactive prompt where you can run RethinkDB
 queries such as:
 
 ```none
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
+
 # List all the DBs in RethinkDB
 > r.dbList()
 [ 'dtr2',
@@ -95,10 +99,6 @@ queries such as:
     namespaceAccountID: '924bf131-6213-43fa-a5ed-d73c7ccf392e',
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
-...
-
-# List problems detected within the rethinkdb cluster
-> r.db("rethinkdb").table("current_issues")
 ...
 ```
 

--- a/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -69,6 +69,10 @@ tool launches an interactive prompt where you can run RethinkDB
 queries such as:
 
 ```none
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
+
 # List all the DBs in RethinkDB
 > r.dbList()
 [ 'dtr2',
@@ -95,10 +99,6 @@ queries such as:
     namespaceAccountID: '924bf131-6213-43fa-a5ed-d73c7ccf392e',
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
-...
-
-# List problems detected within the rethinkdb cluster
-> r.db("rethinkdb").table("current_issues")
 ...
 ```
 


### PR DESCRIPTION
This section of the docs is about troubleshooting and table quorum is a common
issue so we should make the `current_issues` table most obvious.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>