### PR TITLE
Update API version matrix for 18.06 and 18.09

### DIFF
--- a/_includes/api-version-matrix.md
+++ b/_includes/api-version-matrix.md
@@ -1,6 +1,8 @@
 
 | Docker version | Maximum API version        | Change log                                               |
 |:---------------|:---------------------------|:---------------------------------------------------------|
+| 18.09          | [1.39](/engine/api/v1.39/) | [changes](/engine/api/version-history/#v139-api-changes) |
+| 18.06          | [1.38](/engine/api/v1.38/) | [changes](/engine/api/version-history/#v138-api-changes) |
 | 18.05          | [1.37](/engine/api/v1.37/) | [changes](/engine/api/version-history/#v137-api-changes) |
 | 18.04          | [1.37](/engine/api/v1.37/) | [changes](/engine/api/version-history/#v137-api-changes) |
 | 18.03          | [1.37](/engine/api/v1.37/) | [changes](/engine/api/version-history/#v137-api-changes) |


### PR DESCRIPTION
The Docker 18.06 and 18.09 releases were missing in the API version matrix.


See;

- 18.06.0: https://github.com/docker/docker-ce/blob/v18.06.0-ce/components/engine/api/swagger.yaml#L22
- 18.09.0: https://github.com/docker/docker-ce/blob/v18.09.0/components/engine/api/swagger.yaml#L22