### PR TITLE
changed docker run argument order

### DIFF
--- a/network/network-tutorial-host.md
+++ b/network/network-tutorial-host.md
@@ -31,7 +31,7 @@ host.
 1.  Create and start the container as a detached process.
 
     ```bash
-    docker run --rm -itd --network host --name my_nginx nginx
+    docker run --rm -dit --network host --name my_nginx nginx
     ```
 
 2.  Access Nginx by browsing to


### PR DESCRIPTION
The docker run argument order is `-dit `in most part, bu i found a different order `-idt` here. I believe it is  better to have inconsistent order in the entire documentation. It can be confusing for new-bees if they see these parameters are ordered inconsistently across documentation flow.
