### PR TITLE
Engine 18.03

### DIFF
--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -201,7 +201,7 @@ To manually install Docker EE, download the `.{{ package-format | downcase }}` f
 
 {% if linux-dist == "centos" %}
 1.  Go to the Docker EE repository URL associated with your trial or subscription
-    in your browser. Go to `{{ linux-dist-url-slug }}/7/x86_64/stable-{{ site.docker_ee_version }}/Packages`
+    in your browser. Go to `{{ linux-dist-url-slug }}/7/x86_64/stable-<VERSION>/Packages`
     and download the `.{{ package-format | downcase }}` file for the Docker version you want to install.
 {% endif %}
 

--- a/ee/engine/release-notes.md
+++ b/ee/engine/release-notes.md
@@ -19,6 +19,28 @@ it references. However, Docker EE also includes back-ported fixes
 defect fixes that you can use in environments where new features cannot be
 adopted as quickly for consistency and compatibility reasons.
 
+## 18.03.1-ee-1 (2018-06-27)
+
+### Important notes about this release
+
+- If you're deploying UCP or DTR, use Docker EE Engine 17.06.
+
+### Client
+
++ Update to docker-ce 18.03.1 client.
++ Add `docker trust` command for image signing and enabling the secure supply chain from development to deployment.
++ Add docker compose on Kubernentes.
+
+### Runtime
+
++ Update to docker-ce 18.03.1 engine.
++ Add support for FIPS 140-2 on x86_64.
++ Add support for Microsoft Windows Server 1709.
++ Add support for Microsoft Windows Server 1803.
++ Windows opt-out telemetry stream.
++ Support for `--chown` with `COPY` and `ADD` in `Dockerfile`.
++ Add support for multiple logging drivers for `docker logs`.
+
 ## 17.06.2-ee-14 (2018-06-21)
 
 ### Client

--- a/ee/engine/release-notes.md
+++ b/ee/engine/release-notes.md
@@ -21,9 +21,10 @@ adopted as quickly for consistency and compatibility reasons.
 
 ## 18.03.1-ee-1 (2018-06-27)
 
-### Important notes about this release
-
-- If you're deploying UCP or DTR, use Docker EE Engine 17.06.
+> Important notes about this release
+>
+> If you're deploying UCP or DTR, use Docker EE Engine 17.06.
+{: .important}
 
 ### Client
 

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -15,8 +15,11 @@ and supported to provide enterprises with the most secure container platform
 in the industry. For more info about Docker EE, including purchasing
 options, see [Docker Enterprise Edition](https://www.docker.com/enterprise-edition/).
 
-<!-- This is populated by logic in js/archive.js -->
-<p id="ee-version-div"></p>
+There are currently two versions of Docker EE Engine available:
+
+* 18.03 - Use this version if you're only running Docker EE Engine.
+* 16.06 - Use this version if you're using Docker Enterprise Edition (Docker
+Engine, UCP, and DTR).
 
 ## Docker EE tiers
 
@@ -88,16 +91,10 @@ and third-party ecosystem solution briefs.
 
 ## Docker Enterprise Edition release cycles
 
