### PR TITLE
Remove unsupported strftime code

### DIFF
--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -169,7 +169,6 @@ The following `strftime` codes are supported:
 | `%p` | AM or PM.                                                        | AM       |
 | `%M` | Minute as a zero-padded decimal number.                          | 57       |
 | `%S` | Second as a zero-padded decimal number.                          | 04       |
-| `%L` | Milliseconds as a zero-padded decimal number.                    | 123      |
 | `%f` | Microseconds as a zero-padded decimal number.                    | 000345   |
 | `%z` | UTC offset in the form +HHMM or -HHMM.                           | +1300    |
 | `%Z` | Time zone name.                                                  | PST      |


### PR DESCRIPTION
Remove the `%L` option as it is not supported by `awslogs-datetime-format`.
