### PR TITLE
updating link to engine specs

### DIFF
--- a/ee/ucp/admin/install/system-requirements.md
+++ b/ee/ucp/admin/install/system-requirements.md
@@ -13,7 +13,7 @@ Before installing, be sure your infrastructure has these requirements.
 
 You can install UCP on-premises or on a cloud provider. Common requirements:
 
-* [Docker EE Engine](/engine/installation/index.md) version 17.06.2-ee-8; 
+* [Docker EE Engine](/ee/supported-platforms.md) version 17.06.2-ee-8; 
   values of `n` in the `-ee-<n>` suffix must be 8 or higher
 * Linux kernel version 3.10 or higher
 * A static IP address


### PR DESCRIPTION
### Proposed changes

link was redirecting to CE engine page. the link has been fixed to redirect to the EE engine page.
