### PR TITLE
Revert "Netlify redirects interlock"

### DIFF
--- a/ee/ucp/interlock/architecture.md
+++ b/ee/ucp/interlock/architecture.md
@@ -3,8 +3,6 @@ title: Interlock architecture
 description: Learn more about the architecture of the layer 7 routing solution
   for Docker swarm services.
 keywords: routing, UCP, interlock, load balancing
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/intro/architecture/
 ---
 
 This document covers the following considerations:

--- a/ee/ucp/interlock/config/custom-template.md
+++ b/ee/ucp/interlock/config/custom-template.md
@@ -2,8 +2,6 @@
 title: Custom templates
 description: Learn how to use a custom extension template
 keywords: routing, proxy, interlock, load balancing
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/ops/custom_template/
 ---
 
 Use a custom extension if a needed option is not available in the extension configuration.

--- a/ee/ucp/interlock/config/haproxy-config.md
+++ b/ee/ucp/interlock/config/haproxy-config.md
@@ -2,8 +2,6 @@
 title: Configure HAProxy
 description: Learn how to configure an HAProxy extension
 keywords: routing, proxy, interlock, load balancing
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/config/extensions/haproxy/
 ---
 
 The following HAProxy configuration options are available:

--- a/ee/ucp/interlock/config/host-mode-networking.md
+++ b/ee/ucp/interlock/config/host-mode-networking.md
@@ -6,7 +6,6 @@ keywords: routing, proxy, interlock, load balancing
 redirect_from:
   - /ee/ucp/interlock/usage/host-mode-networking/
   - /ee/ucp/interlock/deploy/host-mode-networking/
-  - https://interlock-dev-docs.netlify.com/usage/host_mode/
 ---
 
 By default, layer 7 routing components communicate with one another using

--- a/ee/ucp/interlock/config/index.md
+++ b/ee/ucp/interlock/config/index.md
@@ -5,7 +5,6 @@ keywords: routing, proxy, interlock, load balancing
 redirect_from:
   - /ee/ucp/interlock/deploy/configure/
   - /ee/ucp/interlock/usage/default-service/
-  - https://interlock-dev-docs.netlify.com/config/interlock/
 ---
 
 To further customize the layer 7 routing solution, you must update the

--- a/ee/ucp/interlock/config/nginx-config.md
+++ b/ee/ucp/interlock/config/nginx-config.md
@@ -2,8 +2,6 @@
 title: Configure Nginx 
 description: Learn how to configure an nginx extension
 keywords: routing, proxy, interlock, load balancing
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/config/extensions/nginx/
 ---
 
 By default, nginx is used as a proxy, so the following configuration options are

--- a/ee/ucp/interlock/config/service-labels.md
+++ b/ee/ucp/interlock/config/service-labels.md
@@ -2,8 +2,6 @@
 title: Use application service labels
 description: Learn how applications use service labels for publishing
 keywords: routing, proxy, interlock, load balancing
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/config/service_labels/
 ---
 
 Service labels define hostnames that are routed to the

--- a/ee/ucp/interlock/config/tuning.md
+++ b/ee/ucp/interlock/config/tuning.md
@@ -2,8 +2,6 @@
 title: Tune the proxy service
 description: Learn how to tune the proxy service for environment optimization
 keywords: routing, proxy, interlock
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/ops/tuning/
 ---
 
 ## Constrain the proxy service to multiple dedicated worker nodes

--- a/ee/ucp/interlock/config/updates.md
+++ b/ee/ucp/interlock/config/updates.md
@@ -2,8 +2,6 @@
 title: Update Interlock services
 description: Learn how to update the UCP layer 7 routing solution services
 keywords: routing, proxy, interlock
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/ops/updates/
 ---
 
 There are two parts to the update process:

--- a/ee/ucp/interlock/deploy/index.md
+++ b/ee/ucp/interlock/deploy/index.md
@@ -4,7 +4,6 @@ description: Learn the deployment steps for the UCP layer 7 routing solution
 keywords: routing, proxy, interlock
 redirect_from:
   - /ee/ucp/interlock/deploy/configuration-reference/
-  - https://interlock-dev-docs.netlify.com/install/
 ---
 
 This topic covers deploying a layer 7 routing solution into a Docker Swarm to route traffic to Swarm services. Layer 7 routing is also referred to as an HTTP routing mesh.

--- a/ee/ucp/interlock/deploy/offline-install.md
+++ b/ee/ucp/interlock/deploy/offline-install.md
@@ -2,8 +2,6 @@
 title: Offline installation considerations
 description: Learn how to to install Interlock on a Docker cluster without internet access.
 keywords: routing, proxy, interlock
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/install/offline/
 ---
 
 To install Interlock on a Docker cluster without internet access, the Docker images must be loaded.  This topic describes how to export the images from a local Docker

--- a/ee/ucp/interlock/deploy/production.md
+++ b/ee/ucp/interlock/deploy/production.md
@@ -3,8 +3,6 @@ title: Configure layer 7 routing for production
 description: Learn how to configure the layer 7 routing solution for a production
   environment.
 keywords: routing, proxy, interlock
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/install/production/
 ---
 
 This section includes documentation on configuring Interlock

