### PR TITLE
Release notes for 2.0.4.0 mac (Edge)

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -29,19 +29,22 @@ for Mac](install.md#download-docker-for-mac).
   - [Kubernetes 1.14.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#changelog-since-v1141)
 
 * New
-  - App: Docker CLI Plugin to configure, share and install applications
+  - App: Docker CLI plugin to configure, share, and install applications
+  
     - Extend Compose files with metadata and parameters
-    - Re-use same application across multiple environments (Development/QA/Staging/Production)
-    - Multi orchestrator installation (Swarm or Kubernetes)
-    - Push/Pull/Promotion/Signing supported for application, with same workflow as images
+    - Reuse the same application across multiple environments (Development/QA/Staging/Production)
+    - Multi-orchestrator installation (Swarm or Kubernetes)
+    - Push/Pull/Promotion/Signing supported for application, with the same workflow as images
     - Fully CNAB compliant
-    - Full support of Docker Contexts
+    - Full support for Docker Contexts
+    
   - Buildx (Tech Preview): Docker CLI plugin for extended build capabilities with BuildKit
+  
     - Familiar UI from docker build
     - Full BuildKit capabilities with container driver
     - Multiple builder instance support
-    - Multi-node builds for cross-platform images (out-of-the-box support for linux/arm/v7 & linux/arm64)
-    - Parallel building of compose files
+    - Multi-node builds for cross-platform images (out-of-the-box support for linux/arm/v7 and linux/arm64)
+    - Parallel building of Compose files
     - High-level build constructs with `bake`
 
 * Bug fixes and minor changes

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -18,6 +18,35 @@ for Mac](install.md#download-docker-for-mac).
 
 ## Edge Releases of 2019
 
+### Docker Community Edition 2.0.4.0 2019-04-30
+
+[Download](https://download.docker.com/mac/edge/33772/Docker.dmg)
+
+* Upgrades
+  - [Docker 19.03.0-beta3](https://github.com/docker/docker-ce/releases/tag/v19.03.0-beta3)
+  - [Docker Compose 1.24.0](https://github.com/docker/compose/releases/tag/1.24.0)
+  - [Compose on Kubernetes 0.4.22](https://github.com/docker/compose-on-kubernetes/releases/tag/v0.4.22)
+  - [Kubernetes 1.14.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#changelog-since-v1141)
+
+* New
+  - App: Docker CLI Plugin to configure, share and install applications
+    - Extend Compose files with metadata and parameters
+    - Re-use same application across multiple environments (Development/QA/Staging/Production)
+    - Multi orchestrator installation (Swarm or Kubernetes)
+    - Push/Pull/Promotion/Signing supported for application, with same workflow as images
+    - Fully CNAB compliant
+    - Full support of Docker Contexts
+  - Buildx (Tech Preview): Docker CLI plugin for extended build capabilities with BuildKit
+    - Familiar UI from docker build
+    - Full BuildKit capabilities with container driver
+    - Multiple builder instance support
+    - Multi-node builds for cross-platform images (out-of-the-box support for linux/arm/v7 & linux/arm64)
+    - Parallel building of compose files
+    - High-level build constructs with `bake`
+
+* Bug fixes and minor changes
+  - Truncate UDP DNS responses which are over 512 bytes in size
+
 ### Docker Community Edition 2.0.3.0 2019-03-05
 
 [Download](https://download.docker.com/mac/edge/31778/Docker.dmg)


### PR DESCRIPTION
### Proposed changes

Updated https://docs.docker.com/docker-for-mac/edge-release-notes/ with the latest release notes.