### PR TITLE
Fix incorrect description in example

### DIFF
--- a/machine/drivers/hyper-v.md
+++ b/machine/drivers/hyper-v.md
@@ -65,7 +65,7 @@ Make sure you have Ethernet connectivity while you are doing this.
 
 Open the **Hyper-V Manager**. (On Windows 10, just search for the Hyper-V Manager in the search field in the lower left search field.)
 
-Select the Virtual Switch Manager on the left-side **Actions** panel.
+Select the Virtual Switch Manager in the right-side **Actions** panel.
 
 ![Hyper-V manager](../img/hyperv-manager.png)
 


### PR DESCRIPTION
Actions panel was incorrectly described as being on the left-hand side of the window.


### Proposed changes

From the issue:
>Before the picture it says "Select the Virtual Switch Manager on the left-side Actions panel.", this should say "right-side"

This PR simply changes 'left-side' to 'right-side' to be consistent with the image.

### Related issues

Fixes #6275