### PR TITLE
404 for existing link to Expose Intro

### DIFF
--- a/ee/ucp/kubernetes/index.md
+++ b/ee/ucp/kubernetes/index.md
@@ -102,7 +102,8 @@ The service connects the cluster's internal port 80 to the external port
 
 The YAML definition connects the service to the NGINX server by using the
 app label `nginx` and a corresponding label selector.
-[Learn about using a service to expose your app](https://v1-8.docs.kubernetes.io/docs/tutorials/kubernetes-basics/expose-intro/).
+[Learn about using a service to expose your app](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose/expose-intro/
+).
 
 ## Update the deployment
 


### PR DESCRIPTION
The current link - https://v1-8.docs.kubernetes.io/docs/tutorials/kubernetes-basics/expose-intro/ to the expose intro is broken (Gives 404 not found) and hence updated it to - https://kubernetes.io/docs/tutorials/kubernetes-basics/expose/expose-intro/

