### PR TITLE
Update zfs-driver.md

### DIFF
--- a/storage/storagedriver/zfs-driver.md
+++ b/storage/storagedriver/zfs-driver.md
@@ -263,7 +263,7 @@ There are several factors that influence the performance of Docker using the
   filesystems like ZFS. ZFS mitigates this by using a small block size of 128k.
   The ZFS intent log (ZIL) and the coalescing of writes (delayed writes) also
   help to reduce fragmentation. You can monitor fragmentation using
-  `zpool status`. However, there is no way to defragment ZFS without reformatting
+  `zpool list`. However, there is no way to defragment ZFS without reformatting
   and restoring the filesystem.
 
 - **Use the native ZFS driver for Linux**: The ZFS FUSE implementation is not

--- a/storage/storagedriver/zfs-driver.md
+++ b/storage/storagedriver/zfs-driver.md
@@ -263,7 +263,7 @@ There are several factors that influence the performance of Docker using the
   filesystems like ZFS. ZFS mitigates this by using a small block size of 128k.
   The ZFS intent log (ZIL) and the coalescing of writes (delayed writes) also
   help to reduce fragmentation. You can monitor fragmentation using
-  `zfs status`. However, there is no way to defragment ZFS without reformatting
+  `zpool status`. However, there is no way to defragment ZFS without reformatting
   and restoring the filesystem.
 
 - **Use the native ZFS driver for Linux**: The ZFS FUSE implementation is not


### PR DESCRIPTION
### Proposed changes

The command "zfs status" does not exist. To check the fragmentation level of a ZFS-Pool, use "zpool status".