### PR TITLE
Adding October 2018 patch release notes for EE Engine, UCP, and DTR.

### DIFF
--- a/datacenter/dtr/2.3/guides/release-notes.md
+++ b/datacenter/dtr/2.3/guides/release-notes.md
@@ -11,6 +11,18 @@ known issues for each DTR version.
 You can then use [the upgrade instructions](admin/upgrade.md),
 to upgrade your installation to the latest release.
 
+## Version 2.3.9
+
+(25 October 2018)
+
+### Bug Fixes
+* Added CSP (Content Security Policy). (docker/dhe-deploy#9368 and docker/dhe-deploy#9588)
+* Fixed critical vulnerability in RethinkDB. (docker/dhe-deploy#9575)
+
+### Changelog
+* Patched security vulnerabilities in the load balancer.
+* Patch packages and base OS to eliminate and address some critical vulnerabilities in DTR dependencies.
+
 ## Version 2.3.8
 
 (26 July 2018)

--- a/ee/dtr/release-notes.md
+++ b/ee/dtr/release-notes.md
@@ -20,6 +20,17 @@ to upgrade your installation to the latest release.
 
 # Version 2.5
 
+## 2.5.6 (2018-10-25)
+
+### Bug Fixes
+* Fixed a bug where Windows images could not be promoted. (docker/dhe-deploy#9215)
+* Removed Python3 from base image. (docker/dhe-deploy#9219)
+* Added CSP (docker/dhe-deploy#9366)
+* Included foreign layers in scanned images. (docker/dhe-deploy#9488)
+* Added dotnet.marsu to nautilus base image. (docker/dhe-deploy#9503)
+* Backported ManifestList fixes. (docker/dhe-deploy#9547)
+* Removed support sidebar link and associated content. (docker/dhe-deploy#9411)
+
 ## 2.5.5 (2018-8-30)
 
 ### Bug Fixes
@@ -160,6 +171,18 @@ specify `--log-protocol`.
   FATAL:  database files are incompatible with server
 
 # Version 2.4
+
+## Version 2.4.7
+
+(25 October 2018)
+
+### Bug Fixes
+* Added CSP (Content Security Policy). (docker/dhe-deploy#9367 and docker/dhe-deploy#9584)
+* Fixed critical vulnerability in RethinkDB. (docker/dhe-deploy#9574)
+
+### Changelog
+* Patched security vulnerabilities in the load balancer.
+* Patch packages and base OS to eliminate and address some critical vulnerabilities in DTR dependencies.
 
 ## Version 2.4.6
 

--- a/ee/engine/release-notes.md
+++ b/ee/engine/release-notes.md
@@ -19,6 +19,40 @@ it references. However, Docker EE also includes back-ported fixes
 defect fixes that you can use in environments where new features cannot be
 adopted as quickly for consistency and compatibility reasons.
 
+## 18.03.1-ee-4 (2018-10-25)
+
+> Important notes about this release
+>
+> If you're deploying UCP or DTR, use Docker EE Engine 17.06.
+{: .important}
+
+### Client
+
+- Fixed help message flags on `docker stack` commands and child commands. [docker/cli#1251](https://github.com/docker/cli/pull/1251)
+- Fixed typo breaking zsh `docker update` autocomplete. [docker/cli#1232](https://github.com/docker/cli/pull/1232)
+
+### Networking
+
+- Added optimizations to reduce the messages in the NetworkDB queue. [docker/libnetwork#2225](https://github.com/docker/libnetwork/pull/2225)
+- Fixed a very rare condition where managers are not correctly triggering the reconnection logic. [docker/libnetwork#2226](https://github.com/docker/libnetwork/pull/2226)
+- Changed loglevel from ***error*** to ***warning*** for missing `disable_ipv6` file. [docker/libnetwork#2224](https://github.com/docker/libnetwork/pull/2224)
+
+### Runtime
+
+- Fixed denial of service with large numbers in `cpuset-cpus` and `cpuset-mems`. [moby/moby#37967](https://github.com/moby/moby/pull/37967)
+- Added stability improvements for `devicemapper` shutdown. [moby/moby#36307](https://github.com/moby/moby/pull/36307) [moby/moby#36438](https://github.com/moby/moby/pull/36438)
+
+### Swarm Mode
+
+- Fixed the logic used for skipping over running tasks. [docker/swarmkit#2724](https://github.com/docker/swarmkit/pull/2724)
+- Addressed unassigned task leak when a service is removed. [docker/swarmkit#2709](https://github.com/docker/swarmkit/pull/2709)
+
+
+### Builder
+
+- Added an error if build args are missing during `docker build`. [docker/engine#25](https://github.com/docker/engine/pull/25)
+- Fixed an issue where HealthCheck runs while an image is building. [moby/moby#37413](https://github.com/moby/moby/pull/37413)
+
 ## 18.03.1-ee-3 (2018-08-30)
 
 > Important notes about this release
@@ -84,6 +118,25 @@ adopted as quickly for consistency and compatibility reasons.
 + Windows opt-out telemetry stream.
 + Support for `--chown` with `COPY` and `ADD` in `Dockerfile`.
 + Add support for multiple logging drivers for `docker logs`.
+
+## 17.06.2-ee-17 (2018-10-25)
+
+### Networking
+
+- Changed loglevel from ***error*** to ***warning*** for missing `disable_ipv6` file. [docker/libnetwork#2223](https://github.com/docker/libnetwork/pull/2223)
+- Fixed subnet allocation to avoid reallocating recently freed subnets. [docker/libnetwork#2255](https://github.com/docker/libnetwork/pull/2255)
+- Fixed libnetwork issue which caused errors to be returned when `iptables` or `firewalld` issues transient warnings. [docker/libnetwork#2218](https://github.com/docker/libnetwork/pull/2218)
+
+### Plugins
+
+- Fixed too many "Plugin not found" error messages. [moby/moby#36119](https://github.com/moby/moby/pull/36119)
+
+### Swarm mode
+
+- Added failed allocations retry immediately upon a deallocation to overcome IP exhaustion. [docker/swarmkit#2711](https://github.com/docker/swarmkit/pull/2711)
+- Fixed leaking task resources. [docker/swarmkit#2755](https://github.com/docker/swarmkit/pull/2755)
+- Fixed deadlock in dispatcher that could cause node to crash. [docker/swarmkit#2753](https://github.com/docker/swarmkit/pull/2753)
+
 
 ## 17.06.2-ee-16 (2018-07-26)
 

--- a/ee/engine/release-notes.md
+++ b/ee/engine/release-notes.md
@@ -47,12 +47,6 @@ adopted as quickly for consistency and compatibility reasons.
 - Fixed the logic used for skipping over running tasks. [docker/swarmkit#2724](https://github.com/docker/swarmkit/pull/2724)
 - Addressed unassigned task leak when a service is removed. [docker/swarmkit#2709](https://github.com/docker/swarmkit/pull/2709)
 
-
-### Builder
-
-- Added an error if build args are missing during `docker build`. [docker/engine#25](https://github.com/docker/engine/pull/25)
-- Fixed an issue where HealthCheck runs while an image is building. [moby/moby#37413](https://github.com/moby/moby/pull/37413)
-
 ## 18.03.1-ee-3 (2018-08-30)
 
 > Important notes about this release

--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -20,6 +20,29 @@ upgrade your installation to the latest release.
 
 # Version 3.0
 
+## 3.0.6 (2018-10-25)
+
+**Bug fixes**
+
+* Core
+
+  * Bumped Kubernetes version to 1.8.15.
+  * Fixed an issue where LDAP sync jobs would crash when handling an org admin search result which does not correspond to an existing user. (docker/escalation#784 #docker/escalation#888)
+  * Fixed an issue that caused RethinkDB client lock contention. (docker/escalation#902 and docker/escalation#906)
+  * Fixed an issue that prevented Azure IPAM from releasing addresses. (docker/escalation#815)
+  * Fixed an issue that caused installation of UCP on Azure to be unsuccessful. (docker/escalation#863)
+  * Fixed an issue that caused Interlock proxy service to keep restarting. (docker/escalation#814)
+  * Fixed an issue that prevented Kubernetes DNS from working. (docker/orca#14064 and docker/orca#11981)
+  * Fixed an issue that caused "Missing swarm placement constraints" warning banner to appear unnecessarily. (docker/orca#14539)
+
+* Security
+
+  * Fixed `libcurl` vulnerability in RethinkDB image. (docker/orca#15169)
+
+* UI
+
+  * Fixed an issue that prevented "Per User Limit" on Admin Settings from working. (docker/escalation#639)
+
 ## 3.0.5 (2018-08-30)
 
 **Bug fixes**
@@ -290,6 +313,17 @@ from the UCP web UI. You can configure Docker Engine for this.
 deprecated. Deploy your applications as Swarm services or Kubernetes workloads.
 
 # Version 2.2
+
+## Version 2.2.14 (2018-10-25)
+
+**Bug fixes**
+
+* Core 
+  * Resolved an issue where LDAP sync jobs would crash when handling an org admin search result which does not correspond to an existing user. (docker/escalation#784 #docker/escalation#888)
+  * Fixed an issue that caused RethinkDB client lock contention. (docker/escalation#902 and docker/escalation#906)
+
+* UI
+  * Fixed an issue that prevented "Per User Limit" on Admin Settings from working. (docker/escalation#639)
 
 ## Version 2.2.13 (2018-08-30)
 


### PR DESCRIPTION
### Proposed changes

This includes the following patch release updates:
- Engine: 18.03.1-ee-4 and 17.06.2-ee-17
- UCP: 3.0.6, 2.2.14
- DTR: 2.5.6, 2.4.7, and 2.3.9

Closes [docs-private#697](https://github.com/docker/docs-private/issues/697).

