### PR TITLE
Update running_ssh_service.md

### DIFF
--- a/engine/examples/running_ssh_service.md
+++ b/engine/examples/running_ssh_service.md
@@ -6,16 +6,24 @@ title: Dockerize an SSH service
 
 ## Build an `eg_sshd` image
 
+### Generate a secure root password for your image
+
+Using a static password for root access is dangerous. Create a random password before proceeding.
+
+### Build the image
+
 The following `Dockerfile` sets up an SSHd service in a container that you
 can use to connect to and inspect other container's volumes, or to get
-quick access to a test container.
+quick access to a test container. 
+
+__Note: Replace "THEPASSWORDYOUCREATED" with the password that you created in the previous step.__
 
 ```Dockerfile
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
-RUN echo 'root:screencast' | chpasswd
+RUN echo 'root:THEPASSWORDYOUCREATED' | chpasswd
 RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login


### PR DESCRIPTION
### Proposed changes

The Dockerfile [here](https://docs.docker.com/engine/examples/running_ssh_service/#build-an-eg_sshd-image) specifies a static root password, `screencast`. Hard-coding this password into the container creates a security issue; if the container is bridged to the internet, either via NAT or a badly-configured hosting service, it becomes an easy target for attackers.

This change goes some way towards fixing this by specifying that readers should generate a random password before building this image; however, this is a temporary solution. Long term, we need to determine how to wrap this Dockerfile in something that generates a random password at build time.

### Related issues (optional)

Fixes #8390 
