### PR TITLE
Update certify-images.md

### DIFF
--- a/docker-store/certify-images.md
+++ b/docker-store/certify-images.md
@@ -40,7 +40,13 @@ The `inspectDockerimage` tool does the following:
 
 - Attempts to stop the container to ensure that it can be stopped gracefully.
 
-> The `inspectDockerimage` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you try to resolve them.
+> The `inspectDockerimage` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you should try to resolve them.
+
+> If you are publishing and certifying multiple versions for a docker image, you will need to run the `inspectDockerimage` tool on each docker image and send each result to Docker Store.
+
+> If you are publishing and certifying multi architecture docker image (e.g. Linux, Power, s390x, windows, etc.) you will need to run the `inspectDockerimage` tool on Docker EE server running on each architecture and send the resuls to Docker Store.
+
+> Details on how to run the `inspectDockerimage` tool and send the results to Docker Store are documented below.
 
 ### Prerequisites
 

--- a/docker-store/certify-images.md
+++ b/docker-store/certify-images.md
@@ -40,13 +40,13 @@ The `inspectDockerimage` tool does the following:
 
 - Attempts to stop the container to ensure that it can be stopped gracefully.
 
-> The `inspectDockerimage` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you should try to resolve them.
+The `inspectDockerimage` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you should try to resolve them.
 
-> If you are publishing and certifying multiple versions for a docker image, you will need to run the `inspectDockerimage` tool on each docker image and send each result to Docker Store.
+If you are publishing and certifying multiple versions for a Docker image, you will need to run the `inspectDockerimage` tool on each Docker image and send each result to Docker Store.
 
-> If you are publishing and certifying multi architecture docker image (e.g. Linux, Power, s390x, windows, etc.) you will need to run the `inspectDockerimage` tool on Docker EE server running on each architecture and send the resuls to Docker Store.
+If you are publishing and certifying multi-architecture Docker image (e.g. Linux, Power, s390x, windows, etc.) you will need to run the `inspectDockerimage` tool on the Docker EE server running on each architecture and send the results to Docker Store.
 
-> Details on how to run the `inspectDockerimage` tool and send the results to Docker Store are documented below.
+Details on how to run the `inspectDockerimage` tool and send the results to Docker Store are in the sections that follow.
 
 ### Prerequisites
 


### PR DESCRIPTION
@tfoxnc 

Added documentation mentioning that the certification test must be run for each docker image you wish to publish in a repo and the results need to be sent to Docker Store for each of those docker images.  This includes a multi architecture docker images (each architecture must be tested and the results sent to Docker Store).