### PR TITLE
Data exists in stopped containers, but not removed containers

### DIFF
--- a/storage/index.md
+++ b/storage/index.md
@@ -9,7 +9,7 @@ redirect_from:
 By default all files created inside a container are stored on a writable
 container layer. This means that:
 
-- The data doesn't persist when that container is no longer running, and it can be
+- The data doesn't persist when that container no longer exists, and it can be
   difficult to get the data out of the container if another process needs it.
 - A container's writable layer is tightly coupled to the host machine
   where the container is running. You can't easily move the data somewhere else.


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

### Proposed changes

Documentation update since data still persist in a stopped container, but not in a removed container.

### Related issues (optional)

This is in reference to [this stackoverflow question](https://stackoverflow.com/q/53333957/596285).
