### PR TITLE
Update deploying.md

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -322,15 +322,15 @@ $ docker service create \
   --secret domain.key \
   --constraint 'node.labels.registry==true' \
   --mount type=bind,src=/mnt/registry,dst=/var/lib/registry \
-  -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
+  -e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
   -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/secrets/domain.crt \
   -e REGISTRY_HTTP_TLS_KEY=/run/secrets/domain.key \
-  --publish published=80,target=80 \
+  --publish published=443,target=443 \
   --replicas 1 \
   registry:2
 ```
 
-You can access the service on port 80 of any swarm node. Docker sends the
+You can access the service on port 443 of any swarm node. Docker sends the
 requests to the node which is running the service.
 
 ## Load balancing considerations


### PR DESCRIPTION
### Proposed changes

Since these docs are demonstrating how to run a swarm service with TLS support I assume port 443 was intended here.