### PR TITLE
Update https.cnf - Clarify extfile directions

### DIFF
--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -113,24 +113,24 @@ request:
 
     $ openssl req -subj '/CN=client' -new -key key.pem -out client.csr
 
-To make the key suitable for client authentication, create an extensions
+To make the key suitable for client authentication, create a new extensions
 config file:
 
-    $ echo extendedKeyUsage = clientAuth >> extfile.cnf
+    $ echo extendedKeyUsage = clientAuth > extfile-client.cnf
 
 Now, generate the signed certificate:
 
     $ openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem \
-      -CAcreateserial -out cert.pem -extfile extfile.cnf
+      -CAcreateserial -out cert.pem -extfile extfile-client.cnf
     Signature ok
     subject=/CN=client
     Getting CA Private Key
     Enter pass phrase for ca-key.pem:
 
 After generating `cert.pem` and `server-cert.pem` you can safely remove the
-two certificate signing requests:
+two certificate signing requests and extensions config files:
 
-    $ rm -v client.csr server.csr
+    $ rm -v client.csr server.csr extfile.cnf extfile-client.cnf
 
 With a default `umask` of 022, your secret keys are *world-readable* and
 writable for you and your group.

--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -7,10 +7,10 @@ redirect_from:
 title: Protect the Docker daemon socket
 ---
 
-By default, Docker runs via a non-networked Unix socket. It can also
+By default, Docker runs through a non-networked UNIX socket. It can also
 optionally communicate using an HTTP socket.
 
-If you need Docker to be reachable via the network in a safe manner, you can
+If you need Docker to be reachable through the network in a safe manner, you can
 enable TLS by specifying the `tlsverify` flag and pointing Docker's
 `tlscacert` flag to a trusted CA certificate.
 
@@ -73,7 +73,7 @@ to connect to Docker:
 
 Next, we're going to sign the public key with our CA:
 
-Since TLS connections can be made via IP address as well as DNS name, the IP addresses
+Since TLS connections can be made through IP address as well as DNS name, the IP addresses
 need to be specified when creating the certificate. For example, to allow connections
 using `10.10.10.20` and `127.0.0.1`:
 
@@ -180,7 +180,7 @@ certificates and trusted CA:
 ## Secure by default
 
 If you want to secure your Docker client connections by default, you can move
-the files to the `.docker` directory in your home directory -- and set the
+the files to the `.docker` directory in your home directory --- and set the
 `DOCKER_HOST` and `DOCKER_TLS_VERIFY` variables as well (instead of passing
 `-H=tcp://$HOST:2376` and `--tlsverify` on every call).
 


### PR DESCRIPTION
Directions around `extfile.cnf` for client certificates was somewhat confusing.  Edited the document to clarify that a separate file was to be created, not append a line to the file that had just been created for the server.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
