### PR TITLE
Specify that mac_address is a legacy option

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1888,7 +1888,7 @@ volume mounts (shared filesystems)](/docker-for-mac/osxfs-caching.md).
 ### domainname, hostname, ipc, mac\_address, privileged, read\_only, shm\_size, stdin\_open, tty, user, working\_dir
 
 Each of these is a single value, analogous to its
-[docker run](/engine/reference/run.md) counterpart.
+[docker run](/engine/reference/run.md) counterpart. Note that `mac_address` is a legacy option.
 
     user: postgresql
     working_dir: /code


### PR DESCRIPTION
Adds a note on `mac_address` being a legacy option.
