### PR TITLE
Removed HA Proxy Link in Interlock

### DIFF
--- a/ee/ucp/interlock/config/index.md
+++ b/ee/ucp/interlock/config/index.md
@@ -120,7 +120,6 @@ Because Interlock passes the extension configuration directly to the extension, 
 different configuration options available.  Refer to the documentation for each extension for supported options:
 
 - [Nginx](nginx-config.md)
-- [HAproxy](haproxy-config.md)
 
 #### Customize the default proxy service
 The default proxy service used by UCP to provide layer 7 routing is NGINX. If users try to access a route that hasn't been configured, they will see the default NGINX 404 page:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

It looks like as part of https://github.com/docker/docker.github.io/pull/8722 we removed the HA Proxy Config interlock. This left a dead link on https://docs.docker.com/ee/ucp/interlock/config/. 

Related issue: https://github.com/docker/docker.github.io/issues/8802

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
