### PR TITLE
fixing a command's description

### DIFF
--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -118,7 +118,7 @@ config file:
 
     $ echo extendedKeyUsage = clientAuth >> extfile.cnf
 
-Now sign the private key:
+Now, generate the signed certificate:
 
     $ openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem \
       -CAcreateserial -out cert.pem -extfile extfile.cnf

--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -84,7 +84,7 @@ server authentication:
 
     $ echo extendedKeyUsage = serverAuth >> extfile.cnf
 
-Now, generate the key:
+Now, generate the signed certificate:
 
     $ openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem \
       -CAcreateserial -out server-cert.pem -extfile extfile.cnf


### PR DESCRIPTION
### Proposed changes

Updated documentation because the command does not create a key, but generates a signed cert based on the CSR.
