### PR TITLE
Reword to explain the purpose of the diagnostics ID

### DIFF
--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -15,8 +15,7 @@ There are several ways to get the support you need with Docker for Windows. If y
 - Refer to the knowledge base articles at the [Docker Success Center](https://success.docker.com/q/).
 - Browse the logs (in `User\AppData\Local\Docker`) by clicking **log file** in the Diagnose & Feedback window.
 - Ask questions on the [Docker for Windows forum](https://forums.docker.com/c/docker-for-windows).
-- Submit issues at the [Docker for Windows GitHub repo](https://github.com/docker/for-win/issues).
-- Upload diagnostics in the Diagnose & Feedback window. You'll get a unique ID in return.
+- Upload diagnostics in the Diagnose & Feedback window. You'll get a unique ID in return. You can then use this ID to submit issues at the [Docker for Windows GitHub repo](https://github.com/docker/for-win/issues).
 
 ![Diagnose & Feedback with ID](images/diagnostic-id.png){:width="500px"}
 


### PR DESCRIPTION
Signed-off-by: Stephen Turner <stephen.turner@docker.com>

### Proposed changes

Reword bullet points because it wasn't clear
1. Why you want a diagnostics ID
2. That Github issues should come with a diagnostics ID
