### PR TITLE
Update ubuntu version and common driver on storagedriver docs

### DIFF
--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -27,14 +27,14 @@ instruction in the image's Dockerfile. Each layer except the very last one is
 read-only. Consider the following Dockerfile:
 
 ```conf
-FROM ubuntu:15.04
+FROM ubuntu:18.04
 COPY . /app
 RUN make /app
 CMD python /app/app.py
 ```
 
 This Dockerfile contains four commands, each of which creates a layer. The
-`FROM` statement starts out by creating a layer from the `ubuntu:15.04` image.
+`FROM` statement starts out by creating a layer from the `ubuntu:18.04` image.
 The `COPY` command adds some files from your Docker client's current directory.
 The `RUN` command builds your application using the `make` command. Finally,
 the last layer specifies what command to run within the container.
@@ -45,7 +45,7 @@ writable layer on top of the underlying layers. This layer is often called the
 "container layer". All changes made to the running container, such as writing
 new files, modifying existing files, and deleting files, are written to this thin
 writable container layer. The diagram below shows a container based on the Ubuntu
-15.04 image.
+18.04 image.
 
 ![Layers of a container based on the Ubuntu image](images/container-layers.jpg)
 
@@ -63,7 +63,7 @@ deleted. The underlying image remains unchanged.
 Because each container has its own writable container layer, and all changes are
 stored in this container layer, multiple containers can share access to the same
 underlying image and yet have their own data state. The diagram below shows
-multiple containers sharing the same Ubuntu 15.04 image.
+multiple containers sharing the same Ubuntu 18.04 image.
 
 ![Containers sharing same image](images/sharing-layers.jpg)
 
@@ -130,28 +130,28 @@ usually `/var/lib/docker/` on Linux hosts. You can see these layers being pulled
 in this example:
 
 ```bash
-$ docker pull ubuntu:15.04
-
-15.04: Pulling from library/ubuntu
-1ba8ac955b97: Pull complete
-f157c4e5ede7: Pull complete
-0b7e98f84c4c: Pull complete
-a3ed95caeb02: Pull complete
-Digest: sha256:5e279a9df07990286cce22e1b0f5b0490629ca6d187698746ae5e28e604a640e
-Status: Downloaded newer image for ubuntu:15.04
+$ docker pull ubuntu:18.04
+18.04: Pulling from library/ubuntu
+f476d66f5408: Pull complete
+8882c27f669e: Pull complete
+d9af21273955: Pull complete
+f5029279ec12: Pull complete
+Digest: sha256:ab6cb8de3ad7bb33e2534677f865008535427390b117d7939193f8d1a6613e34
+Status: Downloaded newer image for ubuntu:18.04
 ```
 
 Each of these layers is stored in its own directory inside the Docker host's
 local storage area. To examine the layers on the filesystem, list the contents
-of `/var/lib/docker/<storage-driver>/layers/`. This example uses the `aufs` 
+of `/var/lib/docker/<storage-driver>`. This example uses the `overlay2` 
 storage driver:
 
 ```bash
-$ ls /var/lib/docker/aufs/layers
-1d6674ff835b10f76e354806e16b950f91a191d3b471236609ab13a930275e24
-5dbb0cbe0148cf447b9464a358c1587be586058d9a4c9ce079320265e2bb94e7
-bef7199f2ed8e86fa4ada1309cfad3089e0542fec8894690529e4c04a7ca2d73
-ebf814eccfe98f2704660ca1d844e4348db3b5ccc637eb905d4818fbfb00a06a
+$ ls /var/lib/docker/overlay2
+16802227a96c24dcbeab5b37821e2b67a9f921749cd9a2e386d5a6d5bc6fc6d3
+377d73dbb466e0bc7c9ee23166771b35ebdbe02ef17753d79fd3571d4ce659d7
+3f02d96212b03e3383160d31d7c6aeca750d2d8a1879965b89fe8146594c453d
+ec1ec45792908e90484f7e629330666e7eee599f08729c93890a7205a6ba35f5
+l
 ```
 
 The directory names do not correspond to the layer IDs (this has been true since
@@ -161,7 +161,7 @@ Now imagine that you have two different Dockerfiles. You use the first one to
 create an image called `acme/my-base-image:1.0`.
 
 ```conf
-FROM ubuntu:16.10
+FROM ubuntu:18.04
 COPY . /app
 ```
 
@@ -209,10 +209,9 @@ layers are the same.
 
     ```bash
     $ docker build -t acme/my-base-image:1.0 -f Dockerfile.base .
-
-    Sending build context to Docker daemon  4.096kB
-    Step 1/2 : FROM ubuntu:16.10
-     ---> 31005225a745
+    Sending build context to Docker daemon  812.4MB
+    Step 1/2 : FROM ubuntu:18.04
+     ---> d131e0fa2585
     Step 2/2 : COPY . /app
      ---> Using cache
      ---> bd09118bcef6
@@ -252,7 +251,7 @@ layers are the same.
     $ docker history bd09118bcef6
     IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
     bd09118bcef6        4 minutes ago       /bin/sh -c #(nop) COPY dir:35a7eb158c1504e...   100B                
-    31005225a745        3 months ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
+    d131e0fa2585        3 months ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
     <missing>           3 months ago        /bin/sh -c mkdir -p /run/systemd && echo '...   7B                  
     <missing>           3 months ago        /bin/sh -c sed -i 's/^#\s*\(deb.*universe\...   2.78kB              
     <missing>           3 months ago        /bin/sh -c rm -rf /var/lib/apt/lists/*          0B                  
@@ -266,7 +265,7 @@ layers are the same.
     IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
     dbf995fc07ff        3 minutes ago       /bin/sh -c #(nop)  CMD ["/bin/sh" "-c" "/a...   0B                  
     bd09118bcef6        5 minutes ago       /bin/sh -c #(nop) COPY dir:35a7eb158c1504e...   100B                
-    31005225a745        3 months ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
+    d131e0fa2585        3 months ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
     <missing>           3 months ago        /bin/sh -c mkdir -p /run/systemd && echo '...   7B                  
     <missing>           3 months ago        /bin/sh -c sed -i 's/^#\s*\(deb.*universe\...   2.78kB              
     <missing>           3 months ago        /bin/sh -c rm -rf /var/lib/apt/lists/*          0B                  


### PR DESCRIPTION
### Proposed changes

Update storagedriver docs:

- Updates and unifies all ubuntu versions to the latest LTS one
- Uses commoner storage driver as example

### Unreleased project version (optional)

n/a

### Related issues (optional)

n/a

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
