### PR TITLE
Numbers were confused

### DIFF
--- a/network/network-tutorial-overlay.md
+++ b/network/network-tutorial-overlay.md
@@ -623,7 +623,7 @@ need to have Docker installed and running.
     ping: bad address 'alpine2'
     ```
 
-7.  Detach from `alpine2` without stopping it by using the detach sequence,
+7.  Detach from `alpine1` without stopping it by using the detach sequence,
     `CTRL` + `p` `CTRL` + `q` (hold down `CTRL` and type `p` followed by `q`).
     If you wish, attach to `alpine2` and repeat steps 4, 5, and 6 there,
     substituting `alpine1` for `alpine2`.


### PR DESCRIPTION
In the tutorial, you connect to alpine1 (ONE!), do some stuff, can't ping alpine2 and I guess the author was confused at this point because immediately after not being able to ping alpine2 comes detaching from the one you're connected to and that's alpine1.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
