### PR TITLE
interlock arch: fix constraint summary

### DIFF
--- a/ee/ucp/interlock/architecture.md
+++ b/ee/ucp/interlock/architecture.md
@@ -22,9 +22,9 @@ routing in UCP:
 
 ![](../images/interlock-architecture-1.svg)
 
-An Interlock service starts running on a manager node, an Interlock-extension
-service starts running on a worker node, and two replicas of the
-Interlock-proxy service run on worker nodes.
+The Interlock service starts a single replica on a manager node. The
+Interlock-extension service runs a single replica on any available node, and
+the Interlock-proxy service starts two replicas on any available node.
 
 If you don't have any worker nodes in your cluster, then all Interlock
 components run on manager nodes.


### PR DESCRIPTION
Technical:
- Neither interlock extension nor interlock proxy are constrained to worker nodes. From a default install on UCP 3.0.4:

    ```
    [vagrant@ucp-1 ~]$ docker service inspect ucp-interlock-proxy |jq '.[]|.Spec.TaskTemplate.Placement.Constraints'
    [
      "node.labels.com.docker.ucp.orchestrator.swarm==true",
      "node.platform.os==linux"
    ]
    ```

    ```
    [vagrant@ucp-1 ~]$ docker service inspect ucp-interlock-extension |jq '.[]|.Spec.TaskTemplate.Placement.Constraints'  
    [
      "node.labels.com.docker.ucp.orchestrator.swarm==true",
      "node.platform.os==linux"
    ]
    ```


Style:
- Break up run-on sentence

testedon: UCP 3.0.4


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->


<!--Tell us what you did and why-->


<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->


<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->