### PR TITLE
Release docs for Docker CE 18.01

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks"]
 
 docker_ce_stable_version: "17.12"
 latest_stable_docker_engine_api_version: "1.35"
-docker_ce_edge_version: "17.12"
+docker_ce_edge_version: "18.01"
 docker_ee_version: "17.06"
 compose_version: "1.18.0"
 machine_version: "0.13.0"

--- a/_data/engine-cli-edge/docker.yaml
+++ b/_data/engine-cli-edge/docker.yaml
@@ -113,4 +113,7 @@ clink:
 - docker_wait.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_attach.yaml
+++ b/_data/engine-cli-edge/docker_attach.yaml
@@ -69,18 +69,27 @@ options:
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-stdin
   value_type: bool
   default_value: "false"
   description: Do not attach STDIN
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sig-proxy
   value_type: bool
   default_value: "true"
   description: Proxy all received signals to the process
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Attach to and detach from a running container
 
@@ -151,4 +160,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_build.yaml
+++ b/_data/engine-cli-edge/docker_build.yaml
@@ -112,40 +112,61 @@ options:
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: build-arg
   value_type: list
   description: Set build-time variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cache-from
   value_type: stringSlice
   default_value: '[]'
   description: Images to consider as cache sources
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cgroup-parent
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: compress
   value_type: bool
   default_value: "false"
   description: Compress the build context using gzip
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -153,49 +174,76 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: file
   shorthand: f
   value_type: string
   description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force-rm
   value_type: bool
   default_value: "false"
   description: Always remove intermediate containers
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: iidfile
   value_type: string
   description: Write the image ID to the file
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Container isolation technology
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   value_type: list
   description: Set metadata for an image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -203,6 +251,9 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -210,6 +261,9 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network
   value_type: string
   default_value: default
@@ -218,24 +272,36 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-cache
   value_type: bool
   default_value: "false"
   description: Do not use cache when building the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pull
   value_type: bool
   default_value: "false"
   description: Always attempt to pull a newer version of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -243,24 +309,36 @@ options:
   description: Suppress the build output and print image ID on success
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rm
   value_type: bool
   default_value: "true"
   description: Remove intermediate containers after a successful build
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: security-opt
   value_type: stringSlice
   default_value: '[]'
   description: Security options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: shm-size
   value_type: bytes
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: squash
   value_type: bool
   default_value: "false"
@@ -268,6 +346,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stream
   value_type: bool
   default_value: "false"
@@ -275,23 +356,35 @@ options:
   deprecated: false
   min_api_version: "1.31"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tag
   shorthand: t
   value_type: list
   description: Name and optionally a tag in the 'name:tag' format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: target
   value_type: string
   description: Set the target build stage to build.
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ulimit
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Build with PATH\n\n```bash\n$ docker build .\n\nUploading context 10240
   bytes\nStep 1/3 : FROM busybox\nPulling repository busybox\n ---> e9aa60c60128MB/2.284
   MB (100%) endpoint: https://cdn-registry-1.docker.io/v1/\nStep 2/3 : RUN ls -lh
@@ -476,4 +569,7 @@ examples: "### Build with PATH\n\n```bash\n$ docker build .\n\nUploading context
   make sure the `HELLO` envvar's value is `world`."
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_checkpoint.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint.yaml
@@ -15,4 +15,7 @@ clink:
 deprecated: false
 min_api_version: "1.25"
 experimental: true
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_checkpoint_create.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint_create.yaml
@@ -10,13 +10,22 @@ options:
   description: Use a custom checkpoint storage directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: leave-running
   value_type: bool
   default_value: "false"
   description: Leave the container running after checkpoint
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.25"
 experimental: true
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_checkpoint_ls.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint_ls.yaml
@@ -11,7 +11,13 @@ options:
   description: Use a custom checkpoint storage directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.25"
 experimental: true
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_checkpoint_rm.yaml
+++ b/_data/engine-cli-edge/docker_checkpoint_rm.yaml
@@ -11,7 +11,13 @@ options:
   description: Use a custom checkpoint storage directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.25"
 experimental: true
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_commit.yaml
+++ b/_data/engine-cli-edge/docker_commit.yaml
@@ -28,18 +28,27 @@ options:
   description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: change
   shorthand: c
   value_type: list
   description: Apply Dockerfile instruction to the created image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: message
   shorthand: m
   value_type: string
   description: Commit message
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pause
   shorthand: p
   value_type: bool
@@ -47,6 +56,9 @@ options:
   description: Pause container during commit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Commit a container
 
@@ -115,4 +127,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_config.yaml
+++ b/_data/engine-cli-edge/docker_config.yaml
@@ -17,4 +17,7 @@ clink:
 deprecated: false
 min_api_version: "1.30"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_config_create.yaml
+++ b/_data/engine-cli-edge/docker_config_create.yaml
@@ -11,7 +11,13 @@ options:
   description: Config labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.30"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_config_inspect.yaml
+++ b/_data/engine-cli-edge/docker_config_inspect.yaml
@@ -11,13 +11,22 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pretty
   value_type: bool
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.30"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_config_ls.yaml
+++ b/_data/engine-cli-edge/docker_config_ls.yaml
@@ -12,11 +12,17 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print configs using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -24,7 +30,13 @@ options:
   description: Only display IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.30"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_config_rm.yaml
+++ b/_data/engine-cli-edge/docker_config_rm.yaml
@@ -8,4 +8,7 @@ plink: docker_config.yaml
 deprecated: false
 min_api_version: "1.30"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_container.yaml
+++ b/_data/engine-cli-edge/docker_container.yaml
@@ -58,4 +58,7 @@ clink:
 - docker_container_wait.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_attach.yaml
+++ b/_data/engine-cli-edge/docker_container_attach.yaml
@@ -10,18 +10,30 @@ options:
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-stdin
   value_type: bool
   default_value: "false"
   description: Do not attach STDIN
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sig-proxy
   value_type: bool
   default_value: "true"
   description: Proxy all received signals to the process
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_commit.yaml
+++ b/_data/engine-cli-edge/docker_container_commit.yaml
@@ -11,18 +11,27 @@ options:
   description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: change
   shorthand: c
   value_type: list
   description: Apply Dockerfile instruction to the created image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: message
   shorthand: m
   value_type: string
   description: Commit message
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pause
   shorthand: p
   value_type: bool
@@ -30,6 +39,12 @@ options:
   description: Pause container during commit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_cp.yaml
+++ b/_data/engine-cli-edge/docker_container_cp.yaml
@@ -19,6 +19,9 @@ options:
   description: Archive mode (copy all uid/gid information)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: follow-link
   shorthand: L
   value_type: bool
@@ -26,6 +29,12 @@ options:
   description: Always follow symbol link in SRC_PATH
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_create.yaml
+++ b/_data/engine-cli-edge/docker_container_create.yaml
@@ -10,12 +10,18 @@ options:
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: attach
   shorthand: a
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight
   value_type: uint16
   default_value: "0"
@@ -23,56 +29,86 @@ options:
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight-device
   value_type: list
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-add
   value_type: list
   description: Add Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-drop
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cgroup-parent
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-count
   value_type: int64
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-percent
   value_type: int64
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-period
   value_type: int64
   default_value: "0"
@@ -80,6 +116,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-runtime
   value_type: int64
   default_value: "0"
@@ -87,6 +126,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -94,125 +136,194 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpus
   value_type: decimal
   description: Number of CPUs
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device
   value_type: list
   description: Add a host device to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-cgroup-rule
   value_type: list
   description: Add a rule to the cgroup allowed devices list
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-bps
   value_type: list
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-iops
   value_type: list
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-bps
   value_type: list
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-iops
   value_type: list
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns
   value_type: list
   description: Set custom DNS servers
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-opt
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-option
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-search
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: entrypoint
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env
   shorthand: e
   value_type: list
   description: Set environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env-file
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: expose
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: group-add
   value_type: list
   description: Add additional groups to join
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-cmd
   value_type: string
   description: Command to run to check health
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-interval
   value_type: duration
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-retries
   value_type: int
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-start-period
   value_type: duration
   default_value: 0s
@@ -221,6 +332,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-timeout
   value_type: duration
   default_value: 0s
@@ -228,18 +342,27 @@ options:
     Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: help
   value_type: bool
   default_value: "false"
   description: Print usage
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: hostname
   shorthand: h
   value_type: string
   description: Container host name
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: init
   value_type: bool
   default_value: "false"
@@ -248,6 +371,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -255,6 +381,9 @@ options:
   description: Keep STDIN open even if not attached
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
@@ -262,74 +391,116 @@ options:
     Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxiops
   value_type: uint64
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip6
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ipc
   value_type: string
   description: IPC mode to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Container isolation technology
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: kernel-memory
   value_type: bytes
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   shorthand: l
   value_type: list
   description: Set meta data on a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-file
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link
   value_type: list
   description: Add link to another container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link-local-ip
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-driver
   value_type: string
   description: Logging driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-opt
   value_type: list
   description: Log driver options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mac-address
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -337,12 +508,18 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-reservation
   value_type: bytes
   default_value: "0"
   description: Memory soft limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -350,91 +527,139 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swappiness
   value_type: int64
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mount
   value_type: mount
   description: Attach a filesystem mount to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: name
   value_type: string
   description: Assign a name to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-healthcheck
   value_type: bool
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-kill-disable
   value_type: bool
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-score-adj
   value_type: int
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pid
   value_type: string
   description: PID namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pids-limit
   value_type: int64
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: privileged
   value_type: bool
   default_value: "false"
   description: Give extended privileges to this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish
   shorthand: p
   value_type: list
   description: Publish a container's port(s) to the host
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish-all
   shorthand: P
   value_type: bool
@@ -442,46 +667,70 @@ options:
   description: Publish all exposed ports to random ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: read-only
   value_type: bool
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart
   value_type: string
   default_value: "no"
   description: Restart policy to apply when a container exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rm
   value_type: bool
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: runtime
   value_type: string
   description: Runtime to use for this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: security-opt
   value_type: list
   description: Security Options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: shm-size
   value_type: bytes
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-signal
   value_type: string
   default_value: SIGTERM
   description: Signal to stop a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-timeout
   value_type: int
   default_value: "0"
