### PR TITLE
Removed "encryption" detail from unencrypted example

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/backups-and-disaster-recovery.md
+++ b/datacenter/ucp/2.2/guides/admin/backups-and-disaster-recovery.md
@@ -76,7 +76,7 @@ The example below shows how to create a backup of a UCP manager node and
 verify its contents:
 
 ```none
-# Create a backup, encrypt it, and store it on /tmp/backup.tar
+# Create a backup and store it in /tmp/backup.tar
 $ docker container run --log-driver none --rm -i --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} backup --interactive > /tmp/backup.tar


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Removed phrasing around "encryption" in unencrypted backup example
