### PR TITLE
Update network-tutorial-macvlan.md

### DIFF
--- a/network/network-tutorial-macvlan.md
+++ b/network/network-tutorial-macvlan.md
@@ -55,7 +55,7 @@ on your network, your container appears to be physically attached to the network
     to it. The `--rm` flag means the container is removed when it is stopped.
 
     ```bash
-    $ docker run --rm -itd \
+    $ docker run --rm -dit \
       --network my-macvlan-net \
       --name my-macvlan-alpine \
       alpine:latest \


### PR DESCRIPTION
### Proposed changes

Line number 54 has the following sentence: 

> The`-dit` flags start the container in the background but allow you to attach

However, when the command is invoked it uses `--itd`. 

> `docker run --rm -itd `

Matching up description with the actual command