### PR TITLE
#6215: compose-file-v2.md, fix 'version: 3.2' typo

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1147,7 +1147,7 @@ expressed in the short form.
 
 
 ```none
-version: "3.2"
+version: "2.3"
 services:
   web:
     image: nginx:alpine


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
The documentation for `compose-file-v2/#long-syntax` incorrectly references `version: "3.2"`, when it should be `version: "2.3"`.  I've made only this small change in the documentation.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Fixes #6215
