### PR TITLE
Fixes UCP 3.0 offline bundles

### DIFF
--- a/datacenter/ucp/3.0/guides/admin/install/install-offline.md
+++ b/datacenter/ucp/3.0/guides/admin/install/install-offline.md
@@ -27,7 +27,7 @@ installation will fail.
 Use a computer with internet access to download the UCP package from the
 following links.
 
-{% include components/ddc_url_list_2.html product="ucp" version="3.1" %}
+{% include components/ddc_url_list_2.html product="ucp" version="3.0" %}
 
 ## Download the offline package
 

--- a/datacenter/ucp/3.0/guides/admin/install/upgrade-offline.md
+++ b/datacenter/ucp/3.0/guides/admin/install/upgrade-offline.md
@@ -17,7 +17,7 @@ copy this package to the host where you upgrade UCP.
 Use a computer with internet access to download the UCP package from the
 following links.
 
-{% include components/ddc_url_list_2.html product="ucp" version="2.2" %}
+{% include components/ddc_url_list_2.html product="ucp" version="3.0" %}
 
 ## Download the offline package
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I noticed https://github.com/docker/docker.github.io/pull/7792 was incorrect, it changed the UCP 3.0 offline bundles from UCP 2.2 to UCP 3.1. This PR fixes that. It will also update the relevant `Upgrade-Offline` page.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
