### PR TITLE
Adding "windows" label to Windows node.

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/configure/join-windows-worker-nodes.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/join-windows-worker-nodes.md
@@ -33,6 +33,17 @@ Follow these steps to configure the docker daemon and the Windows environment.
 1.  Pull the Windows-specific image of `ucp-agent`, which is named `ucp-agent-win`.
 2.  Run the Windows worker setup script provided with `ucp-agent-win`.
 3.  Join the swarm with the token provided by the UCP web UI.
+4.  Create a file `daemon.json`.
+5.  Paste following content and save it under `$env:ProgramFiles\Docker\config\`
+    ```
+    {
+    "labels": ["os=windows"]
+    }
+    ``` 
+6.  Restart the docker service.
+    ```
+    Restart-Service docker
+    ```
 
 ### Pull the Windows-specific images
 

--- a/datacenter/ucp/2.2/guides/admin/configure/join-windows-worker-nodes.md
+++ b/datacenter/ucp/2.2/guides/admin/configure/join-windows-worker-nodes.md
@@ -34,7 +34,7 @@ Follow these steps to configure the docker daemon and the Windows environment.
 2.  Run the Windows worker setup script provided with `ucp-agent-win`.
 3.  Join the swarm with the token provided by the UCP web UI.
 4.  Create a file `daemon.json`.
-5.  Paste following content and save it under `$env:ProgramFiles\Docker\config\`
+5.  Paste following content and save it under `$env:ProgramData\Docker\config\`
     ```
     {
     "labels": ["os=windows"]


### PR DESCRIPTION
Additional steps to add label to Windows Nodes.  This will allow admin to filter Windows node when creating a service like this.
`docker service create --constraint engine.labels.os==windows --name winonly microsoft/nanoserver`  The same steps are on this article: https://success.docker.com/article/how-can-i-assign-a-service-to-windows-nodes-only

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
