### PR TITLE
Document journald tag as SYSLOG_IDENTIFIER

### DIFF
--- a/config/containers/logging/journald.md
+++ b/config/containers/logging/journald.md
@@ -29,8 +29,8 @@ To use the `journald` driver as the default logging driver, set the `log-driver`
 and `log-opt` keys to appropriate values in the `daemon.json` file, which is
 located in `/etc/docker/` on Linux hosts or
 `C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-+configuring Docker using `daemon.json`, see
-+[daemon.json](/engine/reference/commandline/dockerd.md#daemon-configuration-file).
+configuring Docker using `daemon.json`, see
+[daemon.json](/engine/reference/commandline/dockerd.md#daemon-configuration-file).
 
 The following example sets the log driver to `journald`:
 
@@ -51,7 +51,8 @@ $ docker run --log-driver=journald ...
 
 ## Options
 
-Use the `--log-opt NAME=VALUE` flag to specify additional `journald` logging driver options.
+Use the `--log-opt NAME=VALUE` flag to specify additional `journald` logging
+driver options.
 
 | Option      | Required | Description                                                                                                                                                                                      |
 |:------------|:---------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -60,12 +61,14 @@ Use the `--log-opt NAME=VALUE` flag to specify additional `journald` logging dri
 | `env`       | optional | Comma-separated list of keys of environment variables, which should be included in message, if these variables are specified for the container.                                                  |
 | `env-regex` | optional | Similar to and compatible with env. A regular expression to match logging-related environment variables. Used for advanced [log tag options](/engine/admin/logging/log_tags/).                   |
 
-If a collision occurs between label and env keys, the value of the env takes precedence. Each option adds additional fields to the attributes of a logging message.
+If a collision occurs between label and env keys, the value of the env takes
+precedence. Each option adds additional fields to the attributes of a logging
+message.
 
 Below is an example of the logging options required to log to journald.
 
 ```bash
-docker run --log-driver=journald \
+$ docker run --log-driver=journald \
     --log-opt labels=location \
     --log-opt env=TEST \
     --env "TEST=false" \
@@ -73,7 +76,10 @@ docker run --log-driver=journald \
     your/application
 ```
 
-This configuration also directs the driver to include in the payload the label location, and the environment variable TEST.  If the `--env "TEST=false"` or `--label location=west` arguments were omitted, the corresponding key would not be set in the journald log.
+This configuration also directs the driver to include in the payload the label
+location, and the environment variable TEST.  If the `--env "TEST=false"`
+or `--label location=west` arguments were omitted, the corresponding key would
+not be set in the journald log.
 
 ## Note regarding container names
 

--- a/config/containers/logging/journald.md
+++ b/config/containers/logging/journald.md
@@ -15,13 +15,13 @@ Log entries can be retrieved using the `journalctl` command, through use of the
 In addition to the text of the log message itself, the `journald` log driver
 stores the following metadata in the journal with each message:
 
-| Field                       | Description                                                                                                                                            |
-|:----------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `CONTAINER_ID`              | The container ID truncated to 12 characters.                                                                                                           |
-| `CONTAINER_ID_FULL`         | The full 64-character container ID.                                                                                                                    |
-| `CONTAINER_NAME`            | The container name at the time it was started. If you use `docker rename` to rename a container, the new name is not reflected in the journal entries. |
-| `CONTAINER_TAG`             | The container tag ([log tag option documentation](log_tags.md)).                                                                                       |
-| `CONTAINER_PARTIAL_MESSAGE` | A field that flags log integrity. Improve logging of long log lines.                                                                                   |
+| Field                                | Description                                                                                                                                            |
+|:-------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CONTAINER_ID`                       | The container ID truncated to 12 characters.                                                                                                           |
+| `CONTAINER_ID_FULL`                  | The full 64-character container ID.                                                                                                                    |
+| `CONTAINER_NAME`                     | The container name at the time it was started. If you use `docker rename` to rename a container, the new name is not reflected in the journal entries. |
+| `CONTAINER_TAG`, `SYSLOG_IDENTIFIER` | The container tag ([log tag option documentation](log_tags.md)).                                                                                       |
+| `CONTAINER_PARTIAL_MESSAGE`          | A field that flags log integrity. Improve logging of long log lines.                                                                                   |
 
 ## Usage
 
@@ -53,12 +53,12 @@ $ docker run --log-driver=journald ...
 
 Use the `--log-opt NAME=VALUE` flag to specify additional `journald` logging driver options.
 
-| Option | Required | Description |
-| -- | -- | -- |
-| `tag` | optional | Specify template to set `CONTAINER_TAG` value in journald logs. Refer to [log tag option documentation](/engine/admin/logging/log_tags/) to customize the log tag format |
-| `label` | optional | Comma-separated list of keys of labels, which should be included in message, if these labels are specified for the container. |
-| `env` | optional | Comma-separated list of keys of environment variables, which should be included in message, if these variables are specified for the container. |
-| `env-regex` | optional | Similar to and compatible with env. A regular expression to match logging-related environment variables. Used for advanced [log tag options](/engine/admin/logging/log_tags/).
+| Option      | Required | Description                                                                                                                                                                                      |
+|:------------|:---------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `tag`       | optional | Specify template to set `CONTAINER_TAG` and `SYSLOG_IDENTIFIER` value in journald logs. Refer to [log tag option documentation](/engine/admin/logging/log_tags/) to customize the log tag format |
+| `label`     | optional | Comma-separated list of keys of labels, which should be included in message, if these labels are specified for the container.                                                                    |
+| `env`       | optional | Comma-separated list of keys of environment variables, which should be included in message, if these variables are specified for the container.                                                  |
+| `env-regex` | optional | Similar to and compatible with env. A regular expression to match logging-related environment variables. Used for advanced [log tag options](/engine/admin/logging/log_tags/).                   |
 
 If a collision occurs between label and env keys, the value of the env takes precedence. Each option adds additional fields to the attributes of a logging message.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added `SYSLOG_IDENTIFIER` to journald tag option to reflect changes in https://github.com/moby/moby/pull/35570.

Fixed linting issues 
- long lines
- table formatting
- forgotten `+` from file diff :wink:

<!--Tell us what you did and why-->

### Related issues (optional)

Closes #5843.
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
