### PR TITLE
Bump Engine, UCP, DTR

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,7 +115,7 @@ defaults:
   - scope:
       path: "install"
     values:
-      win_latest_build: "docker-17.06.2-ee-6"
+      win_latest_build: "docker-17.06.2-ee-7"
   - scope:
       path: "kitematic"
     values:

--- a/_config.yml
+++ b/_config.yml
@@ -139,7 +139,7 @@ defaults:
   - scope:
       path: "datacenter"
     values:
-      ucp_latest_image: "docker/ucp:2.2.4"
+      ucp_latest_image: "docker/ucp:2.2.6"
       dtr_latest_image: "docker/dtr:2.4.1"
       enterprise: true
   - scope:
@@ -176,7 +176,7 @@ defaults:
     values:
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "2.2.5"
+      ucp_version: "2.2.6"
   - scope:
       path: "datacenter/ucp/2.1"
     values:

--- a/_config.yml
+++ b/_config.yml
@@ -140,14 +140,14 @@ defaults:
       path: "datacenter"
     values:
       ucp_latest_image: "docker/ucp:2.2.6"
-      dtr_latest_image: "docker/dtr:2.4.1"
+      dtr_latest_image: "docker/dtr:2.4.3"
       enterprise: true
   - scope:
       path: "datacenter/dtr/2.4"
     values:
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.4.2"
+      dtr_version: "2.4.3"
   - scope:
       path: "datacenter/dtr/2.3"
     values:

--- a/datacenter/dtr/2.4/guides/release-notes.md
+++ b/datacenter/dtr/2.4/guides/release-notes.md
@@ -11,9 +11,13 @@ known issues for each DTR version.
 You can then use [the upgrade instructions](admin/upgrade.md),
 to upgrade your installation to the latest release.
 
-## Version 2.4.2
+## Version 2.4.3 (2018-03-19)
 
-(13 February 2018)
+**Security**
+
+* Dependencies updated to consume upstream CVE patches.
+
+## Version 2.4.2 (13 February 2018)
 
 **Security notice**
 
@@ -29,9 +33,7 @@ potentially disclosed due to the vulnerability.
 Use the `--log-driver=none` option for `docker run` when running a DTR backup, HA
 cluster join or dumpcerts.
 
-## 2.4.1
-
-(20 November 2017)
+## 2.4.1 (20 November 2017)
 
 **Bug fixes**
 
@@ -62,9 +64,7 @@ removed in DTR 2.5. You can use the
 `/api/v0/imagescan/repositories/{namespace}/{reponame}/{tag}` endpoint instead.
 
 
-## DTR 2.4.0
-
-(2 November 2017)
+## DTR 2.4.0 (2 November 2017)
 
 **New features**
 

--- a/datacenter/ucp/2.2/guides/release-notes.md
+++ b/datacenter/ucp/2.2/guides/release-notes.md
@@ -10,6 +10,60 @@ known issues for the latest UCP version.
 You can then use [the upgrade instructions](admin/install/upgrade.md), to
 upgrade your installation to the latest release.
 
+## Version 2.2.6 (2018-03-19)
+
+**New features**
+
+* Security
+  * Default TLS connections to TLS 1.2, and allow users to configure the minimum
+  TLS version used by the UCP controller.
+* Support and troubleshoot
+  * The support dump now includes the output of `dmesg`.
+  * Added more information to the telemetry data: kernel version, graph driver, and
+  logging driver.
+  * The `dsinfo` image used for support dumps is now smaller.
+
+**Bug fixes**
+
+* Core
+  * The HRM service is no longer deployed with constraints that might prevent
+  the service from ever getting scheduled.
+  * Fixed a problem causing the HRM service to be restarted multiple times.
+  * The `ucp-agent` service is now deployed without adding extra collection labels.
+  This doesn't change the behavior of the service.
+  * Fixed problem causing a healthy `ucp-auth-store` component to be reported as
+  unhealthy.
+  * Fixed a race condition causing the labels for the UCP controller container
+  to be reset.
+  * Fixed an issue causing the `ucp-agent` service to be deployed with the wrong
+  architecture on Windows nodes.
+* RBAC
+  * Role-based access control can now be enforced for third-party volume plugins,
+  fixing a known issue from UCP 2.2.5.
+  * Admins can now clean up volumes and networks that had inconsistent collection
+  labels across different nodes in the cluster. Previously, they would have had
+  to go onto each node and clean up those resources directly.
+  * When upgrading from UCP 2.1, inactive user accounts are no longer migrated
+  to the new RBAC model.
+  * Fixed an issue preventing users from seeing a collection when they have
+  permissions to deploy services on a child collection.
+  * Grants are now deleted when deleting an organization whose teams have grants.
+* UI
+  * Fixed a problem in the Settings page that would cause Docker to stop when
+  you made changes to UCP settings and a new manager node is promoted to leader.
+  * Fixed bug causing the Grants list page not to render after deleting an
+  organization mentioned used on a grant.
+  * Fixed a problem that would intermittently cause settings not to be persisted.
+  * Fixed an issue that prevented users from being able to change LDAP settings.
+
+**Known issues**
+
+* RethinkDB can only run with up to 127 CPU cores.
+* When integrating with LDAP and using multiple domain servers, if the
+default server configuration is not chosen, then the last server configuration
+is always used, regardless of which one is actually the best match.
+
+
 ## Version 2.2.5
 
 (16 January 2018)

