### PR TITLE
Change calicoctl version to 3.x for 'Disable IP in IP overlay...'

### DIFF
--- a/ee/ucp/kubernetes/install-cni-plugin.md
+++ b/ee/ucp/kubernetes/install-cni-plugin.md
@@ -71,14 +71,13 @@ commands on the Kubernetes master node to disable IPIP overlay tunneling.
 # Exec into the Calico Kubernetes controller container.
 docker exec -it $(docker ps --filter name=k8s_calico-kube-controllers_calico-kube-controllers -q) sh
 
-# Download calicoctl, which must be included in the container image.
-apk update && apk add ca-certificates && update-ca-certificates && apk add openssl
-wget https://github.com/projectcalico/calicoctl/releases/download/v1.6.3/calicoctl
+# Download calicoctl
+wget https://github.com/projectcalico/calicoctl/releases/download/v3.1.1/calicoctl
 
 # Get the IP pool configuration. 
 ./calicoctl get ippool -o yaml > ippool.yaml
 
-# Edit the file: Disable IPIP in ippool.yaml by setting "enabled: false".
+# Edit the file: Disable IPIP in ippool.yaml by setting "ipipMode: Never".
 
 # Apply the edited file to the Calico plugin.
 ./calicoctl apply -f ippool.yaml


### PR DESCRIPTION
calicoctl 1.6.x does not work for this doc in UCP3.0 environment, suggest to use Calico 3.x.
Note: the ippool yaml spec changed from v1 to v3, I'm not sure if only modifying "ipipMode: Never" is correct, please confirm with folks of network team.
