### PR TITLE
UCP Upgrade Page Title Typo

### DIFF
--- a/ee/ucp/admin/install/upgrade.md
+++ b/ee/ucp/admin/install/upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade to UCP 3.0
+title: Upgrade to UCP 3.1
 description: Learn how to upgrade Docker Universal Control Plane with minimal impact to your users.
 keywords: UCP, upgrade, update
 ---


### PR DESCRIPTION
### Proposed changes

I noticed the UCP Upgrade page had incorrect Title.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
