### PR TITLE
Update reset-user-password.md

### DIFF
--- a/ee/ucp/authorization/reset-user-password.md
+++ b/ee/ucp/authorization/reset-user-password.md
@@ -23,7 +23,7 @@ or use **ssh** to log in to a manager node managed by Docker EE and run:
 
 ```none
 {% raw %}
-docker run --net=host -v ucp-auth-api-certs:/tls -it "$(docker inspect --format '{{ .Spec.TaskTemplate.ContainerSpec.Image }}' ucp-auth-api)" "$(docker inspect --format '{{ index .Spec.TaskTemplate.ContainerSpec.Args 0 }}' ucp-auth-api)" passwd -i
+docker run --net=host -v ucp-auth-api-certs:/tls -it "$(docker inspect --format '{{ .Image }}' ucp-auth-api)" "$(docker inspect --format '{{ index .Args 0 }}' ucp-auth-api)" passwd -i
 {% endraw %}
 ```
 


### PR DESCRIPTION
I'm not sure, but I'm pretty sure, that the argument should be the following:

```
docker run --net=host -v ucp-auth-api-certs:/tls -it "$(docker inspect --format '{{ .Image }}' ucp-auth-api)" "$(docker inspect --format '{{ index .Args 0 }}' ucp-auth-api)" passwd -i
```

and not

```
docker run --net=host -v ucp-auth-api-certs:/tls -it "$(docker inspect --format '{{ .Spec.TaskTemplate.ContainerSpec.Image }}' ucp-auth-api)" "$(docker inspect --format '{{ index .Spec.TaskTemplate.ContainerSpec.Args 0 }}' ucp-auth-api)" passwd -i
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
