### PR TITLE
Update "select a storage driver" with current status

### DIFF
--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -98,7 +98,7 @@ configurations work on recent versions of the Linux distribution:
 | Docker CE on CentOS | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
 | Docker CE on Fedora | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
 
-¹) The `overlay` storage driver is deprecated in Docker 18.09, and will be
+¹) The `overlay` storage driver is deprecated in Docker Engine - Enterprise 18.09, and will be
 removed in a future release. It is recommended that users of the `overlay` storage driver 
 migrate to `overlay2`.
 

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -50,7 +50,7 @@ Docker supports the following storage drivers:
    driver is poor, and is not generally recommended for production use.
 
 Docker's source code defines the selection order. You can see the order at
-[the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L50)
+[the source code for Docker Engine - Community {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L50)
 
 If you run a different version of Docker, you can use the branch selector at the top of the file viewer to choose a different branch.
 {: id="storage-driver-order" }
@@ -65,7 +65,7 @@ for help in making the final decision.
 > ***NOTE***: Your choice may be limited by your Docker edition, operating system, and distribution. 
 > For instance, `aufs` is only supported on Ubuntu and Debian, and may require extra packages 
 > to be installed, while `btrfs` is only supported on SLES, which is only supported with Docker
-> EE. See [Support storage drivers per Linux distribution](#supported-storage-drivers-per-linux-distribution) 
+> Enterprise. See [Support storage drivers per Linux distribution](#supported-storage-drivers-per-linux-distribution) 
 > for more information.
 
 
@@ -78,31 +78,31 @@ In addition, Docker does not recommend any configuration that requires you to
 disable security features of your operating system, such as the need to disable
 `selinux` if you use the `overlay` or `overlay2` driver on CentOS.
 
-### Docker Engine Enterprise and Docker EE
+### Docker Engine - Enterprise and Docker Enterprise
 
-For Docker Engine Enterprise and Docker EE, the definitive resource for which
+For Docker Engine - Enterprise and Docker Enterprise, the definitive resource for which
 storage drivers are supported is the
 [Product compatibility matrix](https://success.docker.com/Policies/Compatibility_Matrix).
 To get commercial support from Docker, you must use a supported configuration.
 
-### Docker Engine Community and Docker CE
+### Docker Engine - Community
 
-For Docker Engine Community, only some configurations are tested, and your operating
+For Docker Engine - Community, only some configurations are tested, and your operating
 system's kernel may not support every storage driver. In general, the following
 configurations work on recent versions of the Linux distribution:
 
 | Linux distribution  | Recommended storage drivers                                            | Alternative drivers                               |
 |:--------------------|:-----------------------------------------------------------------------|:--------------------------------------------------|
-| Docker CE on Ubuntu | `overlay2` or `aufs` (for Ubuntu 14.04 running on kernel 3.13)         | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
-| Docker CE on Debian | `overlay2` (Debian Stretch), `aufs` or `devicemapper` (older versions) | `overlay`¹, `vfs`                                 |
-| Docker CE on CentOS | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
-| Docker CE on Fedora | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
+| Docker Engine - Community on Ubuntu | `overlay2` or `aufs` (for Ubuntu 14.04 running on kernel 3.13)         | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
+| Docker Engine - Community on Debian | `overlay2` (Debian Stretch), `aufs` or `devicemapper` (older versions) | `overlay`¹, `vfs`                                 |
+| Docker Engine - Community on CentOS | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
+| Docker Engine - Community on Fedora | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
 
 ¹) The `overlay` storage driver is deprecated in Docker Engine - Enterprise 18.09, and will be
 removed in a future release. It is recommended that users of the `overlay` storage driver 
 migrate to `overlay2`.
 
-²) The `devicemapper` storage driver is deprecated in Docker 18.09, and will be
+²) The `devicemapper` storage driver is deprecated in Docker Engine 18.09, and will be
 removed in a future release. It is recommended that users of the `overlay` storage driver 
 migrate to `overlay2`.
 
@@ -126,10 +126,10 @@ storage driver, be sure to read about
 [its performance and storage characteristics and limitations](vfs-driver.md).
 
 > **Expectations for non-recommended storage drivers**: Commercial support is
-> not available for Docker CE, and you can technically use any storage driver
+> not available for Docker Engine - Community, and you can technically use any storage driver
 > that is available for your platform. For instance, you can use `btrfs` with
-> Docker CE, even though it is not recommended on any platform for Docker CE,
-> and you do so at your own risk.
+> Docker Engine - Community, even though it is not recommended on any platform for
+> Docker Engine - Community, and you do so at your own risk.
 >
 > The recommendations in the table above are based on automated regression
 > testing and the configurations that are known to work for a large number of

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -21,56 +21,54 @@ After you have read the [storage driver overview](index.md), the
 next step is to choose the best storage driver for your workloads. In making
 this decision, there are three high-level factors to consider:
 
-- If multiple storage drivers are supported in your kernel, Docker has a
-  prioritized list of which storage driver to use if no storage driver is
-  explicitly configured, assuming that the prerequisites for that storage driver
-  are met:
+If multiple storage drivers are supported in your kernel, Docker has prioritized 
+list of which storage driver to use if no storage driver is explicitly configured, 
+assuming that the that storage driver meets the prerequisites.
 
-  - Try to use the storage driver with the best overall performance and stability
-    in the most usual scenarios.
+Use the storage driver with the best overall performance and stability in the most 
+usual scenarios.
+  
+Docker supports the following storage drivers:
 
-    - `overlay2` is the preferred storage driver, for all currently supported
-      Linux distributions, and requires no extra configuration.
-    - `aufs` is the preferred storage driver for Docker 18.06 and older, when
-      running on Ubuntu 14.04 on kernel 3.13 (which has no support for `overlay2`.
-    - `devicemapper` is next, but requires `direct-lvm` for production
-      environments, because `loopback-lvm`, while zero-configuration, has very
-      poor performance. `devicemapper` was the recommended storage driver for
-      CentOS and RHEL, as their kernel version did not support `overlay2`. However,
-      current versions of CentOS and RHEL now have support for `overlay2`, and
-      is now the recommended driver.
-    - The `btrfs` and `zfs` storage drivers are used if they are the backing
-      filesystem (the filesystem of the host on which Docker is installed).
-      These filesystems allow for advanced options, such as creating "snapshots",
-      but require more maintenance and setup. Each of these relies on the backing
-      filesystem being configured correctly.
-    - The `vfs` storage driver is intended for testing purposes, and for situations
-      where no copy-on-write filesystem can be used. Performance of this storage
-      driver is poor, and not generally recommended for production use.
+* `overlay2` is the preferred storage driver, for all currently supported
+   Linux distributions, and requires no extra configuration.
+* `aufs` is the preferred storage driver for Docker 18.06 and older, when
+   running on Ubuntu 14.04 on kernel 3.13 (which has no support for `overlay2`.
+* `devicemapper` is supported, but requires `direct-lvm` for production
+   environments, because `loopback-lvm`, while zero-configuration, has very
+   poor performance. `devicemapper` was the recommended storage driver for
+   CentOS and RHEL, as their kernel version did not support `overlay2`. However,
+   current versions of CentOS and RHEL now have support for `overlay2`, and
+   is now the recommended driver.
+ * The `btrfs` and `zfs` storage drivers are used if they are the backing
+   filesystem (the filesystem of the host on which Docker is installed).
+   These filesystems allow for advanced options, such as creating "snapshots",
+   but require more maintenance and setup. Each of these relies on the backing
+   filesystem being configured correctly.
+ * The `vfs` storage driver is intended for testing purposes, and for situations
+   where no copy-on-write filesystem can be used. Performance of this storage
+   driver is poor, and not generally recommended for production use.
 
-  The selection order is defined in Docker's source code. You can see the order
-  by looking at
-  [the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L50)
-  You can use the branch selector at the top of the file viewer to choose a
-  different branch, if you run a different version of Docker.
-  {: id="storage-driver-order" }
+Docker's source code defines the selection order. You can see the order at
+[the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L50)
 
-- Your choice may be limited by your Docker edition, operating system, and
-  distribution. For instance, `aufs` is only supported on Ubuntu and Debian, and
-  may require extra packages to be installed,
-  while `btrfs` is only supported on SLES, which is only supported with Docker
-  EE. See
-  [Support storage drivers per Linux distribution](#supported-storage-drivers-per-linux-distribution).
+You can use the branch selector at the top of the file viewer to choose a different branch, if you run a 
+different version of Docker.
+{: id="storage-driver-order" }
 
-- Some storage drivers require you to use a specific format for the backing
-  filesystem. If you have external requirements to use a specific backing
-  filesystem, this may limit your choices. See
-  [Supported backing filesystems](#supported-backing-filesystems).
+Some storage drivers require you to use a specific format for the backing filesystem. If you have external 
+requirements to use a specific backing filesystem, this may limit your choices. See [Supported backing filesystems](#supported-backing-filesystems).
 
-- After you have narrowed down which storage drivers you can choose from, your
-  choice are determined by the characteristics of your workload and the
-  level of stability you need. See [Other considerations](#other-considerations)
-  for help making the final decision.
+After you have narrowed down which storage drivers you can choose from, your choice are determined by the 
+characteristics of your workload and the level of stability you need. See [Other considerations](#other-considerations)
+for help making the final decision.
+
+> ***NOTE***: Your choice may be limited by your Docker edition, operating system, and distribution. 
+> For instance, `aufs` is only supported on Ubuntu and Debian, and may require extra packages 
+> to be installed, while `btrfs` is only supported on SLES, which is only supported with Docker
+> EE. See [Support storage drivers per Linux distribution](#supported-storage-drivers-per-linux-distribution) 
+> for more information.
+
 
 ## Supported storage drivers per Linux distribution
 

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -23,7 +23,7 @@ this decision, there are three high-level factors to consider:
 
 If multiple storage drivers are supported in your kernel, Docker has a prioritized 
 list of which storage driver to use if no storage driver is explicitly configured, 
-assuming that the that storage driver meets the prerequisites.
+assuming that the storage driver meets the prerequisites.
 
 Use the storage driver with the best overall performance and stability in the most 
 usual scenarios.
@@ -33,12 +33,12 @@ Docker supports the following storage drivers:
 * `overlay2` is the preferred storage driver, for all currently supported
    Linux distributions, and requires no extra configuration.
 * `aufs` is the preferred storage driver for Docker 18.06 and older, when
-   running on Ubuntu 14.04 on kernel 3.13 (which has no support for `overlay2`.
+   running on Ubuntu 14.04 on kernel 3.13 which has no support for `overlay2`.
 * `devicemapper` is supported, but requires `direct-lvm` for production
    environments, because `loopback-lvm`, while zero-configuration, has very
    poor performance. `devicemapper` was the recommended storage driver for
    CentOS and RHEL, as their kernel version did not support `overlay2`. However,
-   current versions of CentOS and RHEL now have support for `overlay2`, and
+   current versions of CentOS and RHEL now have support for `overlay2`,
    which is now the recommended driver.
  * The `btrfs` and `zfs` storage drivers are used if they are the backing
    filesystem (the filesystem of the host on which Docker is installed).
@@ -47,21 +47,20 @@ Docker supports the following storage drivers:
    filesystem being configured correctly.
  * The `vfs` storage driver is intended for testing purposes, and for situations
    where no copy-on-write filesystem can be used. Performance of this storage
-   driver is poor, and not generally recommended for production use.
+   driver is poor, and is not generally recommended for production use.
 
 Docker's source code defines the selection order. You can see the order at
 [the source code for Docker CE {{ site.docker_ce_stable_version }}](https://github.com/docker/docker-ce/blob/{{ site.docker_ce_stable_version }}/components/engine/daemon/graphdriver/driver_linux.go#L50)
 
-You can use the branch selector at the top of the file viewer to choose a different branch, if you run a 
-different version of Docker.
+If you run a different version of Docker, you can use the branch selector at the top of the file viewer to choose a different branch.
 {: id="storage-driver-order" }
 
 Some storage drivers require you to use a specific format for the backing filesystem. If you have external 
 requirements to use a specific backing filesystem, this may limit your choices. See [Supported backing filesystems](#supported-backing-filesystems).
 
-After you have narrowed down which storage drivers you can choose from, your choice are determined by the 
+After you have narrowed down which storage drivers you can choose from, your choice is determined by the 
 characteristics of your workload and the level of stability you need. See [Other considerations](#other-considerations)
-for help making the final decision.
+for help in making the final decision.
 
 > ***NOTE***: Your choice may be limited by your Docker edition, operating system, and distribution. 
 > For instance, `aufs` is only supported on Ubuntu and Debian, and may require extra packages 
@@ -99,13 +98,13 @@ configurations work on recent versions of the Linux distribution:
 | Docker CE on CentOS | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
 | Docker CE on Fedora | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
 
-¹) The `overlay` storage driver is marked deprecated in docker 18.09, and will be
-removed in a future release. Users of the `overlay` storage driver are recommended
-to migrate to `overlay2`.
+¹) The `overlay` storage driver is deprecated in Docker 18.09, and will be
+removed in a future release. It is recommended that users of the `overlay` storage driver 
+migrate to `overlay2`.
 
-²) The `devicemapper` storage driver is marked deprecated in docker 18.09, and will be
-removed in a future release. Users of the `devicemapper` storage driver are recommended
-to migrate to `overlay2`.
+²) The `devicemapper` storage driver is deprecated in Docker 18.09, and will be
+removed in a future release. It is recommended that users of the `overlay` storage driver 
+migrate to `overlay2`.
 
 
 When possible, `overlay2` is the recommended storage driver. When installing

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -21,7 +21,7 @@ After you have read the [storage driver overview](index.md), the
 next step is to choose the best storage driver for your workloads. In making
 this decision, there are three high-level factors to consider:
 
-If multiple storage drivers are supported in your kernel, Docker has prioritized 
+If multiple storage drivers are supported in your kernel, Docker has a prioritized 
 list of which storage driver to use if no storage driver is explicitly configured, 
 assuming that the that storage driver meets the prerequisites.
 
@@ -39,7 +39,7 @@ Docker supports the following storage drivers:
    poor performance. `devicemapper` was the recommended storage driver for
    CentOS and RHEL, as their kernel version did not support `overlay2`. However,
    current versions of CentOS and RHEL now have support for `overlay2`, and
-   is now the recommended driver.
+   which is now the recommended driver.
  * The `btrfs` and `zfs` storage drivers are used if they are the backing
    filesystem (the filesystem of the host on which Docker is installed).
    These filesystems allow for advanced options, such as creating "snapshots",


### PR DESCRIPTION
The information on this page was a bit outdated, and with "overlay" and "devicemapper" being phased-out, could use some changes;

- de-emphasize "overlay", "devicemapper" and "aufs"
- split "recommended" and "alternative drivers" columns
  (vfs was listed as a "recommended" driver, but definitely
  is not recommended for production use).
- add notes about "overlay" and "devicemapper" being
  deprecated in Docker 18.09
- some other textual changes.


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

- https://github.com/docker/cli/pull/1424 Deprecate "devicemapper" storage driver. (see https://github.com/docker/cli/pull/1424#issuecomment-437162893)
- https://github.com/docker/cli/pull/1425 Deprecate legacy overlay storage driver
- https://github.com/docker/cli/pull/1455 [18.09 backport] deprecate devicemapper and legacy overlay storage drivers 