### PR TITLE
removed trusty from docs to match docker ce build

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -37,8 +37,6 @@ versions:
 
 Docker CE is supported on Ubuntu on `x86_64`, `armhf`, `s390x` (IBM Z), and `ppc64le` (IBM Power) architectures.
 
-> **`ppc64le` and `s390x` limitations**: Packages for IBM Z and Power architectures are only available on Ubuntu Xenial and above.
-
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. If these are

--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -34,7 +34,6 @@ versions:
 
 - Bionic 18.04 (LTS)
 - Xenial 16.04 (LTS)
-- Trusty 14.04 (LTS)
 
 Docker CE is supported on Ubuntu on `x86_64`, `armhf`, `s390x` (IBM Z), and `ppc64le` (IBM Power) architectures.
 
@@ -68,35 +67,10 @@ outlined below.
 
 #### Extra steps for aufs
 
-<ul class="nav nav-tabs">
-  <li class="active"><a data-toggle="tab" data-target="#aufs_prep_xenial">Xenial 16.04 and newer</a></li>
-  <li><a data-toggle="tab" data-target="#aufs_prep_trusty">Trusty 14.04</a></li>
-</ul>
-<div class="tab-content">
-<div id="aufs_prep_xenial" class="tab-pane fade in active" markdown="1">
-
 For Ubuntu 16.04 and higher, the Linux kernel includes support for OverlayFS,
 and Docker CE uses the `overlay2` storage driver by default. If you need
 to use `aufs` instead, you need to configure it manually.
 See [aufs](/engine/userguide/storagedriver/aufs-driver.md)
-
-</div>
-<div id="aufs_prep_trusty" class="tab-pane fade" markdown="1">
-
-Unless you have a strong reason not to, install the
-`linux-image-extra-*` packages, which allow Docker to use the `aufs` storage
-drivers.
-
-```bash
-$ sudo apt-get update
-
-$ sudo apt-get install \
-    linux-image-extra-$(uname -r) \
-    linux-image-extra-virtual
-```
-
-</div>
-</div> <!-- tab-content -->
 
 ## Install Docker CE
 
@@ -170,7 +144,7 @@ the repository.
     > Ubuntu distribution, such as `xenial`. Sometimes, in a distribution
     > like Linux Mint, you might need to change `$(lsb_release -cs)`
     > to your parent Ubuntu distribution. For example, if you are using
-    >  `Linux Mint Rafaela`, you could use `trusty`.
+    >  `Linux Mint Sarah`, you could use `xenial`.
 
 
     <ul class="nav nav-tabs">


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Removed Ubuntu Trusty (14.04 LTS) from docs since the build was removed from the docker ce code as well:
https://github.com/docker/docker-ce/commit/d2178be92a56cb45b25ebe9275340ef9cd54c8a6#diff-9be7b725da4b31d018cc9310c9d57ec9

This removes the need for the tab as well so I removed that structure.  I also bumped the example that mentions Trusty forward to Xenial (16.04 LTS)


### Unreleased project version (optional)

This applies builds of docker-ce after 18.09.0.

### Related issues (optional)
Link above.