### PR TITLE
Remove link to latest download

### DIFF
--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -10,10 +10,6 @@ Windows systems that do not
 meet minimal system requirements for the [Docker Desktop for
 Windows](/docker-for-windows/index.md) app.
 
-If you have not done so already, download the installer here:
-
-[Get Docker Toolbox for Windows](https://download.docker.com/win/stable/DockerToolbox.exe){: class="button outline-btn" }
-
 ## What you get and how it works
 
 Docker Toolbox includes the following Docker tools:


### PR DESCRIPTION
I debated whether to have a note and link to https://github.com/docker/toolbox/releases/download/v18.09.3/DockerToolbox-18.09.3.exe, since we aren't  updating the official download.docker.com link.

Please let me know your thoughts.
