### PR TITLE
Removing "Windows is not officially tested"

### DIFF
--- a/notary/getting_started.md
+++ b/notary/getting_started.md
@@ -27,8 +27,6 @@ freshness of your content.
 You can download precompiled notary binary for 64 bit Linux or macOS from the
 Notary repository's
 [Releases page on Github](https://github.com/docker/notary/releases).
-Windows is not officially tested, but if you are a developer and Windows user,
-we would appreciate any insight you can provide regarding issues.
 
 ## Understand Notary naming
 


### PR DESCRIPTION
According to the dev, this is no longer the case.  We did test the integration with Notary for Windows images.  Let me know if you need more information around this.
 
"Windows is not officially tested, but if you are a developer and Windows user,
we would appreciate any insight you can provide regarding issues."

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
