### PR TITLE
Clean up EE engine install instructions

### DIFF
--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -127,7 +127,20 @@ You only need to set up the repository once, after which you can install Docker 
 
 {% elsif section == "install-using-yum-repo" %}
 
-1.  Install the _latest version_ of Docker EE, or go to the next step to install a specific version:
+There are currently two versions of Docker EE Engine available:
+
+* 18.03 - Use this version if you're only running Docker EE Engine.
+* 17.06 - Use this version if you're using Docker Enterprise Edition 2.0 (Docker
+Engine, UCP, and DTR).
+
+1. By default, Docker EE Engine 17.06 is installed. If you want to install the
+18.03 version run:
+
+    ```bash
+    sudo yum-config-manager --enable docker-ee-stable-18.03
+    ```
+
+2.  Install the latest patch release, or go to the next step to install a specific version:
 
     ```bash
     $ sudo yum -y install docker-ee
@@ -135,7 +148,7 @@ You only need to set up the repository once, after which you can install Docker 
 
     If prompted to accept the GPG key, verify that the fingerprint matches `{{ gpg-fingerprint }}`, and if so, accept it.
 
-2.  To install a _specific version_ of Docker EE (recommended in production), list versions and install:
+3.  To install a _specific version_ of Docker EE (recommended in production), list versions and install:
 
     a.  List and sort the versions available in your repo. This example sorts results by version number, highest to lowest, and is truncated:
 
@@ -155,7 +168,7 @@ You only need to set up the repository once, after which you can install Docker 
 
     Docker is installed but not started. The `docker` group is created, but no users are added to the group.
 
-3.  Start Docker:
+4.  Start Docker:
 
     > If using `devicemapper`, ensure it is properly configured before starting Docker, per the [storage guide](/storage/storagedriver/device-mapper-driver/){: target="_blank" class="_" }.
 
@@ -163,7 +176,7 @@ You only need to set up the repository once, after which you can install Docker 
     $ sudo systemctl start docker
     ```
 
-4.  Verify that Docker EE is installed correctly by running the `hello-world`
+5.  Verify that Docker EE is installed correctly by running the `hello-world`
     image. This command downloads a test image, runs it in a container, prints
     an informational message, and exits:
 

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -21,6 +21,8 @@ There are currently two versions of Docker EE Engine available:
 * 17.06 - Use this version if you're using Docker Enterprise Edition 2.0 (Docker
 Engine, UCP, and DTR).
 
+[Learn more](https://success.docker.com/article/KB000807)
+
 ## Docker EE tiers
 
 {% include docker_ce_ee.md %}

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -21,7 +21,7 @@ There are currently two versions of Docker EE Engine available:
 * 17.06 - Use this version if you're using Docker Enterprise Edition 2.0 (Docker
 Engine, UCP, and DTR).
 
