### PR TITLE
Direct download link to Docker for Mac and Windows (#6910) (#7179)

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -4,11 +4,7 @@ keywords: mac, beta, alpha, install, download
 title: Install Docker for Mac
 ---
 
-Docker for Mac is the
-[Community Edition (CE)](https://www.docker.com/community-edition)
-of Docker for MacOS. To download Docker for Mac, head to Docker Store.
-
-[Download from Docker Store](https://store.docker.com/editions/community/docker-ce-desktop-mac){: .button .outline-btn}
+[Download Community Edition (CE)](https://download.docker.com/mac/stable/Docker.dmg)
 
 ##  What to know before you install
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -4,12 +4,8 @@ keywords: windows, beta, edge, alpha, install, download
 title: Install Docker for Windows
 ---
 
-Docker for Windows is the
-[Community Edition (CE)](https://www.docker.com/community-edition)
-of Docker for Microsoft Windows. To download Docker for Windows, head to Docker
-Store.
+[Download Community Edition (CE)](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
 
-[Download from Docker Store](https://store.docker.com/editions/community/docker-ce-desktop-windows){: .button .outline-btn}
 
 ##  What to know before you install
 


### PR DESCRIPTION
This fixes https://github.com/docker/docker.github.io/issues/6910 https://github.com/docker/docker.github.io/issues/7179
- Put direct download link.
- Remove mention to Docker Store.