### PR TITLE
Mark "docker-compose down" as code, not a link

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -75,7 +75,7 @@ Compose to set up and run WordPress. Before starting, make sure you have
 
 Now, run `docker-compose up -d` from your project directory.
 
-This runs [docker-compose up](/compose/reference/up/) in detached mode, pulls
+This runs [`docker-compose up`](/compose/reference/up/) in detached mode, pulls
 the needed Docker images, and starts the wordpress and database containers, as shown in
 the example below.
 
@@ -130,13 +130,11 @@ browser.
 
 ### Shutdown and cleanup
 
-The command `docker-compose down` removes the
+The command [`docker-compose down`](/compose/reference/down.md) removes the
 containers and default network, but preserves your WordPress database.
 
 The command `docker-compose down --volumes` removes the containers, default
 network, and the WordPress database.
-
-[Learn more about the `docker-compose down` command](/compose/reference/down.md)
 
 ## More Compose documentation
 

--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -130,11 +130,13 @@ browser.
 
 ### Shutdown and cleanup
 
-The command [docker-compose down](/compose/reference/down.md) removes the
+The command `docker-compose down` removes the
 containers and default network, but preserves your WordPress database.
 
 The command `docker-compose down --volumes` removes the containers, default
 network, and the WordPress database.
+
+[Learn more about the `docker-compose down` command](/compose/reference/down.md)
 
 ## More Compose documentation
 


### PR DESCRIPTION
### Proposed changes

To make it clear `docker-compose down` is a command, mark it as code and include a link to documentation below.