### PR TITLE
Add offline bundles for October Patches

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,7 +92,7 @@ defaults:
   - scope:
       path: "install"
     values:
-      win_latest_build: "docker-17.06.2-ee-16"
+      win_latest_build: "docker-17.06.2-ee-17"
   - scope:
       path: "datacenter"
     values:
@@ -102,21 +102,21 @@ defaults:
     values:
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.5.5"
+      dtr_version: "2.5.6"
   - scope:
       path: "datacenter/dtr/2.4"
     values:
       hide_from_sitemap: true
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.4.6"
+      dtr_version: "2.4.7"
   - scope:
       path: "datacenter/dtr/2.3"
     values:
       hide_from_sitemap: true
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.3.8"
+      dtr_version: "2.3.9"
   - scope:
       path: "datacenter/dtr/2.2"
     values:
@@ -138,23 +138,23 @@ defaults:
     values:
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "3.0.5"
+      ucp_version: "3.0.6"
   - scope: # This is a bit of a hack for the get-support.md topic.
       path: "ee"
     values:
       ucp_org: "docker"
       ucp_repo: "ucp"
       dtr_repo: "dtr"
-      ucp_version: "3.0.5"
+      ucp_version: "3.0.6"
       dtr_version: "2.5.0"
-      dtr_latest_image: "docker/dtr:2.5.5"
+      dtr_latest_image: "docker/dtr:2.5.6"
   - scope:
       path: "datacenter/ucp/2.2"
     values:
       hide_from_sitemap: true
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "2.2.13"
+      ucp_version: "2.2.14"
   - scope:
       path: "datacenter/ucp/2.1"
     values:

--- a/_data/ddc_offline_files_2.yaml
+++ b/_data/ddc_offline_files_2.yaml
@@ -6,6 +6,16 @@
 - product: "ucp"
   version: "3.0"
   tar-files:
+    - description: "3.0.6 Linux"
+      url: https://packages.docker.com/caas/ucp_images_3.0.6.tar.gz
+    - description: "3.0.6 IBM Z"
+      url: https://packages.docker.com/caas/ucp_images_s390x_3.0.6.tar.gz
+    - description: "3.0.6 Windows Server 2016 LTSC"
+      url: https://packages.docker.com/caas/ucp_images_win_2016_3.0.6.tar.gz
+    - description: "3.0.6 Windows Server 1709"
+      url: https://packages.docker.com/caas/ucp_images_win_1709_3.0.6.tar.gz
+    - description: "3.0.6 Windows Server 1803"
+      url: https://packages.docker.com/caas/ucp_images_win_1803_3.0.6.tar.gz
     - description: "3.0.5 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.0.5.tar.gz
     - description: "3.0.5 IBM Z"
@@ -53,6 +63,12 @@
 - product: "ucp"
   version: "2.2"
   tar-files:
+    - description: "2.2.14 Linux"
+      url: https://packages.docker.com/caas/ucp_images_2.2.14.tar.gz
+    - description: "2.2.14 IBM Z"
+      url: https://packages.docker.com/caas/ucp_images_s390x_2.2.14.tar.gz
+    - description: "2.2.14 Windows"
+      url: https://packages.docker.com/caas/ucp_images_win_2.2.14.tar.gz
     - description: "2.2.13 Linux"
       url: https://packages.docker.com/caas/ucp_images_2.2.13.tar.gz
     - description: "2.2.13 IBM Z"
@@ -128,6 +144,10 @@
 - product: "dtr"
   version: "2.5"
   tar-files:
+    - description: "DTR 2.5.6 Linux x86"
+      url: https://packages.docker.com/caas/dtr_images_2.5.6.tar.gz
+    - description: "DTR 2.5.6 IBM Z"
+      url: https://packages.docker.com/caas/dtr_images_s390x_2.5.6.tar.gz
     - description: "DTR 2.5.5 Linux x86"
       url: https://packages.docker.com/caas/dtr_images_2.5.5.tar.gz
     - description: "DTR 2.5.5 IBM Z"
@@ -151,6 +171,10 @@
 - product: "dtr"
   version: "2.4"
   tar-files:
+    - description: "DTR 2.4.7 Linux x86"
+      url: https://packages.docker.com/caas/dtr_images_2.4.7.tar.gz
+    - description: "DTR 2.4.7 IBM Z"
+      url: https://packages.docker.com/caas/dtr_images_s390x_2.4.7.tar.gz 
     - description: "DTR 2.4.6 Linux x86"
       url: https://packages.docker.com/caas/dtr_images_2.4.6.tar.gz
     - description: "DTR 2.4.6 IBM Z"
@@ -182,6 +206,8 @@
 - product: "dtr"
   version: "2.3"
   tar-files:
+    - description: "DTR 2.3.9"
+      url: https://packages.docker.com/caas/dtr_images_2.3.9.tar.gz  
     - description: "DTR 2.3.8"
       url: https://packages.docker.com/caas/dtr_images_2.3.8.tar.gz  
     - description: "DTR 2.3.7"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
 
Update the offline bundles for: 

UCP: 3.0.6, 2.2.14
DTR: 2.5.6, 2.4.7, and 2.3.9

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
