### PR TITLE
Several Minor Fixes to various pages

### DIFF
--- a/404.md
+++ b/404.md
@@ -11,6 +11,6 @@ track, maybe you found a broken link. Who knows?
 
 Either way, here's a couple of options for you:
 
-* [Open an issue](https://github.com/docker/docker.github.io/issues/new?title=I%20found%20a%20broken%20link&body=%3CDescribe%20how%20you%20got%20there%3E)
+* [Open an issue](https://github.com/docker/for-win/issues/new)
 * [Go to back](/)
 * [Tweet us something](https://twitter.com/docker)

--- a/docker-cloud/migration/kube-primer.md
+++ b/docker-cloud/migration/kube-primer.md
@@ -94,7 +94,7 @@ This command deploys a Docker application, named `test-app`, from a YAML configu
 $ docker stack deploy -c app1.yml test-app
 ```
 
-This command deploys a Kubernetes application from a YAML manifest file called `k8s-app1.yml`:
+This command deploys a Kubernetes application from a YAML manifest file called `k8s-app.yml`:
 
 ```
 $ kubectl create -f k8s-app.yml

--- a/engine/docker-overview.md
+++ b/engine/docker-overview.md
@@ -206,8 +206,8 @@ the default registry configuration):
     connect to external networks using the host machine's network connection.
 
 5.  Docker starts the container and executes `/bin/bash`. Because the container
-    is run interactively and attached to your terminal (due to the `-i` and `-t`
-    flags), you can provide input using your keyboard and output is logged to
+    is running interactively and is attached to your terminal (due to the `-i` and `-t`
+    flags), you can provide input using your keyboard while the output is logged to
     your terminal.
 
 6.  When you type `exit` to terminate the `/bin/bash` command, the container


### PR DESCRIPTION
### Proposed changes

<!--Tell us what you did and why-->
- Fixed a typo in kuber-primer.md where the name of the file was incorrectly written as k8-app1.yml when it should be k8-app.yml

- Restructured a sentence in docker-overview.md because of grammatical issues.

- Fixed incorrect link when clicking the Open an Issue hyperlink to redirect to the correct GitHub Issue template.


### Related issues (optional)
Refer to issues: #6742, #6699, and #6686 respectively for the above mentioned changes.
