### PR TITLE
fix channel for docker-ee install on ubuntu

### DIFF
--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -185,7 +185,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=amd64] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       $DOCKER_EE_VERSION"
+       stable-17.06"
     ```
 
     </div>
@@ -195,7 +195,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=s390x] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       $DOCKER_EE_VERSION"
+       stable-17.06"
     ```
 
     </div>
@@ -205,7 +205,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=ppc64el] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       $DOCKER_EE_VERSION"
+       stable-17.06"
     ```
 
     </div>


### PR DESCRIPTION
In setting up the apt repository, should specify the channel name, not the docker ee version. For this PR I put in the `stable-17.06` channel as example.

Should be similar to the docker-ce docs: https://github.com/docker/docker.github.io/blob/5781f702466f798622f57e98c39c5d4026bdc35e/install/linux/docker-ce/ubuntu.md#set-up-the-repository