### PR TITLE
Clarify the webhook's definiton in webhooks.md

### DIFF
--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -13,8 +13,8 @@ Configure webhooks on `https://hub.docker.com/r/<USERNAME>/<REPOSITORY>/~/settin
 
 ![Create Webhook](/docker-hub/images/webhooks.png)
 
-With your webhook, you specify a target URL to POST to. Docker Hub POSTs Docker Hub POSTs
-the URL with the following payload:
+With your webhook, you specify a target URL to POST to. Docker Hub POSTs the URL
+with the following payload:
 
 ```json
 {

--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -13,7 +13,7 @@ Configure webhooks on `https://hub.docker.com/r/<USERNAME>/<REPOSITORY>/~/settin
 
 ![Create Webhook](/docker-hub/images/webhooks.png)
 
-With your webhook, you specify a target URL to POST to. URL that accepts data from the Webhook, stores this POST request in JSON or XML format. Docker Hub POSTs
+With your webhook, you specify a target URL to POST to. Docker Hub POSTs Docker Hub POSTs
 the URL with the following payload:
 
 ```json

--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -6,14 +6,14 @@ title: Webhooks for automated builds
 
 If you have an automated build repository in Docker Hub, you can use Webhooks to
 cause an action in another application in response to an event in the
-repository. Docker Hub webhooks fire when an image is built in, or a new tag
+repository. Webhook is a POST request sent to a defined URL which provides the service. Docker Hub webhooks fire when an image is built in, or a new tag
 is added to, your automated build repository.
 
 Configure webhooks on `https://hub.docker.com/r/<USERNAME>/<REPOSITORY>/~/settings/webhooks/`.
 
 ![Create Webhook](/docker-hub/images/webhooks.png)
 
-With your webhook, you specify a target URL to POST to. Docker Hub POSTs
+With your webhook, you specify a target URL to POST to. URL that accepts data from the Webhook, stores this POST request in JSON or XML format. Docker Hub POSTs
 the URL with the following payload:
 
 ```json


### PR DESCRIPTION
Here is necessary to clarify the real definition of webhook which is a request with POST action to a specified url ( when this happen, the url going to return the result, in this context, is when we do 'docker push'  to submit a image to registry, it fires the automatically build

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
