### PR TITLE
Removing a link to the UCP WS1809 offline bundle

### DIFF
--- a/_data/ddc_offline_files_2.yaml
+++ b/_data/ddc_offline_files_2.yaml
@@ -6,10 +6,6 @@
 - product: "ucp"
   version: "3.1"
   tar-files: 
-    - description: "3.1.3 Windows Server 2019"
-      url: https://packages.docker.com/caas/ucp_images_win_2019_3.1.3.tar.gz
-    - description: "3.1.3 Windows Server 1809"
-      url: https://packages.docker.com/caas/ucp_images_win_1809_3.1.3.tar.gz
     - description: "3.1.3 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.1.3.tar.gz
     - description: "3.1.3 Windows Server 2016 LTSC"
@@ -18,6 +14,8 @@
       url: https://packages.docker.com/caas/ucp_images_win_1709_3.1.3.tar.gz
     - description: "3.1.3 Windows Server 1803"
       url: https://packages.docker.com/caas/ucp_images_win_1803_3.1.3.tar.gz 
+    - description: "3.1.3 Windows Server 2019 LTSC"
+      url: https://packages.docker.com/caas/ucp_images_win_2019_3.1.3.tar.gz
     - description: "3.1.2 Linux"
       url: https://packages.docker.com/caas/ucp_images_3.1.2.tar.gz
     - description: "3.1.2 Windows Server 2016 LTSC"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I've removed a link to the UCP WS1809 offline bundle as I don't believe we have a separate bundle for this. 

```
$ docker manifest inspect docker/ucp-agent-win:3.1.3 | jq -r '.manifests |.[].platform."os.version"' | sort
10.0.14393.2551 # WS2016 LTSC / WS1607 SAC
10.0.16299.904  # WS1709 SAC
10.0.17134.523  # WS1803 SAC
10.0.17763.253  # WS2019 LTSC / WS1809 SAC
```

The 10.0.17763.253 images will work fine for both Win Server 2019 LTSC and Win Server 1809 SAC.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
