### PR TITLE
Add restart to options not supported in stacks

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -787,6 +787,7 @@ The following sub-options (supported for `docker compose up` and `docker compose
 - [external_links](#external_links)
 - [links](#links)
 - [network_mode](#network_mode)
+- [restart](#restart)
 - [security_opt](#security_opt)
 - [stop_signal](#stop_signal)
 - [sysctls](#sysctls)
@@ -1764,6 +1765,10 @@ on-failure error.
     restart: always
     restart: on-failure
     restart: unless-stopped
+    
+> **Note**: This option is ignored when
+> [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
+> with a (version 3) Compose file. Use [restart_policy](#restart_policy) instead.
 
 ### domainname, hostname, ipc, mac\_address, privileged, read\_only, shm\_size, stdin\_open, tty, user, working\_dir
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

In compose file documentation: 

- added restart to list of sub-options not supported in stack deploy
- added note to the bottom of restart description that it isn't supported in stack deploy, and to use restart_policy instead.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