-Docker EE is released quarterly. Releases use a time-based versioning
-scheme, so for example, Docker EE version 17.03 was released
-in March 2017. For schedule details, see
-[Time-based release schedule](/engine/installation/#time-based-release-schedule).
-
-Each Docker EE release is supported and maintained for one year and
+Each Docker EE release is supported and maintained for 24 months, and
 receives security and critical bug fixes during this period.
 
-The Docker API version is independent of the Docker platform version. The API
-version doesn't change from Docker 1.13.1 to Docker 17.03. We maintain
+The Docker API version is independent of the Docker platform version. We maintain
 careful API backward compatibility and deprecate APIs and features slowly and
 conservatively. We remove features after deprecating them for a period of
 three stable releases. Docker 1.13 introduced improved interoperability

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -18,7 +18,7 @@ options, see [Docker Enterprise Edition](https://www.docker.com/enterprise-editi
 There are currently two versions of Docker EE Engine available:
 
 * 18.03 - Use this version if you're only running Docker EE Engine.
-* 16.06 - Use this version if you're using Docker Enterprise Edition (Docker
+* 17.06 - Use this version if you're using Docker Enterprise Edition 2.0 (Docker
 Engine, UCP, and DTR).
 
 ## Docker EE tiers

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -22,6 +22,29 @@ options, see [Docker Enterprise Edition](https://www.docker.com/enterprise-editi
 
 {% include docker_ce_ee.md %}
 
+### Enterprise Edition Basic
+
+With Docker EE Basic, you can deploy Docker Enterprise Engine
+to manage your container workloads in a flexible way. You can manage workloads
+on Windows, Linux, on-premise or on the cloud.
+
+Docker EE Basic has enterprise class support with defined SLAs, extended
+maintenance cycles for patches for up to 24 months.
+
+[Learn more about the supported platforms](#supported-platforms).
+
+### Enterprise Edition Standard and Advanced
+
+Docker EE Standard has everything the Basic edition has, and extends it with
+private image management, integrated image signing policies, and cluster
+management with support for Kubernetes and Swarm orchestrators.
+
+Docker EE Advanced takes this one step further and allows you to implement
+node-based RBAC policies, image promotion policies, image mirroring, and
+scan your images for vulnerabilities.
+
+[Learn more about Docker EE Standard and Advanced](/ee/index.md).
+
 ## Supported platforms
 
 The following table shows all of the platforms that are available for Docker EE.

--- a/install/linux/docker-ee/oracle.md
+++ b/install/linux/docker-ee/oracle.md
@@ -27,7 +27,7 @@ This section lists what you need to consider before installing Docker EE. Items 
 - Find the URL for your Docker EE repo at [Docker Store](https://store.docker.com/my-content){: target="_blank" class="_" }.
 - Uninstall old versions of Docker.
 - Remove old Docker repos from `/etc/yum.repos.d/`.
-- Disable SELinux if installing or upgrading Docker EE 17.06.1.
+- Disable SELinux if installing or upgrading Docker EE 17.06.1 or newer.
 
 ### Architectures and storage drivers
 
@@ -56,7 +56,7 @@ $ sudo yum remove docker \
 {% capture selinux-warning %}
 > Docker EE cannot install on {{ linux-dist-long }} with SELinux enabled
 >
-> If you have `selinux` enabled and you attempt to install Docker EE 17.06.1, you get an error that the `container-selinux` package cannot be found..
+> If you have `selinux` enabled and you attempt to install Docker EE 17.06.1 or newer, you get an error that the `container-selinux` package cannot be found..
 {:.warning}
 {% endcapture %}
 {{ selinux-warning }}

--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -36,15 +36,10 @@ Use this URL when you see the placeholder text `<DOCKER-EE-URL>`.
 To learn more about Docker EE, see
 [Docker Enterprise Edition](https://www.docker.com/enterprise-edition/){: target="_blank" class="_" }.
 
-### OS requirements
+### System requirements
 
-To install Docker EE, you need the 64-bit version of one of these Ubuntu versions:
-
-- Xenial 16.04 (LTS)
-- Trusty 14.04 (LTS)
-
-Docker EE is supported on `x86_64` (or `amd64`), `s390x` (IBM Z), and `ppc64el`
-(IBM Power) architectures.
+To learn more about software requirements and supported storage drivers,
+check the [compatibility matrix](https://success.docker.com/article/compatibility-matrix).
 
 ### Uninstall old versions
 
@@ -60,29 +55,20 @@ It's OK if `apt-get` reports that none of these packages are installed.
 The contents of `/var/lib/docker/`, including images, containers, volumes, and
 networks, are preserved. The Docker EE package is now called `docker-ee`.
 
-### Supported storage drivers
-
-Docker EE on Ubuntu supports `overlay2` and `aufs` storage drivers.
-
-- For new installations on version 4 and higher of the Linux kernel, `overlay2`
-  is supported and preferred over `aufs`.
-- For version 3 of the Linux kernel, `aufs` is supported because `overlay` or
-  `overlay2` drivers are not supported by that kernel version.
-
-If you need to use `aufs`, you need to do additional preparation as
-outlined below.
-
 #### Extra steps for aufs
 
+If your version supports the `aufs` storage driver, you need some preparation
+before installing Docker.
+
 <ul class="nav nav-tabs">
-  <li class="active"><a data-toggle="tab" data-target="#aufs_prep_xenial">Xenial 16.04 and newer</a></li>
+  <li class="active"><a data-toggle="tab" data-target="#aufs_prep_xenial">Xenial 16.04 or higher</a></li>
   <li><a data-toggle="tab" data-target="#aufs_prep_trusty">Trusty 14.04</a></li>
 </ul>
 <div class="tab-content">
 <div id="aufs_prep_xenial" class="tab-pane fade in active" markdown="1">
 
-For Ubuntu 16.04 and higher, the Linux kernel includes support for OverlayFS,
-and Docker CE uses the `overlay2` storage driver by default. If you need
+For Ubuntu 16.04 and higher, the Linux kernel includes support for overlay2,
+and Docker EE uses it as the default storage driver. If you need
 to use `aufs` instead, you need to configure it manually.
 See [aufs](/engine/userguide/storagedriver/aufs-driver.md)
 
@@ -149,7 +135,18 @@ from the repository.
       $ DOCKER_EE_URL="<DOCKER-EE-URL>"
       ```
 
-4.  Add Docker's official GPG key using your customer Docker EE repository URL:
+4. Temporarily add a `$DOCKER_EE_VERSION` variable into your environment.
+    There are currently two versions of Docker EE Engine available:
+
+    * `stable-18.03` - Use this version if you're only running Docker EE Engine.
+    * `stable-17.06` - Use this version if you're using Docker Enterprise Edition (Docker
+    Engine, UCP, and DTR).
+
+    ```bash
+    $ DOCKER_EE_VERSION=<YOUR_VERSION>
+    ```
+
+5.  Add Docker's official GPG key using your customer Docker EE repository URL:
 
     ```bash
     $ curl -fsSL "${DOCKER_EE_URL}/ubuntu/gpg" | sudo apt-key add -
@@ -169,7 +166,7 @@ from the repository.
     sub   4096R/6D085F96 2017-02-22
     ```
 
-5.  Use the following command to set up the **stable** repository. Use the
+6.  Use the following command to set up the **stable** repository. Use the
     command as-is. It works because of the variable you set earlier.
 
     > **Note**: The `lsb_release -cs` sub-command below returns the name of your
@@ -188,7 +185,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=amd64] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       stable-{{ site.docker_ee_version }}"
+       $DOCKER_EE_VERSION"
     ```
 
     </div>
@@ -198,7 +195,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=s390x] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       stable-{{ site.docker_ee_version }}"
+       $DOCKER_EE_VERSION"
     ```
 
     </div>
@@ -208,7 +205,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=ppc64el] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       stable-{{ site.docker_ee_version }}"
+       $DOCKER_EE_VERSION"
     ```
 
     </div>
@@ -299,7 +296,7 @@ a new file each time you want to upgrade Docker EE.
 
 1.  Go to the Docker EE repository URL associated with your
     trial or subscription in your browser. Go to
-    `ubuntu/x86_64/stable-{{ site.docker_ee_version }}` and download the `.deb` file for the
+    `ubuntu/x86_64/stable-<VERSION>` and download the `.deb` file for the
     Docker EE version and architecture you want to install.
 
 2.  Install Docker EE, changing the path below to the path where you downloaded
@@ -353,5 +350,4 @@ You must delete any edited configuration files manually.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md).
-
 - Continue with the [User Guide](/engine/userguide/index.md).

--- a/install/windows/docker-ee.md
+++ b/install/windows/docker-ee.md
@@ -7,35 +7,17 @@ redirect_from:
 - /engine/installation/windows/docker-ee/
 ---
 
-{% capture filename %}{{ page.win_latest_build }}.zip{% endcapture %}
-{% capture download_url %}https://download.docker.com/components/engine/windows-server/{{ site.docker_ee_version }}/{{ filename }}{% endcapture %}
-
-
 Docker Enterprise Edition for Windows Server (*Docker EE*) enables native
 Docker containers on Windows Server. Windows Server 2016 and later versions are supported. The Docker EE installation package
 includes everything you need to run Docker on Windows Server.
 This topic describes pre-install considerations, and how to download and
 install Docker EE.
 
->**Looking for Release Notes?** [Get release notes for all
-versions here](/release-notes/) or subscribe to the
-[releases feed on the Docker Blog](http://blog.docker.com/category/engineering/docker-releases/).
-
-## Docker Universal Control Plane and Windows
-
-With Docker EE, your Windows nodes can join swarms that are managed
-by Docker Universal Control Plane (UCP). When you have Docker EE installed
-on Windows Server 2016 or 1709 and you have a
-[UCP manager node provisioned](/ee/ucp/admin/install/), you can
-[join your Windows worker nodes to a swarm](/ee/ucp/admin/configure/join-nodes/join-windows-nodes-to-cluster/).
+> Release notes
+>
+> You can [get release notes for all versions here](/release-notes/)
 
 ## Install Docker EE
-
->Windows Server 1803
->
->Docker Universal Control Plane is not currently supported on Windows Server 1803 due to image incompatibility issues.
->To use UCP, for now, use the current LTSB Windows release or Windows Server 1709 as UCP Workers.
-
 
 Docker EE for Windows requires Windows Server 2016 or later. See
 [What to know before you install](#what-to-know-before-you-install) for a
@@ -54,7 +36,7 @@ full list of prerequisites.
     (Install-WindowsFeature Containers).RestartNeeded
     ```
     If the output of this command is **Yes**, then restart the server with:
-    
+
     ```PowerShell
     Restart-Computer
     ```
@@ -75,7 +57,6 @@ full list of prerequisites.
 
     Hello from Docker!
     This message shows that your installation appears to be working correctly.
-    <snip>
     ```
 
 ### (optional) Make sure you have all required updates
@@ -89,60 +70,6 @@ sconfig
 ```
 
 Select option `6) Download and Install Updates`.
-
-## Use a script to install Docker EE
-
-Use the following steps when you want to install manually, script automated
-installs, or install on air-gapped systems.
-
-1.  In a PowerShell command prompt, download the installer archive on a machine
-    that has a connection.
-
-    ```PowerShell
-    # On an online machine, download the zip file.
-    invoke-webrequest -UseBasicparsing -Outfile {{ filename }} {{ download_url }}
-    ```
-
-2.  Copy the zip file to the machine where you want to install Docker. In a
-    PowerShell command prompt, use the following commands to extract the archive,
-    register, and start the Docker service.
-
-    ```PowerShell
-    #Stop Docker service
-    Stop-Service docker
-    
-    # Extract the archive.
-    Expand-Archive {{ filename }} -DestinationPath $Env:ProgramFiles -Force
-
-    # Clean up the zip file.
-    Remove-Item -Force {{ filename }}
-
-    # Install Docker. This requires rebooting.
-    $null = Install-WindowsFeature containers
-
-    # Add Docker to the path for the current session.
-    $env:path += ";$env:ProgramFiles\docker"
-
-    # Optionally, modify PATH to persist across sessions.
-    $newPath = "$env:ProgramFiles\docker;" +
-    [Environment]::GetEnvironmentVariable("PATH",
-    [EnvironmentVariableTarget]::Machine)
-
-    [Environment]::SetEnvironmentVariable("PATH", $newPath,
-    [EnvironmentVariableTarget]::Machine)
-
-    # Register the Docker daemon as a service.
-    dockerd --register-service
-
-    # Start the Docker service.
-    Start-Service docker
-    ```
-
-3.  Test your Docker EE installation by running the `hello-world` container.
-
-    ```PowerShell
-    docker container run hello-world:nanoserver
-    ```
 
 ## Install a specific version
 

--- a/js/archive.js
+++ b/js/archive.js
@@ -50,9 +50,5 @@ if (window.navigator.onLine) {
       });
     } else {
       isArchive = false;
-      /* This is only relevant to /enterprise/index.md */
-      if (document.getElementById('ee-version-div')) {
-        document.getElementById('ee-version-div').textContent += "The latest version of Docker EE Engine is {{ site.docker_ee_version }}.";
-      }
     }  });
 }


### PR DESCRIPTION
This change updates the installation instructions for the upcoming 18.03 EE engine.
The docs don't have clean versioning for EE-related things, so for the time being I left a couple of notes telling users when to install 17.06 or 18.03.