### PR TITLE
Change "Linux" limitation wording

### DIFF
--- a/develop/develop-images/build_enhancements.md
+++ b/develop/develop-images/build_enhancements.md
@@ -23,7 +23,7 @@ For more information on build options, see the reference guide on the [command l
 ## Limitations
 
 * BuildKit mode is incompatible with UCP and Swarm Classic
-* Only supported on Linux
+* Only supported for building Linux containers
 
 ## To enable buildkit builds
 


### PR DESCRIPTION
### Proposed changes

I read the previous wording as "Only works when run from a Linux host", where what it means is "Only works when building a Linux container".

In other words, build enhancements work just fine if building Linux containers via Docker for Mac/Windows.

I've changed the wording to make this clearer.
