### PR TITLE
Content Trust link update

### DIFF
--- a/ee/dtr/admin/upgrade.md
+++ b/ee/dtr/admin/upgrade.md
@@ -43,7 +43,7 @@ Before starting your upgrade, make sure that:
 * The version of UCP you are using is supported by the version of DTR you
 are trying to upgrade to. [Check the compatibility matrix](https://success.docker.com/Policies/Compatibility_Matrix).
 * You have a recent [DTR backup](disaster-recovery/create-a-backup.md).
-* You [disable Docker content trust in UCP](/datacenter/ucp/2.2/guides/admin/configure/run-only-the-images-you-trust.md).
+* You [disable Docker content trust in UCP](https://docs.docker.com/ee/ucp/admin/configure/run-only-the-images-you-trust/).
 
 ### Step 1. Upgrade DTR to {{ previous_version }} if necessary
 

--- a/ee/dtr/admin/upgrade.md
+++ b/ee/dtr/admin/upgrade.md
@@ -43,7 +43,7 @@ Before starting your upgrade, make sure that:
 * The version of UCP you are using is supported by the version of DTR you
 are trying to upgrade to. [Check the compatibility matrix](https://success.docker.com/Policies/Compatibility_Matrix).
 * You have a recent [DTR backup](disaster-recovery/create-a-backup.md).
-* You [disable Docker content trust in UCP](https://docs.docker.com/ee/ucp/admin/configure/run-only-the-images-you-trust/).
+* You [disable Docker content trust in UCP](/ee/ucp/admin/configure/run-only-the-images-you-trust/).
 
 ### Step 1. Upgrade DTR to {{ previous_version }} if necessary
 


### PR DESCRIPTION
Update the Disable Content trust link to refer to UCP 3.0.x doc section (instead of UCP 2.2.x)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Update the DTR 2.5.x upgrade link for 'Content Trust' to UCP 3.0.x

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
