### PR TITLE
Update configs.md

### DIFF
--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -122,8 +122,8 @@ Docker configs.
 
 ### Defining and using configs in compose files
 
-The `docker stack` command supports defining configs in a compose file.
-However, the 'configs' key is not supported for `docker compose`. See
+The `docker stack` command supports defining configs in a Compose file.
+However, the `configs` key is not supported for `docker compose`. See
 [the Compose file reference](/compose/compose-file/#configs) for details.
 
 ### Simple example: Get started with configs

--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -122,8 +122,8 @@ Docker configs.
 
 ### Defining and using configs in compose files
 
-Both the `docker compose` and `docker stack` commands support defining configs
-in a compose file. See
+`docker stack` command supports defining configs in a compose file, though
+`docker compose` will ignore the `configs` key as is not supported. See
 [the Compose file reference](/compose/compose-file/#configs) for details.
 
 ### Simple example: Get started with configs

--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -122,8 +122,8 @@ Docker configs.
 
 ### Defining and using configs in compose files
 
-`docker stack` command supports defining configs in a compose file, though
-`docker compose` will ignore the `configs` key as is not supported. See
+The `docker stack` command supports defining configs in a compose file.
+However, the 'configs' key is not supported for `docker compose`. See
 [the Compose file reference](/compose/compose-file/#configs) for details.
 
 ### Simple example: Get started with configs


### PR DESCRIPTION
configs key is not (and will not be) supported in docker compose

### Proposed changes

state that `configs` key will be ignored on compose

### Related issues (optional)

Related: https://github.com/docker/compose/issues/5110
