### PR TITLE
Shorten all (-a) and quite (-q) in recap cheatsheet

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -425,10 +425,10 @@ docker container ls -a             # List all containers, even those not running
 docker container stop <hash>           # Gracefully stop the specified container
 docker container kill <hash>         # Force shutdown of the specified container
 docker container rm <hash>        # Remove specified container from this machine
-docker container rm $(docker container ls -a -q)         # Remove all containers
+docker container rm $(docker container ls -aq)         # Remove all containers
 docker image ls -a                             # List all images on this machine
 docker image rm <image id>            # Remove specified image from this machine
-docker image rm $(docker image ls -a -q)   # Remove all images from this machine
+docker image rm $(docker image ls -aq)   # Remove all images from this machine
 docker login             # Log in this CLI session using your Docker credentials
 docker tag <image> username/repository:tag  # Tag <image> for upload to registry
 docker push username/repository:tag            # Upload tagged image to registry


### PR DESCRIPTION
### Proposed changes

Shorten all, `-a` and quite, `-q` params  to `--aq`