### PR TITLE
Add node.hostname to Go template placeholder options

### DIFF
--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -947,6 +947,7 @@ Valid placeholders for the Go template are:
 | `.Service.Name`   | Service name   |
 | `.Service.Labels` | Service labels |
 | `.Node.ID`        | Node ID        |
+| `.Node.hostname`  | Node hostname  |
 | `.Task.Name`      | Task name      |
 | `.Task.Slot`      | Task slot      |
 


### PR DESCRIPTION
The following command works on Docker CE 18.03.1-ce so .node.hostname should be included in the doc:

`docker service create --name myservice --hostname="{{.Node.Hostname}}-{{.Service.Name}}" busybox top`

This does not yet work however on the latest EE release, so I'd like some help knowing how best to add a note indicating this on the page.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
