### PR TITLE
Fix some typos in the compose file docs

### DIFF
--- a/_includes/content/compose-matrix.md
+++ b/_includes/content/compose-matrix.md
@@ -19,7 +19,7 @@ This table shows which Compose file versions support specific Docker releases.
 In addition to Compose file format versions shown in the table, the Compose
 itself is on a release schedule, as shown in [Compose
 releases](https://github.com/docker/compose/releases/), but file format versions
-do not necessairly increment with each release. For example, Compose file format
+do not necessarily increment with each release. For example, Compose file format
 3.0 was first introduced in [Compose release
 1.10.0](https://github.com/docker/compose/releases/tag/1.10.0), and versioned
 gradually in subsequent releases.

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -792,7 +792,7 @@ services:
 
 #### Not supported for `docker stack deploy`
 
-The following sub-options (supported for `docker compose up` and `docker compose run`) are _not supported_ for `docker stack deploy` or the `deploy` key.
+The following sub-options (supported for `docker-compose up` and `docker-compose run`) are _not supported_ for `docker stack deploy` or the `deploy` key.
 
 - [build](#build)
 - [cgroup_parent](#cgroup_parent)


### PR DESCRIPTION
### Proposed changes

Fixed some typos in the compose file reference docs 👍 

If I run the command-line snippet as-is in the docs, I get the following error:
> `docker: 'compose' is not a docker command.`
