### PR TITLE
fix missing symbol to indicate start of command

### DIFF
--- a/engine/swarm/swarm-tutorial/create-swarm.md
+++ b/engine/swarm/swarm-tutorial/create-swarm.md
@@ -20,7 +20,7 @@ machines.
 2.  Run the following command to create a new swarm:
 
     ```bash
-    docker swarm init --advertise-addr <MANAGER-IP>
+    $ docker swarm init --advertise-addr <MANAGER-IP>
     ```
 
     >**Note**: If you are using Docker for Mac or Docker for Windows to test


### PR DESCRIPTION
In sample code area, some commands are missing '$' symbol
to indicate start of command.

### Proposed changes

Add '$' symbol to indicate start of command.