### PR TITLE
Add instructions to install aarch64 verison.

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -36,7 +36,7 @@ versions:
 - Xenial 16.04 (LTS)
 - Trusty 14.04 (LTS)
 
-Docker CE is supported on Ubuntu on `x86_64`, `armhf`, `s390x` (IBM Z), and `ppc64le` (IBM Power) architectures.
+Docker CE is supported on Ubuntu on `x86_64`, `arm64`, `armhf`, `s390x` (IBM Z), and `ppc64le` (IBM Power) architectures.
 
 > **`ppc64le` and `s390x` limitations**: Packages for IBM Z and Power architectures are only available on Ubuntu Xenial and above.
 
@@ -175,6 +175,7 @@ the repository.
 
     <ul class="nav nav-tabs">
       <li class="active"><a data-toggle="tab" data-target="#x86_64_repo">x86_64 / amd64</a></li>
+      <li><a data-toggle="tab" data-target="#arm64">arm64</a></li>
       <li><a data-toggle="tab" data-target="#armhf">armhf</a></li>
       <li><a data-toggle="tab" data-target="#ppc64le_repo">IBM Power (ppc64le)</a></li>
       <li><a data-toggle="tab" data-target="#s390x_repo">IBM Z (s390x)</a></li>
@@ -190,6 +191,16 @@ the repository.
     ```
 
     </div>
+    <div id="arm64" class="tab-pane fade" markdown="1">
+
+    ```bash
+    $ sudo add-apt-repository \
+       "deb [arch=arm64] {{ download-url-base }} \
+       $(lsb_release -cs) \
+       stable"
+    ```
+
+    </div>   
     <div id="armhf" class="tab-pane fade" markdown="1">
 
     ```bash
@@ -299,8 +310,8 @@ a new file each time you want to upgrade Docker CE.
 
 1.  Go to [{{ download-url-base }}/dists/]({{ download-url-base }}/dists/),
     choose your Ubuntu version, browse to `pool/stable/` and choose `amd64`,
-    `armhf`, `ppc64el`, or `s390x`. Download the `.deb` file for the Docker
-    version you want to install.
+    `arm64`, `armhf`, `ppc64el`, or `s390x`. Download the `.deb` file for the 
+    Docker version you want to install.
 
     > **Note**: To install an **edge**  package, change the word
     > `stable` in the  URL to `edge`.


### PR DESCRIPTION
### Proposed changes

AArch64 (aka arm64 on Debian) has a Docker-CE version. Update the install instructions to include installing Docker-CE on aarch64.