### PR TITLE
remind compose file how to build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 version: "2"
 services:
   docs:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: docs/docstage
     ports:
      - "4000:4000"


### PR DESCRIPTION
helpful since pages are now compiled during `build` and served statically.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>