### PR TITLE
Add docs for Compose file v3.5 and v3.6

### DIFF
--- a/_includes/content/compose-matrix.md
+++ b/_includes/content/compose-matrix.md
@@ -2,6 +2,8 @@ This table shows which Compose file versions support specific Docker releases.
 
 | **Compose file format** | **Docker Engine release** |
 |  -------------------    |    ------------------     |
+|      3.6                |       18.02.0+            |
+|      3.5                |       17.12.0+            |
 |      3.4                |       17.09.0+            |
 |      3.3                |       17.06.0+            |
 |      3.2                |       17.04.0+            |

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -277,6 +277,15 @@ Introduces the following additional parameters:
 - `name` for networks, secrets and configs
 - `shm_size` in [build configurations](index.md#build)
 
+### Version 3.6
+
+An upgrade of [version 3](#version-3) that introduces new parameters. It is
+only available with Docker Engine version **18.02.0** and higher.
+
+Introduces the following additional parameters:
+
+- [`tmpfs` size](index.md#long-syntax-3) for `tmpfs`-type mounts
+
 ## Upgrading
 
 ### Version 2.x to 3.x

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1663,7 +1663,8 @@ expressed in the short form.
 - `volume`: configure additional volume options
   - `nocopy`: flag to disable copying of data from a container when a volume is
     created
-
+- `tmpfs`: configure additional tmpfs options
+  - `size`: the size for the tmpfs mount in bytes
 
 ```none
 version: "3.2"


### PR DESCRIPTION
### Proposed changes

- Add entries for v3.5 and v3.6 in compatibility matrix
- Document new fields in v3.6

### Unreleased project version (optional)

18.02.0-ce

### Related issues (optional)

Fixes #5831 