### PR TITLE
Add sudo to CLI-based access snippet

### DIFF
--- a/datacenter/ucp/1.1/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/1.1/access-ucp/cli-based-access.md
@@ -84,7 +84,7 @@ this example we'll be using `curl` for making the web requests to the API, and
 To install these tools on an Ubuntu distribution, you can run:
 
 ```bash
-$ sudo apt-get update && apt-get install curl jq
+$ sudo apt-get update && sudo apt-get install curl jq
 ```
 
 Then you get an authentication token from UCP, and use it to download the

--- a/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.0/guides/access-ucp/cli-based-access.md
@@ -77,7 +77,7 @@ this example we'll be using `curl` for making the web requests to the API, and
 To install these tools on a Ubuntu distribution, you can run:
 
 ```none
-$ sudo apt-get update && apt-get install curl jq
+$ sudo apt-get update && sudo apt-get install curl jq
 ```
 
 Then you get an authentication token from UCP, and use it to download the

--- a/datacenter/ucp/2.2/guides/user/access-ucp/cli-based-access.md
+++ b/datacenter/ucp/2.2/guides/user/access-ucp/cli-based-access.md
@@ -82,7 +82,7 @@ responses.
 To install these tools on a Ubuntu distribution, you can run:
 
 ```bash
-$ sudo apt-get update && apt-get install curl jq
+$ sudo apt-get update && sudo apt-get install curl jq
 ```
 
 Then you get an authentication token from UCP, and use it to download the


### PR DESCRIPTION
Update snippet for [CLI based access](https://docs.docker.com/datacenter/ucp/2.2/guides/user/access-ucp/cli-based-access/#client-certificates-for-administrators):

`sudo apt-get update && apt-get install curl jq` 

with:

`sudo apt-get update && sudo apt-get install curl jq`