### PR TITLE
Mac: phase out the Data/com.docker.driver.amd64-linux directory

### DIFF
--- a/docker-for-mac/docker-toolbox.md
+++ b/docker-for-mac/docker-toolbox.md
@@ -213,8 +213,7 @@ $ echo "$dimg"
 ```
 
 In this case the format is `raw` (it could have been `qcow2`), and the location
-is `~Library/Containers/com.docker.docker/Data/vms/0/` (it could have been
-`~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/`).
+is `~/Library/Containers/com.docker.docker/Data/vms/0/`.
 
 Then:
 - if your format is qcow2, run

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -229,12 +229,9 @@ recommend the use of [Docker Toolbox](/toolbox/overview.md).
 
 ### What is the disk image?
 
-The containers and images are stored in a _disk image_ named
-`Docker.raw` or `Docker.qcow2` depending on your settings (see below).
-By default, the disk image is stored in
-`~/Library/Containers/com.docker.docker/Data`, in the `vms/0`
-subdirectory starting with Docker for Mac 18.01, and
-`com.docker.driver.amd64-linux` before.
+The containers and images are stored in a _disk image_ named `Docker.raw` or
+`Docker.qcow2` depending on your settings (see below).  By default, the disk
+image is stored in `~/Library/Containers/com.docker.docker/Data/vms/0`.
 
 ### Qcow2 or Raw?
 
@@ -252,8 +249,7 @@ physical size, add the `-ks` switch; to see the logical size in human readable
 form, add `-lh`:
 
 ```bash
-$ cd ~/Library/Containers/com.docker.docker/Data
-$ cd vms/0   # or com.docker.driver.amd64-linux
+$ cd ~/Library/Containers/com.docker.docker/Data/vms/0
 $ ls -klsh Docker.raw
 2333548 -rw-r--r--@ 1 akim  staff    64G Dec 13 17:42 Docker.raw
 ```


### PR DESCRIPTION
cc @gtardif @jasonbivins 

### Proposed changes

We should no longer document it, otherwise it will prevent us from
removing the backward compatibility treaks we had installed in Docker
for Mac.

### Unreleased project version (optional)

That change was made in Docker for Mac 18.01.  The versioned versions of the doc are still there for people using the set up.
