### PR TITLE
Typo

### DIFF
--- a/network/overlay.md
+++ b/network/overlay.md
@@ -153,7 +153,7 @@ services which publish ports, such as a WordPress service which publishes port
       --ingress \
       --subnet=10.11.0.0/16 \
       --gateway=10.11.0.2 \
-      --opt com.docker.network.mtu=1200 \
+      --opt com.docker.network.driver.mtu=1200 \
       my-ingress
     ```
 
@@ -180,7 +180,7 @@ from the swarm.
     ```bash
     $ sudo ip link set docker_gwbridge down
 
-    $ sudo ip link del name docker_gwbridge
+    $ sudo ip link del dev docker_gwbridge
     ```
 
 3.  Start Docker. Do not join or initialize the swarm.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Typo

- Correct option name for MTU is `com.docker.network.driver.mtu`
- `ip link del name` -> `ip link del dev`
```
$ sudo ip link del name docker_gwbridge
Not enough information: "dev" argument is required.
```