### PR TITLE
Fix search page to not render raw HTML

### DIFF
--- a/search.md
+++ b/search.md
@@ -4,7 +4,7 @@ keywords: Search, Docker, documentation, manual, guide, reference, api
 noratings: true
 notoc: true
 notags: true
-title: "Docs search <span id='searchTerm'></span>"
+title: "Docs search"
 tree: false
 ---
 
@@ -45,10 +45,13 @@ tree: false
 <script defer>
 setTimeout(function(){
   $(document).ready(function() {
-    if (decodeURI(queryString().q) != "undefined" && decodeURI(queryString().q) && decodeURI(queryString().q).length > 0) {
-      $("#st-search-input").val(decodeURI(queryString().q));
+    let searchTerm = decodeURI(queryString().q);
+    if(searchTerm != 'undefined' && searchTerm != "") {
+      $("#st-search-input").val(searchTerm);
       $("#st-search-input").focus();
-      $("#searchTerm").html("results for: " + decodeURI(queryString().q))
+      // Update heading with term user searched for
+      let currHeading = $("h1").text();
+      $("h1").text(currHeading + " results for: " + searchTerm);
     }
   });
 }, 1);


### PR DESCRIPTION
Fixes some logic in the /search.md page, causing that page to show raw HTML in the `<title>`.
Also does a bit of refactoring, making the logic easier to read.

Fixes #5851 

Before
![screen shot 2018-02-20 at 16 27 05](https://user-images.githubusercontent.com/1525937/36456718-17e8d0ec-165b-11e8-904e-0f5ef6375982.png)

After
![screen shot 2018-02-20 at 16 32 05](https://user-images.githubusercontent.com/1525937/36456801-9e367b86-165b-11e8-9d9f-b70beda367b7.png)
