### PR TITLE
adds port 4000

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -158,7 +158,7 @@ is not filtered by service:
 docker container ls -q
 ```
 
-You can run `curl -4 http://localhost` several times in a row, or go to that URL in
+You can run `curl -4 http://localhost:4000` several times in a row, or go to that URL in
 your browser and hit refresh a few times.
 
 ![Hello World in browser](images/app80-in-browser.png)


### PR DESCRIPTION
In the docker-compose file, the ports sections maps host port 4000 to container port 80, so if we want to see our app in a browser we should check on port 4000.

### Proposed changes
I added port 4000 because that is the port mapped to the container's port 80. So if we want to view our app in the browser or with curl we need to include port 4000 in the url.


### Related issues (optional)
The screenshot image should be updated, too.

Fixes #6904 