### PR TITLE
Removed Build from Compose on Docker Desktop Example

### DIFF
--- a/_includes/kubernetes-mac-win.md
+++ b/_includes/kubernetes-mac-win.md
@@ -145,27 +145,22 @@ version: '3.3'
 
 services:
   web:
-    build: web
     image: dockerdemos/lab-web
-    volumes:
-     - "./web/static:/static"
     ports:
      - "80:80"
 
   words:
-    build: words
     image: dockerdemos/lab-words
     deploy:
       replicas: 5
       endpoint_mode: dnsrr
       resources:
         limits:
-          memory: 16M
+          memory: 50M
         reservations:
-          memory: 16M
+          memory: 50M
 
   db:
-    build: db
     image: dockerdemos/lab-db
 ```
 

--- a/_includes/kubernetes-mac-win.md
+++ b/_includes/kubernetes-mac-win.md
@@ -145,12 +145,12 @@ version: '3.3'
 
 services:
   web:
-    image: dockerdemos/lab-web
+    image: dockersamples/k8s-wordsmith-web
     ports:
      - "80:80"
 
   words:
-    image: dockerdemos/lab-words
+    image: dockersamples/k8s-wordsmith-api
     deploy:
       replicas: 5
       endpoint_mode: dnsrr
@@ -161,7 +161,7 @@ services:
           memory: 50M
 
   db:
-    image: dockerdemos/lab-db
+    image: dockersamples/k8s-wordsmith-db
 ```
 
 If you already have a Kubernetes YAML file, you can deploy it using the

--- a/ee/ucp/kubernetes/deploy-with-compose.md
+++ b/ee/ucp/kubernetes/deploy-with-compose.md
@@ -29,19 +29,16 @@ version: '3.3'
 
 services:
   web:
-    build: web
     image: dockersamples/k8s-wordsmith-web
     ports:
      - "8080:80"
 
   words:
-    build: words
     image: dockersamples/k8s-wordsmith-api
     deploy:
       replicas: 5
 
   db:
-    build: db
     image: dockersamples/k8s-wordsmith-db
 ```
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I was testing compose on kubernetes yesterday as part of Docker Desktop Enterprise on Windows 10, and noticed the sample application here didn't work. 

I got the following errors so adjusted accordingly: 

- `Ignoring unsupported options: build` - Therefore removed build
- As I didn't have a directory /static as I don't know what files should be there - I removed the bind mount
- Finally OOM was killing my words services, so I increased the resource limits. 

Following these changes I was able to succesfully deploy the word app with `$ docker stack deploy -c .\docker-compose.yaml --orchestrator kubernetes demo`

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
