### PR TITLE
Gemfile: bump gh-pages to v177

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,5 @@ source "https://rubygems.org"
 # live site deploy, which uses the Dockerfiles found in the publish-tools
 # branch.
 
-gem "github-pages", "175"
+gem "github-pages", "177"
 gem 'wdm' if Gem.win_platform?


### PR DESCRIPTION
There is no particular reason other than to be in-line with https://github.com/docker/docker.github.io/pull/6153 and https://github.com/docker/docker.github.io/pull/6159, as per @joaofnfernandes [request](https://github.com/docker/docker.github.io/pull/6153#discussion_r172627040).