### PR TITLE
A frustrating typo

### DIFF
--- a/compose/reference/pull.md
+++ b/compose/reference/pull.md
@@ -34,7 +34,7 @@ services:
       - db
 ```
 
-If you run `docker-compose pull ServiceName` in the same directory as the `docker-compose.yml` file that defines the service, Docker will pull the postgres image. For example, to call the `postgres` image configured as the `db` service in our example, you would run `docker-compose pull db`.
+If you run `docker-compose pull ServiceName` in the same directory as the `docker-compose.yml` file that defines the service, Docker will pull the associated image. For example, to call the `postgres` image configured as the `db` service in our example, you would run `docker-compose pull db`.
 
 ```
 $ docker-compose pull db


### PR DESCRIPTION
The point of the sentence is to remain general, in direct contrast to the following sentence which becomes specific.  For that very reason I lost time considering whether I had a misunderstanding before convincing myself that it was a typo.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
