### PR TITLE
Fix link in security.md

### DIFF
--- a/engine/security/security.md
+++ b/engine/security/security.md
@@ -212,7 +212,7 @@ This feature provides more insight to administrators than previously available w
 the CLI for enforcing and performing image signature verification. 
 
 For more information on configuring Docker Content Trust Signature Verificiation, go to 
-(Content trust in Docker)[engine/security/trust/content_trust].
+[Content trust in Docker](../security/trust/content_trust).
 
 ## Other kernel security features
 


### PR DESCRIPTION
Format (Markdown) for "Content trust in Docker" link was incorrect. Also updated the link itself to be inline with the rest of them (at the bottom of the page).