### PR TITLE
Improve `fluentd-async-connect` option

### DIFF
--- a/config/containers/logging/fluentd.md
+++ b/config/containers/logging/fluentd.md
@@ -110,7 +110,7 @@ for advanced [log tag options](log_tags.md).
 ### fluentd-async-connect
 
 Docker connects to Fluentd in the background. Messages are buffered until the
-connection is established.
+connection is established. Defaults to `false`.
 
 ### fluentd-buffer-limit
 
@@ -123,11 +123,11 @@ How long to wait between retries. Defaults to 1 second.
 
 ### fluentd-max-retries
 
-The maximum number of retries. Defaults to 10.
+The maximum number of retries. Defaults to `10`.
 
 ### fluentd-sub-second-precision
 
-Generates event logs in nanosecond resolution. Defaults to false.
+Generates event logs in nanosecond resolution. Defaults to `false`.
 
 ## Fluentd daemon management with Docker
 


### PR DESCRIPTION
### Proposed changes

- According to https://github.com/moby/moby/blob/c093c1e08b605a6e4c763962c52e3c82ec0e934f/daemon/logger/fluentd/fluentd.go#L114 I added the _Defaults to `false`._ statement to `fluentd-async-connect` option.
- Added inline code formatting for other default values
