### PR TITLE
 Adding 18.09 as UCP/DTR compatible engine version

### DIFF
--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -139,7 +139,7 @@ Ubuntu 14.04 "Trusty Tahr" [docker-ce-packaging#255](https://github.com/docker/d
 
 > Important notes about this release
 >
-> If you're deploying UCP or DTR, use Docker EE Engine 17.06.
+> If you're deploying UCP or DTR, use Docker EE Engine 17.06 or 18.09. Consult the [Docker Compatibility Matrix](https://success.docker.com/article/compatibility-matrix) for more information
 {: .important}
 
 #### Runtime
@@ -152,7 +152,7 @@ Ubuntu 14.04 "Trusty Tahr" [docker-ce-packaging#255](https://github.com/docker/d
 
 > Important notes about this release
 >
-> If you're deploying UCP or DTR, use Docker EE Engine 17.06.
+> If you're deploying UCP or DTR, use Docker EE Engine 17.06 or 18.09. Consult the [Docker Compatibility Matrix](https://success.docker.com/article/compatibility-matrix) for more information
 {: .important}
 
 #### Client

--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -137,9 +137,9 @@ Ubuntu 14.04 "Trusty Tahr" [docker-ce-packaging#255](https://github.com/docker/d
 ### 18.03.1-ee-2
 2018-07-10
 
-> Important notes about this release
+> #### Important notes about this release
 >
-> If you're deploying UCP or DTR, use Docker EE Engine 17.06 or 18.09. Consult the [Docker Compatibility Matrix](https://success.docker.com/article/compatibility-matrix) for more information
+> If you're deploying UCP or DTR, use Docker Engine EE `17.06` or `18.09`. See [Docker Compatibility Matrix](https://success.docker.com/article/compatibility-matrix) for more information.
 {: .important}
 
 #### Runtime
@@ -150,9 +150,9 @@ Ubuntu 14.04 "Trusty Tahr" [docker-ce-packaging#255](https://github.com/docker/d
 ### 18.03.1-ee-1
 2018-06-27
 
-> Important notes about this release
+> #### Important notes about this release
 >
-> If you're deploying UCP or DTR, use Docker EE Engine 17.06 or 18.09. Consult the [Docker Compatibility Matrix](https://success.docker.com/article/compatibility-matrix) for more information
+> If you're deploying UCP or DTR, use Docker Engine EE `17.06` or `18.09`. See [Docker Compatibility Matrix](https://success.docker.com/article/compatibility-matrix) for more information.
 {: .important}
 
 #### Client


### PR DESCRIPTION
### Proposed changes

<!--Tell us what you did and why-->
Adding 18.09 as UCP/DTR compatible engine version under the 18.03 release notes
18.03 is not compatible with any version UCP or DTR. With the release of EE 2.1, UCP and DTR can be deployed not only with 17.06, but 18.09 as well. Linking to compatibility matrix for additional clarification.

