### PR TITLE
Added documentation for fluentd plugin sub-second-precision flag

### DIFF
--- a/engine/admin/logging/fluentd.md
+++ b/engine/admin/logging/fluentd.md
@@ -118,6 +118,10 @@ How long to wait between retries. Defaults to 1 second.
 
 The maximum number of retries. Defaults to 10.
 
+### fluentd-sub-second-precision
+
+Generates event logs in nanosecond resolution. Defaults to false.
+
 ## Fluentd daemon management with Docker
 
 About `Fluentd` itself, see [the project webpage](http://www.fluentd.org)


### PR DESCRIPTION
Signed-off-by: dungeonmaster18 <umesh4257@gmail.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

###Proposed changes

Add documentaion for fluentd-sub-second-precision flag in fluentd plugin.

Added a short description for fluentd-sub-second-precision flag in fluentd.md.
###Unreleased project version (optional)

17.12

###Team

area/engine

###Related issues (optional)

Closes #5425