### PR TITLE
Added a way to find the ubuntu parent distribution

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -134,8 +134,7 @@ from the repository.
     > **Note**: The `lsb_release -cs` sub-command below returns the name of your
     > Ubuntu distribution, such as `xenial`. Sometimes, in a distribution
     > like Linux Mint, you might need to change `$(lsb_release -cs)`
-    > to your parent Ubuntu distribution. For example, if you are using
-    >  `Linux Mint Tessa`, you could use `bionic`. Docker does not offer any guarantees on untested
+    > to your parent Ubuntu distribution. You can do so by calling `$grep "UBUNTU_CODENAME" /etc/os-release | sed 's/.*=//'` Docker does not offer any guarantees on untested
     > and unsupported Ubuntu distributions.
 
 


### PR DESCRIPTION
This was only tested on Sylvia and might not be portable. I do not know how to test it somewhere else.

### Proposed changes

I added a bash command that should help people figure out which ubuntu distribution their mint is based upon

### Related issues (optional)

Closes #8699 
