### PR TITLE
Switch places of subtitles DNS and Proxy settings

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -174,7 +174,7 @@ friendlyhello         latest              326387cea398
 ```
 >  Troubleshooting for Linux users
 >
-> _DNS settings_
+> _Proxy server settings_
 >
 > Proxy servers can block connections to your web app once it's up and running.
 > If you are behind a proxy server, add the following lines to your
@@ -187,7 +187,7 @@ friendlyhello         latest              326387cea398
 > ENV https_proxy host:port
 > ```
 >
-> _Proxy server settings_
+> _DNS settings_
 >
 > DNS misconfigurations can generate problems with `pip`. You need to set your
 > own DNS server address to make `pip` work properly. You might want


### PR DESCRIPTION
Proxy settings titles was placed in the DNS misconfiguration part, and the DNS settings title was placed in the proxy configuration part. This changes moves the places of the titles so that they both present the section they intend to.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
