### PR TITLE
dtr: align haproxy timeouts with recommendations

### DIFF
--- a/datacenter/dtr/2.2/guides/admin/configure/use-a-load-balancer.md
+++ b/datacenter/dtr/2.2/guides/admin/configure/use-a-load-balancer.md
@@ -137,9 +137,11 @@ global
 defaults
         mode    tcp
         option  dontlognull
-        timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+        timeout connect 5s
+        timeout client 50s
+        timeout server 50s
+        timeout tunnel 1h
+        timeout client-fin 50s
 ### frontends
 # Optional HAProxy Stats Page accessible at http://<host-ip>:8181/haproxy?stats
 frontend dtr_stats

--- a/datacenter/dtr/2.3/guides/admin/configure/use-a-load-balancer.md
+++ b/datacenter/dtr/2.3/guides/admin/configure/use-a-load-balancer.md
@@ -140,9 +140,11 @@ global
 defaults
         mode    tcp
         option  dontlognull
-        timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+        timeout connect 5s
+        timeout client 50s
+        timeout server 50s
+        timeout tunnel 1h
+        timeout client-fin 50s
 ### frontends
 # Optional HAProxy Stats Page accessible at http://<host-ip>:8181/haproxy?stats
 frontend dtr_stats

--- a/datacenter/dtr/2.4/guides/admin/configure/use-a-load-balancer.md
+++ b/datacenter/dtr/2.4/guides/admin/configure/use-a-load-balancer.md
@@ -140,9 +140,11 @@ global
 defaults
         mode    tcp
         option  dontlognull
-        timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+        timeout connect 5s
+        timeout client 50s
+        timeout server 50s
+        timeout tunnel 1h
+        timeout client-fin 50s
 ### frontends
 # Optional HAProxy Stats Page accessible at http://<host-ip>:8181/haproxy?stats
 frontend dtr_stats

--- a/ee/dtr/admin/configure/use-a-load-balancer.md
+++ b/ee/dtr/admin/configure/use-a-load-balancer.md
@@ -122,9 +122,11 @@ global
 defaults
         mode    tcp
         option  dontlognull
-        timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+        timeout connect 5s
+        timeout client 50s
+        timeout server 50s
+        timeout tunnel 1h
+        timeout client-fin 50s
 ### frontends
 # Optional HAProxy Stats Page accessible at http://<host-ip>:8181/haproxy?stats
 frontend dtr_stats


### PR DESCRIPTION
ported #6573 to DTR docs.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>