### PR TITLE
Patch Release Notes for December 2018

### DIFF
--- a/ee/dtr/release-notes.md
+++ b/ee/dtr/release-notes.md
@@ -21,6 +21,13 @@ to upgrade your installation to the latest release.
 
 # Version 2.6
 
+## 2.6.1 (2018-12-13)
+
+### Bug Fixes
+* Fixed a bug where notary signing data was not being backed up properly
+* Allow a cluster to go from 2 replicas to 1 without forcing removal
+* Fixed a race condition in initialization of the scan vulnerability database
+
 ## 2.6.0 
 
 (2018-11-08)
@@ -81,6 +88,13 @@ to upgrade your installation to the latest release.
 
 
 # Version 2.5
+
+## 2.5.7 (2018-12-13)
+
+### Bug Fixes
+* Fixed a bug where manifest lists were being appended to existing manifests lists when pushed. 
+* Updated GoRethink library to avoid potential lock contention. 
+* Fixed a bug where notary signing data was not being backed up properly. 
 
 ## 2.5.6 
 

--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -21,6 +21,28 @@ upgrade your installation to the latest release.
 
 # Version 3.1
 
+## 3.1.2 (2018-12-13)
+
+**Authentication and Authorization**
+* SAML Single Logout is now supported in UCP.
+* Identity Provider initiated SAML Single Signon is now supported in UCP.  The admin can 
+enable this feature in Admin Settings -> SAML Settings.
+
+**UI**
+* Added instrumentation to all the Kubernetes resource types.
+
+**Bug Fixes**
+* Core
+  * Significantly reduced database load in environments with a lot of concurrent 
+  and repeated API requests by the same user. (docker/escalation#911)
+  * UCP backend will now complain when a service is created/updated if the
+   `com.docker.lb.network` label is not correctly specified. (#15015) 
+  * LDAP group member attribute is now case insensitive. (docker/escalation#917)
+* Interlock
+  * Interlock headers can now be hidden. (docker/escalation#833)
+  * (FIXME) Pending  https://github.com/docker/orca/pull/15459 docker/escalation/issues/871
+  * (FIXME) Pending docker/interlock#169. docker/interlock#206  that addresses escalation/920
+
 ## 3.1.1 (2018-12-04)
 
 * To address CVE-2018-1002105, a critical security issue in the Kubernetes API Server, Docker is using Kubernetes 1.11.5 for UCP 3.1.1.
@@ -116,6 +138,29 @@ The following features are deprecated in UCP 3.1.
     * `--cni-install-url` is deprecated in favor of `--unmanaged-cni`
 
 # Version 3.0
+
+## 3.0.8 (2018-12-13)
+
+**Bug fixes**
+* Core
+  * Significantly reduced database load in environments with a lot of concurrent 
+  and repeated API requests by the same user. 
+  * Added the ability to set custom HTTP response headers to be returned by the
+   UCP Controller API Server. 
+  * UCP backend will now complain when a service is created/updated if the
+   `com.docker.lb.network` label is not correctly specified. 
+  * LDAP group member attribute is now case insensitive. 
+* Interlock
+  * Interlock headers can now be hidden. 
+  * Respect `com.docker.lb.network` labels and only attach the specified networks to the Interlock proxy. 
+  * Pending  https://github.com/docker/orca/pull/15459 
+  * Add support for 'VIP' backend mode, in which the Interlock proxy connects to the backend service's Virtual IP instead of load-balancing directly to each task IP. 
+
+## 3.0.7 (2018-12-04)
+ **Security**
+  * Kubernetes has been updated to version 1.11.5, this version also addressed CVE-2018-1002105, 
+ a critical security issue in the Kubernetes API Server. 
+ 
 
 ## 3.0.7 (2018-12-04)
 
@@ -425,6 +470,15 @@ from the UCP web UI. You can configure Docker Engine for this.
 deprecated. Deploy your applications as Swarm services or Kubernetes workloads.
 
 # Version 2.2
+
+## Version 2.2.15 (2018-12-13)
+
+**Bug fixes**
+* Core
+  * Significantly reduced database load in environments with a lot of concurrent and repeated API requests by the same user. 
+  * Added the ability to set custom HTTP response headers to be returned by the UCP Controller API Server. 
+* UI
+  * Fixed stack creation for non admin user when UCP uses a custom controller port. 
 
 ## Version 2.2.14 (2018-10-25)
 

--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -17,6 +17,47 @@ Docker EE is a superset of all the features in Docker CE. It incorporates defect
 that you can use in environments where new features cannot be adopted as quickly for 
 consistency and compatibility reasons.
 
+## 18.09.1
+2018-12-13
+
+### Security fixes for Docker Engine EE
+* Fixed authz plugin for 0-length content and path validation.
+
+### New features for Docker Engine EE and CE
+* Update to BuildKit 0.3.3 [docker/engine#122]
+* Added bash completion for experimental CLI commands (manifest) [docker/cli#1542]
+
+### Improvements for Docker Engine EE and CE
+* Updated to BuildKit 0.3.3 [docker/engine#122](https://github.com/docker/engine/pull/122)
+* Updated to containerd 1.2.1-rc.0 [docker/engine#121](https://github.com/docker/engine/pull/121)
+* Provide additional warnings for use of deprecated legacy overlay and devicemapper storage drivers [docker/engine#85](https://github.com/docker/engine/pull/85)
+* prune: perform image pruning before build cache pruning [docker/cli#1532](https://github.com/docker/cli/pull/1532)
+
+### Fixes for Docker Engine EE and CE
+* Fixed inefficient networking configuration [docker/engine#123](https://github.com/docker/engine/pull/123)
+* Fixed docker system prune doesn't accept until filter [docker/engine#122](https://github.com/docker/engine/pull/122)
+* Avoid unset credentials in `containerd` [docker/engine#122](https://github.com/docker/engine/pull/122)
+* Fixed iptables compatibility on Debian [docker/engine#107](https://github.com/docker/engine/pull/107)
+* Fixed `yamldocs` outputing `[flags]` in usage output [docker/cli#1540](https://github.com/docker/cli/pull/1540)
+* Fixed setting default schema to tcp for docker host [docker/cli#1454](https://github.com/docker/cli/pull/1454)
+* Fixed bash completion for `service update --force`  [docker/cli#1526](https://github.com/docker/cli/pull/1526)
+* Added `/proc/asound` to masked paths [docker/engine#126](https://github.com/docker/engine/pull/126)
+* Windows: allow process isolation [docker/engine#81](https://github.com/docker/engine/pull/81)
+* Windows: DetachVhd attempt in cleanup [docker/engine#113](https://github.com/docker/engine/pull/113)
+* API: properly handle invalid JSON to return a 400 status [docker/engine#110](https://github.com/docker/engine/pull/110)
+* API: ignore default address-pools on API < 1.39 [docker/engine#118](https://github.com/docker/engine/pull/118)
+* API: add missing default address pool fields to swagger [docker/engine#119](https://github.com/docker/engine/pull/119)
+* awslogs: account for UTF-8 normalization in limits [docker/engine#112](https://github.com/docker/engine/pull/112)
+* Prohibit reading more than 1MB in HTTP error responses [docker/engine#114](https://github.com/docker/engine/pull/114)
+* apparmor: allow receiving of signals from `docker kill` [docker/engine#116](https://github.com/docker/engine/pull/116)
+* overlay2: use index=off if possible (fix EBUSY on mount) [docker/engine#84](https://github.com/docker/engine/pull/84)
+
+### Packaging
+
+* Add docker.socket requirement for docker.service. [docker/docker-ce-packaging#276](https://github.com/docker/docker-ce-packaging/pull/276)
+* Add socket activation for RHEL-based distributions. [docker/docker-ce-packaging#274](https://github.com/docker/docker-ce-packaging/pull/274)
+* Add libseccomp requirement for RPM packages. [docker/docker-ce-packaging#266](https://github.com/docker/docker-ce-packaging/pull/266)
+
 ## 18.09 
 2018-11-08
 

--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -1,6 +1,6 @@
 ---
 description: Learn the technologies that support storage drivers.
-keywords: container, storage, driver, AUFS, btfs, devicemapper,zvfs
+keywords: container, storage, driver, AUFS, btfs, devicemapper,zvfs,overlay2
 title: About storage drivers
 redirect_from:
 - /en/latest/terms/layer/
@@ -9,14 +9,15 @@ redirect_from:
 - /storage/storagedriver/imagesandcontainers/
 ---
 
+Storage drivers create data in the writable layer of your container.  The files won't 
+be persisted after the container is deleted, and both read and write speeds are low.
+
+Docker recommends Overlay2 for the storage driver.
+
 To use storage drivers effectively, it's important to know how Docker builds and
 stores images, and how these images are used by containers. You can use this
 information to make informed choices about the best way to persist data from
 your applications and avoid performance problems along the way.
-
-Storage drivers allow you to create data in the writable layer of your container.
-The files won't be persisted after the container is deleted, and both read and
-write speeds are low.
 
 [Learn how to use volumes](../volumes.md) to persist data and improve performance.
 
@@ -292,8 +293,8 @@ layer. This means that the writable layer is as small as possible.
 
 When an existing file in a container is modified, the storage driver performs a
 copy-on-write operation. The specifics steps involved depend on the specific
-storage driver. For the `aufs`, `overlay`, and `overlay2` drivers, the 
-copy-on-write operation follows this rough sequence:
+storage driver. For the `aufs` and `overlay2` drivers, the copy-on-write operation 
+follows this rough sequence:
 
 *  Search through the image layers for the file to update. The process starts
    at the newest layer and works down to the base layer one layer at a time.

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -76,7 +76,7 @@ the Docker edition you use.
 
 In addition, Docker does not recommend any configuration that requires you to
 disable security features of your operating system, such as the need to disable
-`selinux` if you use the `overlay` or `overlay2` driver on CentOS.
+`selinux` if you use the `overlay2` driver on CentOS.
 
 ### Docker Engine - Enterprise and Docker Enterprise
 


### PR DESCRIPTION
Initial commit for Patch Release Notes for December 2018. This currently is engine. UCP, if not already created, will be added to this.
