### PR TITLE
Service templates: Capitalize .Node.Hostname

### DIFF
--- a/engine/swarm/services.md
+++ b/engine/swarm/services.md
@@ -947,7 +947,7 @@ Valid placeholders for the Go template are:
 | `.Service.Name`   | Service name   |
 | `.Service.Labels` | Service labels |
 | `.Node.ID`        | Node ID        |
-| `.Node.hostname`  | Node hostname  |
+| `.Node.Hostname`  | Node hostname  |
 | `.Task.Name`      | Task name      |
 | `.Task.Slot`      | Task slot      |
 


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Trying to use Node.hostname leads to error:

```
failed to update service : Error response from daemon: rpc error: code = InvalidArgument desc = expanding env failed:
expanding env "{{.Node.hostname}}": template: expansion:1:19:
executing "expansion" at <.Node.hostname>:
can't evaluate field hostname in type struct { ID string; Hostname string; Platform template.Platform }
```

I suppose this is a typo.