### PR TITLE
Update docker-compose run --rm doc

### DIFF
--- a/compose/reference/run.md
+++ b/compose/reference/run.md
@@ -20,6 +20,7 @@ Options:
     -u, --user=""         Run as specified username or uid
     --no-deps             Don't start linked services.
     --rm                  Remove container after run. Ignored in detached mode.
+                          Overrides the container's restart policy.
     -p, --publish=[]      Publish a container's port(s) to the host
     --service-ports       Run command with the service's ports enabled and mapped
                           to the host.

--- a/compose/reference/run.md
+++ b/compose/reference/run.md
@@ -20,7 +20,6 @@ Options:
     -u, --user=""         Run as specified username or uid
     --no-deps             Don't start linked services.
     --rm                  Remove container after run. Ignored in detached mode.
-                          Overrides the container's restart policy.
     -p, --publish=[]      Publish a container's port(s) to the host
     --service-ports       Run command with the service's ports enabled and mapped
                           to the host.
@@ -57,3 +56,9 @@ This opens an interactive PostgreSQL shell for the linked `db` container.
 If you do not want the `run` command to start linked containers, use the `--no-deps` flag:
 
     docker-compose run --no-deps web python manage.py shell
+
+If you want to remove the container after running while overriding the container's restart policy, use the `--rm` flag:
+
+    docker-compose run --rm web python manage.py db upgrade
+
+This runs a database upgrade script, and removes the container when finished running, even if a restart policy is specified in the service configuration.


### PR DESCRIPTION
### Proposed changes

Add `Overrides the container's restart policy` to `docker-compose run --rm`'s documentation.

### Related issues

It makes the following change explicit in the documentation
https://github.com/funkyfuture/docker-compose/commit/24ab933ebfd3169491beeb18f0041cabebe4d2d2
https://github.com/docker/compose/issues/1013

I had to use Google to and follow the discussion in #1013 in order to know how to properly achieve what I wanted, after not finding the answer in `docker-compose run --help`.

Related to https://github.com/docker/compose/pull/5997