### PR TITLE
Update hub auto build doc

### DIFF
--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -292,25 +292,6 @@ You could also use capture groups to build and label images that come from vario
 
 `/(alice|bob)-v([0-9.]+)/` -->
 
-### Create multiple Docker tags from a single build
-
-By default, each build rule builds a source branch or tag into a Docker image,
-and then tags that image with a single tag. However, you can also create several
-tagged Docker images from a single build rule.
-
-To create multiple tags from a single build rule, enter a comma-separated list
-of tags in the **Docker tag** field in the build rule. If an image with that tag
-already exists, Docker Hub overwrites the image when the build completes
-successfully. If you have automated tests configured, the build must pass these
-tests as well before the image is overwritten. You can use both regex references
-and plain text values in this field simultaneously.
-
-For example if you want to update the image tagged with `latest` at the same
-time as you a tag an image for a specific version, you could enter
-`{sourceref},latest` in the Docker Tag field.
-
-If you need to update a tag _in another repository_, use [a post_build hook](advanced.md#push-to-multiple-repos) to push to a second repository.
-
 ## Build repositories with linked private submodules
 
 Docker Hub sets up a deploy key in your source code repository that allows it


### PR DESCRIPTION
Hub backend dose not support `Create multiple Docker tags from a single build` https://docs.docker.com/docker-hub/builds/#create-multiple-docker-tags-from-a-single-build.  Take it off from the docs. Already received several issues asking about why it is not working according to the doc.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
