### PR TITLE
Updated Windows EE Engine install for UCP 3.0.2

### DIFF
--- a/ee/ucp/admin/configure/join-nodes/join-windows-nodes-to-cluster.md
+++ b/ee/ucp/admin/configure/join-nodes/join-windows-nodes-to-cluster.md
@@ -6,7 +6,7 @@ redirect_from:
   - /datacenter/ucp/3.0/guides/admin/configure/join-nodes/join-windows-nodes-to-cluster/
 ---
 
-Docker Enterprise Edition supports worker nodes that run on Windows Server 2016.
+Docker Enterprise Edition supports worker nodes that run on Windows Server 2016 or 1709.
 Only worker nodes are supported on Windows, and all manager nodes in the cluster
 must run on Linux.
 
@@ -16,10 +16,10 @@ Follow these steps to enable a worker node on Windows.
 2.  Configure the Windows node.
 3.  Join the Windows node to the cluster.
 
-## Install Docker EE Engine on Windows Server 2016
+## Install Docker EE Engine on Windows Server 2016 or 1709
 
 [Install Docker EE Engine](/engine/installation/windows/docker-ee/#use-a-script-to-install-docker-ee)
-on a Windows Server 2016 instance to enable joining a cluster that's managed by
+on a Windows Server 2016 or 1709 instance to enable joining a cluster that's managed by
 Docker Enterprise Edition.
 
 ## Configure the Windows node

--- a/install/windows/docker-ee.md
+++ b/install/windows/docker-ee.md
@@ -25,16 +25,16 @@ versions here](/release-notes/) or subscribe to the
 
 With Docker EE, your Windows nodes can join swarms that are managed
 by Docker Universal Control Plane (UCP). When you have Docker EE installed
-on Windows Server 2016 and you have a
-[UCP manager node provisioned](/datacenter/ucp/2.2/guides/admin/install/), you can
-[join your Windows worker nodes to a swarm](/datacenter/ucp/2.2/guides/admin/configure/join-windows-worker-nodes/).
+on Windows Server 2016 or 1709 and you have a
+[UCP manager node provisioned](/ee/ucp/admin/install/), you can
+[join your Windows worker nodes to a swarm](/ee/ucp/admin/configure/join-nodes/join-windows-nodes-to-cluster/).
 
 ## Install Docker EE
 
->Windows Server 1709
+>Windows Server 1803
 >
->Docker Universal Control Plane is not currently supported on Windows Server 1709 due to image incompatibility issues.
->To use UCP, for now, use the current LTSB Windows release and not 1709.
+>Docker Universal Control Plane is not currently supported on Windows Server 1803 due to image incompatibility issues.
+>To use UCP, for now, use the current LTSB Windows release or Windows Server 1709 as UCP Workers.
 
 
 Docker EE for Windows requires Windows Server 2016 or later. See


### PR DESCRIPTION
### Proposed changes
Now with UCP 3.0.2 we support 1709 UCP workers, updated the installation warning banner to reflect that. However in this release we do not support 1803 UCP Workers. 

Also updated links to UCP 3.x not UCP 2.2.x

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
