### PR TITLE
Adds 'digitalocean-ssh-key-path' CLI option

### DIFF
--- a/machine/drivers/digital-ocean.md
+++ b/machine/drivers/digital-ocean.md
@@ -34,6 +34,7 @@ Control Panel and pass that to `docker-machine create` with the `--digitalocean-
 -   `--digitalocean-region`: The region to create the droplet in, see [Regions API](https://developers.digitalocean.com/documentation/v2/#regions) for how to get a list.
 -   `--digitalocean-size`: The size of the Digital Ocean droplet (larger than default options are of the form `2gb`).
 -   `--digitalocean-ssh-key-fingerprint`: Use an existing SSH key instead of creating a new one, see [SSH keys](https://developers.digitalocean.com/documentation/v2/#ssh-keys).
+-   `--digitalocean-ssh-key-path`: SSH private key path.
 -   `--digitalocean-ssh-port`: SSH port.
 -   `--digitalocean-ssh-user`: SSH username.
 -   `--digitalocean-tags`: Comma-separated list of tags to apply to the Droplet, see [Droplet tagging](https://developers.digitalocean.com/documentation/v2/#tags)
@@ -53,6 +54,7 @@ The DigitalOcean driver uses `ubuntu-16-04-x64` as the default image.
 | `--digitalocean-region`             | `DIGITALOCEAN_REGION`             | `nyc3`             |
 | `--digitalocean-size`               | `DIGITALOCEAN_SIZE`               | `512mb`            |
 | `--digitalocean-ssh-key-fingerprint`| `DIGITALOCEAN_SSH_KEY_FINGERPRINT`| -                  |
+| `--digitalocean-ssh-key-path`       | `DIGITALOCEAN_SSH_KEY_PATH`       | -                  |
 | `--digitalocean-ssh-port`           | `DIGITALOCEAN_SSH_PORT`           | 22                 |
 | `--digitalocean-ssh-user`           | `DIGITALOCEAN_SSH_USER`           | `root`             |
 | `--digitalocean-tags`               | `DIGITALOCEAN_TAGS`               | -                  |


### PR DESCRIPTION
Adds documentation about 'digitalocean-ssh-key-path' CLI option. (https://github.com/docker/machine/blob/master/drivers/digitalocean/digitalocean.go#L70)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
