### PR TITLE
ISCSI support in Kubernetes via UCP

### DIFF
--- a/ee/ucp/kubernetes/iscsi/dci.sh
+++ b/ee/ucp/kubernetes/iscsi/dci.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# Prior to executing this script, user should have
+# setup `dci secrets` specific to their cloud provider.
+# I used AWS and setup access keys prior.
+
+export DCI_CLOUD=aws
+export DCI_DEPLOYMENT=core-storage9
+export DCI_REPOSITORY=dockereng
+
+# To override the dci container image, use this option
+# For most cases, setting this to ${DCI_CLOUD}-local is sufficient.
+export DCI_TAG=aws-9857f6f
+
+# Initialize cluster
+dci cluster init
+
+# Install a specific development version of UCP
+# Perform a few other cluster specific configs.
+dci cluster config set use_dev_version true
+dci cluster config set docker_ucp_image_repository dockereng
+dci cluster config set docker_ucp_version "3.2.0-latest"
+dci cluster config set docker_ucp_storage_driver iscsi
+
+# Preserve install containers. Ansible is case sensitive. 'False', not 'false'
+dci cluster config set docker_remove_containers False
+
+# set log level to debug.
+# Use this to test --iscsiadm-path and --iscsidb-path
+dci cluster config set docker_ucp_install_args "'--debug'"
+
+dci cluster config set region us-west-2
+dci cluster config set linux_ucp_worker_count 2
+dci cluster config set linux_dtr_count 0
+
+# Apply presets
+dci cluster apply-preset "RHEL 7.5"
+
+dci cluster provision
+
+# Post provision installs.
+dci cluster ssh "sudo yum install -y iscsi-initiator-utils"
+dci cluster ssh "sudo modprobe iscsi_tcp"
+# master doubles up as iscsi target. So let firewalld allow iscsi traffic.
+# Restarting firewalld before installing dockerd is least intrusive;
+# else iptable rules get messed up
+dci cluster ssh "sudo yum install -y firewalld"
+dci cluster ssh "sudo systemctl enable firewalld"
+dci cluster ssh "sudo systemctl start firewalld"
+dci cluster ssh "sudo firewall-cmd --add-service=iscsi-target --permanent"
+dci cluster ssh "sudo firewall-cmd --add-port=18700/tcp --permanent"
+dci cluster ssh "sudo firewall-cmd --reload"
+
+# Install cluster. This is essential
+# Apply = provision + install
+dci cluster install --log-level debug

--- a/ee/ucp/kubernetes/iscsi/iscsi-provisioner-d.yaml
+++ b/ee/ucp/kubernetes/iscsi/iscsi-provisioner-d.yaml
@@ -1,0 +1,71 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: iscsi-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: run-iscsi-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: iscsi-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: iscsi-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iscsi-provisioner
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: iscsi-provisioner
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: iscsi-provisioner
+    spec:
+      containers:
+        - name: iscsi-provisioner
+          imagePullPolicy: Always
+          image: quay.io/external_storage/iscsi-controller:latest
+          args:
+            - "start"
+          env:
+            - name: PROVISIONER_NAME
+              value: iscsi-targetd
+            - name: LOG_LEVEL
+              value: debug
+            - name: TARGETD_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: targetd-account
+                  key: username
+            - name: TARGETD_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: targetd-account
+                  key: password
+            - name: TARGETD_ADDRESS
+              value: 172.31.8.88
+      serviceAccount: iscsi-provisioner

--- a/ee/ucp/kubernetes/iscsi/iscsi-pvc.yaml
+++ b/ee/ucp/kubernetes/iscsi/iscsi-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: iscsi-claim
+spec:
+  storageClassName: "iscsi-targetd-vg-targetd"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/ee/ucp/kubernetes/iscsi/iscsi-storageclass.yaml
+++ b/ee/ucp/kubernetes/iscsi/iscsi-storageclass.yaml
@@ -1,0 +1,13 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: iscsi-targetd-vg-targetd
+provisioner: iscsi-targetd
+parameters:
+  targetPortal: 172.31.8.88
+  iqn: iqn.2019-01.org.iscsi.docker:targetd
+  iscsiInterface: default
+  volumeGroup: vg-targetd
+  initiators: iqn.2019-01.com.example:node1
+  chapAuthDiscovery: "false"
+  chapAuthSession: "false"

--- a/ee/ucp/kubernetes/iscsi/iscsi_target.sh
+++ b/ee/ucp/kubernetes/iscsi/iscsi_target.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Main customization needed for this script is
+# setting the iscsi target_name. Default is
+# "iqn.2019-01.org.iscsi.docker:targetd". Feel free to change it,
+# as long as it follows IQN naming rules.
+
+# Run this script as root
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root"
+   exit 1
+fi
+
+# Setup volume group on Loopback device.
+mkdir /var/lib/loopback
+cd /var/lib/loopback
+dd if=/dev/zero of=disk.img bs=1G count=2
+
+export LOOP=`sudo losetup -f`
+losetup $LOOP disk.img
+vgcreate vg-targetd $LOOP
+
+
+# Install targetd and targetcli
+yum install -y targetcli targetd
+
+# Enable targetcli
+systemctl enable target
+systemctl start target
+
+# Configure targetd
+
+echo "password: ciao
+
+# defaults below; uncomment and edit
+# if using a thin pool, use <volume group name>/<thin pool name>
+# e.g vg-targetd/pool
+pool_name: vg-targetd
+user: admin
+ssl: false
+target_name: iqn.2019-01.org.iscsi.docker:targetd" > /etc/target/targetd.yaml
+
+# Enable targetd
+systemctl enable targetd
+systemctl start targetd

