### PR TITLE
DO-NOT-MERGE update the docs for using host-network

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2066,8 +2066,7 @@ services:
 
 networks:
   hostnet:
-    external:
-      name: host
+    name: host
 ```
 
 ```yaml
@@ -2079,8 +2078,7 @@ services:
 
 networks:
   nonet:
-    external:
-      name: none
+    name: none
 ```
 
 ### driver_opts

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2066,6 +2066,7 @@ services:
 
 networks:
   hostnet:
+    external: true
     name: host
 ```
 
@@ -2078,6 +2079,7 @@ services:
 
 networks:
   nonet:
+    external: true
     name: none
 ```
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2052,7 +2052,7 @@ Use the host's networking stack, or no networking. Equivalent to
 use [network_mode](#network_mode) instead.
 
 The syntax for using built-in networks like `host` and `none` is a little
-different. Define an external network with the name `host` or `none` (which
+different. Define an external network with the name `host` or `none` (that
 Docker has already created automatically) and an alias that Compose can use
 (`hostnet` or `nonet` in these examples), then grant the service access to that
 network, using the alias.


### PR DESCRIPTION
with syntax before, there is
`WARN[0000] network hostnet: network.external.name is deprecated in favor of network.name `

tested with docker-compose-file-version 3.5
Server Version: 17.12.0-ce

in swarm mode

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
