### PR TITLE
Added moby#36951 to 18.09.4 release notes

### DIFF
--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -46,6 +46,7 @@ consistency and compatibility reasons.
 
 ### Swarm Mode
 * Fixed nil pointer exception when joining node to swarm. [moby/moby#38618](https://github.com/moby/moby/issues/38618)
+* Fixed issue for swarm nodes not being able to join as masters if http proxy is set. [moby/moby#36951]
 
 ### Known Issues
 * There are [important changes to the upgrade process](/ee/upgrade) that, if not correctly followed, can have impact on the availability of applications running on the Swarm during upgrades. These constraints impact any upgrades coming from any version before 18.09 to version 18.09 or later.


### PR DESCRIPTION
### Proposed changes
As per Engineering update on https://docker.atlassian.net/browse/FIELD-28, https://github.com/moby/moby/issues/36951 was included in 18.09.4 patch release.

This patch fix was already included in the [18.03.1-ee8 release notes](https://docs.docker.com/engine/release-notes/#18031-ee-8), so used that patch fix summary line.

### Related issues (optional)
https://github.com/moby/moby/issues/36951
https://github.com/docker/swarmkit/pull/2802
