### PR TITLE
Fix `-OutFile` argument to be the correct path

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -77,14 +77,14 @@ Docker Compose. To do so, follow these steps:
     version of Compose you want to use:
 
     ```none
-    Invoke-WebRequest "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
+    Invoke-WebRequest "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\Docker\Docker\resources\bin\docker-compose.exe
     ```
 
     For example, to download Compose version {{site.compose_version}},
     the command is:
 
     ```none
-    Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\docker\docker-compose.exe
+    Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\Docker\Docker\resources\bin\docker-compose.exe
     ```
     > Use the latest Compose release number in the download command.
     >


### PR DESCRIPTION
I found a problem with the Windows installation instructions for *docker-compose*.

### Proposed changes

Changed the documentation sample powershell to put the *docker-compose.exe* in the correct directory. ``$Env:ProgramFiles\Docker\Docker\resources\bin\docker-compose.exe``

The examples now work as advertised.