### PR TITLE
Ensure PMU Virtualization is turned off

### DIFF
--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -488,6 +488,10 @@ with Linux containers.
   Check the settings in **Hardware → CPU & Memory → Advanced Options → Enable
   nested virtualization** (the exact menu sequence might vary slightly).
 
+* Ensure "PMU Virtualization" is turned off in Parallels on Macs. Check the 
+  settings in **Hardware → CPU & Memory → Advanced Settings → PMU 
+  Virtualization**
+
 * Configure your VM with at least 2 CPUs and sufficient memory to run your
   workloads.
 


### PR DESCRIPTION
Having PMU Virtualization turned on in Parallels on Macs may cause the MobyLinuxVM to not properly start up and consume considerable amount of CPU finally letting Docker on Windows to fail altogether

### Proposed changes

I was not able to run Docker for Windows on my MacBook Pro Mid 2018 as host running Parallels Version 14.1.0 (45387) with a Windows 10 (1809, 17763.195) VM. Docker for Windows complained about "No activity on VM" and failed. I tried all things mentioned #2404 and #1808 and others, such as completely re-installing Docker for Windows, ensuring to have the latest Windows 10 build (I initially started having this issue with an earlier version than stated above).

### Related issues (optional)

May help for #2404 and #1808