-[Learn more](https://success.docker.com/article/KB000807)
+[Learn more](https://success.docker.com/article/engine-18-03-faqs)
 
 ## Docker EE tiers
 

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -71,10 +71,15 @@ These are the operating systems where you can install Docker EE.
 | [SUSE Linux Enterprise Server]({{ page.install-prefix-ee }}/suse.md) | {{ page.green-check }} | {{ page.green-check }} | {{ page.green-check }} |
 | [Ubuntu]({{ page.install-prefix-ee }}/ubuntu.md)                     | {{ page.green-check }} | {{ page.green-check }} | {{ page.green-check }} |
 | [Microsoft Windows Server 2016](/install/windows/docker-ee.md)       | {{ page.green-check }} |                        |                        |
+| [Microsoft Windows Server 1709](/install/windows/docker-ee.md)       | {{ page.green-check }} |                        |                        |
+| [Microsoft Windows Server 1803](/install/windows/docker-ee.md)       | {{ page.green-check }} |                        |                        |
 
-> Limitations on IBM Power architecture
+
+> When using Docker EE Standard or Advanced
 >
-> Neither UCP managers nor workers are supported on IBM Power.
+> IBM Power is not supported as managers or workers.
+> Microsoft Windows Server is not supported as a manager. Microsoft Windows
+> Server 1803 is not supported as a worker.
 
 ### Docker Certified Infrastructure
 

--- a/install/linux/docker-ee/centos.md
+++ b/install/linux/docker-ee/centos.md
@@ -19,7 +19,8 @@ title: Get Docker EE for CentOS
 
 ## Prerequisites
 
-This section lists what you need to consider before installing Docker EE. Items that require action are explained below.
+This section lists what you need to consider before installing Docker EE. Items
+that require action are explained below.
 
 - Use {{ linux-dist-cap }} 64-bit 7.1 and higher on `x86_64`.
 - Use storage driver `overlay2` or `devicemapper` (`direct-lvm` mode in production).

--- a/install/linux/docker-ee/suse.md
+++ b/install/linux/docker-ee/suse.md
@@ -164,6 +164,12 @@ Before you install Docker EE for the first time on a new host machine, you need
 to set up the Docker repository. Afterward, you can install and update Docker EE
 from the repository.
 
+There are currently two versions of Docker EE Engine available:
+
+* 18.03 - Use this version if you're only running Docker EE Engine.
+* 17.06 - Use this version if you're using Docker Enterprise Edition 2.0 (Docker
+Engine, UCP, and DTR).
+
 #### Set up the repository
 
 1.  Temporarily add a `$DOCKER_EE_URL` variable into your environment. This
@@ -171,49 +177,27 @@ from the repository.
     with the URL you noted down in the [prerequisites](#prerequisites).
 
     ```bash
-    $ DOCKER_EE_URL="<DOCKER-EE-URL>"
+    $ DOCKER_EE_URL="<DOCKER-EE-URL>/sles/12.3/<ARCHITECTURE>/stable-<VERSION>"
+    ```
+
+    Where:
+    * `DOCKER-EE-URL` is the URL from your Docker Store subscription.
+    * `ARCHITECTURE` is `x86_64`, `s390x`, or `ppc64le`.
+    * `VERSION` is `18.03` or `17.06`.
+
+    As an example your command should look like:
+
+    ```bash
+    DOCKER_EE_URL="https://storebits.docker.com/ee/sles/sub-555-55-555/sles/12.3/x86_64/stable-17.06"
     ```
 
 2.  Use the following command to set up the **stable** repository. Use the
     command as-is. It works because of the variable you set in the previous
     step.
 
-    <ul class="nav nav-tabs">
-      <li class="active"><a data-toggle="tab" data-target="#x86_64_repo">x86_64 / amd64</a></li>
-      <li><a data-toggle="tab" data-target="#s390x_repo">IBM Z (s390x)</a></li>
-      <li><a data-toggle="tab" data-target="#ppc64le_repo">IBM Power (ppc64le)</a></li>
-    </ul>
-    <div class="tab-content">
-    <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
-
     ```bash
-    $ sudo zypper addrepo \
-        "${DOCKER_EE_URL}/sles/12.3/x86_64/stable-{{ site.docker_ee_version }}" \
-        docker-ee-stable
+    $ sudo zypper addrepo $DOCKER_EE_URL docker-ee-stable
     ```
-
-    </div>
-    <div id="s390x_repo" class="tab-pane fade" markdown="1">
-
-    ```bash
-    $ sudo zypper addrepo \
-        "${DOCKER_EE_URL}/sles/12.3/s390x/stable-{{ site.docker_ee_version }}" \
-        docker-ee-stable
-    ```
-
-    </div>
-
-    <div id="ppc64le_repo" class="tab-pane fade" markdown="1">
-
-    ```bash
-    $ sudo zypper addrepo \
-        "${DOCKER_EE_URL}/sles/12.3/ppc64le/stable-{{ site.docker_ee_version }}" \
-        docker-ee-stable
-    ```
-
-    </div>
-    </div><!--tab-content-->
-
 
 3.  Import the GPG key from the repository. Use the command as-is. It works
     because of the variable you set earlier.


### PR DESCRIPTION
This change makes it clear for linux users how to install EE engine 17.06 or 18.03.