### PR TITLE
Remove reference to --graph

### DIFF
--- a/config/daemon/systemd.md
+++ b/config/daemon/systemd.md
@@ -56,7 +56,7 @@ To accomplish this, set the following flags in the `daemon.json` file:
 
 ```none
 {
-    "graph": "/mnt/docker-data",
+    "data-root": "/mnt/docker-data",
     "storage-driver": "overlay"
 }
 ```


### PR DESCRIPTION
Fixes #5922

I couldn't find any other references to the `-g` or `--graph` flag, so I think we are good.