### PR TITLE
multi-service containers

### DIFF
--- a/config/containers/multi-service_container.md
+++ b/config/containers/multi-service_container.md
@@ -83,6 +83,41 @@ this in a few different ways.
   CMD ./my_wrapper_script.sh
   ```
 
+- If you have one main process that needs to start first and stay running but
+  you temporarily need to run some other processes (perhaps to interact with
+  the main process) then you can use bash's job control to facilitate that.
+  First, the wrapper script:
+
+
+  ```bash
+  #!/bin/bash
+
+  # turn on bash's job control
+  set -m
+
+  # Start the primary process and put it in the background
+  ./my_main_process &
+
+  # Start the helper process
+  ./my_helper_process
+
+  # the my_helper_process might need to know how to wait on the
+  # primary process to start before it does its work and returns
+
+
+  # now we bring the primary process back into the foreground
+  # and leave it there
+  fg %1
+  ```
+ 
+  ```conf
+  FROM ubuntu:latest
+  COPY my_main_process my_main_process
+  COPY my_helper_process my_helper_process
+  COPY my_wrapper_script.sh my_wrapper_script.sh
+  CMD ./my_wrapper_script.sh
+  ```
+
 - Use a process manager like `supervisord`. This is a moderately heavy-weight
   approach that requires you to package `supervisord` and its configuration in
   your image (or base your image on one that includes `supervisord`), along with


### PR DESCRIPTION
### Proposed changes

I added a solution for spawning helper processes that interact with a
primary process before ultimately putting the primary process
back in the foreground.
I needed to do this (that is, turn my container into a multi-service container just for a short while) and I thought it might help others.