### PR TITLE
Update part2.md

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -65,11 +65,11 @@ your new Dockerfile.
 # Use an official Python runtime as a parent image
 FROM python:2.7-slim
 
-# Set the working directory to /app
-WORKDIR /app
-
 # Copy the current directory contents into the container at /app
 ADD . /app
+
+# Set the working directory to /app
+WORKDIR /app
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --trusted-host pypi.python.org -r requirements.txt


### PR DESCRIPTION
When running 'docker build -t friendly hello .', I encountered the following error on Step 4/7:
Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'

I switched the WORKDIR and ADD steps in the dockerfile and then was able to build successfully.

### Proposed changes

Switch WORKDIR and ADD steps in dockerfile example in Get Started: Part 2
