### PR TITLE
Insert shell env var into env var priority order

### DIFF
--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -130,9 +130,10 @@ When you set the same environment variable in multiple files, here's the
 priority used by Compose to choose which value to use:
 
 1. Compose file,
-2. Environment file,
-3. Dockerfile,
-4. Variable is not defined.
+2. Shell environment variables,
+3. Environment file,
+4. Dockerfile,
+5. Variable is not defined.
 
 In the example below, we set the same environment variable on an Environment
 file, and the Compose file:

--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -129,11 +129,11 @@ services:
 When you set the same environment variable in multiple files, here's the
 priority used by Compose to choose which value to use:
 
-1. Compose file,
-2. Shell environment variables,
-3. Environment file,
-4. Dockerfile,
-5. Variable is not defined.
+1. Compose file
+2. Shell environment variables
+3. Environment file
+4. Dockerfile
+5. Variable is not defined
 
 In the example below, we set the same environment variable on an Environment
 file, and the Compose file:


### PR DESCRIPTION
As mentioned in lines 115 through 117, "Values in the shell take precedence over those specified in the `.env` file. If you set `TAG` to a different value in your shell, the substitution in `image` uses that instead:".

This context should also be represented in the order of priority in which variables are processed.