### PR TITLE
Update from microsoft/* to mcr.microsoft.com/*.

### DIFF
--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -41,7 +41,7 @@ Windows](/docker-for-windows/). Read more on [switching containers](/docker-for-
    the `Dockerfile` to use the DLL file of your project.
 
 ```dockerfile
-FROM microsoft/dotnet:sdk AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -53,7 +53,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/dotnet:aspnetcore-runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "aspnetapp.dll"]


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Update Dockerfile with following changes:

1. Switch .NET Core Images from legacy location at Docker Hub Registry (`microsoft/*`) to a new location at Microsoft Container Registry (`mcr.microsoft.com/*`).
2. Since Microsoft no longer supports the tag `latest`, I set a specific version of `2.2` (current), which is the most recent stable release.

### Related issues (optional)

- Improved discovery experience for Microsoft containers on Docker Hub:
https://cloudblogs.microsoft.com/opensource/2019/01/17/improved-discovery-experience-microsoft-containers-docker-hub/
- Removing the ‘latest’ Tag + An Update on MCR:
https://techcommunity.microsoft.com/t5/Containers/Removing-the-latest-Tag-An-Update-on-MCR/ba-p/393045
