### PR TITLE
Cannot find reference to --net

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1246,7 +1246,7 @@ For a full list of supported logging drivers and their options, see
 
 ### network_mode
 
-Network mode. Use the same values as the docker client `--net` parameter, plus
+Network mode. Use the same values as the docker client `--network` parameter, plus
 the special form `service:[service name]`.
 
     network_mode: "bridge"


### PR DESCRIPTION
### Proposed changes

Is network intended? It looks like this is talking about 
https://docs.docker.com/engine/reference/run/#network-settings
### Unreleased project version (optional)
N/A

### Related issues (optional)
N/A