### PR TITLE
Fixed redis volume path 

### DIFF
--- a/get-started/part5.md
+++ b/get-started/part5.md
@@ -197,7 +197,7 @@ Redis service. Be sure to replace `username/repo:tag` with your image details.
         ports:
           - "6379:6379"
         volumes:
-          - /home/docker/data:/data
+          - "/home/docker/data:/data"
         deploy:
           placement:
             constraints: [node.role == manager]


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Redis service wasn't starting due to no quotes around redis volume path. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
