### PR TITLE
Refine release notes on docker/orca#16122

### DIFF
--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -149,7 +149,7 @@ upgrade your installation to the latest release.
 ### Bug Fixes
 * Bump the Golang version that is used to build UCP to version 1.10.8. (docker/orca#16068)
 * Fixed an issue that caused UCP upgrade failure to upgrade with Interlock deployment. (docker/orca#16009)
-* Fixed an issue that caused Windows node ucp-agent(s) to constantly reboot when audit logging is enabled. (docker/orca#16122)
+* Fixed an issue that caused ucp-agent(s) on worker nodes to constantly reboot when audit logging is enabled. (docker/orca#16122)
 * Fixed an issue to ensure that non-admin user actions (with the RestrictedControl role) against RBAC resources are read-only. (docker/orca#16121)
 * Fixed an issue to prevent UCP users from updating services with a port that conflicts with the UCP controller port. (escalation#855)
 * Fixed an issue to validate Calico certs expiration dates and update accordingly. (escalation#981)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
UCP 3.1.4 release notes mention that `Fixed an issue that caused Windows node ucp-agent(s) to constantly reboot when audit logging is enabled. (docker/orca#16122)` . This is not accurate and some customers might ignore this issue. Actually the original issue impacts all worker nodes. For details, please see: https://github.com/docker/orca/issues/16122#issuecomment-459874081

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
