### PR TITLE
NO_PROXY does not support CIDR notation.

### DIFF
--- a/config/daemon/systemd.md
+++ b/config/daemon/systemd.md
@@ -101,7 +101,7 @@ you need to add this configuration in the Docker systemd service file.
     The `NO_PROXY` variable specifies a string that contains comma-separated
     values for hosts that should be excluded from proxying. These are the
     options you can specify to exclude hosts: 
-    * IP address prefix (`1.2.3.4`) or in CIDR notation (`1.2.3.4/8`)    
+    * IP address prefix (`1.2.3.4`)   
     * Domain name, or a special DNS label (`*`)
     * A domain name matches that name and all subdomains. A domain name with
       a leading "." matches subdomains only. For example, given the domains


### PR DESCRIPTION
NO_PROXY does not support CIDR notation. #8191

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Delete CIDR notation.
<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

NO_PROXY does not support CIDR notation. #8191
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
