### PR TITLE
Fixed broken dtr_version rendering

### DIFF
--- a/datacenter/dtr/2.4/guides/admin/configure/external-storage/nfs.md
+++ b/datacenter/dtr/2.4/guides/admin/configure/external-storage/nfs.md
@@ -31,7 +31,7 @@ mkdir /tmp/mydir && sudo mount -t nfs <nfs server>:<directory>
 One way to configure DTR to use an NFS directory is at install time:
 
 ```none
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version }} install \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} install \
   --nfs-storage-url <nfs-storage-url> \
   <other options>
 ```
@@ -50,7 +50,7 @@ If you want to start using the new DTR built-in support for NFS you can
 reconfigure DTR:
 
 ```none
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version }} reconfigure \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} reconfigure \
   --nfs-storage-url <nfs-storage-url>
 ```
 
@@ -58,7 +58,7 @@ If you want to reconfigure DTR to stop using NFS storage, leave the option
 in blank:
 
 ```none
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version}} reconfigure \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version}} reconfigure \
   --nfs-storage-url ""
 ```
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Commands were failing because the DTR version number wasn't rendering. I fixed it on this page by replacing "dtr_version" with "page.dtr_version" in three places.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
