### PR TITLE
Fix docker images example command with incorrect format

### DIFF
--- a/_data/engine-cli-edge/docker_history.yaml
+++ b/_data/engine-cli-edge/docker_history.yaml
@@ -92,7 +92,7 @@ examples: |-
   `ID` and `CreatedSince` entries separated by a colon for all images:
 
   ```bash
-  $ docker images --format "{{.ID}}: {{.Created}} ago"
+  $ docker images --format "{{.ID}}: {{.CreatedSince}} ago"
 
   cc1b61406712: 2 weeks ago
   <missing>: 2 weeks ago

--- a/_data/engine-cli/docker_history.yaml
+++ b/_data/engine-cli/docker_history.yaml
@@ -80,7 +80,7 @@ examples: |-
   `ID` and `CreatedSince` entries separated by a colon for all images:
 
   ```bash
-  $ docker images --format "{{.ID}}: {{.Created}} ago"
+  $ docker images --format "{{.ID}}: {{.CreatedSince}} ago"
 
   cc1b61406712: 2 weeks ago
   <missing>: 2 weeks ago


### PR DESCRIPTION
### Proposed changes

Fix example commands with invalid template variable `{{.Created}}`

```
$ docker images --format "{{.ID}}: {{.Created}} ago"
Template parsing error: template: :1:11: executing "" at <.Created>: can't evaluate field Created in type *formatter.imageContext
```