### PR TITLE
Fix run-container example

### DIFF
--- a/develop/sdk/examples.md
+++ b/develop/sdk/examples.md
@@ -56,14 +56,16 @@ func main() {
 		panic(err)
 	}
 
-	_, err = cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
+	reader, err := cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
 	if err != nil {
 		panic(err)
 	}
+	io.Copy(os.Stdout, reader)
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: "alpine",
 		Cmd:   []string{"echo", "hello world"},
+		Tty:   true,
 	}, nil, nil, "")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
### Proposed changes

The [very first example](https://docs.docker.com/develop/sdk/examples/#run-a-container) has two annoying issues fixed by this patch:

1. The `ImagePull` call does not complete before the subsequent `ContainerCreate` call is issued. As a result, there is a race between pulling the image and starting the container from the image. For locally cached images, `ContainerCreate` will still work, but for images that have to be pulled, it will likely fail. This was [reported on StackOverflow](https://stackoverflow.com/questions/42816132/docker-run-using-golang-api-docker-docs) but not fixed yet.

2. The `ContainerLogs` call doesn't return a string, but rather an intermixed byte buffer with the stdout and stderr from the container. This can be highly confusing. Added `Tty: true` to the `ContainerCreate` call such that the `ContainerLogs` output only includes stdout.