### PR TITLE
Update docs for macOS hostname

### DIFF
--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -85,8 +85,8 @@ There are two scenarios that the above limitations affect:
 #### I want to connect from a container to a service on the host
 
 The Mac has a changing IP address (or none if you have no network access). From
-17.06 onwards our recommendation is to connect to the special Mac-only DNS
-name `docker.for.mac.localhost` which resolves to the internal IP address
+17.12 onwards our recommendation is to connect to the special Mac-only DNS
+name `docker.for.mac.host.internal`, which resolves to the internal IP address
 used by the host.
 
 #### I want to connect to a container from the Mac


### PR DESCRIPTION
### Proposed changes

Updated the macOS specific local hostname to use `docker.for.mac.host.internal` to reflect the changes made in version 17.12.0.

See: https://github.com/docker/docker.github.io/blob/master/docker-for-mac/release-notes.md#docker-community-edition-17120-ce-mac46-2018-01-09-stable

### Related issues (optional)

* docker/for-mac#1837