### PR TITLE
interlock config: fix indentation

### DIFF
--- a/ee/ucp/interlock/deploy/configure.md
+++ b/ee/ucp/interlock/deploy/configure.md
@@ -15,30 +15,30 @@ Here's how it works:
 1. Find out what configuration is currently being used for the `ucp-interlock`
 service and save it to a file:
 
-{% raw %}
-```bash
-CURRENT_CONFIG_NAME=$(docker service inspect --format '{{ (index .Spec.TaskTemplate.ContainerSpec.Configs 0).ConfigName }}' ucp-interlock)
-docker config inspect --format '{{ printf "%s" .Spec.Data }}' $CURRENT_CONFIG_NAME > config.toml
-```
-{% endraw %}
+   {% raw %}
+   ```bash
+   CURRENT_CONFIG_NAME=$(docker service inspect --format '{{ (index .Spec.TaskTemplate.ContainerSpec.Configs 0).ConfigName }}' ucp-interlock)
+   docker config inspect --format '{{ printf "%s" .Spec.Data }}' $CURRENT_CONFIG_NAME > config.toml
+   ```
+   {% endraw %}
 
 2. Make the necessary changes to the `config.toml` file.
-[Learn about the configuration options available](configuration-reference.md).
+   [Learn about the configuration options available](configuration-reference.md).
+
 3. Create a new Docker configuration object from the file you've edited:
 
-```bash
-NEW_CONFIG_NAME="com.docker.ucp.interlock.conf-$(( $(cut -d '-' -f 2 <<< "$CURRENT_CONFIG_NAME") + 1 ))"
-docker config create $NEW_CONFIG_NAME config.toml
-```
+   ```bash
+   docker config create $NEW_CONFIG_NAME config.toml
+   ```
 
 3. Update the `ucp-interlock` service to start using the new configuration:
 
-```bash
-docker service update \
-  --config-rm $CURRENT_CONFIG_NAME \
-  --config-add source=$NEW_CONFIG_NAME,target=/config.toml \
-  ucp-interlock
-```
+   ```bash
+   docker service update \
+     --config-rm $CURRENT_CONFIG_NAME \
+     --config-add source=$NEW_CONFIG_NAME,target=/config.toml \
+     ucp-interlock
+   ```
 
 By default the `ucp-interlock` service is configured to pause if you provide an
 invalid configuration. The service won't restart without a manual intervention.


### PR DESCRIPTION

before:
![2018-05-03-163658_1745x1416_scrot](https://user-images.githubusercontent.com/3613189/39601563-4fefbbfe-4ef0-11e8-8089-cdc2468a3499.png)

after:
![2018-05-03-163715_986x1434_scrot](https://user-images.githubusercontent.com/3613189/39601568-567a5326-4ef0-11e8-9a02-1a5ebcef36e7.png)



Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>