### PR TITLE
Fix broken link

### DIFF
--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -22,7 +22,7 @@ Services are built once and then tagged, by default as `project_service`. For
 example, `composetest_db`. If the Compose file specifies an
 [image](/compose/compose-file/index.md#image) name, the image is
 tagged with that name, substituting any variables beforehand. See [variable
-substitution](compose/compose-file/#variable-substitution).
+substitution](/compose/compose-file/#variable-substitution).
 
 If you change a service's Dockerfile or the contents of its
 build directory, run `docker-compose build` to rebuild it.

--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -22,7 +22,7 @@ Services are built once and then tagged, by default as `project_service`. For
 example, `composetest_db`. If the Compose file specifies an
 [image](/compose/compose-file/index.md#image) name, the image is
 tagged with that name, substituting any variables beforehand. See [variable
-substitution](#variable-substitution).
+substitution](compose/compose-file/#variable-substitution).
 
 If you change a service's Dockerfile or the contents of its
 build directory, run `docker-compose build` to rebuild it.


### PR DESCRIPTION
Changed link

Link to "variable substitution" was borked


NOTE: I cannot test this change
