### PR TITLE
Fix typo in user namespace docs

### DIFF
--- a/engine/security/userns-remap.md
+++ b/engine/security/userns-remap.md
@@ -71,7 +71,7 @@ avoid these situations.
     want to use an existing user, Docker can create one for you and use that. If
     you want to use an existing username or user ID, it must already exist.
     Typically, this means that the relevant entries need to be in
-    `/etc/password` and `/etc/group`, but if you are using a different
+    `/etc/passwd` and `/etc/group`, but if you are using a different
     authentication back-end, this requirement may translate differently.
 
     To verify this, use the `id` command:


### PR DESCRIPTION
There was a typo in a file name.
should be /etc/passwd not /etc/password

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Fixes #5880 
