### PR TITLE
Update release notes with fixed known issue

### DIFF
--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -38,6 +38,7 @@ upgrade your installation to the latest release.
  * Non-admin users can no longer create `PersistentVolumes` that mount host directories. (docker/orca#15936)
  * Added support for the limit arg in `docker ps`. (docker/orca#15812)
  * Fixed an issue with ucp-proxy health check. (docker/orca#15814, docker/orca#15813, docker/orca#16021, docker/orca#15811)
+ * Fixed an issue where manually creating a **ClusterRoleBinding** or **RoleBinding** for `User` or `Group` subjects required the ID of the user, organization, or team. (docker/orca#14935)
  
 ### Known issue
  * By default, Kubelet begins deleting images, starting with the oldest unused images, after exceeding 85% disk space utilization. This causes an issue in an air-gapped environment. (docker/orca#16082)

--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -38,7 +38,7 @@ upgrade your installation to the latest release.
  * Non-admin users can no longer create `PersistentVolumes` that mount host directories. (docker/orca#15936)
  * Added support for the limit arg in `docker ps`. (docker/orca#15812)
  * Fixed an issue with ucp-proxy health check. (docker/orca#15814, docker/orca#15813, docker/orca#16021, docker/orca#15811)
- * Fixed an issue where manually creating a **ClusterRoleBinding** or **RoleBinding** for `User` or `Group` subjects required the ID of the user, organization, or team. (docker/orca#14935)
+ * Fixed an issue with manual creation of a **ClusterRoleBinding** or **RoleBinding** for `User` or `Group` subjects requiring the ID of the user, organization, or team. (docker/orca#14935)
  
 ### Known issue
  * By default, Kubelet begins deleting images, starting with the oldest unused images, after exceeding 85% disk space utilization. This causes an issue in an air-gapped environment. (docker/orca#16082)


### PR DESCRIPTION
### Proposed changes

The known issue that was introduced in the 3.1.0 release that required the ID of the user when manually creating RoleBinding or ClusterRoleBinding, is fixed in 3.1.3 and this change updates the release notes to reflect this information.