### PR TITLE
ucp support dump: include hostname and time

### DIFF
--- a/datacenter/ucp/2.0/guides/support.md
+++ b/datacenter/ucp/2.0/guides/support.md
@@ -35,5 +35,6 @@ docker run --rm \
   --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   {{ page.docker_image }} \
-  support > docker-support.tgz
+  support > \
+  docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```

--- a/datacenter/ucp/2.1/guides/get-support.md
+++ b/datacenter/ucp/2.1/guides/get-support.md
@@ -35,7 +35,8 @@ docker run --rm \
   --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   {{ page.docker_image }} \
-  support > docker-support.tgz
+  support > \
+  docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```
 
 This support dump only contains logs for the node where you're running the

--- a/datacenter/ucp/2.2/guides/admin/install/architecture-specific-images.md
+++ b/datacenter/ucp/2.2/guides/admin/install/architecture-specific-images.md
@@ -24,7 +24,8 @@ docker container run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --log-driver none \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }}${_ARCH} \
-  support > docker-support.tgz
+  support > \
+  docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```
 
 In this example, the environment variable is named `_ARCH`, but you can use any 

--- a/datacenter/ucp/2.2/guides/get-support.md
+++ b/datacenter/ucp/2.2/guides/get-support.md
@@ -39,7 +39,8 @@ docker container run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --log-driver none \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} \
-  support > docker-support.tgz
+  support > \
+  docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```
 
 This support dump only contains logs for the node where you're running the

--- a/ee/get-support.md
+++ b/ee/get-support.md
@@ -37,7 +37,8 @@ docker container run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --log-driver none \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} \
-  support > docker-support.tgz
+  support > \
+  docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```
 
 This support dump only contains logs for the node where you're running the

--- a/ee/ucp/admin/install/architecture-specific-images.md
+++ b/ee/ucp/admin/install/architecture-specific-images.md
@@ -26,7 +26,8 @@ docker container run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --log-driver none \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }}${_ARCH} \
-  support > docker-support.tgz
+  support > \
+  docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```
 
 In this example, the environment variable is named `_ARCH`, but you can use any 


### PR DESCRIPTION
What I did:

1. Use `sed` to modify `docker/ucp > docker-support.tgz` to include hostname and timestamp in the output file

        git grep -l docker-support |grep -v reference  |xargs sed -i  '/docker-support/ s:docker-support:\\\
          docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S):

    Changing this:

        docker run --rm \
          --name ucp \
          -v /var/run/docker.sock:/var/run/docker.sock \
          docker/ucp:2.0.3 \
          support > \ docker-support.tgz

    To this:

        docker run --rm \
          --name ucp \
          -v /var/run/docker.sock:/var/run/docker.sock \
          docker/ucp:2.0.3 \
          support > \
          docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz

    ... in all files where `docker-support` appeared, except for the `docker/ucp` reference docs, since those are derived from `docker/ucp --help`, where the example hasn't changed.

2. Review changes locally at http://0.0.0.0:4000 via `docker-compose buil && docker-compose up`

Why:

Getting 10 files named `docker-support.tgz` on a support case gets tiresome.