### PR TITLE
A typo in docker-overview.md

### DIFF
--- a/engine/docker-overview.md
+++ b/engine/docker-overview.md
@@ -206,8 +206,8 @@ the default registry configuration):
     connect to external networks using the host machine's network connection.
 
 5.  Docker starts the container and executes `/bin/bash`. Because the container
-    is run interactively and attached to your terminal (due to the `-i` and `-t`)
-    flags, you can provide input using your keyboard and output is logged to
+    is run interactively and attached to your terminal (due to the `-i` and `-t` 
+    flags), you can provide input using your keyboard and output is logged to
     your terminal.
 
 6.  When you type `exit` to terminate the `/bin/bash` command, the container

--- a/engine/docker-overview.md
+++ b/engine/docker-overview.md
@@ -206,7 +206,7 @@ the default registry configuration):
     connect to external networks using the host machine's network connection.
 
 5.  Docker starts the container and executes `/bin/bash`. Because the container
-    is run interactively and attached to your terminal (due to the `-i` and `-t` 
+    is run interactively and attached to your terminal (due to the `-i` and `-t`
     flags), you can provide input using your keyboard and output is logged to
     your terminal.
 


### PR DESCRIPTION
### Proposed changes
```
Because the container is run interactively and attached to your terminal (due to the `-i` and `-t`)
flags
```
Move `flags` inside the parentheses.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
