### PR TITLE
Fixed a typo

### DIFF
--- a/engine/admin/volumes/volumes.md
+++ b/engine/admin/volumes/volumes.md
@@ -75,7 +75,7 @@ If you need to specify volume driver options, you must use `--mount`.
     will be mounted in the container. May be specified as `destination`, `dst`,
     or `target`.
   - The `readonly` option, if present, causes the bind mount to be [mounted into
-    the container as read-only](#use-a-read-only-bind-mount).
+    the container as read-only](#use-a-read-only-volume).
   - The `volume-opt` option, which can be specified more than once, takes a
     key-value pair consisting of the option name and its value.
 


### PR DESCRIPTION
Fixed a minor typo, looks like the text vas coppied from Bind Mounts and the anchor was not edited accordingly.