### PR TITLE
Update startup-order.md

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -54,7 +54,7 @@ script:
     check. For example, you might want to wait until Postgres is definitely
     ready to accept commands:
 
-        #!/bin/bash
+        #!/bin/sh
         # wait-for-postgres.sh
 
         set -e


### PR DESCRIPTION
### Changing /bin/bash to /bin/sh in wait-for-postgres.sh

Since /bin/bash is not necessarily installed, this scripts fails to run. So changing /bin/bash to /bin/sh makes the script work and the example run in an alpine.
