### PR TITLE
[WIP] Add Docker App plugin reference documentation

### DIFF
--- a/_data/docker-app/docker_app.yaml
+++ b/_data/docker-app/docker_app.yaml
@@ -1,0 +1,45 @@
+command: docker app
+short: Docker Application
+long: A tool to build and manage Docker Applications.
+pname: docker
+plink: docker.yaml
+cname:
+- docker app bundle
+- docker app completion
+- docker app init
+- docker app inspect
+- docker app install
+- docker app list
+- docker app merge
+- docker app pull
+- docker app push
+- docker app render
+- docker app split
+- docker app status
+- docker app uninstall
+- docker app upgrade
+- docker app validate
+- docker app version
+clink:
+- docker_app_bundle.yaml
+- docker_app_completion.yaml
+- docker_app_init.yaml
+- docker_app_inspect.yaml
+- docker_app_install.yaml
+- docker_app_list.yaml
+- docker_app_merge.yaml
+- docker_app_pull.yaml
+- docker_app_push.yaml
+- docker_app_render.yaml
+- docker_app_split.yaml
+- docker_app_status.yaml
+- docker_app_uninstall.yaml
+- docker_app_upgrade.yaml
+- docker_app_validate.yaml
+- docker_app_version.yaml
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_bundle.yaml
+++ b/_data/docker-app/docker_app_bundle.yaml
@@ -1,0 +1,24 @@
+command: docker app bundle
+short: Create a CNAB invocation image and `bundle.json` for the application
+long: Create a CNAB invocation image and `bundle.json` for the application
+usage: docker app bundle [APP_NAME] [--output OUTPUT_FILE]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: output
+  shorthand: o
+  value_type: string
+  default_value: bundle.json
+  description: Output file (- for stdout)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app bundle myapp.dockerapp
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_completion.yaml
+++ b/_data/docker-app/docker_app_completion.yaml
@@ -1,0 +1,24 @@
+command: docker app completion
+short: Generates completion scripts for the specified shell (bash or zsh)
+long: |
+  # Load the "docker app" completion code for bash into the current shell
+  . <(docker app completion bash)
+  # Set the "docker app" completion code for bash to autoload on startup in your ~/.bashrc,
+  # ~/.profile or ~/.bash_profile
+  . <(docker app completion bash)
+  # Note: bash-completion is needed.
+
+  # Load the "docker app" completion code for zsh into the current shell
+  source <(docker app completion zsh)
+  # Set the "docker app" completion code for zsh to autoload on startup in your ~/.zshrc,
+  source <(docker app completion zsh)
+usage: docker app completion SHELL
+pname: docker app
+plink: docker_app.yaml
+examples: $ . <(docker app completion bash)
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_init.yaml
+++ b/_data/docker-app/docker_app_init.yaml
@@ -1,0 +1,51 @@
+command: docker app init
+short: Initialize Docker Application definition
+long: Start building a Docker Application package. If there is a docker-compose.yml
+  file in the current directory it will be copied and used.
+usage: docker app init APP_NAME [--compose-file COMPOSE_FILE] [--description DESCRIPTION]
+  [--maintainer NAME:EMAIL ...] [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: compose-file
+  value_type: string
+  description: Compose file to use as application base (optional)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: description
+  value_type: string
+  description: Human readable description of your application (optional)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: maintainer
+  value_type: stringArray
+  default_value: '[]'
+  description: |
+    Name and email address of person responsible for the application (name:email) (optional)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: single-file
+  value_type: bool
+  default_value: "false"
+  description: Create a single-file Docker Application definition
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app init myapp --description "a useful description"
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_inspect.yaml
+++ b/_data/docker-app/docker_app_inspect.yaml
@@ -1,0 +1,52 @@
+command: docker app inspect
+short: Shows metadata, parameters and a summary of the Compose file for a given application
+long: Shows metadata, parameters and a summary of the Compose file for a given application
+usage: docker app inspect [APP_NAME] [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: insecure-registries
+  value_type: stringSlice
+  default_value: '[]'
+  description: |
+    Use HTTP instead of HTTPS when pulling from/pushing to those registries
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: parameters-file
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameters file
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: bool
+  default_value: "false"
+  description: Pull the bundle
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: set
+  shorthand: s
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameter value
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app inspect myapp.dockerapp
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_install.yaml
+++ b/_data/docker-app/docker_app_install.yaml
@@ -1,0 +1,115 @@
+command: docker app install
+aliases: deploy
+short: Install an application
+long: |-
+  Install an application.
+  By default, the application definition in the current directory will be
+  installed. The APP_NAME can also be:
+  - a path to a Docker Application definition (.dockerapp) or a CNAB bundle.json
+  - a registry Application Package reference
+usage: docker app install [APP_NAME] [--name INSTALLATION_NAME] [--target-context
+  TARGET_CONTEXT] [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: credential-set
+  value_type: stringArray
+  default_value: '[]'
+  description: |
+    Use a YAML file containing a credential set or a credential set present in the credential store
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: insecure-registries
+  value_type: stringSlice
+  default_value: '[]'
+  description: |
+    Use HTTP instead of HTTPS when pulling from/pushing to those registries
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: kubernetes-namespace
+  value_type: string
+  default_value: default
+  description: Kubernetes namespace to install into
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: name
+  value_type: string
+  description: Installation name (defaults to application name)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: orchestrator
+  value_type: string
+  description: Orchestrator to install on (swarm, kubernetes)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: parameters-file
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameters file
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: bool
+  default_value: "false"
+  description: Pull the bundle
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: set
+  shorthand: s
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameter value
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: target-context
+  value_type: string
+  description: |
+    Context on which the application is installed (default: <current-context>)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: with-registry-auth
+  value_type: bool
+  default_value: "false"
+  description: Sends registry auth
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: |-
+  $ docker app install myapp.dockerapp --name myinstallation --target-context=mycontext
+  $ docker app install myrepo/myapp:mytag --name myinstallation --target-context=mycontext
+  $ docker app install bundle.json --name myinstallation --credential-set=mycredentials.yml
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_list.yaml
+++ b/_data/docker-app/docker_app_list.yaml
@@ -1,0 +1,22 @@
+command: docker app list
+aliases: ls
+short: List the installations and their last known installation result
+long: List the installations and their last known installation result
+usage: docker app list [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: target-context
+  value_type: string
+  description: List installations on this context
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_merge.yaml
+++ b/_data/docker-app/docker_app_merge.yaml
@@ -1,0 +1,23 @@
+command: docker app merge
+short: Merge a directory format Docker Application definition into a single file
+long: Merge a directory format Docker Application definition into a single file
+usage: docker app merge [APP_NAME] [--output OUTPUT_FILE]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: output
+  shorthand: o
+  value_type: string
+  description: 'Output file (default: in-place)'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app merge myapp.dockerapp --output myapp-single.dockerapp
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_pull.yaml
+++ b/_data/docker-app/docker_app_pull.yaml
@@ -1,0 +1,24 @@
+command: docker app pull
+short: Pull an application package from a registry
+long: Pull an application package from a registry
+usage: docker app pull NAME:TAG [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: insecure-registries
+  value_type: stringSlice
+  default_value: '[]'
+  description: |
+    Use HTTP instead of HTTPS when pulling from/pushing to those registries
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app pull docker/app-example:0.1.0
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_push.yaml
+++ b/_data/docker-app/docker_app_push.yaml
@@ -1,0 +1,44 @@
+command: docker app push
+short: Push an application package to a registry
+long: Push an application package to a registry
+usage: docker app push [APP_NAME] --tag TARGET_REFERENCE [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: insecure-registries
+  value_type: stringSlice
+  default_value: '[]'
+  description: |
+    Use HTTP instead of HTTPS when pulling from/pushing to those registries
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: platform
+  value_type: stringSlice
+  default_value: '[]'
+  description: |
+    For multi-arch service images, only push the specified platforms
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: tag
+  shorthand: t
+  value_type: string
+  description: |
+    Target registry reference (default: <name>:<version> from metadata)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app push myapp --tag myrepo/myapp:mytag
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_render.yaml
+++ b/_data/docker-app/docker_app_render.yaml
@@ -1,0 +1,72 @@
+command: docker app render
+short: Render the Compose file for an Application Package
+long: Render the Compose file for an Application Package
+usage: docker app render [APP_NAME] [--set KEY=VALUE ...] [--parameters-file PARAMETERS-FILE
+  ...] [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: formatter
+  value_type: string
+  default_value: yaml
+  description: Configure the output format (yaml|json)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: insecure-registries
+  value_type: stringSlice
+  default_value: '[]'
+  description: |
+    Use HTTP instead of HTTPS when pulling from/pushing to those registries
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: output
+  shorthand: o
+  value_type: string
+  default_value: '-'
+  description: Output file
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: parameters-file
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameters file
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: bool
+  default_value: "false"
+  description: Pull the bundle
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: set
+  shorthand: s
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameter value
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app render myapp.dockerapp --set key=value
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_split.yaml
+++ b/_data/docker-app/docker_app_split.yaml
@@ -1,0 +1,23 @@
+command: docker app split
+short: Split a single-file Docker Application definition into the directory format
+long: Split a single-file Docker Application definition into the directory format
+usage: docker app split [APP_NAME] [--output OUTPUT_DIRECTORY]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: output
+  shorthand: o
+  value_type: string
+  description: 'Output directory (default: in-place)'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app split myapp.dockerapp --output myapp-directory.dockerapp
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_status.yaml
+++ b/_data/docker-app/docker_app_status.yaml
@@ -1,0 +1,43 @@
+command: docker app status
+short: Get the installation status of an application
+long: Get the installation status of an application. If the installation is a Docker
+  Application, the status shows the stack services.
+usage: docker app status INSTALLATION_NAME [--target-context TARGET_CONTEXT] [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: credential-set
+  value_type: stringArray
+  default_value: '[]'
+  description: |
+    Use a YAML file containing a credential set or a credential set present in the credential store
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: target-context
+  value_type: string
+  description: |
+    Context on which the application is installed (default: <current-context>)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: with-registry-auth
+  value_type: bool
+  default_value: "false"
+  description: Sends registry auth
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app status myinstallation --target-context=mycontext
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_uninstall.yaml
+++ b/_data/docker-app/docker_app_uninstall.yaml
@@ -1,0 +1,51 @@
+command: docker app uninstall
+short: Uninstall an application
+long: Uninstall an application
+usage: docker app uninstall INSTALLATION_NAME [--target-context TARGET_CONTEXT] [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: credential-set
+  value_type: stringArray
+  default_value: '[]'
+  description: |
+    Use a YAML file containing a credential set or a credential set present in the credential store
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: force
+  value_type: bool
+  default_value: "false"
+  description: Force removal of installation
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: target-context
+  value_type: string
+  description: |
+    Context on which the application is installed (default: <current-context>)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: with-registry-auth
+  value_type: bool
+  default_value: "false"
+  description: Sends registry auth
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app uninstall myinstallation --target-context=mycontext
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_upgrade.yaml
+++ b/_data/docker-app/docker_app_upgrade.yaml
@@ -1,0 +1,88 @@
+command: docker app upgrade
+short: Upgrade an installed application
+long: Upgrade an installed application
+usage: docker app upgrade INSTALLATION_NAME [--target-context TARGET_CONTEXT] [OPTIONS]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: app-name
+  value_type: string
+  description: Override the installation with another Application Package
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: credential-set
+  value_type: stringArray
+  default_value: '[]'
+  description: |
+    Use a YAML file containing a credential set or a credential set present in the credential store
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: insecure-registries
+  value_type: stringSlice
+  default_value: '[]'
+  description: |
+    Use HTTP instead of HTTPS when pulling from/pushing to those registries
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: parameters-file
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameters file
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: bool
+  default_value: "false"
+  description: Pull the bundle
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: set
+  shorthand: s
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameter value
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: target-context
+  value_type: string
+  description: |
+    Context on which the application is installed (default: <current-context>)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: with-registry-auth
+  value_type: bool
+  default_value: "false"
+  description: Sends registry auth
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: $ docker app upgrade myinstallation --target-context=mycontext --set key=value
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_validate.yaml
+++ b/_data/docker-app/docker_app_validate.yaml
@@ -1,0 +1,32 @@
+command: docker app validate
+short: Checks the rendered application is syntactically correct
+long: Checks the rendered application is syntactically correct
+usage: docker app validate [APP_NAME] [--set KEY=VALUE ...] [--parameters-file PARAMETERS_FILE]
+pname: docker app
+plink: docker_app.yaml
+options:
+- option: parameters-file
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameters file
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: set
+  shorthand: s
+  value_type: stringArray
+  default_value: '[]'
+  description: Override parameter value
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/docker-app/docker_app_version.yaml
+++ b/_data/docker-app/docker_app_version.yaml
@@ -1,0 +1,12 @@
+command: docker app version
+short: Print version information
+long: Print version information
+usage: docker app version
+pname: docker app
+plink: docker_app.yaml
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -536,6 +536,42 @@ reference:
       title: Use the Docker command line
     - path: /engine/reference/commandline/docker/
       title: docker (base command)
+    - sectiontitle: docker app *
+      section:
+        - path: /engine/reference/commandline/app/
+          title: docker app
+        - path: /engine/reference/commandline/app_bundle/
+          title: docker app bundle
+        - path: /engine/reference/commandline/app_completion/
+          title: docker app completion
+        - path: /engine/reference/commandline/app_init/
+          title: docker app init
+        - path: /engine/reference/commandline/app_inspect/
+          title: docker app inspect
+        - path: /engine/reference/commandline/app_install/
+          title: docker app install
+        - path: /engine/reference/commandline/app_list/
+          title: docker app list
+        - path: /engine/reference/commandline/app_merge/
+          title: docker app merge
+        - path: /engine/reference/commandline/app_pull/
+          title: docker app pull
+        - path: /engine/reference/commandline/app_push/
+          title: docker app push
+        - path: /engine/reference/commandline/app_render/
+          title: docker app render
+        - path: /engine/reference/commandline/app_split/
+          title: docker app split
+        - path: /engine/reference/commandline/app_status/
+          title: docker app status
+        - path: /engine/reference/commandline/app_uninstall/
+          title: docker app uninstall
+        - path: /engine/reference/commandline/app_upgrade/
+          title: docker app upgrade
+        - path: /engine/reference/commandline/app_validate/
+          title: docker app validate
+        - path: /engine/reference/commandline/app_version/
+          title: docker app version
     - path: /engine/reference/commandline/attach/
       title: docker attach
     - path: /engine/reference/commandline/build/

--- a/engine/reference/commandline/app.md
+++ b/engine/reference/commandline/app.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app
+title: docker app
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_bundle.md
+++ b/engine/reference/commandline/app_bundle.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_bundle
+title: docker app bundle
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_completion.md
+++ b/engine/reference/commandline/app_completion.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_completion
+title: docker app completion
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_init.md
+++ b/engine/reference/commandline/app_init.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_init
+title: docker app init
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_inspect.md
+++ b/engine/reference/commandline/app_inspect.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_inspect
+title: docker app inspect
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_install.md
+++ b/engine/reference/commandline/app_install.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_install
+title: docker app install
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_list.md
+++ b/engine/reference/commandline/app_list.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_list
+title: docker app list
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_merge.md
+++ b/engine/reference/commandline/app_merge.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_merge
+title: docker app merge
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_pull.md
+++ b/engine/reference/commandline/app_pull.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_pull
+title: docker app pull
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_push.md
+++ b/engine/reference/commandline/app_push.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_push
+title: docker app push
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_render.md
+++ b/engine/reference/commandline/app_render.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_render
+title: docker app render
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_split.md
+++ b/engine/reference/commandline/app_split.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_split
+title: docker app split
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_status.md
+++ b/engine/reference/commandline/app_status.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_status
+title: docker app status
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_uninstall.md
+++ b/engine/reference/commandline/app_uninstall.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_uninstall
+title: docker app uninstall
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_upgrade.md
+++ b/engine/reference/commandline/app_upgrade.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_upgrade
+title: docker app upgrade
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_validate.md
+++ b/engine/reference/commandline/app_validate.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_validate
+title: docker app validate
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/app_version.md
+++ b/engine/reference/commandline/app_version.md
@@ -1,0 +1,13 @@
+---
+datafolder: docker-app
+datafile: docker_app_version
+title: docker app version
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+
+https://github.com/docker/app
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
related: https://github.com/docker/app/pull/533

marking this "WIP" as the plugin is shipping with Docker 19.03, which has not been released yet. We also need to review the information in the YAML, as we would likely want to indicate that this is a plugin.

In addition, looks like formatting of the examples (obtained from the extended description in code) doesn't work well;

<img width="430" alt="Screenshot 2019-05-04 at 14 02 14" src="https://user-images.githubusercontent.com/1804568/57184802-d24cfa80-6e75-11e9-9a76-37cd345ff73d.png">

We should either use the same approach as in the docker/cli, and move those to markdown files in the upstream repository (which will get included in the generated YAML), or find a way to add Markdown formatting to the code (and check if it gets rendered properly both on the CLI and in the docs)