### PR TITLE
clarify v2 vs. v3 compose file format for different use cases

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -11,8 +11,8 @@ The Compose file formats are now described in these references, specific to each
 
 | **Reference file**                                    | **What changed in this version** |
 |:------------------------------------------------------|:---------------------------------|
-| [Version 3](index.md) (most current, and recommended) | [Version 3 updates](#version-3)  |
-| [Version 2](compose-file-v2.md)                       | [Version 2 updates](#version-2)  |
+| [Version 3](index.md) (recommended for swarm/kubernetes stacks) | [Version 3 updates](#version-3)  |
+| [Version 2](compose-file-v2.md) (recommended for docker-compose cli)                       | [Version 2 updates](#version-2)  |
 | [Version 1](compose-file-v1.md)                       | [Version 1 updates](#version-1)  |
 
 The topics below explain the differences among the versions, Docker Engine

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -9,11 +9,11 @@ networks, and volumes for a Docker application.
 
 The Compose file formats are now described in these references, specific to each version.
 
-| **Reference file**                                    | **What changed in this version** |
-|:------------------------------------------------------|:---------------------------------|
-| [Version 3](index.md) (recommended for swarm/kubernetes stacks) | [Version 3 updates](#version-3)  |
-| [Version 2](compose-file-v2.md) (recommended for docker-compose cli)                       | [Version 2 updates](#version-2)  |
-| [Version 1](compose-file-v1.md)                       | [Version 1 updates](#version-1)  |
+| **Reference file**                                                   | **What changed in this version** |
+|:---------------------------------------------------------------------|:---------------------------------|
+| [Version 3](index.md) (recommended for Swarm/Kubernetes stacks)      | [Version 3 updates](#version-3)  |
+| [Version 2](compose-file-v2.md) (recommended for docker-compose CLI) | [Version 2 updates](#version-2)  |
+| [Version 1](compose-file-v1.md)                                      | [Version 1 updates](#version-1)  |
 
 The topics below explain the differences among the versions, Docker Engine
 compatibility, and [how to upgrade](#upgrading).
@@ -41,16 +41,20 @@ For details on versions and how to upgrade, see
 
 ## Versioning
 
-There are currently three versions of the Compose file format:
+There are currently three major versions of the Compose file format:
 
 - Version 1, the legacy format. This is specified by
 omitting a `version` key at the root of the YAML.
 
-- Version 2.x. This is specified with a `version: '2'` or `version: '2.1'`, etc., entry at the root of the YAML.
+- Version 2.x, optimized for docker-compose CLI use with a single machine. 
+New features are still being added
+for development workflows, and some features only exist in 2.x versions.
+This is specified with a `version: '2'` or `version: '2.1'`, etc., entry at the root of the YAML.
 
-- Version 3.x, the latest and recommended version, designed to
-be cross-compatible between Compose and the Docker Engine's
-[swarm mode](/engine/swarm/index.md). This is specified with a `version: '3'` or `version: '3.1'`, etc., entry at the root of the YAML.
+- Version 3.x, the latest and recommended version if you desire to 
+be cross-compatible between docker-compose CLI and orchestrators including Docker Engine's
+[swarm mode](/engine/swarm/index.md) and Kubernetes (when used with Docker Desktop or Docker Enterprise.)
+This is specified with a `version: '3'` or `version: '3.1'`, etc., entry at the root of the YAML.
 
 
 The [Compatibility Matrix](#compatibility-matrix) shows Compose file versions mapped to Docker Engine releases.


### PR DESCRIPTION
## TL;DR

I'd like to use this PR to talk about how we can improve docs for helping people choose either compose file format versions 2.x vs. 3.x.  I'm willing to add/change the messaging to help direct people to the correct version for their use case, and this may need to be tweaked in multiple files, but I'd like to get feedback on the right approach and docker team(s) strategy.

@garethr @shin- @thaJeztah (maybe others)

## Brief History of Compose Version Usage:

* We were all happy in our 2.x days and then Swarm Mode came along and needed some new compose file concepts that wouldn't work in docker-compose cli. It made sense to create a new major version because many Swarm concepts wouldn't work in a single-daemon docker-compose scenario. 3.x was born, and it was awesome.
* We all starting changing *every* compose file to 3.x thinking that was the future for everything and a total superset of compose file features. New files started with `version: 3.1` in early 2017
* Then [SwarmKit didn't get all the features](https://github.com/docker/docker/issues/25303) that `docker run` had and we needed some things in docker-compose that weren't yea in Swarm, so then 2.x was re-born with 2.2 (or 2.1 I can't remember,) and it was useful, but the choice became confusing between 2.x and 3.x.
* Messaging still said "we recommend 3.x" and our demos and tools were all still changing to 3.x. Today the common understanding in my workshops, weekly online chats, and online students are "2.x is old, always use 3.x" but the featureset doesn't match that sentiment.
* What I've been trying to communicate through 2018 is that 2.x lives on, as a featureset for people only using the file with docker-compose cli and don't intend to use that compose file with Stacks. 2.x has device support and now "healthcheck aware `depends_on`" which makes it useful as a separate version fork from the 3.x track which seems focused on multi-node orchestration compatibility.

## The Problem

The problem is those feature differences are not being talked about much, and this PR is suggesting what might need to be the first of multiple file changes to help educate users on when they should choose 2.x or 3.x for a specific compose file.

When Swarm Mode and 3.x was released, many of us tried to use the "one compose file to rule them all" approach and for various reasons, I don't think it stuck.  Even `.env` options, overrides, and templating was not enough to create a single-file experience for dev->test->prod. Too many things like multi-value compose arrays, complexities of dev vs. prod, and version differences have created a world where most teams, including docker's own examples, use `docker-compose.yml` for docker-compose local dev, and `docker-stack.yml` for Stack deployments. Honestly, this is fine, and not something I'm worried about.

But the value of 2.x versions and their features since 1.12 release is lost on everyone I meet IRL and online. There's no message that "2.x is of value and should still be used in certain use cases."

## The Fix

My assumption is that this is what the current strategy is, and I'd like to help clear it up in docs:

* 3.x is focused on Stacks, with as much backward compatibility as docker-compose cli can support.
* 2.x is focused on docker-compose workflows and `docker run` features, with as much forward compatibility as stacks can support.

If this is the case, then what other things besides this small PR file change can support helping people chose their version. Should we have a separate "2 vs. 3" file linked from the main compose files? What other ways can I help make this strategy plain to the compose user?

Thanks for your help.