### PR TITLE
Systemd examples keep required [Service] header like in the example above it

### DIFF
--- a/engine/admin/systemd.md
+++ b/engine/admin/systemd.md
@@ -99,12 +99,14 @@ you will need to add this configuration in the Docker systemd service file.
     proxying you can specify them via the `NO_PROXY` environment variable:
 
     ```conf
+    [Service]    
     Environment="HTTP_PROXY=http://proxy.example.com:80/" "NO_PROXY=localhost,127.0.0.1,docker-registry.somecorporation.com"
     ```
 
     Or, if you are behind an HTTPS proxy server:
 
     ```conf
+    [Service]    
     Environment="HTTPS_PROXY=https://proxy.example.com:443/" "NO_PROXY=localhost,127.0.0.1,docker-registry.somecorporation.com"
     ```
 


### PR DESCRIPTION
Systemd examples keep required [Service] header like in the example above it

