### PR TITLE
Removed RUN command from Dockerfile.build in multistage-build.md

### DIFF
--- a/engine/userguide/eng-image/multistage-build.md
+++ b/engine/userguide/eng-image/multistage-build.md
@@ -38,7 +38,6 @@ builder pattern above:
 ```conf
 FROM golang:1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
-RUN go get -d -v golang.org/x/net/html  
 COPY app.go .
 RUN go get -d -v golang.org/x/net/html \
   && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .


### PR DESCRIPTION
### Proposed changes

`RUN` command was removed from `Dockerfile.build `snippet code in multistage-build.md. It is an unnecessary command because it was written along with  `CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .` command.

Even this was for showing the "two RUN commands together" bad practice example, having the same command twice is wrong so that could be a bit confused.

