### PR TITLE
Broken link for filter jobs via UI & API

### DIFF
--- a/ee/dtr/admin/manage-jobs/job-queue.md
+++ b/ee/dtr/admin/manage-jobs/job-queue.md
@@ -31,7 +31,7 @@ so that other replicas can claim the job.
 
 ## Job Types
 
-DTR runs periodic and long-running jobs. The following is a complete list of jobs you can filter for via [the user interface](view-job-logs.md) or [the API](../troubleshoot-batch-jobs.md).   
+DTR runs periodic and long-running jobs. The following is a complete list of jobs you can filter for via [the user interface](../audit-jobs-via-ui.md) or [the API](../audit-jobs-via-api.md).   
 
 | Job               | Description                                                                                                                                                                                                                                               |
 |:------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
The "Jobs Type" section had broken link for viewing the jobs list from the User interface and through API. Corrected those links to point to proper pages as above.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
