### PR TITLE
Ensure custom build hooks consume DOCKERFILE_PATH

### DIFF
--- a/docker-cloud/builds/advanced.md
+++ b/docker-cloud/builds/advanced.md
@@ -19,6 +19,7 @@ processes and do not affect your service's run environment.
 * `SOURCE_COMMIT`: the SHA1 hash of the commit being tested.
 * `COMMIT_MSG`: the message from the commit being tested and built.
 * `DOCKER_REPO`: the name of the Docker repository being built.
+* `DOCKERFILE_PATH`: the dockerfile currently being built.
 * `CACHE_TAG`: the Docker repository tag being built.
 * `IMAGE_NAME`: the name and tag of the Docker repository being built. (This variable is a combination of `DOCKER_REPO`:`CACHE_TAG`.)
 
@@ -77,10 +78,10 @@ The following hooks are available:
 
 Docker Cloud allows you to define build environment variables either in the hook files, or from the automated build UI (which you can then reference in hooks).
 
-In the following example, we define a build hook that uses `docker build` arguments to set the variable `CUSTOM` based on the value of variable we defined using the Docker Cloud build settings. `$IMAGE_NAME` is a variable that we provide with the name of the image being built.
+In the following example, we define a build hook that uses `docker build` arguments to set the variable `CUSTOM` based on the value of variable we defined using the Docker Cloud build settings. `$DOCKERFILE_PATH` is a variable that we provide with the name of the Dockerfile we wish to build, and `$IMAGE_NAME` is the name of the image being built.
 
 ```none
-docker build --build-arg CUSTOM=$VAR -t $IMAGE_NAME .
+docker build --build-arg CUSTOM=$VAR -f $DOCKERFILE_PATH -t $IMAGE_NAME .
 ```
 
 > **Caution**: A `hooks/build` file overrides the basic [docker build](/engine/reference/commandline/build.md) command


### PR DESCRIPTION
I have a custom build hook to pass in build arguments on a repository from which I build two Docker images (tags), from two Dockerfiles.

My second build, however, with the custom Dockerfile, was not being built correctly. It was being built with the default `Dockerfile`, instead of my specified custom one.

I quickly figured out the custom build hook was to blame because it doesn't specify which Dockerfile it should build from, but there was no mention in the documentation of an environmental variable I can consume to get the custom "Dockerfile location" value. By dumping the env vars during the build process, I can there is an environmental variable with that value: `DOCKERFILE_PATH`.

This PR updates the documentation accordingly, to:

1) Expose the fact this environmental variable exists, and explains its purpose
2) Make sure its consumed in the example custom build hook, so any copy-pasters find themselves already supporting custom Dockerfiles, rather than struggling with the same problem

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
