### PR TITLE
Typo fixed: "Virtualbox" to "VirtualBox".

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -1228,7 +1228,7 @@ events or unexpected unmounts.
 * osxfs: fixed an issue causing `inotify` creation events to fail
 * osxfs: increased the `fs.inotify.max_user_watches` limit in Moby to 524288
 * The UI shows documentation link for sharing volumes
-* Clearer error message when running with outdated Virtualbox version
+* Clearer error message when running with outdated VirtualBox version
 * Added link to sources for qemu-img
 
 **Known issues**
@@ -1648,7 +1648,7 @@ lead to `Docker.app` not starting on reboot
 - Fixed RAM amount error message
 - Fixed wording of CPU error dialog
 - Removed status from Preferences
-- Check for incompatible versions of Virtualbox
+- Check for incompatible versions of VirtualBox
 
 ### Beta 4 Release (2016-03-22 1.10.3-beta4)
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -334,7 +334,7 @@ HyperKit is a hypervisor built on top of the Hypervisor.framework in macOS. It r
 dependencies.
 
 We use HyperKit to eliminate the need for other VM products, such as Oracle
-Virtualbox or VMWare Fusion.
+VirtualBox or VMWare Fusion.
 
 ### What is the benefit of HyperKit?
 

--- a/machine/reference/create.md
+++ b/machine/reference/create.md
@@ -156,7 +156,7 @@ $ docker-machine create -d virtualbox \
     foobarmachine
 ```
 
-This creates a virtual machine running locally in Virtualbox which uses the
+This creates a virtual machine running locally in VirtualBox which uses the
 `overlay` storage backend, has the key-value pairs `foo=bar` and `spam=eggs` as
 labels on the engine, and allows pushing / pulling from the insecure registry
 located at `registry.myco.com`. You can verify much of this by inspecting the

--- a/release-notes/docker-machine.md
+++ b/release-notes/docker-machine.md
@@ -523,7 +523,7 @@ toc_max: 2
   - Update Boot2Docker cache in PreCreateCheck phase
 - OpenStack
  - Filter floating IPs by tenant ID
-- Virtualbox
+- VirtualBox
   - Reject duplicate hostonlyifs Name/IP with clear message
   - Detect when hostonlyif can't be created. Point to known working version of VirtualBox
   - Don't create the VM if no hardware virtualization is available and add a flag to force create
@@ -581,7 +581,7 @@ Non-core driver plugins should still work as intended (in externally distributed
 - Generic
 	- Support password protected ssh keys though ssh-agent
 	- Support DNS names
-- Virtualbox
+- VirtualBox
 	- Show a warning if virtualbox is too old
 	- Recognize yet another Hardware Virtualization issue pattern
 	- Fix Hardware Virtualization on Linux/AMD


### PR DESCRIPTION
"Virtualbox" and "VirtualBox" are not consistent, and I think "VirtualBox" is better.