### PR TITLE
swarm init for DockerToolbox requires --advertise-addr

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -119,6 +119,11 @@ Before we can use the `docker stack deploy` command we first run:
 docker swarm init
 ```
 
+>**Note**: If running via DockerToolbox, you need to run:
+```shell
+docker swarm init --advertise-addr 192.168.99.100:2377
+```
+
 >**Note**: We get into the meaning of that command in [part 4](part4.md).
 > If you don't run `docker swarm init` you get an error that "this node is not a swarm manager."
 


### PR DESCRIPTION
See more info here:
https://stackoverflow.com/questions/38602903/docker-swarm-init-could-not-choose-an-ip-address-error

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
