### PR TITLE
Corrected docker stack deploy environment override

### DIFF
--- a/_data/engine-cli/docker_stack_deploy.yaml
+++ b/_data/engine-cli/docker_stack_deploy.yaml
@@ -117,7 +117,7 @@ examples: |-
   `--compose-file` flags.
 
   ```bash
-  $ docker stack deploy --compose-file docker-compose.yml -f docker-compose.prod.yml vossibility
+  $ docker stack deploy --compose-file docker-compose.yml -c docker-compose.prod.yml vossibility
 
   Ignoring unsupported options: links
 


### PR DESCRIPTION
The docker stack deploy command with environment override should use -c instead of -f.

### Proposed changes

Replacing -f by -c in the docker stack deploy example demonstrating an environment override.

### Related issues (optional)

Fixes #7483
