### PR TITLE
Reduce user failure in part 4 port mapping.

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -170,7 +170,7 @@ to become a swarm manager with `docker swarm init` and look for output like
 this:
 
 ```shell
-$ docker-machine ssh myvm1 "docker swarm init --advertise-addr <myvm1 ip>"
+$ docker-machine ssh myvm1 "docker swarm init --advertise-addr <myvm1 ip>:2377"
 Swarm initialized: current node <node ID> is now a manager.
 
 To add a worker to this swarm, run the following command:
@@ -182,7 +182,7 @@ To add a worker to this swarm, run the following command:
 To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
 ```
 
-> Ports 2377 and 2376
+> About Ports 2377 and 2376
 >
 > Always run `docker swarm init` and `docker swarm join` with port 2377
 > (the swarm management port), or no port at all and let it take the default.


### PR DESCRIPTION
### Proposed changes
As a new user and because of the default ls output, the text at https://docs.docker.com/get-started/part4/ still maintains port 2376 as default port for setting the swarm leader. A new user, as a default procedure, will specify port 2376 when initializing a swarm manager... Despite the short quip about default management ports, the tutorial instructions can be confusing and frustrating to new users. I suggest the example command be this:

`docker-machine ssh myvm1 "docker swarm init --advertise-addr <myvm1 ip>:2377"`

Thus the note following about daemon port 2376 and setting management to port 2377 will be intuitive as will the correct procedure for setting the swarm leader.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
