### PR TITLE
TAR-301 Fix ubuntu installation instructions for EE

### DIFF
--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -137,13 +137,13 @@ from the repository.
 
 4. Temporarily add a `$DOCKER_EE_VERSION` variable into your environment.
 
-   > ***NOTE:*** If you need to run Docker EE 2.0, please see the following instructions:
+   > ***NOTE:*** If you need to run something other than Docker EE 2.0, please see the following instructions:
    > * [18.03](https://docs.docker.com/v18.03/ee/supported-platforms/) - Older Docker EE Engine only release
    > * [17.06](https://docs.docker.com/v17.06/engine/installation/) - Docker Enterprise Edition 2.0 (Docker Engine, 
    > UCP, and DTR).
 
     ```bash
-    $ DOCKER_EE_VERSION=<YOUR_VERSION>
+    $ DOCKER_EE_VERSION=18.09
     ```
 
 5.  Add Docker's official GPG key using your customer Docker EE repository URL:
@@ -173,46 +173,12 @@ from the repository.
     > Ubuntu distribution, such as `xenial`.
     >
 
-    <ul class="nav nav-tabs">
-      <li class="active"><a data-toggle="tab" data-target="#x86_64_repo">x86_64 / amd64</a></li>
-      <li><a data-toggle="tab" data-target="#s390x_repo">IBM Z (s390x)</a></li>
-      <li><a data-toggle="tab" data-target="#ppc64el_repo">IBM Power (ppc64el)</a></li>
-    </ul>
-    <div class="tab-content">
-    <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
-
     ```bash
     $ sudo add-apt-repository \
-       "deb [arch=amd64] $DOCKER_EE_URL/ubuntu \
+       "deb [arch=$(dpkg --print-architecture)] $DOCKER_EE_URL/ubuntu \
        $(lsb_release -cs) \
-       $DOCKER_EE_VERSION stable"
-       
+       stable-$DOCKER_EE_VERSION"
     ```
-
-    </div>
-    <div id="s390x_repo" class="tab-pane fade" markdown="1">
-
-    ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=s390x] $DOCKER_EE_URL/ubuntu \
-       $(lsb_release -cs) \
-       $DOCKER_EE_VERSION stable"
-
-    ```
-
-    </div>
-    <div id="ppc64el_repo" class="tab-pane fade" markdown="1">
-
-    ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=ppc64el] $DOCKER_EE_URL/ubuntu \
-       $(lsb_release -cs) \
-       $DOCKER_EE_VERSION stable"
-
-    ```
-
-    </div>
-    </div> <!-- tab-content -->
 
 #### Install Docker EE
 


### PR DESCRIPTION

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Was pointing to a non-existent `$DOCKER_EE_VERSION` repository, and still had
installation instructions for s390x and ppc64el which we do not support
with the latest EE release.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->


CC @thaJeztah @ahh-docker @L-Hudson @dave-tucker 