### PR TITLE
Remove adjtimex from seccomp blocked syscall list.

### DIFF
--- a/engine/security/seccomp.md
+++ b/engine/security/seccomp.md
@@ -66,7 +66,6 @@ the reason each syscall is blocked rather than white-listed.
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | `acct`              | Accounting syscall which could let containers disable their own resource limits or process accounting. Also gated by `CAP_SYS_PACCT`. |
 | `add_key`           | Prevent containers from using the kernel keyring, which is not namespaced.                                   |
-| `adjtimex`          | Similar to `clock_settime` and `settimeofday`, time/date is not namespaced.  Also gated by `CAP_SYS_TIME`.   |
 | `bpf`               | Deny loading potentially persistent bpf programs into kernel, already gated by `CAP_SYS_ADMIN`.              |
 | `clock_adjtime`     | Time/date is not namespaced. Also gated by `CAP_SYS_TIME`.                                                   |
 | `clock_settime`     | Time/date is not namespaced. Also gated by `CAP_SYS_TIME`.                                                   |


### PR DESCRIPTION


### Proposed changes

I removed adjtimex from the list of blocked syscalls by the default profile in docker.
It is whitelisted in the current default seccomp profile.

https://github.com/moby/moby/blob/master/profiles/seccomp/default.json#L58

### Related issues (optional)

https://github.com/moby/moby/issues/33126