### PR TITLE
update to include the \. from %L

### DIFF
--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -169,7 +169,7 @@ The following `strftime` codes are supported:
 | `%p` | AM or PM.                                                        | AM       |
 | `%M` | Minute as a zero-padded decimal number.                          | 57       |
 | `%S` | Second as a zero-padded decimal number.                          | 04       |
-| `%L` | Milliseconds as a zero-padded decimal number.                    | 123      |
+| `%L` | Milliseconds as a zero-padded decimal number.                    | .123      |
 | `%f` | Microseconds as a zero-padded decimal number.                    | 000345   |
 | `%z` | UTC offset in the form +HHMM or -HHMM.                           | +1300    |
 | `%Z` | Time zone name.                                                  | PST      |


### PR DESCRIPTION
### Proposed changes
In the code you must have a ```.``` at the start of your %L, ( https://github.com/moby/moby/blob/master/daemon/logger/awslogs/cloudwatchlogs.go#L306 ) 

This change calls that out in the doc

### Related issues (optional)

https://github.com/docker/docker.github.io/issues/8322
