### PR TITLE
driver exoscale: clarify the image template name.

### DIFF
--- a/machine/drivers/exoscale.md
+++ b/machine/drivers/exoscale.md
@@ -10,25 +10,24 @@ Get your API key and API secret key from [API details](https://portal.exoscale.c
 
 ## Usage
 
-    $ docker-machine create --driver exoscale --exoscale-api-key=API --exoscale-api-secret-key=SECRET vm
+    $ docker-machine create --driver exoscale \
+        --exoscale-api-key=API \
+        --exoscale-api-secret-key=SECRET \
+        vm
 
 ## Options
 
--   `--exoscale-url`: Your API endpoint.
--   `--exoscale-api-key`: **required** Your API key.
--   `--exoscale-api-secret-key`: **required** Your API secret key.
--   `--exoscale-instance-profile`: Instance profile.
--   `--exoscale-disk-size`: Disk size for the host in GB (10, 50, 100, 200, 400).
--   `--exoscale-image`: Image template (e.g. ubuntu-16.04, ubuntu-15.10).
--   `--exoscale-security-group`: Security group. It will be created if it doesn't exist.
--   `--exoscale-availability-zone`: Exoscale availability zone.
--   `--exoscale-ssh-user`: SSH username, which must match the default SSH user for the used image.
--   `--exoscale-userdata`: Path to file containing user data for cloud-init.
--   `--exoscale-affinity-group`: Affinity group the machine will be started in.
-
-If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule. Moreover, if you want to use Swarm, also add TCP port 3376.
-
-There is a limit to the number of docker machines that an anti-affinity group can have.  This can be worked around by specifying an additional anti-affinity group using `--exoscale-affinity-group=docker-machineX`
+-   `--exoscale-url`: Your API endpoint;
+-   `--exoscale-api-key`: **required** Your API key;
+-   `--exoscale-api-secret-key`: **required** Your API secret key;
+-   `--exoscale-instance-profile`: Instance profile (Small, Medium, Large, ...);
+-   `--exoscale-disk-size`: Disk size for the host in GB (10, 50, 100, 200, 400);
+-   `--exoscale-image`: Image template (e.g. `Linux Ubuntu 16.04 LTS 64-bit` also known as `ubuntu-16.04`, [see below](#image-template-name));
+-   `--exoscale-security-group`: Security group. _It will be created if it doesn't exist_;
+-   `--exoscale-availability-zone`: Exoscale [availability zone][datacenters] (CH-DK-2, AT-VIE-1, DE-FRA-1, ...);
+-   `--exoscale-ssh-user`: SSH username (e.g. `ubuntu`, [see below](#ssh-username));
+-   `--exoscale-userdata`: Path to file containing user data for [cloud-init](https://cloud-init.io/);
+-   `--exoscale-affinity-group`: [Anti-affinity group][anti-affinity] the machine will be started in.
 
 ### Environment variables and default values
 
@@ -39,9 +38,50 @@ There is a limit to the number of docker machines that an anti-affinity group ca
 | **`--exoscale-api-secret-key`** | `EXOSCALE_API_SECRET`        | -                                 |
 | `--exoscale-instance-profile`   | `EXOSCALE_INSTANCE_PROFILE`  | `small`                           |
 | `--exoscale-disk-size`          | `EXOSCALE_DISK_SIZE`         | `50`                              |
-| `--exoscale-image`              | `EXOSCALE_IMAGE`             | `ubuntu-16.04`                    |
+| `--exoscale-image`              | `EXOSCALE_IMAGE`             | `Linux Ubuntu 16.04 LTS 64-bit`   |
 | `--exoscale-security-group`     | `EXOSCALE_SECURITY_GROUP`    | `docker-machine`                  |
 | `--exoscale-availability-zone`  | `EXOSCALE_AVAILABILITY_ZONE` | `ch-dk-2`                         |
-| `--exoscale-ssh-user`           | `EXOSCALE_SSH_USER`          | `ubuntu`                          |
+| `--exoscale-ssh-user`           | `EXOSCALE_SSH_USER`          | -                                 |
 | `--exoscale-userdata`           | `EXOSCALE_USERDATA`          | -                                 |
 | `--exoscale-affinity-group`     | `EXOSCALE_AFFINITY_GROUP`    | -                                 |
+
+**NB:** the _instance profile_, _image_, and _availability zone_ are case insensitive.
+
+### Image template name
+
+The [VM templates][templates] available at Exoscale are listed on the Portal when adding a new instance.
+
+For any Linux template, you may use the shorter name composed only of the name and version. E.g.
+
+| Full name                       | Short name           |
+| ------------------------------- | -------------------- |
+| Linux Debian 8 64-bit           | `debian-8`           |
+| Linux Ubuntu 16.04 LTS 64-bit   | `ubuntu-16.04`       |
+| Linux CentOS 7.3 64-bit         | `centos-7.3`         |
+| Linux CoreOS stable 1298 64-bit | `coreos-stable-1298` |
+
+**NB:** Docker won't work for non-Linux machines like OpenBSD and Windows Server.
+
+### SSH Username
+
+The exoscale driver does a wild guess to match the default SSH user. If left empty, it picks a suitable one:
+
+- `centos` for Centos 7.3+;
+- `core` for Linux CoreOS;
+- `debian` for Debian 8+;
+- `ubuntu` for Ubuntu;
+- otherwise, `root`.
+
+### Custom security group
+
+If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule.
+
+Moreover, if you want to use [Docker Swarm](/engine/swarm/swarm-tutorial/), also add TCP port 2377.
+
+### More than 8 docker machines?
+
+There is a limit to the number of machines that an anti-affinity group can have.  This can be worked around by specifying an additional anti-affinity group using `--exoscale-affinity-group=docker-machineX`
+
+[templates]: https://www.exoscale.ch/open-cloud/templates/
+[datacenters]: https://www.exoscale.ch/infrastructure/datacenters/
+[anti-affinity]: https://community.exoscale.ch/documentation/compute/anti-affinity-groups/


### PR DESCRIPTION
### Proposed changes

It clarifies some aspects of the docker-machine exoscale driver usage. It wasn't super easy to guess the image name from the ones displayed in the UI.

### Related issues (optional)

- https://github.com/docker/machine/pull/4334
