### PR TITLE
Compose: Update build docs, Add --quiet flag

### DIFF
--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -17,6 +17,7 @@ Options:
     -m, --memory MEM        Sets memory limit for the build container.
     --build-arg key=val     Set build-time variables for services.
     --parallel              Build images in parallel.
+    -q, --quiet             Don't print anything to STDOUT.
 ```
 
 Services are built once and then tagged, by default as `project_service`. For


### PR DESCRIPTION
Adds -q, --quiet flags to docker-compose build reference docs.

This change is made in [#6542](https://github.com/docker/compose/pull/6542) on [docker/compose](https://github.com/docker/compose) project repo.

@ijc docs updated.