### PR TITLE
Fix missing .0 in engine version release notes

### DIFF
--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -63,7 +63,7 @@ consistency and compatibility reasons.
 ### Known Issues
 * When upgrading from 18.09.0 to 18.09.1, `containerd` is not upgraded to the correct version on Ubuntu.  [Learn more](https://success.docker.com/article/error-upgrading-to-engine-18091-with-containerd).
 
-## 18.09 
+## 18.09.0
 2018-11-08
 
 ### New features for Docker Engine EE 


### PR DESCRIPTION
The version is 18.09.0, but I wasn't sure if we have links to this anchor, so decided to push it as a separate PR


ping @ahh-docker