### PR TITLE
Fix typo in journald log options

### DIFF
--- a/config/containers/logging/journald.md
+++ b/config/containers/logging/journald.md
@@ -57,7 +57,7 @@ driver options.
 | Option      | Required | Description                                                                                                                                                                                      |
 |:------------|:---------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `tag`       | optional | Specify template to set `CONTAINER_TAG` and `SYSLOG_IDENTIFIER` value in journald logs. Refer to [log tag option documentation](/engine/admin/logging/log_tags/) to customize the log tag format |
-| `label`     | optional | Comma-separated list of keys of labels, which should be included in message, if these labels are specified for the container.                                                                    |
+| `labels`     | optional | Comma-separated list of keys of labels, which should be included in message, if these labels are specified for the container.                                                                    |
 | `env`       | optional | Comma-separated list of keys of environment variables, which should be included in message, if these variables are specified for the container.                                                  |
 | `env-regex` | optional | Similar to and compatible with env. A regular expression to match logging-related environment variables. Used for advanced [log tag options](/engine/admin/logging/log_tags/).                   |
 


### PR DESCRIPTION

### Proposed changes

Fixed a typo. The `label` option is actually called `labels`.
