### PR TITLE
Added 3.1.1 value to ee/ucp pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -148,7 +148,7 @@ defaults:
     values:
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "3.1.0"
+      ucp_version: "3.1.1"
   - scope: # This is a bit of a hack for the get-support.md topic.
       path: "ee"
     values:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I noticed pages /ee have been updated to 3.1.1, however I missed pages on /ee/ucp. Mistake was in PR #7806 

See: https://docs.docker.com/ee/end-to-end-install/

```
docker container run --rm -it --name ucp \
  -v /var/run/docker.sock:/var/run/docker.sock \
  docker/ucp:3.1.1 install \
  --host-address <node-ip-address> \
  --interactive
```

See: https://docs.docker.com/ee/ucp/admin/install/

```
docker container run --rm -it --name ucp \
  -v /var/run/docker.sock:/var/run/docker.sock \
  docker/ucp:3.1.0 install \
  --host-address <node-ip-address> \
  --interactive
```
 
### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
