### PR TITLE
Fixing typo in Publish ports table.

### DIFF
--- a/network/overlay.md
+++ b/network/overlay.md
@@ -279,7 +279,7 @@ routing on the individual Docker daemon hosts.
 | `-p 8080:80`                    | Map TCP port 80 in the container to port 8080 on the overlay network.                                                                               |
 | `-p 8080:80/udp`                | Map UDP port 80 in the container to port 8080 on the overlay network.                                                                               |
 | `-p 8080:80/sctp`               | Map SCTP port 80 in the container to port 8080 on the overlay network.                                                                              |
-| `-p 8080:80/tcp -p 8080:80/udp` | Map TCP port 80 in the container to TCP port 8080 on the overlay network, and map UDP port 80 in the container to UDP port 8080 on the overlay networkt. |
+| `-p 8080:80/tcp -p 8080:80/udp` | Map TCP port 80 in the container to TCP port 8080 on the overlay network, and map UDP port 80 in the container to UDP port 8080 on the overlay network. |
 
 ### Container discovery
 


### PR DESCRIPTION
Extra "t" typo on "network" in the publish ports table.