### PR TITLE
Fixing Windows Event Log command

### DIFF
--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -245,7 +245,7 @@ The Docker daemon log can be viewed by using one of the following methods:
 - By running `journalctl -u docker.service` on Linux systems using `systemctl`
 - `/var/log/messages`, `/var/log/daemon.log`, or `/var/log/docker.log` on older
   Linux systems
-- By running `Get-EventLog -LogName Application -Source Docker -After (Get-Date).AddMinutes(-5) | Sort-Object Time` on Docker EE for Windows Server
+- By running `Get-EventLog -LogName Application -Source Docker -After (Get-Date).AddMinutes(-5) | Sort-Object Time | Export-CSV ~/last5minutes.CSV` on Docker EE for Windows Server
 
 > **Note**: It is not possible to manually generate a stack trace on Docker for
 > Mac or Docker for Windows. However, you can click the Docker taskbar icon and


### PR DESCRIPTION
When you pull the log using "Get-EventLog" to a display, a line get cut off and important log data will not show up.  It should be piped to a csv file to capture the whole message just like how MS explains it here https://docs.microsoft.com/en-us/virtualization/windowscontainers/troubleshooting

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
