### PR TITLE
Recommend alpine base image

### DIFF
--- a/engine/userguide/eng-image/dockerfile_best-practices.md
+++ b/engine/userguide/eng-image/dockerfile_best-practices.md
@@ -177,8 +177,8 @@ various instructions available for use in a `Dockerfile`.
 [Dockerfile reference for the FROM instruction](../../reference/builder.md#from)
 
 Whenever possible, use current Official Repositories as the basis for your
-image. We recommend the [Debian image](https://hub.docker.com/_/debian/)
-since it’s very tightly controlled and kept minimal (currently under 150 mb),
+image. We recommend the [Alpine image](https://hub.docker.com/_/alpine/)
+since it’s very tightly controlled and kept minimal (currently under 5 mb),
 while still being a full distribution.
 
 ### LABEL


### PR DESCRIPTION
Hi,

I noticed that the recommended image is debian while I notice more and more recommendations using alpine as a base image.
This PR suggests users to use the alpine base image, allowing building smaller images.

Please consider this PR as a question opening discussion upon what are the latest recommendations regarding base images.

### Proposed changes

Suggest users to use alpine base image by default. 
