### PR TITLE
Update docker-ee.md

### DIFF
--- a/install/windows/docker-ee.md
+++ b/install/windows/docker-ee.md
@@ -159,7 +159,7 @@ manually, via a script, or on air-gapped systems.
     Stop-Service docker
     
     # Extract the archive.
-    Expand-Archive {{ filename }} -DestinationPath $Env:ProgramFiles -Force
+    Microsoft.PowerShell.Archive\Expand-Archive {{ filename }} -DestinationPath $Env:ProgramFiles -Force
 
     # Clean up the zip file.
     Remove-Item -Force {{ filename }}


### PR DESCRIPTION
Make change to allow for the ability to install even if you have the Pscx Modules installed

### Proposed changes

Change the command that is used for Expand-Archive.  There is an issue if you have the Pscx (Powershell Community Extensions) installed on a server then it will use that modules version of the Expand-Archive.  The change is just to isolate the Expand-Archive to use the Microsoft.PowerShell.Archive version of Expand-Archive

### Related issues (optional)

Fixes #8927
