### PR TITLE
Update port explanation

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -220,7 +220,7 @@ $ curl http://localhost:4000
 
 This port remapping of `4000:80` is to demonstrate the difference
 between what you `EXPOSE` within the `Dockerfile`, and what you `publish` using
-`docker run -p`. In later steps, we just map port 80 on the host to port 80
+`docker run -p`. In later steps, we just map port 4000 on the host to port 80
 in the container and use `http://localhost`.
 
 Hit `CTRL+C` in your terminal to quit.


### PR DESCRIPTION
It was mention a map of port 80:80 instead of 4000:80 as shown in the command lines

### Proposed changes

Fix a typo from 80 to 4000 so that explanation matches the example
