### PR TITLE
ENV section should be before tha RUN in Dockerfile

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -71,14 +71,14 @@ WORKDIR /app
 # Copy the current directory contents into the container at /app
 ADD . /app
 
+# Define environment variable
+ENV NAME World
+
 # Install any needed packages specified in requirements.txt
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 # Make port 80 available to the world outside this container
 EXPOSE 80
-
-# Define environment variable
-ENV NAME World
 
 # Run app.py when the container launches
 CMD ["python", "app.py"]
@@ -179,7 +179,9 @@ friendlyhello         latest              326387cea398
 > Proxy servers can block connections to your web app once it's up and running.
 > If you are behind a proxy server, add the following lines to your
 > Dockerfile, using the `ENV` command to specify the host and port for your
-> proxy servers:
+> proxy servers and make sure that `ENV` section are before that `RUN`, this to
+> set up the variables enviroment before run everything needed.
+> command section :
 >
 > ```conf
 > # Set proxy server, replace host:port with values for your servers

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -71,11 +71,11 @@ WORKDIR /app
 # Copy the current directory contents into the container at /app
 ADD . /app
 
-# Define environment variable
-ENV NAME World
-
 # Install any needed packages specified in requirements.txt
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
+
+# Define environment variable
+ENV NAME World
 
 # Make port 80 available to the world outside this container
 EXPOSE 80


### PR DESCRIPTION
Im learning Docker and Im following the get-staterd guide.
Im behind a proxy.

Following the guide such as is document, when I run  `root@felipe# docker build -t happydocker  .  ` I get a error 

Sending build context to Docker daemon  45.75MB
Step 1/14 : FROM python:2.7-slim
 ---> b16fde09c92c
Step 2/14 : WORKDIR /app
 ---> Using cache
 ---> 2842bfbc0a0a
Step 3/14 : ADD . /app
 ---> 23dad6764edc
Step 4/14 : RUN pip install --trusted-host pypi.python.org -r requirements.txt
 ---> Running in e137a0f36fdb
Collecting Flask (from -r requirements.txt (line 1))
  Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ConnectTimeoutError(<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fcf5f021910>, 'Connection to pypi.python.org timed out. (connect timeout=15)')': /simple/flask/

The librarys indicate in requirements.txt file are not installed for error connection : This is a signal that proxy ENV are not passed for the app container yet.
This because in the Dockerfile first execute RUN command and the import the ENV variables.

# Install any needed packages specified in requirements.txt
RUN pip install --trusted-host pypi.python.org -r requirements.txt
# Define environment variable
ENV NAME World
ENV http_proxy host:port

If first indicate ENV variables in the that going to be installed in the container app and then RUN command in the Dockerfile, the image is create succesfully.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
