### PR TITLE
engine/security: update apparmor docs to not unload all profiles

### DIFF
--- a/engine/security/apparmor.md
+++ b/engine/security/apparmor.md
@@ -55,12 +55,8 @@ $ docker run --rm -it --security-opt apparmor=your_profile hello-world
 To unload a profile from AppArmor:
 
 ```bash
-# stop apparmor
-$ /etc/init.d/apparmor stop
 # unload the profile
 $ apparmor_parser -R /path/to/profile
-# start apparmor
-$ /etc/init.d/apparmor start
 ```
 
 ### Resources for writing profiles


### PR DESCRIPTION
### Proposed changes

Restarting AppArmor isn't necessary to unload a profile. In fact, it has the negative impact of causing all running processes to become unrestricted. See #8289.

Update docs to only unload the profile.

### Unreleased project version (optional)

### Related issues (optional)

Fixes #8289

Signed-off-by: Eric Chiang <ericchiang@google.com>