### PR TITLE
engine rn: recorrect EE version in dm deprecation

### DIFF
--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -246,7 +246,7 @@ Update your configuration if this command prints a non-empty value for `MountFla
 
 ### Deprecation Notice
 
-As of EE 2.2, Docker will deprecate support for Device Mapper as a storage driver. It will continue to be supported at this 
+As of EE 2.1, Docker has deprecated support for Device Mapper as a storage driver. It will continue to be supported at this 
 time, but support will be removed in a future release. Docker will continue to support Device Mapper for existing 
 EE 2.0 and 2.1 customers. Please contact Sales for more information.
 


### PR DESCRIPTION
https://github.com/docker/docker.github.io/pull/8377/commits/4b5fbbdbc9ed26dfe9d3e298c48594ab80fd9c8e#diff-96cb98afede3eeb9803f82e78366de1e threw out some baby with bathwater.

PR 8427 cherry picks commit f0639301f4226cc221be13ff6c984aa472fe5050