### PR TITLE
Update port mapping 4000 to 80 for consistency

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -84,7 +84,7 @@ services:
       restart_policy:
         condition: on-failure
     ports:
-      - "4000:80"
+      - "80:80"
     networks:
       - webnet
 networks:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

As of now, docker-compose.yml file `ports` section is in https://docs.docker.com/get-started/part3/, is not consistent with terminal recording and also with what is specified in https://docs.docker.com/get-started/part5/

```
diff --git a/get-started/part3.md b/get-started/part3.md
index 9a1436f571..95c5132bbd 100644
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -84,7 +84,7 @@ services:
       restart_policy:
         condition: on-failure
     ports:
-      - "4000:80"
+      - "80:80"
     networks:
       - webnet
 networks:
```
> Required changes

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
