### PR TITLE
Remove references to Qemu requirements in multiarch documentation

### DIFF
--- a/docker-for-mac/multi-arch.md
+++ b/docker-for-mac/multi-arch.md
@@ -11,13 +11,12 @@ Docker for Mac provides `binfmt_misc` multi architecture support, so you can run
 containers for different Linux architectures, such as `arm`, `mips`, `ppc64le`,
 and even `s390x`.
 
-This should just work without any configuration, but the containers you run need
-to have the appropriate `qemu` binary inside before you can do
-this. (See <a href="http://wiki.qemu.org/" target="_blank">QEMU</a> for more
-information.)
+This does not require any special configuration in the container itself as it uses
+<a href="http://wiki.qemu.org/" target="_blank">qemu-static</a> from the Docker for
+Mac VM.
 
-So, you can run a container that already has this set up, like the <a
-href="https://resin.io/how-it-works/" target="_blank">resin</a> arm builds:
+You can run an ARM container, like the <a href="https://resin.io/how-it-works/" target="_blank">
+resin</a> arm builds:
 
 ```
 $ docker run resin/armv7hf-debian uname -a
@@ -30,10 +29,6 @@ Linux edd13885f316 4.1.12 #1 SMP Tue Jan 12 10:51:00 UTC 2016 ppc64le GNU/Linux
 
 ```
 
-Running containers pre-configured with `qemu` has the advantage that you can use
-these to do builds `FROM`, so you can build new Multi-CPU architecture packages.
-
-Alternatively, you can bind mount in the `qemu` static binaries to any
-cross-architecture package, such as the semi-official ones using a script like
-this one [https://github.com/justincormack/cross-docker](https://github.com/justincormack/cross-docker). (See the README at the
-given link for details on how to use the script.)
+Multi architecture support makes it easy to build <a href="https://blog.docker.com/2017/11/multi-arch-all-the-things/" target="_blank">
+multi architecture Docker images</a> or experiment with ARM images and binaries
+from your Mac.


### PR DESCRIPTION
It is not actually required to have qemu inside of the container as binfmt_misc uses qemu on the host to function.

Example using a `scratch` image:

```
➜  test git:(master) ✗ CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -ldflags '-w -extldflags "-static"' -o main_arm64 ./main.go
➜  test git:(master) ✗ file main_arm64
main_arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
➜  test git:(master) ✗ cat Dockerfile
FROM scratch
COPY main_arm64 /main_arm64
ENTRYPOINT ["/main_arm64"]
➜  test git:(master) ✗ docker build -t armtest .
Sending build context to Docker daemon   10.2MB
Step 1/3 : FROM scratch
 --->
Step 2/3 : COPY main_arm64 /main_arm64
 ---> Using cache
 ---> 0ecc33c549a3
Step 3/3 : ENTRYPOINT ["/main_arm64"]
 ---> Using cache
 ---> 878434a51a4a
Successfully built 878434a51a4a
Successfully tagged armtest:latest
➜  test git:(master) ✗ docker run armtest
Hello world!
➜  test git:(master) ✗
```