### PR TITLE
Remove Google+ and change linkt to GitHub org

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -86,8 +86,7 @@
                 <ul class="nav-social">
                     <li class="fa fa-twitter"><a href="http://twitter.com/docker">Twitter</a></li>
                     <li class="fa fa-youtube"><a href="http://www.youtube.com/user/dockerrun">Youtube</a></li>
-                    <li class="fa fa-google-plus"><a href="https://plus.google.com/u/0/communities/108146856671494713993">Google</a></li>
-                    <li class="fa fa-github"><a href="https://github.com/docker/docker">Github</a></li>
+                    <li class="fa fa-github"><a href="https://github.com/docker">GitHub</a></li>
                     <li class="fa fa-linkedin"><a href="https://www.linkedin.com/company/docker">Linkedin</a></li>
                     <li class="fa fa-facebook"><a href="https://www.facebook.com/docker.run">Facebook</a></li>
                     <li class="fa fa-reddit"><a href="http://www.reddit.com/r/docker">Reddit</a></li>


### PR DESCRIPTION
### Proposed changes

Removes the link to Google+, which was closed in Apr 2019.
Changes the link to GitHub repo, which does not eem suitable now as was renamed as moby/moby.

### Unreleased project version (optional)

n/a

### Related issues (optional)

n/a

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
