### PR TITLE
Fix JSON example on webhooks page

### DIFF
--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -30,7 +30,7 @@ with the following payload:
     "tag": "latest"
   },
   "repository": {
-    "comment_count": "0",
+    "comment_count": 0,
     "date_created": 1.417494799e+09,
     "description": "",
     "dockerfile": "#\n# BUILD\u0009\u0009docker build -t svendowideit/apt-cacher .\n# RUN\u0009\u0009docker run -d -p 3142:3142 -name apt-cacher-run apt-cacher\n#\n# and then you can run containers with:\n# \u0009\u0009docker run -t -i -rm -e http_proxy http://192.168.1.2:3142/ debian bash\n#\nFROM\u0009\u0009ubuntu\n\n\nVOLUME\u0009\u0009[\/var/cache/apt-cacher-ng\]\nRUN\u0009\u0009apt-get update ; apt-get install -yq apt-cacher-ng\n\nEXPOSE \u0009\u00093142\nCMD\u0009\u0009chmod 777 /var/cache/apt-cacher-ng ; /etc/init.d/apt-cacher-ng start ; tail -f /var/log/apt-cacher-ng/*\n",


### PR DESCRIPTION
### Proposed changes
Correct the JSON example on the Webhooks page. The comment_count parameter in the JSON body is a number, not a string.