### PR TITLE
ucp: auth store reconfigure update output

### DIFF
--- a/datacenter/ucp/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-configurations.md
+++ b/datacenter/ucp/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-configurations.md
@@ -137,8 +137,8 @@ docker container run --rm -v ucp-auth-store-certs:/tls docker/ucp-auth:${VERSION
 time="2017-07-14T20:46:09Z" level=debug msg="Connecting to db ..."
 time="2017-07-14T20:46:09Z" level=debug msg="connecting to DB Addrs: [192.168.1.25:12383]"
 time="2017-07-14T20:46:09Z" level=debug msg="Reconfiguring number of replicas to 1"
-time="2017-07-14T20:46:09Z" level=debug msg="(00/16) Emergency Repairing Tables..."
-time="2017-07-14T20:46:09Z" level=debug msg="(01/16) Emergency Repaired Table \"grant_objects\""
+time="2017-07-14T20:46:09Z" level=debug msg="(00/16) Reconfiguring Table Replication..."
+time="2017-07-14T20:46:09Z" level=debug msg="(01/16) Reconfigured Replication of Table \"grant_objects\""
 ...
 ```
 {% endraw %}

--- a/datacenter/ucp/3.0/guides/admin/monitor-and-troubleshoot/troubleshoot-configurations.md
+++ b/datacenter/ucp/3.0/guides/admin/monitor-and-troubleshoot/troubleshoot-configurations.md
@@ -137,8 +137,8 @@ docker container run --rm -v ucp-auth-store-certs:/tls docker/ucp-auth:${VERSION
 time="2017-07-14T20:46:09Z" level=debug msg="Connecting to db ..."
 time="2017-07-14T20:46:09Z" level=debug msg="connecting to DB Addrs: [192.168.1.25:12383]"
 time="2017-07-14T20:46:09Z" level=debug msg="Reconfiguring number of replicas to 1"
-time="2017-07-14T20:46:09Z" level=debug msg="(00/16) Emergency Repairing Tables..."
-time="2017-07-14T20:46:09Z" level=debug msg="(01/16) Emergency Repaired Table \"grant_objects\""
+time="2017-07-14T20:46:09Z" level=debug msg="(00/16) Reconfiguring Table Replication..."
+time="2017-07-14T20:46:09Z" level=debug msg="(01/16) Reconfigured Replication of Table \"grant_objects\""
 ...
 ```
 {% endraw %}

--- a/ee/ucp/admin/monitor-and-troubleshoot/troubleshoot-configurations.md
+++ b/ee/ucp/admin/monitor-and-troubleshoot/troubleshoot-configurations.md
@@ -137,8 +137,8 @@ docker container run --rm -v ucp-auth-store-certs:/tls docker/ucp-auth:${VERSION
 time="2017-07-14T20:46:09Z" level=debug msg="Connecting to db ..."
 time="2017-07-14T20:46:09Z" level=debug msg="connecting to DB Addrs: [192.168.1.25:12383]"
 time="2017-07-14T20:46:09Z" level=debug msg="Reconfiguring number of replicas to 1"
-time="2017-07-14T20:46:09Z" level=debug msg="(00/16) Emergency Repairing Tables..."
-time="2017-07-14T20:46:09Z" level=debug msg="(01/16) Emergency Repaired Table \"grant_objects\""
+time="2017-07-14T20:46:09Z" level=debug msg="(00/16) Reconfiguring Table Replication..."
+time="2017-07-14T20:46:09Z" level=debug msg="(01/16) Reconfigured Replication of Table \"grant_objects\""
 ...
 {% endraw %}
 ```


### PR DESCRIPTION
## what I did:
removed references to emergency repair from output of ucp auth reconfiguration, since emergency repair only appears when using `--emergency-repair`, which we've removed from the example command.  This could be considered a follow-up to #7667.

## how I did it:

```
git grep -l 'Emergency Repairing Tables' |xargs sed -i 's:Emergency Repairing Tables:Reconfiguring Table Replication:'
git grep -l 'Emergency Repaired Table' |xargs sed -i 's:Emergency Repaired:Reconfigured Replication of:'
```

Actual output from UCP 3.1.0 cluster, for reference:

```
[vagrant@ucp-1 ~]$ docker container run --rm -v ucp-auth-store-certs:/tls docker/ucp-auth:${VERSION} --db-addr=${NODE_ADDRESS}:12383 --debug reconfigure-db --num-replicas ${NUM_MANAGERS}                                     
time="2019-01-24T23:56:20Z" level=debug msg="Connecting to db ..."                                             
time="2019-01-24T23:56:20Z" level=debug msg="connecting to DB Addrs: [192.168.56.101:12383]"                   
time="2019-01-24T23:56:20Z" level=debug msg="Reconfiguring number of replicas to 1"                            
time="2019-01-24T23:56:20Z" level=debug msg="(00/19) Reconfiguring Table Replication..."                       
time="2019-01-24T23:56:20Z" level=debug msg="(01/19) Reconfigured Replication of Table \"userDefaultCollection\""
time="2019-01-24T23:56:20Z" level=debug msg="(02/19) Reconfigured Replication of Table \"accounts\""
[...]
```