### PR TITLE
Fix XFS 'ftype' option typo

### DIFF
--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -152,14 +152,14 @@ With regard to Docker, the backing filesystem is the filesystem where
 `/var/lib/docker/` is located. Some storage drivers only work with specific
 backing filesystems.
 
-| Storage driver        | Supported backing filesystems |
+| Storage driver        | Supported backing filesystems  |
 |:----------------------|:------------------------------|
-| `overlay2`, `overlay` | `xfs` with fstype=1, `ext4`   |
+| `overlay2`, `overlay` | `xfs` with ftype=1, `ext4`    |
 | `aufs`                | `xfs`, `ext4`                 |
 | `devicemapper`        | `direct-lvm`                  |
 | `btrfs`               | `btrfs`                       |
 | `zfs`                 | `zfs`                         |
-| `vfs`                 | any filesystem                |
+| `vfs`                 | any filesystem                 |
 
 ## Other considerations
 


### PR DESCRIPTION
The required XFS option is called ftype, not fstype:

```
xfs_info / | grep ftype
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
