### PR TITLE
Included a step to verify if Windows needs a restart

### DIFF
--- a/install/windows/docker-ee.md
+++ b/install/windows/docker-ee.md
@@ -48,7 +48,18 @@ full list of prerequisites.
     Install-Package Docker -ProviderName DockerProvider -Force
     ```
 
-2.  Test your Docker EE installation by running the `hello-world` container.
+2.  Server may need to restart if the installation process installed Containers Windows service, to check if a reboot is required execute the following command.
+
+    ```PowerShell
+    (Install-WindowsFeature Containers).RestartNeeded
+    ```
+    If the output of this command is **Yes**, then restart the server with:
+    
+    ```PowerShell
+    Restart-Computer
+    ```
+
+3.  Test your Docker EE installation by running the `hello-world` container.
 
     ```PowerShell
     docker container run hello-world:nanoserver

--- a/install/windows/docker-ee.md
+++ b/install/windows/docker-ee.md
@@ -48,7 +48,7 @@ full list of prerequisites.
     Install-Package Docker -ProviderName DockerProvider -Force
     ```
 
-2.  Server may need to restart if the installation process installed Containers Windows service, to check if a reboot is required execute the following command.
+2.  Check if a reboot is required, and if yes, restart your instance:
 
     ```PowerShell
     (Install-WindowsFeature Containers).RestartNeeded


### PR DESCRIPTION
Docker installation process installs Containers Windows service and this service when installed requires a reboot, the steps included will check if a reboot is needed and then the cmdlet to perform the reboot. I included a test first because Windows Server, depending on where it is installed may already have the Containers service installed and the server may already had rebooted so we just skip the reboot part. This is important because the hello-world test fails and that may frustrate newcomers right in the beginning of their Docker experience on Windows.