### PR TITLE
Update docker sdk go example

### DIFF
--- a/develop/sdk/index.md
+++ b/develop/sdk/index.md
@@ -177,23 +177,22 @@ Docker API directly, or using the Python or Go SDK.
 package main
 
 import (
-    "io"
+    "context"
     "os"
 
     "github.com/docker/docker/client"
     "github.com/docker/docker/api/types"
     "github.com/docker/docker/api/types/container"
     "github.com/docker/docker/pkg/stdcopy"
-
-    "golang.org/x/net/context"
 )
 
 func main() {
     ctx := context.Background()
-    cli, err := client.NewEnvClient()
+    cli, err := client.NewClientWithOpts(client.FromEnv)
     if err != nil {
         panic(err)
     }
+    cli.NegotiateAPIVersion(ctx)
 
     _, err = cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
     if err != nil {


### PR DESCRIPTION
Signed-off-by: Jorge Alarcon Ochoa <alarcj137@gmail.com>

### Proposed changes

The example doesn't compile due to the use of `github.com/docker/docker/pkg/stdcopy` instead of `io.Copy`.
Also, replaced `newEnvClient`, which is deprecated, with `NewClientWithOpts`.