### PR TITLE
Proxy configuration is now in stable as well

### DIFF
--- a/engine/userguide/networking/index.md
+++ b/engine/userguide/networking/index.md
@@ -580,8 +580,6 @@ configure it in different ways:
 
 ### Configure the Docker Client
 
-{% include edge_only.md section="option" %}
-
 1.  On the Docker client, create or edit the file `~/.config.json` in the
     home directory of the user which starts containers. Add JSON such as the
     following, substituting the type of proxy with `httpsProxy` or `ftpProxy` if


### PR DESCRIPTION
This feature was introduced in Docker 17.07 (https://github.com/docker/cli/pull/93), so has been available in stable release 17.09 and up.