### PR TITLE
Fix conflicting docs on single/multiple tags

### DIFF
--- a/docker-cloud/builds/advanced.md
+++ b/docker-cloud/builds/advanced.md
@@ -102,11 +102,9 @@ docker run --privileged \
   centurylink/golang-builder
 ```
 
-#### Push to multiple tags
+#### Push to multiple repos
 
-By default the build process tags the resulting Docker image with a single tag and pushes the image only to the repository where the build settings are configured.
-
-If you needed to give the resulting image multiple tags, or push the same image to multiple repositories, you could set up a `post_push` hook to add additional tags and push to more repositories.
+By default the build process pushes the image only to the repository where the build settings are configured. If you need to push the same image to multiple repositories, you can set up a `post_push` hook to add additional tags and push to more repositories.
 
 ```none
 docker tag $IMAGE_NAME $DOCKER_REPO:$SOURCE_COMMIT

--- a/docker-cloud/builds/automated-build.md
+++ b/docker-cloud/builds/automated-build.md
@@ -321,7 +321,7 @@ For example if you want to update the image tagged with `latest` at the same
 time as you a tag an image for a specific version, you could enter
 `{sourceref},latest` in the Docker Tag field.
 
-If you need to update a tag _in another repository_, use [a post_build hook](advanced.md#push-to-multiple-tags) to push to a second repository.
+If you need to update a tag _in another repository_, use [a post_build hook](advanced.md#push-to-multiple-repos) to push to a second repository.
 
 ## Build repositories with linked private submodules
 


### PR DESCRIPTION
### Proposed changes

Removed conflicting information regarding multiple tags for an image when using auto-build. The `automated-build.md` page indicates how to add several tags to an image (just comma-separate them in the UI), but the `advanced.md` page said a post-build hook was required. Simplified that section of `advanced.md` to only deal with pushing a built image to multiple **repositories** (not just set multiple tags), and updated the corresponding link in `automated-build.md`.