### PR TITLE
Add more packages to uninstall before installation

### DIFF
--- a/install/linux/docker-ce/centos.md
+++ b/install/linux/docker-ce/centos.md
@@ -41,8 +41,14 @@ installed, uninstall them, along with associated dependencies.
 
 ```bash
 $ sudo yum remove docker \
+                  docker-client \
+                  docker-client-latest \
                   docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
                   docker-selinux \
+                  docker-engine-selinux \
                   docker-engine
 ```
 

--- a/install/linux/docker-ce/fedora.md
+++ b/install/linux/docker-ce/fedora.md
@@ -35,7 +35,12 @@ installed, uninstall them, along with associated dependencies.
 
 ```bash
 $ sudo dnf remove docker \
+                  docker-client \
+                  docker-client-latest \
                   docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
                   docker-selinux \
                   docker-engine-selinux \
                   docker-engine

--- a/install/linux/docker-ee/centos.md
+++ b/install/linux/docker-ee/centos.md
@@ -57,7 +57,12 @@ if you are upgrading from Docker CE to Docker EE, remove the Docker CE package.
 
 ```bash
 $ sudo yum remove docker \
+                  docker-client \
+                  docker-client-latest \
                   docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
                   docker-selinux \
                   docker-engine-selinux \
                   docker-engine \

--- a/install/linux/docker-ee/rhel.md
+++ b/install/linux/docker-ee/rhel.md
@@ -67,10 +67,16 @@ installed, uninstall them, along with associated dependencies.
 
 ```bash
 $ sudo yum remove docker \
+                  docker-client \
+                  docker-client-latest \
                   docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
                   docker-selinux \
                   docker-engine-selinux \
-                  docker-engine
+                  docker-engine \
+                  docker-ce
 ```
 
 It's OK if `yum` reports that none of these packages are installed.


### PR DESCRIPTION
The CentOS, Red Hat, and Fedora package-repositories contain
several versions of the docker package. Some of those were
missing from the list of packages to uninstall, and could
conflict with the docker-ce/docker-ee package.

On CentOS 7:

<details>

```
[root@centos-s-1vcpu-1gb-ams3-01 ~]# yum search docker
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: ftp.nluug.nl
 * extras: mirror.seedvps.com
 * updates: centos.mirror.transip.nl
========================================================================================================================================================== N/S matched: docker ==========================================================================================================================================================
cockpit-docker.x86_64 : Cockpit user interface for Docker containers
docker-client.x86_64 : Client side files for Docker
docker-client-latest.x86_64 : Client side files for Docker
docker-common.x86_64 : Common files for docker and docker-latest
docker-distribution.x86_64 : Docker toolset to pack, ship, store, and deliver content
docker-latest-logrotate.x86_64 : cron job to run logrotate on Docker containers
docker-latest-v1.10-migrator.x86_64 : Calculates SHA256 checksums for docker layer content
docker-logrotate.x86_64 : cron job to run logrotate on Docker containers
docker-lvm-plugin.x86_64 : Docker volume driver for lvm volumes
docker-python.x86_64 : An API client for docker written in Python
docker-registry.x86_64 : Registry server for Docker
docker-v1.10-migrator.x86_64 : Calculates SHA256 checksums for docker layer content
pcp-pmda-docker.x86_64 : Performance Co-Pilot (PCP) metrics from the Docker daemon
python-docker-py.noarch : An API client for docker written in Python
python-docker-pycreds.noarch : Python bindings for the docker credentials store API
docker.x86_64 : Automates deployment of containerized applications
docker-devel.x86_64 : A golang registry for global request variables (source libraries)
docker-forward-journald.x86_64 : Forward stdin to journald
docker-latest.x86_64 : Automates deployment of containerized applications
docker-novolume-plugin.x86_64 : Block container starts with local volumes defined
docker-unit-test.x86_64 : Automates deployment of containerized applications - for running unit tests
oci-systemd-hook.x86_64 : OCI systemd hook for docker
oci-umount.x86_64 : OCI umount hook for docker
skopeo.x86_64 : Inspect Docker images and repositories on registries

  Name and summary matches only, use "search all" for everything.
```

