### PR TITLE
Fix link text for API versions 1.34 and 1.35

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1311,9 +1311,9 @@ reference:
       - path: /engine/api/version-history/
         title: Version history overview
       - path: /engine/api/v1.35/
-        title: v1.33 reference
+        title: v1.35 reference
       - path: /engine/api/v1.34/
-        title: v1.33 reference
+        title: v1.34 reference
       - path: /engine/api/v1.33/
         title: v1.33 reference
       - path: /engine/api/v1.32/


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I noticed that the links to the API docs for versions 1.34 and 1.35 in the sidebar under `API reference by version` were both listed as `v1.33 reference`. This PR updates the link text to match the actual URL for those version links.