### PR TITLE
Docker Machine - Installation steps broken

### DIFF
--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -19,12 +19,9 @@ on GitHub.
 
 1.  Install [Docker](/engine/installation/index.md){: target="_blank" class="_" }.
 
-2.  
+2.  Download the Docker Machine binary and extract it to your PATH.
 
-
-the Docker Machine binary and extract it to your PATH.
-
-    If you are running on **macOS**:
+    If you are running **macOS**:
 
     ```console
     $ base=https://github.com/docker/machine/releases/tag/v{{site.machine_version}} &&
@@ -32,7 +29,7 @@ the Docker Machine binary and extract it to your PATH.
       chmod +x /usr/local/bin/docker-machine
     ```
 
-    If you are running on **Linux**:
+    If you are running **Linux**:
 
     ```console
     $ base=https://github.com/docker/machine/releases/tag/v{{site.machine_version}} &&
@@ -40,7 +37,7 @@ the Docker Machine binary and extract it to your PATH.
       sudo install /tmp/docker-machine /usr/local/bin/docker-machine
     ```
 
-    If you are running with **Windows** with [Git BASH](https://git-for-windows.github.io/){: target="_blank" class="_"}:
+    If you are running **Windows** with [Git BASH](https://git-for-windows.github.io/){: target="_blank" class="_"}:
 
     ```console
     $ base=https://github.com/docker/machine/releases/tag/v{{site.machine_version}} &&

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -19,12 +19,15 @@ on GitHub.
 
 1.  Install [Docker](/engine/installation/index.md){: target="_blank" class="_" }.
 
-2.  Download the Docker Machine binary and extract it to your PATH.
+2.  
+
+
+the Docker Machine binary and extract it to your PATH.
 
     If you are running on **macOS**:
 
     ```console
-    $ base=https://github.com/docker/machine/releases/download/v{{site.machine_version}} &&
+    $ base=https://github.com/docker/machine/releases/tag/v{{site.machine_version}} &&
       curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/usr/local/bin/docker-machine &&
       chmod +x /usr/local/bin/docker-machine
     ```
@@ -32,7 +35,7 @@ on GitHub.
     If you are running on **Linux**:
 
     ```console
-    $ base=https://github.com/docker/machine/releases/download/v{{site.machine_version}} &&
+    $ base=https://github.com/docker/machine/releases/tag/v{{site.machine_version}} &&
       curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine &&
       sudo install /tmp/docker-machine /usr/local/bin/docker-machine
     ```
@@ -40,7 +43,7 @@ on GitHub.
     If you are running with **Windows** with [Git BASH](https://git-for-windows.github.io/){: target="_blank" class="_"}:
 
     ```console
-    $ base=https://github.com/docker/machine/releases/download/v{{site.machine_version}} &&
+    $ base=https://github.com/docker/machine/releases/tag/v{{site.machine_version}} &&
       mkdir -p "$HOME/bin" &&
       curl -L $base/docker-machine-Windows-x86_64.exe > "$HOME/bin/docker-machine.exe" &&
       chmod +x "$HOME/bin/docker-machine.exe"


### PR DESCRIPTION
https://github.com/docker/machine/downloads/ is no longer available. The path mentioned in the documentation is to be replaced with https://github.com/docker/machine/releases/tags


### Proposed changes
The path to the DockerMachine installation files on Github has been updated. The old path is broken and no longer working.