### PR TITLE
Add 17.03.2 Docker CE release notes

### DIFF
--- a/release-notes/docker-ce.md
+++ b/release-notes/docker-ce.md
@@ -403,6 +403,28 @@ Release notes for stable versions are listed first. You can
 
 * Disable legacy registry (v1) by default [#33629](https://github.com/moby/moby/pull/33629)
 
+## 17.03.2-ce (2017-05-29)
+
+### Networking
+
+- Fix a concurrency issue preventing network creation [#33273](https://github.com/moby/moby/pull/33273)
+
+### Runtime
+
+- Relabel secrets path to avoid a Permission Denied on selinux enabled systems [#33236](https://github.com/moby/moby/pull/33236) (ref [#32529](https://github.com/moby/moby/pull/32529)
+- Fix cases where local volume were not properly relabeled if needed [#33236](https://github.com/moby/moby/pull/33236) (ref [#29428](https://github.com/moby/moby/pull/29428))
+- Fix an issue while upgrading if a plugin rootfs was still mounted [#33236](https://github.com/moby/moby/pull/33236) (ref [#32525](https://github.com/moby/moby/pull/32525))
+- Fix an issue where volume wouldn't default to the `rprivate` propagation mode [#33236](https://github.com/moby/moby/pull/33236) (ref [#32851](https://github.com/moby/moby/pull/32851))
+- Fix a panic that could occur when a volume driver could not be retrieved [#33236](https://github.com/moby/moby/pull/33236) (ref [#32347](https://github.com/moby/moby/pull/32347))
++ Add a warning in `docker info` when the `overlay` or `overlay2` graphdriver is used on a filesystem without `d_type` support [#33236](https://github.com/moby/moby/pull/33236) (ref [#31290](https://github.com/moby/moby/pull/31290))
+- Fix an issue with backporting mount spec to older volumes [#33207](https://github.com/moby/moby/pull/33207)
+- Fix issue where a failed unmount can lead to data loss on local volume remove [#33120](https://github.com/moby/moby/pull/33120)
+
+### Swarm Mode
+
+- Fix a case where tasks could get killed unexpectedly [#33118](https://github.com/moby/moby/pull/33118)
+- Fix an issue preventing to deploy services if the registry cannot be reached despite the needed images being locally present [#33117](https://github.com/moby/moby/pull/33117)
+
 ## 17.03.1-ce (2017-03-27)
 
 ### Remote API (v1.27) & Client


### PR DESCRIPTION
Add release notes for Docker CE 17.03.2 (which got overlooked for some reason). 

Fixes #5985 