### PR TITLE
use access tokens for CLI access to DTR

### DIFF
--- a/ee/dtr/admin/configure/enable-single-sign-on.md
+++ b/ee/dtr/admin/configure/enable-single-sign-on.md
@@ -10,6 +10,9 @@ separately on the web UI of both applications.
 You can configure DTR to have single sign-on (SSO) with UCP, so that users only
 have to authenticate once.
 
+> **Note**: After configuring single sign-on with DTR, users accessing DTR via 
+> `docker login` should create an [access token](https://docs.docker.com/ee/dtr/user/access-tokens/) and use it to authenticate. 
+
 ## At installation time
 
 When installing DTR, use the `docker/dtr install --dtr-external-url <url>`

--- a/ee/dtr/admin/configure/enable-single-sign-on.md
+++ b/ee/dtr/admin/configure/enable-single-sign-on.md
@@ -11,7 +11,7 @@ You can configure DTR to have single sign-on (SSO) with UCP, so that users only
 have to authenticate once.
 
 > **Note**: After configuring single sign-on with DTR, users accessing DTR via 
-> `docker login` should create an [access token](https://docs.docker.com/ee/dtr/user/access-tokens/) and use it to authenticate. 
+> `docker login` should create an [access token](/ee/dtr/user/access-tokens/) and use it to authenticate. 
 
 ## At installation time
 


### PR DESCRIPTION
Added note advising users to use access tokens with DTR after configuring SAML for UI authentication. This is necessary per slack conversation here: https://docker.slack.com/archives/C1329M30T/p1547584120183300

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
