### PR TITLE
HRM and Window Servers

### DIFF
--- a/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
+++ b/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
@@ -70,6 +70,8 @@ Now that WordPress is deployed, add a new DNS entry that maps
 When testing locally, you can also change your `/etc/hosts` file to
 create this mapping, instead of using a DNS service.
 
+Note:- Windows Server doesn't support Swarm Mode Routing Mesh yet (not considering Windows Server version 1709 which will be out soon). This means the hrm service is exposed only through the manager node's ip (since Windows Server cannot be a manager node). Therefore the DNS entry for the host name ('wordpress.example.org' in this example) should be mapped to the manager node and not to any of the Windows worker nodes.
+
 Once this is done, you can access the wordpress service from your browser.
 
 ![](../../images/use-domain-names-7.png){: .with-border}

--- a/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
+++ b/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
@@ -70,7 +70,14 @@ Now that WordPress is deployed, add a new DNS entry that maps
 When testing locally, you can also change your `/etc/hosts` file to
 create this mapping, instead of using a DNS service.
 
-Note:- Windows Server doesn't support Swarm Mode Routing Mesh yet (not considering Windows Server version 1709 which will be out soon). This means the hrm service is exposed only through the manager node's ip (since Windows Server cannot be a manager node). Therefore the DNS entry for the host name ('wordpress.example.org' in this example) should be mapped to the manager node and not to any of the Windows worker nodes.
+> #### HRM with Windows Server:
+> Windows Server doesn't support Swarm Mode Routing Mesh yet 
+> (*not considering Windows Server version 1709 which will be out soon*).
+> This means the hrm service is exposed only through the manager node's ip 
+> (*since Windows Server cannot be a manager node*).
+> DNS entry for the host name('wordpress.example.org' in this example) should 
+> therefore be mapped to manager nodes and not to any of the Windows worker 
+> nodes.
 
 Once this is done, you can access the wordpress service from your browser.
 


### PR DESCRIPTION
Note:- Windows Server doesn't support Swarm Mode Routing Mesh yet (not considering Windows Server version 1709 which will be out soon). This means the hrm service is exposed only through the manager node's ip (since Windows Server cannot be a manager node). Therefore the DNS entry for the host name ('wordpress.example.org' in this example) should be mapped to the manager node and not to any of the Windows worker nodes.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
