### PR TITLE
Fix SLES gpg url

### DIFF
--- a/install/linux/docker-ee/suse.md
+++ b/install/linux/docker-ee/suse.md
@@ -199,11 +199,11 @@ Engine, UCP, and DTR).
     $ sudo zypper addrepo $DOCKER_EE_URL docker-ee-stable
     ```
 
-3.  Import the GPG key from the repository. Use the command as-is. It works
-    because of the variable you set earlier.
+3.  Import the GPG key from the repository. Replace `<DOCKER-EE-URL>`
+    with the URL you noted down in the [prerequisites](#prerequisites).
 
     ```bash
-    $ sudo rpm --import "${DOCKER_EE_URL}/sles/gpg"
+    $ sudo rpm --import "<DOCKER-EE-URL>/sles/gpg"
     ```
 
 #### Install Docker EE


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The gpg key is in the top level directory for each distribution, using "${DOCKER_EE_URL}/sles/gpg" will attempt to load the gpg key from within the 12.3/\<architecture>/\<version>/ subdirectory, because of how DOCKER_EE_URL is set before.
