### PR TITLE
Update instructions to install specific version

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -260,9 +260,9 @@ the repository.
     ```
 
     b. Install a specific version by its fully qualified package name, which is
-       the package name (`docker-ce`) plus the version string (2nd column) up to
-       the first hyphen, separated by a an equals sign (`=`), for example,
-       `docker-ce=18.03.0.ce`.
+       the package name (`docker-ce`) plus the version string (2nd column),
+       separated by a an equals sign (`=`), for example,
+       `docker-ce=18.03.0~ce-0~ubuntu`.
 
     ```bash
     $ sudo apt-get install docker-ce=<VERSION>

--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -260,8 +260,7 @@ the repository.
     ```
 
     b. Install a specific version by its fully qualified package name, which is
-       the package name (`docker-ce`) plus the version string (2nd column),
-       separated by a an equals sign (`=`), for example,
+       package name (`docker-ce`) "=" version string (2nd column), for example,
        `docker-ce=18.03.0~ce-0~ubuntu`.
 
     ```bash


### PR DESCRIPTION
Issue #6758

### Proposed changes

The instructions for install an older version of docker-ce are inaccurate

Fixes #6758