### PR TITLE
Fixes Docker Hub repository tag env var name

### DIFF
--- a/docker-hub/builds/advanced.md
+++ b/docker-hub/builds/advanced.md
@@ -22,8 +22,8 @@ processes and do not affect your service's run environment.
 * `COMMIT_MSG`: the message from the commit being tested and built.
 * `DOCKER_REPO`: the name of the Docker repository being built.
 * `DOCKERFILE_PATH`: the dockerfile currently being built.
-* `CACHE_TAG`: the Docker repository tag being built.
-* `IMAGE_NAME`: the name and tag of the Docker repository being built. (This variable is a combination of `DOCKER_REPO`:`CACHE_TAG`.)
+* `DOCKER_TAG`: the Docker repository tag being built.
+* `IMAGE_NAME`: the name and tag of the Docker repository being built. (This variable is a combination of `DOCKER_REPO`:`DOCKER_TAG`.)
 
 If you are using these build environment variables in a
 `docker-compose.test.yml` file for automated testing, declare them in your `sut`


### PR DESCRIPTION
### Proposed changes

As noted in issue #6684 `CACHE_TAG` environment variable is actually empty in the builds, turns out the documented value is represented by a `DOCKER_TAG` variable instead.

Here's a sample debug dump from a build hook:
```
CACHE_TAG:
IMAGE_NAME: index.docker.io/tykio/tyk-identity-broker:unstable
DOCKER_REPO: index.docker.io/tykio/tyk-identity-broker
DOCKER_TAG: unstable
```

### Related issues (optional)

Fixes #6684 