### PR TITLE
Adding emphasis on Static IP requirement

### DIFF
--- a/ee/ucp/admin/install/system-requirements.md
+++ b/ee/ucp/admin/install/system-requirements.md
@@ -16,8 +16,8 @@ You can install UCP on-premises or on a cloud provider. Common requirements:
 * [Docker EE Engine](/ee/supported-platforms.md) version 17.06.2-ee-8; 
   values of `n` in the `-ee-<n>` suffix must be 8 or higher
 * Linux kernel version 3.10 or higher
-* A static IP address
-
+* **A static IP address**
+ 
 ### Minimum requirements
 
 * 8GB of RAM for manager nodes

--- a/ee/ucp/admin/install/system-requirements.md
+++ b/ee/ucp/admin/install/system-requirements.md
@@ -16,7 +16,7 @@ You can install UCP on-premises or on a cloud provider. Common requirements:
 * [Docker EE Engine](/ee/supported-platforms.md) version 17.06.2-ee-8; 
   values of `n` in the `-ee-<n>` suffix must be 8 or higher
 * Linux kernel version 3.10 or higher
-* **A static IP address**
+* [A static IP address for each node in the cluster](/ee/ucp/admin/install/plan-installation/#static-ip-addresses)
  
 ### Minimum requirements
 


### PR DESCRIPTION
### Proposed changes
 
Static IP is so fundamental to UCP's functionality especially for managers.  Change could affects many parts of the system.
 
However, many users are used to dynamic IP on cloud providers.  For this reason, this should be emphasized and leave no room for misunderstanding/oversight.
 
### Unreleased project version (optional)

UCP 3.0.x

### Related issues (optional)

n/a