### PR TITLE
Add exec_die to the list of known container events

### DIFF
--- a/_data/engine-cli/docker_events.yaml
+++ b/_data/engine-cli/docker_events.yaml
@@ -19,6 +19,7 @@ long: |-
   - `die`
   - `exec_create`
   - `exec_detach`
+  - `exec_die`
   - `exec_start`
   - `export`
   - `health_status`


### PR DESCRIPTION
Hey there!

This could be an implementation of https://github.com/docker/docker.github.io/issues/6579

### Proposed changes

Since https://github.com/moby/moby/pull/35744 your containers could also dispatch an `exec_die` event. Juding by the pull request, I'm assuming this behavior is intended and should be listed in the "known container events" list.

### Related issues (optional)

Fixes #6579
