### PR TITLE
Navigation under "Reference" and "Manuals," Registry warning, "Latest" UCP/DTR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _site/**
 CNAME
 Gemfile.lock
 _samples/library/**
+_kbase/**

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ docker_ee_version: "17.06"
 compose_version: "1.17.0"
 machine_version: "0.13.0"
 distribution_version: "2.6"
+dtr_version: "2.4"
+ucp_version: "2.2"
 
 ucp_versions:
   - version: "2.2"

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -207,6 +207,7 @@ guides:
           title: Overview
         - path: /develop/sdk/examples/
           title: SDK and API examples
+
 - sectiontitle: Configure networking
   section:
   - path: /engine/userguide/networking/
@@ -536,6 +537,7 @@ guides:
     title: Where to chat or get help
   - path: /opensource/doc-style/
     title: Style guide for Docker documentation
+
 - sectiontitle:
   section:
   - path: /docsarchive/
@@ -544,766 +546,733 @@ guides:
     path: /hackathon/
 
 reference:
-- title: Dockerfile reference
-  path: /engine/reference/builder/
-
-- sectiontitle: Daemon CLI (dockerd)
+- sectiontitle: File formats
   section:
-  - title: Stable
-    path: /engine/reference/commandline/dockerd/
-  - title: Edge
-    path: /edge/engine/reference/commandline/dockerd/
+  - title: File formats overview
+    path: /reference/#file-formats
+  - title: Dockerfile reference
+    path: /engine/reference/builder/
+  - title: Compose file reference
+    path: /compose/compose-file/
+    nosync: true
+  - title: Cloud stack file reference
+    path: /docker-cloud/apps/stack-yaml-reference/
+    nosync: true
 
-- sectiontitle: Docker CLI
+- sectiontitle: Command-Line Interfaces (CLIs)
   section:
-  - sectiontitle: Stable
+  - title: CLIs overview
+    path: /reference/#command-line-interfaces-clis
+  - sectiontitle: Docker CLI (docker)
     section:
-    - path: /engine/reference/run/
-      title: Docker run reference
-    - path: /engine/reference/commandline/cli/
-      title: Use the Docker command line
-    - path: /engine/reference/commandline/docker/
-      title: docker (base command)
-    - path: /engine/reference/commandline/attach/
-      title: docker attach
-    - path: /engine/reference/commandline/build/
-      title: docker build
-    - sectiontitle: docker checkpoint *
+    - sectiontitle: Stable
       section:
-      - path: /engine/reference/commandline/checkpoint/
-        title: docker checkpoint
-      - path: /engine/reference/commandline/checkpoint_create/
-        title: docker checkpoint create
-      - path: /engine/reference/commandline/checkpoint_ls/
-        title: docker checkpoint ls
-      - path: /engine/reference/commandline/checkpoint_rm/
-        title: docker checkpoint rm
-    - path: /engine/reference/commandline/commit/
-      title: docker commit
-    - sectiontitle: docker config *
+      - path: /engine/reference/run/
+        title: Docker run reference
+      - path: /engine/reference/commandline/cli/
+        title: Use the Docker command line
+      - path: /engine/reference/commandline/docker/
+        title: docker (base command)
+      - path: /engine/reference/commandline/attach/
+        title: docker attach
+      - path: /engine/reference/commandline/build/
+        title: docker build
+      - sectiontitle: docker checkpoint *
+        section:
+        - path: /engine/reference/commandline/checkpoint/
+          title: docker checkpoint
+        - path: /engine/reference/commandline/checkpoint_create/
+          title: docker checkpoint create
+        - path: /engine/reference/commandline/checkpoint_ls/
+          title: docker checkpoint ls
+        - path: /engine/reference/commandline/checkpoint_rm/
+          title: docker checkpoint rm
+      - path: /engine/reference/commandline/commit/
+        title: docker commit
+      - sectiontitle: docker config *
+        section:
+        - path: /engine/reference/commandline/config/
+          title: docker config
+        - path: /engine/reference/commandline/config_create/
+          title: docker config create
+        - path: /engine/reference/commandline/config_inspect/
+          title: docker config inspect
+        - path: /engine/reference/commandline/config_ls/
+          title: docker config ls
+        - path: /engine/reference/commandline/config_rm/
+          title: docker config rm
+      - sectiontitle: docker container *
+        section:
+        - path: /engine/reference/commandline/container/
+          title: docker container
+        - path: /engine/reference/commandline/container_attach/
+          title: docker container attach
+        - path: /engine/reference/commandline/container_commit/
+          title: docker container commit
+        - path: /engine/reference/commandline/container_cp/
+          title: docker container cp
+        - path: /engine/reference/commandline/container_create/
+          title: docker container create
+        - path: /engine/reference/commandline/container_diff/
+          title: docker container diff
+        - path: /engine/reference/commandline/container_exec/
+          title: docker container exec
+        - path: /engine/reference/commandline/container_export/
+          title: docker container export
+        - path: /engine/reference/commandline/container_inspect/
+          title: docker container inspect
+        - path: /engine/reference/commandline/container_kill/
+          title: docker container kill
+        - path: /engine/reference/commandline/container_logs/
+          title: docker container logs
+        - path: /engine/reference/commandline/container_ls/
+          title: docker container ls
+        - path: /engine/reference/commandline/container_pause/
+          title: docker container pause
+        - path: /engine/reference/commandline/container_port/
+          title: docker container port
+        - path: /engine/reference/commandline/container_prune/
+          title: docker container prune
+        - path: /engine/reference/commandline/container_rename/
+          title: docker container rename
+        - path: /engine/reference/commandline/container_restart/
+          title: docker container restart
+        - path: /engine/reference/commandline/container_rm/
+          title: docker container rm
+        - path: /engine/reference/commandline/container_run/
+          title: docker container run
+        - path: /engine/reference/commandline/container_start/
+          title: docker container start
+        - path: /engine/reference/commandline/container_stats/
+          title: docker container stats
+        - path: /engine/reference/commandline/container_stop/
+          title: docker container stop
+        - path: /engine/reference/commandline/container_top/
+          title: docker container top
+        - path: /engine/reference/commandline/container_unpause/
+          title: docker container unpause
+        - path: /engine/reference/commandline/container_update/
+          title: docker container update
+        - path: /engine/reference/commandline/container_wait/
+          title: docker container wait
+      - path: /engine/reference/commandline/cp/
+        title: docker cp
+      - path: /engine/reference/commandline/create/
+        title: docker create
+      - path: /engine/reference/commandline/deploy/
+        title: docker deploy
+      - path: /engine/reference/commandline/diff/
+        title: docker diff
+      - path: /engine/reference/commandline/events/
+        title: docker events
+      - path: /engine/reference/commandline/exec/
+        title: docker exec
+      - path: /engine/reference/commandline/export/
+        title: docker export
+      - path: /engine/reference/commandline/history/
+        title: docker history
+      - sectiontitle: docker image *
+        section:
+        - path: /engine/reference/commandline/image/
+          title: docker image
+        - path: /engine/reference/commandline/image_build/
+          title: docker image build
+        - path: /engine/reference/commandline/image_history/
+          title: docker image history
+        - path: /engine/reference/commandline/image_import/
+          title: docker image import
+        - path: /engine/reference/commandline/image_inspect/
+          title: docker image inspect
+        - path: /engine/reference/commandline/image_load/
+          title: docker image load
+        - path: /engine/reference/commandline/image_ls/
+          title: docker image ls
+        - path: /engine/reference/commandline/image_prune/
+          title: docker image prune
+        - path: /engine/reference/commandline/image_pull/
+          title: docker image pull
+        - path: /engine/reference/commandline/image_push/
+          title: docker image push
+        - path: /engine/reference/commandline/image_rm/
+          title: docker image rm
+        - path: /engine/reference/commandline/image_save/
+          title: docker image save
+        - path: /engine/reference/commandline/image_tag/
+          title: docker image tag
+      - path: /engine/reference/commandline/images/
+        title: docker images
+      - path: /engine/reference/commandline/import/
+        title: docker import
+      - path: /engine/reference/commandline/info/
+        title: docker info
+      - path: /engine/reference/commandline/inspect/
+        title: docker inspect
+      - path: /engine/reference/commandline/kill/
+        title: docker kill
+      - path: /engine/reference/commandline/load/
+        title: docker load
+      - path: /engine/reference/commandline/login/
+        title: docker login
+      - path: /engine/reference/commandline/logout/
+        title: docker logout
+      - path: /engine/reference/commandline/logs/
+        title: docker logs
+      - sectiontitle: docker network *
+        section:
+        - path: /engine/reference/commandline/network/
+          title: docker network
+        - path: /engine/reference/commandline/network_connect/
+          title: docker network connect
+        - path: /engine/reference/commandline/network_create/
+          title: docker network create
+        - path: /engine/reference/commandline/network_disconnect/
+          title: docker network disconnect
+        - path: /engine/reference/commandline/network_inspect/
+          title: docker network inspect
+        - path: /engine/reference/commandline/network_ls/
+          title: docker network ls
+        - path: /engine/reference/commandline/network_prune/
+          title: docker network prune
+        - path: /engine/reference/commandline/network_rm/
+          title: docker network rm
+      - sectiontitle: docker node *
+        section:
+        - path: /engine/reference/commandline/node/
+          title: docker node
+        - path: /engine/reference/commandline/node_demote/
+          title: docker node demote
+        - path: /engine/reference/commandline/node_inspect/
+          title: docker node inspect
+        - path: /engine/reference/commandline/node_ls/
+          title: docker node ls
+        - path: /engine/reference/commandline/node_promote/
+          title: docker node promote
+        - path: /engine/reference/commandline/node_ps/
+          title: docker node ps
+        - path: /engine/reference/commandline/node_rm/
+          title: docker node rm
+        - path: /engine/reference/commandline/node_update/
+          title: docker node update
+      - path: /engine/reference/commandline/pause/
+        title: docker pause
+      - sectiontitle: docker plugin *
+        section:
+        - path: /engine/reference/commandline/plugin/
+          title: docker plugin
+        - path: /engine/reference/commandline/plugin_create/
+          title: docker plugin create
+        - path: /engine/reference/commandline/plugin_disable/
+          title: docker plugin disable
+        - path: /engine/reference/commandline/plugin_enable/
+          title: docker plugin enable
+        - path: /engine/reference/commandline/plugin_inspect/
+          title: docker plugin inspect
+        - path: /engine/reference/commandline/plugin_install/
+          title: docker plugin install
+        - path: /engine/reference/commandline/plugin_ls/
+          title: docker plugin ls
+        - path: /engine/reference/commandline/plugin_rm/
+          title: docker plugin rm
+        - path: /engine/reference/commandline/plugin_set/
+          title: docker plugin set
+        - path: /engine/reference/commandline/plugin_upgrade/
+          title: docker plugin upgrade
+      - path: /engine/reference/commandline/port/
+        title: docker port
+      - path: /engine/reference/commandline/ps/
+        title: docker ps
+      - path: /engine/reference/commandline/pull/
+        title: docker pull
+      - path: /engine/reference/commandline/push/
+        title: docker push
+      - path: /engine/reference/commandline/rename/
+        title: docker rename
+      - path: /engine/reference/commandline/restart/
+        title: docker restart
+      - path: /engine/reference/commandline/rm/
+        title: docker rm
+      - path: /engine/reference/commandline/rmi/
+        title: docker rmi
+      - path: /engine/reference/commandline/run/
+        title: docker run
+      - path: /engine/reference/commandline/save/
+        title: docker save
+      - path: /engine/reference/commandline/search/
+        title: docker search
+      - sectiontitle: docker secret *
+        section:
+        - path: /engine/reference/commandline/secret/
+          title: docker secret
+        - path: /engine/reference/commandline/secret_create/
+          title: docker secret create
+        - path: /engine/reference/commandline/secret_inspect/
+          title: docker secret inspect
+        - path: /engine/reference/commandline/secret_ls/
+          title: docker secret ls
+        - path: /engine/reference/commandline/secret_rm/
+          title: docker secret rm
+      - sectiontitle: docker service *
+        section:
+        - path: /engine/reference/commandline/service/
+          title: docker service
+        - path: /engine/reference/commandline/service_create/
+          title: docker service create
+        - path: /engine/reference/commandline/service_inspect/
+          title: docker service inspect
+        - path: /engine/reference/commandline/service_logs/
+          title: docker service logs
+        - path: /engine/reference/commandline/service_ls/
+          title: docker service ls
+        - path: /engine/reference/commandline/service_ps/
+          title: docker service ps
+        - path: /engine/reference/commandline/service_rollback/
+          title: docker service rollback
+        - path: /engine/reference/commandline/service_rm/
+          title: docker service rm
+        - path: /engine/reference/commandline/service_scale/
+          title: docker service scale
+        - path: /engine/reference/commandline/service_update/
+          title: docker service update
+      - sectiontitle: docker stack *
+        section:
+        - path: /engine/reference/commandline/stack/
+          title: docker stack
+        - path: /engine/reference/commandline/stack_deploy/
+          title: docker stack deploy
+        - path: /engine/reference/commandline/stack_ps/
+          title: docker stack ps
+        - path: /engine/reference/commandline/stack_rm/
+          title: docker stack rm
+        - path: /engine/reference/commandline/stack_services/
+          title: docker stack services
+      - path: /engine/reference/commandline/start/
+        title: docker start
+      - path: /engine/reference/commandline/stats/
+        title: docker stats
+      - path: /engine/reference/commandline/stop/
+        title: docker stop
+      - sectiontitle: docker swarm *
+        section:
+        - path: /engine/reference/commandline/swarm/
+          title: docker swarm
+        - path: /engine/reference/commandline/swarm_ca/
+          title: docker swarm ca
+        - path: /engine/reference/commandline/swarm_init/
+          title: docker swarm init
+        - path: /engine/reference/commandline/swarm_join-token/
+          title: docker swarm join-token
+        - path: /engine/reference/commandline/swarm_join/
+          title: docker swarm join
+        - path: /engine/reference/commandline/swarm_leave/
+          title: docker swarm leave
+        - path: /engine/reference/commandline/swarm_unlock-key/
+          title: docker swarm unlock-key
+        - path: /engine/reference/commandline/swarm_unlock/
+          title: docker swarm unlock
+        - path: /engine/reference/commandline/swarm_update/
+          title: docker swarm update
+      - sectiontitle: docker system *
+        section:
+        - path: /engine/reference/commandline/system/
+          title: docker system
+        - path: /engine/reference/commandline/system_df/
+          title: docker system df
+        - path: /engine/reference/commandline/system_events/
+          title: docker system events
+        - path: /engine/reference/commandline/system_info/
+          title: docker system info
+        - path: /engine/reference/commandline/system_prune/
+          title: docker system prune
+      - path: /engine/reference/commandline/tag/
+        title: docker tag
+      - path: /engine/reference/commandline/top/
+        title: docker top
+      - path: /engine/reference/commandline/unpause/
+        title: docker unpause
+      - path: /engine/reference/commandline/update/
+        title: docker update
+      - path: /engine/reference/commandline/version/
+        title: docker version
+      - sectiontitle: docker volume *
+        section:
+        - path: /engine/reference/commandline/volume_create/
+          title: docker volume create
+        - path: /engine/reference/commandline/volume_inspect/
+          title: docker volume inspect
+        - path: /engine/reference/commandline/volume_ls/
+          title: docker volume ls
+        - path: /engine/reference/commandline/volume_prune/
+          title: docker volume prune
+        - path: /engine/reference/commandline/volume_rm/
+          title: docker volume rm
+      - path: /engine/reference/commandline/wait/
+        title: docker wait
+    - sectiontitle: Edge
       section:
-      - path: /engine/reference/commandline/config/
-        title: docker config
-      - path: /engine/reference/commandline/config_create/
-        title: docker config create
-      - path: /engine/reference/commandline/config_inspect/
-        title: docker config inspect
-      - path: /engine/reference/commandline/config_ls/
-        title: docker config ls
-      - path: /engine/reference/commandline/config_rm/
-        title: docker config rm
-    - sectiontitle: docker container *
-      section:
-      - path: /engine/reference/commandline/container/
-        title: docker container
-      - path: /engine/reference/commandline/container_attach/
-        title: docker container attach
-      - path: /engine/reference/commandline/container_commit/
-        title: docker container commit
-      - path: /engine/reference/commandline/container_cp/
-        title: docker container cp
-      - path: /engine/reference/commandline/container_create/
-        title: docker container create
-      - path: /engine/reference/commandline/container_diff/
-        title: docker container diff
-      - path: /engine/reference/commandline/container_exec/
-        title: docker container exec
-      - path: /engine/reference/commandline/container_export/
-        title: docker container export
-      - path: /engine/reference/commandline/container_inspect/
-        title: docker container inspect
-      - path: /engine/reference/commandline/container_kill/
-        title: docker container kill
-      - path: /engine/reference/commandline/container_logs/
-        title: docker container logs
-      - path: /engine/reference/commandline/container_ls/
-        title: docker container ls
-      - path: /engine/reference/commandline/container_pause/
-        title: docker container pause
-      - path: /engine/reference/commandline/container_port/
-        title: docker container port
-      - path: /engine/reference/commandline/container_prune/
-        title: docker container prune
-      - path: /engine/reference/commandline/container_rename/
-        title: docker container rename
-      - path: /engine/reference/commandline/container_restart/
-        title: docker container restart
-      - path: /engine/reference/commandline/container_rm/
-        title: docker container rm
-      - path: /engine/reference/commandline/container_run/
-        title: docker container run
-      - path: /engine/reference/commandline/container_start/
-        title: docker container start
-      - path: /engine/reference/commandline/container_stats/
-        title: docker container stats
-      - path: /engine/reference/commandline/container_stop/
-        title: docker container stop
-      - path: /engine/reference/commandline/container_top/
-        title: docker container top
-      - path: /engine/reference/commandline/container_unpause/
-        title: docker container unpause
-      - path: /engine/reference/commandline/container_update/
-        title: docker container update
-      - path: /engine/reference/commandline/container_wait/
-        title: docker container wait
-    - path: /engine/reference/commandline/cp/
-      title: docker cp
-    - path: /engine/reference/commandline/create/
-      title: docker create
-    - path: /engine/reference/commandline/deploy/
-      title: docker deploy
-    - path: /engine/reference/commandline/diff/
-      title: docker diff
-    - path: /engine/reference/commandline/events/
-      title: docker events
-    - path: /engine/reference/commandline/exec/
-      title: docker exec
-    - path: /engine/reference/commandline/export/
-      title: docker export
-    - path: /engine/reference/commandline/history/
-      title: docker history
-    - sectiontitle: docker image *
-      section:
-      - path: /engine/reference/commandline/image/
-        title: docker image
-      - path: /engine/reference/commandline/image_build/
-        title: docker image build
-      - path: /engine/reference/commandline/image_history/
-        title: docker image history
-      - path: /engine/reference/commandline/image_import/
-        title: docker image import
-      - path: /engine/reference/commandline/image_inspect/
-        title: docker image inspect
-      - path: /engine/reference/commandline/image_load/
-        title: docker image load
-      - path: /engine/reference/commandline/image_ls/
-        title: docker image ls
-      - path: /engine/reference/commandline/image_prune/
-        title: docker image prune
-      - path: /engine/reference/commandline/image_pull/
-        title: docker image pull
-      - path: /engine/reference/commandline/image_push/
-        title: docker image push
-      - path: /engine/reference/commandline/image_rm/
-        title: docker image rm
-      - path: /engine/reference/commandline/image_save/
-        title: docker image save
-      - path: /engine/reference/commandline/image_tag/
-        title: docker image tag
-    - path: /engine/reference/commandline/images/
-      title: docker images
-    - path: /engine/reference/commandline/import/
-      title: docker import
-    - path: /engine/reference/commandline/info/
-      title: docker info
-    - path: /engine/reference/commandline/inspect/
-      title: docker inspect
-    - path: /engine/reference/commandline/kill/
-      title: docker kill
-    - path: /engine/reference/commandline/load/
-      title: docker load
-    - path: /engine/reference/commandline/login/
-      title: docker login
-    - path: /engine/reference/commandline/logout/
-      title: docker logout
-    - path: /engine/reference/commandline/logs/
-      title: docker logs
-    - sectiontitle: docker network *
-      section:
-      - path: /engine/reference/commandline/network/
-        title: docker network
-      - path: /engine/reference/commandline/network_connect/
-        title: docker network connect
-      - path: /engine/reference/commandline/network_create/
-        title: docker network create
-      - path: /engine/reference/commandline/network_disconnect/
-        title: docker network disconnect
-      - path: /engine/reference/commandline/network_inspect/
-        title: docker network inspect
-      - path: /engine/reference/commandline/network_ls/
-        title: docker network ls
-      - path: /engine/reference/commandline/network_prune/
-        title: docker network prune
-      - path: /engine/reference/commandline/network_rm/
-        title: docker network rm
-    - sectiontitle: docker node *
-      section:
-      - path: /engine/reference/commandline/node/
-        title: docker node
-      - path: /engine/reference/commandline/node_demote/
-        title: docker node demote
-      - path: /engine/reference/commandline/node_inspect/
-        title: docker node inspect
-      - path: /engine/reference/commandline/node_ls/
-        title: docker node ls
-      - path: /engine/reference/commandline/node_promote/
-        title: docker node promote
-      - path: /engine/reference/commandline/node_ps/
-        title: docker node ps
-      - path: /engine/reference/commandline/node_rm/
-        title: docker node rm
-      - path: /engine/reference/commandline/node_update/
-        title: docker node update
-    - path: /engine/reference/commandline/pause/
-      title: docker pause
-    - sectiontitle: docker plugin *
-      section:
-      - path: /engine/reference/commandline/plugin/
-        title: docker plugin
-      - path: /engine/reference/commandline/plugin_create/
-        title: docker plugin create
-      - path: /engine/reference/commandline/plugin_disable/
-        title: docker plugin disable
-      - path: /engine/reference/commandline/plugin_enable/
-        title: docker plugin enable
-      - path: /engine/reference/commandline/plugin_inspect/
-        title: docker plugin inspect
-      - path: /engine/reference/commandline/plugin_install/
-        title: docker plugin install
-      - path: /engine/reference/commandline/plugin_ls/
-        title: docker plugin ls
-      - path: /engine/reference/commandline/plugin_rm/
-        title: docker plugin rm
-      - path: /engine/reference/commandline/plugin_set/
-        title: docker plugin set
-      - path: /engine/reference/commandline/plugin_upgrade/
-        title: docker plugin upgrade
-    - path: /engine/reference/commandline/port/
-      title: docker port
-    - path: /engine/reference/commandline/ps/
-      title: docker ps
-    - path: /engine/reference/commandline/pull/
-      title: docker pull
-    - path: /engine/reference/commandline/push/
-      title: docker push
-    - path: /engine/reference/commandline/rename/
-      title: docker rename
-    - path: /engine/reference/commandline/restart/
-      title: docker restart
-    - path: /engine/reference/commandline/rm/
-      title: docker rm
-    - path: /engine/reference/commandline/rmi/
-      title: docker rmi
-    - path: /engine/reference/commandline/run/
-      title: docker run
-    - path: /engine/reference/commandline/save/
-      title: docker save
-    - path: /engine/reference/commandline/search/
-      title: docker search
-    - sectiontitle: docker secret *
-      section:
-      - path: /engine/reference/commandline/secret/
-        title: docker secret
-      - path: /engine/reference/commandline/secret_create/
-        title: docker secret create
-      - path: /engine/reference/commandline/secret_inspect/
-        title: docker secret inspect
-      - path: /engine/reference/commandline/secret_ls/
-        title: docker secret ls
-      - path: /engine/reference/commandline/secret_rm/
-        title: docker secret rm
-    - sectiontitle: docker service *
-      section:
-      - path: /engine/reference/commandline/service/
-        title: docker service
-      - path: /engine/reference/commandline/service_create/
-        title: docker service create
-      - path: /engine/reference/commandline/service_inspect/
-        title: docker service inspect
-      - path: /engine/reference/commandline/service_logs/
-        title: docker service logs
-      - path: /engine/reference/commandline/service_ls/
-        title: docker service ls
-      - path: /engine/reference/commandline/service_ps/
-        title: docker service ps
-      - path: /engine/reference/commandline/service_rollback/
-        title: docker service rollback
-      - path: /engine/reference/commandline/service_rm/
-        title: docker service rm
-      - path: /engine/reference/commandline/service_scale/
-        title: docker service scale
-      - path: /engine/reference/commandline/service_update/
-        title: docker service update
-    - sectiontitle: docker stack *
-      section:
-      - path: /engine/reference/commandline/stack/
-        title: docker stack
-      - path: /engine/reference/commandline/stack_deploy/
-        title: docker stack deploy
-      - path: /engine/reference/commandline/stack_ps/
-        title: docker stack ps
-      - path: /engine/reference/commandline/stack_rm/
-        title: docker stack rm
-      - path: /engine/reference/commandline/stack_services/
-        title: docker stack services
-    - path: /engine/reference/commandline/start/
-      title: docker start
-    - path: /engine/reference/commandline/stats/
-      title: docker stats
-    - path: /engine/reference/commandline/stop/
-      title: docker stop
-    - sectiontitle: docker swarm *
-      section:
-      - path: /engine/reference/commandline/swarm/
-        title: docker swarm
-      - path: /engine/reference/commandline/swarm_ca/
-        title: docker swarm ca
-      - path: /engine/reference/commandline/swarm_init/
-        title: docker swarm init
-      - path: /engine/reference/commandline/swarm_join-token/
-        title: docker swarm join-token
-      - path: /engine/reference/commandline/swarm_join/
-        title: docker swarm join
-      - path: /engine/reference/commandline/swarm_leave/
-        title: docker swarm leave
-      - path: /engine/reference/commandline/swarm_unlock-key/
-        title: docker swarm unlock-key
-      - path: /engine/reference/commandline/swarm_unlock/
-        title: docker swarm unlock
-      - path: /engine/reference/commandline/swarm_update/
-        title: docker swarm update
-    - sectiontitle: docker system *
-      section:
-      - path: /engine/reference/commandline/system/
-        title: docker system
-      - path: /engine/reference/commandline/system_df/
-        title: docker system df
-      - path: /engine/reference/commandline/system_events/
-        title: docker system events
-      - path: /engine/reference/commandline/system_info/
-        title: docker system info
-      - path: /engine/reference/commandline/system_prune/
-        title: docker system prune
-    - path: /engine/reference/commandline/tag/
-      title: docker tag
-    - path: /engine/reference/commandline/top/
-      title: docker top
-    - path: /engine/reference/commandline/unpause/
-      title: docker unpause
-    - path: /engine/reference/commandline/update/
-      title: docker update
-    - path: /engine/reference/commandline/version/
-      title: docker version
-    - sectiontitle: docker volume *
-      section:
-      - path: /engine/reference/commandline/volume_create/
-        title: docker volume create
-      - path: /engine/reference/commandline/volume_inspect/
-        title: docker volume inspect
-      - path: /engine/reference/commandline/volume_ls/
-        title: docker volume ls
-      - path: /engine/reference/commandline/volume_prune/
-        title: docker volume prune
-      - path: /engine/reference/commandline/volume_rm/
-        title: docker volume rm
-    - path: /engine/reference/commandline/wait/
-      title: docker wait
-  - sectiontitle: Edge
+      - path: /edge/engine/reference/run/
+        title: Docker run reference
+      - path: /edge/engine/reference/commandline/cli/
+        title: Use the Docker command line
+      - path: /edge/engine/reference/commandline/docker/
+        title: docker (base command)
+      - path: /edge/engine/reference/commandline/attach/
+        title: docker attach
+      - path: /edge/engine/reference/commandline/build/
+        title: docker build
+      - sectiontitle: docker checkpoint *
+        section:
+        - path: /edge/engine/reference/commandline/checkpoint/
+          title: docker checkpoint
+        - path: /edge/engine/reference/commandline/checkpoint_create/
+          title: docker checkpoint create
+        - path: /edge/engine/reference/commandline/checkpoint_create/
+          title: docker checkpoint create
+        - path: /edge/engine/reference/commandline/checkpoint_ls/
+          title: docker checkpoint ls
+        - path: /edge/engine/reference/commandline/checkpoint_rm/
+          title: docker checkpoint rm
+      - path: /edge/engine/reference/commandline/commit/
+        title: docker commit
+      - sectiontitle: docker config *
+        section:
+        - path: /edge/engine/reference/commandline/config/
+          title: docker config
+        - path: /edge/engine/reference/commandline/config_create/
+          title: docker config create
+        - path: /edge/engine/reference/commandline/config_inspect/
+          title: docker config inspect
+        - path: /edge/engine/reference/commandline/config_ls/
+          title: docker config ls
+        - path: /edge/engine/reference/commandline/config_rm/
+          title: docker config rm
+      - sectiontitle: docker container *
+        section:
+        - path: /edge/engine/reference/commandline/container/
+          title: docker container
+        - path: /edge/engine/reference/commandline/container_attach/
+          title: docker container attach
+        - path: /edge/engine/reference/commandline/container_commit/
+          title: docker container commit
+        - path: /edge/engine/reference/commandline/container_cp/
+          title: docker container cp
+        - path: /edge/engine/reference/commandline/container_create/
+          title: docker container create
+        - path: /edge/engine/reference/commandline/container_diff/
+          title: docker container diff
+        - path: /edge/engine/reference/commandline/container_exec/
+          title: docker container exec
+        - path: /edge/engine/reference/commandline/container_export/
+          title: docker container export
+        - path: /edge/engine/reference/commandline/container_inspect/
+          title: docker container inspect
+        - path: /edge/engine/reference/commandline/container_kill/
+          title: docker container kill
+        - path: /edge/engine/reference/commandline/container_logs/
+          title: docker container logs
+        - path: /edge/engine/reference/commandline/container_ls/
+          title: docker container ls
+        - path: /edge/engine/reference/commandline/container_pause/
+          title: docker container pause
+        - path: /edge/engine/reference/commandline/container_port/
+          title: docker container port
+        - path: /edge/engine/reference/commandline/container_prune/
+          title: docker container prune
+        - path: /edge/engine/reference/commandline/container_rename/
+          title: docker container rename
+        - path: /edge/engine/reference/commandline/container_restart/
+          title: docker container restart
+        - path: /edge/engine/reference/commandline/container_rm/
+          title: docker container rm
+        - path: /edge/engine/reference/commandline/container_run/
+          title: docker container run
+        - path: /edge/engine/reference/commandline/container_start/
+          title: docker container start
+        - path: /edge/engine/reference/commandline/container_stats/
+          title: docker container stats
+        - path: /edge/engine/reference/commandline/container_stop/
+          title: docker container stop
+        - path: /edge/engine/reference/commandline/container_top/
+          title: docker container top
+        - path: /edge/engine/reference/commandline/container_unpause/
+          title: docker container unpause
+        - path: /edge/engine/reference/commandline/container_update/
+          title: docker container update
+        - path: /edge/engine/reference/commandline/container_wait/
+          title: docker container wait
+      - path: /edge/engine/reference/commandline/cp/
+        title: docker cp
+      - path: /edge/engine/reference/commandline/create/
+        title: docker create
+      - path: /edge/engine/reference/commandline/deploy/
+        title: docker deploy
+      - path: /edge/engine/reference/commandline/diff/
+        title: docker diff
+      - path: /edge/engine/reference/commandline/events/
+        title: docker events
+      - path: /edge/engine/reference/commandline/exec/
+        title: docker exec
+      - path: /edge/engine/reference/commandline/export/
+        title: docker export
+      - path: /edge/engine/reference/commandline/history/
+        title: docker history
+      - sectiontitle: docker image *
+        section:
+        - path: /edge/engine/reference/commandline/image/
+          title: docker image
+        - path: /edge/engine/reference/commandline/image_build/
+          title: docker image build
+        - path: /edge/engine/reference/commandline/image_history/
+          title: docker image history
+        - path: /edge/engine/reference/commandline/image_import/
+          title: docker image import
+        - path: /edge/engine/reference/commandline/image_inspect/
+          title: docker image inspect
+        - path: /edge/engine/reference/commandline/image_load/
+          title: docker image load
+        - path: /edge/engine/reference/commandline/image_ls/
+          title: docker image ls
+        - path: /edge/engine/reference/commandline/image_prune/
+          title: docker image prune
+        - path: /edge/engine/reference/commandline/image_pull/
+          title: docker image pull
+        - path: /edge/engine/reference/commandline/image_push/
+          title: docker image push
+        - path: /edge/engine/reference/commandline/image_rm/
+          title: docker image rm
+        - path: /edge/engine/reference/commandline/image_save/
+          title: docker image save
+        - path: /edge/engine/reference/commandline/image_tag/
+          title: docker image tag
+      - path: /edge/engine/reference/commandline/images/
+        title: docker images
+      - path: /edge/engine/reference/commandline/import/
+        title: docker import
+      - path: /edge/engine/reference/commandline/info/
+        title: docker info
+      - path: /edge/engine/reference/commandline/inspect/
+        title: docker inspect
+      - path: /edge/engine/reference/commandline/kill/
+        title: docker kill
+      - path: /edge/engine/reference/commandline/load/
+        title: docker load
+      - path: /edge/engine/reference/commandline/login/
+        title: docker login
+      - path: /edge/engine/reference/commandline/logout/
+        title: docker logout
+      - path: /edge/engine/reference/commandline/logs/
+        title: docker logs
+      - sectiontitle: docker network *
+        section:
+        - path: /edge/engine/reference/commandline/network/
+          title: docker network
+        - path: /edge/engine/reference/commandline/network_connect/
+          title: docker network connect
+        - path: /edge/engine/reference/commandline/network_create/
+          title: docker network create
+        - path: /edge/engine/reference/commandline/network_disconnect/
+          title: docker network disconnect
+        - path: /edge/engine/reference/commandline/network_inspect/
+          title: docker network inspect
+        - path: /edge/engine/reference/commandline/network_ls/
+          title: docker network ls
+        - path: /edge/engine/reference/commandline/network_prune/
+          title: docker network prune
+        - path: /edge/engine/reference/commandline/network_rm/
+          title: docker network rm
+      - sectiontitle: docker node *
+        section:
+        - path: /edge/engine/reference/commandline/node/
+          title: docker node
+        - path: /edge/engine/reference/commandline/node_demote/
+          title: docker node demote
+        - path: /edge/engine/reference/commandline/node_inspect/
+          title: docker node inspect
+        - path: /edge/engine/reference/commandline/node_ls/
+          title: docker node ls
+        - path: /edge/engine/reference/commandline/node_promote/
+          title: docker node promote
+        - path: /edge/engine/reference/commandline/node_ps/
+          title: docker node ps
+        - path: /edge/engine/reference/commandline/node_rm/
+          title: docker node rm
+        - path: /edge/engine/reference/commandline/node_update/
+          title: docker node update
+      - path: /edge/engine/reference/commandline/pause/
+        title: docker pause
+      - sectiontitle: docker plugin *
+        section:
+        - path: /edge/engine/reference/commandline/plugin/
+          title: docker plugin
+        - path: /edge/engine/reference/commandline/plugin_create/
+          title: docker plugin create
+        - path: /edge/engine/reference/commandline/plugin_disable/
+          title: docker plugin disable
+        - path: /edge/engine/reference/commandline/plugin_enable/
+          title: docker plugin enable
+        - path: /edge/engine/reference/commandline/plugin_inspect/
+          title: docker plugin inspect
+        - path: /edge/engine/reference/commandline/plugin_install/
+          title: docker plugin install
+        - path: /edge/engine/reference/commandline/plugin_ls/
+          title: docker plugin ls
+        - path: /edge/engine/reference/commandline/plugin_rm/
+          title: docker plugin rm
+        - path: /edge/engine/reference/commandline/plugin_set/
+          title: docker plugin set
+        - path: /edge/engine/reference/commandline/plugin_upgrade/
+          title: docker plugin upgrade
+      - path: /edge/engine/reference/commandline/port/
+        title: docker port
+      - path: /edge/engine/reference/commandline/ps/
+        title: docker ps
+      - path: /edge/engine/reference/commandline/pull/
+        title: docker pull
+      - path: /edge/engine/reference/commandline/push/
+        title: docker push
+      - path: /edge/engine/reference/commandline/rename/
+        title: docker rename
+      - path: /edge/engine/reference/commandline/restart/
+        title: docker restart
+      - path: /edge/engine/reference/commandline/rm/
+        title: docker rm
+      - path: /edge/engine/reference/commandline/rmi/
+        title: docker rmi
+      - path: /edge/engine/reference/commandline/run/
+        title: docker run
+      - path: /edge/engine/reference/commandline/save/
+        title: docker save
+      - path: /edge/engine/reference/commandline/search/
+        title: docker search
+      - sectiontitle: docker secret *
+        section:
+        - path: /edge/engine/reference/commandline/secret/
+          title: docker secret
+        - path: /edge/engine/reference/commandline/secret_create/
+          title: docker secret create
+        - path: /edge/engine/reference/commandline/secret_inspect/
+          title: docker secret inspect
+        - path: /edge/engine/reference/commandline/secret_ls/
+          title: docker secret ls
+        - path: /edge/engine/reference/commandline/secret_rm/
+          title: docker secret rm
+      - sectiontitle: docker service *
+        section:
+        - path: /edge/engine/reference/commandline/service/
+          title: docker service
+        - path: /edge/engine/reference/commandline/service_create/
+          title: docker service create
+        - path: /edge/engine/reference/commandline/service_inspect/
+          title: docker service inspect
+        - path: /edge/engine/reference/commandline/service_logs/
+          title: docker service logs
+        - path: /edge/engine/reference/commandline/service_ls/
+          title: docker service ls
+        - path: /edge/engine/reference/commandline/service_ps/
+          title: docker service ps
+        - path: /edge/engine/reference/commandline/service_rollback/
+          title: docker service rollback
+        - path: /edge/engine/reference/commandline/service_rm/
+          title: docker service rm
+        - path: /edge/engine/reference/commandline/service_scale/
+          title: docker service scale
+        - path: /edge/engine/reference/commandline/service_update/
+          title: docker service update
+      - sectiontitle: docker stack *
+        section:
+        - path: /edge/engine/reference/commandline/stack/
+          title: docker stack
+        - path: /edge/engine/reference/commandline/stack_deploy/
+          title: docker stack deploy
+        - path: /edge/engine/reference/commandline/stack_ps/
+          title: docker stack ps
+        - path: /edge/engine/reference/commandline/stack_rm/
+          title: docker stack rm
+        - path: /edge/engine/reference/commandline/stack_services/
+          title: docker stack services
+      - path: /edge/engine/reference/commandline/start/
+        title: docker start
+      - path: /edge/engine/reference/commandline/stats/
+        title: docker stats
+      - path: /edge/engine/reference/commandline/stop/
+        title: docker stop
+      - sectiontitle: docker swarm *
+        section:
+        - path: /edge/engine/reference/commandline/swarm/
+          title: docker swarm
+        - path: /edge/engine/reference/commandline/swarm_ca/
+          title: docker swarm ca
+        - path: /edge/engine/reference/commandline/swarm_init/
+          title: docker swarm init
+        - path: /edge/engine/reference/commandline/swarm_join-token/
+          title: docker swarm join-token
+        - path: /edge/engine/reference/commandline/swarm_join/
+          title: docker swarm join
+        - path: /edge/engine/reference/commandline/swarm_leave/
+          title: docker swarm leave
+        - path: /edge/engine/reference/commandline/swarm_unlock-key/
+          title: docker swarm unlock-key
+        - path: /edge/engine/reference/commandline/swarm_unlock/
+          title: docker swarm unlock
+        - path: /edge/engine/reference/commandline/swarm_update/
+          title: docker swarm update
+      - sectiontitle: docker system *
+        section:
+        - path: /edge/engine/reference/commandline/system/
+          title: docker system
+        - path: /edge/engine/reference/commandline/system_df/
+          title: docker system df
+        - path: /edge/engine/reference/commandline/system_events/
+          title: docker system events
+        - path: /edge/engine/reference/commandline/system_info/
+          title: docker system info
+        - path: /edge/engine/reference/commandline/system_prune/
+          title: docker system prune
+      - path: /edge/engine/reference/commandline/tag/
+        title: docker tag
+      - path: /edge/engine/reference/commandline/top/
+        title: docker top
+      - sectiontitle: docker trust *
+        section:
+        - path: /edge/engine/reference/commandline/trust/
+          title: docker trust
+        - path: /edge/engine/reference/commandline/trust_revoke/
+          title: docker trust revoke
+        - path: /edge/engine/reference/commandline/trust_sign/
+          title: docker trust sign
+        - path: /edge/engine/reference/commandline/trust_view/
+          title: docker trust view
+      - path: /edge/engine/reference/commandline/unpause/
+        title: docker unpause
+      - path: /edge/engine/reference/commandline/update/
+        title: docker update
+      - path: /edge/engine/reference/commandline/version/
+        title: docker version
+      - sectiontitle: docker volume *
+        section:
+        - path: /edge/engine/reference/commandline/volume_create/
+          title: docker volume create
+        - path: /edge/engine/reference/commandline/volume_inspect/
+          title: docker volume inspect
+        - path: /edge/engine/reference/commandline/volume_ls/
+          title: docker volume ls
+        - path: /edge/engine/reference/commandline/volume_prune/
+          title: docker volume prune
+        - path: /edge/engine/reference/commandline/volume_rm/
+          title: docker volume rm
+      - path: /edge/engine/reference/commandline/wait/
+        title: docker wait
+  - sectiontitle: Daemon CLI (dockerd)
     section:
-    - path: /edge/engine/reference/run/
-      title: Docker run reference
-    - path: /edge/engine/reference/commandline/cli/
-      title: Use the Docker command line
-    - path: /edge/engine/reference/commandline/docker/
-      title: docker (base command)
-    - path: /edge/engine/reference/commandline/attach/
-      title: docker attach
-    - path: /edge/engine/reference/commandline/build/
-      title: docker build
-    - sectiontitle: docker checkpoint *
-      section:
-      - path: /edge/engine/reference/commandline/checkpoint/
-        title: docker checkpoint
-      - path: /edge/engine/reference/commandline/checkpoint_create/
-        title: docker checkpoint create
-      - path: /edge/engine/reference/commandline/checkpoint_create/
-        title: docker checkpoint create
-      - path: /edge/engine/reference/commandline/checkpoint_ls/
-        title: docker checkpoint ls
-      - path: /edge/engine/reference/commandline/checkpoint_rm/
-        title: docker checkpoint rm
-    - path: /edge/engine/reference/commandline/commit/
-      title: docker commit
-    - sectiontitle: docker config *
-      section:
-      - path: /edge/engine/reference/commandline/config/
-        title: docker config
-      - path: /edge/engine/reference/commandline/config_create/
-        title: docker config create
-      - path: /edge/engine/reference/commandline/config_inspect/
-        title: docker config inspect
-      - path: /edge/engine/reference/commandline/config_ls/
-        title: docker config ls
-      - path: /edge/engine/reference/commandline/config_rm/
-        title: docker config rm
-    - sectiontitle: docker container *
-      section:
-      - path: /edge/engine/reference/commandline/container/
-        title: docker container
-      - path: /edge/engine/reference/commandline/container_attach/
-        title: docker container attach
-      - path: /edge/engine/reference/commandline/container_commit/
-        title: docker container commit
-      - path: /edge/engine/reference/commandline/container_cp/
-        title: docker container cp
-      - path: /edge/engine/reference/commandline/container_create/
-        title: docker container create
-      - path: /edge/engine/reference/commandline/container_diff/
-        title: docker container diff
-      - path: /edge/engine/reference/commandline/container_exec/
-        title: docker container exec
-      - path: /edge/engine/reference/commandline/container_export/
-        title: docker container export
-      - path: /edge/engine/reference/commandline/container_inspect/
-        title: docker container inspect
-      - path: /edge/engine/reference/commandline/container_kill/
-        title: docker container kill
-      - path: /edge/engine/reference/commandline/container_logs/
-        title: docker container logs
-      - path: /edge/engine/reference/commandline/container_ls/
-        title: docker container ls
-      - path: /edge/engine/reference/commandline/container_pause/
-        title: docker container pause
-      - path: /edge/engine/reference/commandline/container_port/
-        title: docker container port
-      - path: /edge/engine/reference/commandline/container_prune/
-        title: docker container prune
-      - path: /edge/engine/reference/commandline/container_rename/
-        title: docker container rename
-      - path: /edge/engine/reference/commandline/container_restart/
-        title: docker container restart
-      - path: /edge/engine/reference/commandline/container_rm/
-        title: docker container rm
-      - path: /edge/engine/reference/commandline/container_run/
-        title: docker container run
-      - path: /edge/engine/reference/commandline/container_start/
-        title: docker container start
-      - path: /edge/engine/reference/commandline/container_stats/
-        title: docker container stats
-      - path: /edge/engine/reference/commandline/container_stop/
-        title: docker container stop
-      - path: /edge/engine/reference/commandline/container_top/
-        title: docker container top
-      - path: /edge/engine/reference/commandline/container_unpause/
-        title: docker container unpause
-      - path: /edge/engine/reference/commandline/container_update/
-        title: docker container update
-      - path: /edge/engine/reference/commandline/container_wait/
-        title: docker container wait
-    - path: /edge/engine/reference/commandline/cp/
-      title: docker cp
-    - path: /edge/engine/reference/commandline/create/
-      title: docker create
-    - path: /edge/engine/reference/commandline/deploy/
-      title: docker deploy
-    - path: /edge/engine/reference/commandline/diff/
-      title: docker diff
-    - path: /edge/engine/reference/commandline/events/
-      title: docker events
-    - path: /edge/engine/reference/commandline/exec/
-      title: docker exec
-    - path: /edge/engine/reference/commandline/export/
-      title: docker export
-    - path: /edge/engine/reference/commandline/history/
-      title: docker history
-    - sectiontitle: docker image *
-      section:
-      - path: /edge/engine/reference/commandline/image/
-        title: docker image
-      - path: /edge/engine/reference/commandline/image_build/
-        title: docker image build
-      - path: /edge/engine/reference/commandline/image_history/
-        title: docker image history
-      - path: /edge/engine/reference/commandline/image_import/
-        title: docker image import
-      - path: /edge/engine/reference/commandline/image_inspect/
-        title: docker image inspect
-      - path: /edge/engine/reference/commandline/image_load/
-        title: docker image load
-      - path: /edge/engine/reference/commandline/image_ls/
-        title: docker image ls
-      - path: /edge/engine/reference/commandline/image_prune/
-        title: docker image prune
-      - path: /edge/engine/reference/commandline/image_pull/
-        title: docker image pull
-      - path: /edge/engine/reference/commandline/image_push/
-        title: docker image push
-      - path: /edge/engine/reference/commandline/image_rm/
-        title: docker image rm
-      - path: /edge/engine/reference/commandline/image_save/
-        title: docker image save
-      - path: /edge/engine/reference/commandline/image_tag/
-        title: docker image tag
-    - path: /edge/engine/reference/commandline/images/
-      title: docker images
-    - path: /edge/engine/reference/commandline/import/
-      title: docker import
-    - path: /edge/engine/reference/commandline/info/
-      title: docker info
-    - path: /edge/engine/reference/commandline/inspect/
-      title: docker inspect
-    - path: /edge/engine/reference/commandline/kill/
-      title: docker kill
-    - path: /edge/engine/reference/commandline/load/
-      title: docker load
-    - path: /edge/engine/reference/commandline/login/
-      title: docker login
-    - path: /edge/engine/reference/commandline/logout/
-      title: docker logout
-    - path: /edge/engine/reference/commandline/logs/
-      title: docker logs
-    - sectiontitle: docker network *
-      section:
-      - path: /edge/engine/reference/commandline/network/
-        title: docker network
-      - path: /edge/engine/reference/commandline/network_connect/
-        title: docker network connect
-      - path: /edge/engine/reference/commandline/network_create/
-        title: docker network create
-      - path: /edge/engine/reference/commandline/network_disconnect/
-        title: docker network disconnect
-      - path: /edge/engine/reference/commandline/network_inspect/
-        title: docker network inspect
-      - path: /edge/engine/reference/commandline/network_ls/
-        title: docker network ls
-      - path: /edge/engine/reference/commandline/network_prune/
-        title: docker network prune
-      - path: /edge/engine/reference/commandline/network_rm/
-        title: docker network rm
-    - sectiontitle: docker node *
-      section:
-      - path: /edge/engine/reference/commandline/node/
-        title: docker node
-      - path: /edge/engine/reference/commandline/node_demote/
-        title: docker node demote
-      - path: /edge/engine/reference/commandline/node_inspect/
-        title: docker node inspect
-      - path: /edge/engine/reference/commandline/node_ls/
-        title: docker node ls
-      - path: /edge/engine/reference/commandline/node_promote/
-        title: docker node promote
-      - path: /edge/engine/reference/commandline/node_ps/
-        title: docker node ps
-      - path: /edge/engine/reference/commandline/node_rm/
-        title: docker node rm
-      - path: /edge/engine/reference/commandline/node_update/
-        title: docker node update
-    - path: /edge/engine/reference/commandline/pause/
-      title: docker pause
-    - sectiontitle: docker plugin *
-      section:
-      - path: /edge/engine/reference/commandline/plugin/
-        title: docker plugin
-      - path: /edge/engine/reference/commandline/plugin_create/
-        title: docker plugin create
-      - path: /edge/engine/reference/commandline/plugin_disable/
-        title: docker plugin disable
-      - path: /edge/engine/reference/commandline/plugin_enable/
-        title: docker plugin enable
-      - path: /edge/engine/reference/commandline/plugin_inspect/
-        title: docker plugin inspect
-      - path: /edge/engine/reference/commandline/plugin_install/
-        title: docker plugin install
-      - path: /edge/engine/reference/commandline/plugin_ls/
-        title: docker plugin ls
-      - path: /edge/engine/reference/commandline/plugin_rm/
-        title: docker plugin rm
-      - path: /edge/engine/reference/commandline/plugin_set/
-        title: docker plugin set
-      - path: /edge/engine/reference/commandline/plugin_upgrade/
-        title: docker plugin upgrade
-    - path: /edge/engine/reference/commandline/port/
-      title: docker port
-    - path: /edge/engine/reference/commandline/ps/
-      title: docker ps
-    - path: /edge/engine/reference/commandline/pull/
-      title: docker pull
-    - path: /edge/engine/reference/commandline/push/
-      title: docker push
-    - path: /edge/engine/reference/commandline/rename/
-      title: docker rename
-    - path: /edge/engine/reference/commandline/restart/
-      title: docker restart
-    - path: /edge/engine/reference/commandline/rm/
-      title: docker rm
-    - path: /edge/engine/reference/commandline/rmi/
-      title: docker rmi
-    - path: /edge/engine/reference/commandline/run/
-      title: docker run
-    - path: /edge/engine/reference/commandline/save/
-      title: docker save
-    - path: /edge/engine/reference/commandline/search/
-      title: docker search
-    - sectiontitle: docker secret *
-      section:
-      - path: /edge/engine/reference/commandline/secret/
-        title: docker secret
-      - path: /edge/engine/reference/commandline/secret_create/
-        title: docker secret create
-      - path: /edge/engine/reference/commandline/secret_inspect/
-        title: docker secret inspect
-      - path: /edge/engine/reference/commandline/secret_ls/
-        title: docker secret ls
-      - path: /edge/engine/reference/commandline/secret_rm/
-        title: docker secret rm
-    - sectiontitle: docker service *
-      section:
-      - path: /edge/engine/reference/commandline/service/
-        title: docker service
-      - path: /edge/engine/reference/commandline/service_create/
-        title: docker service create
-      - path: /edge/engine/reference/commandline/service_inspect/
-        title: docker service inspect
-      - path: /edge/engine/reference/commandline/service_logs/
-        title: docker service logs
-      - path: /edge/engine/reference/commandline/service_ls/
-        title: docker service ls
-      - path: /edge/engine/reference/commandline/service_ps/
-        title: docker service ps
-      - path: /edge/engine/reference/commandline/service_rollback/
-        title: docker service rollback
-      - path: /edge/engine/reference/commandline/service_rm/
-        title: docker service rm
-      - path: /edge/engine/reference/commandline/service_scale/
-        title: docker service scale
-      - path: /edge/engine/reference/commandline/service_update/
-        title: docker service update
-    - sectiontitle: docker stack *
-      section:
-      - path: /edge/engine/reference/commandline/stack/
-        title: docker stack
-      - path: /edge/engine/reference/commandline/stack_deploy/
-        title: docker stack deploy
-      - path: /edge/engine/reference/commandline/stack_ps/
-        title: docker stack ps
-      - path: /edge/engine/reference/commandline/stack_rm/
-        title: docker stack rm
-      - path: /edge/engine/reference/commandline/stack_services/
-        title: docker stack services
-    - path: /edge/engine/reference/commandline/start/
-      title: docker start
-    - path: /edge/engine/reference/commandline/stats/
-      title: docker stats
-    - path: /edge/engine/reference/commandline/stop/
-      title: docker stop
-    - sectiontitle: docker swarm *
-      section:
-      - path: /edge/engine/reference/commandline/swarm/
-        title: docker swarm
-      - path: /edge/engine/reference/commandline/swarm_ca/
-        title: docker swarm ca
-      - path: /edge/engine/reference/commandline/swarm_init/
-        title: docker swarm init
-      - path: /edge/engine/reference/commandline/swarm_join-token/
-        title: docker swarm join-token
-      - path: /edge/engine/reference/commandline/swarm_join/
-        title: docker swarm join
-      - path: /edge/engine/reference/commandline/swarm_leave/
-        title: docker swarm leave
-      - path: /edge/engine/reference/commandline/swarm_unlock-key/
-        title: docker swarm unlock-key
-      - path: /edge/engine/reference/commandline/swarm_unlock/
-        title: docker swarm unlock
-      - path: /edge/engine/reference/commandline/swarm_update/
-        title: docker swarm update
-    - sectiontitle: docker system *
-      section:
-      - path: /edge/engine/reference/commandline/system/
-        title: docker system
-      - path: /edge/engine/reference/commandline/system_df/
-        title: docker system df
-      - path: /edge/engine/reference/commandline/system_events/
-        title: docker system events
-      - path: /edge/engine/reference/commandline/system_info/
-        title: docker system info
-      - path: /edge/engine/reference/commandline/system_prune/
-        title: docker system prune
-    - path: /edge/engine/reference/commandline/tag/
-      title: docker tag
-    - path: /edge/engine/reference/commandline/top/
-      title: docker top
-    - sectiontitle: docker trust *
-      section:
-      - path: /edge/engine/reference/commandline/trust/
-        title: docker trust
-      - path: /edge/engine/reference/commandline/trust_revoke/
-        title: docker trust revoke
-      - path: /edge/engine/reference/commandline/trust_sign/
-        title: docker trust sign
-      - path: /edge/engine/reference/commandline/trust_view/
-        title: docker trust view
-    - path: /edge/engine/reference/commandline/unpause/
-      title: docker unpause
-    - path: /edge/engine/reference/commandline/update/
-      title: docker update
-    - path: /edge/engine/reference/commandline/version/
-      title: docker version
-    - sectiontitle: docker volume *
-      section:
-      - path: /edge/engine/reference/commandline/volume_create/
-        title: docker volume create
-      - path: /edge/engine/reference/commandline/volume_inspect/
-        title: docker volume inspect
-      - path: /edge/engine/reference/commandline/volume_ls/
-        title: docker volume ls
-      - path: /edge/engine/reference/commandline/volume_prune/
-        title: docker volume prune
-      - path: /edge/engine/reference/commandline/volume_rm/
-        title: docker volume rm
-    - path: /edge/engine/reference/commandline/wait/
-      title: docker wait
-
-- sectiontitle: Docker Engine API
-  section:
-  - path: /engine/api/
-    title: Overview
-  - path: /engine/api/get-started/
-    title: Get started
-  - path: /engine/api/sdks/
-    title: SDKs
-  - path: /engine/api/latest/
-    title: v{{ site.latest_stable_docker_engine_api_version }} reference (latest stable)
-  - sectiontitle: API reference by version
-    section:
-    - path: /engine/api/version-history/
-      title: Version history overview
-    - path: /engine/api/v1.33/
-      title: v1.33 reference
-    - path: /engine/api/v1.32/
-      title: v1.32 Reference
-    - path: /engine/api/v1.31/
-      title: v1.31 Reference
-    - path: /engine/api/v1.30/
-      title: v1.30 Reference
-    - path: /engine/api/v1.29/
-      title: v1.29 Reference
-    - path: /engine/api/v1.28/
-      title: v1.28 reference
-    - path: /engine/api/v1.27/
-      title: v1.27 reference
-    - path: /engine/api/v1.26/
-      title: v1.26 reference
-    - path: /engine/api/v1.25/
-      title: v1.25 reference
-    - path: /engine/api/v1.24/
-      title: v1.24 reference
-    - path: /engine/api/v1.23/
-      title: v1.23 reference
-    - path: /engine/api/v1.22/
-      title: v1.22 reference
-    - path: /engine/api/v1.21/
-      title: v1.21 reference
-    - path: /engine/api/v1.20/
-      title: v1.20 reference
-    - path: /engine/api/v1.19/
-      title: v1.19 reference
-    - path: /engine/api/v1.18/
-      title: v1.18 reference
-
-- sectiontitle: Docker Enterprise Edition references
-  section:
-  - title: Trusted Registry API
-    path: /datacenter/dtr/2.4/reference/api/
+    - title: Daemon CLI (dockerd) - Stable
+      path: /engine/reference/commandline/dockerd/
+    - title: Daemon CLI (dockerd) - Edge
+      path: /edge/engine/reference/commandline/dockerd/
+  - title: Machine (docker-machine) CLI
+    path: /machine/reference/
+    nosync: true
+  - title: Compose (docker-compose) CLI
+    path: /compose/reference/overview/
+    nosync: true
   - title: Trusted Registry CLI
     path: /datacenter/dtr/2.4/reference/cli/
     nosync: true
@@ -1311,16 +1280,79 @@ reference:
     path: /datacenter/ucp/2.2/reference/cli/
     nosync: true
 
-- sectiontitle: Docker Cloud references
+- sectiontitle: Application Programming Interfaces (APIs)
   section:
+  - title: APIs overview
+    path: /reference/#application-programming-interfaces-apis
+  - title: File formats overview
+    path: /reference/#file-formats
+  - sectiontitle: Docker Engine API
+    section:
+    - path: /engine/api/
+      title: Overview
+    - path: /engine/api/get-started/
+      title: Get started
+    - path: /engine/api/sdks/
+      title: SDKs
+    - path: /engine/api/latest/
+      title: v{{ site.latest_stable_docker_engine_api_version }} reference (latest stable)
+    - sectiontitle: API reference by version
+      section:
+      - path: /engine/api/version-history/
+        title: Version history overview
+      - path: /engine/api/v1.33/
+        title: v1.33 reference
+      - path: /engine/api/v1.32/
+        title: v1.32 Reference
+      - path: /engine/api/v1.31/
+        title: v1.31 Reference
+      - path: /engine/api/v1.30/
+        title: v1.30 Reference
+      - path: /engine/api/v1.29/
+        title: v1.29 Reference
+      - path: /engine/api/v1.28/
+        title: v1.28 reference
+      - path: /engine/api/v1.27/
+        title: v1.27 reference
+      - path: /engine/api/v1.26/
+        title: v1.26 reference
+      - path: /engine/api/v1.25/
+        title: v1.25 reference
+      - path: /engine/api/v1.24/
+        title: v1.24 reference
+      - path: /engine/api/v1.23/
+        title: v1.23 reference
+      - path: /engine/api/v1.22/
+        title: v1.22 reference
+      - path: /engine/api/v1.21/
+        title: v1.21 reference
+      - path: /engine/api/v1.20/
+        title: v1.20 reference
+      - path: /engine/api/v1.19/
+        title: v1.19 reference
+      - path: /engine/api/v1.18/
+        title: v1.18 reference
+  - title: Trusted Registry API
+    path: /datacenter/dtr/2.4/reference/api/
+  - title: Registry API
+    path: /registry/spec/api/
+    nosync: true
   - title: Cloud API
     path: /apidocs/docker-cloud/
     nosync: true
-  - title: Cloud stack file reference
-    path: /docker-cloud/apps/stack-yaml-reference/
-    nosync: true
 
-- sectiontitle: Compliance control reference
+- sectiontitle: Drivers and specifications
+  section:
+  - title: Image specification
+    path: /registry/spec/manifest-v2-2/
+  - title: Machine drivers
+    path: /machine/drivers/os-base/
+  - title: Registry token authentication
+    path: /registry/spec/auth/
+  - title: Registry storage drivers
+    path: /registry/storage-drivers/
+
+- sectiontitle: Compliance control references
   section:
   - sectiontitle: NIST 800-53
     section:
@@ -1363,22 +1395,8 @@ reference:
     - path: /compliance/reference/800-53/sa/
       title: System and services acquisition
 
-- sectiontitle: Compose references
-  section:
-  - title: Compose file reference
-    path: /compose/compose-file/
-    nosync: true
-  - title: Compose (docker-compose) CLI
-    path: /compose/reference/overview/
-    nosync: true
 
-- title: Machine (docker-machine) CLI
-  path: /machine/reference/
-  nosync: true
 
-- title: Registry API
-  path: /registry/spec/api/
-  nosync: true
 
 samples:
 - path: /samples/#tutorial-labs
@@ -2583,28 +2601,6 @@ manuals:
             title: API v1.3.3
         - path: /datacenter/dtr/2.0/support/
           title: Get support
-- sectiontitle: Commercially supported Docker Engine
-  section:
-  - sectiontitle: 1.13
-    section:
-    - path: /cs-engine/1.13/
-      title: Install
-    - path: /cs-engine/1.13/upgrade/
-      title: Upgrade
-    - path: /cs-engine/1.13/release-notes/
-      title: Release notes
-  - sectiontitle: 1.12
-    section:
-    - path: /cs-engine/1.12/
-      title: Install
-    - path: /cs-engine/1.12/upgrade/
-      title: Upgrade
-    - sectiontitle: Release notes
-      section:
-      - path: /cs-engine/1.12/release-notes/release-notes/
-        title: CS Engine release notes
-      - path: /cs-engine/1.12/release-notes/prior-release-notes/
-        title: Prior CS Engine release notes
 - sectiontitle: Docker Cloud
   section:
   - path: /docker-cloud/
@@ -3007,102 +3003,6 @@ manuals:
     title: Migrate from Boot2Docker to Machine
   - path: /release-notes/docker-machine/
     title: Docker Machine release notes
-- sectiontitle: Docker Notary
-  section:
-  - path: /notary/getting_started/
-    title: Getting started with Notary
-  - path: /notary/advanced_usage/
-    title: Use the Notary client
-  - path: /notary/service_architecture/
-    title: Understand the service architecture
-  - path: /notary/running_a_service/
-    title: Running a Notary service
-  - path: /notary/changelog/
-    title: Notary changelog
-  - sectiontitle: Configuration files
-    section:
-    - path: /notary/reference/server-config/
-      title: Server configuration
-    - path: /notary/reference/signer-config/
-      title: Signer configuration
-    - path: /notary/reference/client-config/
-      title: Client configuration
-    - path: /notary/reference/common-configs/
-      title: Common Server and signer configurations
-- sectiontitle: Docker Registry
-  section:
-  - path: /registry/
-    title: Registry overview
-  - path: /registry/introduction/
-    title: Understanding the Registry
-  - path: /registry/deploying/
-    title: Deploy a registry server
-  - path: /registry/configuration/
-    title: Configuring a registry
-  - path: /registry/notifications/
-    title: Working with notifications
-  - sectiontitle: Recipes
-    section:
-    - path: /registry/recipes/
-      title: Recipes overview
-    - path: /registry/recipes/apache/
-      title: Authenticating proxy with apache
-    - path: /registry/recipes/nginx/
-      title: Authenticating proxy with nginx
-    - path: /registry/recipes/mirror/
-      title: Mirroring Docker Hub
-    - path: /registry/recipes/osx-setup-guide/
-      title: Running on macOS
-    - path: /registry/garbage-collection/
-      title: Garbage collection
-    - path: /registry/insecure/
-      title: Testing an insecure registry
-  - path: /registry/deprecated/
-    title: Deprecated features
-  - path: /registry/compatibility/
-    title: Compatibility
-  - path: /registry/help/
-    title: Getting help
-  - sectiontitle: Registry reference
-    section:
-    - path: /registry/spec/api/
-      title: Registry HTTP API v2
-    - sectiontitle: Registry image manifests
-      section:
-      - path: /registry/spec/manifest-v2-1/
-        title: Image manifest v 2, schema 1
-      - path: /registry/spec/manifest-v2-2/
-        title: Image manifest v 2, schema 2
-    - sectiontitle: Registry storage drivers
-      section:
-      - path: /registry/storage-drivers/
-        title: Storage driver overview
-      - path: /registry/storage-drivers/oss/
-        title: Aliyun OSS storage driver
-      - path: /registry/storage-drivers/filesystem/
-        title: Filesystem storage driver
-      - path: /registry/storage-drivers/gcs/
-        title: GCS storage driver
-      - path: /registry/storage-drivers/inmemory/
-        title: In-memory storage driver
-      - path: /registry/storage-drivers/azure/
-        title: Microsoft Azure storage driver
-      - path: /registry/storage-drivers/s3/
-        title: S3 storage driver
-      - path: /registry/storage-drivers/swift/
-        title: Swift storage driver
-    - sectiontitle: Registry specifications
-      section:
-      - path: /registry/spec/auth/
-        title: Docker Registry token authentication
-      - path: /registry/spec/auth/jwt/
-        title: Token authentication implementation
-      - path: /registry/spec/auth/oauth/
-        title: Oauth2 token authentication
-      - path: /registry/spec/auth/scope/
-        title: Token scope documentation
-      - path: /registry/spec/auth/token/
-        title: Token authentication specification
 - sectiontitle: Docker Store
   section:
   - path: /docker-store/
@@ -3113,6 +3013,124 @@ manuals:
     title: Docker Store Trust Chain
   - path: /docker-store/faq/
     title: Consumer FAQs
+- sectiontitle: Docker Hub
+  section:
+  - path: /docker-hub/
+    title: Overview of Docker Hub
+  - path: /docker-hub/accounts/
+    title: Use Docker Hub with Docker ID
+  - path: /docker-hub/orgs/
+    title: Teams &amp; organizations
+  - path: /docker-hub/repos/
+    title: Repositories on Docker Hub
+  - path: /docker-hub/builds/
+    title: Automated builds
+  - path: /docker-hub/webhooks/
+    title: Webhooks for automated builds
+  - path: /docker-hub/bitbucket/
+    title: Automated builds with Bitbucket
+  - path: /docker-hub/github/
+    title: Automated builds from GitHub
+  - path: /docker-hub/official_repos/
+    title: Official repositories on Docker Hub
+- sectiontitle: Open-source projects
+  section:
+  - sectiontitle: Docker Notary
+    section:
+    - path: /notary/getting_started/
+      title: Getting started with Notary
+    - path: /notary/advanced_usage/
+      title: Use the Notary client
+    - path: /notary/service_architecture/
+      title: Understand the service architecture
+    - path: /notary/running_a_service/
+      title: Running a Notary service
+    - path: /notary/changelog/
+      title: Notary changelog
+    - sectiontitle: Configuration files
+      section:
+      - path: /notary/reference/server-config/
+        title: Server configuration
+      - path: /notary/reference/signer-config/
+        title: Signer configuration
+      - path: /notary/reference/client-config/
+        title: Client configuration
+      - path: /notary/reference/common-configs/
+        title: Common Server and signer configurations
+  - sectiontitle: Docker Registry
+    section:
+    - path: /registry/
+      title: Registry overview
+    - path: /registry/introduction/
+      title: Understanding the Registry
+    - path: /registry/deploying/
+      title: Deploy a registry server
+    - path: /registry/configuration/
+      title: Configuring a registry
+    - path: /registry/notifications/
+      title: Working with notifications
+    - sectiontitle: Recipes
+      section:
+      - path: /registry/recipes/
+        title: Recipes overview
+      - path: /registry/recipes/apache/
+        title: Authenticating proxy with apache
+      - path: /registry/recipes/nginx/
+        title: Authenticating proxy with nginx
+      - path: /registry/recipes/mirror/
+        title: Mirroring Docker Hub
+      - path: /registry/recipes/osx-setup-guide/
+        title: Running on macOS
+      - path: /registry/garbage-collection/
+        title: Garbage collection
+      - path: /registry/insecure/
+        title: Testing an insecure registry
+    - path: /registry/deprecated/
+      title: Deprecated features
+    - path: /registry/compatibility/
+      title: Compatibility
+    - path: /registry/help/
+      title: Getting help
+    - sectiontitle: Registry reference
+      section:
+      - path: /registry/spec/api/
+        title: Registry HTTP API v2
+      - sectiontitle: Registry image manifests
+        section:
+        - path: /registry/spec/manifest-v2-1/
+          title: Image manifest v 2, schema 1
+        - path: /registry/spec/manifest-v2-2/
+          title: Image manifest v 2, schema 2
+      - sectiontitle: Registry storage drivers
+        section:
+        - path: /registry/storage-drivers/
+          title: Storage driver overview
+        - path: /registry/storage-drivers/oss/
+          title: Aliyun OSS storage driver
+        - path: /registry/storage-drivers/filesystem/
+          title: Filesystem storage driver
+        - path: /registry/storage-drivers/gcs/
+          title: GCS storage driver
+        - path: /registry/storage-drivers/inmemory/
+          title: In-memory storage driver
+        - path: /registry/storage-drivers/azure/
+          title: Microsoft Azure storage driver
+        - path: /registry/storage-drivers/s3/
+          title: S3 storage driver
+        - path: /registry/storage-drivers/swift/
+          title: Swift storage driver
+      - sectiontitle: Registry specifications
+        section:
+        - path: /registry/spec/auth/
+          title: Docker Registry token authentication
+        - path: /registry/spec/auth/jwt/
+          title: Token authentication implementation
+        - path: /registry/spec/auth/oauth/
+          title: Oauth2 token authentication
+        - path: /registry/spec/auth/scope/
+          title: Token scope documentation
+        - path: /registry/spec/auth/token/
+          title: Token authentication specification
 - sectiontitle: Release notes
   section:
     - path: /release-notes/
@@ -3153,26 +3171,28 @@ manuals:
       nosync: true
 - sectiontitle: Superseded products and tools
   section:
-  - sectiontitle: Docker Hub
+  - sectiontitle: Commercially supported Docker Engine
     section:
-    - path: /docker-hub/
-      title: Overview of Docker Hub
-    - path: /docker-hub/accounts/
-      title: Use Docker Hub with Docker ID
-    - path: /docker-hub/orgs/
-      title: Teams &amp; organizations
-    - path: /docker-hub/repos/
-      title: Repositories on Docker Hub
-    - path: /docker-hub/builds/
-      title: Automated builds
-    - path: /docker-hub/webhooks/
-      title: Webhooks for automated builds
-    - path: /docker-hub/bitbucket/
-      title: Automated builds with Bitbucket
-    - path: /docker-hub/github/
-      title: Automated builds from GitHub
-    - path: /docker-hub/official_repos/
-      title: Official repositories on Docker Hub
+    - sectiontitle: 1.13
+      section:
+      - path: /cs-engine/1.13/
+        title: Install
+      - path: /cs-engine/1.13/upgrade/
+        title: Upgrade
+      - path: /cs-engine/1.13/release-notes/
+        title: Release notes
+    - sectiontitle: 1.12
+      section:
+      - path: /cs-engine/1.12/
+        title: Install
+      - path: /cs-engine/1.12/upgrade/
+        title: Upgrade
+      - sectiontitle: Release notes
+        section:
+        - path: /cs-engine/1.12/release-notes/release-notes/
+          title: CS Engine release notes
+        - path: /cs-engine/1.12/release-notes/prior-release-notes/
+          title: Prior CS Engine release notes
   - sectiontitle: Docker Swarm (standalone)
     section:
     - path: /swarm/overview/

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -548,8 +548,6 @@ guides:
 reference:
 - sectiontitle: File formats
   section:
-  - title: File formats overview
-    path: /reference/#file-formats
   - title: Dockerfile reference
     path: /engine/reference/builder/
   - title: Compose file reference
@@ -561,8 +559,6 @@ reference:
 
 - sectiontitle: Command-Line Interfaces (CLIs)
   section:
-  - title: CLIs overview
-    path: /reference/#command-line-interfaces-clis
   - sectiontitle: Docker CLI (docker)
     section:
     - sectiontitle: Stable
@@ -1282,10 +1278,6 @@ reference:
 
 - sectiontitle: Application Programming Interfaces (APIs)
   section:
-  - title: APIs overview
-    path: /reference/#application-programming-interfaces-apis
-  - title: File formats overview
-    path: /reference/#file-formats
   - sectiontitle: Docker Engine API
     section:
     - path: /engine/api/

--- a/index.md
+++ b/index.md
@@ -338,9 +338,9 @@ the industry to modernize all applications. Docker EE Advanced comes with enterp
         <div class="col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
-                    <a href="datacenter/ucp/2.2/guides/"> <img src="../images/UCP_48.svg" alt="Universal Control Plane"> </a>
+                    <a href="datacenter/ucp/{{ site.ucp_version }}/guides/"> <img src="../images/UCP_48.svg" alt="Universal Control Plane"> </a>
                 </div>
-                <h3 id="ucp"><a href="datacenter/ucp/2.2/guides/">Universal Control Plane</a></h3>
+                <h3 id="ucp"><a href="datacenter/ucp/{{ site.ucp_version }}/guides/">Universal Control Plane</a></h3>
                 <p>(UCP) Manage a cluster of on-premise Docker hosts like a single machine with this enterprise product.</p>
             </div>
         </div>
@@ -348,9 +348,9 @@ the industry to modernize all applications. Docker EE Advanced comes with enterp
         <div class="col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
-                    <a href="datacenter/dtr/2.3/guides/"> <img src="../images/dtr_48.svg" alt="Docker Trusted Registry"> </a>
+                    <a href="datacenter/dtr/{{ site.dtr_version }}/guides/"> <img src="../images/dtr_48.svg" alt="Docker Trusted Registry"> </a>
                 </div>
-                <h3 id="dtr"><a href="datacenter/dtr/2.3/guides/">Docker Trusted Registry</a></h3>
+                <h3 id="dtr"><a href="datacenter/dtr/{{ site.dtr_version }}/guides/">Docker Trusted Registry</a></h3>
                 <p>(DTR) An enterprise image storage solution you can install behind a firewall to manage images and access.</p>
             </div>
         </div>

--- a/reference.md
+++ b/reference.md
@@ -22,8 +22,8 @@ various APIs, CLIs, and file formats.
 | [Engine CLI](/engine/reference/commandline/cli/)          | The main CLI for Docker, includes all `docker` and [`dockerd`](/engine/reference/commandline/dockerd/) commands|
 | [Compose CLI](/compose/reference/overview/)           | The CLI for Docker Compose, which allows you to build and run multi-container applications                       |
 | [Machine CLI](/machine/reference/)                    | Manages virtual machines that are pre-configured to run Docker                                                   |
-| [UCP CLI](/datacenter/ucp/2.2/reference/cli/index.md) | Deploy and manage Universal Control Plane                                                                       |
-| [DTR CLI](/datacenter/dtr/2.4/reference/cli/index.md) | Deploy and manage Docker Trusted Registry                                                                                       |
+| [UCP CLI](/datacenter/ucp/{{ site.ucp_version }}/reference/cli/index.md) | Deploy and manage Universal Control Plane                                                                       |
+| [DTR CLI](/datacenter/dtr/{{ site.dtr_version }}/reference/cli/index.md) | Deploy and manage Docker Trusted Registry                                                                                       |
 
 ## Application programming interfaces (APIs)
 
@@ -44,3 +44,9 @@ various APIs, CLIs, and file formats.
 | [Machine drivers](/machine/drivers/os-base/)           | Enables support for given cloud providers when provisioning resources with Machine |
 | [Registry token authentication](/registry/spec/auth/)  | Outlines the Docker registry authentication scheme                                 |
 | [Registry storage drivers](/registry/storage-drivers/) | Enables support for given cloud providers when storing images with Registry        |
+
+## Compliance control reference
+
+| Reference | Description |
+| --------- | ----------- |
+| [NIST 800-53 control reference](/compliance/reference/800-53/) | All of the NIST 800-53 Rev. 4 controls applicable to Docker Enterprise Edition can be referenced in this section. |

--- a/registry/index.md
+++ b/registry/index.md
@@ -44,7 +44,7 @@ into [Docker Trusted Registry](/datacenter/dtr/2.1/guides/index.md).
 
 The Registry is compatible with Docker engine **version 1.6.0 or higher**.
 
-## TL;DR
+## Basic commands
 
 Start your registry
 

--- a/registry/index.md
+++ b/registry/index.md
@@ -8,8 +8,8 @@ title: Docker Registry
 
 > Looking for Docker Trusted Registry?
 >
-> Docker Trusted Registry (DTR) is a commercial product that has complete
-> image management workflow, LDAP integration, image signing,
+> Docker Trusted Registry (DTR) is a commercial product that enables complete
+> image management workflow, featuring LDAP integration, image signing,
 > security scanning, and integration with Universal Control Plane. DTR is
 > offered as an add-on to Docker Enterprise subscriptions of Standard or
 > higher.

--- a/registry/index.md
+++ b/registry/index.md
@@ -6,6 +6,16 @@ redirect_from:
 title: Docker Registry
 ---
 
+> Looking for Docker Trusted Registry?
+>
+> Docker Trusted Registry (DTR) is a commercial product that has complete
+> image management workflow, LDAP integration, image signing,
+> security scanning, and integration with Universal Control Plane. DTR is
+> offered as an add-on to Docker Enterprise subscriptions of Standard or
+> higher.
+>
+> [Go to Docker Trusted Registry](/datacenter/dtr/{{ site.dtr_version }}/guides/){: class="button outline-btn" }
+
 ## What it is
 
 The Registry is a stateless, highly scalable server side application that stores


### PR DESCRIPTION
- Navigation under "Reference" and "Manuals" is revamped 
- /registry has an admonition clarifying that this is NOT "Docker Trusted Registry"
- "Latest" UCP/DTR variables in _config.yml makes linking to `{{ site.dtr_version }}` possible, as with the various Engine variables.