### PR TITLE
Example to indicate behavioral diff. client bundle

### DIFF
--- a/ee/ucp/user-access/cli.md
+++ b/ee/ucp/user-access/cli.md
@@ -149,6 +149,9 @@ unzip bundle.zip
 
 # Run the utility script.
 eval "$(<env.sh)"
+
+# Confirm that you can see UCP containers:
+docker ps -af state=running
 ```
 
 On Windows Server 2016, open an elevated PowerShell prompt and run:


### PR DESCRIPTION
### Proposed changes
We recently had a client open a case, because UCP system containers were not visible when typing `docker ps`, while using a UCP client bundle. Upon hearing that the behavior of the client bundle is different than that seen without the bundle (e.g. `docker ps -a` is necessary to view system containers), he asked that we add some indication to the documentation that this is expected behavior. This is the least invasive way I can think of to introduce such a change to the article. Better ideas welcome!