--- a/ee/ucp/interlock/index.md
+++ b/ee/ucp/interlock/index.md
@@ -2,9 +2,6 @@
 title: Layer 7 routing overview
 description: Learn how to route layer 7 traffic to your Swarm services
 keywords: routing, UCP, interlock, load balancing
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/
-  - https://interlock-dev-docs.netlify.com/intro/about/
 ---
 
 Application-layer (Layer 7) routing is the application routing and load balancing (ingress routing) system included with Docker Enterprise for Swarm orchestration. Interlock architecture takes advantage of the underlying Swarm components to provide scalable Layer 7 routing and Layer 4 VIP mode functionality.

--- a/ee/ucp/interlock/usage/canary.md
+++ b/ee/ucp/interlock/usage/canary.md
@@ -2,8 +2,6 @@
 title: Publish Canary application instances
 description: Learn how to do canary deployments for your Docker swarm services
 keywords: routing, proxy
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/usage/canary/
 ---
 
 The following example publishes a service as a canary instance.

--- a/ee/ucp/interlock/usage/context.md
+++ b/ee/ucp/interlock/usage/context.md
@@ -3,8 +3,6 @@ title: Use context and path-based routing
 description: Learn how to route traffic to your Docker swarm services based
   on a url path.
 keywords: routing, proxy
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/usage/context_root/
 ---
 
 The following example publishes a service using context or path based routing.

--- a/ee/ucp/interlock/usage/index.md
+++ b/ee/ucp/interlock/usage/index.md
@@ -5,7 +5,6 @@ keywords: routing, proxy
 redirect_from:
   - /ee/ucp/interlock/deploy/configuration-reference/
   - /ee/ucp/interlock/deploy/configure/
-  - https://interlock-dev-docs.netlify.com/usage/hello/
 ---
 
 After Interlock is deployed, you can launch and publish services and applications.

--- a/ee/ucp/interlock/usage/interlock-vip-mode.md
+++ b/ee/ucp/interlock/usage/interlock-vip-mode.md
@@ -2,8 +2,6 @@
 title: Specify a routing mode
 description: Learn about task and VIP backend routing modes for Layer 7 routing
 keywords: routing, proxy, interlock
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/usage/default_backend/
 ---
 
 You can publish services using "vip" and "task" backend routing modes.

--- a/ee/ucp/interlock/usage/redirects.md
+++ b/ee/ucp/interlock/usage/redirects.md
@@ -3,8 +3,6 @@ title: Implement application redirects
 description: Learn how to implement redirects using swarm services and the
   layer 7 routing solution for UCP.
 keywords: routing, proxy, redirects, interlock
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/usage/redirects/
 ---
 
 The following example publishes a service and configures a redirect from `old.local` to `new.local`.

--- a/ee/ucp/interlock/usage/service-clusters.md
+++ b/ee/ucp/interlock/usage/service-clusters.md
@@ -2,8 +2,6 @@
 title: Implement service clusters
 description: Learn how to route traffic to different proxies using a service cluster.
 keywords: ucp, interlock, load balancing, routing
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/usage/service_clusters/
 ---
 
 ## Configure Proxy Services

--- a/ee/ucp/interlock/usage/sessions.md
+++ b/ee/ucp/interlock/usage/sessions.md
@@ -3,8 +3,6 @@ title: Implement persistent (sticky) sessions
 description: Learn how to configure your swarm services with persistent sessions
   using UCP.
 keywords: routing, proxy, cookies, IP hash
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/usage/sessions/
 ---
 
 You can publish a service and configure the proxy for persistent (sticky) sessions using:

--- a/ee/ucp/interlock/usage/ssl.md
+++ b/ee/ucp/interlock/usage/ssl.md
@@ -4,7 +4,6 @@ description: Learn how to configure your swarm services with SSL.
 keywords: routing, proxy, tls, ssl
 redirect_from:
   - /ee/ucp/interlock/usage/ssl/
-  - https://interlock-dev-docs.netlify.com/usage/ssl/
 ---
 
 This topic covers Swarm services implementation with:

--- a/ee/ucp/interlock/usage/websockets.md
+++ b/ee/ucp/interlock/usage/websockets.md
@@ -2,8 +2,6 @@
 title: Use websockets
 description: Learn how to use websockets in your swarm services.
 keywords: routing, proxy, websockets
-redirect_from:
-  - https://interlock-dev-docs.netlify.com/usage/websockets/
 ---
 
 First, create an overlay network to isolate and secure service traffic:


### PR DESCRIPTION
Reverts docker/docker.github.io#8595

- Jekyll's Redirect From plugin only works with internal pages (basically from old to new post URL). For redirecting from an external domain to the new URL, see _clever hack_ from @allejo in #6433 (hi, and thank you!).

@ollypom see https://help.github.com/en/articles/redirects-on-github-pages for further education. :) 