### PR TITLE
Reflect correct publisher approval flow

### DIFF
--- a/docker-store/index.md
+++ b/docker-store/index.md
@@ -91,7 +91,7 @@ information, see [Bring Your Own License (BYOL) products on Store](byol.md).
 
 ISVs have the ability to create and distribute [plugin images](https://store.docker.com/search?certification_status=certified&q=&type=plugin) for their customers to integrate with the ISV's proprietary hardware or cloud infrastructure and Docker Enterprise Edition deployments.
 
-You can [apply to be a publisher](https://store.docker.com/publisher/signup) and learn more about our [Technology Partner Program](https://www.docker.com/partners/partner-program#/technology_partner).
+You can [apply to be a publisher](https://goto.docker.com/partners) and learn more about our [Technology Partner Program](https://www.docker.com/partners/partner-program#/technology_partner).
 
 ## What's next?
 


### PR DESCRIPTION
Docs updated reflect correct publisher approval flow.

### Proposed changes

Update CTA for publishers to go to https://goto.docker.com/partners vs https://store.docker.com/publish. This reflects the expected mechanism that partners are expected to go through to publish content.
