### PR TITLE
Dockerfile: bump gh-pages to v177

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM starefossen/github-pages
+FROM starefossen/github-pages:177
 
 # This is the source for docs/docs-base. Push to that location to ensure that
 # the production image gets your update :)


### PR DESCRIPTION
This is needed for the following reasons:

1. gh-pages >= 174 is required to fix the issue #4178 (together with https://github.com/docker/docker.github.io/pull/6082)

2. Not using a tag leads to pulling some unknown version of the image, which might or might not work.

3. Not using a tag means the image is never rebuilt.

NOTE: it was not possible to use a tag before, as recent gh-pages releases were not tagged on dockerhub; this is now fixed (see https://github.com/Starefossen/docker-github-pages/issues/36).