### PR TITLE
Kubernetes is now available for D4M Edge

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -297,18 +297,20 @@ choose to discard or not apply changes when asked.
 
 ### Kubernetes
 
-**Kubernetes is only available in Docker for Mac 17.12 CE Edge to participants in the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
+**Kubernetes is only available in Docker for Mac 17.12 CE Edge.** Kubernetes
+support is not included in Docker for Mac 17.12 CE Stable. To find out
+more about Stable and Edge channels and how to switch between them, see
+[General configuration](/docker-for-mac/#general).
 
-If you are participating in the Docker beta program, you can access Docker for
-Mac 17.12 CE Edge, which includes a standalone Kubernetes server that runs on
-your Mac, so that you can test deploying your Docker workloads on Kubernetes.
+Docker for Mac 17.12 CE Edge includes a standalone Kubernetes server that runs
+on your Mac, so that you can test deploying your Docker workloads on Kubernetes.
 
 The Kubernetes client command, `kubectl`, is included and configured to connect
 to the local Kubernetes server. If you have `kubectl` already installed and
 pointing to some other environment, such as `minikube` or a GKE cluster, be sure
 to change context so that `kubectl` is pointing to `docker-for-desktop`:
 
-```
+```bash
 kubectl config get-contexts
 kubectl config use-context docker-for-desktop
 ```

--- a/docker-for-mac/kubernetes.md
+++ b/docker-for-mac/kubernetes.md
@@ -4,12 +4,14 @@ keywords: mac, edge, kubernetes, kubectl, orchestration
 title: Deploy to Kubernetes
 ---
 
-**Kubernetes is only available in Docker for Mac 17.12 CE Edge to participants in the [Docker Beta program](https://beta.docker.com/). To access beta builds, you must be signed in with your Docker ID within Docker for Mac: select ![whale menu](/docker-for-mac/images/whale-x.png){: .inline} -> Sign in / Create Docker ID from the menu bar.**
+**Kubernetes is only available in Docker for Mac 17.12 CE Edge.** Kubernetes
+support is not included in Docker for Mac 17.12 CE Stable. To find out
+more about Stable and Edge channels and how to switch between them, see
+[General configuration](/docker-for-mac/#general).
 
-If you are part of the Docker Beta program, Docker for Mac 17.12 CE Edge
-includes a standalone Kubernetes server and client, as well as Docker CLI
-integration. The Kubernetes server runs locally within your Docker instance, is
-not configurable, and is a single-node cluster.
+Docker for Mac 17.12 CE Edge includes a standalone Kubernetes server and client,
+as well as Docker CLI integration. The Kubernetes server runs locally within
+your Docker instance, is not configurable, and is a single-node cluster.
 
 The Kubernetes server runs within a Docker container on your Mac, and is only
 for local testing. When Kubernetes support is enabled, you can deploy your


### PR DESCRIPTION
Update the docs to reflect that Kubernetes on Docker for Mac is now out of beta and available for all Edge users on D4M!