### PR TITLE
UCP and DTR July Offline Bundles

### DIFF
--- a/_data/ddc_offline_files_2.yaml
+++ b/_data/ddc_offline_files_2.yaml
@@ -8,6 +8,8 @@
   tar-files:
     - description: "3.0.3 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.0.3.tar.gz
+    - description: "3.0.3 IBM Z"
+      url: https://packages.docker.com/caas/ucp_images_s390x_3.0.3.tar.gz
     - description: "3.0.3 Windows Server 2016 LTSC"
       url: https://packages.docker.com/caas/ucp_images_win_2016_3.0.3.tar.gz
     - description: "3.0.3 Windows Server 1709"

--- a/_data/ddc_offline_files_2.yaml
+++ b/_data/ddc_offline_files_2.yaml
@@ -6,6 +6,14 @@
 - product: "ucp"
   version: "3.0"
   tar-files:
+    - description: "3.0.3 Linux"
+      url: https://packages.docker.com/caas/ucp_images_3.0.3.tar.gz
+    - description: "3.0.3 Windows Server 2016 LTSC"
+      url: https://packages.docker.com/caas/ucp_images_win_2016_3.0.3.tar.gz
+    - description: "3.0.3 Windows Server 1709"
+      url: https://packages.docker.com/caas/ucp_images_win_1709_3.0.3.tar.gz
+    - description: "3.0.3 Windows Server 1803"
+      url: https://packages.docker.com/caas/ucp_images_win_1803_3.0.3.tar.gz
     - description: "3.0.2 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.0.2.tar.gz
     - description: "3.0.2 Windows Server 2016 LTSC"
@@ -23,6 +31,12 @@
 - product: "ucp"
   version: "2.2"
   tar-files:
+    - description: "2.2.11 Linux"
+      url: https://packages.docker.com/caas/ucp_images_2.2.11.tar.gz
+    - description: "2.2.11 IBM Z"
+      url: https://packages.docker.com/caas/ucp_images_s390x_2.2.11.tar.gz
+    - description: "2.2.11 Windows"
+      url: https://packages.docker.com/caas/ucp_images_win_2.2.11.tar.gz  
     - description: "2.2.10 Linux"
       url: https://packages.docker.com/caas/ucp_images_2.2.10.tar.gz
     - description: "2.2.10 IBM Z"
@@ -80,6 +94,10 @@
 - product: "dtr"
   version: "2.5"
   tar-files:
+    - description: "DTR 2.5.4 Linux x86"
+      url: https://packages.docker.com/caas/dtr_images_2.5.4.tar.gz
+    - description: "DTR 2.5.4 IBM Z"
+      url: https://packages.docker.com/caas/dtr_images_s390x_2.5.4.tar.gz
     - description: "DTR 2.5.3 Linux x86"
       url: https://packages.docker.com/caas/dtr_images_2.5.3.tar.gz
     - description: "DTR 2.5.3 IBM Z"
@@ -99,6 +117,10 @@
 - product: "dtr"
   version: "2.4"
   tar-files:
+    - description: "DTR 2.4.6 Linux x86"
+      url: https://packages.docker.com/caas/dtr_images_2.4.6.tar.gz
+    - description: "DTR 2.4.6 IBM Z"
+      url: https://packages.docker.com/caas/dtr_images_s390x_2.4.6.tar.gz  
     - description: "DTR 2.4.5 Linux x86"
       url: https://packages.docker.com/caas/dtr_images_2.4.5.tar.gz
     - description: "DTR 2.4.5 IBM Z"
@@ -126,6 +148,8 @@
 - product: "dtr"
   version: "2.3"
   tar-files:
+    - description: "DTR 2.3.8"
+      url: https://packages.docker.com/caas/dtr_images_2.3.8.tar.gz  
     - description: "DTR 2.3.7"
       url: https://packages.docker.com/caas/dtr_images_2.3.7.tar.gz
     - description: "DTR 2.3.6"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added the UCP 3.0.3 and 2.2.11 offline bundles.
Added the DTR 2.5.4, 2.4.6 and 2.3.8 offline bundles. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
