### PR TITLE
Add missing stubs for docker builder subcommands

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -536,6 +536,12 @@ reference:
       title: docker attach
     - path: /engine/reference/commandline/build/
       title: docker build
+    - sectiontitle: docker builder *
+      section:
+        - path: /engine/reference/commandline/builder/
+          title: docker builder
+        - path: /engine/reference/commandline/builder_prune/
+          title: docker builder prune
     - sectiontitle: docker checkpoint *
       section:
       - path: /engine/reference/commandline/checkpoint/

--- a/engine/reference/commandline/builder.md
+++ b/engine/reference/commandline/builder.md
@@ -1,0 +1,15 @@
+---
+datafolder: engine-cli
+datafile: docker_builder
+title: docker builder
+---
+
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/cli
+-->
+
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/builder_prune.md
+++ b/engine/reference/commandline/builder_prune.md
@@ -1,0 +1,15 @@
+---
+datafolder: engine-cli
+datafile: docker_builder_prune
+title: docker builder prune
+---
+
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/cli
+-->
+
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
Similar to https://github.com/docker/docker.github.io/pull/8078, but for the `docker builder prune` command