### PR TITLE
Add redirect for storage driver 404s

### DIFF
--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -5,6 +5,7 @@ keywords: container, storage, driver, aufs, btrfs, devicemapper, zfs, overlay, o
 redirect_from:
 - /engine/userguide/storagedriver/
 - /engine/userguide/storagedriver/selectadriver/
+- /storage/storagedriver/selectadriver/
 ---
 
 Ideally, very little data is written to a container's writable layer, and you


### PR DESCRIPTION
Redirect 
https://docs.docker.com/storage/storagedriver/selectadriver/
to 
https://docs.docker.com/storage/storagedriver/select-storage-driver/

Fixes: #6074 #6151 #6342