### PR TITLE
Fixed broken Link and Power PC to Power

### DIFF
--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -85,13 +85,13 @@ You only need to set up the repository once, after which you can install Docker 
 
     The repository can differ per your architecture and cloud provider, so review the options in this step before running:
 
-    **For all architectures _except_ IBM Power PC:**
+    **For all architectures _except_ IBM Power:**
 
     ```bash
     $ sudo yum-config-manager --enable rhel-7-server-extras-rpms
     ```
 
-    **For IBM Power PC only (little endian):**
+    **For IBM Power only (little endian):**
 
     ```bash
     $ sudo yum-config-manager --enable extras

--- a/ee/ucp/index.md
+++ b/ee/ucp/index.md
@@ -39,7 +39,7 @@ You can also deploy and monitor your applications and services.
 Docker UCP has its own built-in authentication mechanism and integrates with
 LDAP services. It also has role-based access control (RBAC), so that you can
 control who can access and make changes to your cluster and applications.
-[Learn about role-based access control](access-control/index.md).
+[Learn about role-based access control](authorization/index.md).
 
 ![](images/overview-3.png){: .with-border}
 

--- a/install/linux/docker-ee/rhel.md
+++ b/install/linux/docker-ee/rhel.md
@@ -32,11 +32,11 @@ This section lists what you need to consider before installing Docker EE. Items 
 
 ### Architectures and storage drivers
 
-Docker EE supports {{ linux-dist-long }} 64-bit, versions 7.1 and higher (7.1, 7.2, 7.3, 7.4), running on one of the following architectures: `x86_64`, `s390x` (IBM Z), or `ppc64le` (IBM Power PC, little endian format). To ensure you have `ppc64le` (and not `ppc64`), run the command, `uname -m`.
+Docker EE supports {{ linux-dist-long }} 64-bit, versions 7.1 and higher (7.1, 7.2, 7.3, 7.4), running on one of the following architectures: `x86_64`, `s390x` (IBM Z), or `ppc64le` (IBM Power, little endian format). To ensure you have `ppc64le` (and not `ppc64`), run the command, `uname -m`.
 
 > Little endian format only
 >
-> On IBM Power PC systems, Docker EE only supports little endian format, `ppc64le`, even though {{ linux-dist-cap }} 7 ships both big and little endian versions.
+> On IBM Power systems, Docker EE only supports little endian format, `ppc64le`, even though {{ linux-dist-cap }} 7 ships both big and little endian versions.
 
 On {{ linux-dist-long }}, Docker EE supports storage drivers, `overlay2` and `devicemapper`. In Docker EE 17.06.2-ee-5 and higher, `overlay2` is the recommended storage driver. The following limitations apply:
 


### PR DESCRIPTION
### Proposed changes
1. Fixed broken link in ee/ucp/index.md that wasn't redirecting to the correct site. Changed it to authorization/index.md from access-control/index.md (this file doesn't exist) to fix this issue.

2. Changed references of Power PC to Power in 2 files to reflect the actual architecture used.

### Related issues

Refers to #6793 and #6786 
