### PR TITLE
Update certify-plugins-logging.md

### DIFF
--- a/docker-store/certify-plugins-logging.md
+++ b/docker-store/certify-plugins-logging.md
@@ -30,11 +30,11 @@ The `inspectDockerLoggingPlugin` command verifies that your Docker logging plugi
 
 - Displays the container logs and compares it to `quotes.txt`. If they match, the test is successful.
 
-> The `inspectDockerLoggingPlugin` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you should try to resolve them.
+The `inspectDockerLoggingPlugin` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you should try to resolve them.
 
-> If you are publishing and certifying multiple versions for a docker logging plugin, you will need to run the `inspectDockerLoggingPlugin` tool on each docker logging plugin and send each result to Docker Store.
+If you are publishing and certifying multiple versions of a Docker logging plugin, you will need to run the `inspectDockerLoggingPlugin` tool on each Docker logging plugin and send each result to Docker Store.
 
-The syntax for running a specific logging plugin is: `docker container run --log-driver`.
+The syntax for running a specific logging plugin is `docker container run --log-driver`.
 
 No parameters are passed to the logging plugin. If parameters are required for the Docker logging plugin to work correctly, then a custom test script must be written and used. The default `docker container run` command is:
 

--- a/docker-store/certify-plugins-logging.md
+++ b/docker-store/certify-plugins-logging.md
@@ -30,7 +30,9 @@ The `inspectDockerLoggingPlugin` command verifies that your Docker logging plugi
 
 - Displays the container logs and compares it to `quotes.txt`. If they match, the test is successful.
 
-> The `inspectDockerLoggingPlugin` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you try to resolve them.
+> The `inspectDockerLoggingPlugin` tool will detect issues and output them as **warnings** or **errors**. **Errors** must be fixed in order to certify. Resolving **warnings** is not required to certify, but you should try to resolve them.
+
+> If you are publishing and certifying multiple versions for a docker logging plugin, you will need to run the `inspectDockerLoggingPlugin` tool on each docker logging plugin and send each result to Docker Store.
 
 The syntax for running a specific logging plugin is: `docker container run --log-driver`.
 


### PR DESCRIPTION
@tfoxnc 

Added documentation mentioning that the certification test must be run for each docker plugin you wish to publish in a repo and the results need to be sent to Docker Store for each of those docker plugins. This includes multi architecture plugins (each architecture must be tested and each result must be sent to Docker Store).
