### PR TITLE
Update develop/sdk/{index,examples}.md

### DIFF
--- a/develop/sdk/examples.md
+++ b/develop/sdk/examples.md
@@ -40,13 +40,13 @@ command prompt:
 package main
 
 import (
+	"context"
 	"io"
 	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -144,6 +144,7 @@ You can also run containers in the background, the equivalent of typing
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -151,7 +152,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -230,11 +230,11 @@ You can use the API to list containers that are running, just like using
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -305,11 +305,11 @@ This example stops all running containers.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -385,12 +385,12 @@ to change the hard-coded ID of the container to print the logs for.
 package main
 
 import (
+	"context"
 	"io"
 	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -455,11 +455,11 @@ List the images on your Engine, similar to `docker image ls`:
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -524,12 +524,12 @@ Pull an image, like `docker pull`:
 package main
 
 import (
+	"context"
 	"io"
 	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -598,6 +598,7 @@ Pull an image, like `docker pull`, with authentication:
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -605,7 +606,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -697,12 +697,12 @@ Commit a container to create an image from its contents:
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func main() {

--- a/develop/sdk/index.md
+++ b/develop/sdk/index.md
@@ -177,6 +177,7 @@ Docker API directly, or using the Python or Go SDK.
 package main
 
 import (
+    "context"
     "io"
     "os"
 
@@ -184,8 +185,6 @@ import (
     "github.com/docker/docker/api/types"
     "github.com/docker/docker/api/types/container"
     "github.com/docker/docker/pkg/stdcopy"
-
-    "golang.org/x/net/context"
 )
 
 func main() {


### PR DESCRIPTION
`golang.org/x/net/context` package was moved into the standard library as `context` since Go 1.7.