### PR TITLE
Remove "Cloud stack file reference" from navigation

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -528,9 +528,6 @@ reference:
   - title: Compose file reference
     path: /compose/compose-file/
     nosync: true
-  - title: Cloud stack file reference
-    path: /docker-cloud/apps/stack-yaml-reference/
-    nosync: true
 
 - sectiontitle: Command-Line Interfaces (CLIs)
   section:


### PR DESCRIPTION
The content was already removed, and a SEO redirect is present, so we can remove this one from the navigation

relates to https://github.com/docker/docker.github.io/pull/7050/commits/1949171654e8c99a1c80bda2b67064200de62a2a (https://github.com/docker/docker.github.io/pull/7050)