### PR TITLE
Fix add-apt-repository command

### DIFF
--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -185,7 +185,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=amd64] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       $DOCKER_EE_VERSION"
+       $DOCKER_EE_VERSION stable"
        
     ```
 
@@ -196,7 +196,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=s390x] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       $DOCKER_EE_VERSION"
+       $DOCKER_EE_VERSION stable"
 
     ```
 
@@ -207,7 +207,7 @@ from the repository.
     $ sudo add-apt-repository \
        "deb [arch=ppc64el] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       $DOCKER_EE_VERSION"
+       $DOCKER_EE_VERSION stable"
 
     ```
 


### PR DESCRIPTION
### Proposed changes

In the Docker EE Ubuntu installation documentation, the `add-apt-repository` command when entered as-is, produces the error:

```
ubuntu@test-mgr-1:~$ sudo add-apt-repository    "deb [arch=amd64] $DOCKER_EE_URL/ubuntu \
   $(lsb_release -cs) \
   $DOCKER_EE_VERSION"                                                                                            
E: Malformed entry 63 in list file /etc/apt/sources.list (Component)                                              
E: The list of sources could not be read.
```

The line it's referring to reads: (with the url tweaked slightly here to hide my exact personal trial link)

```
deb [arch=amd64] https://storebits.docker.com/ee/trial/sub-3b42bf56-b678-435b-5bd0-f50513347b44/ubuntu bionic
```

The InRelease file found in the referenced software repo has the Component stable listed, so adding the word `stable` to the command fixes it. 

I notice that the Docker CE installation docs are correct.

Thank you for maintaining the Docker documentation!