### PR TITLE
Fix typo in how pki works in swarm

### DIFF
--- a/engine/swarm/how-swarm-mode-works/pki.md
+++ b/engine/swarm/how-swarm-mode-works/pki.md
@@ -13,7 +13,7 @@ When you create a swarm by running `docker swarm init`, Docker designates itself
 as a manager node. By default, the manager node generates a new root Certificate
 Authority (CA) along with a key pair, which are used to secure communications
 with other nodes that join the swarm. If you prefer, you can specify your own
-externally-generated root CA, using the the `--external-ca` flag of the
+externally-generated root CA, using the `--external-ca` flag of the
 [docker swarm init](/engine/reference/commandline/swarm_init.md) command.
 
 The manager node also generates two tokens to use when you join additional nodes


### PR DESCRIPTION
### Proposed changes

This PR fixes a typo in the docs, where the article **the** is duplicated.


