### PR TITLE
Update get-started/part3.md port number and image

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -84,7 +84,7 @@ services:
       restart_policy:
         condition: on-failure
     ports:
-      - "80:80"
+      - "4000:80"
     networks:
       - webnet
 networks:
@@ -161,7 +161,7 @@ docker container ls -q
 You can run `curl -4 http://localhost:4000` several times in a row, or go to that URL in
 your browser and hit refresh a few times.
 
-![Hello World in browser](images/app80-in-browser.png)
+![Hello World in browser](images/app-in-browser.png)
 
 Either way, the container ID changes, demonstrating the
 load-balancing; with each request, one of the 5 tasks is chosen, in a


### PR DESCRIPTION
### Proposed changes
I found that the port in the code example and image are wrong. Just make it 4000 and use app-in-browser.png.
In previous PRs, they announced about only port number in example code. So the image and other words were not changed. I just make them consistent.

### Related issues
 #7789, #6790