### PR TITLE
Update deploy on Kubernetes orchestrator instructions

### DIFF
--- a/_includes/kubernetes-mac-win.md
+++ b/_includes/kubernetes-mac-win.md
@@ -13,7 +13,7 @@ Usage: {% include kubernetes-mac-win.md platform="mac" %}
   {% assign product = "Docker for Mac" %}
 
   {% capture min-version %}{{ product }} **17.12 CE Edge**{% endcapture %}
-  
+
   {% capture version-caveat %}
   Kubernetes is available in {{ min-version }} and higher, and **18.06 Stable** and higher
   {% endcapture%}
@@ -88,7 +88,7 @@ Run `kubectl get services -n my-app` to see only the services deployed in the
 ### Override the default orchestrator
 
 While testing Kubernetes, you may want to deploy some workloads in swarm mode.
-Use the `DOCKER_ORCHESTRATOR` variable to override the default orchestrator for
+Use the `DOCKER_STACK_ORCHESTRATOR` variable to override the default orchestrator for
 a given terminal session or a single Docker command. This variable can be unset
 (the default, in which case Kubernetes is the orchestrator) or set to `swarm` or
 `kubernetes`. The following command overrides the orchestrator for a single
@@ -96,16 +96,23 @@ deployment, by setting the variable{% if platform == "mac"" %}
 at the start of the command itself.
 
 ```bash
-DOCKER_ORCHESTRATOR=swarm docker stack deploy --compose-file /path/to/docker-compose.yml mystack
+DOCKER_STACK_ORCHESTRATOR=swarm docker stack deploy --compose-file /path/to/docker-compose.yml mystack
 ```{% elsif platform == "windows" %}
 before running the command.
 
 ```shell
-set DOCKER_ORCHESTRATOR=swarm
+set DOCKER_STACK_ORCHESTRATOR=swarm
 docker stack deploy --compose-file /path/to/docker-compose.yml mystack
 ```
 
 {% endif %}
+
+Alternatively, the `--orchestrator` flag may be set to `swarm` or `kubernetes`
+when deploying to override the default orchestrator for that deployment.
+
+```bash
+docker stack deploy --orchestrator swarm --compose-file /path/to/docker-compose.yml mystack
+```
 
 > **Note**: Deploying the same app in Kubernetes and swarm mode may lead to
 > conflicts with ports and service names.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
<!--Tell us what you did and why-->
The instructions for `docker stack deploy` to `kubernetes` are incorrect and incomplete. This PR updates the environment variable: `DOCKER_ORCHESTRATOR` to ~`DOCKER_SWARM_ORCHESTRATOR`~ `DOCKER_STACK_ORCHESTRATOR`, and adds the `--orchestrator` cli option to the docs

### Related issues (optional)
Fixes #7913
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
