### PR TITLE
Target ip in the config file needs to be changed

### DIFF
--- a/engine/admin/prometheus.md
+++ b/engine/admin/prometheus.md
@@ -189,7 +189,7 @@ Next, start a single-replica Prometheus service using this configuration.
 
 <ul class="nav nav-tabs">
 <li class="active"><a data-toggle="tab" data-target="#linux-run" data-group="linux">Docker for Linux</a></li>
-<li class="active"><a data-toggle="tab" data-target="#mac-run" data-group="mac">Docker for Mac</a></li>
+<li><a data-toggle="tab" data-target="#mac-run" data-group="mac">Docker for Mac</a></li>
 <li><a data-toggle="tab" data-target="#win-run" data-group="win">Docker for Windows or Windows Server</a></li>
 </ul>
 
@@ -205,7 +205,7 @@ $ docker service create --replicas 1 --name my-prometheus \
 ```
 
 </div><!-- linux -->
-<div id="mac-run" class="tab-pane fade in active" markdown="1">
+<div id="mac-run" class="tab-pane fade" markdown="1">
 
 ```bash
 $ docker service create --replicas 1 --name my-prometheus \

--- a/engine/admin/prometheus.md
+++ b/engine/admin/prometheus.md
@@ -138,7 +138,7 @@ scrape_configs:
          # scheme defaults to 'http'.
 
     static_configs:
-      - targets: ['192.168.65.1:9323']
+      - targets: ['docker.for.mac.host.internal:9323']
 ```
 
 </div><!-- mac -->


### PR DESCRIPTION
I can't access to '192.168.65.1' from the prometheus container, and the webpage can't show the statistics of docker engine.
When I changed it to 'docker.for.mac.host.internal', it works perfectly.

'The Mac has a changing IP address (or none if you have no network access). From 17.12 onwards our recommendation is to connect to the special Mac-only DNS name docker.for.mac.host.internal, which resolves to the internal IP address used by the host.'
refer to 'https://docs.docker.com/docker-for-mac/networking/#known-limitations-use-cases-and-workarounds'.

Thanks.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
