### PR TITLE
Only format the folder name as code

### DIFF
--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -72,7 +72,7 @@ Looking for information on using Windows containers?
     If you haven't already downloaded the installer (`Docker for Windows
     Installer.exe`), you can get it from
     [**download.docker.com**](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe).
-    It typically downloads to your `Downloads folder`, or you can run it from
+    It typically downloads to your `Downloads` folder, or you can run it from
     the recent downloads bar at the bottom of your web browser.
 
 2. Follow the install wizard to accept the license, authorize the installer, and


### PR DESCRIPTION
### Proposed changes

This tiny PR changes the markup of a sentence where a folder is referenced:

Before:
![image](https://user-images.githubusercontent.com/227934/47925468-83220f00-debe-11e8-975c-440e9378b63f.png)

After:
![image](https://user-images.githubusercontent.com/227934/47925508-a351ce00-debe-11e8-924d-d0288c549c0e.png)

