### PR TITLE
Update the "role-based access control" link

### DIFF
--- a/ee/ucp/user-access/index.md
+++ b/ee/ucp/user-access/index.md
@@ -13,7 +13,7 @@ way, from your browser.
 
 
 Docker UCP secures your cluster by using
-[role-based access control](../../access-control/index.md).
+[role-based access control](../authorization/index.md).
 From the browser, administrators can:
 
 * Manage cluster configurations,


### PR DESCRIPTION
### Proposed changes

<!--Tell us what you did and why-->
On page "https://docs.docker.com/ee/ucp/user-access/", updated the hyperlink "role-based access control" to point to "https://docs.docker.com/ee/ucp/authorization/" instead of "https://docs.docker.com/ee/access-control", because the old page does not exist anymore. 

The new page seems like the most appropriate spot to find information regarding RBAC.

### Related issues (optional)
Fixes #8602