### PR TITLE
linked ucp user bundle and clarified --ucp-node

### DIFF
--- a/ee/dtr/admin/install/index.md
+++ b/ee/dtr/admin/install/index.md
@@ -111,7 +111,7 @@ you're going to install these replicas also need to be managed by UCP.
 
 To add replicas to a DTR cluster, use the `docker/dtr join` command:
 
-1. Load your [UCP user bundle](https://docs.docker.com/ee/ucp/user-access/cli/#use-client-certificates).
+1. Load your [UCP user bundle](/ee/ucp/user-access/cli/#use-client-certificates).
 
 2.  Run the join command.
 

--- a/ee/dtr/admin/install/index.md
+++ b/ee/dtr/admin/install/index.md
@@ -111,7 +111,7 @@ you're going to install these replicas also need to be managed by UCP.
 
 To add replicas to a DTR cluster, use the `docker/dtr join` command:
 
-1. Load your UCP user bundle.
+1. Load your [UCP user bundle](https://docs.docker.com/ee/ucp/user-access/cli/#use-client-certificates).
 
 2.  Run the join command.
 
@@ -127,7 +127,13 @@ To add replicas to a DTR cluster, use the `docker/dtr join` command:
       --ucp-node <ucp-node-name> \
       --ucp-insecure-tls
     ```
-
+    
+    > --ucp-node
+    >
+    > The <ucp-node-name> following the --ucp-node flag is the target node to
+    > install the DTR replica. This is NOT the UCP Manager URL.
+    {: .important}
+    
 3. Check that all replicas are running.
 
     In your browser, navigate to the Docker **Universal Control Plane**


### PR DESCRIPTION
### Proposed changes

Linked the UCP user bundle to instructions on how to download and use a UCP user bundle. Added a note to clarify that --ucp-node is the node you are trying to install DTR on. See a lot of people setting this to one of their UCP manager nodes by accident or ignorance.

### Related issues (optional)

Overall, the docs do not advocate the use of the user/client bundle enough. Once UCP is installed, everything should be run through the user/client bundle. It should be a rare exception to run commands directly against the engine.
