### PR TITLE
Temporary fix for broken HTML in YAML files

### DIFF
--- a/_data/engine-cli-edge/docker_service_create.yaml
+++ b/_data/engine-cli-edge/docker_service_create.yaml
@@ -871,7 +871,7 @@ examples: "### Create a service\n\n```bash\n$ docker service create --name redis
   of using the long format\nfor the same service as above:\n\n```bash\n$ docker service
   create --name my_web --replicas 3 --publish published=8080,target=80 nginx\n```\n\nThe
   options you can specify are:\n\n<table>\n<thead>\n<tr>\n  <th>Option</th>\n  <th>Short
-  syntax</th>\n  <th>Long syntax</th>\n  <th>Description</th>\n</tr>\n<tr>\n  <td>published
+  syntax</th>\n  <th>Long syntax</th>\n  <th>Description</th>\n</tr></thead>\n<tr>\n  <td>published
   and target port </td>\n  <td><tt></tt></td>\n  <td><tt></tt></td>\n  <td></td>\n</tr>\n<tr>\n
   \ <td>protocol</td>\n  <td><tt>--publish 8080:80</tt></td>\n  <td><tt>--publish
   published=8080,target=80</tt></td>\n  <td><p>\n    The port to publish the service

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -682,7 +682,7 @@ examples: "### Create a service\n\n```bash\n$ docker service create --name redis
   of using the long format\nfor the same service as above:\n\n```bash\n$ docker service
   create --name my_web --replicas 3 --publish published=8080,target=80 nginx\n```\n\nThe
   options you can specify are:\n\n<table>\n<thead>\n<tr>\n  <th>Option</th>\n  <th>Short
-  syntax</th>\n  <th>Long syntax</th>\n  <th>Description</th>\n</tr>\n<tr>\n  <td>published
+  syntax</th>\n  <th>Long syntax</th>\n  <th>Description</th>\n</tr>\n</thead><tr>\n  <td>published
   and target port </td>\n  <td><tt></tt></td>\n  <td><tt></tt></td>\n  <td></td>\n</tr>\n<tr>\n
   \ <td>protocol</td>\n  <td><tt>--publish 8080:80</tt></td>\n  <td><tt>--publish
   published=8080,target=80</tt></td>\n  <td><p>\n    The port to publish the service


### PR DESCRIPTION
Fixes #5725 

This will ultimately be fixed when https://github.com/docker/docker-ce/pull/384/files gets in, but we don't want to be stuck with broken reference docs until 18.01.

I tested this by building the image locally and going to `/edge/engine/reference/commandline/service_create/#publish-service-ports-externally-to-the-swarm--p-publish` and `/engine/reference/commandline/service_create/#publish-service-ports-externally-to-the-swarm--p-publish`.