### PR TITLE
Simplified Sentence in /develop/index.md

### DIFF
--- a/compose/rails.md
+++ b/compose/rails.md
@@ -9,10 +9,7 @@ a Rails/PostgreSQL app. Before starting, [install Compose](install.md).
 
 ### Define the project
 
-Start by setting up the four files needed to build the app. First, since
-your app is going to run inside a Docker container containing all of its
-dependencies, define exactly what needs to be included in the
-container. This is done using a file called `Dockerfile`. To begin with, the
+Start by setting up the four files needed to build the app. App will run inside a Docker container containing its dependencies. Defining dependencies is done using a file called `Dockerfile`. To begin with, the
 Dockerfile consists of:
 
     FROM ruby:2.5

--- a/datacenter/dtr/2.5/guides/support.md
+++ b/datacenter/dtr/2.5/guides/support.md
@@ -11,7 +11,7 @@ support. The service levels depend on your subscription.
 Before reaching out to Docker Support, make sure you're listed as an authorized
 support contact for your account. If you're not listed as an authorized
 support contact, find a person who is, and ask them to open a case with
-Docker Support in your behalf.
+Docker Support on your behalf.
 
 You can open a new support case at the [Docker support page](https://support.docker.com/).
 If you're unable to submit a new case using the support page, fill in the

--- a/develop/index.md
+++ b/develop/index.md
@@ -29,6 +29,4 @@ most benefits from Docker.
 
 ## Advanced development with the SDK or API
 
-When you're comfortable developing apps by writing Dockerfiles or compose files
-and using the Docker CLI, you can take it to the next level by using the Docker
-Engine SDK for Go or Python or using the HTTP API directly.
+After you can write Dockerfiles or compose files and use Docker CLI, take it to the next level by using Docker Engine SDK for Go/Python or use HTTP API directly.

--- a/develop/index.md
+++ b/develop/index.md
@@ -29,4 +29,4 @@ most benefits from Docker.
 
 ## Advanced development with the SDK or API
 
-After you can write Dockerfiles or compose files and use Docker CLI, take it to the next level by using Docker Engine SDK for Go/Python or use HTTP API directly.
+After you can write Dockerfiles or Compose files and use Docker CLI, take it to the next level by using Docker Engine SDK for Go/Python or use HTTP API directly.

--- a/docker-cloud/dockerid.md
+++ b/docker-cloud/dockerid.md
@@ -25,10 +25,11 @@ Bitbucket from your Docker Cloud account settings.
 
 ## Email addresses
 
-You can associate multiple email addresses with your Docker ID, and one of these
-becomes the primary address for the account. The primary address is used by
-Docker to send password reset notifications and other important information, so
-be sure to keep it updated.
+You can associate multiple email addresses with your Docker ID. 
+You may select an email address to become the primary email for the account. 
+The primary email is used by Docker to send password reset notifications 
+and important information, so be sure to keep it updated.
+
 
 To add another email address to your Docker ID:
 

--- a/docker-cloud/orgs.md
+++ b/docker-cloud/orgs.md
@@ -6,11 +6,7 @@ title: Organizations and Teams in Docker Cloud
 
 You can create Organizations in Docker Cloud to share repositories, and infrastructure and applications with coworkers and collaborators.
 
-Members of an organization can see only the teams to which they belong, and
-their membership. Members of the `Owners` team can see and edit
-all of the teams and all of the team membership lists. Docker Cloud users
-outside an organization cannot see the Organizations or teams another user
-belongs to.
+Members of an organization can see only teams and memberships to which they belong. Members of the `Owners` team can see and edit all teams and team membership lists. Docker Cloud users cannot view another user’s organizations or teams if they do not share an organization.
 
 ## Create an Organization
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -44,7 +44,7 @@ Desktop](https://docs.docker.com/docker-for-mac/faqs/#how-is-personal-data-handl
 If you click on **Report an issue**, this opens [Docker for Windows issues on
 GitHub](https://github.com/docker/for-win/issues/) in your web browser in a
 "create new issue" template, to be completed before submision. Do not forget to
-copy/paste your diagnistic ID.
+include your diagnostic ID.
 
 ![issue-template](images/issue-template.png){:width="600px"}
 

--- a/docker-hub/accounts.md
+++ b/docker-hub/accounts.md
@@ -23,5 +23,5 @@ from the Hub.
 
 ## Password reset process
 
-If you forget your password, or can't access your account for some reason, you
+If you forget your password, or can't access your account, you
 can reset your password from the [*Password Reset*](https://hub.docker.com/reset-password/) page.

--- a/docker-store/index.md
+++ b/docker-store/index.md
@@ -11,10 +11,7 @@ Independent Software Vendors (ISVs) can utilize Docker Store to distribute and
 sell their Dockerized content. Publish your software through Docker Store to
 experience the following benefits:
 
-* **Access to Docker’s large and growing customer-base.** Docker has experienced
-  rapid adoption, and is popular in dev-ops environments. Docker users have
-  pulled images over twelve billion times and they are increasingly turning to
-  Docker Store as the canonical source for high-quality, curated content.
+* **Access to Docker’s large and growing customer-base.** Docker is experiencing rapid adoption. Images have been pulled by Docker users over twelve billion times. More Docker users are turning to Docker Store as the canonical source for high-quality, curated content.
 
 * **Customers can try or buy your software**, right from your product listing.
   Your content is accessible for installation, trial, and purchase from the

--- a/ee/upgrade.md
+++ b/ee/upgrade.md
@@ -194,8 +194,8 @@ i64lee19ia6s         \_ ex_service.11   nginx:latest        tk1706-ubuntu-1     
 ## Manager Upgrades When Moving to Docker Engine - Enterprise 18.09 and later
 
 The following is a constraint introduced by architectural changes to the Swarm overlay networking when 
-upgrading to Docker Engine - Enterprise 18.09 or later. It only applies to this one-time upgrade and to w
-orkloads that are using the Swarm overlay driver. Once upgraded to Docker Engine - Enterprise 18.09, this 
+upgrading to Docker Engine - Enterprise 18.09 or later. It only applies to this one-time upgrade and to workloads 
+that are using the Swarm overlay driver. Once upgraded to Docker Engine - Enterprise 18.09, this 
 constraint does not impact future upgrades.
 
 When upgrading to Docker Engine - Enterprise 18.09, manager nodes cannot reschedule new workloads on the 

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -18,9 +18,7 @@ description: Learn how to write, build, and run a simple app -- the Docker way.
 
 ## Introduction
 
-It's time to begin building an app the Docker way. We start at the bottom of
-the hierarchy of such an app, which is a container, which we cover on this page.
-Above this level is a service, which defines how containers behave in
+It's time to begin building an app the Docker way. We start at the bottom of the hierarchy of such app, a container, which this page covers. Above this level is a service, which defines how containers behave in
 production, covered in [Part 3](part3.md). Finally, at the top level is the
 stack, defining the interactions of all the services, covered in
 [Part 5](part5.md).


### PR DESCRIPTION
Simplified sentence for readability under Advanced development with the SDK or API. 
/develop/index.md

Corrected ambiguity under Email Addresses. 
/docker-cloud/dockerid.md

Simplified sentence structure in second paragraph. 
/docker-cloud/orgs.md

Revised sentence structure in first point. 
/docker-store/index.md

Removed "for some reason" to sound more technical. 
/docker-hub/accounts.md

"in" -> "on", as the meaning of sentence suggests representation. 
/datacenter/dtr/2.5/guides/support.md

"w orkload" -> "workload"
/ee/upgrade.md

Changed sentence structure of second sentence under introduction to reduce repetitiveness.
/get-started/part2.md

"copy/paste" -> "include", "diagnistic" -> "diagnostic"
/docker-for-windows/troubleshoot.md

Restructured instruction sentence under Define the project for better flow.
/compose/rail.md