### PR TITLE
Trying to fix command rendering of '--format "{{ .Names }}"'

### DIFF
--- a/reference/dtr/2.6/cli/backup.md
+++ b/reference/dtr/2.6/cli/backup.md
@@ -23,7 +23,7 @@ docker run -i --rm --log-driver none docker/dtr:{{ page.dtr_version }} \
     backup --ucp-ca "$(cat ca.pem)" --existing-replica-id 5eb9459a7832 > backup.tar
 ```
 
-### Advanced (with chained commands)
+#### Advanced (with chained commands)
 {% raw %}
 ```bash
 DTR_VERSION=$(docker container inspect $(docker container ps -f \

--- a/reference/dtr/2.6/cli/backup.md
+++ b/reference/dtr/2.6/cli/backup.md
@@ -24,6 +24,7 @@ docker run -i --rm --log-driver none docker/dtr:{{ page.dtr_version }} \
 ```
 
 ### Advanced (with chained commands)
+{% raw %}
 ```bash
 DTR_VERSION=$(docker container inspect $(docker container ps -f \
   name=dtr-registry -q) | grep -m1 -Po '(?<=DTR_VERSION=)\d.\d.\d'); \
@@ -41,6 +42,7 @@ docker run --log-driver none -i --rm \
   --existing-replica-id $REPLICA_ID > \
   dtr-metadata-${DTR_VERSION}-backup-$(date +%Y%m%d-%H_%M_%S).tar
 ```
+{% endraw %}
 
 For a detailed explanation on the advanced example, see 
 [Back up your DTR metadata](ee/dtr/admin/disaster-recovery/create-a-backup/#back-up-dtr-metadata).


### PR DESCRIPTION
--format "{{ .Names }}" is showing up in the markup but is rendering as --format "" in the published version. Added {% raw %} tags to try to fix.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
