### PR TITLE
Fix Typo in Staging Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ of [https://docs.docker.com/](https://docs.docker.com/).
 
 ## Staging the docs
 
-You have three options:
+You have two options:
 
 1.  On your local machine, clone this repo and run our staging container:
 


### PR DESCRIPTION
### Proposed changes

Change `three` to `two`.
It said that there were three options for staging docs. Only two were listed.
