### PR TITLE
Remove redundant "be"

### DIFF
--- a/engine/security/trust/content_trust.md
+++ b/engine/security/trust/content_trust.md
@@ -20,7 +20,7 @@ client-side or runtime verification of the integrity and publisher of specific
 image tags. 
 
 Through DCT, image publishers can sign their images and image consumers can 
-ensure that the images they use are signed. Publishers could be be individuals 
+ensure that the images they use are signed. Publishers could be individuals 
 or organizations manually signing their content or automated software supply 
 chains signing content as part of their release process.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Removed a redundant "be" from the content trust document.
