### PR TITLE
Added note to 'ports' section: Port mapping is incompatible with `net…

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1380,6 +1380,8 @@ containers in the bare-metal machine's namespace and vise-versa.
 
 Expose ports.
 
+> **Note:** Port mapping is incompatible with `network_mode: host`
+
 #### Short syntax
 
 Either specify both ports (`HOST:CONTAINER`), or just the container


### PR DESCRIPTION

### Proposed changes

Added note to 'ports' section: Port mapping is incompatible with `network_mode: host`

Took a while to figure this one out.  Source: https://github.com/docker/compose/issues/4799#issuecomment-299605031