### PR TITLE
Fix for not-edited-here Edit this Page link

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -23,7 +23,7 @@
 <!-- Logic for 'edit this button' -->
 {% assign edit_url = "https://github.com/docker/docker.github.io/edit/master/" | append: page.path %}
 {% for entry in site.data.not_edited_here.overrides %}
-	{% if page.url contains entry.path %}
+	{% if page.path contains entry.path %}
 		{% if entry.source %}
 			{% assign edit_url = entry.source %}
 		{% else %}


### PR DESCRIPTION
Using `path` instead of `url` will actually get us the matching we want.