### PR TITLE
fix docker-compose.yml have not link redis

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -87,6 +87,8 @@ the following:
         build: .
         ports:
          - "5000:5000"
+        links:
+         - redis
       redis:
         image: "redis:alpine"
 


### PR DESCRIPTION
rt, if web have not link redis, `redis = Redis(host='redis', port=6379)` will can not recognize the host('redis')

### Proposed changes
- add 'redis' to the web service, it's necessary by next step `redis = Redis(host='redis', port=6379)`, then it can recognize the host 'redis'

if not link redis, it's error like this:
```
redis_1  | 1:M 22 Dec 09:50:22.367 * DB loaded from disk: 0.000 seconds
redis_1  | 1:M 22 Dec 09:50:22.367 * Ready to accept connections
app_1    | [2017-12-22 09:50:23 +0000] [8] [INFO] Booting worker with pid: 8
app_1    | [2017-12-22 09:50:23 +0000] [9] [INFO] Booting worker with pid: 9
app_1    | [2017-12-22 09:50:23 +0000] [10] [INFO] Booting worker with pid: 10
app_1    | [2017-12-22 09:50:34,163] ERROR in app: Exception on / [GET]
app_1    | Traceback (most recent call last):
app_1    |   File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 484, in connect
app_1    |     sock = self._connect()
app_1    |   File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 511, in _connect
app_1    |     socket.SOCK_STREAM):
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/_socketcommon.py", line 288, in getaddrinfo
app_1    |     return get_hub().resolver.getaddrinfo(host, port, family, type, proto, flags)
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/resolver_thread.py", line 65, in getaddrinfo
app_1    |     return self.pool.apply(_socket.getaddrinfo, args, kwargs)
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/pool.py", line 325, in apply
app_1    |     return self.spawn(func, *args, **kwds).get()
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/event.py", line 385, in get
app_1    |     return self.get(block=False)
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/event.py", line 375, in get
app_1    |     return self._raise_exception()
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/event.py", line 355, in _raise_exception
app_1    |     reraise(*self.exc_info)
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/_compat.py", line 33, in reraise
app_1    |     raise value.with_traceback(tb)
app_1    |   File "/usr/local/lib/python3.6/site-packages/gevent/threadpool.py", line 211, in _worker
app_1    |     value = func(*args, **kwargs)
app_1    | socket.gaierror: [Errno -2] Name or service not known
app_1    |
app_1    | During handling of the above exception, another exception occurred:
app_1    |
```