### PR TITLE
Trying to fix command rendering of '--format "{{ .Names }}"'

### DIFF
--- a/ee/dtr/admin/disaster-recovery/create-a-backup.md
+++ b/ee/dtr/admin/disaster-recovery/create-a-backup.md
@@ -132,6 +132,7 @@ recommended for that system.
 To create a DTR backup, load your UCP client bundle, and run the following
 concatenated commands:
 
+{% raw %}
 ```none
 DTR_VERSION=$(docker container inspect $(docker container ps -f name=dtr-registry -q) | \
   grep -m1 -Po '(?<=DTR_VERSION=)\d.\d.\d'); \
@@ -148,6 +149,7 @@ docker run --log-driver none -i --rm \
   --ucp-ca "$(curl https://${UCP_URL}/ca)" \
   --existing-replica-id $REPLICA_ID > dtr-metadata-${DTR_VERSION}-backup-$(date +%Y%m%d-%H_%M_%S).tar
 ```
+{% endraw %}
 
 #### UCP field prompts
 

--- a/ee/dtr/admin/disaster-recovery/create-a-backup.md
+++ b/ee/dtr/admin/disaster-recovery/create-a-backup.md
@@ -130,7 +130,7 @@ recommended for that system.
 ### Back up DTR metadata
 
 To create a DTR backup, load your UCP client bundle, and run the following
-concatenated commands:
+chained commands:
 
 {% raw %}
 ```none
@@ -157,7 +157,7 @@ docker run --log-driver none -i --rm \
 * `<ucp-username>` is the username of a UCP administrator.
 * `<replica-id>` is the DTR replica ID to back up.
 
-The above concatenated commands run through the following tasks:
+The above chained commands run through the following tasks:
 1. Sets your DTR version and replica ID. To back up 
 a specific replica, set the replica ID manually by modifying the 
 `--existing-replica-id` flag in the backup command. 


### PR DESCRIPTION
--format "{{ .Names }}" is showing up in the markup but is rendering as --format "" in the published version. Added {% raw %} tags to try to fix.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
