### PR TITLE
Add fixed-cidr-v6 field

### DIFF
--- a/config/daemon/ipv6.md
+++ b/config/daemon/ipv6.md
@@ -17,7 +17,8 @@ either IPv4 or IPv6 (or both) with any container, service, or network.
 
     ```json
     {
-      "ipv6": true
+      "ipv6": true,
+      "fixed-cidr-v6": "2001:db8:abcd::/48"
     }
     ```
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
Since dockerd does not start without a ipv6 subnet if ipv6 is enabled it is convenient to add this field to the docs.
<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
