### PR TITLE
interlock: add linux to documented constraints

### DIFF
--- a/ee/ucp/interlock/deploy/production.md
+++ b/ee/ucp/interlock/deploy/production.md
@@ -60,7 +60,7 @@ Add another constraint to the `ProxyConstraints` array:
 ```toml
 [Extensions]
   [Extensions.default]
-    ProxyConstraints = ["node.labels.com.docker.ucp.orchestrator.swarm==true", "node.labels.nodetype==loadbalancer"]
+    ProxyConstraints = ["node.labels.com.docker.ucp.orchestrator.swarm==true", "node.platform.os==linux", "node.labels.nodetype==loadbalancer"]
 ```
 
 [Learn how to configure ucp-interlock](configure.md).


### PR DESCRIPTION
lifted this additional constraint from a default UCP 3.0.1 install.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>