### PR TITLE
Internal UCP component version updates

### DIFF
--- a/ee/ucp/ucp-architecture.md
+++ b/ee/ucp/ucp-architecture.md
@@ -68,8 +68,8 @@ on a node depend on whether the node is a manager or a worker.
 
 Internally, UCP uses the following components:
 
-* Calico v3.5
-* Kubernetes v1.11.5
+* Calico v3.5.3
+* Kubernetes v1.11.9
 
 ### UCP components in manager nodes
 


### PR DESCRIPTION
### Proposed changes

Update the UCP components (Calico and Kubernetes) versions to reflect latest GA shipping (UCP 3.1.7).
 
### Related issues (optional)
https://docs.docker.com/ee/ucp/release-notes/#317
