### PR TITLE
 Call out go version required to get client

### DIFF
--- a/develop/sdk/index.md
+++ b/develop/sdk/index.md
@@ -29,6 +29,9 @@ installed and coexist together.
 ```bash
 go get github.com/docker/docker/client
 ```
+The client requires a recent version of Go. Run `go version` and ensure that you 
+are running at least version 1.8 of Go
+
 
 [Read the full Docker Engine Go SDK reference](https://godoc.org/github.com/docker/docker/client).
 

--- a/develop/sdk/index.md
+++ b/develop/sdk/index.md
@@ -30,7 +30,7 @@ installed and coexist together.
 go get github.com/docker/docker/client
 ```
 The client requires a recent version of Go. Run `go version` and ensure that you 
-are running at least version 1.8 of Go
+are running at least version 1.9.4 of Go
 
 
 [Read the full Docker Engine Go SDK reference](https://godoc.org/github.com/docker/docker/client).


### PR DESCRIPTION
### Proposed changes
If you have an old version of go installed on your machine the instruction to 
`go get github.com/docker/docker/client` fails. 

ref https://forums.docker.com/t/possible-doc-bug-for-go-client/47374?u=rkielty

I think that go 1.8 is the required minimum based on the following :
* https://forums.docker.com/t/possible-doc-bug-for-go-client/47374/2?u=rkielty Thanks David Maze!
* I have tested this with go 1.6.2 where it failed as described above
* I have tested this with go 1.10 where it succeed

I cannot find a statement where the required minimum go version to get the client is called out
I checked the above doc along with 
* https://godoc.org/github.com/docker/docker/client
* https://github.com/moby/moby/blob/master/client/README.md

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->


