### PR TITLE
Add network-routing clarification to toolbox/for-mac comparison

### DIFF
--- a/docker-for-mac/docker-toolbox.md
+++ b/docker-for-mac/docker-toolbox.md
@@ -62,6 +62,9 @@ With Docker for Mac, you only get (and only usually need) one VM, managed by Doc
 for Mac. Docker for Mac automatically upgrades the Docker client and
 daemon when updates are available.
 
+Also note that Docker for Mac can’t route traffic to containers, so you can't
+directly access an exposed port on a running container from the hosting machine.
+
 If you do need multiple VMs, such as when testing multi-node swarms, you can
 continue to use Docker Machine, which operates outside the scope of Docker for
 Mac. See [Docker Toolbox and Docker for Mac


### PR DESCRIPTION
### Proposed changes

Adds a single line mentioning what I think is a very important distinction to make between docker-toolbox and docker-for-mac, namely that the latter doesn't support routing traffic to containers. As a result, running containers are not exposed how one might expect. Copied part of the line from [docker-for-mac's own docs](https://docs.docker.com/docker-for-mac/networking/#i-cannot-ping-my-containers).
