### PR TITLE
1.22.0 release notes and documentation

### DIFF
--- a/_includes/content/compose-extfields-sub.md
+++ b/_includes/content/compose-extfields-sub.md
@@ -2,6 +2,12 @@ It is possible to re-use configuration fragments using extension fields. Those
 special fields can be of any format as long as they are located at the root of
 your Compose file and their name start with the `x-` character sequence.
 
+> **Note**
+>
+> Starting with the 3.7 format (for the 3.x series) and 2.4 format
+> (for the 2.x series), extension fields are also allowed at the root
+> of service, volume, network, config and secret definitions.
+
 ```none
 version: '2.1'
 x-custom:

--- a/_includes/content/compose-matrix.md
+++ b/_includes/content/compose-matrix.md
@@ -2,6 +2,7 @@ This table shows which Compose file versions support specific Docker releases.
 
 | **Compose file format** | **Docker Engine release** |
 |  -------------------    |    ------------------     |
+|      3.7                |       18.06.0+            |
 |      3.6                |       18.02.0+            |
 |      3.5                |       17.12.0+            |
 |      3.4                |       17.09.0+            |

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -243,6 +243,8 @@ supported by **Compose 1.21.0+**.
 Introduces the following additional parameters:
 
 - [`platform`](compose-file-v2.md#platform) for service definitions
+- Support for extension fields at the root of service, network, and volume
+  definitions
 
 ### Version 3
 
@@ -300,6 +302,18 @@ only available with Docker Engine version **18.02.0** and higher.
 Introduces the following additional parameters:
 
 - [`tmpfs` size](index.md#long-syntax-3) for `tmpfs`-type mounts
+
+### Version 3.7
+
+An upgrade of [version 3](#version-3) that introduces new parameters. It is
+only available with Docker Engine version **18.06.0** and higher.
+
+Introduces the following additional parameters:
+
+- [`init`](index.md#init) in service definitions
+- [`rollback_config`](index.md#rollback_config) in deploy configurations
+- Support for extension fields at the root of service, network, volume, secret
+  and config definitions
 
 ## Upgrading
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -759,6 +759,20 @@ services:
         window: 120s
 ```
 
+#### rollback_config
+
+> [Version 3.7 file format](compose-versioning.md#version-37) and up
+
+Configures how the service should be rollbacked in case of a failing
+update.
+
+- `parallelism`: The number of containers to rollback at a time. If set to 0, all containers rollback simultaneously.
+- `delay`: The time to wait between each container group's rollback (default 0s).
+- `failure_action`: What to do if a rollback fails. One of `continue` or `pause` (default `pause`)
+- `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
+- `max_failure_ratio`: Failure rate to tolerate during a rollback (default 0).
+- `order`: Order of operations during rollbacks. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks briefly overlap) (default `stop-first`).
+
 #### update_config
 
 Configures how the service should be updated. Useful for configuring rolling
@@ -1117,6 +1131,27 @@ a partial image ID.
 If the image does not exist, Compose attempts to pull it, unless you have also
 specified [build](#build), in which case it builds it using the specified
 options and tags it with the specified tag.
+
+### init
+
+> [Added in version 3.7 file format](compose-versioning.md#version-37).
+
+Run an init inside the container that forwards signals and reaps processes.
+Either set a boolean value to use the default `init`, or specify a path to
+a custom one.
+
+    version: '2.2'
+    services:
+      web:
+        image: alpine:latest
+        init: true
+
+
+    version: '2.2'
+    services:
+      web:
+        image: alpine:latest
+        init: /usr/libexec/docker-init
 
 ### isolation
 

--- a/release-notes/docker-compose.md
+++ b/release-notes/docker-compose.md
@@ -5,6 +5,60 @@ keywords: release notes, compose
 toc_max: 2
 ---
 
+## 1.22.0 (2018-07-12)
+
+### Features
+
+#### Compose format version 3.7
+
+- Introduced version 3.7 of the `docker-compose.yml` specification.
+  This version requires Docker Engine 18.06.0 or above.
+
+- Added support for `rollback_config` in the deploy configuration
+
+- Added support for the `init` parameter in service configurations
+
+- Added support for extension fields in service, network, volume, secret,
+  and config configurations
+
+#### Compose format version 2.4
+
+- Added support for extension fields in service, network,
+  and volume configurations
+
+### Bugfixes
+
+- Fixed a bug that prevented deployment with some Compose files when
+  `DOCKER_DEFAULT_PLATFORM` was set
+
+- Compose will no longer try to create containers or volumes with
+  invalid starting characters
+
+- Fixed several bugs that prevented Compose commands from working properly
+  with containers created with an older version of Compose
+
+- Fixed an issue with the output of `docker-compose config` with the
+  `--compatibility-mode` flag enabled when the source file contains
+  attachable networks
+
+- Fixed a bug that prevented the `gcloud` credential store from working
+  properly when used with the Compose binary on UNIX
+
+- Fixed a bug that caused connection errors when trying to operate
+  over a non-HTTPS TCP connection on Windows
+
+- Fixed a bug that caused builds to fail on Windows if the Dockerfile
+  was located in a subdirectory of the build context
+
+- Fixed an issue that prevented proper parsing of UTF-8 BOM encoded
+  Compose files on Windows
+
+- Fixed an issue with handling of the double-wildcard (`**`) pattern in `.dockerignore` files when using `docker-compose build`
+
+- Fixed a bug that caused auth values in legacy `.dockercfg` files to be ignored
+- `docker-compose build` will no longer attempt to create image names starting with an invalid character
+
+
 ## 1.21.0 (2018-04-11)
 
 ### New features


### PR DESCRIPTION
### Proposed changes

Added release notes and documentation for the upcoming 1.22.0 release of Compose

### Unreleased project version (optional)

1.22.0

