### PR TITLE
Clarify which manager to run the join command on

### DIFF
--- a/engine/swarm/join-nodes.md
+++ b/engine/swarm/join-nodes.md
@@ -89,7 +89,7 @@ To add a manager to this swarm, run the following command:
     192.168.99.100:2377
 ```
 
-Run the command from the output on the manager to join the swarm:
+Run the command from the output on the new manager node to join it to the swarm:
 
 ```bash
 $ docker swarm join \


### PR DESCRIPTION
### Proposed changes

This is a simple change to make it clear which machine the join command will need to be run on.