### PR TITLE
ucp 2.2.11 rn: Swarm vs swarm

### DIFF
--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -273,7 +273,7 @@ deprecated. Deploy your applications as Swarm services or Kubernetes workloads.
   * Fixed an issue that causes some security headers to not be added to all API responses.
 
 * Core
-  * Optimized Swarm service read API calls through UCP.
+  * Optimized swarm service read API calls through UCP.
   * Upgraded `RethinkDB` image to address potential security vulnerabilities.
   * Fixee an issue where removing a worker node from the cluster would cause an etcd member to be removed on a manager node.
   * Upgraded `etcd` version to 2.3.8.


### PR DESCRIPTION
in this case capitalization matters. (swarm classic vs swarmkit)

capitalization on the UCP 3.0.3 note pertaining to the same patch is correct.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->


<!--Tell us what you did and why-->


<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->


<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->