### PR TITLE
Refer Windows Subsystem for Linux for Windows 10

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -171,7 +171,8 @@ the previous command (`docker container ls -q`).
 > Running Windows 10?
 >
 > Windows 10 PowerShell should already have `curl` available, but if not you can
-> grab a Linux terminal emulator like
+> install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+> Alternatively, grab a Linux terminal emulator like
 > [Git BASH](https://git-for-windows.github.io/){: target="_blank" class="_"},
 > or download
 > [wget for Windows](http://gnuwin32.sourceforge.net/packages/wget.htm)


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Hi, 
this is a great guide and I am just following along. Got to this point and found old references to getting bash on windows. So, adding a MSDN reference to install the Windows Subsystem for Linux - https://docs.microsoft.com/en-us/windows/wsl/install-win10. Since bash is available to windows developers through it, proposing this update. There should be no need to install extra software and it is a fantastic utility that helps developers using Windows 10 learning docker.. 
Some developers may have enterprise IT constraints and hence may still require the git bash or wget software and hence retained those references as well.. 
thanks rasane

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
