### PR TITLE
EE Offline Bundle Load Command now works on Windows

### DIFF
--- a/ee/dtr/admin/install/install-offline.md
+++ b/ee/dtr/admin/install/install-offline.md
@@ -44,7 +44,7 @@ For each machine where you want to install DTR:
     `docker load` command to load the Docker images from the tar archive:
 
     ```bash
-    $ docker load < dtr.tar.gz
+    $ docker load -i dtr.tar.gz
     ```
 
 ## Install DTR

--- a/ee/ucp/admin/install/install-offline.md
+++ b/ee/ucp/admin/install/install-offline.md
@@ -57,7 +57,7 @@ For each machine that you want to manage with UCP:
     `docker load` command, to load the Docker images from the tar archive:
 
     ```bash
-    $ docker load < ucp.tar.gz
+    $ docker load -i ucp.tar.gz
     ```
 
 Follow the same steps for the DTR binaries.

--- a/ee/ucp/admin/install/upgrade-offline.md
+++ b/ee/ucp/admin/install/upgrade-offline.md
@@ -47,7 +47,7 @@ For each machine that you want to manage with UCP:
     `docker load` command, to load the Docker images from the tar archive:
 
     ```bash
-    $ docker load < ucp.tar.gz
+    $ docker load -i ucp.tar.gz
     ```
 
 ## Upgrade UCP


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Swapped the docker load command for offline bundles so it now works on Windows and Linux. 

Fixes: https://github.com/docker/docker.github.io/issues/8282

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
