### PR TITLE
Fix incorrect capitalization of --env argument

### DIFF
--- a/network/proxy.md
+++ b/network/proxy.md
@@ -60,8 +60,8 @@ instead.
 
 | Variable      | Dockerfile example                                | `docker run` Example                                |
 |:--------------|:--------------------------------------------------|:----------------------------------------------------|
-| `HTTP_PROXY`  | `ENV HTTP_PROXY "http://127.0.0.1:3001"`          | `--env HTTP_PROXY="http://127.0.0.1:3001"`          |
-| `HTTPS_PROXY` | `ENV HTTPS_PROXY "https://127.0.0.1:3001"`        | `--env HTTPS_PROXY="https://127.0.0.1:3001"`        |
-| `FTP_PROXY`   | `ENV FTP_PROXY "ftp://127.0.0.1:3001"`            | `--env FTP_PROXY="ftp://127.0.0.1:3001"`            |
-| `NO_PROXY`    | `ENV NO_PROXY "*.test.example.com,.example2.com"` | `--env NO_PROXY="*.test.example.com,.example2.com"` |
+| `HTTP_PROXY`  | `ENV HTTP_PROXY "http://127.0.0.1:3001"`          | `--env http_proxy="http://127.0.0.1:3001"`          |
+| `HTTPS_PROXY` | `ENV HTTPS_PROXY "https://127.0.0.1:3001"`        | `--env https_proxy="https://127.0.0.1:3001"`        |
+| `FTP_PROXY`   | `ENV FTP_PROXY "ftp://127.0.0.1:3001"`            | `--env ftp_proxy="ftp://127.0.0.1:3001"`            |
+| `NO_PROXY`    | `ENV NO_PROXY "*.test.example.com,.example2.com"` | `--env no_proxy="*.test.example.com,.example2.com"` |
 


### PR DESCRIPTION
I found, in version `18.03.0-ce, build 0520e24` of docker, that the --env argument *cannot* be capital letters.

**I have only tested this for http_proxy and https_proxy, not ftp_proxy and no_proxy, so I just made the assumption that it should be the same.**

Perhaps the CLI should be more lenient?

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Change the documentation of the argument given to the `--env` flag to be lowercase letters, since uppercase does not work.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
