### PR TITLE
Replace /abc.md links with /abc/ in glossary

### DIFF
--- a/_data/glossary.yaml
+++ b/_data/glossary.yaml
@@ -29,7 +29,7 @@ cgroups: |
 collection: |
   A collection is a group of swarm resources that Docker EE uses for role-based
   access control. Collections enable organizing permissions for resources like
-  nodes, services, containers, volumes, networks, and secrets. [Learn how to manage collections](/datacenter/ucp/2.2/guides/access-control/manage-access-with-collections.md).
+  nodes, services, containers, volumes, networks, and secrets. [Learn how to manage collections](/datacenter/ucp/2.2/guides/access-control/manage-access-with-collections/).
 Compose: |
   [Compose](https://github.com/docker/compose) is a tool for defining and
   running complex applications with Docker. With compose, you define a
@@ -154,7 +154,7 @@ grant: |
   A grant enables role-based access control for managing how users and
   organizations access Docker EE swarm resources. A grant is made up of a
   subject, a role, and a collection. For more about grants and role-based access
-  control, see [Grant permissions to users based on roles](/datacenter/ucp/2.2/guides/access-control/grant-permissions.md).
+  control, see [Grant permissions to users based on roles](/datacenter/ucp/2.2/guides/access-control/grant-permissions/).
 image: |
   Docker images are the basis of [containers](#container). An Image is an
   ordered collection of root filesystem changes and the corresponding
@@ -163,8 +163,8 @@ image: |
   does not have state and it never changes.
 Kitematic: |
   A legacy GUI, bundled with [Docker Toolbox](#toolbox), for managing Docker
-  containers. We recommend upgrading to [Docker for Mac](#docker for mac) or
-  [Docker for Windows](#docker for windows/), which have superseded Kitematic.
+  containers. We recommend upgrading to [Docker for Mac](#docker for Mac) or
+  [Docker for Windows](#docker for Windows), which have superseded Kitematic.
 layer: |
   In an image, a layer is modification to the image, represented by an instruction in the
   Dockerfile. Layers are applied in sequence to the base image to create the final image.
@@ -178,7 +178,7 @@ libcontainer: |
   after the container is created.
 libnetwork: |
   libnetwork provides a native Go implementation for creating and managing container
-  network namespaces and other network resources. It manage the networking lifecycle
+  network namespaces and other network resources. It manages the networking lifecycle
   of the container performing additional operations after the container is created.
 link: |
   links provide a legacy interface to connect Docker containers running on the
@@ -197,7 +197,7 @@ namespace: |
   a namespace can only interact with resources or processes that are part of the same namespace. Namespaces
   are an important part of Docker's isolation model. Namespaces exist for each type of
   resource, including `net` (networking), `mnt` (storage), `pid` (processes), `uts` (hostname control),
-  and `user` (UID mapping). For more information about namespaces, see [Docker run reference](/engine/reference/run.md)
+  and `user` (UID mapping). For more information about namespaces, see [Docker run reference](/engine/reference/run/)
   and [Introduction to user namespaces](https://success.docker.com/KBase/Introduction_to_User_Namespaces_in_Docker_Engine).
 node: |
   A [node](/engine/swarm/how-swarm-mode-works/nodes/) is a physical or virtual
@@ -223,7 +223,7 @@ registry: |
   A Registry is a hosted service containing [repositories](#repository) of [images](#image)
   which responds to the Registry API.
 
-  The default registry can be accessed using a browser at [Docker Hub](#docker Chub)
+  The default registry can be accessed using a browser at [Docker Hub](#docker hub)
   or using the `docker search` command.
 repository: |
   A repository is a set of Docker images. A repository can be shared by pushing it
@@ -236,7 +236,7 @@ role: |
   A role is a set of permitted API operations on a collection of Docker EE swarm
   resources. As part of a grant, a role is assigned to a subject (a user, team, or
   organization) and a collection. For more about roles, see [Roles and
-  permission levels](/datacenter/ucp/2.2/guides/access-control/permission-levels.md).
+  permission levels](/datacenter/ucp/2.2/guides/access-control/permission-levels/).
 role-based access control: |
   Role-based access control enables managing how Docker EE users can access
   swarm resources. UCP administrators create grants to control how users access
@@ -273,7 +273,7 @@ service discovery: |
 subject: |
   A subject represents a user, team, or organization in Docker EE. A subject is
   granted a role for access to a collection of swarm resources.
-  For more about role-based access, see [Authentication](/datacenter/ucp/2.2/guides/access-control/index.md).
+  For more about role-based access, see [Authentication](/datacenter/ucp/2.2/guides/access-control/).
 swarm: |
   A [swarm](/engine/swarm/) is a cluster of one or more Docker Engines running in [swarm mode](#swarm mode).
 Docker Swarm: |


### PR DESCRIPTION
Fix other broken links in glosary.


### Proposed changes

Some links in glossary were still broken after a [recent commit](https://github.com/docker/docker.github.io/commit/97a1001fe91e94fff8b57bef0c6106dfe58784bd). This repairs them.

A typo was introduced in that commit, also fixed.

Fixes #5288

/CC @johndmulhausen