### PR TITLE
Added logging driver section

### DIFF
--- a/install/linux/linux-postinstall.md
+++ b/install/linux/linux-postinstall.md
@@ -120,6 +120,10 @@ For information about the different storage engines, see
 The default storage engine and the list of supported storage engines depend on
 your host's Linux distribution and available kernel drivers.
 
+## Configure default logging driver
+
+Docker provides the [capability](https://docs.docker.com/config/containers/logging/) to collect and view log data from all containers running on a host via a series of logging drivers. The default logging driver, `json-file`, writes log data to JSON formatted files on the host filesystem. Over time, these log files expand in size, leading to potential exhaustion of disk resources. To alleviate such issues, either configure an alternative logging driver such as Splunk or Syslog, or [setup log rotation](https://docs.docker.com/config/containers/logging/configure/#configure-the-default-logging-driver) for the default driver.
+
 ## Configure where the Docker daemon listens for connections
 
 By default, the Docker daemon listens for connections on a UNIX socket to accept requests from local clients. It is possible to allow Docker to accept requests from remote hosts by configuring it to listen on an IP address and port as well as the UNIX socket. For more detailed information on this configuration option take a look at "Bind Docker to another host/port or a unix socket" section of the [Docker CLI Reference](https://docs.docker.com/engine/reference/commandline/dockerd/) article. 

--- a/install/linux/linux-postinstall.md
+++ b/install/linux/linux-postinstall.md
@@ -122,7 +122,7 @@ your host's Linux distribution and available kernel drivers.
 
 ## Configure default logging driver
 
-Docker provides the [capability](https://docs.docker.com/config/containers/logging/) to collect and view log data from all containers running on a host via a series of logging drivers. The default logging driver, `json-file`, writes log data to JSON formatted files on the host filesystem. Over time, these log files expand in size, leading to potential exhaustion of disk resources. To alleviate such issues, either configure an alternative logging driver such as Splunk or Syslog, or [setup log rotation](https://docs.docker.com/config/containers/logging/configure/#configure-the-default-logging-driver) for the default driver.
+Docker provides the [capability](/config/containers/logging/) to collect and view log data from all containers running on a host via a series of logging drivers. The default logging driver, `json-file`, writes log data to JSON-formatted files on the host filesystem. Over time, these log files expand in size, leading to potential exhaustion of disk resources. To alleviate such issues, either configure an alternative logging driver such as Splunk or Syslog, or [set up log rotation](/config/containers/logging/configure/#configure-the-default-logging-driver) for the default driver. If you configure an alternative logging driver, see [Use `docker logs` to read container logs for remote logging drivers](/config/containers/logging/dual-logging/).
 
 ## Configure where the Docker daemon listens for connections
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added a short blurb pointing readers to the Docker Logging Driver documentation. If a user does not setup log rotation at installation time they run the chance of maxing out the local disk with log files, bricking a cluster. Adding a pointer in the install docs, similar to the storage driver information, should help flag that need earlier in the installation process.

(Had a customer have this happen to them)