### PR TITLE
Remove upstream TLS labels

### DIFF
--- a/ee/ucp/interlock/usage/labels-reference.md
+++ b/ee/ucp/interlock/usage/labels-reference.md
@@ -23,8 +23,6 @@ The following labels are available for you to use in swarm services:
 | `com.docker.lb.ssl_key`                | Docker secret to use for the SSL key.                                                                                                          | `example.com.key`      |
 | `com.docker.lb.websocket_endpoints`    | Comma separated list of endpoints to configure to be upgraded for websockets.                                                                  | `/ws,/foo`             |
 | `com.docker.lb.service_cluster`        | Name of the service cluster to use for the application.                                                                                        | `us-east`              |
-| `com.docker.lb.ssl_backend`            | Enable SSL communication to the upstreams.                                                                                                     | `true`                 |
-| `com.docker.lb.ssl_backend_tls_verify` | Verification mode for the upstream TLS.                                                                                                        | `none`                 |
 | `com.docker.lb.sticky_session_cookie`  | Cookie to use for sticky sessions.                                                                                                             | `none`                 |
 | `com.docker.lb.redirects`              | Semi-colon separated list of redirects to add in the format of `<source>,<target>`.  Example: `http://old.example.com,http://new.example.com;` | `none`                 |
 | `com.docker.lb.ssl_passthrough`        | Enable SSL passthrough.                                                                                                                        | `false`                |


### PR DESCRIPTION
Per @ehazlett , upstream TLS labels are not implemented yet in UCP 3.0 or 3.1

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
