### PR TITLE
ubuntu.md: remove old docker-ce-cli

### DIFF
--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -47,7 +47,7 @@ Older versions of Docker were called `docker` or `docker-engine`. In addition,
 if you are upgrading from Docker CE to Docker EE, remove the Docker CE package.
 
 ```bash
-$ sudo apt-get remove docker docker-engine docker-ce docker.io
+$ sudo apt-get remove docker docker-engine docker-ce docker-ce-cli docker.io
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.


### PR DESCRIPTION
I hit the following error when "upgrading" docker-ce 18.09 to docker-ee 17.06:

> dpkg: error processing archive /var/cache/apt/archives/docker-ee_3%3a17.06.2~ee~19~3-0~ubuntu_amd64.deb (--unpack):
 trying to overwrite '/usr/share/fish/vendor_completions.d/docker.fish', which is also in package docker-ce-cli 5:18.09.4~2.1.rc1-0~ubuntu-xenial

This commit adds `docker-ce-cli` to the list in "uninstall old packages" to fix this.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

