### PR TITLE
Correcting command to follow text

### DIFF
--- a/network/none.md
+++ b/network/none.md
@@ -42,7 +42,7 @@ only the loopback device is created. The following example illustrates this.
     the `--rm` flag.
 
     ```bash
-    $ docker container rm no-net-alpine
+    $ docker stop no-net-alpine
     ```
 
 ## Next steps


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The proposed change replaced the "docker container rm" command with a "docker stop" command. This is proposed because
  - the text says that you want to stop the container and that it will be automatically removed due to being started with the --rm option.  
  - the command that is given ("docker container rm") will not work even if the container was not started with the --rm option because you must stop the container before removing it.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
