### PR TITLE
Clarify certification doc regarding Docker EE

### DIFF
--- a/docker-store/certify-images.md
+++ b/docker-store/certify-images.md
@@ -18,7 +18,9 @@ This page explains how publishers can successfully test their **Docker images**.
 
 ## Certify your Docker images
 
-You must use the tool, `inspectDockerImage`, to certify your content for publication on Docker Store by ensuring that your images conform to best practices. The `inspectDockerImage` tool must be run on Docker Enterprise Edition in order for your docker image to pass the certification test.  Best practicies recommends that your docker image be built on Docker Enterprise Edition, but this is not required to pass the certification test.  You can download the `inspectDockerImage` tool [here](#syntax).
+You must use the tool, `inspectDockerImage`, to certify your content for publication on Docker Store by ensuring that your images conform to best practices. You can download the `inspectDockerImage` tool from the [Syntax](#syntax) section on this page.
+
+The `inspectDockerImage` tool must be run on Docker Enterprise Edition for your Docker image to pass the certification test.  To follow best practices build your Docker image on Docker Enterprise Edition, which is not required to pass the certification test.  
 
 The `inspectDockerImage` tool does the following:
 

--- a/docker-store/certify-images.md
+++ b/docker-store/certify-images.md
@@ -18,7 +18,7 @@ This page explains how publishers can successfully test their **Docker images**.
 
 ## Certify your Docker images
 
-You must use the tool, `inspectDockerImage`, to certify your content for publication on Docker Store by ensuring that your images conform to best practices. Download the tool [here](#syntax).
+You must use the tool, `inspectDockerImage`, to certify your content for publication on Docker Store by ensuring that your images conform to best practices. The `inspectDockerImage` tool must be run on Docker Enterprise Edition in order for your docker image to pass the certification test.  Best practicies recommends that your docker image be built on Docker Enterprise Edition, but this is not required to pass the certification test.  You can download the `inspectDockerImage` tool [here](#syntax).
 
 The `inspectDockerImage` tool does the following:
 


### PR DESCRIPTION
Clarify the certification documentation regarding having to run the certification test on Docker EE in order to pass certification, and recommendation that the docker image be built on Docker EE (not required to pass certification).

@tfoxnc 
@mideidocker

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
