### PR TITLE
Update index.md

### DIFF
--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -60,7 +60,7 @@ daemon won't start and prints an error message.
 
 To configure the Docker daemon using a JSON file, create a file at
 `/etc/docker/daemon.json` on Linux systems, or `C:\ProgramData\docker\config\daemon.json`
-on Windows.
+on Windows. On MacOS go to the whale in the taskbar > Preferences > Daemon > Advanced.
 
 Here's what the configuration file looks like:
 


### PR DESCRIPTION
While trying to get https working on my localhost on Mac, I could not find where to edit the docker daemon.json settings.

### Proposed changes

I added a link to the place where the docker daemon settings can be edited.

### Related issues (optional)
This change is inspired by issue https://github.com/docker/docker.github.io/issues/2643.