### PR TITLE
Fix spelling Docker Hub Automated Testing page

### DIFF
--- a/docker-hub/builds/automated-testing.md
+++ b/docker-hub/builds/automated-testing.md
@@ -95,7 +95,7 @@ Docker repository, regardless of the Autotest settings.
 
     > **Note**: For security purposes, autotest on _external pull requests_ is
     limited on public repositories. Private images are not pulled and
-    environment  variables defined in Docker Hub ware not
+    environment  variables defined in Docker Hub are not
     available. Automated builds continue to work as usual.
 
 9. Click **Save** to save the settings, or click **Save and build** to save and


### PR DESCRIPTION
### Proposed changes

I believe `...variables defined in Docker Hub ware not` was meant to read as `...variables defined in Docker Hub are not`.