### PR TITLE
update from fd:// to unix://

### DIFF
--- a/install/linux/linux-postinstall.md
+++ b/install/linux/linux-postinstall.md
@@ -156,7 +156,7 @@ Configuring Docker to accept remote connections can be done with the `docker.ser
     ```none
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// -H tcp://127.0.0.1:2375
+    ExecStart=/usr/bin/dockerd -H unix:// -H tcp://127.0.0.1:2375
     ```
 
 3. Save the file.


### PR DESCRIPTION
**change fd:// to unix://: as fd:// doesn't work with new version**
_reference:_ 
https://forums.docker.com/t/failed-to-load-listeners-no-sockets-found-via-socket-activation-make-sure-the-service-was-started-by-systemd/62505
Tested on Ubuntu 16.04 Server
$docker version

> Client:
>  Version:           18.09.0
>  API version:       1.39
>  Go version:        go1.10.4
>  Git commit:        4d60db4
>  Built:             Wed Nov  7 00:48:57 2018
>  OS/Arch:           linux/amd64
>  Experimental:      false
> 
> Server: Docker Engine - Community
>  Engine:
>   Version:          18.09.0
>   API version:      1.39 (minimum version 1.12)
>   Go version:       go1.10.4
>   Git commit:       4d60db4
>   Built:            Wed Nov  7 00:16:44 2018
>   OS/Arch:          linux/amd64
>   Experimental:     false


before the changes it was producing the following Error and Docker failed to start :
Failed to load listeners: no sockets found via socket activation: make sure the service was started by systemd

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
