### PR TITLE
Add warning about package building policy

### DIFF
--- a/install/linux/docker-ce/centos.md
+++ b/install/linux/docker-ce/centos.md
@@ -149,6 +149,13 @@ from the repository.
     > `yum update` command always installs the highest possible version,
     > which may not be appropriate for your stability needs.
 
+    > **Warning**:
+    >
+    > Our policy is to only build new packages when we release new versions of Docker. This means that new distribution versions will not have a Docker package built for them until the next release of Docker.
+    >
+    > If no package is available for your distribution yet (`yum` replies `No package docker-ce available`), you can try one of the other methods listed on this page.
+    {:.warning}
+
     Docker is installed but not started. The `docker` group is created, but no users are added to the group.
 
 2.  To install a _specific version_ of Docker CE, list the available versions

--- a/install/linux/docker-ce/debian.md
+++ b/install/linux/docker-ce/debian.md
@@ -231,6 +231,13 @@ from the repository.
     > `apt-get update` command always installs the highest possible version,
     > which may not be appropriate for your stability needs.
 
+    > **Warning**:
+    >
+    > Our policy is to only build new packages when we release new versions of Docker. This means that new distribution versions will not have a Docker package built for them until the next release of Docker.
+    >
+    > If no package is available for your distribution yet (`apt-get` replies `unable to locate package docker-ce`), you can try one of the other methods listed on this page.
+    {:.warning}
+
 3.  To install a _specific version_ of Docker CE, list the available versions in the repo, then select and install:
 
     a. List the versions available in your repo:

--- a/install/linux/docker-ce/fedora.md
+++ b/install/linux/docker-ce/fedora.md
@@ -138,6 +138,13 @@ from the repository.
     > `dnf update` command always installs the highest possible version,
     > which may not be appropriate for your stability needs.
 
+    > **Warning**:
+    >
+    > Our policy is to only build new packages when we release new versions of Docker. This means that new distribution versions will not have a Docker package built for them until the next release of Docker.
+    >
+    > If no package is available for your distribution yet (`dnf` replies `No match for argument: docker-ce`), you can try one of the other methods listed on this page.
+    {:.warning}
+
     Docker is installed but not started. The `docker` group is created, but no users are added to the group.
 
 2.  To install a _specific version_ of Docker CE, list the available versions

--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -249,6 +249,13 @@ the repository.
     > `apt-get update` command always installs the highest possible version,
     > which may not be appropriate for your stability needs.
 
+    > **Warning**:
+    >
+    > Our policy is to only build new packages when we release new versions of Docker. This means that new distribution versions will not have a Docker package built for them until the next release of Docker.
+    >
+    > If no package is available for your distribution yet (`apt-get` replies `unable to locate package docker-ce`), you can try one of the other methods listed on this page.
+    {:.warning}
+
 3.  To install a _specific version_ of Docker CE, list the available versions in the repo, then select and install:
 
     a. List the versions available in your repo:


### PR DESCRIPTION
### Proposed changes

Explain to users why Docker packages might be missing. I was told on https://github.com/moby/moby/issues/37247#issuecomment-396416563 that this was an official policy, it should therefore be stated.