### PR TITLE
Instructions to deploy a DTR Cache with Kubernetes

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -2307,8 +2307,10 @@ manuals:
             path: /ee/dtr/admin/configure/deploy-caches/
           - title: Cache deployment strategy
             path: /ee/dtr/admin/configure/deploy-caches/strategy/
-          - title: Deploy a DTR cache
+          - title: Deploy a DTR cache with Docker Swarm
             path: /ee/dtr/admin/configure/deploy-caches/simple/
+          - title: Deploy a DTR cache with Kubernetes
+            path: /ee/dtr/admin/configure/deploy-caches/simple-kube/
           - title: Configure caches for high availability
             path: /ee/dtr/admin/configure/deploy-caches/high-availability/
           - title: Cache configuration reference

--- a/ee/dtr/admin/configure/deploy-caches/simple-kube.md
+++ b/ee/dtr/admin/configure/deploy-caches/simple-kube.md
@@ -80,7 +80,7 @@ The cache, by default, is configured to store image data inside its container.
 Therefore if something goes wrong with the cache service, and Kubernetes deploys
 a new pod, cached data is not persisted. Data will not be lost as it is still 
 stored in the primary DTR. You can 
-[customize the storage parameters](/registry/configuration.md#storage),
+[customize the storage parameters](/registry/configuration/#storage),
 if you want the cached images to be backend by persistent storage.
 
 > Note Kubernetes Peristent Volumes or Persistent Volume Claims would have to be 
@@ -189,7 +189,7 @@ You will also need the `kubectl` command line tool configured to talk to your
 Kubernetes cluster, either through a Kubernetes Config file or a [Universal
 Control Plane client bundle](/ee/ucp/user-access/kubectl/).
 
-First we will create a Kubernetes namespace to logically seperate all of our 
+First we will create a Kubernetes namespace to logically separate all of our 
 DTR cache components.
 
 ```
@@ -233,14 +233,16 @@ same interface you created a certificate for [previously](#create-the-dtr-cache-
 Otherwise the TLS certificate may not be valid through this alternative 
 interface.
 
-> Note you only need to expose your DTR cache through 1 external interface.
+> #### DTR Cache Exposure 
+>
+> You only need to expose your DTR cache through ***one*** external interface.
 
 #### NodePort
 
-The first example exposes the DTR cache via NodePort. In this example you would 
-have added a worker nodes FQDN to the TLS Certificate in [step 1](#create-the-dtr-cache-certificates).
+The first example exposes the DTR cache via **NodePort**. In this example you would 
+have added a worker node's FQDN to the TLS Certificate in [step 1](#create-the-dtr-cache-certificates).
 Here you will be accessing the DTR cache through an exposed port on a worker 
-nodes.
+node's FQDN.
 
 ```
 cat > dtrcacheservice.yaml <<EOF
@@ -269,8 +271,8 @@ To find out which port the DTR cache has been exposed on, you will need to run:
 $ kubectl -n dtr get services 
 ```
 
-You can test that your DTR cache is externally reachable by using curl to hit 
-the API endpoint, using both a worker nodes external address, and the NodePort.
+You can test that your DTR cache is externally reachable by using `curl` to hit 
+the API endpoint, using both a worker node's external address, and the **NodePort**.
 
 ```
 curl -X GET https://<workernodefqdn>:<nodeport>/v2/_catalog
@@ -279,16 +281,15 @@ curl -X GET https://<workernodefqdn>:<nodeport>/v2/_catalog
 
 #### Ingress Controller
 
-This second example will expose the DTR cache through an ingress object. In 
+This second example will expose the DTR cache through an **ingress** object. In 
 this example you will need to create a DNS rule in your environment that will 
 resolve a DTR cache external FQDN address to the address of your ingress 
 controller. You should have also specified the same DTR cache external FQDN
 address within the DTR cache certificate in [step 1](#create-the-dtr-cache-certificates).
 
-> Note an ingress controller is a pre-requsite for this example. If you have not 
-> deployed an ingress controller on your cluster, here are instructions for the 
-> NGINX ingress controller for [UCP](ucp/kubernetes/layer-7-routing). This 
-> ingress controller will also need to support SSL pass through.
+> Note an ingress controller is a prerequisite for this example. If you have not 
+> deployed an ingress controller on your cluster, see [Layer 7 Routing for UCP](ucp/kubernetes/layer-7-routing). This 
+> ingress controller will also need to support SSL passthrough.
 
 ```
 cat > dtrcacheservice.yaml <<EOF
@@ -340,4 +341,4 @@ curl -X GET https://external-dtr-cache-fqdn/v2/_catalog
 
 ## Next Steps 
 
-[Integrate your cache into DTR and configure users](simple.md#register-the-cache-with-dtr)
+[Integrate your cache into DTR and configure users](simple#register-the-cache-with-dtr)

--- a/ee/dtr/admin/configure/deploy-caches/simple-kube.md
+++ b/ee/dtr/admin/configure/deploy-caches/simple-kube.md
@@ -115,7 +115,7 @@ middleware:
 EOF
 ```
 
-A full list of configuration options can be found [here](/registry/configuration/#list-of-configuration-options)
+See [Configuration Options](/registry/configuration/#list-of-configuration-options) for a full list of registry configuration options.
 
 ### Define Kubernetes Resources
 

--- a/ee/dtr/admin/configure/deploy-caches/simple-kube.md
+++ b/ee/dtr/admin/configure/deploy-caches/simple-kube.md
@@ -224,9 +224,9 @@ If you need to troubleshoot your deployment, you can use
 
 For external access to the DTR cache we need to expose the Cache Pods to the 
 outside world. In Kubernetes there are multiple ways for you to expose a service,
-dependent on your infrastructure and your environment. For more information see
-the Kubernetes docs 
-[here](https://kubernetes.io/docs/concepts/services-networking/#publishing-services-service-types)
+dependent on your infrastructure and your environment. For more information,
+see [Publishing services - service types
+](https://kubernetes.io/docs/concepts/services-networking/#publishing-services-service-types) on the Kubernetes docs.
 It is important though that you are consistent in exposing the cache through the 
 same interface you created a certificate for [previously](#create-the-dtr-cache-certificates).
 Otherwise the TLS certificate may not be valid through this alternative 
@@ -287,7 +287,7 @@ controller. You should have also specified the same DTR cache external FQDN
 address within the DTR cache certificate in [step 1](#create-the-dtr-cache-certificates).
 
 > Note an ingress controller is a prerequisite for this example. If you have not 
-> deployed an ingress controller on your cluster, see [Layer 7 Routing for UCP](ucp/kubernetes/layer-7-routing). This 
+> deployed an ingress controller on your cluster, see [Layer 7 Routing for UCP](/ee/ucp/kubernetes/layer-7-routing). This 
 > ingress controller will also need to support SSL passthrough.
 
 ```

--- a/ee/dtr/admin/configure/deploy-caches/simple-kube.md
+++ b/ee/dtr/admin/configure/deploy-caches/simple-kube.md
@@ -1,12 +1,12 @@
 ---
 title: Deploy a DTR cache with Kubernetes
-description: Deploy a DTR cache to make users in remove geographical locations
-  pull images faster.
+description: Deploy a DTR cache to allow users in remote geographical locations
+to pull images faster.
 keywords: DTR, cache, kubernetes
 ---
 
 This example guides you through deploying a DTR cache, assuming that you've got
-a DTR deployment up and running. The below guide has been tested to work on 
+a DTR deployment up and running. The below guide has been tested on 
 Universal Control Plane 3.1, however it should work on any Kubernetes Cluster 
 1.8 or higher. 
 
@@ -36,8 +36,8 @@ workstation:
 ### Create the DTR Cache certificates
 
 The DTR cache will be deployed with a TLS endpoint. For this you will need to 
-generate a TLS ceritificate and key from a certificate authority. Depending on 
-how you would like to expose the DTR Cache it will change the SANs required for 
+generate a TLS ceritificate and key from a certificate authority. The way you 
+expose the DTR Cache will change the SANs required for 
 this certificate.
 
 For example:
@@ -46,16 +46,16 @@ For example:
     [Ingress Object](https://kubernetes.io/docs/concepts/services-networking/ingress/) 
     you will need to use an external DTR cache address which resolves to your 
     ingress controller as part of your certificate. 
-  - If you exposing the DTR cache through a Kubernetes
+  - If you are exposing the DTR cache through a Kubernetes
     [Cloud Provider](https://kubernetes.io/docs/concepts/services-networking/#loadbalancer)
     then you will need the external Loadbalancer address as part of your 
     certificate. 
   - If you are exposing the DTR Cache through a 
     [Node Port](https://kubernetes.io/docs/concepts/services-networking/#nodeport)
-     or a Host Port you will need to use a Node's FQDN as a SAN in your 
+     or a Host Port you will need to use a node's FQDN as a SAN in your 
      certificate.
 
-On your workstation, create a directory called `certs`. Within here place the 
+On your workstation, create a directory called `certs`. Within it place the 
 newly created certificate `cache.cert.pem` and key `cache.key.pem` for your DTR 
 cache. Also place the certificate authority (including any intermedite 
 certificate authorities) of the certificate from your DTR deployment. This could 
@@ -81,9 +81,9 @@ Therefore if something goes wrong with the cache service, and Kubernetes deploys
 a new pod, cached data is not persisted. Data will not be lost as it is still 
 stored in the primary DTR. You can 
 [customize the storage parameters](/registry/configuration/#storage),
-if you want the cached images to be backend by persistent storage.
+if you want the cached images to be backended by persistent storage.
 
-> Note Kubernetes Peristent Volumes or Persistent Volume Claims would have to be 
+> Note: Kubernetes Peristent Volumes or Persistent Volume Claims would have to be 
 > used to provide persistent backend storage capabilities for the cache.
 
 ```
@@ -224,11 +224,11 @@ If you need to troubleshoot your deployment, you can use
 ### Exposing the DTR Cache
 
 For external access to the DTR cache we need to expose the Cache Pods to the 
-outside world. In Kubernetes there are multiple ways for you to expose a service
+outside world. In Kubernetes there are multiple ways for you to expose a service,
 dependent on your infrastructure and your environment. For more information see
 the Kubernetes docs 
 [here](https://kubernetes.io/docs/concepts/services-networking/#publishing-services-service-types)
-It is important though that you are consistent in exposing the Cache through the 
+It is important though that you are consistent in exposing the cache through the 
 same interface you created a certificate for [previously](#create-the-dtr-cache-certificates).
 Otherwise the TLS certificate may not be valid through this alternative 
 interface.
@@ -239,7 +239,7 @@ interface.
 
 #### NodePort
 
-The first example exposes the DTR cache via **NodePort**. In this example you would 
+The first example exposes the DTR cache through **NodePort**. In this example you would 
 have added a worker node's FQDN to the TLS Certificate in [step 1](#create-the-dtr-cache-certificates).
 Here you will be accessing the DTR cache through an exposed port on a worker 
 node's FQDN.

--- a/ee/dtr/admin/configure/deploy-caches/simple-kube.md
+++ b/ee/dtr/admin/configure/deploy-caches/simple-kube.md
@@ -1,7 +1,6 @@
 ---
 title: Deploy a DTR cache with Kubernetes
-description: Deploy a DTR cache to allow users in remote geographical locations
-to pull images faster.
+description: Deploy a DTR cache to allow users in remote geographical locations to pull images faster.
 keywords: DTR, cache, kubernetes
 ---
 

--- a/ee/dtr/admin/configure/deploy-caches/simple-kube.md
+++ b/ee/dtr/admin/configure/deploy-caches/simple-kube.md
@@ -1,0 +1,229 @@
+---
+title: Deploy a DTR cache with Kubernetes
+description: Deploy a DTR cache to make users in remove geographical locations
+  pull images faster.
+keywords: DTR, cache, kubernetes
+---
+
+This example guides you through deploying a DTR cache, assuming that you've got
+a DTR deployment up and running. It also assumes that you've provisioned
+a Kubernetes Cluster of 1.8 or higher.
+
+The DTR cache is going to be deployed as a Kubernetes Deployment, so that Kubernetes
+automatically takes care of scheduling and restarting the service if
+something goes wrong.
+
+We'll manage the cache configuration using a Kubernetes Config Map, and the TLS
+certificates using Kubernetes secrets. This allows you to manage the configurations
+securely and independently of the node where the cache is actually running.
+
+## Prepare the cache deployment
+
+At the end of this exercise you should have a file structure that looks like this:
+
+```
+├── dtrcache.yml        # Yaml file to deploy cache with a single command
+├── config.yml          # The cache configuration file
+└── certs
+    ├── cache.cert.pem  # The cache public key certificate
+    ├── cache.key.pem   # The cache private key
+    └── dtr.cert.pem    # DTR CA certificate
+```
+
+### Create the DTR Cache certicates
+
+The DTR cache will be deployed with a TLS endpoint. For this you will need to generate
+a SSL ceritificate and key from a certificate authority. Depending on how you would
+ like to expose the DTR Cache it will depend on the SANs required for this certificate.
+
+For example:
+
+  - If you are deploying the DTR Cache with an 
+    [Ingress Object](https://kubernetes.io/docs/concepts/services-networking/ingress/) 
+    you will need to use the FQDN of your `Ingress Object` as part of your certificate. 
+  - If you exposing the DTR cache through a Kubernetes
+    [Cloud Provider](https://kubernetes.io/docs/concepts/services-networking/#loadbalancer)
+    then you will need the external Loadbalancer address as part of your certificate. 
+  - If you are exposing the DTR Cache through a 
+    [Node Port](https://kubernetes.io/docs/concepts/services-networking/#nodeport)` or a
+    `Host Port]` you will need to use a Node's FQDN as a SAN in your certificate. You could use
+    a Kubernetes `NodeScheduler` to pin the node the DTR cache is deployed on.
+
+On your workstation, create a directory called `certs`. Within here place the newly 
+created certificate `cache.cert.pem` and key `cache.key.pem` for your DTR cache. Also
+ place the certificate authority (including any intermedite certificate authorities)
+ of the certificate from your DTR deployment. This could be sourced from curl.
+`curl -s https://<dtr-fqdn>/ca -o certs/dtr.cert.pem`.
+
+### Create the DTR Config
+
+This is the configuration file of the registry component of the DTR Cache. This yaml
+should be updated with the relevant `cache-fqdn` and `dtr-fqdn`.
+
+```
+version: 0.1
+log:
+  level: info
+storage:
+  delete:
+    enabled: true
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: 0.0.0.0:443
+  secret: generate-random-secret
+  host: https://<external-fqdn-dtrcache> # Could be Ingress / LB / Host
+  tls:
+    certificate: /certs/cache.cert.pem
+    key: /certs/cache.key.pem
+middleware:
+  registry:
+      - name: downstream
+        options:
+          blobttl: 24h
+          upstreams:
+            - https://<dtr-url>
+          cas:
+            - /certs/dtr.cert.pem
+```
+
+With this configuration, the cache fetches image layers from DTR and keeps
+a local copy for 24 hours. After that, if a user requests that image layer,
+the cache fetches it again from DTR.
+
+The cache is configured to persist data inside its container.
+If something goes wrong with the cache service, Docker automatically redeploys a
+new container, but previously cached data is not persisted.
+You can [customize the storage parameters](/registry/configuration.md#storage),
+if you want to store the image layers using a persistent storage backend.
+
+### Create Kubernetes Resources
+
+Create a Kubernetes namespace to logical seperate all of our DTR cache components.
+
+```
+$ kubectl create ns dtr
+```
+
+Create the Kubernetes Secrets and the Kubernetes ConfigMaps. Note the commands below
+will only work if your workstation directory was configured our examples structure 
+above. 
+
+```
+$ kubectl create secret generic dtr-certs \
+    --from-file=certs/dtr.cert.pem \
+    --from-file=certs/cache.cert.pem \
+    --from-file=certs/cache.key.pem
+
+$ kubectl create configmap dtr-cache-config \
+    --from-file=config.yml
+```
+
+Create the Kubernetes Deployment. 
+
+```
+cat <<EOF | kubectl create -f -
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: dtr-cache
+  namespace: dtr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dtr-cache
+  template:
+    metadata:
+      labels:
+        app: dtr-cache
+      annotations:
+       seccomp.security.alpha.kubernetes.io/pod: docker/default
+    spec:
+      containers:
+        - name: dtr-cache
+          image: {{ page.dtr_org }}/{{ page.dtr_repo }}-content-cache:{{ page.dtr_version }}
+          command: ["bin/sh"]
+          args:
+            - start.sh
+            - /config/config.yml
+          ports:
+          - name: https
+            containerPort: 443
+          volumeMounts:
+          - name: dtr-certs
+            readOnly: true
+            mountPath: /certs/
+          - name: dtr-cache-config
+            readOnly: true
+            mountPath: /config
+      volumes:
+      - name: dtr-certs
+        secret:
+          secretName: dtr-certs
+      - name: dtr-cache-config
+        configMap:
+          defaultMode: 0666
+          name: dtr-cache-config
+EOF
+```
+
+You can check if the deployment has been successful with `kubectl get pods -n dtr`.
+If you need to troubleshoot your deployment, you can use `kubectl describe -n dtr <pods>`
+and / or `kubectl logs -n dtr <pods>`
+
+For external access to the DTR cache you could expose your DTR cache through 
+multiple interfaces: Ingress Object, Node Port, Host Port or Loadbalancer. 
+The following yaml will expose the DTR cache through an ingress obect.
+
+> Note an ingress controller is a pre-requsite for this example. If you have not deploy
+> an ingress controller on your cluster, here are instructions for the Nginx ingress
+> controller for [UCP](ucp/kubernetes/layer-7-routing). 
+
+```
+cat <<EOF | kubectl create -f -
+kind: Service
+apiVersion: v1
+metadata:
+  name: dtr-cache
+  namespace: dtr
+spec:
+  selector:
+    app: dtr-cache
+  ports:
+  - protocol: TCP
+    port: 443
+    targetPort: 443
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dtr-cache
+  namespace: dtr
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+spec:
+  tls:
+  - hosts:
+    - <external-dtr-cache-fqdn>
+  rules:
+  - host: <external-dtr-cache-fqdn>
+    http:
+      paths:
+      - backend:
+          serviceName: dtr-cache
+          servicePort: 443
+```
+
+You can test that your DTR cache is externally reachable by curling the API endpoint.
+
+```
+curl -X GET https://<dtr-cache-endpoint>/v2/_catalog
+{"repositories":[]}
+```
+
+
+## Next Steps 
+
+[Integrate your cache into DTR and configure users](simple.md#register-the-cache-with-dtr)

--- a/ee/dtr/admin/configure/deploy-caches/simple.md
+++ b/ee/dtr/admin/configure/deploy-caches/simple.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy a DTR cache
+title: Deploy a DTR cache with Swarm
 description: Deploy a DTR cache to make users in remove geographical locations
   pull images faster.
 keywords: DTR, cache


### PR DESCRIPTION
### Proposed changes

I have added instructions on how to deploy a DTR cache with any 1.8 or higher kubernetes platform. These instructions will deploy the Cache as a kubernetes deployment, taking advantage of kubernetes secrets and config maps.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
