### PR TITLE
Update link to Docker Trusted Registry

### DIFF
--- a/registry/index.md
+++ b/registry/index.md
@@ -14,7 +14,7 @@ title: Docker Registry
 > offered as an add-on to Docker Enterprise subscriptions of Standard or
 > higher.
 >
-> [Go to Docker Trusted Registry](/datacenter/dtr/{{ site.dtr_version }}/guides/){: class="button outline-btn" }
+> [Go to Docker Trusted Registry](/ee/dtr/){: class="button outline-btn" }
 
 ## What it is
 


### PR DESCRIPTION
(dead) https://docs.docker.com/datacenter/dtr/2.5/guides/ => (new) https://docs.docker.com/ee/dtr/

See the original data: https://github.com/docker/docker.github.io/blob/ac1a3b0e9782dc327f2aaa0e7f040bed779cd3e3/_config_authoring.yml#L45

### Proposed changes

Fix a dead link to DTR.