### PR TITLE
Include httpsProxy key/value in sample client config.json

### DIFF
--- a/network/proxy.md
+++ b/network/proxy.md
@@ -36,6 +36,7 @@ configure it in different ways:
        "default":
        {
          "httpProxy": "http://127.0.0.1:3001",
+         "httpsProxy": "http://127.0.0.1:3001",
          "noProxy": "*.test.example.com,.example2.com"
        }
      }


### PR DESCRIPTION
https://docs.docker.com/network/proxy/#configure-the-docker-client

I think that the example client `config.json` should include the `httpsProxy` key:

- Increasingly (and rightly), software-delivery and other internet requests will use HTTPS
- Some software and url libs that use env-config require `https_proxy` to be explicitly set for HTTPS requests - `http_proxy` won't do.
- Many developers in a hurry will just copy the `config.json` from this page as a first attempt, without reading about the `httpsProxy` key above.
- I find that the benefit of having the key there outweighs any value in showing that it is optional.
