### PR TITLE
Changed port to 80 instead of 4000

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -158,7 +158,7 @@ is not filtered by service:
 docker container ls -q
 ```
 
-You can run `curl -4 http://localhost:4000` several times in a row, or go to that URL in
+You can run `curl -4 http://localhost` several times in a row, or go to that URL in
 your browser and hit refresh a few times.
 
 ![Hello World in browser](images/app80-in-browser.png)


### PR DESCRIPTION

### Proposed changes

The docker-compose.yml specifies that it runs on port 80

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
