### PR TITLE
Add HideInfoHeaders in interlock configuration

### DIFF
--- a/ee/ucp/interlock/deploy/configuration-reference.md
+++ b/ee/ucp/interlock/deploy/configuration-reference.md
@@ -76,6 +76,7 @@ PollInterval = "3s"
       LargeClientHeaderBuffers = "4 8k"
       ClientBodyTimeout = "60s"
       UnderscoresInHeaders = false
+      HideInfoHeaders = false
 ```
 
 ## Core configurations
@@ -140,6 +141,7 @@ available for the proxy service:
 | `RLimitNoFile`          | int    | Number of maxiumum open files for the proxy service.                                                 |
 | `SSLCiphers`            | string | SSL ciphers to use for the proxy service.                                                            |
 | `SSLProtocols`          | string | Enable the specified TLS protocols.                                                                  |
+| `HideInfoHeaders`       | bool   | Hide proxy related response headers.                                                                |
 | `AccessLogPath`         | string | Path to use for access logs (default: `/dev/stdout`).                                                |
 | `ErrorLogPath`          | string | Path to use for error logs (default: `/dev/stdout`).                                                 |
 | `MainLogFormat`         | string | [Format](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) to use for main logger.  |


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

UCP Interlock now supports `HideInfoHeaders` configuration. 
Customers/Users need to know how to configure it.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
See internal https://github.com/docker/orca/issues/15403#issuecomment-468192489
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
