### PR TITLE
Add kubectl context instructions and tighten text

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -297,7 +297,7 @@ choose to discard or not apply changes when asked.
 
 ### Kubernetes
 
-**Kubernetes is only available in the private beta of Docker for Mac 17.12 CE Edge through the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
+**Kubernetes is only available in Docker for Mac 17.12 CE Edge to participants in the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
 
 If you are participating in the Docker beta program, you can access Docker for
 Mac 17.12 CE Edge, which includes a standalone Kubernetes server that runs on

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -309,9 +309,11 @@ pointing to some other environment, such as minikube or a gke cluster, be sure
 to change context so that kubectl is pointing to `docker-for-desktop`:
 
 ```
-kubectl config view
+kubectl config get-contexts
 kubectl config use-context docker-for-desktop
 ```
+
+If you installed `kubectl` with homebrew and encounter a symlink error, remove `/usr/local/bin/kubectl`.
 
 - To enable Kubernetes support and install a standalone instance of Kubernetes
   running as a Docker container, select **Enable Kubernetes** and click the

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -305,15 +305,16 @@ your Mac, so that you can test deploying your Docker workloads on Kubernetes.
 
 The Kubernetes client command, `kubectl`, is included and configured to connect
 to the local Kubernetes server. If you have `kubectl` already installed and
-pointing to some other environment, such as minikube or a gke cluster, be sure
-to change context so that kubectl is pointing to `docker-for-desktop`:
+pointing to some other environment, such as `minikube` or a GKE cluster, be sure
+to change context so that `kubectl` is pointing to `docker-for-desktop`:
 
 ```
 kubectl config get-contexts
 kubectl config use-context docker-for-desktop
 ```
 
-If you installed `kubectl` with homebrew and encounter a symlink error, remove `/usr/local/bin/kubectl`.
+If you installed `kubectl` with Homebrew, or by some other method, and
+experience conflicts, remove `/usr/local/bin/kubectl`.
 
 - To enable Kubernetes support and install a standalone instance of Kubernetes
   running as a Docker container, select **Enable Kubernetes** and click the

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -297,15 +297,21 @@ choose to discard or not apply changes when asked.
 
 ### Kubernetes
 
-**Kubernetes is only available if you are part of the private beta for Docker for Mac 17.12. To access beta builds, you must be signed in within Docker for Mac using your Docker ID.**
+**Kubernetes is only available in the private beta of Docker for Mac 17.12 CE Edge through the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
 
 If you are participating in the Docker beta program, you can access Docker for
 Mac 17.12 CE Edge, which includes a standalone Kubernetes server that runs on
 your Mac, so that you can test deploying your Docker workloads on Kubernetes.
-The Kubernetes client command, `kubectl`, is included and configured to connect
-to the local Kubernetes server.
 
-To log in with your Docker ID, select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> **Sign in / Create Docker ID** from the menu bar.
+The Kubernetes client command, `kubectl`, is included and configured to connect
+to the local Kubernetes server. If you have `kubectl` already installed and
+pointing to some other environment, such as minikube or a gke cluster, be sure
+to change context so that kubectl is pointing to `docker-for-desktop`:
+
+```
+kubectl config view
+kubectl config use-context docker-for-desktop
+```
 
 - To enable Kubernetes support and install a standalone instance of Kubernetes
   running as a Docker container, select **Enable Kubernetes** and click the

--- a/docker-for-mac/kubernetes.md
+++ b/docker-for-mac/kubernetes.md
@@ -4,7 +4,7 @@ keywords: mac, edge, kubernetes, kubectl, orchestration
 title: Deploy to Kubernetes
 ---
 
-**Kubernetes is only available in the private beta of Docker for Mac 17.12 CE Edge through the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
+**Kubernetes is only available in Docker for Mac 17.12 CE Edge to participants in the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
 
 If you are part of the Docker Beta program, Docker for Mac 17.12 CE Edge
 includes a standalone Kubernetes server and client, as well as Docker CLI

--- a/docker-for-mac/kubernetes.md
+++ b/docker-for-mac/kubernetes.md
@@ -6,9 +6,10 @@ title: Deploy to Kubernetes
 
 **Kubernetes is only available in the private beta of Docker for Mac 17.12 CE Edge through the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
 
-Docker for Mac 17.12 CE Edge includes a standalone Kubernetes server and client,
-as well as Docker CLI integration. The Kubernetes server runs locally within
-your Docker instance, is not configurable, and is a single-node cluster.
+If you are part of the Docker Beta program, Docker for Mac 17.12 CE Edge
+includes a standalone Kubernetes server and client, as well as Docker CLI
+integration. The Kubernetes server runs locally within your Docker instance, is
+not configurable, and is a single-node cluster.
 
 The Kubernetes server runs within a Docker container on your Mac, and is only
 for local testing. When Kubernetes support is enabled, you can deploy your
