### PR TITLE
Fix some minor issues in vfs storage-driver section

### DIFF
--- a/storage/storagedriver/vfs-driver.md
+++ b/storage/storagedriver/vfs-driver.md
@@ -13,8 +13,6 @@ performance and more space used on disk than other storage drivers. However, it
 is robust, stable, and works in every environment. It can also be used as a
 mechanism to verify other storage back-ends against, in a testing environment.
 
-Docker 17.12 and higher include support for quotas when using the VFS driver.
-
 ## Configure Docker with the `vfs` storage driver
 
 1. Stop Docker.
@@ -33,11 +31,12 @@ Docker 17.12 and higher include support for quotas when using the VFS driver.
     ```
 
     If you want to set a quota to control the maximum size the VFS storage
-    driver can use, set the `size` option on the `storage-drivers` key. Quotas
-    are only supported in Docker 17.12 CE and higher.
+    driver can use, set the `size` option on the `storage-opts` key. Quotas
+    are only supported in Docker 17.12 and higher.
 
     ```json
     {
+      "storage-driver": "vfs",
       "storage-opts": ["size=256M"]
     }
     ```
@@ -51,14 +50,13 @@ Docker 17.12 and higher include support for quotas when using the VFS driver.
     ```
 
 4.  Verify that the daemon is using the `vfs` storage driver.
-    Use the `docker info` command and look for `Storage Driver` and
-    `Backing filesystem`.
+    Use the `docker info` command and look for `Storage Driver`.
 
     ```bash
     $ docker info
 
     Storage Driver: vfs
-    <output truncated>
+    ...
     ```
 
 Docker is now using the `vfs` storage driver. Docker has automatically


### PR DESCRIPTION
- Fix mention of `storage-drivers` instead of `storage-opts`
- Repeat the selected driver in the second `daemon.json` example
- Remove mention of `CE` as this driver can be used
  on Docker EE (although it's mainly intending for
  debugging, so not a "supported" driver)

