### PR TITLE
ONBUILD variant deprecation, remove dead Ruby link

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -756,7 +756,7 @@ A Docker build executes `ONBUILD` commands before any command in a child
 `ONBUILD` is useful for images that are going to be built `FROM` a given
 image. For example, you would use `ONBUILD` for a language stack image that
 builds arbitrary user software written in that language within the
-`Dockerfile`, as you can see in [Ruby’s `ONBUILD` variants](https://github.com/docker-library/ruby/blob/master/2.4/jessie/onbuild/Dockerfile).
+`Dockerfile`.
 
 Images built from `ONBUILD` should get a separate tag, for example:
 `ruby:1.9-onbuild` or `ruby:2.0-onbuild`.

--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -763,8 +763,13 @@ Images built from `ONBUILD` should get a separate tag, for example:
 
 Be careful when putting `ADD` or `COPY` in `ONBUILD`. The “onbuild” image
 fails catastrophically if the new build's context is missing the resource being
-added. Adding a separate tag, as recommended above, helps mitigate this by
-allowing the `Dockerfile` author to make a choice.
+added. Customizing when the `ONBUILD` instruction executes is also not possible
+- it always occurs before the first instruction in the child image build.
+Note also that docker-library `ONBUILD` image variants
+[have been deprecated](https://github.com/docker-library/official-images/issues/2076).
+
+Adding a separate tag, as recommended above, helps mitigate these limitations
+by allowing the `Dockerfile` author to make a choice.
 
 ## Examples for Official Repositories
 


### PR DESCRIPTION
Removes a link to the Ruby `ONBUILD` `Dockerfile` variant, which was burniated in https://github.com/docker-library/ruby/commit/b9e495c8e400363e6cc2d4db6d944235b7989584 .  Most `ONBUILD` variants of base library images are deprecated/removed per https://github.com/docker-library/official-images/issues/2076 .  Maybe the doc on the use of `BUILD` could have more warnings on its limitations, so a second commit here with a note on the deprecations in base images.