### PR TITLE
Friendly script for distros based on Ubuntu

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -185,7 +185,7 @@ the repository.
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=amd64] {{ download-url-base }} \
-       $(lsb_release -cs) \
+       $(lsb_release -u -cs) \
        stable"
     ```
 
@@ -195,7 +195,7 @@ the repository.
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=armhf] {{ download-url-base }} \
-       $(lsb_release -cs) \
+       $(lsb_release -u -cs) \
        stable"
     ```
 
@@ -205,7 +205,7 @@ the repository.
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=ppc64el] {{ download-url-base }} \
-       $(lsb_release -cs) \
+       $(lsb_release -u -cs) \
        stable"
     ```
 
@@ -215,7 +215,7 @@ the repository.
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=s390x] {{ download-url-base }} \
-       $(lsb_release -cs) \
+       $(lsb_release -u -cs) \
        stable"
     ```
 


### PR DESCRIPTION
### Proposed changes

Use `-u` to show upstream LSB data.

I use Elementary OS, it's a distro based on Ubuntu and with the command `lsb_release -cs` the output is `juno`.

If I use `lsb_release -u -cs` the output is `bionic`
