### PR TITLE
Hostname mismatch

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -215,7 +215,7 @@ You can also use the `curl` command in a shell to view the same content.
 ```shell
 $ curl http://localhost:4000
 
-<h3>Hello World!</h3><b>Hostname:</b> 8fc990912a14<br/><b>Visits:</b> <i>cannot connect to Redis, counter disabled</i>
+<h3>Hello World!</h3><b>Hostname:</b> 45e721203503<br/><b>Visits:</b> <i>cannot connect to Redis, counter disabled</i>
 ```
 
 This port remapping of `4000:80` is to demonstrate the difference


### PR DESCRIPTION
Hostname from the browser should match the curl output.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
