### PR TITLE
Explain how `volumes` and `devices` are merged

### DIFF
--- a/compose/extends.md
+++ b/compose/extends.md
@@ -326,8 +326,10 @@ For the **multi-value options** `ports`, `expose`, `external_links`, `dns`,
       - "4000"
       - "5000"
 
-In the case of `environment`, `labels`, `volumes` and `devices`, Compose
-"merges" entries together with locally-defined values taking precedence:
+In the case of `environment`, `labels`, `volumes`, and `devices`, Compose
+"merges" entries together with locally-defined values taking precedence. For
+`environment` and `labels`, the environment variable or label name determines
+which value is used:
 
     # original service
     environment:
@@ -345,6 +347,24 @@ In the case of `environment`, `labels`, `volumes` and `devices`, Compose
       - BAR=local
       - BAZ=local
 
+Entries for `volumes` and `devices` are merged using the mount path in the
+container:
+
+    # original service
+    volumes:
+      - ./original:/foo
+      - ./original:/bar
+
+    # local service
+    volumes:
+      - ./local:/bar
+      - ./local:/baz
+
+    # result
+    volumes:
+      - ./original:/foo
+      - ./local:/bar
+      - ./local:/baz
 
 
 


### PR DESCRIPTION
### Proposed changes

I've added a short explanation and an example about how `volumes` and `devices` are merged if more than one Compose configuration file is used. The current version of the "Adding and overriding configuration" section only has an example for `environments` and it's unclear how entries are merged if they don't have a `key=value` format.

### Related issue

Fixes docker/compose#2633