@@ -489,22 +738,34 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: storage-opt
   value_type: list
   description: Storage driver options for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sysctl
   value_type: map
   default_value: map[]
   description: Sysctl options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tmpfs
   value_type: list
   description: Mount a tmpfs directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -512,50 +773,80 @@ options:
   description: Allocate a pseudo-TTY
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ulimit
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: userns
   value_type: string
   description: User namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: uts
   value_type: string
   description: UTS namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume
   shorthand: v
   value_type: list
   description: Bind mount a volume
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume-driver
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volumes-from
   value_type: list
   description: Mount volumes from the specified container(s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
   description: Working directory inside the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_diff.yaml
+++ b/_data/engine-cli-edge/docker_container_diff.yaml
@@ -6,4 +6,7 @@ pname: docker container
 plink: docker_container.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_exec.yaml
+++ b/_data/engine-cli-edge/docker_container_exec.yaml
@@ -12,11 +12,17 @@ options:
   description: 'Detached mode: run command in the background'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach-keys
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env
   shorthand: e
   value_type: list
@@ -24,6 +30,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -31,12 +40,18 @@ options:
   description: Keep STDIN open even if not attached
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: privileged
   value_type: bool
   default_value: "false"
   description: Give extended privileges to the command
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -44,12 +59,18 @@ options:
   description: Allocate a pseudo-TTY
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
@@ -57,6 +78,12 @@ options:
   deprecated: false
   min_api_version: "1.35"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_export.yaml
+++ b/_data/engine-cli-edge/docker_container_export.yaml
@@ -11,6 +11,12 @@ options:
   description: Write to a file, instead of STDOUT
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_inspect.yaml
+++ b/_data/engine-cli-edge/docker_container_inspect.yaml
@@ -11,6 +11,9 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: size
   shorthand: s
   value_type: bool
@@ -18,6 +21,12 @@ options:
   description: Display total file sizes
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_kill.yaml
+++ b/_data/engine-cli-edge/docker_container_kill.yaml
@@ -12,6 +12,12 @@ options:
   description: Signal to send to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_logs.yaml
+++ b/_data/engine-cli-edge/docker_container_logs.yaml
@@ -11,6 +11,9 @@ options:
   description: Show extra details provided to logs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: follow
   shorthand: f
   value_type: bool
@@ -18,18 +21,27 @@ options:
   description: Follow log output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: since
   value_type: string
   description: |
     Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tail
   value_type: string
   default_value: all
   description: Number of lines to show from the end of the logs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: timestamps
   shorthand: t
   value_type: bool
@@ -37,6 +49,9 @@ options:
   description: Show timestamps
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: until
   value_type: string
   description: |
@@ -44,6 +59,12 @@ options:
   deprecated: false
   min_api_version: "1.35"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_ls.yaml
+++ b/_data/engine-cli-edge/docker_container_ls.yaml
@@ -13,17 +13,26 @@ options:
   description: Show all containers (default shows just running)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: filter
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print containers using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: last
   shorthand: "n"
   value_type: int
@@ -31,6 +40,9 @@ options:
   description: Show n last created containers (includes all states)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: latest
   shorthand: l
   value_type: bool
@@ -38,12 +50,18 @@ options:
   description: Show the latest created container (includes all states)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -51,6 +69,9 @@ options:
   description: Only display numeric IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: size
   shorthand: s
   value_type: bool
@@ -58,6 +79,12 @@ options:
   description: Display total file sizes
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_pause.yaml
+++ b/_data/engine-cli-edge/docker_container_pause.yaml
@@ -6,4 +6,7 @@ pname: docker container
 plink: docker_container.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_port.yaml
+++ b/_data/engine-cli-edge/docker_container_port.yaml
@@ -6,4 +6,7 @@ pname: docker container
 plink: docker_container.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_prune.yaml
+++ b/_data/engine-cli-edge/docker_container_prune.yaml
@@ -10,6 +10,9 @@ options:
   description: Provide filter values (e.g. 'until=<timestamp>')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force
   shorthand: f
   value_type: bool
@@ -17,6 +20,9 @@ options:
   description: Do not prompt for confirmation
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Prune containers
 
@@ -33,7 +39,7 @@ examples: |-
 
   ### Filtering
 
-  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
   The currently supported filters are:
@@ -104,4 +110,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_rename.yaml
+++ b/_data/engine-cli-edge/docker_container_rename.yaml
@@ -6,4 +6,7 @@ pname: docker container
 plink: docker_container.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_restart.yaml
+++ b/_data/engine-cli-edge/docker_container_restart.yaml
@@ -12,6 +12,12 @@ options:
   description: Seconds to wait for stop before killing the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_rm.yaml
+++ b/_data/engine-cli-edge/docker_container_rm.yaml
@@ -12,6 +12,9 @@ options:
   description: Force the removal of a running container (uses SIGKILL)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link
   shorthand: l
   value_type: bool
@@ -19,6 +22,9 @@ options:
   description: Remove the specified link
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volumes
   shorthand: v
   value_type: bool
@@ -26,6 +32,12 @@ options:
   description: Remove the volumes associated with the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_run.yaml
+++ b/_data/engine-cli-edge/docker_container_run.yaml
@@ -10,12 +10,18 @@ options:
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: attach
   shorthand: a
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight
   value_type: uint16
   default_value: "0"
@@ -23,56 +29,86 @@ options:
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight-device
   value_type: list
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-add
   value_type: list
   description: Add Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-drop
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cgroup-parent
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-count
   value_type: int64
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-percent
   value_type: int64
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-period
   value_type: int64
   default_value: "0"
@@ -80,6 +116,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-runtime
   value_type: int64
   default_value: "0"
@@ -87,6 +126,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -94,22 +136,34 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpus
   value_type: decimal
   description: Number of CPUs
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach
   shorthand: d
   value_type: bool
@@ -117,114 +171,177 @@ options:
   description: Run container in background and print container ID
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach-keys
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device
   value_type: list
   description: Add a host device to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-cgroup-rule
   value_type: list
   description: Add a rule to the cgroup allowed devices list
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-bps
   value_type: list
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-iops
   value_type: list
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-bps
   value_type: list
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-iops
   value_type: list
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns
   value_type: list
   description: Set custom DNS servers
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-opt
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-option
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-search
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: entrypoint
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env
   shorthand: e
   value_type: list
   description: Set environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env-file
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: expose
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: group-add
   value_type: list
   description: Add additional groups to join
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-cmd
   value_type: string
   description: Command to run to check health
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-interval
   value_type: duration
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-retries
   value_type: int
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-start-period
   value_type: duration
   default_value: 0s
@@ -233,6 +350,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-timeout
   value_type: duration
   default_value: 0s
@@ -240,18 +360,27 @@ options:
     Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: help
   value_type: bool
   default_value: "false"
   description: Print usage
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: hostname
   shorthand: h
   value_type: string
   description: Container host name
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: init
   value_type: bool
   default_value: "false"
@@ -260,6 +389,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -267,6 +399,9 @@ options:
   description: Keep STDIN open even if not attached
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
@@ -274,74 +409,116 @@ options:
     Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxiops
   value_type: uint64
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip6
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ipc
   value_type: string
   description: IPC mode to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Container isolation technology
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: kernel-memory
   value_type: bytes
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   shorthand: l
   value_type: list
   description: Set meta data on a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-file
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link
   value_type: list
   description: Add link to another container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link-local-ip
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-driver
   value_type: string
   description: Logging driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-opt
   value_type: list
   description: Log driver options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mac-address
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -349,12 +526,18 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-reservation
   value_type: bytes
   default_value: "0"
   description: Memory soft limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -362,91 +545,139 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swappiness
   value_type: int64
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mount
   value_type: mount
   description: Attach a filesystem mount to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: name
   value_type: string
   description: Assign a name to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-healthcheck
   value_type: bool
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-kill-disable
   value_type: bool
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-score-adj
   value_type: int
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pid
   value_type: string
   description: PID namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pids-limit
   value_type: int64
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: privileged
   value_type: bool
   default_value: "false"
   description: Give extended privileges to this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish
   shorthand: p
   value_type: list
   description: Publish a container's port(s) to the host
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish-all
   shorthand: P
   value_type: bool
@@ -454,52 +685,79 @@ options:
   description: Publish all exposed ports to random ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: read-only
   value_type: bool
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart
   value_type: string
   default_value: "no"
   description: Restart policy to apply when a container exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rm
   value_type: bool
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: runtime
   value_type: string
   description: Runtime to use for this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: security-opt
   value_type: list
   description: Security Options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: shm-size
   value_type: bytes
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sig-proxy
   value_type: bool
   default_value: "true"
   description: Proxy received signals to the process
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-signal
   value_type: string
   default_value: SIGTERM
   description: Signal to stop a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-timeout
   value_type: int
   default_value: "0"
@@ -507,22 +765,34 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: storage-opt
   value_type: list
   description: Storage driver options for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sysctl
   value_type: map
   default_value: map[]
   description: Sysctl options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tmpfs
   value_type: list
   description: Mount a tmpfs directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -530,50 +800,80 @@ options:
   description: Allocate a pseudo-TTY
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ulimit
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: userns
   value_type: string
   description: User namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: uts
   value_type: string
   description: UTS namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume
   shorthand: v
   value_type: list
   description: Bind mount a volume
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume-driver
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volumes-from
   value_type: list
   description: Mount volumes from the specified container(s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
   description: Working directory inside the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_start.yaml
+++ b/_data/engine-cli-edge/docker_container_start.yaml
@@ -12,21 +12,33 @@ options:
   description: Attach STDOUT/STDERR and forward signals
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: checkpoint
   value_type: string
   description: Restore from this checkpoint
   deprecated: false
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: checkpoint-dir
   value_type: string
   description: Use a custom checkpoint storage directory
   deprecated: false
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach-keys
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -34,6 +46,12 @@ options:
   description: Attach container's STDIN
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_stats.yaml
+++ b/_data/engine-cli-edge/docker_container_stats.yaml
@@ -12,23 +12,38 @@ options:
   description: Show all containers (default shows just running)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print images using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-stream
   value_type: bool
   default_value: "false"
   description: Disable streaming stats and only pull the first result
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Do not truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_stop.yaml
+++ b/_data/engine-cli-edge/docker_container_stop.yaml
@@ -12,6 +12,12 @@ options:
   description: Seconds to wait for stop before killing it
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_top.yaml
+++ b/_data/engine-cli-edge/docker_container_top.yaml
@@ -6,4 +6,7 @@ pname: docker container
 plink: docker_container.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_unpause.yaml
+++ b/_data/engine-cli-edge/docker_container_unpause.yaml
@@ -6,4 +6,7 @@ pname: docker container
 plink: docker_container.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_update.yaml
+++ b/_data/engine-cli-edge/docker_container_update.yaml
@@ -12,18 +12,27 @@ options:
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-period
   value_type: int64
   default_value: "0"
@@ -31,6 +40,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-runtime
   value_type: int64
   default_value: "0"
@@ -38,6 +50,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -45,28 +60,43 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpus
   value_type: decimal
   description: Number of CPUs
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: kernel-memory
   value_type: bytes
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -74,12 +104,18 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-reservation
   value_type: bytes
   default_value: "0"
   description: Memory soft limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -87,11 +123,20 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart
   value_type: string
   description: Restart policy to apply when a container exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_container_wait.yaml
+++ b/_data/engine-cli-edge/docker_container_wait.yaml
@@ -6,4 +6,7 @@ pname: docker container
 plink: docker_container.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_cp.yaml
+++ b/_data/engine-cli-edge/docker_cp.yaml
@@ -95,6 +95,9 @@ options:
   description: Archive mode (copy all uid/gid information)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: follow-link
   shorthand: L
   value_type: bool
@@ -102,6 +105,12 @@ options:
   description: Always follow symbol link in SRC_PATH
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_create.yaml
+++ b/_data/engine-cli-edge/docker_create.yaml
@@ -21,12 +21,18 @@ options:
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: attach
   shorthand: a
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight
   value_type: uint16
   default_value: "0"
@@ -34,56 +40,86 @@ options:
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight-device
   value_type: list
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-add
   value_type: list
   description: Add Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-drop
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cgroup-parent
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-count
   value_type: int64
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-percent
   value_type: int64
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-period
   value_type: int64
   default_value: "0"
@@ -91,6 +127,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-runtime
   value_type: int64
   default_value: "0"
@@ -98,6 +137,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -105,125 +147,194 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpus
   value_type: decimal
   description: Number of CPUs
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device
   value_type: list
   description: Add a host device to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-cgroup-rule
   value_type: list
   description: Add a rule to the cgroup allowed devices list
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-bps
   value_type: list
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-iops
   value_type: list
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-bps
   value_type: list
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-iops
   value_type: list
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns
   value_type: list
   description: Set custom DNS servers
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-opt
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-option
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-search
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: entrypoint
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env
   shorthand: e
   value_type: list
   description: Set environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env-file
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: expose
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: group-add
   value_type: list
   description: Add additional groups to join
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-cmd
   value_type: string
   description: Command to run to check health
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-interval
   value_type: duration
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-retries
   value_type: int
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-start-period
   value_type: duration
   default_value: 0s
@@ -232,6 +343,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-timeout
   value_type: duration
   default_value: 0s
@@ -239,18 +353,27 @@ options:
     Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: help
   value_type: bool
   default_value: "false"
   description: Print usage
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: hostname
   shorthand: h
   value_type: string
   description: Container host name
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: init
   value_type: bool
   default_value: "false"
@@ -259,6 +382,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -266,6 +392,9 @@ options:
   description: Keep STDIN open even if not attached
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
@@ -273,74 +402,116 @@ options:
     Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxiops
   value_type: uint64
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip6
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ipc
   value_type: string
   description: IPC mode to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Container isolation technology
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: kernel-memory
   value_type: bytes
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   shorthand: l
   value_type: list
   description: Set meta data on a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-file
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link
   value_type: list
   description: Add link to another container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link-local-ip
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-driver
   value_type: string
   description: Logging driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-opt
   value_type: list
   description: Log driver options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mac-address
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -348,12 +519,18 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-reservation
   value_type: bytes
   default_value: "0"
   description: Memory soft limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -361,91 +538,139 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swappiness
   value_type: int64
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mount
   value_type: mount
   description: Attach a filesystem mount to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: name
   value_type: string
   description: Assign a name to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-healthcheck
   value_type: bool
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-kill-disable
   value_type: bool
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-score-adj
   value_type: int
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pid
   value_type: string
   description: PID namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pids-limit
   value_type: int64
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: privileged
   value_type: bool
   default_value: "false"
   description: Give extended privileges to this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish
   shorthand: p
   value_type: list
   description: Publish a container's port(s) to the host
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish-all
   shorthand: P
   value_type: bool
@@ -453,46 +678,70 @@ options:
   description: Publish all exposed ports to random ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: read-only
   value_type: bool
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart
   value_type: string
   default_value: "no"
   description: Restart policy to apply when a container exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rm
   value_type: bool
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: runtime
   value_type: string
   description: Runtime to use for this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: security-opt
   value_type: list
   description: Security Options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: shm-size
   value_type: bytes
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-signal
   value_type: string
   default_value: SIGTERM
   description: Signal to stop a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-timeout
   value_type: int
   default_value: "0"
@@ -500,22 +749,34 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: storage-opt
   value_type: list
   description: Storage driver options for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sysctl
   value_type: map
   default_value: map[]
   description: Sysctl options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tmpfs
   value_type: list
   description: Mount a tmpfs directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -523,50 +784,77 @@ options:
   description: Allocate a pseudo-TTY
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ulimit
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: userns
   value_type: string
   description: User namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: uts
   value_type: string
   description: UTS namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume
   shorthand: v
   value_type: list
   description: Bind mount a volume
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume-driver
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volumes-from
   value_type: list
   description: Mount volumes from the specified container(s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
   description: Working directory inside the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Create and start a container
 
@@ -677,4 +965,7 @@ examples: |-
   the create/run command
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_deploy.yaml
+++ b/_data/engine-cli-edge/docker_deploy.yaml
@@ -12,6 +12,9 @@ options:
   description: Path to a Distributed Application Bundle file
   deprecated: false
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: compose-file
   shorthand: c
   value_type: string
@@ -19,6 +22,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: prune
   value_type: bool
   default_value: "false"
@@ -26,6 +32,9 @@ options:
   deprecated: false
   min_api_version: "1.27"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: resolve-image
   value_type: string
   default_value: always
@@ -34,12 +43,18 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: with-registry-auth
   value_type: bool
   default_value: "false"
   description: Send registry authentication details to Swarm agents
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 examples: |-
   ### Compose file
 
@@ -104,4 +119,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: true
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_diff.yaml
+++ b/_data/engine-cli-edge/docker_diff.yaml
@@ -43,4 +43,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_events.yaml
+++ b/_data/engine-cli-edge/docker_events.yaml
@@ -180,21 +180,33 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: since
   value_type: string
   description: Show all events created since timestamp
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: until
   value_type: string
   description: Stream events until this timestamp
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Basic example
 
@@ -406,4 +418,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_exec.yaml
+++ b/_data/engine-cli-edge/docker_exec.yaml
@@ -25,11 +25,17 @@ options:
   description: 'Detached mode: run command in the background'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach-keys
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env
   shorthand: e
   value_type: list
@@ -37,6 +43,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -44,12 +53,18 @@ options:
   description: Keep STDIN open even if not attached
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: privileged
   value_type: bool
   default_value: "false"
   description: Give extended privileges to the command
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -57,12 +72,18 @@ options:
   description: Allocate a pseudo-TTY
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
@@ -70,6 +91,9 @@ options:
   deprecated: false
   min_api_version: "1.35"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Run `docker exec` on a running container\n\nFirst, start a container.\n\n```bash\n$
   docker run --name ubuntu_bash --rm -i -t ubuntu bash\n```\n\nThis will create a
   container named `ubuntu_bash` and start a Bash session.\n\nNext, execute a command
@@ -94,4 +118,7 @@ examples: "### Run `docker exec` on a running container\n\nFirst, start a contai
   paused, unpause the container before exec\n\n$ echo $?\n1\n```"
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_export.yaml
+++ b/_data/engine-cli-edge/docker_export.yaml
@@ -18,6 +18,9 @@ options:
   description: Write to a file, instead of STDOUT
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ch of these commands has the same result.
 
@@ -30,4 +33,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_history.yaml
+++ b/_data/engine-cli-edge/docker_history.yaml
@@ -10,6 +10,9 @@ options:
   description: Pretty-print images using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: human
   shorthand: H
   value_type: bool
@@ -17,12 +20,18 @@ options:
   description: Print sizes and dates in human readable format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -30,6 +39,9 @@ options:
   description: Only show numeric IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   To see how the `docker:latest` image was built:
 
@@ -93,4 +105,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image.yaml
+++ b/_data/engine-cli-edge/docker_image.yaml
@@ -32,4 +32,7 @@ clink:
 - docker_image_tag.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_build.yaml
+++ b/_data/engine-cli-edge/docker_image_build.yaml
@@ -10,40 +10,61 @@ options:
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: build-arg
   value_type: list
   description: Set build-time variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cache-from
   value_type: stringSlice
   default_value: '[]'
   description: Images to consider as cache sources
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cgroup-parent
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: compress
   value_type: bool
   default_value: "false"
   description: Compress the build context using gzip
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -51,49 +72,76 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: file
   shorthand: f
   value_type: string
   description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force-rm
   value_type: bool
   default_value: "false"
   description: Always remove intermediate containers
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: iidfile
   value_type: string
   description: Write the image ID to the file
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Container isolation technology
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   value_type: list
   description: Set metadata for an image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -101,6 +149,9 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -108,6 +159,9 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network
   value_type: string
   default_value: default
@@ -116,24 +170,36 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-cache
   value_type: bool
   default_value: "false"
   description: Do not use cache when building the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pull
   value_type: bool
   default_value: "false"
   description: Always attempt to pull a newer version of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -141,24 +207,36 @@ options:
   description: Suppress the build output and print image ID on success
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rm
   value_type: bool
   default_value: "true"
   description: Remove intermediate containers after a successful build
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: security-opt
   value_type: stringSlice
   default_value: '[]'
   description: Security options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: shm-size
   value_type: bytes
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: squash
   value_type: bool
   default_value: "false"
@@ -166,6 +244,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stream
   value_type: bool
   default_value: "false"
@@ -173,23 +254,38 @@ options:
   deprecated: false
   min_api_version: "1.31"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tag
   shorthand: t
   value_type: list
   description: Name and optionally a tag in the 'name:tag' format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: target
   value_type: string
   description: Set the target build stage to build.
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ulimit
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_history.yaml
+++ b/_data/engine-cli-edge/docker_image_history.yaml
@@ -10,6 +10,9 @@ options:
   description: Pretty-print images using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: human
   shorthand: H
   value_type: bool
@@ -17,12 +20,18 @@ options:
   description: Print sizes and dates in human readable format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -30,6 +39,12 @@ options:
   description: Only show numeric IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_import.yaml
+++ b/_data/engine-cli-edge/docker_image_import.yaml
@@ -11,12 +11,21 @@ options:
   description: Apply Dockerfile instruction to the created image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: message
   shorthand: m
   value_type: string
   description: Set commit message for imported image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_inspect.yaml
+++ b/_data/engine-cli-edge/docker_image_inspect.yaml
@@ -11,6 +11,12 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_load.yaml
+++ b/_data/engine-cli-edge/docker_image_load.yaml
@@ -11,6 +11,9 @@ options:
   description: Read from tar archive file, instead of STDIN
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -18,6 +21,12 @@ options:
   description: Suppress the load output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_ls.yaml
+++ b/_data/engine-cli-edge/docker_image_ls.yaml
@@ -13,29 +13,44 @@ options:
   description: Show all images (default hides intermediate images)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: digests
   value_type: bool
   default_value: "false"
   description: Show digests
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: filter
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print images using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -43,6 +58,12 @@ options:
   description: Only show numeric IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_prune.yaml
+++ b/_data/engine-cli-edge/docker_image_prune.yaml
@@ -13,11 +13,17 @@ options:
   description: Remove all unused images, not just dangling ones
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: filter
   value_type: filter
   description: Provide filter values (e.g. 'until=<timestamp>')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force
   shorthand: f
   value_type: bool
@@ -25,6 +31,9 @@ options:
   description: Do not prompt for confirmation
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |2-
    output:
 
@@ -63,7 +72,7 @@ examples: |2-
 
   ### Filtering
 
-  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
   The currently supported filters are:
@@ -157,4 +166,7 @@ examples: |2-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_pull.yaml
+++ b/_data/engine-cli-edge/docker_image_pull.yaml
@@ -12,18 +12,30 @@ options:
   description: Download all tagged images in the repository
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_push.yaml
+++ b/_data/engine-cli-edge/docker_image_push.yaml
@@ -11,6 +11,12 @@ options:
   description: Skip image signing
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_rm.yaml
+++ b/_data/engine-cli-edge/docker_image_rm.yaml
@@ -13,12 +13,21 @@ options:
   description: Force removal of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-prune
   value_type: bool
   default_value: "false"
   description: Do not delete untagged parents
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_save.yaml
+++ b/_data/engine-cli-edge/docker_image_save.yaml
@@ -11,6 +11,12 @@ options:
   description: Write to a file, instead of STDOUT
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_image_tag.yaml
+++ b/_data/engine-cli-edge/docker_image_tag.yaml
@@ -6,4 +6,7 @@ pname: docker image
 plink: docker_image.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_images.yaml
+++ b/_data/engine-cli-edge/docker_images.yaml
@@ -27,29 +27,44 @@ options:
   description: Show all images (default hides intermediate images)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: digests
   value_type: bool
   default_value: "false"
   description: Show digests
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: filter
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print images using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -57,6 +72,9 @@ options:
   description: Only show numeric IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### List the most recently created images
 
@@ -346,4 +364,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_import.yaml
+++ b/_data/engine-cli-edge/docker_import.yaml
@@ -23,12 +23,18 @@ options:
   description: Apply Dockerfile instruction to the created image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: message
   shorthand: m
   value_type: string
   description: Set commit message for imported image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Import from a remote location
 
@@ -76,4 +82,7 @@ examples: |-
   tar, then the ownerships might not get preserved.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_info.yaml
+++ b/_data/engine-cli-edge/docker_info.yaml
@@ -28,6 +28,9 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Show output
 
@@ -227,4 +230,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_inspect.yaml
+++ b/_data/engine-cli-edge/docker_inspect.yaml
@@ -14,6 +14,9 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: size
   shorthand: s
   value_type: bool
@@ -21,11 +24,17 @@ options:
   description: Display total file sizes if the type is container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: type
   value_type: string
   description: Return JSON for specified type
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Get an instance's IP address
 
@@ -89,4 +98,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_kill.yaml
+++ b/_data/engine-cli-edge/docker_kill.yaml
@@ -18,6 +18,12 @@ options:
   description: Signal to send to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_load.yaml
+++ b/_data/engine-cli-edge/docker_load.yaml
@@ -13,6 +13,9 @@ options:
   description: Read from tar archive file, instead of STDIN
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -20,6 +23,9 @@ options:
   description: Suppress the load output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker images
@@ -50,4 +56,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_login.yaml
+++ b/_data/engine-cli-edge/docker_login.yaml
@@ -12,7 +12,7 @@ long: "Login to a registry.\n\n### Login to a self-hosted registry\n\nIf you wan
   `root`, except when:\n\n1.  connecting to a remote daemon, such as a `docker-machine`
   provisioned `docker engine`.\n2.  user is added to the `docker` group.  This will
   impact the security of your system; the `docker` group is `root` equivalent.  See
-  [Docker Daemon Attack Surface](https://docs.docker.com/security/security/#docker-daemon-attack-surface)
+  [Docker Daemon Attack Surface](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface)
   for details.\n\nYou can log into any public or private repository for which you
   have\ncredentials.  When you log in, the command stores credentials in\n`$HOME/.docker/config.json`
   on Linux or `%USERPROFILE%/.docker/config.json` on\nWindows, via the procedure described
@@ -78,18 +78,30 @@ options:
   description: Password
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: password-stdin
   value_type: bool
   default_value: "false"
   description: Take the password from stdin
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: username
   shorthand: u
   value_type: string
   description: Username
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_logout.yaml
+++ b/_data/engine-cli-edge/docker_logout.yaml
@@ -10,4 +10,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_logs.yaml
+++ b/_data/engine-cli-edge/docker_logs.yaml
@@ -46,6 +46,9 @@ options:
   description: Show extra details provided to logs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: follow
   shorthand: f
   value_type: bool
@@ -53,18 +56,27 @@ options:
   description: Follow log output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: since
   value_type: string
   description: |
     Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tail
   value_type: string
   default_value: all
   description: Number of lines to show from the end of the logs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: timestamps
   shorthand: t
   value_type: bool
@@ -72,6 +84,9 @@ options:
   description: Show timestamps
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: until
   value_type: string
   description: |
@@ -79,6 +94,9 @@ options:
   deprecated: false
   min_api_version: "1.35"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Retrieve logs until a specific point in time
 
@@ -95,4 +113,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network.yaml
+++ b/_data/engine-cli-edge/docker_network.yaml
@@ -24,4 +24,7 @@ clink:
 - docker_network_rm.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network_connect.yaml
+++ b/_data/engine-cli-edge/docker_network_connect.yaml
@@ -14,27 +14,42 @@ options:
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip6
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link
   value_type: list
   description: Add link to another container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link-local-ip
   value_type: stringSlice
   default_value: '[]'
   description: Add a link-local address for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Connect a running container to a network
 
@@ -105,4 +120,7 @@ examples: |-
   You can connect a container to one or more networks. The networks need not be the same type. For example, you can connect a single container bridge and overlay networks.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network_create.yaml
+++ b/_data/engine-cli-edge/docker_network_create.yaml
@@ -59,18 +59,27 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: aux-address
   value_type: map
   default_value: map[]
   description: Auxiliary IPv4 or IPv6 addresses used by Network driver
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: config-from
   value_type: string
   description: The network from which copying the configuration
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: config-only
   value_type: bool
   default_value: "false"
@@ -78,6 +87,9 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: driver
   shorthand: d
   value_type: string
@@ -85,12 +97,18 @@ options:
   description: Driver to manage the Network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: gateway
   value_type: stringSlice
   default_value: '[]'
   description: IPv4 or IPv6 Gateway for the master subnet
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ingress
   value_type: bool
   default_value: "false"
@@ -98,41 +116,62 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: internal
   value_type: bool
   default_value: "false"
   description: Restrict external access to the network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip-range
   value_type: stringSlice
   default_value: '[]'
   description: Allocate container ip from a sub-range
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ipam-driver
   value_type: string
   default_value: default
   description: IP Address Management Driver
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ipam-opt
   value_type: map
   default_value: map[]
   description: Set IPAM driver specific options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ipv6
   value_type: bool
   default_value: "false"
   description: Enable IPv6 networking
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   value_type: list
   description: Set metadata on a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: opt
   shorthand: o
   value_type: map
@@ -140,18 +179,27 @@ options:
   description: Set driver specific options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: scope
   value_type: string
   description: Control the network's scope
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: subnet
   value_type: stringSlice
   default_value: '[]'
   description: Subnet in CIDR format that represents a network segment
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Connect containers
 
@@ -276,4 +324,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network_disconnect.yaml
+++ b/_data/engine-cli-edge/docker_network_disconnect.yaml
@@ -14,10 +14,16 @@ options:
   description: Force the container to disconnect from a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
     $ docker network disconnect multi-host-network container1
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network_inspect.yaml
+++ b/_data/engine-cli-edge/docker_network_inspect.yaml
@@ -13,6 +13,9 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: verbose
   shorthand: v
   value_type: bool
@@ -20,6 +23,12 @@ options:
   description: Verbose output for diagnostics
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network_ls.yaml
+++ b/_data/engine-cli-edge/docker_network_ls.yaml
@@ -14,17 +14,26 @@ options:
   description: Provide filter values (e.g. 'driver=bridge')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print networks using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Do not truncate the output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -32,6 +41,9 @@ options:
   description: Only display network IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### List all networks\n\n```bash\n$ sudo docker network ls\nNETWORK ID
   \         NAME                DRIVER          SCOPE\n7fca4eb8c647        bridge
   \             bridge          local\n9f904ee27bf5        none                null
@@ -114,4 +126,7 @@ examples: "### List all networks\n\n```bash\n$ sudo docker network ls\nNETWORK I
   {{.Driver}}\"\nafaaab448eb2: bridge\nd1584f8dc718: host\n391df270dc66: null\n```"
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network_prune.yaml
+++ b/_data/engine-cli-edge/docker_network_prune.yaml
@@ -12,6 +12,9 @@ options:
   description: Provide filter values (e.g. 'until=<timestamp>')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force
   shorthand: f
   value_type: bool
@@ -19,6 +22,9 @@ options:
   description: Do not prompt for confirmation
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker network prune
@@ -32,7 +38,7 @@ examples: |-
 
   ### Filtering
 
-  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
   The currently supported filters are:
@@ -86,4 +92,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_network_rm.yaml
+++ b/_data/engine-cli-edge/docker_network_rm.yaml
@@ -32,4 +32,7 @@ examples: |-
   deletion.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_node.yaml
+++ b/_data/engine-cli-edge/docker_node.yaml
@@ -23,4 +23,7 @@ clink:
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_node_demote.yaml
+++ b/_data/engine-cli-edge/docker_node_demote.yaml
@@ -13,4 +13,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_node_inspect.yaml
+++ b/_data/engine-cli-edge/docker_node_inspect.yaml
@@ -16,12 +16,18 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pretty
   value_type: bool
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Inspect a node\n\n```none\n$ docker node inspect swarm-manager\n\n[\n{\n
   \   \"ID\": \"e216jshn25ckzbvmwlnh5jr3g\",\n    \"Version\": {\n        \"Index\":
   10\n    },\n    \"CreatedAt\": \"2017-05-16T22:52:44.9910662Z\",\n    \"UpdatedAt\":
@@ -61,4 +67,7 @@ examples: "### Inspect a node\n\n```none\n$ docker node inspect swarm-manager\n\
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_node_ls.yaml
+++ b/_data/engine-cli-edge/docker_node_ls.yaml
@@ -15,11 +15,17 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print nodes using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -27,6 +33,9 @@ options:
   description: Only display IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "```bash\n$ docker node ls\n\nID                           HOSTNAME        STATUS
   \ AVAILABILITY  MANAGER STATUS\n1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready
   \  Active\n38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active\ne216jshn25ckzbvmwlnh5jr3g
@@ -78,4 +87,7 @@ examples: "```bash\n$ docker node ls\n\nID                           HOSTNAME   
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_node_promote.yaml
+++ b/_data/engine-cli-edge/docker_node_promote.yaml
@@ -13,4 +13,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_node_ps.yaml
+++ b/_data/engine-cli-edge/docker_node_ps.yaml
@@ -13,23 +13,35 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print tasks using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-resolve
   value_type: bool
   default_value: "false"
   description: Do not map IDs to Names
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Do not truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -37,6 +49,9 @@ options:
   description: Only display task IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker node ps swarm-manager1
@@ -142,4 +157,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_node_rm.yaml
+++ b/_data/engine-cli-edge/docker_node_rm.yaml
@@ -13,6 +13,9 @@ options:
   description: Force remove a node from the swarm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Remove a stopped node from the swarm
 
@@ -51,4 +54,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_node_update.yaml
+++ b/_data/engine-cli-edge/docker_node_update.yaml
@@ -10,21 +10,33 @@ options:
   description: Availability of the node ("active"|"pause"|"drain")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-add
   value_type: list
   description: Add or update a node label (key=value)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-rm
   value_type: list
   description: Remove a node label if exists
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: role
   value_type: string
   description: Role of the node ("worker"|"manager")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Add label metadata to a node
 
@@ -61,4 +73,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_pause.yaml
+++ b/_data/engine-cli-edge/docker_pause.yaml
@@ -20,4 +20,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin.yaml
+++ b/_data/engine-cli-edge/docker_plugin.yaml
@@ -29,4 +29,7 @@ clink:
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_create.yaml
+++ b/_data/engine-cli-edge/docker_plugin_create.yaml
@@ -14,6 +14,9 @@ options:
   description: Compress the context using gzip
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following example shows how to create a sample `plugin`.
 
@@ -38,4 +41,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_disable.yaml
+++ b/_data/engine-cli-edge/docker_plugin_disable.yaml
@@ -15,6 +15,9 @@ options:
   description: Force the disable of an active plugin
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following example shows that the `sample-volume-plugin` plugin is installed
   and enabled:
@@ -41,4 +44,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_enable.yaml
+++ b/_data/engine-cli-edge/docker_plugin_enable.yaml
@@ -13,6 +13,9 @@ options:
   description: HTTP client timeout (in seconds)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following example shows that the `sample-volume-plugin` plugin is installed,
   but disabled:
@@ -39,4 +42,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_inspect.yaml
+++ b/_data/engine-cli-edge/docker_plugin_inspect.yaml
@@ -13,6 +13,9 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```none
   $ docker plugin inspect tiborvass/sample-volume-plugin:latest
@@ -136,4 +139,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_install.yaml
+++ b/_data/engine-cli-edge/docker_plugin_install.yaml
@@ -14,24 +14,36 @@ options:
   description: Local name for plugin
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable
   value_type: bool
   default_value: "false"
   description: Do not enable the plugin on install
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: grant-all-permissions
   value_type: bool
   default_value: "false"
   description: Grant all permissions necessary to run the plugin
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following example installs `vieus/sshfs` plugin and [sets](plugin_set.md) its
   `DEBUG` environment variable to `1`. To install, `pull` the plugin from Docker
@@ -60,4 +72,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_ls.yaml
+++ b/_data/engine-cli-edge/docker_plugin_ls.yaml
@@ -16,17 +16,26 @@ options:
   description: Provide filter values (e.g. 'enabled=true')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print plugins using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -34,6 +43,9 @@ options:
   description: Only display plugin IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker plugin ls
@@ -102,4 +114,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_push.yaml
+++ b/_data/engine-cli-edge/docker_plugin_push.yaml
@@ -16,6 +16,9 @@ options:
   description: Skip image signing
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following example shows how to push a sample `user/plugin`.
 
@@ -30,4 +33,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_rm.yaml
+++ b/_data/engine-cli-edge/docker_plugin_rm.yaml
@@ -17,6 +17,9 @@ options:
   description: Force the removal of an active plugin
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following example disables and removes the `sample-volume-plugin:latest`
   plugin:
@@ -33,4 +36,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_set.yaml
+++ b/_data/engine-cli-edge/docker_plugin_set.yaml
@@ -83,4 +83,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_plugin_upgrade.yaml
+++ b/_data/engine-cli-edge/docker_plugin_upgrade.yaml
@@ -15,12 +15,18 @@ options:
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: grant-all-permissions
   value_type: bool
   default_value: "false"
   description: Grant all permissions necessary to run the plugin
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: skip-remote-check
   value_type: bool
   default_value: "false"
@@ -28,6 +34,9 @@ options:
     Do not check if specified remote plugin matches existing plugin image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following example installs `vieus/sshfs` plugin, uses it to create and use
   a volume, then upgrades the plugin.
@@ -82,4 +91,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.26"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_port.yaml
+++ b/_data/engine-cli-edge/docker_port.yaml
@@ -26,4 +26,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_ps.yaml
+++ b/_data/engine-cli-edge/docker_ps.yaml
@@ -12,17 +12,26 @@ options:
   description: Show all containers (default shows just running)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: filter
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print containers using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: last
   shorthand: "n"
   value_type: int
@@ -30,6 +39,9 @@ options:
   description: Show n last created containers (includes all states)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: latest
   shorthand: l
   value_type: bool
@@ -37,12 +49,18 @@ options:
   description: Show the latest created container (includes all states)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -50,6 +68,9 @@ options:
   description: Only display numeric IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: size
   shorthand: s
   value_type: bool
@@ -57,6 +78,9 @@ options:
   description: Display total file sizes
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Prevent truncating output
 
@@ -442,4 +466,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_pull.yaml
+++ b/_data/engine-cli-edge/docker_pull.yaml
@@ -36,18 +36,27 @@ options:
   description: Download all tagged images in the repository
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Pull an image from Docker Hub
 
@@ -248,4 +257,7 @@ examples: |-
   > lost for other reasons than a manual interaction, the pull is also aborted.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_push.yaml
+++ b/_data/engine-cli-edge/docker_push.yaml
@@ -22,6 +22,9 @@ options:
   description: Skip image signing
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Push a new image to a registry
 
@@ -54,4 +57,7 @@ examples: |-
   listed.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_rename.yaml
+++ b/_data/engine-cli-edge/docker_rename.yaml
@@ -10,4 +10,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_restart.yaml
+++ b/_data/engine-cli-edge/docker_restart.yaml
@@ -12,10 +12,16 @@ options:
   description: Seconds to wait for stop before killing the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker restart my_container
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_rm.yaml
+++ b/_data/engine-cli-edge/docker_rm.yaml
@@ -12,6 +12,9 @@ options:
   description: Force the removal of a running container (uses SIGKILL)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link
   shorthand: l
   value_type: bool
@@ -19,6 +22,9 @@ options:
   description: Remove the specified link
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volumes
   shorthand: v
   value_type: bool
@@ -26,6 +32,9 @@ options:
   description: Remove the volumes associated with the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Remove a container
 
@@ -98,4 +107,7 @@ examples: |-
   `--volumes-from`.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_rmi.yaml
+++ b/_data/engine-cli-edge/docker_rmi.yaml
@@ -12,12 +12,18 @@ options:
   description: Force removal of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-prune
   value_type: bool
   default_value: "false"
   description: Do not delete untagged parents
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   You can remove an image using its short or long ID, its tag, or its digest. If
   an image has one or more tags referencing it, you must remove all of them before
@@ -96,4 +102,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_run.yaml
+++ b/_data/engine-cli-edge/docker_run.yaml
@@ -21,12 +21,18 @@ options:
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: attach
   shorthand: a
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight
   value_type: uint16
   default_value: "0"
@@ -34,56 +40,86 @@ options:
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: blkio-weight-device
   value_type: list
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-add
   value_type: list
   description: Add Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cap-drop
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cgroup-parent
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-count
   value_type: int64
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-percent
   value_type: int64
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-period
   value_type: int64
   default_value: "0"
@@ -91,6 +127,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-runtime
   value_type: int64
   default_value: "0"
@@ -98,6 +137,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -105,22 +147,34 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpus
   value_type: decimal
   description: Number of CPUs
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach
   shorthand: d
   value_type: bool
@@ -128,114 +182,177 @@ options:
   description: Run container in background and print container ID
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach-keys
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device
   value_type: list
   description: Add a host device to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-cgroup-rule
   value_type: list
   description: Add a rule to the cgroup allowed devices list
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-bps
   value_type: list
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-read-iops
   value_type: list
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-bps
   value_type: list
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: device-write-iops
   value_type: list
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image verification
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns
   value_type: list
   description: Set custom DNS servers
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-opt
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-option
   value_type: list
   description: Set DNS options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-search
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: entrypoint
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env
   shorthand: e
   value_type: list
   description: Set environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env-file
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: expose
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: group-add
   value_type: list
   description: Add additional groups to join
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-cmd
   value_type: string
   description: Command to run to check health
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-interval
   value_type: duration
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-retries
   value_type: int
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-start-period
   value_type: duration
   default_value: 0s
@@ -244,6 +361,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-timeout
   value_type: duration
   default_value: 0s
@@ -251,18 +371,27 @@ options:
     Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: help
   value_type: bool
   default_value: "false"
   description: Print usage
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: hostname
   shorthand: h
   value_type: string
   description: Container host name
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: init
   value_type: bool
   default_value: "false"
@@ -271,6 +400,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -278,6 +410,9 @@ options:
   description: Keep STDIN open even if not attached
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
@@ -285,74 +420,116 @@ options:
     Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: io-maxiops
   value_type: uint64
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ip6
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ipc
   value_type: string
   description: IPC mode to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Container isolation technology
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: kernel-memory
   value_type: bytes
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   shorthand: l
   value_type: list
   description: Set meta data on a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-file
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link
   value_type: list
   description: Add link to another container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: link-local-ip
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-driver
   value_type: string
   description: Logging driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-opt
   value_type: list
   description: Log driver options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mac-address
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -360,12 +537,18 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-reservation
   value_type: bytes
   default_value: "0"
   description: Memory soft limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -373,91 +556,139 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swappiness
   value_type: int64
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mount
   value_type: mount
   description: Attach a filesystem mount to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: name
   value_type: string
   description: Assign a name to the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: net-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network
   value_type: string
   default_value: default
   description: Connect a container to a network
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network-alias
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-healthcheck
   value_type: bool
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-kill-disable
   value_type: bool
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: oom-score-adj
   value_type: int
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pid
   value_type: string
   description: PID namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pids-limit
   value_type: int64
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: platform
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: privileged
   value_type: bool
   default_value: "false"
   description: Give extended privileges to this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish
   shorthand: p
   value_type: list
   description: Publish a container's port(s) to the host
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish-all
   shorthand: P
   value_type: bool
@@ -465,52 +696,79 @@ options:
   description: Publish all exposed ports to random ports
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: read-only
   value_type: bool
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart
   value_type: string
   default_value: "no"
   description: Restart policy to apply when a container exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rm
   value_type: bool
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: runtime
   value_type: string
   description: Runtime to use for this container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: security-opt
   value_type: list
   description: Security Options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: shm-size
   value_type: bytes
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sig-proxy
   value_type: bool
   default_value: "true"
   description: Proxy received signals to the process
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-signal
   value_type: string
   default_value: SIGTERM
   description: Signal to stop a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-timeout
   value_type: int
   default_value: "0"
@@ -518,22 +776,34 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: storage-opt
   value_type: list
   description: Storage driver options for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: sysctl
   value_type: map
   default_value: map[]
   description: Sysctl options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tmpfs
   value_type: list
   description: Mount a tmpfs directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -541,50 +811,77 @@ options:
   description: Allocate a pseudo-TTY
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ulimit
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: userns
   value_type: string
   description: User namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: uts
   value_type: string
   description: UTS namespace to use
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume
   shorthand: v
   value_type: list
   description: Bind mount a volume
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volume-driver
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volumes-from
   value_type: list
   description: Mount volumes from the specified container(s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
   description: Working directory inside the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Assign name and allocate pseudo-TTY (--name, -it)
 
@@ -1238,4 +1535,7 @@ examples: |-
     If you use the `--network=host` option using these sysctls will not be allowed.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_save.yaml
+++ b/_data/engine-cli-edge/docker_save.yaml
@@ -14,6 +14,9 @@ options:
   description: Write to a file, instead of STDOUT
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Create a backup that can then be used with `docker load`.
 
@@ -44,4 +47,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_search.yaml
+++ b/_data/engine-cli-edge/docker_search.yaml
@@ -17,29 +17,44 @@ options:
   description: Only show automated builds
   deprecated: true
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: filter
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print search using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: limit
   value_type: int
   default_value: "25"
   description: Max number of search results
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Don't truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stars
   shorthand: s
   value_type: uint
@@ -47,6 +62,9 @@ options:
   description: Only displays with at least x stars
   deprecated: true
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Search images by name\n\nThis example displays images with a name containing
   'busybox':\n\n```none\n$ docker search busybox\n\nNAME                             DESCRIPTION
   \                                    STARS     OFFICIAL   AUTOMATED\nbusybox                          Busybox
@@ -130,4 +148,7 @@ examples: "### Search images by name\n\nThis example displays images with a name
   \               \n{% endraw %}\n```"
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_secret.yaml
+++ b/_data/engine-cli-edge/docker_secret.yaml
@@ -17,4 +17,7 @@ clink:
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_secret_create.yaml
+++ b/_data/engine-cli-edge/docker_secret_create.yaml
@@ -14,12 +14,18 @@ options:
   deprecated: false
   min_api_version: "1.31"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   shorthand: l
   value_type: list
   description: Secret labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Create a secret
 
@@ -81,4 +87,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_secret_inspect.yaml
+++ b/_data/engine-cli-edge/docker_secret_inspect.yaml
@@ -21,12 +21,18 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pretty
   value_type: bool
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Inspect a secret by name or ID
 
@@ -77,4 +83,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_secret_ls.yaml
+++ b/_data/engine-cli-edge/docker_secret_ls.yaml
@@ -15,11 +15,17 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print secrets using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -27,6 +33,9 @@ options:
   description: Only display IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker secret ls
@@ -142,4 +151,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_secret_rm.yaml
+++ b/_data/engine-cli-edge/docker_secret_rm.yaml
@@ -22,4 +22,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service.yaml
+++ b/_data/engine-cli-edge/docker_service.yaml
@@ -27,4 +27,7 @@ clink:
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_create.yaml
+++ b/_data/engine-cli-edge/docker_service_create.yaml
@@ -13,22 +13,34 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: constraint
   value_type: list
   description: Placement constraints
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: container-label
   value_type: list
   description: Container labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: credential-spec
   value_type: credential-spec
   description: Credential spec for managed service account (Windows only)
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach
   shorthand: d
   value_type: bool
@@ -38,69 +50,105 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns
   value_type: list
   description: Set custom DNS servers
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-option
   value_type: list
   description: Set DNS options
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-search
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: endpoint-mode
   value_type: string
   default_value: vip
   description: Endpoint mode (vip or dnsrr)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: entrypoint
   value_type: command
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env
   shorthand: e
   value_type: list
   description: Set environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env-file
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: generic-resource
   value_type: list
   description: User defined resources
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: group
   value_type: list
   description: Set one or more supplementary user groups for the container
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-cmd
   value_type: string
   description: Command to run to check health
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-interval
   value_type: duration
   description: Time between running the check (ms|s|m|h)
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-retries
   value_type: int
   default_value: "0"
@@ -108,6 +156,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-start-period
   value_type: duration
   description: |
@@ -115,78 +166,120 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-timeout
   value_type: duration
   description: Maximum time to allow one check to run (ms|s|m|h)
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: host
   value_type: list
   description: Set one or more custom host-to-IP mappings (host:ip)
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: hostname
   value_type: string
   description: Container hostname
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Service container isolation mode
   deprecated: false
   min_api_version: "1.35"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   shorthand: l
   value_type: list
   description: Service labels
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: limit-cpu
   value_type: decimal
   description: Limit CPUs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: limit-memory
   value_type: bytes
   default_value: "0"
   description: Limit Memory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-driver
   value_type: string
   description: Logging driver for service
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-opt
   value_type: list
   description: Logging driver options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mode
   value_type: string
   default_value: replicated
   description: Service mode (replicated or global)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mount
   value_type: mount
   description: Attach a filesystem mount to the service
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: name
   value_type: string
   description: Service name
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network
   value_type: network
   description: Network attachments
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-healthcheck
   value_type: bool
   default_value: "false"
@@ -194,6 +287,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-resolve-image
   value_type: bool
   default_value: "false"
@@ -202,18 +298,27 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: placement-pref
   value_type: pref
   description: Add a placement preference
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish
   shorthand: p
   value_type: port
   description: Publish a port as a node port
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -221,6 +326,9 @@ options:
   description: Suppress progress output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: read-only
   value_type: bool
   default_value: "false"
@@ -228,43 +336,67 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: replicas
   value_type: uint
   description: Number of tasks
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: reserve-cpu
   value_type: decimal
   description: Reserve CPUs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: reserve-memory
   value_type: bytes
   default_value: "0"
   description: Reserve Memory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-condition
   value_type: string
   description: |
     Restart when condition is met ("none"|"on-failure"|"any") (default "any")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-delay
   value_type: duration
   description: Delay between restart attempts (ns|us|ms|s|m|h) (default 5s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-max-attempts
   value_type: uint
   description: Maximum number of restarts before giving up
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-window
   value_type: duration
   description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-delay
   value_type: duration
   default_value: 0s
@@ -272,6 +404,9 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-failure-action
   value_type: string
   description: |
@@ -279,6 +414,9 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-max-failure-ratio
   value_type: float
   default_value: "0"
@@ -286,6 +424,9 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-monitor
   value_type: duration
   default_value: 0s
@@ -294,6 +435,9 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-order
   value_type: string
   description: |
@@ -301,6 +445,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-parallelism
   value_type: uint64
   default_value: "1"
@@ -309,24 +456,36 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: secret
   value_type: secret
   description: Specify secrets to expose to the service
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-grace-period
   value_type: duration
   description: |
     Time to wait before force killing a container (ns|us|ms|s|m|h) (default 10s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-signal
   value_type: string
   description: Signal to stop the container
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -335,18 +494,27 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-delay
   value_type: duration
   default_value: 0s
   description: Delay between updates (ns|us|ms|s|m|h) (default 0s)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-failure-action
   value_type: string
   description: |
     Action on update failure ("pause"|"continue"|"rollback") (default "pause")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-max-failure-ratio
   value_type: float
   default_value: "0"
@@ -354,6 +522,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-monitor
   value_type: duration
   default_value: 0s
@@ -362,6 +533,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-order
   value_type: string
   description: |
@@ -369,6 +543,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-parallelism
   value_type: uint64
   default_value: "1"
@@ -376,24 +553,36 @@ options:
     Maximum number of tasks updated simultaneously (0 to update all at once)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: with-registry-auth
   value_type: bool
   default_value: "false"
   description: Send registry authentication details to swarm agents
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
   description: Working directory inside the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Create a service\n\n```bash\n$ docker service create --name redis redis:3.0.6\n\ndmu1ept4cxcfe8k8lhtux3ro3\n\n$
   docker service create --mode global --name redis2 redis:3.0.6\n\na8q9dasaafudfs8q8w32udass\n\n$
   docker service ls\n\nID            NAME    MODE        REPLICAS  IMAGE\ndmu1ept4cxcf
@@ -745,4 +934,7 @@ examples: "### Create a service\n\n```bash\n$ docker service create --name redis
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_inspect.yaml
+++ b/_data/engine-cli-edge/docker_service_inspect.yaml
@@ -19,12 +19,18 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: pretty
   value_type: bool
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Inspect a service by name or ID\n\nYou can inspect a service, either
   by its *name*, or *ID*\n\nFor example, given the following service;\n\n```bash\n$
   docker service ls\nID            NAME   MODE        REPLICAS  IMAGE\ndmu1ept4cxcf
@@ -59,4 +65,7 @@ examples: "### Inspect a service by name or ID\n\nYou can inspect a service, eit
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_logs.yaml
+++ b/_data/engine-cli-edge/docker_service_logs.yaml
@@ -52,6 +52,9 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: follow
   shorthand: f
   value_type: bool
@@ -59,24 +62,36 @@ options:
   description: Follow log output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-resolve
   value_type: bool
   default_value: "false"
   description: Do not map IDs to Names in output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-task-ids
   value_type: bool
   default_value: "false"
   description: Do not include task IDs in output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Do not truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: raw
   value_type: bool
   default_value: "false"
@@ -84,18 +99,27 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: since
   value_type: string
   description: |
     Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tail
   value_type: string
   default_value: all
   description: Number of lines to show from the end of the logs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: timestamps
   shorthand: t
   value_type: bool
@@ -103,7 +127,13 @@ options:
   description: Show timestamps
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.29"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_ls.yaml
+++ b/_data/engine-cli-edge/docker_service_ls.yaml
@@ -14,11 +14,17 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print services using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -26,6 +32,9 @@ options:
   description: Only display IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   On a manager node:
 
@@ -145,4 +154,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_ps.yaml
+++ b/_data/engine-cli-edge/docker_service_ps.yaml
@@ -13,23 +13,35 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print tasks using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-resolve
   value_type: bool
   default_value: "false"
   description: Do not map IDs to Names
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Do not truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -37,6 +49,9 @@ options:
   description: Only display task IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### List the tasks that are part of a service
 
@@ -186,4 +201,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_rm.yaml
+++ b/_data/engine-cli-edge/docker_service_rm.yaml
@@ -25,4 +25,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_rollback.yaml
+++ b/_data/engine-cli-edge/docker_service_rollback.yaml
@@ -16,6 +16,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -23,6 +26,9 @@ options:
   description: Suppress progress output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Roll back to the previous version of a service
 
@@ -75,4 +81,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.31"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_scale.yaml
+++ b/_data/engine-cli-edge/docker_service_scale.yaml
@@ -19,6 +19,9 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Scale a single service
 
@@ -81,4 +84,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_service_update.yaml
+++ b/_data/engine-cli-edge/docker_service_update.yaml
@@ -19,44 +19,68 @@ options:
   description: Service command args
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: config-add
   value_type: config
   description: Add or update a config file on a service
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: config-rm
   value_type: list
   description: Remove a configuration file
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: constraint-add
   value_type: list
   description: Add or update a placement constraint
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: constraint-rm
   value_type: list
   description: Remove a constraint
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: container-label-add
   value_type: list
   description: Add or update a container label
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: container-label-rm
   value_type: list
   description: Remove a container label by its key
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: credential-spec
   value_type: credential-spec
   description: Credential spec for managed service account (Windows only)
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach
   shorthand: d
   value_type: bool
@@ -66,62 +90,95 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-add
   value_type: list
   description: Add or update a custom DNS server
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-option-add
   value_type: list
   description: Add or update a DNS option
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-option-rm
   value_type: list
   description: Remove a DNS option
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-rm
   value_type: list
   description: Remove a custom DNS server
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-search-add
   value_type: list
   description: Add or update a custom DNS search domain
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dns-search-rm
   value_type: list
   description: Remove a DNS search domain
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: endpoint-mode
   value_type: string
   description: Endpoint mode (vip or dnsrr)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: entrypoint
   value_type: command
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env-add
   value_type: list
   description: Add or update an environment variable
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: env-rm
   value_type: list
   description: Remove an environment variable
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force
   value_type: bool
   default_value: "false"
@@ -129,22 +186,34 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: generic-resource-add
   value_type: list
   description: Add a Generic resource
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: generic-resource-rm
   value_type: list
   description: Remove a Generic resource
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: group-add
   value_type: list
   description: Add an additional supplementary user group to the container
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: group-rm
   value_type: list
   description: |
@@ -152,18 +221,27 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-cmd
   value_type: string
   description: Command to run to check health
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-interval
   value_type: duration
   description: Time between running the check (ms|s|m|h)
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-retries
   value_type: int
   default_value: "0"
@@ -171,6 +249,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-start-period
   value_type: duration
   description: |
@@ -178,94 +259,145 @@ options:
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: health-timeout
   value_type: duration
   description: Maximum time to allow one check to run (ms|s|m|h)
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: host-add
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
   min_api_version: "1.32"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: host-rm
   value_type: list
   description: Remove a custom host-to-IP mapping (host:ip)
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: hostname
   value_type: string
   description: Container hostname
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: image
   value_type: string
   description: Service image tag
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: isolation
   value_type: string
   description: Service container isolation mode
   deprecated: false
   min_api_version: "1.35"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-add
   value_type: list
   description: Add or update a service label
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label-rm
   value_type: list
   description: Remove a label by its key
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: limit-cpu
   value_type: decimal
   description: Limit CPUs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: limit-memory
   value_type: bytes
   default_value: "0"
   description: Limit Memory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-driver
   value_type: string
   description: Logging driver for service
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: log-opt
   value_type: list
   description: Logging driver options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mount-add
   value_type: mount
   description: Add or update a mount on a service
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mount-rm
   value_type: list
   description: Remove a mount by its target path
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network-add
   value_type: network
   description: Add a network
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: network-rm
   value_type: list
   description: Remove a network
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-healthcheck
   value_type: bool
   default_value: "false"
@@ -273,6 +405,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-resolve-image
   value_type: bool
   default_value: "false"
@@ -281,28 +416,43 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: placement-pref-add
   value_type: pref
   description: Add a placement preference
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: placement-pref-rm
   value_type: pref
   description: Remove a placement preference
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish-add
   value_type: port
   description: Add or update a published port
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: publish-rm
   value_type: port
   description: Remove a published port by its target port
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -310,6 +460,9 @@ options:
   description: Suppress progress output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: read-only
   value_type: bool
   default_value: "false"
@@ -317,42 +470,66 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: replicas
   value_type: uint
   description: Number of tasks
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: reserve-cpu
   value_type: decimal
   description: Reserve CPUs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: reserve-memory
   value_type: bytes
   default_value: "0"
   description: Reserve Memory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-condition
   value_type: string
   description: Restart when condition is met ("none"|"on-failure"|"any")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-delay
   value_type: duration
   description: Delay between restart attempts (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-max-attempts
   value_type: uint
   description: Maximum number of restarts before giving up
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart-window
   value_type: duration
   description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback
   value_type: bool
   default_value: "false"
@@ -360,6 +537,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-delay
   value_type: duration
   default_value: 0s
@@ -367,12 +547,18 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-failure-action
   value_type: string
   description: Action on rollback failure ("pause"|"continue")
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-max-failure-ratio
   value_type: float
   default_value: "0"
@@ -380,6 +566,9 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-monitor
   value_type: duration
   default_value: 0s
@@ -388,12 +577,18 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-order
   value_type: string
   description: Rollback order ("start-first"|"stop-first")
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rollback-parallelism
   value_type: uint64
   default_value: "0"
@@ -402,30 +597,45 @@ options:
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: secret-add
   value_type: secret
   description: Add or update a secret on a service
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: secret-rm
   value_type: list
   description: Remove a secret
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-grace-period
   value_type: duration
   description: |
     Time to wait before force killing a container (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: stop-signal
   value_type: string
   description: Signal to stop the container
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: tty
   shorthand: t
   value_type: bool
@@ -434,17 +644,26 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-delay
   value_type: duration
   default_value: 0s
   description: Delay between updates (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-failure-action
   value_type: string
   description: Action on update failure ("pause"|"continue"|"rollback")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-max-failure-ratio
   value_type: float
   default_value: "0"
@@ -452,6 +671,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-monitor
   value_type: duration
   default_value: 0s
@@ -460,12 +682,18 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-order
   value_type: string
   description: Update order ("start-first"|"stop-first")
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-parallelism
   value_type: uint64
   default_value: "0"
@@ -473,24 +701,36 @@ options:
     Maximum number of tasks updated simultaneously (0 to update all at once)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: user
   shorthand: u
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: with-registry-auth
   value_type: bool
   default_value: "false"
   description: Send registry authentication details to swarm agents
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: workdir
   shorthand: w
   value_type: string
   description: Working directory inside the container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Update a service
 
@@ -658,4 +898,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_stack.yaml
+++ b/_data/engine-cli-edge/docker_stack.yaml
@@ -16,7 +16,28 @@ clink:
 - docker_stack_ps.yaml
 - docker_stack_rm.yaml
 - docker_stack_services.yaml
+options:
+- option: kubeconfig
+  value_type: string
+  description: Kubernetes config file
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
+- option: namespace
+  value_type: string
+  default_value: default
+  description: Kubernetes namespace to use
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_stack_deploy.yaml
+++ b/_data/engine-cli-edge/docker_stack_deploy.yaml
@@ -13,6 +13,9 @@ options:
   description: Path to a Distributed Application Bundle file
   deprecated: false
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: compose-file
   shorthand: c
   value_type: string
@@ -20,6 +23,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: prune
   value_type: bool
   default_value: "false"
@@ -27,6 +33,9 @@ options:
   deprecated: false
   min_api_version: "1.27"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: resolve-image
   value_type: string
   default_value: always
@@ -35,12 +44,36 @@ options:
   deprecated: false
   min_api_version: "1.30"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: with-registry-auth
   value_type: bool
   default_value: "false"
   description: Send registry authentication details to Swarm agents
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
+inherited_options:
+- option: kubeconfig
+  value_type: string
+  description: Kubernetes config file
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
+- option: namespace
+  value_type: string
+  default_value: default
+  description: Kubernetes namespace to use
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
 examples: |-
   ### Compose file
 
@@ -143,4 +176,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_stack_ls.yaml
+++ b/_data/engine-cli-edge/docker_stack_ls.yaml
@@ -11,6 +11,27 @@ options:
   description: Pretty-print stacks using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+inherited_options:
+- option: kubeconfig
+  value_type: string
+  description: Kubernetes config file
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
+- option: namespace
+  value_type: string
+  default_value: default
+  description: Kubernetes namespace to use
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
 examples: |-
   The following command shows all stacks and some additional information:
 
@@ -48,4 +69,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_stack_ps.yaml
+++ b/_data/engine-cli-edge/docker_stack_ps.yaml
@@ -13,23 +13,35 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: format
   value_type: string
   description: Pretty-print tasks using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-resolve
   value_type: bool
   default_value: "false"
   description: Do not map IDs to Names
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Do not truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -37,6 +49,27 @@ options:
   description: Only display task IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+inherited_options:
+- option: kubeconfig
+  value_type: string
+  description: Kubernetes config file
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
+- option: namespace
+  value_type: string
+  default_value: default
+  description: Kubernetes namespace to use
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
 examples: |-
   ### List the tasks that are part of a stack
 
@@ -226,4 +259,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_stack_rm.yaml
+++ b/_data/engine-cli-edge/docker_stack_rm.yaml
@@ -7,6 +7,24 @@ long: |-
 usage: docker stack rm STACK [STACK...]
 pname: docker stack
 plink: docker_stack.yaml
+inherited_options:
+- option: kubeconfig
+  value_type: string
+  description: Kubernetes config file
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
+- option: namespace
+  value_type: string
+  default_value: default
+  description: Kubernetes namespace to use
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
 examples: |-
   ### Remove a stack
 
@@ -46,4 +64,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_stack_services.yaml
+++ b/_data/engine-cli-edge/docker_stack_services.yaml
@@ -13,11 +13,17 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: format
   value_type: string
   description: Pretty-print services using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -25,6 +31,27 @@ options:
   description: Only display IDs
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+inherited_options:
+- option: kubeconfig
+  value_type: string
+  description: Kubernetes config file
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
+- option: namespace
+  value_type: string
+  default_value: default
+  description: Kubernetes namespace to use
+  deprecated: false
+  experimental: false
+  experimentalcli: true
+  kubernetes: true
+  swarm: false
 examples: |-
   The following command shows all services in the `myapp` stack:
 
@@ -89,4 +116,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_start.yaml
+++ b/_data/engine-cli-edge/docker_start.yaml
@@ -12,21 +12,33 @@ options:
   description: Attach STDOUT/STDERR and forward signals
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: checkpoint
   value_type: string
   description: Restore from this checkpoint
   deprecated: false
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: checkpoint-dir
   value_type: string
   description: Use a custom checkpoint storage directory
   deprecated: false
   experimental: true
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach-keys
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool
@@ -34,10 +46,16 @@ options:
   description: Attach container's STDIN
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker start my_container
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_stats.yaml
+++ b/_data/engine-cli-edge/docker_stats.yaml
@@ -17,23 +17,35 @@ options:
   description: Show all containers (default shows just running)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print images using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-stream
   value_type: bool
   default_value: "false"
   description: Disable streaming stats and only pull the first result
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: no-trunc
   value_type: bool
   default_value: "false"
   description: Do not truncate output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   Running `docker stats` on all running containers against a Linux daemon.
 
@@ -158,4 +170,7 @@ examples: |-
   > stead of `{{.ID}}\t{{.Name}}`.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_stop.yaml
+++ b/_data/engine-cli-edge/docker_stop.yaml
@@ -14,10 +14,16 @@ options:
   description: Seconds to wait for stop before killing it
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker stop my_container
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_swarm.yaml
+++ b/_data/engine-cli-edge/docker_swarm.yaml
@@ -25,4 +25,7 @@ clink:
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_ca.yaml
+++ b/_data/engine-cli-edge/docker_swarm_ca.yaml
@@ -12,18 +12,27 @@ options:
     Path to the PEM-formatted root CA certificate to use for the new cluster
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: ca-key
   value_type: pem-file
   description: |
     Path to the PEM-formatted root CA key to use for the new cluster
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cert-expiry
   value_type: duration
   default_value: 2160h0m0s
   description: Validity period for node certificates (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: detach
   shorthand: d
   value_type: bool
@@ -32,11 +41,17 @@ options:
     Exit immediately instead of waiting for the root rotation to converge
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: external-ca
   value_type: external-ca
   description: Specifications of one or more certificate signing endpoints
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -44,6 +59,9 @@ options:
   description: Suppress progress output
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rotate
   value_type: bool
   default_value: "false"
@@ -51,6 +69,9 @@ options:
     Rotate the swarm CA - if no certificate or key are provided, new ones will be generated
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   Run the `docker swarm ca` command without any options to view the current root CA certificate
   in PEM format.
@@ -129,4 +150,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.30"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_init.yaml
+++ b/_data/engine-cli-edge/docker_swarm_init.yaml
@@ -12,6 +12,9 @@ options:
   description: 'Advertised address (format: <ip|interface>[:port])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: autolock
   value_type: bool
   default_value: "false"
@@ -19,47 +22,71 @@ options:
     Enable manager autolocking (requiring an unlock key to start a stopped manager)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: availability
   value_type: string
   default_value: active
   description: Availability of the node ("active"|"pause"|"drain")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cert-expiry
   value_type: duration
   default_value: 2160h0m0s
   description: Validity period for node certificates (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: data-path-addr
   value_type: string
   description: |
     Address or interface to use for data path traffic (format: <ip|interface>)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dispatcher-heartbeat
   value_type: duration
   default_value: 5s
   description: Dispatcher heartbeat period (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: external-ca
   value_type: external-ca
   description: Specifications of one or more certificate signing endpoints
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force-new-cluster
   value_type: bool
   default_value: "false"
   description: Force create a new cluster from current state
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: listen-addr
   value_type: node-addr
   default_value: 0.0.0.0:2377
   description: 'Listen address (format: <ip|interface>[:port])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: max-snapshots
   value_type: uint64
   default_value: "0"
@@ -67,6 +94,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: snapshot-interval
   value_type: uint64
   default_value: "10000"
@@ -74,12 +104,18 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: task-history-limit
   value_type: int64
   default_value: "5"
   description: Task history retention limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker swarm init --advertise-addr 192.168.99.121
@@ -196,4 +232,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_join-token.yaml
+++ b/_data/engine-cli-edge/docker_swarm_join-token.yaml
@@ -12,13 +12,22 @@ options:
   description: Only display token
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rotate
   value_type: bool
   default_value: "false"
   description: Rotate join token
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_join.yaml
+++ b/_data/engine-cli-edge/docker_swarm_join.yaml
@@ -13,29 +13,44 @@ options:
   description: 'Advertised address (format: <ip|interface>[:port])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: availability
   value_type: string
   default_value: active
   description: Availability of the node ("active"|"pause"|"drain")
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: data-path-addr
   value_type: string
   description: |
     Address or interface to use for data path traffic (format: <ip|interface>)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: listen-addr
   value_type: node-addr
   default_value: 0.0.0.0:2377
   description: 'Listen address (format: <ip|interface>[:port])'
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: token
   value_type: string
   description: Token for entry into the swarm
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Join a node to swarm as a manager
 
@@ -123,4 +138,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_leave.yaml
+++ b/_data/engine-cli-edge/docker_swarm_leave.yaml
@@ -20,6 +20,9 @@ options:
   description: Force this node to leave the swarm, ignoring warnings
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   Consider the following swarm, as seen from the manager:
 
@@ -45,4 +48,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_unlock-key.yaml
+++ b/_data/engine-cli-edge/docker_swarm_unlock-key.yaml
@@ -12,13 +12,22 @@ options:
   description: Only display token
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: rotate
   value_type: bool
   default_value: "false"
   description: Rotate unlock key
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_unlock.yaml
+++ b/_data/engine-cli-edge/docker_swarm_unlock.yaml
@@ -16,4 +16,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_swarm_update.yaml
+++ b/_data/engine-cli-edge/docker_swarm_update.yaml
@@ -12,23 +12,35 @@ options:
   description: Change manager autolocking setting (true|false)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cert-expiry
   value_type: duration
   default_value: 2160h0m0s
   description: Validity period for node certificates (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: dispatcher-heartbeat
   value_type: duration
   default_value: 5s
   description: Dispatcher heartbeat period (ns|us|ms|s|m|h)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: external-ca
   value_type: external-ca
   description: Specifications of one or more certificate signing endpoints
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: max-snapshots
   value_type: uint64
   default_value: "0"
@@ -36,6 +48,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: snapshot-interval
   value_type: uint64
   default_value: "10000"
@@ -43,12 +58,18 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: task-history-limit
   value_type: int64
   default_value: "5"
   description: Task history retention limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker swarm update --cert-expiry 720h
@@ -56,4 +77,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.24"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: true
 

--- a/_data/engine-cli-edge/docker_system.yaml
+++ b/_data/engine-cli-edge/docker_system.yaml
@@ -16,4 +16,7 @@ clink:
 - docker_system_prune.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_system_df.yaml
+++ b/_data/engine-cli-edge/docker_system_df.yaml
@@ -12,6 +12,9 @@ options:
   description: Pretty-print images using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: verbose
   shorthand: v
   value_type: bool
@@ -19,6 +22,9 @@ options:
   description: Show detailed information on space usage
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   By default the command will just show a summary of the data used:
 
@@ -67,4 +73,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_system_events.yaml
+++ b/_data/engine-cli-edge/docker_system_events.yaml
@@ -142,21 +142,33 @@ options:
   description: Filter output based on conditions provided
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: since
   value_type: string
   description: Show all events created since timestamp
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: until
   value_type: string
   description: Stream events until this timestamp
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Basic example
 
@@ -339,4 +351,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_system_info.yaml
+++ b/_data/engine-cli-edge/docker_system_info.yaml
@@ -11,6 +11,12 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_system_prune.yaml
+++ b/_data/engine-cli-edge/docker_system_prune.yaml
@@ -14,12 +14,18 @@ options:
   description: Remove all unused images not just dangling ones
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: filter
   value_type: filter
   description: Provide filter values (e.g. 'label=<key>=<value>')
   deprecated: false
   min_api_version: "1.28"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force
   shorthand: f
   value_type: bool
@@ -27,12 +33,18 @@ options:
   description: Do not prompt for confirmation
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: volumes
   value_type: bool
   default_value: "false"
   description: Prune volumes
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker system prune
@@ -141,4 +153,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_tag.yaml
+++ b/_data/engine-cli-edge/docker_tag.yaml
@@ -60,4 +60,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_top.yaml
+++ b/_data/engine-cli-edge/docker_top.yaml
@@ -6,4 +6,7 @@ pname: docker
 plink: docker.yaml
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust.yaml
+++ b/_data/engine-cli-edge/docker_trust.yaml
@@ -20,4 +20,7 @@ clink:
 - docker_trust_view.yaml
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_inspect.yaml
+++ b/_data/engine-cli-edge/docker_trust_inspect.yaml
@@ -113,4 +113,7 @@ examples: "### Get low-level details about signatures for a single image tag\n\n
   \               ]\n            }\n        ]\n    }\n]\n```"
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_key.yaml
+++ b/_data/engine-cli-edge/docker_trust_key.yaml
@@ -12,4 +12,7 @@ clink:
 - docker_trust_key_load.yaml
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_key_generate.yaml
+++ b/_data/engine-cli-edge/docker_trust_key_generate.yaml
@@ -10,6 +10,12 @@ options:
   description: Directory to generate key in, defaults to current directory
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_key_load.yaml
+++ b/_data/engine-cli-edge/docker_trust_key_load.yaml
@@ -11,6 +11,12 @@ options:
   description: Name for the loaded key
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_revoke.yaml
+++ b/_data/engine-cli-edge/docker_trust_revoke.yaml
@@ -15,6 +15,9 @@ options:
   description: Do not prompt for confirmation
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Revoke signatures from a signed tag\n\nHere's an example of a repo
   with two signed tags:\n\n\n```bash\n$ docker trust view example/trust-demo\nSIGNED
   TAG          DIGEST                                                              SIGNERS\nred
@@ -55,4 +58,7 @@ examples: "### Revoke signatures from a signed tag\n\nHere's an example of a rep
   Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```"
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_sign.yaml
+++ b/_data/engine-cli-edge/docker_trust_sign.yaml
@@ -14,6 +14,9 @@ options:
   description: Sign a locally tagged image
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: "### Sign a tag as a repo admin\n\nGiven an image:\n\n```bash\n$ docker
   trust view example/trust-demo\nSIGNED TAG          DIGEST                                                             SIGNERS\nv1
   \                 c24134c079c35e698060beabe110bb83ab285d0d978de7d92fed2c8c83570a41
@@ -54,4 +57,7 @@ examples: "### Sign a tag as a repo admin\n\nGiven an image:\n\n```bash\n$ docke
   Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```"
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_signer.yaml
+++ b/_data/engine-cli-edge/docker_trust_signer.yaml
@@ -12,4 +12,7 @@ clink:
 - docker_trust_signer_remove.yaml
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_signer_add.yaml
+++ b/_data/engine-cli-edge/docker_trust_signer_add.yaml
@@ -10,6 +10,12 @@ options:
   description: Path to the signer's public key file
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_signer_remove.yaml
+++ b/_data/engine-cli-edge/docker_trust_signer_remove.yaml
@@ -13,6 +13,12 @@ options:
     Do not prompt for confirmation before removing the most recent signer
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_trust_view.yaml
+++ b/_data/engine-cli-edge/docker_trust_view.yaml
@@ -63,4 +63,7 @@ examples: "### Get details about signatures for a single image tag\n\n\n```bash\
   Key:\t40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f\n```"
 deprecated: false
 experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_unpause.yaml
+++ b/_data/engine-cli-edge/docker_unpause.yaml
@@ -17,4 +17,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_update.yaml
+++ b/_data/engine-cli-edge/docker_update.yaml
@@ -26,18 +26,27 @@ options:
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-period
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-quota
   value_type: int64
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-period
   value_type: int64
   default_value: "0"
@@ -45,6 +54,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-rt-runtime
   value_type: int64
   default_value: "0"
@@ -52,6 +64,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpu-shares
   shorthand: c
   value_type: int64
@@ -59,28 +74,43 @@ options:
   description: CPU shares (relative weight)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpus
   value_type: decimal
   description: Number of CPUs
   deprecated: false
   min_api_version: "1.29"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-cpus
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cpuset-mems
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: kernel-memory
   value_type: bytes
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory
   shorthand: m
   value_type: bytes
@@ -88,12 +118,18 @@ options:
   description: Memory limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-reservation
   value_type: bytes
   default_value: "0"
   description: Memory soft limit
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: memory-swap
   value_type: bytes
   default_value: "0"
@@ -101,11 +137,17 @@ options:
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: restart
   value_type: string
   description: Restart policy to apply when a container exits
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   The following sections illustrate ways to use this command.
 
@@ -177,4 +219,7 @@ examples: |-
   container.
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_version.yaml
+++ b/_data/engine-cli-edge/docker_version.yaml
@@ -16,6 +16,9 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Default output
 
@@ -56,4 +59,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_volume.yaml
+++ b/_data/engine-cli-edge/docker_volume.yaml
@@ -21,4 +21,7 @@ clink:
 deprecated: false
 min_api_version: "1.21"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_volume_create.yaml
+++ b/_data/engine-cli-edge/docker_volume_create.yaml
@@ -14,16 +14,25 @@ options:
   description: Specify volume driver name
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: label
   value_type: list
   description: Set metadata for a volume
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: name
   value_type: string
   description: Specify volume name
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: opt
   shorthand: o
   value_type: map
@@ -31,6 +40,9 @@ options:
   description: Set driver specific options
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   Create a volume and then configure the container to use it:
 
@@ -116,4 +128,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.21"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_volume_inspect.yaml
+++ b/_data/engine-cli-edge/docker_volume_inspect.yaml
@@ -16,6 +16,9 @@ options:
   description: Format the output using the given Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker volume create
@@ -36,4 +39,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.21"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_volume_ls.yaml
+++ b/_data/engine-cli-edge/docker_volume_ls.yaml
@@ -15,11 +15,17 @@ options:
   description: Provide filter values (e.g. 'dangling=true')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: format
   value_type: string
   description: Pretty-print volumes using a Go template
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: quiet
   shorthand: q
   value_type: bool
@@ -27,6 +33,9 @@ options:
   description: Only display volume names
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Create a volume
   ```bash
@@ -178,4 +187,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.21"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_volume_prune.yaml
+++ b/_data/engine-cli-edge/docker_volume_prune.yaml
@@ -11,6 +11,9 @@ options:
   description: Provide filter values (e.g. 'label=<label>')
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: force
   shorthand: f
   value_type: bool
@@ -18,6 +21,9 @@ options:
   description: Do not prompt for confirmation
   deprecated: false
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
   $ docker volume prune
@@ -33,4 +39,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.25"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_volume_rm.yaml
+++ b/_data/engine-cli-edge/docker_volume_rm.yaml
@@ -14,6 +14,9 @@ options:
   deprecated: false
   min_api_version: "1.25"
   experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ```bash
     $ docker volume rm hello
@@ -22,4 +25,7 @@ examples: |-
 deprecated: false
 min_api_version: "1.21"
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_data/engine-cli-edge/docker_wait.yaml
+++ b/_data/engine-cli-edge/docker_wait.yaml
@@ -34,4 +34,7 @@ examples: |-
   ```
 deprecated: false
 experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
 

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -33,10 +33,33 @@ your client and daemon API versions.
 
 > This command is experimental.
 >
-> It should not be used in production environments.
+> This command is experimental on the Docker daemon. It should not be used in production environments.
 {: .important }
 
 {% endif %}
+
+{% if site.data[include.datafolder][include.datafile].experimentalcli %}
+
+> This command is experimental.
+>
+> This  command is experimental on the Docker client. It should not be used in production environments.
+{: .important }
+
+{% endif %}
+
+{% capture command-orchestrator %}
+{% if site.data[include.datafolder][include.datafile].swarm %}
+
+<span class="badge badge-info">Swarm</span> This command works with the Swarm orchestrator.
+
+{% endif %}
+{% if site.data[include.datafolder][include.datafile].kubernetes %}
+
+<span class="badge badge-info">Kubernetes</span> This command works with the Kubernetes orchestrator.
+
+{% endif %}
+{% endcapture %}{{ command-orchestrator }}
+
 
 {% if site.data[include.datafolder][include.datafile].usage %}
 
@@ -48,7 +71,11 @@ your client and daemon API versions.
 
 {% endif %}
 {% if site.data[include.datafolder][include.datafile].options %}
-
+  {% if site.data[include.datafolder][include.datafile].inherited_options %}
+    {% assign alloptions = site.data[include.datafolder][include.datafile].options | concat:site.data[include.datafolder][include.datafile].inherited_options %}
+  {% else %}
+    {% assign alloptions = site.data[include.datafolder][include.datafile].options %}
+  {% endif %}
 ## Options
 
 <table>
@@ -60,11 +87,12 @@ your client and daemon API versions.
   </tr>
 </thead>
 <tbody>
-{% for option in site.data[include.datafolder][include.datafile].options %}
+{% for option in alloptions %}
 
   {% capture min-api %}{% if option.min_api_version %}<span class="badge badge-info">API {{ option.min_api_version }}+</span>&nbsp;{% endif %}{%endcapture%}
-  {% capture stability-string %}{% if option.deprecated and option.experimental %}<span class="badge badge-danger">deprecated</span>&nbsp;<span class="badge badge-warning">experimental</span>&nbsp;{% elsif option.deprecated %}<span class="badge badge-danger">deprecated</span>&nbsp;{% elsif option.experimental %}<span class="badge badge-warning">experimental</span>&nbsp;{% endif %}{% endcapture %}
-  {% capture all-badges %}{% unless min-api == '' and stability-string == '' %}{{ min-api }}{{ stability-string }}<br />{% endunless %}{% endcapture %}
+  {% capture stability-string %}{% if option.deprecated and (option.experimental or option.experimentalcli) %}<span class="badge badge-danger">deprecated</span>&nbsp;<span class="badge badge-warning">experimental</span>&nbsp;{% elsif option.deprecated %}<span class="badge badge-danger">deprecated</span>&nbsp;{% elsif (option.experimental or option.experimentalcli) %}<span class="badge badge-warning">experimental</span>&nbsp;{% endif %}{% endcapture %}
+  {% capture flag-orchestrator %}{% if option.swarm %}<span class="badge badge-info">Swarm</span>{% endif %}{% if option.kubernetes %}<span class="badge badge-info">Kubernetes</span>{% endif %}{% endcapture %}
+  {% capture all-badges %}{% unless min-api == '' and stability-string == '' %}{{ min-api }}{{ stability-string }}{{ flag-orchestrator }}<br />{% endunless %}{% endcapture %}
   {% assign defaults-to-skip = "[],map[],false,0,0s,default,'',\"\"" | split: ',' %}
   {% capture option-default %}{% if option.default_value %}{% unless defaults-to-skip contains option.default_value or defaults-to-skip == blank %}`{{ option.default_value }}`{% endunless %}{% endif %}{% endcapture %}
   <tr>

--- a/_scripts/fetch-upstream-resources.sh
+++ b/_scripts/fetch-upstream-resources.sh
@@ -31,7 +31,7 @@ sed -i "s/{{ site.latest_stable_docker_engine_api_version }}/$latest_stable_dock
 # Engine stable
 ENGINE_SVN_BRANCH="branches/17.12"
 ENGINE_BRANCH="17.12"
-ENGINE_EDGE_BRANCH="17.12"
+ENGINE_EDGE_BRANCH="18.01"
 
 # Distribution
 DISTRIBUTION_SVN_BRANCH="branches/release/2.6"

--- a/release-notes/docker-ce.md
+++ b/release-notes/docker-ce.md
@@ -484,6 +484,63 @@ Upgrading from Docker 1.13.1 to 17.03.0 is expected to be simple and low-risk.
 
 # Edge releases
 
+## 18.01.0-ce (2018-01-10)
+
+### Builder
+
+* Fix files not being deleted if user-namespaces are enabled [moby/moby#35822](https://github.com/moby/moby/pull/35822)
+- Add support for expanding environment-variables in `docker commit --change ...` [moby/moby#35582](https://github.com/moby/moby/pull/35582)
+
+### Client
+
+* Return errors from client in stack deploy configs [docker/cli#757](https://github.com/docker/cli/pull/757)
+- Fix description of filter flag in prune commands [docker/cli#774](https://github.com/docker/cli/pull/774)
++ Add "pid" to unsupported options list [docker/cli#768](https://github.com/docker/cli/pull/768)
++ Add support for experimental Cli configuration [docker/cli#758](https://github.com/docker/cli/pull/758)
++ Add support for generic resources to bash completion [docker/cli#749](https://github.com/docker/cli/pull/749)
+- Fix error in zsh completion script for docker exec [docker/cli#751](https://github.com/docker/cli/pull/751)
++ Add a debug message when client closes websocket attach connection [moby/moby#35720](https://github.com/moby/moby/pull/35720)
+- Fix bash completion for `"docker swarm"` [docker/cli#772](https://github.com/docker/cli/pull/772)
+
+
+### Documentation
+* Correct references to `--publish` long syntax in docs [docker/cli#746](https://github.com/docker/cli/pull/746)
+* Corrected descriptions for MAC_ADMIN and MAC_OVERRIDE [docker/cli#761](https://github.com/docker/cli/pull/761)
+* Updated developer doc to explain external CLI [moby/moby#35681](https://github.com/moby/moby/pull/35681)
+- Fix `"on-failure"` restart policy being documented as "failure" [docker/cli#754](https://github.com/docker/cli/pull/754)
+- Fix anchors to "Storage driver options" [docker/cli#748](https://github.com/docker/cli/pull/748)
+
+### Experimental
+
++ Add kubernetes support to `docker stack` command [docker/cli#721](https://github.com/docker/cli/pull/721)
+* Don't append the container id to custom directory checkpoints. [moby/moby#35694](https://github.com/moby/moby/pull/35694)
+
+### Logging
+
+* Fix daemon crash when using the GELF log driver over TCP when the GELF server goes down [moby/moby#35765](https://github.com/moby/moby/pull/35765)
+- Fix awslogs batch size calculation for large logs [moby/moby#35726](https://github.com/moby/moby/pull/35726)
+
+### Networking
+
+- Windows: Fix to allow docker service to start on Windows VM [docker/libnetwork#1916](https://github.com/docker/libnetwork/pull/1916)
+- Fix for docker intercepting DNS requests on ICS network [docker/libnetwork#2014](https://github.com/docker/libnetwork/pull/2014)
++ Windows: Added a new network creation driver option [docker/libnetwork#2021](https://github.com/docker/libnetwork/pull/2021)
+
+
+### Runtime
+
+* Validate Mount-specs on container start to prevent missing host-path [moby/moby#35833](https://github.com/moby/moby/pull/35833)
+- Fix overlay2 storage driver inside a user namespace [moby/moby#35794](https://github.com/moby/moby/pull/35794)
+* Zfs: fix busy error on container stop [moby/moby#35674](https://github.com/moby/moby/pull/35674)
+- Fix health checks not using the container's working directory [moby/moby#35845](https://github.com/moby/moby/pull/35845)
+- Fix VFS graph driver failure to initialize because of failure to setup fs quota [moby/moby#35827](https://github.com/moby/moby/pull/35827)
+- Fix containerd events being processed twice [moby/moby#35896](https://github.com/moby/moby/pull/35896)
+
+### Swarm mode
+
+- Fix published ports not being updated if a service has the same number of host-mode published ports with Published Port 0 [docker/swarmkit#2376](https://github.com/docker/swarmkit/pull/2376)
+* Make the task termination order deterministic [docker/swarmkit#2265](https://github.com/docker/swarmkit/pull/2265)
+
 ## 17.11.0-ce (2017-11-20)
 
 > **Important**: Docker CE 17.11 is the first Docker release based on


### PR DESCRIPTION
cc/ @andrewhsu @seemethere 

Also updated the CLI template to show the Kubernetes / Swarm support, to differentiate between experimental in the daemon and CLI,  and to accommodate the new `inherited_options` key (when did that get added??) since we were not displaying a lot of options we should have.

I will wait for reviews before merging. Please build and test locally using `docker build` and `docker run` before giving +1. To verify the CLI ref changes, look at `docker config` and `docker stack` and `docker trust` sub-commands.