### PR TITLE
Cgroup is a namespace.

### DIFF
--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -21,8 +21,7 @@ There are four major areas to consider when reviewing Docker security:
 
 Docker containers are very similar to LXC containers, and they have
 similar security features. When you start a container with
-`docker run`, behind the scenes Docker creates a set of namespaces and control
-groups for the container.
+`docker run`, behind the scenes Docker creates a set of namespaces for the container.
 
 **Namespaces provide the first and most straightforward form of
 isolation**: processes running within a container cannot see, and even


### PR DESCRIPTION
Cgroup is a namespace, it would be confusing to name namespaces and cgroups seperately.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
Removed control group form the following sentence:
When you start a container with docker run, behind the scenes Docker creates a set of namespaces and control groups for the container.

This is done because Cgroup is according to the Linux Man pages a namespace. It would be confusing to list namespaces and control groups separately. It would imply that cgroup/control group is not a namespace.

Linux man page: 
http://man7.org/linux/man-pages/man7/namespaces.7.html  

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
