### PR TITLE
Clarify that --existing-config uses latest config

### DIFF
--- a/datacenter/ucp/2.2/reference/cli/install.md
+++ b/datacenter/ucp/2.2/reference/cli/install.md
@@ -63,7 +63,7 @@ command.
 | `--dns-opt`              | Set DNS options for the UCP containers                                                           |
 | `--dns-search`           | Set custom DNS search domains for the UCP containers                                             |
 | `--unlock-key`           | The unlock key for this swarm-mode cluster, if one exists.                                       |
-| `--existing-config`      | Use an existing UCP config during this installation. The install fails if a config is not found. |
+| `--existing-config`      | Use the latest existing UCP config during this installation. The install fails if a config is not found. |
 | `--pull`                 | Pull UCP images: `always`, when `missing`, or `never`                                            |
 | `--registry-username`    | Username to use when pulling images                                                              |
 | `--registry-password`    | Password to use when pulling images                                                              |

--- a/reference/ucp/3.0/cli/install.md
+++ b/reference/ucp/3.0/cli/install.md
@@ -64,7 +64,7 @@ command.
 | `--dns-opt`              | Set DNS options for the UCP containers                                                           |
 | `--dns-search`           | Set custom DNS search domains for the UCP containers                                             |
 | `--unlock-key`           | The unlock key for this swarm-mode cluster, if one exists.                                       |
-| `--existing-config`      | Use an existing UCP config during this installation. The install fails if a config is not found. |
+| `--existing-config`      | Use the latest existing UCP config during this installation. The install fails if a config is not found. |
 | `--force-minimums`       | Force the install/upgrade even if the system doesn't meet the minimum requirements.              |
 | `--pull`                 | Pull UCP images: `always`, when `missing`, or `never`                                            |
 | `--registry-username`    | Username to use when pulling images                                                              |


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

`--existing-config` is a flag that uses the latest UCP config found in the environment and does not accept a config as a flag variable.  The current documentation seems to suggest that this flag can accept a given config, when in reality it cannot.  This should help clarify that.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
