### PR TITLE
update engine deprecation policy

### DIFF
--- a/engine/index.md
+++ b/engine/index.md
@@ -98,8 +98,8 @@ on the separate [Release Notes page](/release-notes)
 As changes are made to Docker there may be times when existing features
 need to be removed or replaced with newer features. Before an existing
 feature is removed it is labeled as "deprecated" within the documentation
-and remains in Docker for at least 3 stable releases. After that time it may be
-removed.
+and remains in Docker for at least 3 stable releases unless specified
+explicitly otherwise. After that time it may be removed.
 
 Users are expected to take note of the list of deprecated features each
 release and plan their migration away from those features, and (if applicable)


### PR DESCRIPTION
### Proposed changes

Update the engine feature deprecation policy https://docs.docker.com/engine/#feature-deprecation-policy to allow for a specific, explicit period for feature removal.

### Related issues (optional)

* https://github.com/moby/moby/pull/39365
* https://github.com/docker/cli/pull/1956