### PR TITLE
Download http_api_endpoint

### DIFF
--- a/docker-store/certify-plugins-logging.md
+++ b/docker-store/certify-plugins-logging.md
@@ -158,15 +158,30 @@ There are three steps: (1) install git, (2) configure credentials, and (3) confi
     | Linux/IBMZ | [https://s3.amazonaws.com/store-logos-us-east-1/certification/zlinux/inspectDockerLoggingPlugin](https://s3.amazonaws.com/store-logos-us-east-1/certification/zlinux/inspectDockerLoggingPlugin) |
     | Linux/IBMPOWER | [https://s3.amazonaws.com/store-logos-us-east-1/certification/power/inspectDockerLoggingPlugin](https://s3.amazonaws.com/store-logos-us-east-1/certification/power/inspectDockerLoggingPlugin) |
 
-2.  Set permissions on `inspectDockerLoggingPlugin` so that it is executable:
+2.  Set permissions on `inspectDockerLoggingPlugin` for linux, zlinux and power so that it is executable:
 
     ```
     chmod u+x inspectDockerLoggingPlugin
     ```
 
-3.  Download [`quotes.txt`](https://s3.amazonaws.com/store-logos-us-east-1/certification/quotes.txt) and put it in the same directory.
+3. Download `http_api_endpoint` command
 
-4.  Get the product ID from the plan page you'd like to reference for the certification test. Make sure the checkbox is checked and the plan is saved first.
+    | OS/Architecture | Download Link |
+    |-----------------|------------------|
+    | Windows/X86  | [https://s3.amazonaws.com/store-logos-us-east-1/certification/windows/http_api_endpoint.exe](https://s3.amazonaws.com/store-logos-us-east-1/certification/windows/http_api_endpoint.exe) |
+    | Linux/X86 | [https://s3.amazonaws.com/store-logos-us-east-1/certification/linux/http_api_endpoint](https://s3.amazonaws.com/store-logos-us-east-1/certification/linux/http_api_endpoint) |
+    | Linux/IBMZ | [https://s3.amazonaws.com/store-logos-us-east-1/certification/zlinux/http_api_endpoint](https://s3.amazonaws.com/store-logos-us-east-1/certification/zlinux/http_api_endpoint) |
+    | Linux/IBMPOWER | [https://s3.amazonaws.com/store-logos-us-east-1/certification/power/http_api_endpoint](https://s3.amazonaws.com/store-logos-us-east-1/certification/power/http_api_endpoint) |
+
+4.  Set permissions on `http_api_endpoint` for linux, zlinux and power so that it is executable:
+
+    ```
+    chmod u+x http_api_endpoint
+    ```
+
+5.  Download [`quotes.txt`](https://s3.amazonaws.com/store-logos-us-east-1/certification/quotes.txt) and put it in the same directory.
+
+6.  Get the product ID from the plan page you'd like to reference for the certification test. Make sure the checkbox is checked and the plan is saved first.
 
     ![product ID](images/store-product-id.png)
 


### PR DESCRIPTION
Added documentation to download the http_api_endpoint binaries.

@gbarr01 
@meticulous-dft 

Ming, I could not find the http_api_endpoint binaries for power and zlinux.

The http_api_endpoint binary is in the s3 bucket for linux and windows.
https://s3.amazonaws.com/store-logos-us-east-1/certification/windows/http_api_endpoint.exe
https://s3.amazonaws.com/store-logos-us-east-1/certification/linux/http_api_endpoint

Could not find it for zlinux and power.

https://s3.amazonaws.com/store-logos-us-east-1/certification/zlinux/http_api_endpoint
https://s3.amazonaws.com/store-logos-us-east-1/certification/power/http_api_endpoint

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
