### PR TITLE
added explanation of -dit further up

### DIFF
--- a/network/network-tutorial-overlay.md
+++ b/network/network-tutorial-overlay.md
@@ -379,7 +379,10 @@ The example uses Linux hosts, but the same commands work on Windows.
               --network test-net \
               alpine
     ```
-
+    The `-dit` flags mean to start the container detached
+    (in the background), interactive (with the ability to type into it), and
+    with a TTY (so you can see the input and output).
+    
     > **Note**: There is nothing to prevent you from using the same container
     > name on multiple hosts, but automatic service discovery will not work if
     > you do, and you will need to refer to the containers by IP address.


### PR DESCRIPTION
The explanation of dit in the "Communicate between a container and a swarm service" was helpful but wasn't written in an earlier walk through on the same page. I just simply added it to the "Use an overlay network for standalone containers" walkthrough so that people come across it in case they only see this one walkthrough.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added more information to one of the walkthroughs as was done in a later walkthrough on the same page. Would have been helpful to know in one of the earlier walkthroughs.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
