### PR TITLE
Edge has been deprecated in favor of nightly channel

### DIFF
--- a/edge/index.md
+++ b/edge/index.md
@@ -4,7 +4,9 @@ description: Information about current Docker Edge releases
 keywords: engine, edge, installation
 ---
 
-The current Docker CE Edge release is **[{{ site.docker_ce_edge_version }}](https://docs.docker.com/release-notes/docker-ce/#edge-releases)**.
+> **The Docker CE Edge channel is deprecated in favor of nightly channel. See [About Docker CE](/install/index.md) for details on how to access the nightly channel.**
+
+The latest Docker CE Edge release is **[{{ site.docker_ce_edge_version }}](https://docs.docker.com/release-notes/docker-ce/#edge-releases)**.
 
 The Docker CE Edge channel provides monthly releases which allow you to try new
 features of Docker and verify bug fixes quickly. Each edge release is only
@@ -14,7 +16,7 @@ available.
 Stable releases are not published to the Edge channel, so Linux repository users
 should subscribe to both Edge and Stable channels.
 
-> Commercial support is not available for Docker CE. For information about all Docker release channels and expectations about support, see [Dockerchannels](/install/index.md#docker-channels).
+> Commercial support is not available for Docker CE. For information about all Docker release channels and expectations about support, see [About Docker CE](/install/index.md).
 
 Documentation for API and CLI references is updated with each Edge release as
 appropriate. However, full documentation for features may not be available until


### PR DESCRIPTION
Per this blog post: https://blog.docker.com/2018/07/extending-support-cycle-docker-community-edition/