### PR TITLE
Update compose install command to always pick the latest version.

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -112,7 +112,8 @@ by step instructions are also included below.
 1.  Run this command to download the latest version of Docker Compose:
 
     ```bash
-    sudo curl -L "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    version=$(curl --silent "https://api.github.com/repos/docker/compose/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+    sudo curl -L "https://github.com/docker/compose/releases/download/$version/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     ```
 
     > Use the latest Compose release number in the download command.


### PR DESCRIPTION
This changes the Compose download command for Linux systems to always point to the latest version. 
This makes the command easier to use in installation scripts.