### PR TITLE
use port 4000 instead of 80 on host

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -84,7 +84,7 @@ services:
       restart_policy:
         condition: on-failure
     ports:
-      - "80:80"
+      - "4000:80"
     networks:
       - webnet
 networks:


### PR DESCRIPTION
### Proposed changes

I changed the `docker-compose.yml` example to map port `4000` to the host, as described later in the tutorial:

> "Map port 4000 on the host to web’s port 80."


Thanks for the great tutorial!
Ryan