### PR TITLE
Fix link to resolve on GitHub and Docker.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ help. If a reviewer realizes you have based your work on the wrong branch, we'll
 let you know so that you can rebase it.
 
 >**Note**: To contribute code to Docker projects, see the
-[Contribution guidelines](opensource/project/who-written-for).
+[Contribution guidelines](opensource/).
 
 ### Files not edited here
 


### PR DESCRIPTION
It's a directory on GitHub so interested developer will need to click index.md, but no 404 from GitHub and page loads normally on docs.docker.com.