### PR TITLE
Added Latest UCP DTR Offline Bundles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -102,7 +102,7 @@ defaults:
     values:
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.5.3"
+      dtr_version: "2.5.5"
   - scope:
       path: "datacenter/dtr/2.4"
     values:
@@ -138,23 +138,23 @@ defaults:
     values:
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "3.0.4"
+      ucp_version: "3.0.5"
   - scope: # This is a bit of a hack for the get-support.md topic.
       path: "ee"
     values:
       ucp_org: "docker"
       ucp_repo: "ucp"
       dtr_repo: "dtr"
-      ucp_version: "3.0.4"
+      ucp_version: "3.0.5"
       dtr_version: "2.5.0"
-      dtr_latest_image: "docker/dtr:2.5.3"
+      dtr_latest_image: "docker/dtr:2.5.5"
   - scope:
       path: "datacenter/ucp/2.2"
     values:
       hide_from_sitemap: true
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "2.2.12"
+      ucp_version: "2.2.13"
   - scope:
       path: "datacenter/ucp/2.1"
     values:

--- a/_data/ddc_offline_files_2.yaml
+++ b/_data/ddc_offline_files_2.yaml
@@ -6,6 +6,16 @@
 - product: "ucp"
   version: "3.0"
   tar-files:
+    - description: "3.0.5 Linux"
+      url: https://packages.docker.com/caas/ucp_images_3.0.5.tar.gz
+    - description: "3.0.5 IBM Z"
+      url: https://packages.docker.com/caas/ucp_images_s390x_3.0.5.tar.gz
+    - description: "3.0.5 Windows Server 2016 LTSC"
+      url: https://packages.docker.com/caas/ucp_images_win_2016_3.0.5.tar.gz
+    - description: "3.0.5 Windows Server 1709"
+      url: https://packages.docker.com/caas/ucp_images_win_1709_3.0.5.tar.gz
+    - description: "3.0.5 Windows Server 1803"
+      url: https://packages.docker.com/caas/ucp_images_win_1803_3.0.5.tar.gz
     - description: "3.0.4 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.0.4.tar.gz
     - description: "3.0.4 IBM Z"
@@ -43,6 +53,12 @@
 - product: "ucp"
   version: "2.2"
   tar-files:
+    - description: "2.2.13 Linux"
+      url: https://packages.docker.com/caas/ucp_images_2.2.13.tar.gz
+    - description: "2.2.13 IBM Z"
+      url: https://packages.docker.com/caas/ucp_images_s390x_2.2.13.tar.gz
+    - description: "2.2.13 Windows"
+      url: https://packages.docker.com/caas/ucp_images_win_2.2.13.tar.gz  
     - description: "2.2.12 Linux"
       url: https://packages.docker.com/caas/ucp_images_2.2.12.tar.gz
     - description: "2.2.12 IBM Z"
@@ -112,10 +128,10 @@
 - product: "dtr"
   version: "2.5"
   tar-files:
-    - description: "DTR 2.5.4 Linux x86"
-      url: https://packages.docker.com/caas/dtr_images_2.5.4.tar.gz
-    - description: "DTR 2.5.4 IBM Z"
-      url: https://packages.docker.com/caas/dtr_images_s390x_2.5.4.tar.gz
+    - description: "DTR 2.5.5 Linux x86"
+      url: https://packages.docker.com/caas/dtr_images_2.5.5.tar.gz
+    - description: "DTR 2.5.5 IBM Z"
+      url: https://packages.docker.com/caas/dtr_images_s390x_2.5.5.tar.gz
     - description: "DTR 2.5.3 Linux x86"
       url: https://packages.docker.com/caas/dtr_images_2.5.3.tar.gz
     - description: "DTR 2.5.3 IBM Z"


### PR DESCRIPTION
### Proposed changes

Updated the Docs to that latest build numbers: UCP 3.0.5 and 2.2.12. DTR 2.5.5

Added Offline Bundles for those Builds as well. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
