### PR TITLE
Add missing cross-references to "Not supported for docker stack deploy"

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -809,10 +809,12 @@ services:
 The following sub-options (supported for `docker-compose up` and `docker-compose run`) are _not supported_ for `docker stack deploy` or the `deploy` key.
 
 - [build](#build)
+- [cap_add, cap_drop](#cap_add-cap_drop)
 - [cgroup_parent](#cgroup_parent)
 - [container_name](#container_name)
 - [devices](#devices)
-- [tmpfs](#tmpfs)
+- [depends_on](#depends_on)
+- [tmpfs](#tmpfs) (version 3-3.5)
 - [external_links](#external_links)
 - [links](#links)
 - [network_mode](#network_mode)


### PR DESCRIPTION
### Proposed changes

Added three of the option entries which are individually labeled as "ignored when deploying a stack in swarm mode" -- but which do not appear in the list "Not supported" list.

-  `cap_add, cap_drop`
-  `depends_on`

Also for `tmpfs` added a list note that it is not supported in `stack deploy` for `(version 3-3.5)` -- as described on its individual entry
