### PR TITLE
Modified command for OSX compatibility

### DIFF
--- a/reference/dtr/2.6/cli/backup.md
+++ b/reference/dtr/2.6/cli/backup.md
@@ -27,7 +27,8 @@ docker run -i --rm --log-driver none docker/dtr:{{ page.dtr_version }} \
 {% raw %}
 ```bash
 DTR_VERSION=$(docker container inspect $(docker container ps -f \
-  name=dtr-registry -q) | grep -m1 -Po '(?<=DTR_VERSION=)\d.\d.\d'); \
+  name=dtr-registry -q) | grep -m1 DTR_VERSION | \
+  sed 's/.*DTR_VERSION=\([0-9].[0-9].[0-9]\)",/\1/'); \
 REPLICA_ID=$(docker ps --filter name=dtr-rethinkdb \
   --format "{{ .Names }}" | head -1 | sed 's|.*/||' | sed 's/dtr-rethinkdb-//'); \
 read -p 'ucp-url (The UCP URL including domain and port): ' UCP_URL; \


### PR DESCRIPTION
OSX doesn't support `grep -m1 -Po '(?<=DTR_VERSION=)\d.\d.\d')` so modified the command to use `grep -m1 DTR_VERSION | sed 's/.*DTR_VERSION=\([0-9].[0-9].[0-9]\)",/\1/')` which works on Linux and OSX.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
