### PR TITLE
Updated as certificate  as expire in  documented version

### DIFF
--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -77,9 +77,9 @@ the `trustsandbox` container, the Notary server, and the Registry server.
         version: "2"
         services:
           notaryserver:
-            image: dockersecurity/notary_autobuilds:server-v0.4.2
+            image: dockersecurity/notary_autobuilds:server-v0.5.1
             volumes:
-              - notarycerts:/go/src/github.com/docker/notary/fixtures
+              - notarycerts:/var/lib/notary/fixtures
             networks:
               - sandbox
             environment:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The current  documentation points to use a version of notary which has an expired certificate. 

Updated the version of notary_autobuilds to 0.5.1 from 0.4.2.

Change the shared volume to notarycerts:/var/lib/notary/fixtures from notarycerts:/go/src/github.com/docker/notary/fixtures  as location of certificate has changed.



### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
Fixes issue I raised in https://github.com/theupdateframework/notary/issues/1417