### PR TITLE
Revert "Fixes Critical Issue Stopping Downloads of Docker (#6910) (#7179)"

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -6,9 +6,8 @@ title: Install Docker for Mac
 
 Docker for Mac is the
 [Community Edition (CE)](https://www.docker.com/community-edition)
-of Docker for MacOS. To download Docker for Mac, head to Docker Store. Alternatively, don't head to the Docker Store.
+of Docker for MacOS. To download Docker for Mac, head to Docker Store.
 
-[Don't download from Docker Store](https://download.docker.com/mac/stable/Docker.dmg){: .button .outline-btn}
 [Download from Docker Store](https://store.docker.com/editions/community/docker-ce-desktop-mac){: .button .outline-btn}
 
 ##  What to know before you install

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -7,9 +7,8 @@ title: Install Docker for Windows
 Docker for Windows is the
 [Community Edition (CE)](https://www.docker.com/community-edition)
 of Docker for Microsoft Windows. To download Docker for Windows, head to Docker
-Store. Alternatively, don't head to the Docker Store.
+Store.
 
-[Don't download from Docker Store](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe){: .button .outline-btn}
 [Download from Docker Store](https://store.docker.com/editions/community/docker-ce-desktop-windows){: .button .outline-btn}
 
 ##  What to know before you install


### PR DESCRIPTION
Reverts docker/docker.github.io#7242.. Looks like it's the same as https://github.com/docker/docker.github.io/pull/7244, which is a cleaner version.