### PR TITLE
Standardize “digitalocean” keyword

### DIFF
--- a/machine/drivers/digital-ocean.md
+++ b/machine/drivers/digital-ocean.md
@@ -1,6 +1,6 @@
 ---
 description: Digital Ocean driver for machine
-keywords: machine, Digital Ocean, driver
+keywords: machine, digitalocean, driver
 title: Digital Ocean
 ---
 

--- a/machine/examples/ocean.md
+++ b/machine/examples/ocean.md
@@ -1,6 +1,6 @@
 ---
 description: Using Docker Machine to provision hosts on Digital Ocean
-keywords: docker, machine, cloud, digital ocean
+keywords: docker, machine, cloud, digitalocean
 title: Digital Ocean example
 ---
 


### PR DESCRIPTION
Most DigitalOcean-related pages use the [`digitalocean`](https://docs.docker.com/glossary/?term=digitalocean) keyword, however, [one page used `digital ocean`](https://docs.docker.com/machine/examples/ocean/) and [another `Digital Ocean`](https://docs.docker.com/machine/drivers/digital-ocean/). This pull request standardizes all of them to `digitalocean`.

See also #8938.