### PR TITLE
Note about setting ipv4/ipv6 not working in swarm

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1291,6 +1291,7 @@ The corresponding network configuration in the
 `ipam` block with subnet configurations covering each static address. If IPv6
 addressing is desired, the [`enable_ipv6`](#enableipv6) option must be set, and
 you must use a version 2.x Compose file, such as the one below.
+> **Note**: These options do not currently work in docker swarm mode
 
 An example:
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1291,32 +1291,35 @@ The corresponding network configuration in the
 `ipam` block with subnet configurations covering each static address. If IPv6
 addressing is desired, the [`enable_ipv6`](#enableipv6) option must be set, and
 you must use a version 2.x Compose file, such as the one below.
-> **Note**: These options do not currently work in docker swarm mode
+
+> **Note**: These options do not currently work in swarm mode.
 
 An example:
 
-    version: '2.1'
+```yaml
+version: '2.1'
 
-    services:
-      app:
-        image: busybox
-        command: ifconfig
-        networks:
-          app_net:
-            ipv4_address: 172.16.238.10
-            ipv6_address: 2001:3984:3989::10
-
+services:
+  app:
+    image: busybox
+    command: ifconfig
     networks:
       app_net:
-        driver: bridge
-        enable_ipv6: true
-        ipam:
-          driver: default
-          config:
-          -
-            subnet: 172.16.238.0/24
-          -
-            subnet: 2001:3984:3989::/64
+        ipv4_address: 172.16.238.10
+        ipv6_address: 2001:3984:3989::10
+
+networks:
+  app_net:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+      -
+        subnet: 172.16.238.0/24
+      -
+        subnet: 2001:3984:3989::/64
+```
 
 ### pid
 


### PR DESCRIPTION
### Proposed changes

I spent a few hours yesterday working under the assumption that it was possible to set a static IP address for in a swarm, but it turns out it isn't.  Hopefully this will help prevent others from making the same mistake I did.