### PR TITLE
Distinguish command from placeholder

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -321,7 +321,7 @@ username, repository, and tag names so that the image uploads to your
 desired destination. The syntax of the command is:
 
 ```shell
-docker tag image username/repository:tag
+docker tag <image id> <username>/<repository id>:<tag name>
 ```
 
 For example:
@@ -348,7 +348,7 @@ python                   2.7-slim            1c7128a655f6        5 days ago     
 Upload your tagged image to the repository:
 
 ```shell
-docker push username/repository:tag
+docker push <username>/<repository id>:<tag name>
 ```
 
 Once complete, the results of this upload are publicly available. If you log in
@@ -361,7 +361,7 @@ From now on, you can use `docker run` and run your app on any machine with this
 command:
 
 ```shell
-docker run -p 4000:80 username/repository:tag
+docker run -p 4000:80 <username>/<repository id>:<tag name>
 ```
 
 If the image isn't available locally on the machine, Docker pulls it from


### PR DESCRIPTION
To avoid ambiguity where the command (the plain word) is the same as the placeholder (now in <>) such as `image` and `tag` and no actual examples are given to clarify.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
