### PR TITLE
Fix compose file defaults

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -736,7 +736,7 @@ Configures if and how to restart containers when they exit. Replaces
 
 - `condition`: One of `none`, `on-failure` or `any` (default: `any`).
 - `delay`: How long to wait between restart attempts, specified as a
-  [duration](#specifying-durations) (default: 0).
+  [duration](#specifying-durations) (default: 5s).
 - `max_attempts`: How many times to attempt to restart a container before giving
   up (default: never give up). If the restart does not succeed within the configured
   `window`, this attempt doesn't count toward the configured `max_attempts` value.
@@ -766,25 +766,24 @@ services:
 Configures how the service should be rollbacked in case of a failing
 update.
 
-- `parallelism`: The number of containers to rollback at a time. If set to 0, all containers rollback simultaneously.
-- `delay`: The time to wait between each container group's rollback (default 0s).
-- `failure_action`: What to do if a rollback fails. One of `continue` or `pause` (default `pause`)
-- `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
-- `max_failure_ratio`: Failure rate to tolerate during a rollback (default 0).
-- `order`: Order of operations during rollbacks. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks briefly overlap) (default `stop-first`).
+- `parallelism`: The number of containers to rollback at a time. If set to 0, all containers rollback simultaneously (default: 1).
+- `delay`: The time to wait between each container group's rollback (default: 0s).
+- `failure_action`: What to do if a rollback fails. One of `continue` or `pause` (default: `pause`).
+- `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default: 5s).
+- `max_failure_ratio`: Failure rate to tolerate during a rollback (default: 0).
+- `order`: Order of operations during rollbacks. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks briefly overlap) (default: `stop-first`).
 
 #### update_config
 
 Configures how the service should be updated. Useful for configuring rolling
 updates.
 
-- `parallelism`: The number of containers to update at a time.
-- `delay`: The time to wait between updating a group of containers.
-- `failure_action`: What to do if an update fails. One of `continue`, `rollback`, or `pause`
-  (default: `pause`).
-- `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
-- `max_failure_ratio`: Failure rate to tolerate during an update.
-- `order`: Order of operations during updates. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks briefly overlap) (default `stop-first`) **Note**: Only supported for v3.4 and higher.
+- `parallelism`: The number of containers to update at a time (default: 1).
+- `delay`: The time to wait between updating a group of containers (default: 0s).
+- `failure_action`: What to do if an update fails. One of `continue`, `rollback`, or `pause` (default: `pause`).
+- `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default: 5s).
+- `max_failure_ratio`: Failure rate to tolerate during an update (default: 0).
+- `order`: Order of operations during updates. One of `stop-first` (old task is stopped before starting new one), or `start-first` (new task is started first, and the running tasks briefly overlap) (default: `stop-first`). **Note**: Only supported for v3.4 and higher.
 
 > **Note**: `order` is only supported for v3.4 and higher of the compose
 file format.
@@ -852,7 +851,7 @@ behaviors:
 - `docker-compose up SERVICE` automatically includes `SERVICE`'s
   dependencies. In the following example, `docker-compose up web` also
   creates and starts `db` and `redis`.
-  
+
 - `docker-compose stop` stops services in dependency order. In the following
   example, `web` is stopped before `db` and `redis`.
 
@@ -2367,7 +2366,7 @@ secrets:
 ```
 
 ### Compose File v3.4 and under
-```none    
+```none
   my_second_secret:
     external:
       name: redis_secret


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Correct and complement default values in compose file documentation to reflect the actual defaults in code.

- `restart_policy.delay` defaults to `5s`

https://github.com/docker/swarmkit/blob/87d4106b01c7764aab51847f445ac9369fae161c/api/defaults/service.go#L23-L26

- `update_ / rollback_config`'s `monitor` defaults to `5s` and `parallelism` defaults to `1`. 

https://github.com/docker/swarmkit/blob/87d4106b01c7764aab51847f445ac9369fae161c/api/defaults/service.go#L29-L40