### PR TITLE
Showing Build Cache Information on the example output

### DIFF
--- a/_data/engine-cli/docker_system_df.yaml
+++ b/_data/engine-cli/docker_system_df.yaml
@@ -35,6 +35,7 @@ examples: |-
   Images              5                   2                   16.43 MB            11.63 MB (70%)
   Containers          2                   0                   212 B               212 B (100%)
   Local Volumes       2                   1                   36 B                0 B (0%)
+  Build Cache         0                   0                   0B                  0B
   ```
 
   A more detailed view can be requested using the `-v, --verbose` flag:
@@ -62,6 +63,10 @@ examples: |-
   NAME                                                               LINKS               SIZE
   07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e   2                   36 B
   my-named-vol                                                       0                   0 B
+  
+  Build cache usage: 0B
+
+  CACHE ID            CACHE TYPE          SIZE                CREATED             LAST USED           USAGE               SHARED
   ```
 
   * `SHARED SIZE` is the amount of space that an image shares with another one (i.e. their common data)

--- a/_data/engine-cli/docker_system_df.yaml
+++ b/_data/engine-cli/docker_system_df.yaml
@@ -66,7 +66,11 @@ examples: |-
   
   Build cache usage: 0B
 
+ 
   CACHE ID            CACHE TYPE          SIZE                CREATED             LAST USED           USAGE               SHARED
+  0d8ab63ff30d        regular             4.34MB              7 days ago                              0                   true
+  189876ac9226        regular             11.5MB              7 days ago                              0                   true
+
   ```
 
   * `SHARED SIZE` is the amount of space that an image shares with another one (i.e. their common data)


### PR DESCRIPTION
### Proposed changes

Build Cache was added [latter](https://github.com/docker/docker-ce/commit/1d7ec4c7d51a611c36ae17ec1aa95195b833a6b6) so, it is missing on this documentation page.

This commit attempts to show an updated output example after running the command `docker system df` and the verbose version of the same command (`docker system df -v`).

Signed-off-by: Gepser Hoil <geharold@gmail.com>
