### PR TITLE
Add FIPS 140-2 to toc to address erroneous documentation page

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -483,6 +483,8 @@ guides:
       title: NIST SP 800-53
     - path: /compliance/nist/800_190/
       title: NIST SP 800-190
+    - path: /compliance/nist/fips140_2/
+      title: FIPS 140-2
     - path: /compliance/nist/nistir_8176/
       title: NISTIR 8176
     - path: /compliance/nist/itl_october2017/


### PR DESCRIPTION
For quite some time, a placeholder page for FIPS 140-2 content was accidentally published and lingering out on docs -> https://docs.docker.com/compliance/nist/fips140_2/. This PR address this by adding an entry for FIPS 140-2 in the toc. The actual content has also been updated in https://github.com/docker/compliance/blob/master/docs/compliance/nist/fips140_2.md and this PR will trigger the content refresh via https://github.com/docker/docker.github.io/blob/master/_scripts/fetch-upstream-resources.sh#L82.