@@ -20,11 +21,10 @@ See [Docker for Mac > Getting started](/docker-for-mac/index.md#kubernetes) to
 enable Kubernetes and begin testing the deployment of your workloads on
 Kubernetes.
 
-> If you independently installed the Kubernetes CLI, `kubectl`, make sure that it
-> is pointing to `docker-for-desktop` and not some other context such as minikube
-> or a gke cluster. Run: `kubectl config use-context docker-for-desktop`. If you
-> installed `kubectl` with homebrew and encounter a symlink error, remove
-> `/usr/local/bin/kubectl`.
+> If you independently installed the Kubernetes CLI, `kubectl`, make sure that
+> it is pointing to `docker-for-desktop` and not some other context such as
+> `minikube` or a GKE cluster. Run: `kubectl config use-context docker-for-desktop`.
+> If you experience conflicts with an existing `kubectl` installation, remove `/usr/local/bin/kubectl`.
 
 ## Use Docker commands
 

--- a/docker-for-mac/kubernetes.md
+++ b/docker-for-mac/kubernetes.md
@@ -18,9 +18,13 @@ workloads.
 
 See [Docker for Mac > Getting started](/docker-for-mac/index.md#kubernetes) to
 enable Kubernetes and begin testing the deployment of your workloads on
-Kubernetes. If you independently installed the Kubernetes CLI, `kubectl`, make
-sure that it is pointing to `docker-for-desktop` and not some other context such
-as minikube or a gke cluster. Run: `kubectl config use-context docker-for-desktop`.
+Kubernetes.
+
+> If you independently installed the Kubernetes CLI, `kubectl`, make sure that it
+> is pointing to `docker-for-desktop` and not some other context such as minikube
+> or a gke cluster. Run: `kubectl config use-context docker-for-desktop`. If you
+> installed `kubectl` with homebrew and encounter a symlink error, remove
+> `/usr/local/bin/kubectl`.
 
 ## Use Docker commands
 

--- a/docker-for-mac/kubernetes.md
+++ b/docker-for-mac/kubernetes.md
@@ -4,24 +4,23 @@ keywords: mac, edge, kubernetes, kubectl, orchestration
 title: Deploy to Kubernetes
 ---
 
-**Kubernetes is only available if you are part of the private beta for Docker for Mac 17.12. To access beta builds, you must be signed in within Docker for Mac using your Docker ID.**
+**Kubernetes is only available in the private beta of Docker for Mac 17.12 CE Edge through the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
 
-If you are participating in the [Docker Beta program](https://beta.docker.com/),
-you can access the beta for Docker for Mac 17.12 CE. This version includes a
-standalone Kubernetes server and client, as well as Docker CLI integration.
+Docker for Mac 17.12 CE Edge includes a standalone Kubernetes server and client,
+as well as Docker CLI integration. The Kubernetes server runs locally within
+your Docker instance, is not configurable, and is a single-node cluster.
 
-To log in with your Docker ID, select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> **Sign in / Create Docker ID** from the menu bar.
+The Kubernetes server runs within a Docker container on your Mac, and is only
+for local testing. When Kubernetes support is enabled, you can deploy your
+workloads, in parallel, on Kubernetes, Swarm, and as standalone containers.
+Enabling or disabling the Kubernetes server does not affect your other
+workloads.
 
-[You can enable this feature](/docker-for-mac/index.md#kubernetes) to test
-deploying your workloads on Kubernetes. The Kubernetes server runs within a
-Docker container on your Mac, and is only for local testing. When Kubernetes
-support is enabled, you are able to deploy your workloads, in parallel, on
-Kubernetes, Swarm, and as standalone containers. Enabling or disabling the
-Kubernetes server does not affect your other workloads.
-
-The Kubernetes server runs locally within your Docker instance, is not
-configurable, and is a single-node cluster. It is provided for development and
-testing only.
+See [Docker for Mac > Getting started](/docker-for-mac/index.md#kubernetes) to
+enable Kubernetes and begin testing the deployment of your workloads on
+Kubernetes. If you independently installed the Kubernetes CLI, `kubectl`, make
+sure that it is pointing to `docker-for-desktop` and not some other context such
+as minikube or a gke cluster. Run: `kubectl config use-context docker-for-desktop`.
 
 ## Use Docker commands
 


### PR DESCRIPTION
Users with `kubectl` already installed and pointing to minikube or a gke cluster must change context to `docker-for-desktop`.

Fixes #5512 