### PR TITLE
HRM routing mesh on Windows Server

### DIFF
--- a/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
+++ b/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
@@ -216,3 +216,5 @@ docker network create -d overlay --label com.docker.ucp.mesh.http=true new-hrm-n
 
 If you're creating a a new HRM network you need to disable the HRM service first, or disable
 and enable the HRM service after you create the network else HRM will not be available on new network.
+
+Note:- Docker on Windows Server doesn't support Swarm Mode Routing Mesh, which means the hrm service is exposed only through the manager node's ip. Therefore DNS needs to configured so that all the host names ('wordpress.example.org' in this example) point to manager nodes and not the worker nodes.


### PR DESCRIPTION
Note:- Docker on Windows Server doesn't support Swarm Mode Routing Mesh, which means the hrm service is exposed only through the manager node's ip. Therefore DNS needs to configured so that all the host names ('wordpress.example.org' in this example) point to manager nodes and not the worker nodes.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
