### PR TITLE
Access rethinkcli through dtr-rethinkdb

### DIFF
--- a/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -40,7 +40,7 @@ You can run this test with any overlay network, and any Docker image that has
 
 DTR uses RethinkDB for persisting data and replicating it across replicas.
 It might be helpful to connect directly to the RethinkDB instance running on a
-DTR replica to check the DTR internal state. 
+DTR replica to check the DTR internal state.
 
 > **Warning**: Modifying RethinkDB directly is not supported and may cause
 > problems.
@@ -51,21 +51,14 @@ commands:
 
 ```bash
 {% raw %}
-# REPLICA_ID will be the replica ID for the current node.
-REPLICA_ID=$(docker ps -lf name='^/dtr-rethinkdb-.{12}$' --format '{{.Names}}' | cut -d- -f3)
 # This command will start a RethinkDB client attached to the database
 # on the current node.
-docker run -it --rm \
-  --net dtr-ol \
-  -v dtr-ca-$REPLICA_ID:/ca dockerhubenterprise/rethinkcli:v2.2.0 \
-  $REPLICA_ID
+docker exec -it $(docker ps -q --filter name=dtr-rethinkdb) rethinkcli
 {% endraw %}
 ```
 
-This container connects to the local DTR replica and launches a RethinkDB client 
-that can be used to inspect the contents of the DB. RethinkDB 
-stores data in different databases that contain multiple tables. The `rethinkcli`
-tool launches an interactive prompt where you can run RethinkDB 
+RethinkDB stores data in different databases that contain multiple tables. The `rethinkcli`
+tool launches an interactive prompt where you can run RethinkDB
 queries such as:
 
 ```none
@@ -91,7 +84,7 @@ queries such as:
   'repositories',
   'repository_team_access',
   'tags' ]
-  
+
 # List the entries in the repositories table
 > r.db('dtr2').table('repositories')
 [ { id: '19f1240a-08d8-4979-a898-6b0b5b2338d8',


### PR DESCRIPTION
 * dtr-rethinkdb now houses the rethinkcli which means we no longer need
 to pull the rethinkcli container from hub.

Signed-off-by: Kyle Squizzato <kyle.squizzato@docker.com>

### Proposed changes
We no longer need to rely on the `rethinkcli` pulled from `dockerhubenterprise` as the tool now sits inside the `dtr-rethinkdb` container by default.  Now, users can just `exec` into this container to access the `rethinkcli` directly.

This patch modifies the instructions for users on how to access `rethinkcli` on v2.4
