### PR TITLE
Modified command for OSX compatibility

### DIFF
--- a/ee/dtr/admin/disaster-recovery/create-a-backup.md
+++ b/ee/dtr/admin/disaster-recovery/create-a-backup.md
@@ -134,8 +134,9 @@ chained commands:
 
 {% raw %}
 ```none
-DTR_VERSION=$(docker container inspect $(docker container ps -f name=dtr-registry -q) | \
-  grep -m1 -Po '(?<=DTR_VERSION=)\d.\d.\d'); \
+DTR_VERSION=$(docker container inspect $(docker container ps -f \
+  name=dtr-registry -q) | grep -m1 DTR_VERSION | \
+  sed 's/.*DTR_VERSION=\([0-9].[0-9].[0-9]\)",/\1/'); \
 REPLICA_ID=$(docker ps --filter name=dtr-rethinkdb --format "{{ .Names }}" | head -1 | \
   sed 's|.*/||' | sed 's/dtr-rethinkdb-//'); \
 read -p 'ucp-url (The UCP URL including domain and port): ' UCP_URL; \
@@ -161,7 +162,7 @@ The above chained commands run through the following tasks:
 1. Sets your DTR version and replica ID. To back up 
 a specific replica, set the replica ID manually by modifying the 
 `--existing-replica-id` flag in the backup command. 
-2. Prompts you for your UCP URL (domain and port) and admin username.
+2. Prompts you for your UCP URL (domain and port), username, and password.
 3. Prompts you for your UCP password without saving it to your disk or printing it on the terminal.
 4. Retrieves the CA certificate for your specified UCP URL. To skip TLS verification, replace the `--ucp-ca` 
 flag with `--ucp-insecure-tls`. Docker does not recommend this flag for production environments.


### PR DESCRIPTION
OSX doesn't support `grep -m1 -Po '(?<=DTR_VERSION=)\d.\d.\d')` so modified the command to use `grep -m1 DTR_VERSION | sed 's/.*DTR_VERSION=\([0-9].[0-9].[0-9]\)",/\1/')` which works on Linux and OSX.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
