### PR TITLE
max-file should be in quotes

### DIFF
--- a/_includes/content/compose-extfields-sub.md
+++ b/_includes/content/compose-extfields-sub.md
@@ -22,7 +22,7 @@ configuration:
 logging:
   options:
     max-size: '12m'
-    max-file: 5
+    max-file: '5'
   driver: json-file
 ```
 
@@ -34,7 +34,7 @@ x-logging:
   &default-logging
   options:
     max-size: '12m'
-    max-file: 5
+    max-file: '5'
   driver: json-file
 
 services:


### PR DESCRIPTION
### Proposed changes

The given syntax does not work with Docker Compose 1.17.1. There must be quotes around `max-file` value 

### Unreleased project version (optional)

N/A

### Related issues (optional)

N/A