### PR TITLE
fix COPY file name in Best practices

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -129,7 +129,7 @@ EOF
 ```
 docker build -t foo https://github.com/thajeztah/pgadmin4-docker.git -f-<<EOF
 FROM busybox
-COPY LICENSE config_local.py /usr/local/lib/python2.7/site-packages/pgadmin4/
+COPY LICENSE config_distro.py /usr/local/lib/python2.7/site-packages/pgadmin4/
 EOF
 ```
 


### PR DESCRIPTION
### Proposed changes
The sample command is outdated, resulting in an error.
Fix `config_local.py` to `config_distro.py` .

The following error occurs.
```
bash-3.2$ docker build -t foo https://github.com/thajeztah/pgadmin4-docker.git -f-<<EOF
> FROM busybox
> COPY LICENSE config_local.py /usr/local/lib/python2.7/site-packages/pgadmin4/
> EOF
Sending build context to Docker daemon  191.6kB
Step 1/2 : FROM busybox
 ---> 59788edf1f3e
Step 2/2 : COPY LICENSE config_local.py /usr/local/lib/python2.7/site-packages/pgadmin4/
COPY failed: stat /var/lib/docker/tmp/docker-builder325052318/config_local.py: no such file or directory
bash-3.2$
```