### PR TITLE
__docker_machine_ps1 is not found

### DIFF
--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -70,6 +70,8 @@ Confirm the version and save scripts to `/etc/bash_completion.d` or
 
 ```bash
 scripts=( docker-machine-prompt.bash docker-machine-wrapper.bash docker-machine.bash ); for i in "${scripts[@]}"; do sudo wget https://raw.githubusercontent.com/docker/machine/v{{site.machine_version}}/contrib/completion/bash/${i} -P /etc/bash_completion.d; done
+
+Then you need to run "source /etc/bash_completion.d/docker-machine-prompt.bash" in your bash terminal to tell your setup where it can find the file docker-machine-prompt.bash that you previously downloaded.
 ```
 
 To enable the `docker-machine` shell


### PR DESCRIPTION
Fix __docker_machine_ps1: command not found

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
