### PR TITLE
Fix port requirement for SSL of docker registry

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -185,7 +185,7 @@ These examples assume the following:
 
 - Your registry URL is `https://myregistry.domain.com/`.
 - Your DNS, routing, and firewall settings allow access to the registry's host
-  on port 5000.
+  on port 443.
 - You have already obtained a certificate from a certificate authority (CA).
 
 If you have been issued an _intermediate_ certificate instead, see


### PR DESCRIPTION
### Proposed changes

Just bellow my edit the port 443 is used, not the port 5000 as mentioned. This PR fixes that.