### PR TITLE
Fix reference to the TUF Key Hierarchy diagram

### DIFF
--- a/notary/service_architecture.md
+++ b/notary/service_architecture.md
@@ -12,7 +12,7 @@ This document assumes familiarity with
 [The Update Framework](https://www.theupdateframework.com/){:target="_blank" class="_"},
 but here is a brief recap of the TUF roles and corresponding key hierarchy:
 
-!TUF Key Hierarchy[](https://cdn.rawgit.com/docker/notary/09f81717080f53276e6881ece57cbbbf91b8e2a7/docs/images/key-hierarchy.svg){:width="400px"}
+![TUF Key Hierarchy](https://cdn.rawgit.com/docker/notary/09f81717080f53276e6881ece57cbbbf91b8e2a7/docs/images/key-hierarchy.svg){:width="400px"}
 
 - The root key is the root of all trust. It signs the
   [root metadata file](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L489){:target="_blank" class="_"},


### PR DESCRIPTION
I'm not quite sure about how the `{:width="400px"}` attribute will be rendered, but it looks like there was a typo preventing the SVG from being rendered on https://docs.docker.com/notary/service_architecture/

### Proposed changes

I've fixed what appears to be a minor typo in the documentation pointing to a key hierarchy diagram.
