### PR TITLE
docker-for-mac: make command line more intuitive

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -54,11 +54,11 @@ docker-machine version {{ site.machine_version }}, build 9ba6da9
     ...
     ```
 
-2.  Start a Dockerized web server. Like the hello-world image above, if the
+2.  Start a Dockerized web server. Like the `hello-world` image above, if the
     image is not found locally, Docker pulls it from Docker Hub.
 
     ```bash
-    $ docker run -d -p 80:80 --name webserver nginx
+    $ docker run --detach --publish=80:80 --name=webserver nginx
     ```
 
 3.  In a web browser, go to `http://localhost/` to view the nginx homepage. Because we specified the default HTTP port, it isn't necessary to append `:80` at the end of the URL.


### PR DESCRIPTION
For a getting-started guide, it makes sense to use the expanded option names that make it explicit what each option does. Later on users will have the chance to learn the shortcuts.

The equal sign convention is also used for the options that take arguments, to make it clearer what each part of that command line refers to.