### PR TITLE
Corrected command to list running containers

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -256,7 +256,7 @@ Hit `CTRL+C` in your terminal to quit.
  >
  > On Windows systems, `CTRL+C` does not stop the container. So, first
  type `CTRL+C` to get the prompt back (or open another shell), then type
- `docker container ls` to list the running containers, followed by
+ `docker container ps` to list the running containers, followed by
  `docker container stop <Container NAME or ID>` to stop the
  container. Otherwise, you get an error response from the daemon
  when you try to re-run the container in the next step.


### PR DESCRIPTION
### Proposed changes
I corrected the command so that now it will list the container IDs, which is what is needed to stop a container. Previously, the command would only list image IDs, which is useless in this context and confusing for new users.