### PR TITLE
Added a command for getting the service

### DIFF
--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -132,7 +132,13 @@ docker stack deploy -c docker-compose.yml getstartedlab
 Our single service stack is running 5 container instances of our deployed image
 on one host. Let's investigate.
 
-Get the service ID for the one service in our application:
+To get the services for a service stack, get the service ID for the one service in our application:
+```shell
+docker stack services getstartedlab
+```
+
+
+If you are using **Kubernetes**, get the service ID for the one service in our application:
 
 ```shell
 docker service ls

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -132,13 +132,7 @@ docker stack deploy -c docker-compose.yml getstartedlab
 Our single service stack is running 5 container instances of our deployed image
 on one host. Let's investigate.
 
-To get the services for a service stack, get the service ID for the one service in our application:
-```shell
-docker stack services getstartedlab
-```
-
-
-If you are using **Kubernetes**, get the service ID for the one service in our application:
+Get the service ID for the one service in our application:
 
 ```shell
 docker service ls
@@ -149,7 +143,7 @@ named it the same as shown in this example, the name is
 `getstartedlab_web`. The service ID is listed as well, along with the number of
 replicas, image name, and exposed ports.
 
-You can also run `docker stack services`, followed by the name of
+Alternatively, you can run `docker stack services`, followed by the name of
 your stack. The following example command lets you view all the services associated with the
 `getstartedlab` stack:
 
@@ -184,7 +178,7 @@ load-balancing; with each request, one of the 5 tasks is chosen, in a
 round-robin fashion, to respond. The container IDs match your output from
 the previous command (`docker container ls -q`).
 
-Additionally, you can run `docker stack ps` to view all tasks of a stack.
+To view all tasks of a stack, you can run `docker stack ps` followed by your app name:
 
 ```bash
 docker stack ps getstartedlab

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -144,7 +144,7 @@ named it the same as shown in this example, the name is
 replicas, image name, and exposed ports.
 
 Alternatively, you can run `docker stack services`, followed by the name of
-your stack. The following example command lets you view all the services associated with the
+your stack. The following example command lets you view all services associated with the
 `getstartedlab` stack:
 
 ```bash
@@ -178,7 +178,7 @@ load-balancing; with each request, one of the 5 tasks is chosen, in a
 round-robin fashion, to respond. The container IDs match your output from
 the previous command (`docker container ls -q`).
 
-To view all tasks of a stack, you can run `docker stack ps` followed by your app name:
+To view all tasks of a stack, you can run `docker stack ps` followed by your app name, as shown in the following example:
 
 ```bash
 docker stack ps getstartedlab

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -149,18 +149,28 @@ named it the same as shown in this example, the name is
 `getstartedlab_web`. The service ID is listed as well, along with the number of
 replicas, image name, and exposed ports.
 
+You can also run `docker stack services`, followed by the name of
+your stack. The following example command lets you view all the services associated with the
+`getstartedlab` stack:
+
+```bash
+docker stack services getstartedlab
+ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
+bqpve1djnk0x        getstartedlab_web   replicated          5/5                 username/repo:tag   *:4000->80/tcp
+```
+
 A single container running in a service is called a **task**. Tasks are given unique
 IDs that numerically increment, up to the number of `replicas` you defined in
 `docker-compose.yml`. List the tasks for your service:
 
-```shell
+```bash
 docker service ps getstartedlab_web
 ```
 
 Tasks also show up if you just list all the containers on your system, though that
 is not filtered by service:
 
-```shell
+```bash
 docker container ls -q
 ```
 
@@ -173,6 +183,18 @@ Either way, the container ID changes, demonstrating the
 load-balancing; with each request, one of the 5 tasks is chosen, in a
 round-robin fashion, to respond. The container IDs match your output from
 the previous command (`docker container ls -q`).
+
+Additionally, you can run `docker stack ps` to view all tasks of a stack.
+
+```bash
+docker stack ps getstartedlab
+ID                  NAME                  IMAGE               NODE                DESIRED STATE       CURRENT STATE           ERROR               PORTS
+uwiaw67sc0eh        getstartedlab_web.1   username/repo:tag   docker-desktop      Running             Running 9 minutes ago                       
+sk50xbhmcae7        getstartedlab_web.2   username/repo:tag   docker-desktop      Running             Running 9 minutes ago                       
+c4uuw5i6h02j        getstartedlab_web.3   username/repo:tag   docker-desktop      Running             Running 9 minutes ago                       
+0dyb70ixu25s        getstartedlab_web.4   username/repo:tag   docker-desktop      Running             Running 9 minutes ago                       
+aocrb88ap8b0        getstartedlab_web.5   username/repo:tag   docker-desktop      Running             Running 9 minutes ago
+```
 
 > Running Windows 10?
 >


### PR DESCRIPTION
### Proposed changes
When you use `docker service ls`, it won't show you the list of services. Instead use `docker stack services getstartedlab` to show the service that was created and thereby getting the Service ID of it.

