### PR TITLE
Moving NFS persistent storage info

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1204,8 +1204,6 @@ manuals:
           title: UCP configuration file
         - path: /ee/ucp/admin/configure/use-node-local-network-in-swarm/
           title: Use a local node network in a swarm
-        - path: /ee/ucp/admin/configure/use-nfs-volumes/
-          title: Use NFS persistent storage
         - path: /ee/ucp/admin/configure/use-your-own-tls-certificates/
           title: Use your own TLS certificates
         - path: /ee/ucp/admin/configure/manage-and-deploy-private-images/
@@ -1345,6 +1343,8 @@ manuals:
       section:
       - title: Access Kubernetes Resources
         path: /ee/ucp/kubernetes/kube-resources/
+      - title: Use NFS persistent storage
+        path: /ee/ucp/admin/configure/use-nfs-volumes/
       - title: Configure AWS EBS Storage for Kubernetes
         path: /ee/ucp/kubernetes/configure-aws-storage/
       - title: Deploy a workload


### PR DESCRIPTION
Moving https://docs.docker.com/ee/ucp/admin/configure/use-nfs-volumes/ to the 'Deploy apps with Kubernetes' section.

