### PR TITLE
Typo: "use HTTP API" => "use the HTTP API"

### DIFF
--- a/develop/index.md
+++ b/develop/index.md
@@ -29,4 +29,4 @@ most benefits from Docker.
 
 ## Advanced development with the SDK or API
 
-After you can write Dockerfiles or Compose files and use Docker CLI, take it to the next level by using Docker Engine SDK for Go/Python or use HTTP API directly.
+After you can write Dockerfiles or Compose files and use Docker CLI, take it to the next level by using Docker Engine SDK for Go/Python or use the HTTP API directly.


### PR DESCRIPTION
### Proposed changes

replace  "use HTTP API" with "use the HTTP API" in develop/index.md

