### PR TITLE
Extra `.0` should be removed for Centos and RHEL `sudo yum-config-manager --enable docker-ee-stable-18.09`

### DIFF
--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -172,7 +172,7 @@ You only need to set up the repository once, after which you can install Docker 
     For example, if you want to install the 18.09 version run the following:
 
     ```bash
-    sudo yum-config-manager --enable docker-ee-stable-18.09.0
+    sudo yum-config-manager --enable docker-ee-stable-18.09
     ```
 
     Docker is installed but not started. The `docker` group is created, but no users are added to the group.


### PR DESCRIPTION
false: sudo yum-config-manager --enable docker-ee-stable-18.09.0
correct: sudo yum-config-manager --enable docker-ee-stable-18.09
 
I bumped into this while setting up a test env on Centos.  Did a quick test on RHEL, and I could see the same issue.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
