### PR TITLE
Repair corrupted yaml file

### DIFF
--- a/_data/engine-cli/docker_export.yaml
+++ b/_data/engine-cli/docker_export.yaml
@@ -19,7 +19,7 @@ options:
   deprecated: false
   experimental: false
 examples: |-
-  ch of these commands has the same result.
+  Each of these commands has the same result.
 
   ```bash
   $ docker export red_panda > latest.tar
@@ -30,4 +30,3 @@ examples: |-
   ```
 deprecated: false
 experimental: false
-


### PR DESCRIPTION
The yaml file, `docker_export.yaml` was somehow corrupted during or after the copy from docker/cli. 

The original looks fine: https://github.com/docker/cli/blob/master/docs/reference/commandline/export.md

Fixes #6145 