### PR TITLE
Fix double-hyphen typographic bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,5 +35,9 @@ source "https://rubygems.org"
 # gem install bundler
 # bundle install
 
-gem "github-pages", "172"
+# This only affects interactive builds (local build, Netlify) and not the
+# live site deploy, which uses the Dockerfiles found in the publish-tools
+# branch.
+
+gem "github-pages", "175"
 gem 'wdm' if Gem.win_platform?

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ name: Docker Documentation
 markdown: kramdown
 kramdown:
   input: GFM
+  gfm_quirks: [paragraph_end, no_auto_typographic]
   html_to_native: true
   hard_wrap: false
   syntax_highlighter: rouge


### PR DESCRIPTION
Signed-off-by: Misty Stanley-Jones <misty@apache.org>

Fixes #4178 

This introduces two changes in the `_config.yml`. One change is a tweak to Kramdown's config, and the other is an update to the version of Github Pages that is used for builds invoked by `jekyll build` (local builds, Netlify, etc). For our actual live deploy, we actually already use the latest version of the Github Pages gem, but don't yet have the tweaked config. The changes to `_config.yml` will need to be backported back to archive branches, possibly all the way back to 17.03, if you care about fixing the typography problem in those.