### PR TITLE
Fix highlighted line in GitHub link to storage driver selection

### DIFF
--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -41,7 +41,7 @@ this decision, there are three high-level factors to consider:
 
   The selection order is defined in Docker's source code. You can see the order
   by looking at
-  [the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L53)
+  [the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L50)
   You can use the branch selector at the top of the file viewer to choose a
   different branch, if you run a different version of Docker.
   {: id="storage-driver-order" }

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -41,7 +41,7 @@ this decision, there are three high-level factors to consider:
 
   The selection order is defined in Docker's source code. You can see the order
   by looking at
-  [the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L54-L63)
+  [the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L53)
   You can use the branch selector at the top of the file viewer to choose a
   different branch, if you run a different version of Docker.
   {: id="storage-driver-order" }


### PR DESCRIPTION
### Proposed changes

The GitHub link for the storage driver selection order links to a few lines below the actual line that should be referred to. This pull request makes GitHub highlight the line that actually contains the storage driver selection order as intended by the documentation.

As the link will always refer to the location for the latest CE stable, this may break again in a newer stable release, but at least this fixes it for now.