### PR TITLE
Include Ubuntu version in Dockerfile

### DIFF
--- a/engine/examples/postgresql_service.md
+++ b/engine/examples/postgresql_service.md
@@ -21,7 +21,7 @@ suitably secure.
 # example Dockerfile for https://docs.docker.com/engine/examples/postgresql_service/
 #
 
-FROM ubuntu
+FROM ubuntu:16.04
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc


### PR DESCRIPTION
### Proposed changes

Added a version to the example Dockerfile since newer versions of Ubuntu throw errors, such as `E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
`

