### PR TITLE
Clarify the DRAIN state w/ regard to containers

### DIFF
--- a/engine/swarm/swarm-tutorial/drain-node.md
+++ b/engine/swarm/swarm-tutorial/drain-node.md
@@ -14,6 +14,10 @@ availability. `DRAIN` availability  prevents a node from receiving new tasks
 from the swarm manager. It also means the manager stops tasks running on the
 node and launches replica tasks on a node with `ACTIVE` availability.
 
+> Note: setting a node to `DRAIN` does not remove containers from that node that 
+were created with `docker run` or `docker-compose up`.  `DRAIN` only acts on swarm
+services.
+
 1.  If you haven't already, open a terminal and ssh into the machine where you
     run your manager node. For example, the tutorial uses a machine named
     `manager1`.

--- a/engine/swarm/swarm-tutorial/drain-node.md
+++ b/engine/swarm/swarm-tutorial/drain-node.md
@@ -14,9 +14,11 @@ availability. `DRAIN` availability  prevents a node from receiving new tasks
 from the swarm manager. It also means the manager stops tasks running on the
 node and launches replica tasks on a node with `ACTIVE` availability.
 
-> Note: setting a node to `DRAIN` does not remove containers from that node that 
-were created with `docker run` or `docker-compose up`.  `DRAIN` only acts on swarm
-services.
+> **Important**: Setting a node to `DRAIN` does not remove standalone containers from that node,
+> such as those created with `docker run`, `docker-compose up`, or the Docker Engine
+> API. A node's status, including `DRAIN`, only affects the node's ability to schedule
+> swarm service workloads.
+{:.important}
 
 1.  If you haven't already, open a terminal and ssh into the machine where you
     run your manager node. For example, the tutorial uses a machine named


### PR DESCRIPTION
Bare containers are not state-reconciled, and are not affected by the swarm DRAIN state

### Proposed changes

Clarify usage of the DRAIN state with regard to bare containers

### Related issues (optional)
Resolves https://github.com/docker/docker.github.io/issues/5800
