### PR TITLE
Fix liquid warnings on DTR troubleshooting page

### DIFF
--- a/datacenter/dtr/2.5/guides/admin/monitor-and-troubleshoot/troubleshoot-dtr.md
+++ b/datacenter/dtr/2.5/guides/admin/monitor-and-troubleshoot/troubleshoot-dtr.md
@@ -67,9 +67,11 @@ On a healthy cluster the output will be `[]`.
 
 Starting in DTR 2.5.5, you can run RethinkCLI from a separate image. First, set an environment variable for your DTR replica ID:
 
+{% raw %}
 ```bash
 REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
 ```
+{% endraw %}
 
 RethinkDB stores data in different databases that contain multiple tables. Run the following command to get into interactive mode
 and query the contents of the DB:

--- a/ee/dtr/admin/monitor-and-troubleshoot/troubleshoot-dtr.md
+++ b/ee/dtr/admin/monitor-and-troubleshoot/troubleshoot-dtr.md
@@ -67,9 +67,11 @@ On a healthy cluster the output will be `[]`.
 
 Starting in DTR 2.5.5, you can run RethinkCLI from a separate image. First, set an environment variable for your DTR replica ID:
 
+{% raw %}
 ```bash
 REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
 ```
+{% endraw %}
 
 RethinkDB stores data in different databases that contain multiple tables. Run the following command to get into interactive mode
 and query the contents of the DB:


### PR DESCRIPTION
Fix a warning during build of the documentation:

```
Liquid Warning: Liquid syntax error (line 64): [:dot, "."] is not a valid expression in "{{.Name}}" in datacenter/dtr/2.5/guides/admin/monitor-and-troubleshoot/troubleshoot-dtr.md
Liquid Warning: Liquid syntax error (line 64): [:dot, "."] is not a valid expression in "{{.Name}}" in ee/dtr/admin/monitor-and-troubleshoot/troubleshoot-dtr.md
```
