### PR TITLE
Added `demo_` prefix to interlock label

### DIFF
--- a/ee/ucp/interlock/usage/index.md
+++ b/ee/ucp/interlock/usage/index.md
@@ -10,7 +10,7 @@ start using it in your swarm services.
 In this example we'll deploy a simple service which:
 
 * Has a JSON endpoint that returns the ID of the task serving the request.
-* Has a web UI that shows how many tasks the service is running.
+* Has a web interface that shows how many tasks the service is running.
 * Can be reached at `http://app.example.org`.
 
 ## Deploy the service
@@ -46,7 +46,7 @@ the host header, that request is forwarded to the demo service.
 should attach to in order to be able to communicate with the demo service.
 To use layer 7 routing, your services need to be attached to at least one network.
 If your service is only attached to a single network, you don't need to add
-a label to specify which network to use for routing.
+a label to specify which network to use for routing. To attach to more than one network, prefix this label with the service name as shown in the above example.
 * The `com.docker.lb.port` label specifies which port the `ucp-interlock-proxy`
 service should use to communicate with this demo service.
 * Your service doesn't need to expose a port in the swarm routing mesh. All

--- a/ee/ucp/interlock/usage/index.md
+++ b/ee/ucp/interlock/usage/index.md
@@ -27,7 +27,7 @@ services:
       replicas: 1
       labels:
         com.docker.lb.hosts: app.example.org
-        com.docker.lb.network: demo-network
+        com.docker.lb.network: demo_demo-network
         com.docker.lb.port: 8080
     networks:
       - demo-network

--- a/ee/ucp/interlock/usage/index.md
+++ b/ee/ucp/interlock/usage/index.md
@@ -46,7 +46,9 @@ the host header, that request is forwarded to the demo service.
 should attach to in order to be able to communicate with the demo service.
 To use layer 7 routing, your services need to be attached to at least one network.
 If your service is only attached to a single network, you don't need to add
-a label to specify which network to use for routing. To attach to more than one network, prefix this label with the stack name as shown in the above example.
+a label to specify which network to use for routing. When using a common stack file for multiple deployments leveraging UCP Interlock / Layer 7 Routing, prefix `com.docker.lb.network` with the stack name to ensure traffic will be directed to the correct overlay network.
+
+
 * The `com.docker.lb.port` label specifies which port the `ucp-interlock-proxy`
 service should use to communicate with this demo service.
 * Your service doesn't need to expose a port in the swarm routing mesh. All

--- a/ee/ucp/interlock/usage/index.md
+++ b/ee/ucp/interlock/usage/index.md
@@ -46,7 +46,7 @@ the host header, that request is forwarded to the demo service.
 should attach to in order to be able to communicate with the demo service.
 To use layer 7 routing, your services need to be attached to at least one network.
 If your service is only attached to a single network, you don't need to add
-a label to specify which network to use for routing. To attach to more than one network, prefix this label with the service name as shown in the above example.
+a label to specify which network to use for routing. To attach to more than one network, prefix this label with the stack name as shown in the above example.
 * The `com.docker.lb.port` label specifies which port the `ucp-interlock-proxy`
 service should use to communicate with this demo service.
 * Your service doesn't need to expose a port in the swarm routing mesh. All


### PR DESCRIPTION
Customer feedback received for the demo stack example: 

```
It leads users to expect that if they define a network in their compose file that they can use that network name in the Interlock network label which is not the case.  The example "works" because the service is only attached to a single network, but in actuality the Interlock network label would need to be prefixed with the stack name in order for the example to work correctly.
```
The concern is valid; so I have added `demo_` as a prefix to the `com.docker.lb.network` label.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
