### PR TITLE
Remove DockerCon '18 SF advert from site

### DIFF
--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -42,10 +42,6 @@
             </nav>
         </div>
     </div>
-    <!-- DockerCon banner -->
-    <div class="banner">
-      <a target="_blank" href="https://2018.dockercon.com/"><img src="/images/dockercon.svg" alt="DockerCon banner"></a>
-    </div>
     <!-- hero banner text -->
     <div class="container-fluid">
         <div class="row">


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

This will remove the DockerCon '18 advert on docs.docker.com

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
