### PR TITLE
2nd node swarm name incorrect

### DIFF
--- a/network/network-tutorial-overlay.md
+++ b/network/network-tutorial-overlay.md
@@ -93,7 +93,7 @@ and will be connected together using an overlay network called `ingress`.
       <IP-ADDRESS-OF-MANAGER>:2377
     ```
 
-3.  On `worker-1`, join the swarm. If the host only has one network interface,
+3.  On `worker-2`, join the swarm. If the host only has one network interface,
     the `--advertise-addr` flag is optional.
 
     ```bash


### PR DESCRIPTION
Just changed `worker-1` to `worker-2` when tutorial instructs joining the second worker node to the swarm.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The name for the second node was changed to `worker-2` instead of `worker-1` since it's already being used to identify the first node. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
