### PR TITLE
Add pip dependencies to compose doc for alpine

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -124,6 +124,10 @@ repository release page on GitHub](https://github.com/docker/compose/releases){:
 target="_blank" class="_"}. Follow the instructions from the link, which involve
 running the `curl` command in your terminal to download the binaries. These step-by-step instructions are also included below.
 
+> For `alpine`, the following dependency packages are needed:
+> `py-pip`, `python-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, `make`
+{: .important}
+
 1.  Run this command to download the current stable release of Docker Compose:
 
     ```bash
@@ -169,6 +173,10 @@ sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 - [Install as a container](#install-as-a-container)
 
 #### Install using pip
+
+> For `alpine`, the following dependency packages are needed:
+> `py-pip`, `python-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, `make`
+{: .important}
 
 Compose can be installed from
 [pypi](https://pypi.python.org/pypi/docker-compose) using `pip`. If you install

--- a/compose/install.md
+++ b/compose/install.md
@@ -125,7 +125,7 @@ target="_blank" class="_"}. Follow the instructions from the link, which involve
 running the `curl` command in your terminal to download the binaries. These step-by-step instructions are also included below.
 
 > For `alpine`, the following dependency packages are needed:
-> `py-pip`, `python-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, `make`
+> `py-pip`, `python-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, and `make`.
 {: .important}
 
 1.  Run this command to download the current stable release of Docker Compose:
@@ -175,7 +175,7 @@ sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 #### Install using pip
 
 > For `alpine`, the following dependency packages are needed:
-> `py-pip`, `python-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, `make`
+> `py-pip`, `python-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, and `make`.
 {: .important}
 
 Compose can be installed from


### PR DESCRIPTION
### Proposed changes

Just added a warning about new dependencies on pip alternative installation

### Related issues (optional)

https://github.com/docker/compose/issues/6617#issuecomment-477974325