### PR TITLE
updating bash_profile

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -460,6 +460,14 @@ ln -s $etc/docker-machine.bash-completion $(brew --prefix)/etc/bash_completion.d
 ln -s $etc/docker-compose.bash-completion $(brew --prefix)/etc/bash_completion.d/docker-compose
 ```
 
+Add the following to your `~/.bash_profile`:
+
+```shell
+if [ -f $(brew --prefix)/etc/bash_completion ]; then
+. $(brew --prefix)/etc/bash_completion
+fi
+```
+
 ### Zsh
 
 In Zsh, the [completion system](http://zsh.sourceforge.net/Doc/Release/Completion-System.html){:target="_blank" class="_"}

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -462,6 +462,13 @@ ln -s $etc/docker-compose.bash-completion $(brew --prefix)/etc/bash_completion.d
 
 Add the following to your `~/.bash_profile`:
 
+
+```shell
+[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
+```
+
+OR
+
 ```shell
 if [ -f $(brew --prefix)/etc/bash_completion ]; then
 . $(brew --prefix)/etc/bash_completion


### PR DESCRIPTION
### Proposed changes

Consolidating some useful information. The following lines have to be added to the ~/.bash_profile for it to work. I pulled this information from https://docs.docker.com/compose/completion/. 

I thought it would be useful to add it here so that all this info could be in one place.
`
if [ -f $(brew --prefix)/etc/bash_completion ]; then
. $(brew --prefix)/etc/bash_completion
fi
`
If not the above, the other command could be 
`
 [ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
`

which is displayed once you've installed bash-completion

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->
