### PR TITLE
Mention btrfs storage driver for Docker CE

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -54,7 +54,8 @@ networks, are preserved. The Docker CE package is now called `docker-ce`.
 
 ### Supported storage drivers
 
-Docker CE on Ubuntu supports `overlay2` and `aufs` storage drivers.
+Docker CE on Ubuntu supports `overlay2`, `aufs` and `btrfs` storage drivers.
+Please note, however, that in Docker EE `btrfs` is only supported on SLES (see [btrfs](/engine/userguide/storagedriver/btrfs-driver.md)).
 
 - For new installations on version 4 and higher of the Linux kernel, `overlay2`
   is supported and preferred over `aufs`.

--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -55,7 +55,8 @@ networks, are preserved. The Docker CE package is now called `docker-ce`.
 ### Supported storage drivers
 
 Docker CE on Ubuntu supports `overlay2`, `aufs` and `btrfs` storage drivers.
-Please note, however, that in Docker EE `btrfs` is only supported on SLES (see [btrfs](/engine/userguide/storagedriver/btrfs-driver.md)).
+> *** Note: *** In Docker Engine - Enterprise, `btrfs` is only supported on SLES. See the documentation on 
+> [btrfs](/engine/userguide/storagedriver/btrfs-driver.md) for more details.
 
 - For new installations on version 4 and higher of the Linux kernel, `overlay2`
   is supported and preferred over `aufs`.


### PR DESCRIPTION
### Proposed changes
Docker CE supports btrfs storage driver on Ubuntu, and Docker EE supports it on SLES.

Mention it in the documentation.
