### PR TITLE
Automated builds was still referring to Services

### DIFF
--- a/docker-hub/builds.md
+++ b/docker-hub/builds.md
@@ -102,9 +102,9 @@ repositories using the `docker push` command.
 
     ![Home page](images/home-page.png)
 
-    Within GitHub, a Docker integration appears in your repositories Settings > Webhooks & services page.
+    Within GitHub, a Docker Hub Webhook appears in your repositories Settings > Webhooks page.
 
-    ![GitHub](images/docker-integration.png)
+    ![GitHub](images/github-webhook.png)
 
     A similar page appears in Bitbucket if you use that code repository. Be
     careful to leave the Docker integration in place. Removing it causes your

--- a/docker-hub/builds.md
+++ b/docker-hub/builds.md
@@ -102,7 +102,7 @@ repositories using the `docker push` command.
 
     ![Home page](images/home-page.png)
 
-    Within GitHub, a Docker Hub Webhook appears in your repositories Settings > Webhooks page.
+    Within GitHub, a Docker Hub webhook appears in your repositories Settings > Webhooks page.
 
     ![GitHub](images/github-webhook.png)
 


### PR DESCRIPTION
I've tested and following the steps to [create an automated build](https://docs.docker.com/docker-hub/builds/#create-an-automated-build) no longer creates a service setup. Instead it creates a web hook correctly, however the builds documentation was outdated. Using exist image for the Webhooks from the GitHub page that was already updated.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Updated to reflect the Webhook now created by the automated build.
