### PR TITLE
Remove bad, breaky advice

### DIFF
--- a/install/linux/docker-ce/centos.md
+++ b/install/linux/docker-ce/centos.md
@@ -49,8 +49,6 @@ $ sudo yum remove docker \
                   docker-latest \
                   docker-latest-logrotate \
                   docker-logrotate \
-                  docker-selinux \
-                  docker-engine-selinux \
                   docker-engine
 ```
 


### PR DESCRIPTION
`yum remove docker-selinux` and `yum remove docker-engine-selinux` result into a prompt to remove `container-selinux` package, which, in turn, is a dependency for `docker-ce`, which results into a prompt to remove it as well.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