--- a/datacenter/ucp/2.2/guides/release-notes.md
+++ b/datacenter/ucp/2.2/guides/release-notes.md
@@ -64,9 +64,7 @@ default server configuration is not chosen, then the last server configuration
 is always used, regardless of which one is actually the best match.
 
 
-## Version 2.2.5
-
-(16 January 2018)
+## Version 2.2.5 (16 January 2018)
 
 **Bug fixes**
 
@@ -86,9 +84,7 @@ and are planning on upgrading UCP, you can skip 2.2.5 and wait for the upcoming
 2.2.6 release, which will provide an alternative way to turn on RBAC enforcement
 for volumes.
 
-## Version 2.2.4
-
-(2 November 2017)
+## Version 2.2.4 (2 November 2017)
 
 **News**
 
@@ -119,9 +115,7 @@ for volumes.
  * Docker currently has limitations related to overlay networking and services using VIP-based endpoints. These limitations apply to use of the HTTP Routing Mesh (HRM). HRM users should familiarize themselves with these limitations. In particular, HRM may encounter virtual IP exhaustion (as evidenced by `failed to allocate network IP for task` Docker log messages). If this happens, and if the HRM service is restarted or rescheduled for any reason, HRM may fail to resume operation automatically. See the Docker EE 17.06-ee5 release notes for details.
  * The Swarm admin UI for UCP versions 2.2.0 and later contain a bug. If used with Docker Engine version 17.06.2-ee5 or earlier, attempting to update "Task History Limit", "Heartbeat Period" and "Node Certificate Expiry" settings using the UI will cause the cluster to crash on next restart. Using UCP 2.2.X and Docker Engine 17.06-ee6 and later, updating these settings will fail (but not cause the cluster to crash). Users are encouraged to update to Docker Engine version 17.06.2-ee6 and later, and to use the Docker CLI (instead of the UCP UI) to update these settings. Rotating join tokens works with any combination of Docker Engine and UCP versions. Docker Engine versions 17.03 and earlier (which use UCP version 2.1 and earlier) are not affected by this problem.
 
-## Version 2.2.3
-
-(13 September 2017)
+## Version 2.2.3 (13 September 2017)
 
 **Bug fixes**
 
@@ -173,9 +167,7 @@ for volumes.
  `<node-name>/<network-name>`.
 
 
-## version 2.2.2
-
-(30 August 2017)
+## version 2.2.2 (30 August 2017)
 
 **Bug fixes**
 
@@ -210,9 +202,7 @@ for volumes.
 include `external: true`, otherwise the deployment fails with the error
 `unable to inspect secret`.
 
-## Version 2.2.0
-
-(16 August 2017)
+## Version 2.2.0 (16 August 2017)
 
 **New features**
 

--- a/enterprise/17.06/index.md
+++ b/enterprise/17.06/index.md
@@ -17,6 +17,57 @@ it references. However, Docker EE also includes back-ported fixes
 defect fixes that you can use in environments where new features cannot be
 adopted as quickly for consistency and compatibility reasons.
 
