### PR TITLE
nginx.md: Add note about potential security isues

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -38,11 +38,10 @@ you want through the secondary authentication mechanism implemented inside your
 proxy, it also requires that you move TLS termination from the Registry to the
 proxy itself.
 
-> Another important thing to note is that by binding your registry to
-> `localhost:5000` without authentication, you open up a potential loophole in
-> your Docker Registry security - anyone who can log on to the server where your
-> Docker Registry is running can push images to your registry, without
-> authentication. This could have potentially devastating effects.
+> ***NOTE:*** Docker does not recommend binding your registry to `localhost:5000` without
+> authentication. This creates a potential loophole in your Docker Registry security.
+> As a result, anyone with access to your Docker Registry can push images without
+> authentication. 
 
 Furthermore, introducing an extra http layer in your communication pipeline
 makes it more complex to deploy, maintain, and debug. Make sure the extra

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -40,8 +40,8 @@ proxy itself.
 
 > ***NOTE:*** Docker does not recommend binding your registry to `localhost:5000` without
 > authentication. This creates a potential loophole in your Docker Registry security.
-> As a result, anyone with access to your Docker Registry can push images without
-> authentication. 
+> As a result, anyone who can log on to the server where your Docker Registry is running 
+> can push images without authentication. 
 
 Furthermore, introducing an extra http layer in your communication pipeline
 makes it more complex to deploy, maintain, and debug. Make sure the extra

--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -38,6 +38,12 @@ you want through the secondary authentication mechanism implemented inside your
 proxy, it also requires that you move TLS termination from the Registry to the
 proxy itself.
 
+> Another important thing to note is that by binding your registry to
+> `localhost:5000` without authentication, you open up a potential loophole in
+> your Docker Registry security - anyone who can log on to the server where your
+> Docker Registry is running can push images to your registry, without
+> authentication. This could have potentially devastating effects.
+
 Furthermore, introducing an extra http layer in your communication pipeline
 makes it more complex to deploy, maintain, and debug. Make sure the extra
 complexity is required.


### PR DESCRIPTION
I thought about this while setting this up, and then found this guide (I was setting it up without the guide first.)

The potential security implications are important, so I think we should mention them here on this web page. (We could even go further by outright _warning_ people about this, but perhaps letting people know about it so they can make an informed decision is a better way to go. This can be perfectly fine for certain intranet scenarios.)
