### PR TITLE
Seperate 2016 and 1709 offline bundles for UCP

### DIFF
--- a/_data/ddc_offline_files_2.yaml
+++ b/_data/ddc_offline_files_2.yaml
@@ -8,15 +8,17 @@
   tar-files:
     - description: "3.0.2 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.0.2.tar.gz
-    - description: "3.0.2 Windows"
+    - description: "3.0.2 Windows Server 2016 LTSC"
+      url: https://packages.docker.com/caas/ucp_images_win_2016_3.0.2.tar.gz
+    - description: "3.0.2 Windows Server 1709"
       url: https://packages.docker.com/caas/ucp_images_win_1709_3.0.2.tar.gz
     - description: "3.0.1 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.0.1.tar.gz
-    - description: "3.0.1 Windows"
+    - description: "3.0.1 Windows Server 2016 LTSC"
       url: https://packages.docker.com/caas/ucp_images_win_3.0.1.tar.gz
     - description: "3.0.0 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.0.0.tar.gz
-    - description: "3.0.0 Windows"
+    - description: "3.0.0 Windows Server 2016 LTSC"
       url: https://packages.docker.com/caas/ucp_images_win_3.0.0.tar.gz
 - product: "ucp"
   version: "2.2"


### PR DESCRIPTION
### Proposed changes

Fixes https://github.com/docker/docker.github.io/issues/6978

Split out 1709 and 2016 offline bundles for UCP .

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
