### PR TITLE
CURRENT STATE instead of LAST STATE with docker 18.09.1

### DIFF
--- a/engine/swarm/swarm-tutorial/inspect-service.md
+++ b/engine/swarm/swarm-tutorial/inspect-service.md
@@ -92,7 +92,7 @@ the Docker CLI to see details about the service running in the swarm.
     ```bash
     [manager1]$ docker service ps helloworld
 
-    NAME                                    IMAGE   NODE     DESIRED STATE  LAST STATE
+    NAME                                    IMAGE   NODE     DESIRED STATE  CURRENT STATE           ERROR               PORTS
     helloworld.1.8p1vev3fq5zm0mi8g0as41w35  alpine  worker2  Running        Running 3 minutes
     ```
 
@@ -100,7 +100,7 @@ the Docker CLI to see details about the service running in the swarm.
     `worker2` node. You may see the service running on your manager node. By
     default, manager nodes in a swarm can execute tasks just like worker nodes.
 
-    Swarm also shows you the `DESIRED STATE` and `LAST STATE` of the service
+    Swarm also shows you the `DESIRED STATE` and `CURRENT STATE` of the service
     task so you can see if tasks are running according to the service
     definition.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Fix documentation for 18.09.1,

With Docker version 18.09.1, build 4c52b90, the command `docker service ps helloworld` shows CURRENT STATE instead of LAST STATE.

Here is sample output of the command:
```
[root@docker01 ~]$docker service ps helloworld
ID                  NAME                IMAGE               NODE                DESIRED STATE       CURRENT STATE           ERROR               PORTS
3tj4b0gho76v        helloworld.1        alpine:latest       docker01            Running             Running 3 minutes ago

[root@docker01 ~]$ docker --version
Docker version 18.09.1, build 4c52b90
```

### Unreleased project version (optional)

N/A
<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

N/A
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->