### PR TITLE
Fix docs for "unless-stopped" restart policy

### DIFF
--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -28,7 +28,7 @@ any of the following:
 |:-----------------|:------------------------------------------------------------------------------------------------|
 | `no`             | Do not automatically restart the container. (the default)                                       |
 | `on-failure`     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.     |
-| `unless-stopped` | Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted. |
+| `unless-stopped` | Restart the container unless it is explicitly stopped.                                          |
 | `always`         | Always restart the container if it stops.                                                       |
 
 The following example starts a Redis container and configures it to always


### PR DESCRIPTION
### Proposed changes
This part:
>or Docker itself is stopped or restarted.

is not accurate. When you restart docker daemon containers with `unless-stopped` policy are also restarted, as long as they haven't been explicitly stopped before the docker daemon restart.

Please read correct examples of documentation for `unless-stopped` restart policy:
* https://github.com/moby/moby/blob/766d9edf39b79e11018bb0f55056b5bd915ddf3c/api/swagger.yaml#L314
* https://github.com/moby/moby/blob/766d9edf39b79e11018bb0f55056b5bd915ddf3c/api/types/container/host_config.go#L279

If you are still in doubt please read the MR that added `unless-stopped` restart policy:
https://github.com/moby/moby/pull/15348
and the inital ticket for it:
https://github.com/moby/moby/issues/11008
