### PR TITLE
typo in "Get Started, Part 2": extraneous 'a'

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -156,7 +156,7 @@ Dockerfile		app.py			requirements.txt
 ```
 
 Now run the build command. This creates a Docker image, which we're going to
-name using the `--tag` option. Use `-t` if you want to use the a shorter option.
+name using the `--tag` option. Use `-t` if you want to use the shorter option.
 
 ```shell
 docker build --tag=friendlyhello .


### PR DESCRIPTION
### Proposed changes

in the **Build the app** section of https://docs.docker.com/get-started/part2/, replace:

`if you want to use the a shorter option` with
`if you want to use the shorter option`

In context:

> Now run the build command. This creates a Docker image, which we’re going to name using the --tag option. Use -t if you want to use the a shorter option.