### PR TITLE
Replace fd:// by unix::// in service override

### DIFF
--- a/install/linux/linux-postinstall.md
+++ b/install/linux/linux-postinstall.md
@@ -156,7 +156,7 @@ Configuring Docker to accept remote connections can be done with the `docker.ser
     ```none
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// -H tcp://127.0.0.1:2375
+    ExecStart=/usr/bin/dockerd -H unix:// -H tcp://127.0.0.1:2375
     ```
 
 3. Save the file.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

On: https://docs.docker.com/install/linux/linux-postinstall/#configuring-remote-access-with-systemd-unit-file

The line below part of instructions to create a docker.service override for configuring connections:
    ```
    ExecStart=/usr/bin/dockerd -H fd:// -H tcp://127.0.0.1:2375
    ```
creates the error below preventing dockerd to start:

**"Failed to load listeners: no sockets found via socket activation: make sure the service was started"**

Replacing in the ExecStart line above ``fd://`` by ``unix://`` (the later being the syntax used in the docker.service default systemd unit) fixes the problem.

I thought it would help readers who copy/paste the code snippet to have it working out-of-the-box for this common use case and for the syntax to be consistent with that in ``/lib/systemd/system/docker.service``.

Environment: Centos 7 on AWS EC2 using Docker 18.06.1 from repository. No hosts configured in daemon.json.
### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
