### PR TITLE
Add features to CLI ref template

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -509,7 +509,7 @@ guides:
       title: Kubernetes Benchmark
   - path: /compliance/fedramp/
     title: FedRAMP
-  
+
 - sectiontitle: Open source at Docker
   section:
   - path: /opensource/
@@ -923,8 +923,6 @@ reference:
         section:
         - path: /edge/engine/reference/commandline/checkpoint/
           title: docker checkpoint
-        - path: /edge/engine/reference/commandline/checkpoint_create/
-          title: docker checkpoint create
         - path: /edge/engine/reference/commandline/checkpoint_create/
           title: docker checkpoint create
         - path: /edge/engine/reference/commandline/checkpoint_ls/

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -12,9 +12,9 @@
 
 {% if site.data[include.datafolder][include.datafile].min_api_version %}
 
-<span class="badge badge-info">API {{ site.data[include.datafolder][include.datafile].min_api_version }}+</span>&nbsp;
+<a href="/engine/api/v{{ site.data[include.datafolder][include.datafile].min_api_version }}/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the {{ site.data[include.datafolder][include.datafile].min_api_version }} API reference (in a new window)">API {{ site.data[include.datafolder][include.datafile].min_api_version }}+</span></a>&nbsp;
 The client and daemon API must both be at least
-{{ site.data[include.datafolder][include.datafile].min_api_version }}
+<a href="/engine/api/v{{ site.data[include.datafolder][include.datafile].min_api_version }}/" target="_blank" class="_">{{ site.data[include.datafolder][include.datafile].min_api_version }}</a>
 to use this command. Use the `docker version` command on the client to check
 your client and daemon API versions.
 
@@ -22,7 +22,7 @@ your client and daemon API versions.
 
 {% if site.data[include.datafolder][include.datafile].deprecated %}
 
-> This command is deprecated.
+> This command is [deprecated](/engine/deprecated.md){: target="_blank" class="_"}.
 >
 > It may be removed in a future Docker version.
 {: .warning }
@@ -34,6 +34,9 @@ your client and daemon API versions.
 > This command is experimental.
 >
 > This command is experimental on the Docker daemon. It should not be used in production environments.
