### PR TITLE
Django has error with Python 3.7

### DIFF
--- a/compose/django.md
+++ b/compose/django.md
@@ -26,7 +26,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
 
 3. Add the following content to the `Dockerfile`.
 
-        FROM python:3
+        FROM python:3.6
         ENV PYTHONUNBUFFERED 1
         RUN mkdir /code
         WORKDIR /code


### PR DESCRIPTION
### Proposed changes

NB I'm a Docker novice, so I might have gotten something wrong here.  This PR reflects my best guess/understanding - please be kind.

Following the current instructions results in an error.  This is because the current version of Django on Pypi has an incompatibility with Python 3.7 (which is now the default for `python:3`.  c.f. https://stackoverflow.com/questions/48822571/syntaxerror-generator-expression-must-be-parenthezised-python-manage-py-migra

What I did to address this was update the instructions to lock us to Python 3.6 for now.