### PR TITLE
Add redirects for apidocs pages

### DIFF
--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -73,6 +73,8 @@ redirect_from:
 - /docker-cloud/docker-errors-faq/
 - /docker-cloud/release-notes/
 - /docker-store/
+- /apidocs/
+- /apidocs/overview/
 ---
 
 [Docker Hub](https://hub.docker.com) is a service provided by Docker for finding and sharing container images with your team. It provides the following major features:


### PR DESCRIPTION
Removes apidocs references and redirect the pages to /docker-hub.
