### PR TITLE
added missing 'end block mark' which made broken block

### DIFF
--- a/machine/reference/scp.md
+++ b/machine/reference/scp.md
@@ -81,4 +81,4 @@ And we can try it out like so:
 ```none
 $ eval $(docker-machine env MACHINE-NAME)
 $ docker-compose run webapp
-
+```


### PR DESCRIPTION
### Proposed changes

There is missing end block mark (```) for one of code blocks in page and it make broken page of reference manual for `scp` subcommand of `docker-machine`.
