### PR TITLE
Added AWS IdleTimeout recommendations

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/configure/use-a-load-balancer.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/use-a-load-balancer.md
@@ -134,6 +134,9 @@ backend ucp_upstream_servers_443
         "Timeout": 2,
         "UnhealthyThreshold": 4
     },
+    "ConnectionSettings": {
+    "IdleTimeout": 600
+    },
     "VPCId": "vpc-XXXXXX",
     "BackendServerDescriptions": [],
     "Instances": [


### PR DESCRIPTION
### Proposed changes
This change deals with long-running DTR operations that requires a 600 second idletimeout and currently missing for our AWS LB recommended configurations. This should help prevent support cases to be generated around this configuration issues concerning DTR. The added syntax was sourced from the following document: [AWS LB Syntax Attributes](http://docs.aws.amazon.com/cli/latest/reference/elb/modify-load-balancer-attributes.html)

```
{
    "LoadBalancerAttributes": {
        "ConnectionSettings": {
            "IdleTimeout": 600
        }
```