### PR TITLE
Remove dns & dns_search from "unsupported in compose v3"

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -769,8 +769,6 @@ The following sub-options (supported for `docker compose up` and `docker compose
 - [cgroup_parent](#cgroup_parent)
 - [container_name](#container_name)
 - [devices](#devices)
-- [dns](#dns)
-- [dns_search](#dns_search)
 - [tmpfs](#tmpfs)
 - [external_links](#external_links)
 - [links](#links)
@@ -847,10 +845,6 @@ Custom DNS servers. Can be a single value or a list.
       - 8.8.8.8
       - 9.9.9.9
 
-> **Note**: This option is ignored when
-> [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
-> with a (version 3) Compose file.
-
 ### dns_search
 
 Custom DNS search domains. Can be a single value or a list.
@@ -859,10 +853,6 @@ Custom DNS search domains. Can be a single value or a list.
     dns_search:
       - dc1.example.com
       - dc2.example.com
-
-> **Note**: This option is ignored when
-> [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
-> with a (version 3) Compose file.
 
 ### tmpfs
 


### PR DESCRIPTION
### Proposed changes

Remove comments saying dns and dns_search are unsupported in v3 compose files


Tested on my lab in 17.06 with the following docker-compose.yml:

```
version: "3"
services:
  bb1:
    image: busybox
    command: nslookup google.com
    dns: 8.8.8.8

  bb2:
    image: busybox
    command: nslookup google.com
```

results in:
 ```
docker service inspect --format "{{ .Spec.TaskTemplate.ContainerSpec.DNSConfig }}" bbdns_bb1
{[8.8.8.8] [] []} 
```

```
 ada@trogdor  ~/docker/docker-ee   17.06  git --no-pager log --all --grep 6b60a60729e0b22cc74197e5d00d1621435da7f7
commit 7254b7d7835250677ba58a10127b51e6db61c4ce
Author: Benjamin Boudreau <boudreau.benjamin@gmail.com>
Date:   Thu Mar 23 19:38:17 2017 -0400

    Adding support for dns in stack files

    Signed-off-by: Benjamin Boudreau <boudreau.benjamin@gmail.com>
    Upstream-commit: 6b60a60729e0b22cc74197e5d00d1621435da7f7
    Component: engine
 ada@trogdor  ~/docker/docker-ee   17.06  git --no-pager tag --contains  7254b7d78v17.06.0-ce
v17.06.0-ce-rc1
v17.06.0-ce-rc2
v17.06.0-ce-rc3
v17.06.0-ce-rc4
v17.06.0-ce-rc5
v17.06.1-ce-rc1
v17.06.1-ee-1
v17.06.1-ee-1-rc1
v17.06.1-ee-1-rc2
v17.06.1-ee-1-rc3
v17.06.1-ee-1-rc4
v17.06.1-ee-2
v17.06.1-ee-2-rc1
v17.06.1-ee-2-rc2
v17.06.2-ee-3
v17.06.2-ee-3-rc1
v17.06.2-ee-4
v17.06.2-ee-4-rc1
v17.06.2-ee-4-rc2
v17.06.2-ee-4-rc3
v17.06.2-ee-5
v17.06.2-ee-5-rc1
v17.06.2-ee-5-rc2
v17.06.2-ee-6
v17.06.2-ee-6-rc1
v17.07.0-ce-rc1
v18.01.0-ee-1-tp3
v18.01.0-ee-1-tp4
v18.01.0-ee-1-tp5 
```

### Related issues (optional)
https://github.com/moby/moby/pull/32059/commits/6b60a60729e0b22cc74197e5d00d1621435da7f7 adds support for custom dns and dns_search settings to 'stack deploy'.


