### PR TITLE
Fixed typo and duplicated block on wrong place.

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -54,7 +54,7 @@ networks, are preserved. The Docker CE package is now called `docker-ce`.
 
 ### Supported storage drivers
 
-Docker EE on Ubuntu supports `overlay2` and `aufs` storage drivers.
+Docker CE on Ubuntu supports `overlay2` and `aufs` storage drivers.
 
 - For new installations on version 4 and higher of the Linux kernel, `overlay2`
   is supported and preferred over `aufs`.

--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -46,13 +46,6 @@ To install Docker EE, you need the 64-bit version of one of these Ubuntu version
 Docker EE is supported on `x86_64` (or `amd64`), `s390x` (IBM Z), and `ppc64el`
 (IBM Power) architectures.
 
-Docker EE on Ubuntu supports `overlay2` and `aufs` storage drivers.
-
-- For new installations on version 4 and higher of the Linux kernel, `overlay2`
-  is supported and preferred over `aufs`.
-- For version 3 of the Linux kernel, `aufs` is supported because `overlay` or
-  `overlay2` drivers are not supported by that kernel version.
-
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. In addition,


### PR DESCRIPTION
Typo on install/linux/docker-ce/ubuntu.md: EE --> CE
Duplicated block on install/linux/docker-ee/ubuntu.md

Deleted block on `docker-ee/ubuntu.md` is on very next paragraph, "Supported storage drivers".
