### PR TITLE
Update Calico version

### DIFF
--- a/ee/ucp/ucp-architecture.md
+++ b/ee/ucp/ucp-architecture.md
@@ -68,7 +68,7 @@ on a node depend on whether the node is a manager or a worker.
 
 Internally, UCP uses the following components:
 
-* Calico 3.0.1
+* Calico 3.0.8
 * Kubernetes 1.8.11
 
 ### UCP components in manager nodes


### PR DESCRIPTION
Previous submitted changes were overwritten with Kubernetes version update PR.

As per https://docs.docker.com/ee/ucp/release-notes/#303-2018-07-26, Calico version is now 3.0.8

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
