### PR TITLE
adds port 4000

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -158,7 +158,7 @@ is not filtered by service:
 docker container ls -q
 ```
 
-You can run `curl -4 http://localhost` several times in a row, or go to that URL in
+You can run `curl -4 http://localhost:4000` several times in a row, or go to that URL in
 your browser and hit refresh a few times.
 
 ![Hello World in browser](images/app80-in-browser.png)


### PR DESCRIPTION
In the docker-compose file, the ports sections maps host port 4000 to container port 80, so if we want to see our app in a browser we should check on port 4000.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
