### PR TITLE
Add using of PGPASSWORD for psql

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -63,7 +63,7 @@ script:
         shift
         cmd="$@"
 
-        until psql -h "$host" -U "postgres" -c '\q'; do
+        until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$host" -U "postgres" -c '\q'; do
           >&2 echo "Postgres is unavailable - sleeping"
           sleep 1
         done


### PR DESCRIPTION
Given example is not complete at least for official postgres image. I have added setting of psql password over POSTGRES_PASSWORD env variable.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
