### PR TITLE
Changed host port from 80 to 4000 in get-started/part3.md

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -26,8 +26,8 @@ Toolbox](/toolbox/overview.md).
 shared image here.
 
 - Be sure your image works as a deployed container. Run this command,
-slotting in your info for `username`, `repo`, and `tag`: `docker run -p 80:80
-username/repo:tag`, then visit `http://localhost/`.
+slotting in your info for `username`, `repo`, and `tag`: `docker run -p 4000:80
+username/repo:tag`, then visit `http://localhost:4000/`.
 
 ## Introduction
 
@@ -84,7 +84,7 @@ services:
       restart_policy:
         condition: on-failure
     ports:
-      - "80:80"
+      - "4000:80"
     networks:
       - webnet
 networks:
@@ -101,7 +101,7 @@ This `docker-compose.yml` file tells Docker to do the following:
 
 - Immediately restart containers if one fails.
 
-- Map port 80 on the host to `web`'s port 80.
+- Map port 4000 on the host to `web`'s port 80.
 
 - Instruct `web`'s containers to share port 80 via a load-balanced network
   called `webnet`. (Internally, the containers themselves publish to


### PR DESCRIPTION
### Proposed changes

The host port is set to 80, which is inconsistent with the previous tutorial and doesn't work on Windows. Changing the port to 4000 keeps consistency and works on Windows.

For reference, here is the error when attempting to run the container on port 80:

_C:\Program Files\Docker\Docker\Resources\bin\docker.exe: Error response from daemon: driver failed programming external connectivity on endpoint focused_euler (079893ea98df78bf7043f86072263317be106cbb7f4a3fcde23c2ef19ad39a01): Error starting userland proxy: Bind for 0.0.0.0:80: unexpected error Permission denied.
ERRO[0000] error waiting for container: context canceled_

