### PR TITLE
introduce rethinkcli non-interactive mode for DTR 2.2-2.5

### DIFF
--- a/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -50,20 +50,31 @@ commands:
 
 {% raw %}
 ```bash
-# This command will start a RethinkDB client attached to the database
-# on the current node.
+# List problems in the cluster detected by the current node.
+echo 'r.db("rethinkdb").table("current_issues")' | \
+  docker exec -i \
+    $(docker ps -q --filter name=dtr-rethinkdb) \
+    rethinkcli non-interactive; \
+    echo
+```
+{% endraw %}
+
+On a healthy cluster the output will be `[]`.
+
+RethinkDB stores data in different databases that contain multiple tables. This
+container can also be used to connect to the local DTR replica and
+interactively query the contents of the DB.
+
+{% raw %}
+```bash
 docker exec -it $(docker ps -q --filter name=dtr-rethinkdb) rethinkcli
 ```
 {% endraw %}
 
-RethinkDB stores data in different databases that contain multiple tables. The `rethinkcli`
-tool launches an interactive prompt where you can run RethinkDB
-queries such as:
-
 ```none
-# List problems detected within the rethinkdb cluster
+# List problems in the cluster detected by the current node.
 > r.db("rethinkdb").table("current_issues")
-...
+[]
 
 # List all the DBs in RethinkDB
 > r.dbList()
@@ -94,7 +105,7 @@ queries such as:
 ...
 ```
 
-Indvidual DBs and tables are a private implementation detail and may change in DTR
+Individual DBs and tables are a private implementation detail and may change in DTR
 from version to version, but you can always use `dbList()` and `tableList()` to explore
 the contents and data structure.
 

--- a/ee/dtr/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/ee/dtr/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -39,7 +39,7 @@ that has `sh` and `ping`.
 
 DTR uses RethinkDB for persisting data and replicating it across replicas.
 It might be helpful to connect directly to the RethinkDB instance running on a
-DTR replica to check the DTR internal state. 
+DTR replica to check the DTR internal state.
 
 > **Warning**: Modifying RethinkDB directly is not supported and may cause
 > problems.
@@ -48,26 +48,34 @@ DTR replica to check the DTR internal state.
 Use SSH to log into a node that is running a DTR replica, and run the following
 commands:
 
-```bash
 {% raw %}
-# REPLICA_ID will be the replica ID for the current node.
-REPLICA_ID=$(docker ps -lf name='^/dtr-rethinkdb-.{12}$' --format '{{.Names}}' | cut -d- -f3)
-# This command will start a RethinkDB client attached to the database
-# on the current node.
-docker run -it --rm \
-  --net dtr-ol \
-  -v dtr-ca-$REPLICA_ID:/ca dockerhubenterprise/rethinkcli:v2.2.0 \
-  $REPLICA_ID
-{% endraw %}
+```bash
+# List problems in the cluster detected by the current node.
+echo 'r.db("rethinkdb").table("current_issues")' | \
+  docker exec -i \
+    $(docker ps -q --filter name=dtr-rethinkdb) \
+    rethinkcli non-interactive; \
+    echo
 ```
+{% endraw %}
 
-This container connects to the local DTR replica and launches a RethinkDB client 
-that can be used to inspect the contents of the DB. RethinkDB 
-stores data in different databases that contain multiple tables. The `rethinkcli`
-tool launches an interactive prompt where you can run RethinkDB 
-queries such as:
+On a healthy cluster the output will be `[]`.
+
+RethinkDB stores data in different databases that contain multiple tables. This
+container can also be used to connect to the local DTR replica and
+interactively query the contents of the DB.
+
+{% raw %}
+```bash
+docker exec -it $(docker ps -q --filter name=dtr-rethinkdb) rethinkcli
+```
+{% endraw %}
 
 ```none
+# List problems in the cluster detected by the current node.
+> r.db("rethinkdb").table("current_issues")
+[]
+
 # List all the DBs in RethinkDB
 > r.dbList()
 [ 'dtr2',
@@ -86,7 +94,7 @@ queries such as:
   'repositories',
   'repository_team_access',
   'tags' ]
-  
+
 # List the entries in the repositories table
 > r.db('dtr2').table('repositories')
 [ { id: '19f1240a-08d8-4979-a898-6b0b5b2338d8',
@@ -95,13 +103,9 @@ queries such as:
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
 ...
-
-# List problems detected within the rethinkdb cluster
-> r.db("rethinkdb").table("current_issues")
-...
 ```
 
-Indvidual DBs and tables are a private implementation detail and may change in DTR
+Individual DBs and tables are a private implementation detail and may change in DTR
 from version to version, but you can always use `dbList()` and `tableList()` to explore
 the contents and data structure.
 


### PR DESCRIPTION
### What I did
1. introduce rethinkcli non-interactive mode for DTR 2.2-2.5
    - This cuts the amount of copy-paste from the docs from at least two to one.
    - Removes the need to precisely position cursor when copying out commands to not copy prompt

2. ported #6061 and #5450 to 2.5 docs 
    - 2.5 has rethinkcli baked in too
    - `current_issues` is still the most interesting table from a membership troubleshooting standpoint

3. Rendered docs locally and tested 2.4/2.5 commands with copy-paste into DTR 2.4.5

4. Rendered docs locally and tested 2.2/2.3 commands with copy-pasted into DTR 2.3.5