### PR TITLE
Update use-domain-names-to-access-services.md

### DIFF
--- a/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
+++ b/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
@@ -188,6 +188,7 @@ apply two labels to your service:
 com.docker.ucp.mesh.http.1=external_route=http://example.org,redirect=https://example.org
 com.docker.ucp.mesh.http.2=external_route=sni://example.org
 ```
+Note: It is not possible to redirect HTTPS to HTTP. 
 
 ### X-Forwarded-For header
 


### PR DESCRIPTION
It is not possible to redirect HTTPS to HTTP. A customer requested that we note this in the documentation.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
