### PR TITLE
Use correct HTML character reference for em dash

### DIFF
--- a/compose/rails.md
+++ b/compose/rails.md
@@ -149,8 +149,8 @@ You can now boot the app with [docker-compose up](/compose/reference/up/):
 
     docker-compose up
 
-If all's well, you should see some PostgreSQL output, and then&8212;after a few
-seconds&8212;the familiar refrain:
+If all's well, you should see some PostgreSQL output, and then &#8212; after a few
+seconds &#8212; the familiar refrain:
 
     Starting rails_db_1 ...
     Starting rails_db_1 ... done


### PR DESCRIPTION
### Proposed changes

Minor typo in the docs - `&#8212;` should be used for an [em dash](https://en.wikipedia.org/wiki/Dash#Common_dashes), not `&8212;`. Please display as a rich diff to see the changes in the rendered markdown.