### PR TITLE
soften statement about storage drivers low I/O

### DIFF
--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -16,7 +16,10 @@ your applications and avoid performance problems along the way.
 
 Storage drivers allow you to create data in the writable layer of your container.
 The files won't be persisted after the container stops, and both read and
-write speeds are lower than native file system performance.
+write speeds are lower than native file system performance. 
+
+> **Note**: Operations that are known to be problematic include write-intensive database storage, 
+particularly when pre-existing data exists in the write-only layer. More details are provided in this document.
 
 [Learn how to use volumes](../index.md) to persist data and improve performance.
 

--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -16,7 +16,7 @@ your applications and avoid performance problems along the way.
 
 Storage drivers allow you to create data in the writable layer of your container.
 The files won't be persisted after the container stops, and both read and
-write speeds are low.
+write speeds are lower than native file system performance.
 
 [Learn how to use volumes](../index.md) to persist data and improve performance.
 


### PR DESCRIPTION
### Proposed changes

While performance is affected when comparing storage driver I/O to native filesystem performance, to summarize it as "low" is a bit harsh, so I softened it up to prevent people from overreacting from the info. More details are given later in the document anyway.