### PR TITLE
Added extra tip for "connectivity trouble"

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -435,6 +435,10 @@ look:
 >
 > - Port 7946 TCP/UDP for container network discovery.
 > - Port 4789 UDP for the container ingress network.
+>
+> Double check what you have in the ports section under your web
+> service and make sure the ip addresses you enter in your browser
+> or curl reflects that
 
 ## Iterating and scaling your app
 


### PR DESCRIPTION
### Proposed changes

Added an extra tip to the "Having connectivity trouble?" section for those who are coming directly from part 3 and haven't changed the port forwarding configuration in their docker-compose.yml file. 
Part 3 has port 4000 forwarding to 80, instead of 80 to 80. This is to save people any headache from trying to troubleshoot why their results aren't lining up with the screenshot example above.