--- a/ee/ucp/kubernetes/iscsi/iscsi_testing.txt
+++ b/ee/ucp/kubernetes/iscsi/iscsi_testing.txt
@@ -1,0 +1,73 @@
+This page describes the ISCSI testing setup for UCP Amberjack release.
+Note: When using this setup, update the scripts to have IP addresses reflecting your cluster.
+
+
+1. Deploy UCP with ISCSI storage using DCI script, dci.sh
+Main thing to note here is that, UCP should be invoked with the newly added
+"--storage=iscsi" option. There are 2 other options that can be used to
+specify the path of the host iscsiadm binary and path of the host iscsi
+database, which are "--iscsiadm-path" and "--iscsidb-path" respectively.
+The default paths for these are "/usr/sbin/iscsiadm", "/etc/iscsi".
+If the hosts in your cluster have iscsi packages installed in a different
+path, use these options to customize the paths.
+
+Another point worth mentioning is that the hosts should have iscsi packages
+installed. This is done in the DCI post-provisioning phase.
+
+2. ISCSI Initiator setup.
+In UCP, all worker nodes are configured as ISCSI initiators.
+Login to worker and configure it as initiator.
+sudo sh -c 'echo "InitiatorName=iqn.2019-01.com.example:node1" > /etc/iscsi/initiatorname.iscsi'
+sudo systemctl restart iscsid
+
+3. ISCSI target setup.
+In my setup, I configure the UCP master to be the ISCSI target as well.
+This is purely for ease of testing in the cluster.
+
+# Copy iscsi_target.sh setup script to master.
+- scp -i anusha-dci.pem iscsi_target.sh ec2-user@54.187.2.136:/tmp/iscsi_target.sh
+
+# login and run script
+sudo /tmp/iscsi_target.sh
+
+
+4. kubectl client setup.
+# Download UCP client bundle and setup kubectl on the client. Ensure that it works.
+$ kubectl version
+Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.3", GitCommit:"d2835416544f298c919e2ead3be3d0864b52323b", GitTreeState:"clean", BuildDate:"2018-02-07T12:22:21Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"13+", GitVersion:"v1.13.0-docker-preview-7", GitCommit:"6f9542764d9cd2eb95ed50b25498f6fe837fac24", GitTreeState:"clean",
+BuildDate:"2019-01-15T18:42:46Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
+
+
+5. Deploy the iscsi provisioner pod.
+
+$ export NS=default
+$ kubectl create secret generic targetd-account --from-literal=username=admin --from-literal=password=ciao -n $NS
+
+# Use the internal IP of master: 172.31.8.88
+$ kubectl apply -f iscsi-provisioner-d.yaml -n $NS
+clusterrole "iscsi-provisioner-runner" created
+clusterrolebinding "run-iscsi-provisioner" created
+serviceaccount "iscsi-provisioner" created
+deployment "iscsi-provisioner" created
+
+6. Apply the storage class.
+$ kubectl apply -f iscsi-storageclass.yaml
+storageclass "iscsi-targetd-vg-targetd" created
+
+$ kubectl get sc
+NAME                       PROVISIONER     AGE
+iscsi-targetd-vg-targetd   iscsi-targetd   30s
+
+7. Apply the PVC
+$ kubectl apply -f iscsi-pvc.yaml -n $NS
+persistentvolumeclaim "iscsi-claim" created
+
+$ kubectl get pvc
+NAME          STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
+iscsi-claim   Bound     pvc-b9560992-24df-11e9-9f09-0242ac11000e   100Mi      RWO            iscsi-targetd-vg-targetd   1m
+
+8. View the PV
+$ kubectl get pv
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS    CLAIM                 STORAGECLASS               REASON    AGE
+pvc-b9560992-24df-11e9-9f09-0242ac11000e   100Mi      RWO            Delete           Bound     default/iscsi-claim   iscsi-targetd-vg-targetd             36s


### PR DESCRIPTION
https://github.com/docker/orca/pull/15547 added intree ISCSI support for Kubernetes in UCP Amberjack. This change explains ISCSI setup and provision workflow including:
- Newly added UCP option, --storage, --iscsiadm-path and --iscsidb-path.
- Docs related to setting up UCP worker nodes as ISCSI
initiators.
- Docs related to setting up an ISCSI target (targetd in this case).
- Deployment of an external ISCSI provisioner as a Kubernetes Pod.
- Creation of ISCSI storage class and Persistent Volume Claims.

