### PR TITLE
get-started: remove trusted host option in pip install example

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -72,7 +72,7 @@ WORKDIR /app
 ADD . /app
 
 # Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
+RUN pip install -r requirements.txt
 
 # Make port 80 available to the world outside this container
 EXPOSE 80


### PR DESCRIPTION
### Proposed changes

Remove usage of pip install option `--trusted-host`. I don't think it's sane to endorse usage of this option because it doesn't verify TLS connections, especially if new users will use this as a starting template for Python projects.

See https://pip.pypa.io/en/stable/reference/pip/#general-options for reference about the option.

What do you think?