### PR TITLE
Explain -s flag on docker ps

### DIFF
--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -107,6 +107,24 @@ examples: |-
   container that exposes TCP ports `100, 101, 102` displays `100-102/tcp` in
   the `PORTS` column.
 
+  ### Show disk usage by container
+
+  The `docker ps -s` command displays two different on-disk-sizes for each container:
+
+  ```bash
+  $ docker ps -s
+
+  CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
+
+  e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours           my_nginx     35.58 kB (virtual 109.2 MB)
+  00c6131c5e30   telegraf:1.5   "/entrypoint.sh"         11 weeks ago   Up 11 weeks          my_telegraf  0 B (virtual 209.5 MB)
+  ```
+
+    * The "size" information shows the amount of data (on disk) that is used for the _writable_ layer of each container
+    * The "virtual size" is the total amount of disk-space used for the read-only _image_ data used by the container and the writable layer.
+  
+  For more information, see: https://docs.docker.com/storage/storagedriver/#container-size-on-disk
+
   ### Filtering
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more


### PR DESCRIPTION

### Proposed changes

Add an example section which explains the `docker ps -s`  command output on the docker ps command details page. 

Why? Because I would never have guessed to look inside a storage driver article for information on the docker ps command. Its a web usability issue. 

### Related issues (optional)

https://github.com/docker/docker.github.io/issues/1520

https://github.com/docker/docker.github.io/issues/1520#issuecomment-467971886
