### PR TITLE
Show hint how to find out what data can be printed

### DIFF
--- a/config/formatting.md
+++ b/config/formatting.md
@@ -91,6 +91,9 @@ docker inspect --format='{{range .NetworkSettings.Networks}}{{println .IPAddress
 # Hint
 
 To find out what data can be printed, show all content as json:
+
+{% raw %} 
 ```
 docker container ls --format='{{json .}}'
 ```
+{% endraw %} 

--- a/config/formatting.md
+++ b/config/formatting.md
@@ -87,3 +87,10 @@ docker inspect --format "{{upper .Name}}" container
 docker inspect --format='{{range .NetworkSettings.Networks}}{{println .IPAddress}}{{end}}' container
 ```
 {% endraw %}
+
+# Hint
+
+To find out what data can be printed, show all content as json:
+```
+docker container ls --format='{{json .}}'
+```


### PR DESCRIPTION
This hint is unnecessary for inspect commands since this is the default. But for other commands, I regularly find out again this trick.

### Proposed changes

Show hint how to find out what data can be printed.

### Related issues

Will be more helpful after #7666 is done.
