### PR TITLE
Update Kube version for kubectl download

### DIFF
--- a/ee/ucp/user-access/kubectl.md
+++ b/ee/ucp/user-access/kubectl.md
@@ -48,7 +48,7 @@ operating system.
 <div id="mac" class="tab-pane fade in active" markdown="1">
 ```
 # Set the Kubernetes version as found in the UCP Dashboard or API
-k8sversion=v1.8.11
+k8sversion=v1.11.2
 
 # Get the kubectl binary.
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$k8sversion/bin/darwin/amd64/kubectl
@@ -64,7 +64,7 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 <div id="linux" class="tab-pane fade" markdown="1">
 ```
 # Set the Kubernetes version as found in the UCP Dashboard or API
-k8sversion=v1.8.11
+k8sversion=v1.11.2
 
 # Get the kubectl binary.
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$k8sversion/bin/linux/amd64/kubectl

--- a/ee/ucp/user-access/kubectl.md
+++ b/ee/ucp/user-access/kubectl.md
@@ -48,7 +48,7 @@ operating system.
 <div id="mac" class="tab-pane fade in active" markdown="1">
 ```
 # Set the Kubernetes version as found in the UCP Dashboard or API
-k8sversion=v1.11.2
+k8sversion=v1.11.5
 
 # Get the kubectl binary.
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$k8sversion/bin/darwin/amd64/kubectl
@@ -64,7 +64,7 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 <div id="linux" class="tab-pane fade" markdown="1">
 ```
 # Set the Kubernetes version as found in the UCP Dashboard or API
-k8sversion=v1.11.2
+k8sversion=v1.11.5
 
 # Get the kubectl binary.
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$k8sversion/bin/linux/amd64/kubectl


### PR DESCRIPTION
Did not modify windows kubectl version instructions, as the path for 1.11.2 did not work.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
