### PR TITLE
Docker for Mac : macOS 10.10 has been deprecated in 17.06 and not supported since 17.09

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -74,14 +74,13 @@ Do the following each time:
 ### What is Docker.app?
 
 `Docker.app` is Docker for Mac, a bundle of Docker client, and Docker Engine.
-`Docker.app` uses the macOS Hypervisor.framework (part of macOS 10.10 Yosemite
-and higher) to run containers, meaning that _**no separate VirtualBox is
+`Docker.app` uses the macOS Hypervisor.framework to run containers, meaning that _**no separate VirtualBox is
 required**_.
 
 ### What are system requirements for Docker for Mac?
 
 You need a Mac that supports hardware virtualization and can run at
-least macOS `10.10.3+` or `10.11` (macOS Yosemite or macOS El Capitan). See also
+least macOS `10.11` (macOS El Capitan). See also
 [What to know before you install](install#what-to-know-before-you-install) in
 the install guide.
 
@@ -310,8 +309,7 @@ on Docker for Mac GitHub issues.
 ## Components of Docker for Mac
 ### What is HyperKit?
 
-HyperKit is a hypervisor built on top of the Hypervisor.framework in macOS 10.10
-Yosemite and higher. It runs entirely in userspace and has no other
+HyperKit is a hypervisor built on top of the Hypervisor.framework in macOS. It runs entirely in userspace and has no other
 dependencies.
 
 We use HyperKit to eliminate the need for other VM products, such as Oracle

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -37,14 +37,7 @@ for Docker for Mac, and how the two products can coexist.
     Unrestricted Mode. You can check to see if your machine has this support by
     running the following command  in a terminal: `sysctl kern.hv_support`
 
-  - macOS El Capitan 10.11 and newer macOS releases are supported. At a minimum,
-    Docker for Mac requires macOS Yosemite 10.10.3 or newer, with the caveat
-    that going forward 10.10.x is a use-at-your-own risk proposition.
-
-  - Starting with Docker for Mac Stable release 1.13, and concurrent
-    Edge releases, we no longer address issues specific to macOS Yosemite
-    10.10. In future releases, Docker for Mac could stop working on macOS Yosemite
-    10.10 due to the deprecated status of this macOS version. We recommend
+  - macOS El Capitan 10.11 and newer macOS releases are supported. We recommend
     upgrading to the latest version of macOS.
 
   - At least 4GB of RAM

--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -52,8 +52,7 @@ which includes an [example](/machine/drivers/hyper-v.md#example) of how to do th
 
 Docker for Mac uses [HyperKit](https://github.com/docker/HyperKit/), a
 lightweight macOS virtualization solution built on top of the
-[Hypervisor.framework](https://developer.apple.com/reference/hypervisor) in macOS
-10.10 Yosemite and higher.
+[Hypervisor.framework](https://developer.apple.com/reference/hypervisor).
 
 Currently, there is no `docker-machine create` driver for HyperKit, so
 use the `virtualbox` driver to create local machines. (See the [Docker Machine


### PR DESCRIPTION
### Proposed changes

Removed messages that might lead users to think Docker for Mac 10.10 should work. It is not supported since D4M 17.09. 
Further deprecation will happen later on with the arrival of newer versions of macOS
