### PR TITLE
Fixed syntax error

### DIFF
--- a/reference/dtr/2.6/cli/backup.md
+++ b/reference/dtr/2.6/cli/backup.md
@@ -32,7 +32,7 @@ The following command has been tested on Linux:
 ```none
 DTR_VERSION=$(docker container inspect $(docker container ps -f \
   name=dtr-registry -q) | grep -m1 -Po '(?<=DTR_VERSION=)\d.\d.\d'); \
-REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')); \
+REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-'); \
 read -p 'ucp-url (The UCP URL including domain and port): ' UCP_URL; \
 read -p 'ucp-username (The UCP administrator username): ' UCP_ADMIN; \
 read -sp 'ucp password: ' UCP_PASSWORD; \


### PR DESCRIPTION
Last edit to the REPLICA_ID command added an extra ')' which causes the command to fail. I fixed it.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
