### PR TITLE
Add support for Fedora 27

### DIFF
--- a/engine/installation/linux/docker-ce/fedora.md
+++ b/engine/installation/linux/docker-ce/fedora.md
@@ -26,6 +26,7 @@ To install Docker, you need the 64-bit version of one of these Fedora versions:
 
 - 25
 - 26
+- 27
 
 ### Uninstall old versions
 
@@ -145,11 +146,11 @@ from the repository.
     ```bash
     $ dnf list docker-ce  --showduplicates | sort -r
 
-    docker-ce.x86_64  {{ site.docker_ce_stable_version }}.0.fc24                               docker-ce-stable  
+    docker-ce.x86_64  {{ site.docker_ce_stable_version }}.0.fc26                              docker-ce-stable
     ```
 
     The contents of the list depend upon which repositories are enabled, and
-    will be specific to your version of Fedora (indicated by the `.fc24` suffix
+    will be specific to your version of Fedora (indicated by the `.fc26` suffix
     on the version, in this example). Choose a specific version to install. The
     second column is the version string. The third column is the repository
     name, which indicates which repository the package is from and by extension

--- a/engine/security/seccomp.md
+++ b/engine/security/seccomp.md
@@ -18,12 +18,10 @@ $ cat /boot/config-`uname -r` | grep CONFIG_SECCOMP=
 CONFIG_SECCOMP=y
 ```
 
-> **Note**: `seccomp` profiles require seccomp 2.2.1 and are only
-> available starting with Debian 9 "Stretch", Ubuntu 16.04 "Xenial",
-> Fedora 22, CentOS 7, and Oracle Linux 7. To use this feature on Ubuntu 14.04,
-> Debian Wheezy, or Debian Jessie, you must download the
-> [latest static Docker Linux binary](../installation/binaries.md).
-> This feature is currently *not* available on other distributions.
+> **Note**: `seccomp` profiles require seccomp 2.2.1 which is not available on
+> Ubuntu 14.04, Debian Wheezy, or Debian Jessie. To use `seccomp` on these
+> distributions, you must download the [latest static Linux binaries](/engine/installation/linux/docker-ce/binaries.md)
+> (rather than packages).
 
 ## Pass a profile for a container
 


### PR DESCRIPTION
- Add support for Fedora 27
- Update references to fc24 to fc26 per [package name](https://download.docker.com/linux/fedora/26/x86_64/test/Packages/)

Fixes #5554 