### PR TITLE
Fix faulty link on line #63 in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,7 +60,7 @@ and supported to provide enterprises with the most secure container platform in
 the industry to modernize all applications. Docker EE Advanced comes with enterprise
 [add-ons](#docker-ee-add-ons) like UCP and DTR.
 
-[Learn more about Docker EE](/ee/index.md){: class="button outline-btn"}
+[Learn more about Docker EE](ee/supported-platforms/){: class="button outline-btn"}
 
 </div>
 </div><!-- end row -->

--- a/index.md
+++ b/index.md
@@ -60,7 +60,7 @@ and supported to provide enterprises with the most secure container platform in
 the industry to modernize all applications. Docker EE Advanced comes with enterprise
 [add-ons](#docker-ee-add-ons) like UCP and DTR.
 
-[Learn more about Docker EE](/install/#platform-support-matrix){: class="button outline-btn"}
+[Learn more about Docker EE](/ee/index.md){: class="button outline-btn"}
 
 </div>
 </div><!-- end row -->


### PR DESCRIPTION
### Proposed changes
The link for 'Learn more about Docker EE' on click led to the 'About Docker CE' page. Therefore,the link was replaced with the proper link to the 'About Docker EE' page

