### PR TITLE
Update Calico version for UCP 3.1.3

### DIFF
--- a/ee/ucp/ucp-architecture.md
+++ b/ee/ucp/ucp-architecture.md
@@ -68,7 +68,7 @@ on a node depend on whether the node is a manager or a worker.
 
 Internally, UCP uses the following components:
 
-* Calico v3.2.3
+* Calico v3.5
 * Kubernetes v1.11.5
 
 ### UCP components in manager nodes


### PR DESCRIPTION
### Proposed changes

Calico version was updated to 3.5 as per UCP 3.1.3 Release:
https://docs.docker.com/ee/ucp/release-notes/#313

### Related issues (optional)

https://github.com/docker/orca/issues/15884