### PR TITLE
Fixed typo in get-started

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -192,7 +192,7 @@ friendlyhello         latest              326387cea398
 > DNS misconfigurations can generate problems with `pip`. You need to set your 
 > own DNS server address to make `pip` work properly. You might want 
 > to change the DNS settings of the Docker daemon. You can edit (or create) the 
-> configurarion file at `/etc/docker/daemon.json` with the `dns` key, as following:
+> configuration file at `/etc/docker/daemon.json` with the `dns` key, as following:
 >
 > ```json
 >{


### PR DESCRIPTION
Fixed typo in get-started documentation

### Proposed changes

Fixed spelling error in get-started documentation file:

`configurarion` -> `configuration`

### Unreleased project version (optional)

### Related issues (optional)
