### PR TITLE
dtr: fix a couple variable templates

### DIFF
--- a/datacenter/dtr/2.3/guides/admin/configure/external-storage/nfs.md
+++ b/datacenter/dtr/2.3/guides/admin/configure/external-storage/nfs.md
@@ -31,7 +31,7 @@ mkdir /tmp/mydir && sudo mount -t nfs <nfs server>:<directory>
 One way to configure DTR to use an NFS directory is at install time:
 
 ```none
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version }} install \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} install \
   --nfs-storage-url <nfs-storage-url> \
   <other options>
 ```
@@ -50,7 +50,7 @@ If you want to start using the new DTR built-in support for NFS you can
 reconfigure DTR:
 
 ```none
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version }} reconfigure \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} reconfigure \
   --nfs-storage-url <nfs-storage-url>
 ```
 
@@ -58,7 +58,7 @@ If you want to reconfigure DTR to stop using NFS storage, leave the option
 in blank:
 
 ```none
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version}} reconfigure \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version}} reconfigure \
   --nfs-storage-url ""
 ```
 

--- a/ee/dtr/admin/configure/external-storage/nfs.md
+++ b/ee/dtr/admin/configure/external-storage/nfs.md
@@ -31,7 +31,7 @@ mkdir /tmp/mydir && sudo mount -t nfs <nfs server>:<directory> /tmp/mydir
 One way to configure DTR to use an NFS directory is at install time:
 
 ```bash
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version }} install \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} install \
   --nfs-storage-url <nfs-storage-url> \
   <other options>
 ```
@@ -51,7 +51,7 @@ To take advantage of the new DTR built-in support for NFS, you can
 reconfigure DTR to use NFS:
 
 ```bash
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version }} reconfigure \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} reconfigure \
   --nfs-storage-url <nfs-storage-url>
 ```
 
@@ -59,7 +59,7 @@ To reconfigure DTR to stop using NFS storage, leave the `--nfs-storage-url` opti
 blank:
 
 ```bash
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ dtr_version}} reconfigure \
+docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version}} reconfigure \
   --nfs-storage-url ""
 ```
 

--- a/ee/dtr/admin/monitor-and-troubleshoot/index.md
+++ b/ee/dtr/admin/monitor-and-troubleshoot/index.md
@@ -41,10 +41,10 @@ replicas.
 
 ## Cluster status
 
-The `/api/v0/meta/cluster_status` [endpoint](/reference/dtr/2.5/api/)
-requires administrator credentials, and returns a JSON object for the entire
-cluster as observed by the replica being queried. You can authenticate your
-requests using HTTP basic auth.
+The `/api/v0/meta/cluster_status` [endpoint](/reference/dtr/{{ site.dtr_version
+}}/api/) requires administrator credentials, and returns a JSON object for the
+entire cluster as observed by the replica being queried. You can authenticate
+your requests using HTTP basic auth.
 
 ```bash
 curl -ksL -u <user>:<pass> https://<dtr-domain>/api/v0/meta/cluster_status


### PR DESCRIPTION
### What I Did
1. Attempt to make the API link from ee/dtr/admin/monitor-and-troubleshoot/index.md dynamic by changing it from literal `2.5` to `{{  dtr_version }}`.  Notice _config.yml says that should be `site.dtr_version`.  Make it so.
2. Search for literal string `{{ dtr_version` and fix existing intances of the error I'd just run into.

### How I Tested
Built (first time with buildkit!) locally.  Verified templates rendered as expected on each page.