### PR TITLE
Pedantic fixing of a typo on docs

### DIFF
--- a/docker-cloud/builds/push-images.md
+++ b/docker-cloud/builds/push-images.md
@@ -12,7 +12,7 @@ Docker Cloud uses Docker Hub as its native registry for storing both public and
 private repositories. Once you push your images to Docker Hub, they are
 available in Docker Cloud.
 
-If you don't have Swarm Mode enable, images pushed to Docker Hub automatically appear for you on the **Services/Wizard** page on Docker Cloud.
+If you don't have Swarm Mode enabled, images pushed to Docker Hub automatically appear for you on the **Services/Wizard** page on Docker Cloud.
 
 > **Note**: You must use Docker Engine 1.6 or later to push to Docker Hub.
 Follow the [official installation instructions](/install/index.md){: target="_blank" class="_" } depending on your system.


### PR DESCRIPTION
Cheeky issue with a missing 'd' on enable. 

> If you don’t have Swarm Mode **enable**, images pushed to Docker Hub automatically appear for you on the Services/Wizard page on Docker Cloud.

Should read:

If you don’t have Swarm Mode **enabled**, images pushed to Docker Hub automatically appear for you on the Services/Wizard page on Docker Cloud.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
