### PR TITLE
ucp: support dump running version

### DIFF
--- a/datacenter/ucp/2.2/guides/get-support.md
+++ b/datacenter/ucp/2.2/guides/get-support.md
@@ -34,11 +34,12 @@ support dump:
 To get the support dump from the CLI, use SSH to log into a node and run:
 
 ```none
+UCP_VERSION=$((docker container inspect ucp-proxy --format {% raw %}'{{index .Config.Labels "com.docker.ucp.version"}}'{% endraw %} 2>/dev/null || echo -n {{ page.ucp_version  }})|tr -d [[:space:]])
 docker container run --rm \
   --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --log-driver none \
-  {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} \
+  {{ page.ucp_org }}/{{ page.ucp_repo }}:${UCP_VERSION} \
   support > \
   docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```

--- a/datacenter/ucp/3.0/guides/get-support.md
+++ b/datacenter/ucp/3.0/guides/get-support.md
@@ -34,11 +34,12 @@ support dump:
 To get the support dump from the CLI, use SSH to log into a node and run:
 
 ```none
+UCP_VERSION=$((docker container inspect ucp-proxy --format {% raw %}'{{index .Config.Labels "com.docker.ucp.version"}}'{% endraw %} 2>/dev/null || echo -n {{ page.ucp_version  }})|tr -d [[:space:]])
 docker container run --rm \
   --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --log-driver none \
-  {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} \
+  {{ page.ucp_org }}/{{ page.ucp_repo }}:${UCP_VERSION} \
   support > \
   docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```

--- a/ee/get-support.md
+++ b/ee/get-support.md
@@ -35,11 +35,12 @@ To get the support dump from the Web UI:
 To get the support dump from the CLI, use SSH to log into a node and run:
 
 ```bash
+UCP_VERSION=$((docker container inspect ucp-proxy --format {% raw %}'{{index .Config.Labels "com.docker.ucp.version"}}'{% endraw %} 2>/dev/null || echo -n {{ page.ucp_version  }})|tr -d [[:space:]])
 docker container run --rm \
   --name ucp \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --log-driver none \
-  {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} \
+  {{ page.ucp_org }}/{{ page.ucp_repo }}:${UCP_VERSION} \
   support > \
   docker-support-${HOSTNAME}-$(date +%Y%m%d-%H_%M_%S).tgz
 ```


### PR DESCRIPTION
Use a bash shell variable to run support dump at the same revision as
the cluster is running.  This is a copy-paste convenience for users in offline environments that might not be running the latest version.

/cc @ekitagawa as a heads up that we might want to do the same thing
with powershell a few lines lower.