### PR TITLE
Update Python and Flask usage in Compose tutorial

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -86,6 +86,7 @@ following:
     WORKDIR /code
     ENV FLASK_APP app.py
     ENV FLASK_RUN_HOST 0.0.0.0
+    RUN apk add --no-cache gcc musl-dev linux-headers
     COPY requirements.txt requirements.txt
     RUN pip install -r requirements.txt
     COPY . .
@@ -96,6 +97,7 @@ This tells Docker to:
 * Build an image starting with the Python 3.7 image.
 * Set the working directory to `/code`.
 * Set environment variables used by the `flask` command.
+* Install gcc so Python packages such as MarkupSafe and SQLAlchemy can compile speedups.
 * Copy `requirements.txt` and install the Python dependencies.
 * Copy the current directory `.` in the project to the workdir `.` in the image.
 * Set the default command for the container to `flask run`.

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -86,19 +86,23 @@ itself.
 In your project directory, create a file named `Dockerfile` and paste the
 following:
 
-    FROM python:3.4-alpine
-    ADD . /code
+    FROM python:3.7-alpine
     WORKDIR /code
+    ENV FLASK_APP app.py
+    ENV FLASK_RUN_HOST 0.0.0.0
+    COPY requirements.txt requirements.txt
     RUN pip install -r requirements.txt
-    CMD ["python", "app.py"]
+    COPY . .
+    CMD ["flask", "run"]
 
 This tells Docker to:
 
-* Build an image starting with the Python 3.4 image.
-* Add the current directory `.` into the path `/code` in the image.
+* Build an image starting with the Python 3.7 image.
 * Set the working directory to `/code`.
-* Install the Python dependencies.
-* Set the default command for the container to `python app.py`.
+* Set environment varialbes used by the `flask` command.
+* Copy `requirements.txt` and install the Python dependencies.
+* Copy the current directory `.` in the project to the workdir `.` in the image.
+* Set the default command for the container to `flask run`.
 
 For more information on how to write Dockerfiles, see the [Docker user
 guide](/engine/tutorials/dockerimages.md#building-an-image-from-a-dockerfile)
@@ -115,7 +119,7 @@ the following:
       web:
         build: .
         ports:
-         - "5000:5000"
+          - "5000:5000"
       redis:
         image: "redis:alpine"
 
@@ -158,13 +162,13 @@ Hub registry.
     Compose pulls a Redis image, builds an image for your code, and starts the
     services you defined. In this case, the code is statically copied into the image at build time.
 
-2.  Enter `http://0.0.0.0:5000/` in a browser to see the application running.
+2.  Enter http://localhost:5000/ in a browser to see the application running.
 
     If you're using Docker natively on Linux, Docker Desktop for Mac, or Docker Desktop for
     Windows, then the web app should now be listening on port 5000 on your
-    Docker daemon host. Point your web browser to `http://localhost:5000` to
+    Docker daemon host. Point your web browser to http://localhost:5000 to
     find the `Hello World` message. If this doesn't resolve, you can also try
-    `http://0.0.0.0:5000`.
+    http://127.0.0.1:5000 or http://0.0.0.0:5000.
 
     If you're using Docker Machine on a Mac or Windows, use `docker-machine ip
     MACHINE_VM` to get the IP address of your Docker host. Then, open
@@ -216,15 +220,19 @@ Edit `docker-compose.yml` in your project directory to add a [bind mount](/engin
       web:
         build: .
         ports:
-         - "5000:5000"
+          - "5000:5000"
         volumes:
-         - .:/code
+          - .:/code
+        environment:
+          FLASK_ENV: development
       redis:
         image: "redis:alpine"
 
 The new `volumes` key mounts the project directory (current directory) on the
 host to `/code` inside the container, allowing you to modify the code on the
-fly, without having to rebuild the image.
+fly, without having to rebuild the image. The `environment` key sets the
+`FLASK_ENV` environment variable, which tells `flask run` to run in development
+mode and reload the code on change. This mode should only be used in development.
 
 ## Step 6: Re-build and run the app with Compose
 

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -95,7 +95,7 @@ This tells Docker to:
 
 * Build an image starting with the Python 3.7 image.
 * Set the working directory to `/code`.
-* Set environment varialbes used by the `flask` command.
+* Set environment variables used by the `flask` command.
 * Copy `requirements.txt` and install the Python dependencies.
 * Copy the current directory `.` in the project to the workdir `.` in the image.
 * Set the default command for the container to `flask run`.
@@ -164,7 +164,7 @@ Hub registry.
     Windows, then the web app should now be listening on port 5000 on your
     Docker daemon host. Point your web browser to http://localhost:5000 to
     find the `Hello World` message. If this doesn't resolve, you can also try
-    http://127.0.0.1:5000 or http://0.0.0.0:5000.
+    http://127.0.0.1:5000.
 
     If you're using Docker Machine on a Mac or Windows, use `docker-machine ip
     MACHINE_VM` to get the IP address of your Docker host. Then, open

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -31,7 +31,6 @@ Define the application dependencies.
         import redis
         from flask import Flask
 
-
         app = Flask(__name__)
         cache = redis.Redis(host='redis', port=6379)
 
@@ -52,9 +51,6 @@ Define the application dependencies.
         def hello():
             count = get_hit_count()
             return 'Hello World! I have been seen {} times.\n'.format(count)
-
-        if __name__ == "__main__":
-            app.run(host="0.0.0.0", debug=True)
 
 
       In this example, `redis` is the hostname of the redis container on the


### PR DESCRIPTION
* Uses the modern Python 3.7 image, as 3.4 is EOL.
* Use `COPY` instead of `ADD`, since behavior of `ADD` is not used, as recommended in the `Dockerfile` reference.
* Separates copying and installing requirements from copying project, to make rebuilds more efficient if no requirements change.
* Uses the recommended `flask run` command. This is especially needed on Windows, where `app.py` incorrectly looks like an executable file when copying into Docker. https://github.com/pallets/werkzeug/issues/1482
* Uses the `FLASK_ENV` env var to control development mode (debugger, reloader). This is only set when demonstrating the `volumes` option for live updating files, as it should not be used in production. Note that the development server (`flask run`, `app.run()`) should not be used in production either, but I think that's outside the scope of this change.
* Install gcc and dev headers so simple C extensions such as MarkupSafe and SQLAlchemy speedups can compile on Alpine (wheels on pypi are only built for glibc).