### PR TITLE
Add Docker hub url in the docker login

### DIFF
--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -40,7 +40,7 @@ To explore Docker Hub, you need to create an account by following the
 directions in [Your Docker ID](/docker-hub/accounts.md).
 
 > **Note**: You can search for and pull Docker images from Hub without logging
-> in, however to push images you must log in.
+> in, however to push images you must log in. `docker login -u <DockerID> https://registry.hub.docker.com` 
 
 Your Docker ID gives you one private Docker Hub repository for free. If you need
 more private repositories, you can upgrade from your free account to a paid


### PR DESCRIPTION
Fix the difficulty in finding Registry URL for Docker HUB
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
