### PR TITLE
Fix typo

### DIFF
--- a/engine/swarm/secrets.md
+++ b/engine/swarm/secrets.md
@@ -145,7 +145,7 @@ a similar way, see
 
 ### Defining and using secrets in compose files
 
-Both the `docker compose` and `docker stack` commands support defining secrets
+Both the `docker-compose` and `docker stack` commands support defining secrets
 in a compose file. See
 [the Compose file reference](/compose/compose-file/#secrets) for details.
 


### PR DESCRIPTION
This patch fixes minor typo of the `docker-compose` command.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
