### PR TITLE
update mgr and agent image location to pull from dockerhub

### DIFF
--- a/ee/ucp/kubernetes/ucp-secureoverlay.yml
+++ b/ee/ucp/kubernetes/ucp-secureoverlay.yml
@@ -120,7 +120,7 @@ spec:
       serviceAccountName: ucp-secureoverlay-agent
       containers:
       - name: ucp-secureoverlay-agent
-        image: ucp-secureoverlay-agent:3.1.0
+        image: docker/ucp-secureoverlay-agent:3.1.0
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]
@@ -162,4 +162,4 @@ spec:
       restartPolicy: Always
       containers:
       - name: ucp-secureoverlay-mgr
-        image: ucp-secureoverlay-mgr:3.1.0
+        image: docker/ucp-secureoverlay-mgr:3.1.0


### PR DESCRIPTION
### Proposed changes

When deploying K8 network encryption using the manifest file, the deployment stuck at Image pull off so updated to pull image from DockerHub. 