### PR TITLE
Error when try to adding gpg on debian 9

### DIFF
--- a/install/linux/docker-ce/debian.md
+++ b/install/linux/docker-ce/debian.md
@@ -137,7 +137,7 @@ from the repository.
 3.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base}}/gpg | sudo apt-key add -
+    $ wget {{ download-url-base}}/gpg | sudo apt-key add gpg
     ```
 
     Verify that you now have the key with the fingerprint


### PR DESCRIPTION
Error :
gpg: no valid OpenPGP data found.

It works with my solution

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
