### PR TITLE
Document the `mode` and `max-buffer-size` log options

### DIFF
--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -108,7 +108,7 @@ The `max-buffer-size` log option controls the size of the ring buffer used for i
 The following example starts an Alpine container with log output in non-blocking mode and a 4 megabyte buffer:
 
 ```bash
-$ docker run --log-opt mode=non-blocking --log-opt max-buffer-size=4m alpine sh
+$ docker run -it --log-opt mode=non-blocking --log-opt max-buffer-size=4m alpine ping 127.0.0.1
 ```
 
 ### Use environment variables or labels with logging drivers

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -89,6 +89,26 @@ json-file
 {% endraw %}
 ```
 
+## Configure the delivery mode of log messages from container to log driver
+
+Docker provides two modes for delivering messages from the container to the log driver since Docker 17.04:
+1. (default) direct, blocking delivery from container to driver
+2. non-blocking delivery that stores log messages in an intermediate per-container ring buffer
+
+The non-blocking mode of message delivery is useful for ensuring that applications will not block when the logging sub-system is unable to keep up with message throughput.
+
+*WARNING*: the oldest messages in memory *will be dropped* when the buffer is full, but this is often preferable to blocking the log-writing process of an application.  
+
+The `mode` log option controls whether to use the `blocking` (default) or `non-blocking` message delivery.
+
+When `mode` is set to `non-blocking`, the `max-buffer-size` log option may be used to control the size of the ring buffer used for intermediate message storage.  `max-buffer-size` defaults to 1 megabyte.
+
+The following example starts an Alpine container with log output in non-blocking mode and a 4 megabyte buffer:
+
+```bash
+$ docker run --log-opt mode=non-blocking --log-opt max-buffer-size=4m alpine sh
+```
+
 ### Use environment variables or labels with logging drivers
 
 Some logging drivers add the value of a container's `--env|-e` or `--label`

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -91,7 +91,7 @@ json-file
 
 ## Configure the delivery mode of log messages from container to log driver
 
-Docker provides two modes for delivering messages from the container to the log driver since Docker 17.04:
+Docker provides two modes for delivering messages from the container to the log driver:
 
 * (default) direct, blocking delivery from container to driver
 * non-blocking delivery that stores log messages in an intermediate per-container ring buffer for consumption by driver

--- a/engine/admin/logging/overview.md
+++ b/engine/admin/logging/overview.md
@@ -92,16 +92,18 @@ json-file
 ## Configure the delivery mode of log messages from container to log driver
 
 Docker provides two modes for delivering messages from the container to the log driver since Docker 17.04:
-1. (default) direct, blocking delivery from container to driver
-2. non-blocking delivery that stores log messages in an intermediate per-container ring buffer
 
-The non-blocking mode of message delivery is useful for ensuring that applications will not block when the logging sub-system is unable to keep up with message throughput.
+* (default) direct, blocking delivery from container to driver
+* non-blocking delivery that stores log messages in an intermediate per-container ring buffer for consumption by driver
 
-*WARNING*: the oldest messages in memory *will be dropped* when the buffer is full, but this is often preferable to blocking the log-writing process of an application.  
+The `non-blocking` message delivery mode prevents applications from blocking due to logging back pressure. Applications will likely fail in unexpected ways when STDERR or STDOUT streams block.
+
+> **WARNING**: When the buffer is full and a new message is enqueued, the oldest message in memory is dropped.  Dropping messages is often preferred to blocking the log-writing process of an application.  
+{: .warning}
 
 The `mode` log option controls whether to use the `blocking` (default) or `non-blocking` message delivery.
 
-When `mode` is set to `non-blocking`, the `max-buffer-size` log option may be used to control the size of the ring buffer used for intermediate message storage.  `max-buffer-size` defaults to 1 megabyte.
+The `max-buffer-size` log option controls the size of the ring buffer used for intermediate message storage when `mode` is set to `non-blocking`.  `max-buffer-size` defaults to 1 megabyte.
 
 The following example starts an Alpine container with log output in non-blocking mode and a 4 megabyte buffer:
 


### PR DESCRIPTION
Document how and why to configure the `mode` and `max-buffer-size` log options.

Documentation based on:
* implementation and comments of the [Ring Logger](https://github.com/moby/moby/blob/master/daemon/logger/ring.go#L49)
* conversation in implementing [PR #28762](https://github.com/moby/moby/pull/28762)

### Proposed changes

Document how and why to configure the `mode` and `max-buffer-size` log options because they are very useful in creating a robust container host configuration.

### Unreleased project version (optional)

N/A - these options were released in Docker 17.04

### Related issues (optional)

Documents changes introduced in #28762

