### PR TITLE
Add how to check that virtualization is enabled in Win 10

### DIFF
--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -61,6 +61,11 @@ To verify your machine meets these requirements, do the following:
 2.  Make sure your Windows system supports Hardware Virtualization Technology and that virtualization is enabled.
 
     <br>
+    **For Windows 10**
+    
+    Run [Speccy](https://www.piriform.com/speccy){: target="_blank" class="_"}, and look at the CPU information.    
+    
+    <br>
     **For Windows 8 or 8.1**
 
     Choose **Start > Task Manager** and navigate to the **Performance** tab.


### PR DESCRIPTION
### Proposed changes

The documentation doesn't explain how to check whether the virtualization is enabled in Microsoft Windows 10. It only explains for Microsoft Windows 7, 8, and 8.1. So I have added how to do it for Microsoft Windows 10.

![image](https://user-images.githubusercontent.com/15331/40879291-716163fe-6652-11e8-90c3-83a9cca5c811.png)

