### PR TITLE
[manage-images] Clarify character limitations on image names

### DIFF
--- a/ee/dtr/user/manage-images/index.md
+++ b/ee/dtr/user/manage-images/index.md
@@ -41,7 +41,7 @@ name of our repository will be `dtr.example.org/dave.lauper/golang`.
 > The 56 character `<user-or-org/repository-name>` limit in DTR is due to an underlying limitation in how the image name information is stored within DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit of 127 characters.
 >
 > When DTR stores the above data it appends a sha256sum comprised of 72 characters to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the 127 character limit in RethinkDB (72+56=128).
-> {: .important}
+{: .important}
 
 ## Where to go next
 

--- a/ee/dtr/user/manage-images/index.md
+++ b/ee/dtr/user/manage-images/index.md
@@ -34,20 +34,15 @@ When creating a repository in DTR, the full name of the repository becomes
 `<dtr-domain-name>/<user-or-org>/<repository-name>`. In this example, the full
 name of our repository will be `dtr.example.org/dave.lauper/golang`.
 
-When creating an image name for use with DTR ensure that the organization and
-repository name has less than 56 characters and that the entire image name
-which includes domain, organization and repository name does not exceed 255
-characters.
-
-*The 56 character `<user-or-org/repository-name>` limit in DTR is due to an
-underlying limitation in how the image name information is stored within
-DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit
-of 127 characters.
-
-When DTR stores the above data it appends a sha256sum comprised of 72 characters
-to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the
-127 character limit in RethinkDB (72+56=128).*
-
+> Image name size for DTR
+>
+> When creating an image name for use with DTR ensure that the organization and repository name has less than 56 characters and that the entire image name which includes domain, organization and repository name does not exceed 255 characters.
+>
+> *The 56 character `<user-or-org/repository-name>` limit in DTR is due to an underlying limitation in how the image name information is stored within DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit of 127 characters.
+>
+> When DTR stores the above data it appends a sha256sum comprised of 72 characters to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the 127 character limit in RethinkDB (72+56=128).*
+>
+{: Important }
 ## Where to go next
 
 - [Pull and push images](pull-and-push-images.md)

--- a/ee/dtr/user/manage-images/index.md
+++ b/ee/dtr/user/manage-images/index.md
@@ -38,10 +38,11 @@ name of our repository will be `dtr.example.org/dave.lauper/golang`.
 >
 > When creating an image name for use with DTR ensure that the organization and repository name has less than 56 characters and that the entire image name which includes domain, organization and repository name does not exceed 255 characters.
 >
-> *The 56 character `<user-or-org/repository-name>` limit in DTR is due to an underlying limitation in how the image name information is stored within DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit of 127 characters.
+> The 56 character `<user-or-org/repository-name>` limit in DTR is due to an underlying limitation in how the image name information is stored within DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit of 127 characters.
 >
 > When DTR stores the above data it appends a sha256sum comprised of 72 characters to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the 127 character limit in RethinkDB (72+56=128).
 {: important}
+
 ## Where to go next
 
 - [Pull and push images](pull-and-push-images.md)

--- a/ee/dtr/user/manage-images/index.md
+++ b/ee/dtr/user/manage-images/index.md
@@ -40,9 +40,8 @@ name of our repository will be `dtr.example.org/dave.lauper/golang`.
 >
 > *The 56 character `<user-or-org/repository-name>` limit in DTR is due to an underlying limitation in how the image name information is stored within DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit of 127 characters.
 >
-> When DTR stores the above data it appends a sha256sum comprised of 72 characters to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the 127 character limit in RethinkDB (72+56=128).*
->
-{: Important }
+> When DTR stores the above data it appends a sha256sum comprised of 72 characters to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the 127 character limit in RethinkDB (72+56=128).
+{: important}
 ## Where to go next
 
 - [Pull and push images](pull-and-push-images.md)

--- a/ee/dtr/user/manage-images/index.md
+++ b/ee/dtr/user/manage-images/index.md
@@ -41,7 +41,7 @@ name of our repository will be `dtr.example.org/dave.lauper/golang`.
 > The 56 character `<user-or-org/repository-name>` limit in DTR is due to an underlying limitation in how the image name information is stored within DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit of 127 characters.
 >
 > When DTR stores the above data it appends a sha256sum comprised of 72 characters to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the 127 character limit in RethinkDB (72+56=128).
-{: important}
+{: .important}
 
 ## Where to go next
 

--- a/ee/dtr/user/manage-images/index.md
+++ b/ee/dtr/user/manage-images/index.md
@@ -34,9 +34,19 @@ When creating a repository in DTR, the full name of the repository becomes
 `<dtr-domain-name>/<user-or-org>/<repository-name>`. In this example, the full
 name of our repository will be `dtr.example.org/dave.lauper/golang`.
 
-DTR only allows image names with 255 characters. This includes the domain,
-organization, and repository name. When you create a repository, make sure
-its full name has less than 255 characters.
+When creating an image name for use with DTR ensure that the organization and
+repository name has less than 56 characters and that the entire image name
+which includes domain, organization and repository name does not exceed 255
+characters.
+
+*The 56 character `<user-or-org/repository-name>` limit in DTR is due to an
+underlying limitation in how the image name information is stored within
+DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit
+of 127 characters.
+
+When DTR stores the above data it appends a sha256sum comprised of 72 characters
+to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the
+127 character limit in RethinkDB (72+56=128).*
 
 ## Where to go next
 

--- a/ee/dtr/user/manage-images/index.md
+++ b/ee/dtr/user/manage-images/index.md
@@ -41,7 +41,7 @@ name of our repository will be `dtr.example.org/dave.lauper/golang`.
 > The 56 character `<user-or-org/repository-name>` limit in DTR is due to an underlying limitation in how the image name information is stored within DTR metadata in RethinkDB.  RethinkDB currently has a Primary Key length limit of 127 characters.
 >
 > When DTR stores the above data it appends a sha256sum comprised of 72 characters to the end of the value to ensure uniqueness within the database.  If the `<user-or-org/repository-name>` exceeds 56 characters it will then exceed the 127 character limit in RethinkDB (72+56=128).
-{: .important}
+> {: .important}
 
 ## Where to go next
 


### PR DESCRIPTION
### Proposed changes
I clarified the character limits on image names users use when formulating a `docker push` command.  This PR came out of need from the discussion and findings in escalation issue 780, specifically the error message `Primary key too long` being observed during a `docker push`.  See more here: https://github.com/docker/escalation/issues/780#issuecomment-409302559

I also am planning to submit a knowledgebase article which further discusses the root cause of the `docker push` error and dives further into the technical portions of the RethinkDB limitation, but felt I should touch on it briefly in the documentation, via a small note blurb.

### Related issues
https://github.com/docker/escalation/issues/780
