### PR TITLE
Update overlayfs-driver.md

### DIFF
--- a/storage/storagedriver/overlayfs-driver.md
+++ b/storage/storagedriver/overlayfs-driver.md
@@ -138,7 +138,7 @@ Before following this procedure, you must first meet all the
 
     Containers: 0
     Images: 0
-    Storage Driver: overlay
+    Storage Driver: overlay2
      Backing Filesystem: extfs
     <output truncated>
     ```


### PR DESCRIPTION
The docker info output shows that the driver is overlay. However, in the path that follows it states that the output confirms that overlay2 is in use. This is likely to cause confusion as the docker info output should state overlay2 if that is what is configured.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
