### PR TITLE
Fix default directory path for Windows

### DIFF
--- a/engine/security/antivirus.md
+++ b/engine/security/antivirus.md
@@ -8,7 +8,7 @@ When antivirus software scans files used by Docker, these files may be locked
 in a way that causes Docker commands to hang.
 
 One way to reduce these problems is to add the Docker data directory
-(`/var/lib/docker` on Linux, `$Env:ProgramData` on Windows Server, or `$HOME/Library/Containers/com.docker.docker/` on Mac) to the
+(`/var/lib/docker` on Linux, `%ProgramData%\docker` on Windows Server, or `$HOME/Library/Containers/com.docker.docker/` on Mac) to the
 antivirus's exclusion list. However, this comes with the trade-off that viruses
 or malware in Docker images, writable layers of containers, or volumes are not
 detected. If you do choose to exclude Docker's data directory from background


### PR DESCRIPTION
As previously stated, the entire `%ProgramData%` directory would be ignored. This also uses a PowerShell syntax for which most people may not be familiar, but most often PowerShell users know how to translate from supported environment variables. The main point is to limit the directory to ignore to just docker. Many, many other applications write to `%ProgramData%`.
