### PR TITLE
Use `docker container create` instead of `docker run`

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -160,10 +160,10 @@ They both work.
 
 A service definition contains configuration which will be applied to each
 container started for that service, much like passing command-line parameters to
-`docker run`. Likewise, network and volume definitions are analogous to
+`docker container create`. Likewise, network and volume definitions are analogous to
 `docker network create` and `docker volume create`.
 
-As with `docker run`, options specified in the Dockerfile (e.g., `CMD`,
+As with `docker container create`, options specified in the Dockerfile (e.g., `CMD`,
 `EXPOSE`, `VOLUME`, `ENV`) are respected by default - you don't need to
 specify them again in `docker-compose.yml`.
 


### PR DESCRIPTION
In this context, I think `docker container create` is more suitable and more respectful to the new syntax and better analogy with `docker network create` and `docker volume create`

### Proposed changes

Use `docker container create` instead of `docker run`

