### PR TITLE
added doc changes for upcoming tmpfs-mode 3.6 compose

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -277,6 +277,16 @@ Introduces the following additional parameters:
 - `name` for networks, secrets and configs
 - `shm_size` in [build configurations](index.md#build)
 
+### Version 3.6
+
+An upgrade of [version 3](#version-3) that introduces new parameters. It is
+only available with Docker Engine version **17.12.0** and higher.
+
+Introduces the following additional parameters:
+
+- [`tmpfs`](index.md#tmpfs) in volume definitions using the [Long Syntax](index.md#long-syntax-3)
+- `size` optional parameter for a tmpfs volume
+
 ## Upgrading
 
 ### Version 2.x to 3.x

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -881,7 +881,17 @@ Mount a temporary file system inside the container. Can be a single value or a l
 
 > **Note**: This option is ignored when
 > [deploying a stack in swarm mode](/engine/reference/commandline/stack_deploy.md)
-> with a (version 3) Compose file.
+> with a (version 3-3.5) Compose file.
+
+> [Version 3.6 file format](compose-versioning.md#version-3) and up.
+
+Mount a temporary file system inside the container. Size parameter specifies the size
+of the tmpfs mount in bytes. Unlimited by default.
+
+     - type: tmpfs
+         target: /app
+         tmpfs:
+           size: 1000
 
 ### entrypoint
 


### PR DESCRIPTION
### Proposed changes

Added documentation for tmpfs long syntax feature added to upcoming 3.6v compose schema. Detailed optional size parameter, and how it allocates a temporary volume of a specified size in bytes.

### Unreleased project version (optional)

Changes to the documentation are added for the unreleased 3.6v schema. 

### Related issues (optional)

https://github.com/docker/cli/pull/808
