### PR TITLE
Fix typos (`8021.q` -> `802.1q`)

### DIFF
--- a/network/macvlan.md
+++ b/network/macvlan.md
@@ -32,7 +32,7 @@ trunk bridge mode.
 
 - In bridge mode,Macvlan traffic goes through a physical device on the host.
 
-- In 8021.q trunk bridge mode, traffic goes through an 8021.q sub-interface
+- In 802.1q trunk bridge mode, traffic goes through an 802.1q sub-interface
   which Docker creates on the fly. This allows you to control routing and
   filtering at a more granular level.
 
@@ -61,7 +61,7 @@ $ docker network create -d macvlan  \
   -o parent=eth0 macnet32
 ```
 
-### 8021.q trunk bridge mode
+### 802.1q trunk bridge mode
 
 If you specify a `parent` interface name with a dot included, such as `eth0.50`,
 Docker interprets that as a sub-interface of `eth0` and creates the sub-interface

--- a/network/network-tutorial-macvlan.md
+++ b/network/network-tutorial-macvlan.md
@@ -1,7 +1,7 @@
 ---
 title: Networking using a macvlan network
-description: Tutorials for networking using a macvlan bridge network and 8021.q trunk bridge network
-keywords: networking, macvlan, 8021.q, standalone
+description: Tutorials for networking using a macvlan bridge network and 802.1q trunk bridge network
+keywords: networking, macvlan, 802.1q, standalone
 ---
 
 This series of tutorials deals with networking standalone containers which
@@ -13,7 +13,7 @@ to the appropriate container. For other networking topics, see the
 ## Goal
 
 The goal of these tutorials is to set up a bridged `macvlan` network and attach
-a container to it, then set up an 8021.q trunked `macvlan` network and attach a
+a container to it, then set up an 802.1q trunked `macvlan` network and attach a
 container to it.
 
 ## Prerequisites
@@ -119,9 +119,9 @@ on your network, your container appears to be physically attached to the network
     $ docker network rm my-macvlan-net
     ```
 
-## 8021.q trunked bridge example
+## 802.1q trunked bridge example
 
-In the 8021.q trunked bridge example, your traffic flows through a sub-interface
+In the 802.1q trunked bridge example, your traffic flows through a sub-interface
 of `eth0` (called `eth0.10`) and Docker routes traffic to your container using
 its MAC address. To network devices on your network, your container appears to
 be physically attached to the network.


### PR DESCRIPTION
### Proposed changes

Global search and replace of `8021.q` with `802.1q`.