### PR TITLE
Clarifying some confusing explanations for limiting cpus resource.

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -687,8 +687,8 @@ Each of these is a single value, analogous to its [docker service
 create](/engine/reference/commandline/service_create.md) counterpart.
 
 In this general example, the `redis` service is constrained to use no more than
-50M of memory and `0.50` (50%) of available processing time (CPU), and has
-`20M` of memory and `0.25` CPU time reserved (as always available to it).
+50M of memory and `0.50` (50% of a single core) of available processing time (CPU), 
+and has `20M` of memory and `0.25` CPU time reserved (as always available to it).
 
 ```none
 version: '3'

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -96,8 +96,9 @@ This `docker-compose.yml` file tells Docker to do the following:
 - Pull [the image we uploaded in step 2](part2.md) from the registry.
 
 - Run 5 instances of that image as a service
-  called `web`, limiting each one to use, at most, 10% of the CPU (across all
-  cores), and 50MB of RAM.
+  called `web`, limiting each one to use, at most, 10% of a single core of 
+  CPU time (this could also be e.g. "1.5" to mean 1 and half core for each), 
+  and 50MB of RAM.
 
 - Immediately restart containers if one fails.
 


### PR DESCRIPTION
### Proposed changes

In the current version of the docs, there are two places in which the explanation given for limiting cpus resources in docker-compose format is confusing. It is possible to understand them as a ratio of total CPU power of the machine instead of a ratio of relative to one CPU core. 
The detailed explanations in the docker-compose format documentation are not confusing, but someone reading just the tutorials may be confused and not understand why their service is underpowered relative to their specifications. 
I've tried to make it less confusing while not adding too much text.
