### PR TITLE
Specify 0.0.0.0 as alternative address

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -186,6 +186,9 @@ the previous command (`docker container ls -q`).
 > address later in the tutorial. For now, the visitor counter isn't working
 > for the same reason; we haven't yet added a service to persist data.
 
+> Unable to connect to localhost?
+> 
+> Check also http://0.0.0.0/
 
 ## Scale the app
 


### PR DESCRIPTION
### Proposed changes
I explained that the app can also  be accessed at http://0.0.0.0/.

On my Debian machine,  `run -p 80:80 usename/get-started:part2` starts an app accessible at http://localhost/ but for some reason  `docker stack deploy -c docker-compose.yml lab` is not accessible at localhost. The browser returns an "Unable to connect" error.

The app is accessible at http://0.0.0.0/ in both cases, when started with `docker run` and  with `docker stack deploy`.
