### PR TITLE
interlock: supports only one path per host

### DIFF
--- a/ee/ucp/interlock/usage/context.md
+++ b/ee/ucp/interlock/usage/context.md
@@ -29,6 +29,8 @@ $> docker service create \
     ehazlett/docker-demo
 ```
 
+> Only one path per host
+>
 > Interlock supports only one path per host per service cluster. Once a
 > particular `com.docker.lb.hosts` label has been applied, it cannot be applied
 > again in the same service cluster.

--- a/ee/ucp/interlock/usage/context.md
+++ b/ee/ucp/interlock/usage/context.md
@@ -29,6 +29,11 @@ $> docker service create \
     ehazlett/docker-demo
 ```
 
+> Interlock supports only one path per host per service cluster. Once a
+> particular `com.docker.lb.hosts` label has been applied, it cannot be applied
+> again in the same service cluster.
+{: .important}
+
 Interlock will detect once the service is available and publish it.  Once the tasks are running
 and the proxy service has been updated the application should be available via `http://demo.local`:
 


### PR DESCRIPTION
Current docs show single context root and the option is singular, but we've had a few folks try for multiple contexts on the same hostname.  Added a call out to avoid this issue.