### PR TITLE
ENV layer persistence clarification

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -461,6 +461,31 @@ Similar to having constant variables in a program (as opposed to hard-coding
 values), this approach lets you change a single `ENV` instruction to
 auto-magically bump the version of the software in your container.
 
+Because a new intermediate layer is created after running the ENV command, the environment variable is effectively persisted.
+If you try to unset the variable afterwards, then the set value of the lower lying layer is used instead:
+Dockerfile
+`FROM alpine
+ENV ADMIN_USER="mark"
+RUN echo $ADMIN_USER > ./mark
+RUN unset ADMIN_USER
+CMD sh`
+
+Build and run: `$ docker run --rm -it test sh` shows:
+`/ # echo $ADMIN_USER
+mark
+`
+
+If the environment variable needs to be unset afther the command, or its content should not be serialized, use:
+Dockerfile
+`FROM alpine
+RUN export ADMIN_USER="mark"; echo $ADMIN_USER > ./mark;  unset ADMIN_USER
+CMD sh`
+
+Build and run: `$ docker run --rm -it test sh` shows:
+`/ # echo $ADMIN_USER
+
+`
+
 ### ADD or COPY
 
 - [Dockerfile reference for the ADD instruction](/engine/reference/builder.md#add)


### PR DESCRIPTION
Hi John,

I came across a Slack conversation that may be relevant for the Dockerfile ENV section. Basically from what I understand the following happens:
When you use ENV, docker build creates a new intermediate layer that persists the environment variable. When you try to unset it in the next layer, the lower layer still keeps the environment variable.

I tried to explain this.

Credits go to @church and @clemenko.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
