### PR TITLE
UCP Kube RBAC Privileges adjusted for Changes in 3.0.2

### DIFF
--- a/ee/ucp/authorization/migrate-kubernetes-roles.md
+++ b/ee/ucp/authorization/migrate-kubernetes-roles.md
@@ -113,8 +113,9 @@ Kubernetes workloads:
 * Docker EE has its own RBAC system, so it's not possible to create
   `ClusterRole` objects, `ClusterRoleBinding` objects, or any other object that is
   created by using the `/apis/rbac.authorization.k8s.io` endpoints.
-* To make sure your cluster is secure, only users with the "Full Control" role of the given Kubernetes namespace can deploy pods with
-  privileged options. These are options like `PodSpec.hostIPC`, `PodSpec.hostNetwork`,
+* To make sure your cluster is secure, only users and service accounts that have been 
+  granted "Full Control" of all Kubernetes namespaces can deploy pods with privileged
+  options. This includes: `PodSpec.hostIPC`, `PodSpec.hostNetwork`,
   `PodSpec.hostPID`, `SecurityContext.allowPrivilegeEscalation`,
   `SecurityContext.capabilities`, `SecurityContext.privileged`, and
   `Volume.hostPath`.

--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -42,6 +42,8 @@ Azure Disk when installing UCP with the `--cloud-provider` option.
    built-in Kubernetes RBAC authorizer. If you had a custom role with
    (for instance) Pod Get permissions, you may need to create a new custom
    role with permissions for each new subresource.
+   * To deploy Pods with Privileged options, users now require a grant with the 
+   role `Full Control` for all namespaces. 
    * The `/api/ucp/config` endpoint now includes default node orchestrator.
    * Added `cni_mtu` and `cni_ipinip_mtu` settings to UCP config for controlling
    MTU sizes in Calico.


### PR DESCRIPTION
Signed-off-by: ollypom <oppomeroy@gmail.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
With UCP 3.0.2 we have increased security on our clusters, users need to have "Full Control" of all namespaces, rather than of 1 namespace, to run privileged options. Basically enforcing that only administrators can start containers with privileged options.
<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
