### PR TITLE
Correct container write layer persistence statement

### DIFF
--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -15,7 +15,7 @@ information to make informed choices about the best way to persist data from
 your applications and avoid performance problems along the way.
 
 Storage drivers allow you to create data in the writable layer of your container.
-The files won't be persisted after the container stops, and both read and
+The files won't be persisted after the container is deleted, and both read and
 write speeds are low.
 
 [Learn how to use volumes](../index.md) to persist data and improve performance.


### PR DESCRIPTION
### Proposed changes

Make it clearer that container storage file changes are persistent until the container is deleted, rather than the container stopped. This now matches statements later in the document.