### PR TITLE
Update doc for setting up Github Autobuils in Hub

### DIFF
--- a/docker-hub/github.md
+++ b/docker-hub/github.md
@@ -9,7 +9,8 @@ skip to [Creating an Automated Build](github.md#creating-an-automated-build).
 
 ## Linking Docker Hub to a GitHub account
 
-> *Note:*
+> Automated Build Permissions
+
 > Automated Builds currently require *read* and *write* access since
 > [Docker Hub](https://hub.docker.com) needs to set up a GitHub webhook.
 > We have no choice here &ndash; this is how GitHub manages permissions.

--- a/docker-hub/github.md
+++ b/docker-hub/github.md
@@ -48,10 +48,10 @@ You can now re-link your account at any time.
 ## GitHub organizations
 
 GitHub organizations and private repositories forked from organizations are
-made available for auto builds using the "Docker Hub Registry" application, which
+made available for autobuilds using the "Docker Hub Registry" application, which
 needs to be added to the organization - and then applied to all users.
 
-To verify access or request access, go to your GitHub **Settings** page, select the
+To verify or request access, go to your GitHub **Settings** page. Select the
 **Applications** section from the left side bar, then click the **View** button for
 "Docker Hub Registry".
 
@@ -95,7 +95,7 @@ You can also select one or more:
 
 You can modify the description for the repository by clicking the "Description" section
 of the repository view.
-The "Full Description" is over-written by the README.md file when the
+The "Full Description" is overwritten by the **README.md** file when the
 next build is triggered.
 
 ## GitHub private submodules
@@ -156,7 +156,7 @@ build.
 ## GitHub webhook
 
 A GitHub webhook allows GitHub to notify Docker Hub when something has
-been committed to a given git repository.
+been committed to a given Git repository.
 
 When you create an Automated Build, a webhook should get automatically added to your GitHub
 repository.

--- a/docker-hub/github.md
+++ b/docker-hub/github.md
@@ -21,23 +21,9 @@ GitHub account. This allows the registry to see your GitHub repositories.
 
 To add, remove or view your linked account, log in to your Docker Hub account. Select **Settings > Linked Accounts & Services**.
 
-![authorized-services](images/authorized-services.png)
-
-When linking to GitHub, select either ***Public and Private***,
-or ***Limited Access***.
-
-![add-authorized-github-service.png](images/add-authorized-github-service.png)
-
-The ***Public and Private*** option is the easiest to use, as it grants the Docker
-Hub full access to all of your repositories. GitHub also allows you to grant
-access to repositories belonging to your GitHub organizations.
-
-If you choose ***Limited Access***, Docker Hub only gets permission to access your
-public data and public repositories.
-
-Follow the onscreen instructions to authorize and link your GitHub account to
-Docker Hub. Once it is linked, you can choose a source repository from
-which to create the Automatic Build.
+Linking to Github grants Docker Hub access to all of your repositories. Follow the
+onscreen instructions to authorize and link your GitHub account to Docker Hub. 
+Once it is linked, you can choose a source repository from which to create the Automatic Build.
 
 You can review and revoke Docker Hub's access by visiting the
 [GitHub User's Applications settings](https://github.com/settings/applications).
@@ -48,20 +34,10 @@ You can review and revoke Docker Hub's access by visiting the
 > using the **Start Build** button on the Hub, or if the webhook on the GitHub repository
 > still exists, it is triggered by any subsequent commits.
 
-## Auto builds and limited linked GitHub accounts
-
-If you chose ***Limited Access*** for your Github account connection, after creating your automated build,
-you will need to either:
-* Manually trigger a Docker Hub build using the **Start a Build** button, or 
-* Add the GitHub webhook manually, as described in [GitHub Webhook](github.md#github-webhook). 
-
-This only works for repositories under the user account, and adding an automated build to a public GitHub
-organization using a ***Limited Access*** link is not possible.
-
 ## Changing the GitHub user link
 
 If you want to remove, or change the level of linking between your GitHub
-account and the Docker Hub, you need to make the change in two places.
+account and Docker Hub, you need to make the change in two places.
 
 First, remove the **Linked Account** from your Docker Hub **Settings**. Then go to
 your GitHub account's Personal settings, and in the **Applications** section,
@@ -72,17 +48,17 @@ You can now re-link your account at any time.
 ## GitHub organizations
 
 GitHub organizations and private repositories forked from organizations are
-made available to auto build using the "Docker Hub Registry" application, which
-needs to be added to the organization - and then applies to all users.
+made available for auto builds using the "Docker Hub Registry" application, which
+needs to be added to the organization - and then applied to all users.
 
-To check, or request access, go to your GitHub **Settings** page, select the
+To verify access or request access, go to your GitHub **Settings** page, select the
 **Applications** section from the left side bar, then click the **View** button for
 "Docker Hub Registry".
 
 ![Check User access to GitHub](images/gh-check-user-org-dh-app-access.png)
 
 The organization's administrators may need to go to the Organization's **Third
-party access** screen in **Settings** to grant or deny access to the Docker Hub
+party access** screen in **Settings** to grant or deny access to Docker Hub
 Registry application. This change applies to all organization members.
 
 ![Check Docker Hub application access to Organization](images/gh-check-admin-org-dh-app-access.png)
@@ -101,8 +77,8 @@ Once you've selected the source repository, you can then configure:
 - The Hub user/org namespace the repository is built to - either your Docker ID name, or the name of any Hub organizations your account is in
 - The Docker repository name the image is built to
 - The description of the repository
-- If the visibility of the Docker repository: "Public" or "Private"
-  You can change the accessibility options after the repository has been created.
+- If the visibility of the Docker repository is "Public" or "Private",
+  you can change the accessibility options after the repository has been created.
   If you add a Private repository to a Hub user namespace, then you can only add other users
   as collaborators, and those users can view and pull all images in that
   repository. To configure more granular access permissions, such as using teams of
@@ -110,11 +86,11 @@ Once you've selected the source repository, you can then configure:
   to add the Private repository to a Hub organization for which your user has Administrator
   privileges.
 - Enable or disable rebuilding the Docker image when a commit is pushed to the
-  GitHub repository.
+  GitHub repository
 
 You can also select one or more:
-- The git branch/tag,
-- A repository sub-directory to use as the context,
+- The git branch/tag
+- A repository sub-directory to use as the context
 - The Docker image tag name
 
 You can modify the description for the repository by clicking the "Description" section
@@ -126,7 +102,7 @@ next build is triggered.
 
 If your GitHub repository contains links to private submodules, your build fails.
 
-Normally, the Docker Hub sets up a deploy key in your GitHub repository.
+Normally, Docker Hub sets up a deploy key in your GitHub repository.
 Unfortunately, GitHub only allows a repository deploy key to access a single
 repository.
 
@@ -179,15 +155,11 @@ build.
 
 ## GitHub webhook
 
-A GitHub webhook allows GitHub to notify the Docker Hub when something has
+A GitHub webhook allows GitHub to notify Docker Hub when something has
 been committed to a given git repository.
 
-When you create an Automated Build from a GitHub user that has full **Public and
-Private** linking, a Service Hook should get automatically added to your GitHub
+When you create an Automated Build, a webhook should get automatically added to your GitHub
 repository.
-
-If your GitHub account link to the Docker Hub is **Limited Access**, then you
-need to add the webhook manually.
 
 To add, confirm, or modify the webhook, log in to GitHub, then navigate to
 the repository. Within the repository,  select **Settings > Webhooks**.


### PR DESCRIPTION
### Proposed changes

Since the _Limited Access_ option when linking a Github repository in Docker Hub was removed, mention of that option should similarly be removed. In addition, some wording was cleaned up (ex. Docker Hub vs the Docker Hub).
