### PR TITLE
Fix support links (Fixes #6764)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -49,7 +49,7 @@
                         <li><a href="https://www.docker.com/docker">Learn</a></li>
                         <li><a href="https://blog.docker.com" target="_blank">Blog</a></li>
                         <li><a href="https://training.docker.com/" target="_blank">Training</a></li>
-                        <li><a href="https://www.docker.com/docker-support-services">Support</a></li>
+                        <li><a href="https://success.docker.com/support">Support</a></li>
                         <li><a href="https://success.docker.com/kbase">Knowledge Base</a></li>
                         <li><a href="https://www.docker.com/products/resources">Resources</a></li>
                     </ul>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -242,7 +242,7 @@
 										<li style="visibility: hidden"><a href="{{ edit_url }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit this page</a></li>{% endif %}
 										<li><a href="https://github.com/docker/docker.github.io/issues/new?body=File: [{{ page.path }}](https://docs.docker.com{{ page.url }})"
 															class="nomunge"><i class="fa fa-check" aria-hidden="true"></i> Request docs changes</a></li>
-										<li><a href="https://www.docker.com/docker-support-services"><i class="fa fa-question" aria-hidden="true"></i> Get support</a></li>
+										<li><a href="https://success.docker.com/support"><i class="fa fa-question" aria-hidden="true"></i> Get support</a></li>
 										<!-- toggle mode -->
 										<li>
 											<div class="toggle-mode">


### PR DESCRIPTION



### Proposed changes

Current link (https://www.docker.com/docker-support-services) gives a 404, as the page no longer exists.
Replaced with link to current support page: https://success.docker.com/support

### Related issues (optional)

Fixes #6764 
