### PR TITLE
Update example for deprecated name

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2352,6 +2352,11 @@ secrets:
   my_second_secret:
     external: true
     name: redis_secret
+    
+  // Deprecated syntax for compose file version 3.5-
+  my_second_secret:
+    external:
+     name: redis_secret
 ```
 
 You still need to [grant access to the secrets](#secrets) to each service in the

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2350,8 +2350,8 @@ secrets:
   my_first_secret:
     file: ./secret_data
   my_second_secret:
-    external:
-      name: redis_secret
+    external: true
+    name: redis_secret
 ```
 
 You still need to [grant access to the secrets](#secrets) to each service in the

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2328,8 +2328,8 @@ stack. The source of the secret is either `file` or `external`.
    and will **not** be scoped with the stack name. Introduced in version 3.5
    file format.
 
-In this example, `my_first_secret` is created (as
-`<stack_name>_my_first_secret)`when the stack is deployed,
+In this example, `my_first_secret` is created as
+`<stack_name>_my_first_secret `when the stack is deployed,
 and `my_second_secret` already exists in Docker.
 
 ```none
@@ -2345,6 +2345,7 @@ is different from the name that exists within the service. The following
 example modifies the previous one to use the external secret called
 `redis_secret`.
 
+### Compose File v3.5 and above
 ```none
 secrets:
   my_first_secret:
@@ -2352,8 +2353,10 @@ secrets:
   my_second_secret:
     external: true
     name: redis_secret
-    
-  // Deprecated syntax for compose file version 3.5-
+```
+
+### Compose File v3.4 and under
+```none    
   my_second_secret:
     external:
       name: redis_secret

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2356,7 +2356,7 @@ secrets:
   // Deprecated syntax for compose file version 3.5-
   my_second_secret:
     external:
-     name: redis_secret
+      name: redis_secret
 ```
 
 You still need to [grant access to the secrets](#secrets) to each service in the


### PR DESCRIPTION
secret.external.name is deprecated in favor of secret.name

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

update doc to use the new format

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
