### PR TITLE
Fix broken link to ONBUILD variants in "Dockerfile best practices"

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -756,7 +756,7 @@ A Docker build executes `ONBUILD` commands before any command in a child
 `ONBUILD` is useful for images that are going to be built `FROM` a given
 image. For example, you would use `ONBUILD` for a language stack image that
 builds arbitrary user software written in that language within the
-`Dockerfile`, as you can see in [Ruby’s `ONBUILD` variants](https://github.com/docker-library/ruby/blob/master/2.4/jessie/onbuild/Dockerfile).
+`Dockerfile`, as you can see in [Maven’s `ONBUILD` variants](https://github.com/carlossg/docker-maven/blob/maven-3.3.3/jdk-8/onbuild/Dockerfile).
 
 Images built from `ONBUILD` should get a separate tag, for example:
 `ruby:1.9-onbuild` or `ruby:2.0-onbuild`.


### PR DESCRIPTION
### Proposed changes

Ruby has [dropped ONBUILD variants](https://hub.docker.com/_/rails/):
'While the onbuild variant is really useful for "getting off the ground running" (zero to Dockerized in a short period of time), it's not recommended for long-term usage within a project due to the lack of control over when the ONBUILD triggers fire (see also docker/docker#5714, docker/docker#8240, docker/docker#11917).'

Changed the link to a Maven's similar example.