### PR TITLE
Add 304 redirect for old installation page

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -14,6 +14,7 @@ redirect_from:
 - /engine/installation/linux/docker-ce/
 - /engine/installation/linux/docker-ee/
 - /engine/installation/
+- /en/latest/installation/
 ---
 
 Docker Community Edition (CE) is ideal for developers and small


### PR DESCRIPTION
This page is mentioned in a blogpost from 2013;
https://blog.docker.com/2013/11/docker-0-7-docker-now-runs-on-any-linux-distribution/

So let's redirect to the new location.


fixes https://github.com/docker/docker.github.io/issues/8262