### PR TITLE
NOREF - Fix Invalid docker-compose.yml sample

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -60,7 +60,7 @@ Compose to set up and run WordPress. Before starting, make sure you have
            WORDPRESS_DB_USER: wordpress
            WORDPRESS_DB_PASSWORD: wordpress
     volumes:
-        db_data:
+        db_data: {}
     ```
 
    > **Notes**:


### PR DESCRIPTION
Without specifying this the user gets:
docker-compose up -d
ERROR: Top level object in './docker-compose.yml' needs to be an object not '<class 'NoneType'>'.

### Proposed changes

Fixed a sample `docker-compose.yml` file
