### PR TITLE
Docs: confusion between `--publish` and `published`

### DIFF
--- a/engine/swarm/ingress.md
+++ b/engine/swarm/ingress.md
@@ -26,10 +26,10 @@ service.
 ## Publish a port for a service
 
 Use the `--publish` flag to publish a port when you create a service. `target`
-is the port inside the container, and `publish` is the port to bind on the
-routing mesh. If you leave off the `publish` port, a random high-numbered port is
-bound for each service task. You will need to inspect the task to determine the
-port.
+is used to specify the port inside the container, and `published` is used to
+specify the port to bind on the routing mesh. If you leave off the `published`
+port, a random high-numbered port is bound for each service task. You will
+need to inspect the task to determine the port.
 
 ```bash
 $ docker service create \


### PR DESCRIPTION
### Proposed changes

There was a bit of confusing between the `--publish` flag and the `published` argument. I hope it is more clear now.

I had to reformat the text paragraph a bit, so the change seems bigger than it really is (it is quite minor in fact).

### Related issues (optional)

There is a similar explaination a couple of paragraph below, maybe it could be merged here? I have not done that.