### PR TITLE
Update to sample output of docker-machine ls (can't have two machines…

### DIFF
--- a/machine/examples/aws.md
+++ b/machine/examples/aws.md
@@ -119,7 +119,7 @@ Follow along with this example to create a Dockerized [Amazon Web Services (AWS)
     NAME             ACTIVE   DRIVER         STATE     URL                         SWARM   DOCKER        ERRORS
     aws-sandbox      *        amazonec2      Running   tcp://52.90.113.128:2376            v1.10.0
     default          -        virtualbox     Running   tcp://192.168.99.100:2376           v1.10.0-rc4
-    digiOc-sandbox   -        digitalocean   Running   tcp://104.131.43.236:2376           v1.9.1
+    digi-sandbox       -      digitalocean   Running   tcp://104.131.43.236:2376           v1.9.1
     ```
 
     The new `aws-sandbox` instance is running and is the active host as

--- a/machine/examples/aws.md
+++ b/machine/examples/aws.md
@@ -119,7 +119,7 @@ Follow along with this example to create a Dockerized [Amazon Web Services (AWS)
     NAME             ACTIVE   DRIVER         STATE     URL                         SWARM   DOCKER        ERRORS
     aws-sandbox      *        amazonec2      Running   tcp://52.90.113.128:2376            v1.10.0
     default          -        virtualbox     Running   tcp://192.168.99.100:2376           v1.10.0-rc4
-    aws-sandbox   -           digitalocean   Running   tcp://104.131.43.236:2376           v1.9.1
+    digiOc-sandbox   -        digitalocean   Running   tcp://104.131.43.236:2376           v1.9.1
     ```
 
     The new `aws-sandbox` instance is running and is the active host as


### PR DESCRIPTION
… with same name)

Hi,
In the sample output on this page, there are two machines with name "aws-sandbox" with difference drivers 
1.  amazonec2 
2. digitalocean
So as docker-machines gives error if same named machine is already registered with it. These names create confusion. So added "digiOc-sangbox" for digital ocean based machine name.

### Proposed changes

The name of two machines is same in the output of docker-machine ls. Seems wrong as I can't register two machines with same name even if they have difference drivers

### Unreleased project version (optional)

### Related issues (optional)

