### PR TITLE
Remove .md extensions that break links

### DIFF
--- a/get-started/nav.html
+++ b/get-started/nav.html
@@ -1,8 +1,8 @@
 <ul class="pagination">
-  <li {% if include.selected=="1"%}class="active"{% endif %}><a href="index.md">1: Orientation</a></li>
-  <li {% if include.selected=="2"%}class="active"{% endif %}><a href="part2.md">2: Containers</a></li>
-  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="part3.md">3: Services</a></li>
-  <li {% if include.selected=="4"%}class="active"{% endif %}><a href="part4.md">4: Swarms</a></li>
-  <li {% if include.selected=="5"%}class="active"{% endif %}><a href="part5.md">5: Stacks</a></li>
-  <li {% if include.selected=="6"%}class="active"{% endif %}><a href="part6.md">6: Deploy your app</a></li>
+  <li {% if include.selected=="1"%}class="active"{% endif %}><a href="index">1: Orientation</a></li>
+  <li {% if include.selected=="2"%}class="active"{% endif %}><a href="part2">2: Containers</a></li>
+  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="part3">3: Services</a></li>
+  <li {% if include.selected=="4"%}class="active"{% endif %}><a href="part4">4: Swarms</a></li>
+  <li {% if include.selected=="5"%}class="active"{% endif %}><a href="part5">5: Stacks</a></li>
+  <li {% if include.selected=="6"%}class="active"{% endif %}><a href="part6">6: Deploy your app</a></li>
 </ul>


### PR DESCRIPTION
### Proposed changes

The navigation links at the start of the content on pages such as https://docs.docker.com/get-started/part2/ have broken links (at least, with JavaScript disabled). The links go to e.g. https://docs.docker.com/get-started/part2.md but should instead go to https://docs.docker.com/get-started/part2 or https://docs.docker.com/get-started/part2/ .

### Related issues (optional)

Similar to #5712.