### PR TITLE
Fix physical/logical typo in D4M FAQ

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -251,7 +251,7 @@ $ ls -klsh Docker.raw
 2333548 -rw-r--r--@ 1 akim  staff    64G Dec 13 17:42 Docker.raw
 ```
 
-In this listing, the logical size is 64GB, but the logical size is
+In this listing, the logical size is 64GB, but the physical size is
 only 2.3GB.
 
 Alternatively, you may use `du` (disk usage):


### PR DESCRIPTION
The FAQ about the new .raw file format added in https://github.com/docker/docker.github.io/pull/5504 accidentally swapped "physical" for "logical"


ping @akimd @mistyhacks 