### PR TITLE
Clear confusion in the restart policies

### DIFF
--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -28,8 +28,8 @@ any of the following:
 |:-----------------|:------------------------------------------------------------------------------------------------|
 | `no`             | Do not automatically restart the container. (the default)                                       |
 | `on-failure`     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.     |
-| `unless-stopped` | Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted. |
-| `always`         | Always restart the container if it stops.                                                       |
+| `always`         | Always restart the container if it stops. If it is manually stopped, it will restart only when Docker daemon restarts or the container itself is manually restarted. (see the second bullet under [restart policy details](#restart-policy-details)) |
+| `unless-stopped` | Similar to `always`, except that when it is manually stopped, it remains stopped even after Docker daemon restarts. |
 
 The following example starts a Redis container and configures it to always
 restart unless it is explicitly stopped or Docker is restarted.

--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -28,8 +28,8 @@ any of the following:
 |:-----------------|:------------------------------------------------------------------------------------------------|
 | `no`             | Do not automatically restart the container. (the default)                                       |
 | `on-failure`     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.     |
-| `always`         | Always restart the container if it stops. If it is manually stopped, it will be restarted only when Docker daemon restarts or the container itself is manually restarted. (see the second bullet under [restart policy details](#restart-policy-details)) |
-| `unless-stopped` | Similar to `always`, except that when the container is manually stopped, it is not restarted even after Docker daemon restarts. |
+| `always`         | Always restart the container if it stops. If it is manually stopped, it is restarted only when Docker daemon restarts or the container itself is manually restarted. (See the second bullet listed in [restart policy details](#restart-policy-details)) |
+| `unless-stopped` | Similar to `always`, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts. |
 
 The following example starts a Redis container and configures it to always
 restart unless it is explicitly stopped or Docker is restarted.

--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -28,8 +28,8 @@ any of the following:
 |:-----------------|:------------------------------------------------------------------------------------------------|
 | `no`             | Do not automatically restart the container. (the default)                                       |
 | `on-failure`     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.     |
-| `always`         | Always restart the container if it stops. If it is manually stopped, it will restart only when Docker daemon restarts or the container itself is manually restarted. (see the second bullet under [restart policy details](#restart-policy-details)) |
-| `unless-stopped` | Similar to `always`, except that when it is manually stopped, it remains stopped even after Docker daemon restarts. |
+| `always`         | Always restart the container if it stops. If it is manually stopped, it will be restarted only when Docker daemon restarts or the container itself is manually restarted. (see the second bullet under [restart policy details](#restart-policy-details)) |
+| `unless-stopped` | Similar to `always`, except that when the container is manually stopped, it is not restarted even after Docker daemon restarts. |
 
 The following example starts a Redis container and configures it to always
 restart unless it is explicitly stopped or Docker is restarted.


### PR DESCRIPTION
### Proposed changes

#### Why the changes?
The docs for the restart policy `unless-stopped` were incorrect: 
  > Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted.  

This implies that a container started with this policy will **not be restarted** if the Docker daemon is restarted, which is incorrect. 

#### What was done?
The functioning of the policy `unless-stopped` was clearly explained. For the sake of clarity, the `active` policy was also explained in a bit more detail.