+> To enable experimental features on the Docker daemon, edit the
+> [daemon.json](/engine/reference/commandline/dockerd.md#daemon-configuration-file)
+> and set `experimental` to `true`.
 {: .important }
 
 {% endif %}
@@ -43,6 +46,9 @@ your client and daemon API versions.
 > This command is experimental.
 >
 > This  command is experimental on the Docker client. It should not be used in production environments.
+> To enable experimental features in the Docker CLI, edit the
+> [config.json](/engine/reference/commandline/cli.md#configuration-files)
+> and set `experimental` to `enabled`.
 {: .important }
 
 {% endif %}
@@ -50,12 +56,12 @@ your client and daemon API versions.
 {% capture command-orchestrator %}
 {% if site.data[include.datafolder][include.datafile].swarm %}
 
-<span class="badge badge-info">Swarm</span> This command works with the Swarm orchestrator.
+<span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="This command works with the Swarm orchestrator.">Swarm</span> This command works with the Swarm orchestrator.
 
 {% endif %}
 {% if site.data[include.datafolder][include.datafile].kubernetes %}
 
-<span class="badge badge-info">Kubernetes</span> This command works with the Kubernetes orchestrator.
+<span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="This command works with the Kubernetes orchestrator.">Kubernetes</span> This command works with the Kubernetes orchestrator.
 
 {% endif %}
 {% endcapture %}{{ command-orchestrator }}
@@ -89,16 +95,20 @@ your client and daemon API versions.
 <tbody>
 {% for option in alloptions %}
 
-  {% capture min-api %}{% if option.min_api_version %}<span class="badge badge-info">API {{ option.min_api_version }}+</span>&nbsp;{% endif %}{%endcapture%}
-  {% capture stability-string %}{% if option.deprecated and (option.experimental or option.experimentalcli) %}<span class="badge badge-danger">deprecated</span>&nbsp;<span class="badge badge-warning">experimental</span>&nbsp;{% elsif option.deprecated %}<span class="badge badge-danger">deprecated</span>&nbsp;{% elsif (option.experimental or option.experimentalcli) %}<span class="badge badge-warning">experimental</span>&nbsp;{% endif %}{% endcapture %}
-  {% capture flag-orchestrator %}{% if option.swarm %}<span class="badge badge-info">Swarm</span>{% endif %}{% if option.kubernetes %}<span class="badge badge-info">Kubernetes</span>{% endif %}{% endcapture %}
-  {% capture all-badges %}{% unless min-api == '' and stability-string == '' %}{{ min-api }}{{ stability-string }}{{ flag-orchestrator }}<br />{% endunless %}{% endcapture %}
+  {% capture deprecated-badge %}{% if option.deprecated %}<a href="/engine/deprecated.md" target="_blank" class="_"><span class="badge badge-danger" data-toggle="tooltip" title="Read the deprecation reference (in a new window).">deprecated</span></a>{% endif %}{% endcapture %}
+  {% capture experimental-daemon-badge %}{% if option.experimental %}<a href="/engine/reference/commandline/dockerd.md#daemon-configuration-file" target="_blank" class="_"><span class="badge badge-warning" data-toggle="tooltip" title="Read about experimental daemon options (in a new window).">experimental (daemon)</span></a>{% endif %}{% endcapture %}
+  {% capture experimental-cli-badge %}{% if option.experimentalcli %}<a href="/engine/reference/commandline/cli.md#configuration-files" target="_blank" class="_"><span class="badge badge-warning"  data-toggle="tooltip" title="Read about experimental CLI options (in a new window).">experimental (CLI)</span></a>{% endif %}{% endcapture %}
+  {% capture min-api %}{% if option.min_api_version %}<a href="/engine/api/v{{ option.min_api_version }}/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" ttitle="Open the {{ site.data[include.datafolder][include.datafile].min_api_version }} API reference (in a new window)">API {{ option.min_api_version }}+</span></a>{% endif %}{%endcapture%}
+  {% capture flag-orchestrator %}{% if option.swarm %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Swarm orchestrator.">Swarm</span>{% endif %}{% if option.kubernetes %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Kubernetes orchestrator.">Kubernetes</span>{% endif %}{% endcapture %}
+
+  {% capture all-badges %}{{ deprecated-badge }}{{ experimental-daemon-badge }}{{ experimental-cli-badge }}{{ min-api }}{{ flag-orchestrator }}{% endcapture %}
+
   {% assign defaults-to-skip = "[],map[],false,0,0s,default,'',\"\"" | split: ',' %}
   {% capture option-default %}{% if option.default_value %}{% unless defaults-to-skip contains option.default_value or defaults-to-skip == blank %}`{{ option.default_value }}`{% endunless %}{% endif %}{% endcapture %}
   <tr>
     <td markdown="span">`--{{ option.option }}{% if option.shorthand %} , -{{ option.shorthand }}{% endif %}`</td>
     <td markdown="span">{{ option-default }}</td>
-    <td markdown="span">{{ all-badges | strip }}{{ option.description | strip }}</td>
+    <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip }}</td>
   </tr>
 
 {% endfor %} <!-- end for option -->

--- a/test.md
+++ b/test.md
@@ -533,6 +533,47 @@ You can have <span class="badge badge-info">badges</span>. You can also have
 <span class="badge badge-warning">yellow badges</span> or
 <span class="badge badge-danger">red badges</span>.
 
+#### Badges as links
+
+You can make a badge a link. Wrap the `<span>` with an `<a>` (not the other way
+around) so that the text on the badge is still white.
+
+```html
+<a href="/test/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page (in a new window)">Test</span></a>
+```
+
+<a href="/test/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page (in a new window)">Test</span></a>
+
+
+You can also put tooltips on badges (as the example above shows). Keep reading for tooltips.
+
+### Tooltips
+
+To add a tooltip to any element, set `data-toggle="tooltip"` and set a `title`.
+Hovering over the element with the mouse pointer will make it visible. Tooltips
+are not visible on mobile devices or touchscreens, so don't rely on them as the
+only way to communicate important info.
+
+```html
+<span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page">Test</span>
+```
+
+<span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page">Test</span>
+
+You can optionally set the `data-placement` attribute to `top`, `bottom`,
+`middle`, `center`, `left`, or `right`. Only set it if not setting it causes
+layout issues.
+
+You don't have to use HTML. You can also set these attributes using Markdown.
+
+```markdown
+This is a paragraph that has a tooltip. We position it to the left so it doesn't align with the middle top of the paragraph (that looks weird).
+{:data-toggle="tooltip" data-placement="left" title="Markdown tooltip example"}
+```
+
+This is a paragraph that has a tooltip. We position it to the left so it doesn't align with the middle top of the paragraph (that looks weird).
+{:data-toggle="tooltip" data-placement="left" title="Markdown tooltip example"}
+
 ## Running in-page Javascript
 
 If you need to run custom Javascript within a page, and it depends upon JQuery


### PR DESCRIPTION
- Differentiate CLI experimental from daemon experimental
- When the whole command is experimental, point to docs for
  how to get it to show up
- Make badges links where possible
- Add tooltips to badges for more context
- Document in the test.md how to make badges into links and how to use tooltips (shows up at `/test/`)

Fixes #5718 (except that the CLI ref needs to be rewritten, but that is out of scope for this PR).

You can test some of this on Netlify but if you want to verify that the badge links actually work, you need to build locally with `docker build` so you get the upstream resources pulled in.

Turning the badges into links is a bit of an Easter egg. They do have tooltips but the point is that they are informative even if people don't realize they can click them. As such, when you do click them it opens the target in a new window / tab.

cc/ @thaJeztah who asked for some of these specifically.