### PR TITLE
Change DockerMsftProvider to DockerProvider 

### DIFF
--- a/install/windows/docker-ee.md
+++ b/install/windows/docker-ee.md
@@ -45,7 +45,7 @@ full list of prerequisites.
 
     ```PowerShell
     Install-Module DockerMsftProvider -Force
-    Install-Package Docker -ProviderName DockerMsftProvider -Force
+    Install-Package Docker -ProviderName DockerProvider -Force
     ```
 
 2.  Check if a reboot is required, and if yes, restart your instance:


### PR DESCRIPTION
### Proposed changes

`DockerMsftProvider` can not be found on Windows Server 2019:

```
PS C:\Users\Administrator> Install-Package Docker -ProviderName DockerMsftProvider -Force
Install-Package : Unable to find package providers (DockerMsftProvider).
At line:1 char:1
+ Install-Package Docker -ProviderName DockerMsftProvider -Force
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (Microsoft.Power....InstallPackage:InstallPackage) [Install-Package], E
   xception
    + FullyQualifiedErrorId : UnknownProviders,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage
```

But `DockerProvider` exists:
```
PS C:\Users\Administrator> Install-Package Docker -ProviderName DockerProvider -Force
WARNING: A restart is required to enable the one or more features. Please restart your machine.

Name                           Version          Source           Summary
----                           -------          ------           -------
Docker                         17.06.2-ee-10    Docker           Docker for Windows Server 2016
```