### PR TITLE
Remove 'docker-datacenter' limitation for EE2.0 DCT

### DIFF
--- a/ee/ucp/admin/configure/run-only-the-images-you-trust.md
+++ b/ee/ucp/admin/configure/run-only-the-images-you-trust.md
@@ -48,13 +48,7 @@ and select those teams from the list.
 ![UCP settings](../../images/run-only-the-images-you-trust-3.png){: .with-border}
 
 If you specify multiple teams, the image needs to be signed by a member of each
-team, or someone that is a member of all those teams, again which must be a part
-of the `docker-datacenter` organization.
-
-> Signing with teams
->
-> Teams used for signing policy enforcement must be in the `docker-datacenter`
-> organization.
+team, or someone that is a member of all those teams.
 
 Click **Save** for UCP to start enforcing the policy. From now on, existing
 services will continue running and can be restarted if needed, but UCP will only


### PR DESCRIPTION
In EE 2.0 `Run only the images you trust` , you can select team from the organization other than `docker-datacenter`.

