### PR TITLE
Add new mount requirements for Ubuntu install

### DIFF
--- a/ee/ucp/admin/install/index.md
+++ b/ee/ucp/admin/install/index.md
@@ -55,13 +55,14 @@ for opening networking ports. Ensure that your hardware or software firewalls
 are open appropriately or disabled.
 
 > Ubuntu 14.04 mounts
-> 
+>
 > For UCP to install correctly on Ubuntu 14.04, `/mnt` and other mounts
 > must be shared:
 > ```
 > sudo mount --make-shared /mnt
-> sudo mount --make-shared / 
-> sudo mount --make-shared /run 
+> sudo mount --make-shared /
+> sudo mount --make-shared /run
+> sudo mount --make-shared /dev
 > ```
 
 To install UCP:
@@ -90,7 +91,7 @@ To install UCP:
 > Custom CNI plugins
 >
 > If you want to use a third-party Container Networking Interface (CNI) plugin,
-> like Flannel or Weave, modify the previous command line to include the 
+> like Flannel or Weave, modify the previous command line to include the
 > `--cni-installer-url` option. Learn how to
 > [install a CNI plugin](../../kubernetes/install-cni-plugin.md).
 {: important}


### PR DESCRIPTION
### Proposed changes
Due to changes to the kubelet to support storage drivers we need to make
`/dev` mount shareable.

### Unreleased project version (optional)

Already released version of UCP 3.0.2

cc @joaofnfernandes 