### PR TITLE
Updating set-up-high-availability.md

### DIFF
--- a/datacenter/dtr/2.4/guides/admin/configure/set-up-high-availability.md
+++ b/datacenter/dtr/2.4/guides/admin/configure/set-up-high-availability.md
@@ -34,7 +34,7 @@ decreases. Don't leave that replica offline for long.
 * Adding too many replicas to the cluster might also lead to performance
 degradation, as data needs to be replicated across all replicas.
 
-To have high-availability on UCP and DTR, you need a minimum of:
+To have high-availability on UCP and DTR, it is recommended to have a minimum of:
 
 * 3 dedicated nodes to install UCP with high availability,
 * 3 dedicated nodes to install DTR with high availability,


### PR DESCRIPTION
### Proposed changes
This request is based on an internal support case with Genesys ( A Docker Enterprise Customer ) who confirmed internally through Docker's sales and engineering departments that we current support installing DTR on the same nodes as UCP manager nodes. Our documentation however says this is a requirement and Genesys has requested we update our documentation to reflect this which is the basis of this change. [Docker Support Case 00033149](https://docker.my.salesforce.com/5000f00001FBE2l)

The change reflects the following verbiage change to our ha documentation:
  
`To have high-availability on UCP and DTR, you need a minimum of:`

`To have high-availability on UCP and DTR, it is recommended to have a minimum of:`