### PR TITLE
Adding port 12388 for UCP 3.1

### DIFF
--- a/ee/ucp/admin/install/system-requirements.md
+++ b/ee/ucp/admin/install/system-requirements.md
@@ -66,7 +66,7 @@ host types:
 | managers          | TCP 2376 (configurable) | Internal           | Port for the Docker Swarm manager. Used for backwards compatibility           |
 | managers          | TCP 2377 (configurable) | Internal,          | Port for control communication between swarm nodes                            |
 | managers, workers | UDP 4789                | Internal,          | Port for overlay networking                                                   |
-| managers          | TCP 6443 (configurable) | External, Internal | Port for UCP Controller Kubernetes API endpiont                                                |
+| managers          | TCP 6443 (configurable) | External, Internal | Port for Kubernetes API server                                                |
 | managers, workers | TCP 6444                | Self               | Port for Kubernetes API reverse proxy                                         |
 | managers, workers | TCP, UDP 7946           | Internal           | Port for gossip-based clustering                                              |
 | managers, workers | TCP 10250               | Internal           | Port for Kubelet                                                              |
@@ -81,7 +81,7 @@ host types:
 | managers          | TCP 12385               | Internal           | Port for the authentication service API                                       |
 | managers          | TCP 12386               | Internal           | Port for the authentication worker                                            |
 | managers          | TCP 12387               | Internal           | Port for the metrics service                                                  |
-| managers          | TCP 12388               | Internal           | Port for the Kubernetes API Server                                                  |
+| managers          | TCP 12388               | Internal           | Internal Port for the Kubernetes API Server                                                  |
 
 ## Enable ESP traffic
 

--- a/ee/ucp/admin/install/system-requirements.md
+++ b/ee/ucp/admin/install/system-requirements.md
@@ -80,7 +80,6 @@ host types:
 | managers          | TCP 12384               | Internal           | Port for the authentication storage backend for replication across managers   |
 | managers          | TCP 12385               | Internal           | Port for the authentication service API                                       |
 | managers          | TCP 12386               | Internal           | Port for the authentication worker                                            |
-| managers          | TCP 12387               | Internal           | Port for the metrics service                                                  |
 | managers          | TCP 12388               | Internal           | Internal Port for the Kubernetes API Server                                                  |
 
 ## Enable ESP traffic

--- a/ee/ucp/admin/install/system-requirements.md
+++ b/ee/ucp/admin/install/system-requirements.md
@@ -66,7 +66,7 @@ host types:
 | managers          | TCP 2376 (configurable) | Internal           | Port for the Docker Swarm manager. Used for backwards compatibility           |
 | managers          | TCP 2377 (configurable) | Internal,          | Port for control communication between swarm nodes                            |
 | managers, workers | UDP 4789                | Internal,          | Port for overlay networking                                                   |
-| managers          | TCP 6443 (configurable) | External, Internal | Port for Kubernetes API server                                                |
+| managers          | TCP 6443 (configurable) | External, Internal | Port for UCP Controller Kubernetes API endpiont                                                |
 | managers, workers | TCP 6444                | Self               | Port for Kubernetes API reverse proxy                                         |
 | managers, workers | TCP, UDP 7946           | Internal           | Port for gossip-based clustering                                              |
 | managers, workers | TCP 10250               | Internal           | Port for Kubelet                                                              |
@@ -81,6 +81,7 @@ host types:
 | managers          | TCP 12385               | Internal           | Port for the authentication service API                                       |
 | managers          | TCP 12386               | Internal           | Port for the authentication worker                                            |
 | managers          | TCP 12387               | Internal           | Port for the metrics service                                                  |
+| managers          | TCP 12388               | Internal           | Port for the Kubernetes API Server                                                  |
 
 ## Enable ESP traffic
 

--- a/ee/ucp/admin/install/system-requirements.md
+++ b/ee/ucp/admin/install/system-requirements.md
@@ -66,7 +66,7 @@ host types:
 | managers          | TCP 2376 (configurable) | Internal           | Port for the Docker Swarm manager. Used for backwards compatibility           |
 | managers          | TCP 2377 (configurable) | Internal,          | Port for control communication between swarm nodes                            |
 | managers, workers | UDP 4789                | Internal,          | Port for overlay networking                                                   |
-| managers          | TCP 6443 (configurable) | External, Internal | Port for Kubernetes API server                                                |
+| managers          | TCP 6443 (configurable) | External, Internal | Port for Kubernetes API server endpoint                                               |
 | managers, workers | TCP 6444                | Self               | Port for Kubernetes API reverse proxy                                         |
 | managers, workers | TCP, UDP 7946           | Internal           | Port for gossip-based clustering                                              |
 | managers, workers | TCP 10250               | Internal           | Port for Kubelet                                                              |


### PR DESCRIPTION
### Proposed changes

Adding port 12388 for Kube server API direct access for UCP 3.1 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
