### PR TITLE
Adding link to ICCS docs

### DIFF
--- a/docker-for-ibm-cloud/faqs.md
+++ b/docker-for-ibm-cloud/faqs.md
@@ -142,6 +142,10 @@ SSH into a manager node. Manager nodes are accessed on port 56422.
 alias ssh-docker='function __t() { ssh-keygen -R [$1]:56422 > /dev/null 2>&1; ssh -A -p 56422 -o StrictHostKeyChecking=no docker@$1; unset -f __t; }; __t'
 ```
 
+## Can I run my containers in Kubernetes clusters?
+
+Docker EE for IBM Cloud supports swarm clusters. If you are looking for the IBM Cloud Container Service for Kubernetes clusters, see the [IBM Cloud documentation](https://console.bluemix.net/docs/containers/container_index.html).
+
 ## Are there any known issues?
 
 Yes. News, updates, and known issues are recorded by version on the [Release notes](release-notes.md) page.

--- a/docker-for-ibm-cloud/index.md
+++ b/docker-for-ibm-cloud/index.md
@@ -11,6 +11,8 @@ Docker EE for IBM Cloud is an unmanaged, native Docker environment within IBM Cl
 
 [Email IBM to request access to the closed beta](mailto:sealbou@us.ibm.com). In the welcome email you receive, you are given the Docker EE installation URL that you use for the beta.
 
+Looking for the IBM Cloud Container Service? See the [IBM Cloud documentation](https://console.bluemix.net/docs/containers/container_index.html).
+
 ## Prerequisites
 
 To create a swarm cluster in IBM Cloud, you must have certain accounts, credentials, and environments set up.


### PR DESCRIPTION
We had some users find the D4IC docs and think that it was the same
thing as the IBM Cloud container service docs. To address this, I added:
* Link on the index page to the ICCS docs
* An FAQ in case they are looking for containers in Kubernetes clusters
