### PR TITLE
Remove out-of-date note about Kubernetes

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -252,12 +252,7 @@ changes, click another preference tab, then choose to discard or not apply chang
 
 ### Kubernetes
 
-**Kubernetes is only available in Docker for Mac 17.12 CE and higher, on the Edge channel.**
-Kubernetes support is not included in Docker for Mac Stable releases. To find
-out more about Stable and Edge channels and how to switch between them, see
-[General configuration](#general){:target="_blank" class="_"}.
-
-Docker for Mac 17.12 CE (and higher) Edge includes a standalone Kubernetes server
+Docker for Mac 17.12 CE (and higher) includes a standalone Kubernetes server
 that runs on your Mac, so that you can test deploying your Docker workloads on
 Kubernetes.
 


### PR DESCRIPTION
### Proposed changes

Remove out-of-date notice about Kubernetes being available only in Edge.

### Related issues (optional)

I'd be happy to create an issue, but this was a simple in-place edit that feels self-explanatory.