+## 17.06.2-ee-7 (2018-03-19)
+
+### Important notes about this release
+
+- The `overlay2` detection has been improved in this release. On
+  Linux distributions where `devicemapper` was the default storage driver,
+  `overlay2` is now used by default, if the kernel supports it.
+
+### Logging
+
+* Set timeout on splunk batch send [moby/moby#35496](https://github.com/moby/moby/pull/35496)
+- AWS: Fix batch size calculation for large logs[moby/moby#35726](https://github.com/moby/moby/pull/35726)
+* Support a proxy in splunk log driver [moby/moby#36220](https://github.com/moby/moby/pull/36220)
+
+### Networking
+
+- Fix NetworkDB node management race condition [docker/libnetwork#2033](https://github.com/docker/libnetwork/pull/2033)
+* Update Netlink socket timeout [docker/libnetwork#2044](https://github.com/docker/libnetwork/pull/2044)
+- Fix for duplicate IP issues [docker/libnetwork#2105](https://github.com/docker/libnetwork/pull/2105)
+
+### Packaging
+
++ Add a platform version to `Docker --version` [docker/cli#427](https://github.com/docker/cli/pull/427) and [moby/moby#35705](https://github.com/moby/moby/pull/35705)
+* SLES and Ubuntu set TasksMax in docker.service [docker/docker-ce-packaging#78](https://github.com/docker/docker-ce-packaging/pull/78)
+
+### Runtime
+
+* Adjust min TLS Version to v1.2 for PCI compliance [docker/go-connections#45](https://github.com/docker/go-connections/pull/45)
+* Fix systemd cgroup after memory type changed [opencontainers/runc#1573](https://github.com/opencontainers/runc/pull/1573)
+* Detect overlay2 support on pre-4.0 kernels [moby/moby#35527](https://github.com/moby/moby/pull/35527)
+* Enables deferred device deletion/removal by default if the driver version in the kernel supports the feature [moby/moby#33698](https://github.com/moby/moby/pull/33698)
+- Fix EBUSY errors under overlayfs and v4.13+ kernels [moby/moby#34914](https://github.com/moby/moby/pull/34914) and [moby/moby#34948](https://github.com/moby/moby/pull/34948)
+- Fix TestMount under a selinux system [moby/moby#34965](https://github.com/moby/moby/pull/34965)
+- Fix devicemapper error: cannot remove container filesystem, layer not retained [moby/moby#36160](https://github.com/moby/moby/pull/36160)
++ Golang bumped to 1.8.7
+* Add timeouts for volume plugin ops [moby/moby#35441](https://github.com/moby/moby/pull/35441)
++ Add `REMOVE` and `ORPHANED` to `TaskState` [moby/moby#36146](https://github.com/moby/moby/pull/36146)
+- Fix abort when setting `may_detach_mounts` [moby/moby#35172](https://github.com/moby/moby/pull/35172)
+* Windows: Ensure Host Network Service exists [moby/moby#34928](https://github.com/moby/moby/pull/34928)
+- Fix issue where network inspect does not show created time in swarm scope [moby/moby#36095](https://github.com/moby/moby/pull/36095)
+* Windows: Daemon should respect `DOCKER_TMPDIR` [moby/moby#35077](https://github.com/moby/moby/pull/35077)
+- Merge global storage options on create [moby/moby#34508](https://github.com/moby/moby/pull/34508)
+- Remove support for overlay/overlay2 without d_type [moby/moby#35514](https://github.com/moby/moby/pull/35514)
+
+### Swarm mode
+
+* Don't delete tasks until they're actually removed by the agent [docker/swarmkit#2461](https://github.com/docker/swarmkit/pull/2461)
+* Add required call to allocate VIPs when endpoints are restored [docker/swarmkit#2468](https://github.com/docker/swarmkit/pull/2468)
+- Synchronize Dispatcher.Stop() with incoming rpcs [docker/swarmkit#2524](https://github.com/docker/swarmkit/pull/2524)
+- Fix IP overlap with empty EndpointSpec [docker/swarmkit#2511](https://github.com/docker/swarmkit/pull/2511)
+
 ## 17.06.2-ee-6 (2017-11-27)
 
 ### Runtime


### PR DESCRIPTION
This change updates the release notes and version variables to release:
* EE Engine 17.06.2-ee-7
* UCP 2.2.6
* DTR 2.4.3

It seems that I can't add a couple of folks as reviewers. We'll update this in the future, but for the time being, /ping @andrewhsu @jose-bigio @corbin-coleman @ry4nz @RobbKistler @gbarr01 