### PR TITLE
Remove extra which

### DIFF
--- a/storage/storagedriver/aufs-driver.md
+++ b/storage/storagedriver/aufs-driver.md
@@ -168,7 +168,7 @@ Consider some scenarios where files in a container are modified.
   However, AUFS works at the file level rather than the block level. This
   means that all copy_up operations copy the entire file, even if the file is
   very large and only a small part of it is being modified. This can have a
-  noticeable impact on container write performance. AUFS, which can suffer
+  noticeable impact on container write performance. AUFS can suffer
   noticeable latencies when searching for files in images with many layers.
   However, it is worth noting that the copy_up operation only occurs the first
   time a given file is written to. Subsequent writes to the same file operate


### PR DESCRIPTION
Change below line

From

AUFS, which can suffer noticeable latencies when searching for files in images with many layers

To

AUFS can suffer noticeable latencies when searching for files in images with many layers

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
