### PR TITLE
Add backup link redirect

### DIFF
--- a/reference/dtr/2.6/cli/backup.md
+++ b/reference/dtr/2.6/cli/backup.md
@@ -2,6 +2,8 @@
 title: docker/dtr backup
 description: Create a backup of DTR
 keywords: dtr, cli, backup
+redirect_from:                                                                                                               
+  - /reference/dtr/2.5/cli/backup/  
 ---
 
 Create a backup of DTR


### PR DESCRIPTION
- Prevents 404 issue for DTR web interface link still pointing to previous version (2.5)

![screenshot from 2018-11-27 17-45-04](https://user-images.githubusercontent.com/5844484/49123102-3555b800-f26c-11e8-8ea0-642d45fbb48e.png)

