### PR TITLE
Azure Docs - Removed Swarm Port

### DIFF
--- a/ee/ucp/admin/install/install-on-azure.md
+++ b/ee/ucp/admin/install/install-on-azure.md
@@ -211,10 +211,9 @@ docker container run --rm -it \
   -v /var/run/docker.sock:/var/run/docker.sock \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} install \
   --host-address <ucp-ip> \
-  --interactive \
-  --swarm-port 3376 \
   --pod-cidr <ip-address-range> \
-  --cloud-provider Azure
+  --cloud-provider Azure \
+  --interactive
 ```
 
 #### Additional Notes


### PR DESCRIPTION
### Proposed changes

I noticed in the Azure docs we specify a Swarm port during the UCP installation. This is an optional configuration and is not required, so we will take it out of the default install docs. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