</details>

On Fedora 27

<details>

```
===================================================================================================================================================== Name Exactly Matched: docker ======================================================================================================================================================
docker.x86_64 : Automates deployment of containerized applications
==================================================================================================================================================== Summary & Name Matched: docker =====================================================================================================================================================
docker-client-java.noarch : Docker Client
pulp-docker-plugins.noarch : Pulp Docker plugins
eclipse-cdt-docker.x86_64 : C/C++ Docker Launcher
eclipse-linuxtools-docker.noarch : Docker Tooling
pulp-docker-doc.noarch : Pulp Docker documentation
fence-agents-docker.x86_64 : Fence agent for Docker
python2-docker-squash.noarch : Docker layer squashing tool
python3-docker-squash.noarch : Docker layer squashing tool
docker-vim.x86_64 : vim syntax highlighting files for Docker
imagefactory-plugins-Docker.noarch : Cloud plugin for Docker
origin-dockerregistry.x86_64 : Docker Registry v2 for Origin
docker-zsh-completion.x86_64 : zsh completion files for Docker
docker-lvm-plugin.x86_64 : Docker volume driver for lvm volumes
docker-common.x86_64 : Common files for docker and docker-latest
docker-compose.noarch : Multi-container orchestration for Docker
docker-fish-completion.x86_64 : fish completion files for Docker
python2-docker.noarch : A Python library for the Docker Engine API
python3-docker.noarch : A Python library for the Docker Engine API
docker-latest-vim.x86_64 : vim syntax highlighting files for Docker
cockpit-docker.x86_64 : Cockpit user interface for Docker containers
docker-anaconda-addon.x86_64 : Anaconda kickstart support for Docker
origin-docker-excluder.noarch : Exclude docker packages from updates
python-docker-py.noarch : An API client for docker written in Python
docker-latest-zsh-completion.x86_64 : zsh completion files for Docker
python2-pulp-docker-common.noarch : Pulp Docker support common library
docker-latest-fish-completion.x86_64 : fish completion files for Docker
python3-docker-py.noarch : An API client for docker written in Python 3
docker-logrotate.x86_64 : cron job to run logrotate on Docker containers
python2-dockerfile-parse.noarch : Python library for Dockerfile manipulation
python3-dockerfile-parse.noarch : Python library for Dockerfile manipulation
pulp-docker-admin-extensions.noarch : The Pulp Docker admin client extensions
docker-latest-logrotate.x86_64 : cron job to run logrotate on Docker containers
pcp-pmda-docker.x86_64 : Performance Co-Pilot (PCP) metrics from the Docker daemon
golang-github-fsouza-go-dockerclient-devel.noarch : Client for the Docker remote API
python-dockerpty.noarch : Python library to use the pseudo-tty of a docker container
python2-docker-pycreds.noarch : Python bindings for the docker credentials store API
python3-docker-pycreds.noarch : Python bindings for the docker credentials store API
docker-distribution.x86_64 : Docker toolset to pack, ship, store, and deliver content
python3-dockerpty.noarch : Python library to use the pseudo-tty of a docker container
docker-rhel-push-plugin.x86_64 : Avoids pushing a RHEL-based image to docker.io registry
fedora-dockerfiles.x86_64 : Example dockerfiles to assist standing up containers quickly
docker-latest-v1.10-migrator.x86_64 : Calculates SHA256 checksums for docker layer content
golang-github-docker-go-unit-test-devel.i686 : Unit tests for golang-github-docker-go package
golang-github-docker-go-unit-test-devel.x86_64 : Unit tests for golang-github-docker-go package
golang-github-docker-libkv-unit-test.x86_64 : Unit tests for golang-github-docker-libkv package
python2-avocado-plugins-runner-docker.noarch : Avocado Runner for Execution on Docker Containers
golang-github-samalba-dockerclient-devel.i686 : Docker client library in Go http://www.docker.com/
golang-github-samalba-dockerclient-devel.x86_64 : Docker client library in Go http://www.docker.com/
golang-github-docker-libtrust-unit-test.x86_64 : Unit tests for golang-github-docker-libtrust package
golang-github-docker-spdystream-unit-test.x86_64 : Unit tests for golang-github-docker-spdystream package
golang-github-docker-go-units-unit-test-devel.i686 : Unit tests for golang-github-docker-go-units package
golang-github-docker-go-units-unit-test-devel.x86_64 : Unit tests for golang-github-docker-go-units package
golang-github-docker-libcontainer-unit-test-devel.i686 : Unit tests for golang-github-docker-libcontainer package
golang-github-docker-libcontainer-unit-test-devel.x86_64 : Unit tests for golang-github-docker-libcontainer package
golang-github-fsouza-go-dockerclient-unit-test.x86_64 : Unit tests for golang-github-fsouza-go-dockerclient package
golang-github-docker-go-connections-unit-test-devel.i686 : Unit tests for golang-github-docker-go-connections package
golang-github-docker-go-connections-unit-test-devel.x86_64 : Unit tests for golang-github-docker-go-connections package
========================================================================================================================================================= Name Matched: docker ==========================================================================================================================================================
kdocker.x86_64 : Dock any application in the system tray
wmdocker.x86_64 : KDE and GNOME2 system tray replacement docking application
docker-devel.noarch : A golang registry for global request variables (source libraries)
gofed-docker.noarch : Run gofed commands as a container
docker-latest.x86_64 : Automates deployment of containerized applications
docker-unit-test.x86_64 : A golang registry for global request variables (source libraries) - for running unit tests
docker-latest-devel.noarch : A golang registry for global request variables (source libraries)
docker-rhsubscription.x86_64 : Red Hat subscription management files needed on the host to enable RHEL containers
docker-novolume-plugin.x86_64 : Block container starts with local volumes defined
openvswitch-ovn-docker.x86_64 : Open vSwitch - Open Virtual Network support
docker-latest-unit-test.x86_64 : A golang registry for global request variables (source libraries) - for running unit tests
docker-latest-rhsubscription.x86_64 : Red Hat subscription management files needed on the host to enable RHEL containers
golang-github-docker-go-devel.noarch : Go packages with small patches autogenerated
golang-github-docker-libkv-devel.noarch : Key/Value store abstraction library
golang-github-docker-libcontainer.x86_64 : Configuration options for containers
golang-github-docker-go-units-devel.noarch : Transform human friendly measurements into machine friendly values
golang-github-docker-libtrust-devel.noarch : Library for managing authentication and authorization
golang-github-docker-spdystream-devel.noarch : A multiplexed stream library using spdy
golang-github-docker-libcontainer-devel.noarch : Configuration options for containers
golang-github-docker-go-connections-devel.noarch : Utility package to work with network connections
======================================================================================================================================================== Summary Matched: docker ========================================================================================================================================================
oci-umount.x86_64 : OCI umount hook for docker
oci-systemd-hook.x86_64 : OCI systemd hook for docker
reg-server.x86_64 : A static UI for a docker registry
atomic-reactor.noarch : Improved builder for Docker images
reg.x86_64 : Docker registry v2 command line client
python3-sen.noarch : Terminal User Interface for docker engine
sen.noarch : Terminal User Interface for docker engine
kompose.x86_64 : Tool to move from 'docker-compose' to Kubernetes
vagrant-adbinfo.noarch : Connection and configuration for a Docker daemon
skopeo.x86_64 : Inspect Docker images and repositories on registries
python2-crane.noarch : A WSGI app providing a docker-registry-like API with redirection
source-to-image.x86_64 : A tool for building artifacts from source and injecting into docker images
source-to-image-devel.noarch : A tool for building artifacts from source and injecting into docker images
```

</details>


ping @seemethere PTAL - I suspect some of these also have to be taken into account in the `install.sh` script and/or included in the "conflicts" list for our packages.