### PR TITLE
ucp config: custom api headers syntax

### DIFF
--- a/ee/ucp/admin/configure/ucp-configuration-file.md
+++ b/ee/ucp/admin/configure/ucp-configuration-file.md
@@ -91,7 +91,7 @@ An array of tables that specifies the DTR instances that the current UCP instanc
 
 Included when you need to set custom API headers. You can repeat this section multiple times to specify multiple separate headers. If you include custom headers, you must specify both `name` and `value`.
 
-[custom_api_server_headers]
+[[custom_api_server_headers]]
 
 | Item | Description |
 | ----------- | ----------- |


### PR DESCRIPTION
Example for this table needs double brackets because it's an array.
Tested on UCP 3.0.8.