### PR TITLE
chore(typo): fix incorrect storage driver reference

### DIFF
--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -103,7 +103,7 @@ removed in a future release. It is recommended that users of the `overlay` stora
 migrate to `overlay2`.
 
 ²) The `devicemapper` storage driver is deprecated in Docker Engine 18.09, and will be
-removed in a future release. It is recommended that users of the `overlay` storage driver 
+removed in a future release. It is recommended that users of the `devicemapper` storage driver 
 migrate to `overlay2`.
 
 


### PR DESCRIPTION
### Proposed changes

during a recent rewrite of this doc section it looks like a copy-paste error slipped through. whoops!
this section is about the deprecation of `devicemapper` but accidentally references `overlay` once instead, so I fixed it.

### Related issues (optional)

introduced in #7669
