### PR TITLE
Update s3.md

### DIFF
--- a/registry/storage-drivers/s3.md
+++ b/registry/storage-drivers/s3.md
@@ -187,22 +187,30 @@ Amazon S3 or S3 compatible services for object storage.
 
 ## S3 permission scopes
 
-The following AWS policy is required by the registry for push and pull. Make sure to replace `S3_BUCKET_NAME` with the name of your bucket.
+The following AWS policy is required by the registry for push and pull. Make sure to replace `S3_BUCKET_NAME` with the name of your bucket and `PRINCIPAL_ARN` with the complete ARN for either the account, role, or user which will be accessing the S3 bucket. See [the IAM JSON Policy Principal Element documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html) for more details.
 
 ```
 {
+  "Id": "DockerRegistryS3StorageBackendPolicy",
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "BucketAccess",
       "Effect": "Allow",
       "Action": [
         "s3:ListBucket",
         "s3:GetBucketLocation",
         "s3:ListBucketMultipartUploads"
       ],
-      "Resource": "arn:aws:s3:::S3_BUCKET_NAME"
+      "Resource": "arn:aws:s3:::S3_BUCKET_NAME",
+      "Principal": {
+        "AWS": [
+          "PRINCIPAL_ARN"
+        ]
+      }
     },
     {
+      "Sid": "ObjectAccess",
       "Effect": "Allow",
       "Action": [
         "s3:PutObject",
@@ -211,7 +219,12 @@ The following AWS policy is required by the registry for push and pull. Make sur
         "s3:ListMultipartUploadParts",
         "s3:AbortMultipartUpload"
       ],
-      "Resource": "arn:aws:s3:::S3_BUCKET_NAME/*"
+      "Resource": "arn:aws:s3:::S3_BUCKET_NAME/*",
+      "Principal": {
+        "AWS": [
+          "PRINCIPAL_ARN"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
I am unsure if this problem is unique to trying to apply this policy to a bucket using Terraform, but I was unable to use the policy straight from the docs to configure my storage backend's bucket permissions. The error I would receive from Terraform is as follows;

```
Error putting S3 policy: MalformedPolicy: Missing required field Principal
```

I recreated the policy using the AWS policy generator and it added the principal section.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
