### PR TITLE
Fix UCP upgrade only upgrades one node

### DIFF
--- a/reference/ucp/3.0/cli/upgrade.md
+++ b/reference/ucp/3.0/cli/upgrade.md
@@ -18,18 +18,13 @@ Upgrade the UCP cluster
 
 ## Description
 
-This command upgrades the UCP running on this node.
-To upgrade UCP:
-
-  * Upgrade the Docker Engine in all nodes (optional)
-  * Run the upgrade command in all manager nodes
-  * Run the upgrade command in all worker nodes
+This command upgrades the UCP running on this cluster.
 
 Before performing an upgrade, you should perform a backup by using the
 [backup](backup.md) command.
 
-After upgrading UCP in a node, go to the UCP web UI and confirm the node is
-healthy, before upgrading other nodes.
+After upgrading UCP, go to the UCP web UI and confirm each node is
+healthy and that all nodes have been upgraded successfully.
 
 
 ## Options


### PR DESCRIPTION
Running the UCP upgrade upgrades all managers and workers to the new version, contrary to what is described here. Here is sample output from running this command:

$ docker container run --rm -it   --name ucp   -v /var/run/docker.sock:/var/run/docker.sock   docker/ucp:2.2.12   upgrade --interactive
Unable to find image 'docker/ucp:2.2.12' locally
2.2.12: Pulling from docker/ucp
a073c86ecf9e: Already exists 
fae35fe3a426: Pull complete 
f13c1be613a6: Pull complete 
Digest: sha256:61d4a2e8969a0139187ecf13af8c0020bb7bb5ff5efa2b06e331394a67bd4b68
Status: Downloaded newer image for docker/ucp:2.2.12
INFO[0000] Your engine version 17.06.2-ee-16, build 9ef4f0a (4.4.0-133-generic) is compatible 
INFO[0000] Upgrade the UCP 2.2.5 installation on this cluster to 2.2.12 for UCP ID: sc3nkn5p6rnc33o1e33mnqa1r 
INFO[0000] Once this operation completes, all nodes in this cluster will be upgraded. 
Do you want proceed with the upgrade? (y/n): y

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
