### PR TITLE
Add Windows unset shell variables instructions

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -475,11 +475,19 @@ docker stack rm getstartedlab
 ### Unsetting docker-machine shell variable settings
 
 You can unset the `docker-machine` environment variables in your current shell
-with the following command:
+with the given command.
 
-```
-eval $(docker-machine env -u)
-```
+  On **Mac or Linux** the command is:
+
+  ```shell
+  eval $(docker-machine env -u)
+  ```
+
+  On **Windows** the command is:
+
+  ```shell
+  & "C:\Program Files\Docker\Docker\Resources\bin\docker-machine.exe" env -u | Invoke-Expression
+  ```
 
 This disconnects the shell from `docker-machine` created virtual machines,
 and allows you to continue working in the same shell, now using native `docker`


### PR DESCRIPTION
Instructions on unsetting docker-machine shell variable settings covered Mac/Linux only. Adding instructions for Windows too.

### Proposed changes

Whilst working through the guide on Windows it took me a few moments to realise what I was supposed to do at this step.  Thought I'd spell it out since the rest of the guide does a good job at breaking down the difference between the Mac/Linux command vs the Windows version.

### Unreleased project version (optional)

### Related issues (optional)