### PR TITLE
Removed Ubuntu 14.04 warnings from Docker UCP install Page

### DIFF
--- a/ee/ucp/admin/install/index.md
+++ b/ee/ucp/admin/install/index.md
@@ -52,17 +52,6 @@ Make sure you follow the [UCP System requirements](system-requirements.md)
 for opening networking ports. Ensure that your hardware or software firewalls
 are open appropriately or disabled.
 
-> Ubuntu 14.04 mounts
->
-> For UCP to install correctly on Ubuntu 14.04, `/mnt` and other mounts
-> must be shared:
-> ```
-> sudo mount --make-shared /mnt
-> sudo mount --make-shared /
-> sudo mount --make-shared /run
-> sudo mount --make-shared /dev
-> ```
-
 To install UCP:
 
 1. Use ssh to log in to the host where you want to install UCP.


### PR DESCRIPTION
We dropped support for Ubuntu 14.04 in Enterprise 2.1 / UCP 3.1, however
the installation instructions still carry 14.04 warnings.

https://success.docker.com/article/compatibility-matrix

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
