### PR TITLE
add ol7_addons repo enable steps for oraclelinux

### DIFF
--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -116,6 +116,16 @@ You only need to set up the repository once, after which you can install Docker 
 
 {% endif %}
 
+{% if linux-dist == "oraclelinux" %}
+
+5.  Enable the `ol7_addons` Oracle repository. This ensures access to the `container-selinux` package required by `docker-ee`.
+
+    ```bash
+    $ sudo yum-config-manager --enable ol7_addons
+    ```
+
+{% endif %}
+
 6.  Add the Docker EE **stable** repository:
 
     ```bash

--- a/install/linux/docker-ee/oracle.md
+++ b/install/linux/docker-ee/oracle.md
@@ -53,14 +53,6 @@ $ sudo yum remove docker \
 
 {% include ee-linux-install-reuse.md section="using-yum-repo" %}
 
-{% capture selinux-warning %}
-> Docker EE cannot install on {{ linux-dist-long }} with SELinux enabled
->
-> If you have `selinux` enabled and you attempt to install Docker EE 17.06.1 or newer, you get an error that the `container-selinux` package cannot be found..
-{:.warning}
-{% endcapture %}
-{{ selinux-warning }}
-
 ### Set up the repository
 
 {% include ee-linux-install-reuse.md section="set-up-yum-repo" %}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

When installing `docker-ee` on Oracle Linux 7, need to enable `ol7_addons` repo to satisfy `container-selinux` dependency. This PR adds the [missing instructions](https://docs.docker.com/install/linux/docker-ee/oracle/#set-up-the-repository) to enable the repo.

The new instructions steps are similar to the steps given for RHEL.