### PR TITLE
Fix typo in suse.md

### DIFF
--- a/install/linux/docker-ee/suse.md
+++ b/install/linux/docker-ee/suse.md
@@ -4,7 +4,7 @@ keywords: requirements, apt, installation, suse, opensuse, sles, rpm, install, u
 redirect_from:
 - /engine/installation/SUSE/
 - /engine/installation/linux/suse/
-- /engine/installatioin/linux/docker-ee/suse/
+- /engine/installation/linux/docker-ee/suse/
 title: Get Docker EE for SLES
 toc_max: 4
 ---


### PR DESCRIPTION
### Proposed changes
Fixed typo in word `installation` from `suse.md`

### Related issues (optional)
This fixes the issue #6257
