### PR TITLE
machine: openstack: add option for enabling configuration drive

### DIFF
--- a/machine/drivers/openstack.md
+++ b/machine/drivers/openstack.md
@@ -20,6 +20,7 @@ Mandatory:
 
 -   `--openstack-active-timeout`: The timeout in seconds until the OpenStack instance must be active.
 -   `--openstack-availability-zone`: The availability zone in which to launch the server.
+-   `--openstack-config-drive`: Whether OpenStack should mount a configuration drive for the machine.
 -   `--openstack-domain-name` or `--openstack-domain-id`: Domain to use for authentication (Keystone v3 only).
 -   `--openstack-endpoint-type`: Endpoint type can be `internalURL`, `adminURL`, or `publicURL`. It is a helper for the driver
     to choose the right URL in the OpenStack service catalog. If not provided the default is `publicURL`.
@@ -47,6 +48,7 @@ Mandatory:
 | `--openstack-active-timeout`    | `OS_ACTIVE_TIMEOUT`    | `200`       |
 | `--openstack-auth-url`          | `OS_AUTH_URL`          | -           |
 | `--openstack-availability-zone` | `OS_AVAILABILITY_ZONE` | -           |
+| `--openstack-config-drive`      | `OS_CONFIG_DRIVE`      | `false`     |
 | `--openstack-domain-id`         | `OS_DOMAIN_ID`         | -           |
 | `--openstack-domain-name`       | `OS_DOMAIN_NAME`       | -           |
 | `--openstack-endpoint-type`     | `OS_ENDPOINT_TYPE`     | `publicURL` |


### PR DESCRIPTION
### Proposed changes

Adding documentation for new --openstack-config-drive command line flag for Docker Machine openstack driver.

### Unreleased project version (optional)

Docs say to base this on vNext-machine and I have.

### Related issues (optional)

This should go in along with https://github.com/docker/machine/pull/4361 .