### PR TITLE
Add println to formatting doc

### DIFF
--- a/config/formatting.md
+++ b/config/formatting.md
@@ -62,3 +62,12 @@ It puts a separator between each element in the list.
 	{% raw %}
 	$ docker inspect --format "{{upper .Name}}" container
 	{% endraw %}
+
+
+## println
+
+`println` prints each value on a new line.
+
+	{% raw %}
+	$ docker inspect --format='{{range .NetworkSettings.Networks}}{{println .IPAddress}}{{end}}' container
+	{% endraw %}


### PR DESCRIPTION
Add documentation for printing values on separate line.
Useful when multiples volumes are mounted or when a container has multiple IPAddress

Fixes  #5963
See moby/moby#35887

Signed By : Yash Jain <ydjainopensource@gmail.com>
