### PR TITLE
fix the install using apt snippet

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -210,7 +210,7 @@ from the repository.
 2.  Install the _latest version_ of Docker CE and containerd, or go to the next step to install a specific version:
 
     ```bash
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io
+    $ sudo apt-get install docker docker-compose 
     ```
 
     > Got multiple Docker repositories?


### PR DESCRIPTION
### Proposed changes
Change the install snippet using apt (docs changes)
the original install snippet was wrong, the apt repository don't holds packages named docker-ce

### Unreleased project version (optional)


### Related issues (optional)

