### PR TITLE
Enable the latest stable repository for CentOS

### DIFF
--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -134,6 +134,12 @@ You only need to set up the repository once, after which you can install Docker 
         "$DOCKERURL/{{ linux-dist-url-slug }}/docker-ee.repo"
     ```
 
+7.  Enable the **latest** stable repository:
+    
+    ```bash
+    $ sudo yum-config-manager --disable docker-*
+    $ sudo yum-config-manager --enable docker-ee-stable
+    ```
 
 {% elsif section == "install-using-yum-repo" %}
 


### PR DESCRIPTION
In the docker-ee.repo file the latest version (18.09) is disabled by default so that when you install the docker-ee package in the next step you get an older release (17.6) which does not fit UCP constraints.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
I have added two lines of code:
1. The first one is to disable all previous docker old repositories.
2. The second one is to enable the latest stable docker-ee repository.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
https://github.com/docker/docker.github.io/issues/7938