### PR TITLE
Adding that DRAIN should not be used  on managers.

### DIFF
--- a/engine/swarm/swarm-tutorial/drain-node.md
+++ b/engine/swarm/swarm-tutorial/drain-node.md
@@ -17,7 +17,7 @@ node and launches replica tasks on a node with `ACTIVE` availability.
 > **Important**: Setting a node to `DRAIN` does not remove standalone containers from that node,
 > such as those created with `docker run`, `docker-compose up`, or the Docker Engine
 > API. A node's status, including `DRAIN`, only affects the node's ability to schedule
-> swarm service workloads.
+> swarm service workloads.In addition this feature may disable DTR or other node capabilities when used on Manager nodes. Using Drain on managers is highly discouraged. 
 {:.important}
 
 1.  If you haven't already, open a terminal and ssh into the machine where you


### PR DESCRIPTION
In addition this feature may disable DTR or other node capabilities when used on Manager nodes. Using Drain on managers is highly discouraged.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
