### PR TITLE
Add Ubuntu Bionic and Fedora 28

### DIFF
--- a/install/linux/docker-ce/fedora.md
+++ b/install/linux/docker-ce/fedora.md
@@ -27,6 +27,7 @@ To install Docker, you need the 64-bit version of one of these Fedora versions:
 
 - 26
 - 27
+- 28
 
 ### Uninstall old versions
 

--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -32,7 +32,7 @@ To learn more about Docker EE, see
 To install Docker CE, you need the 64-bit version of one of these Ubuntu
 versions:
 
-- Bionic 18.04 (Docker CE 18.05 Edge and higher only)
+- Bionic 18.04 (LTS)
 - Artful 17.10
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)


### PR DESCRIPTION
The stable channel now has packages for Ubuntu Bionic (18.04) and Fedora 28

ping @joaofnfernandes @seemethere PTAL