### PR TITLE
recommend overlay2

### DIFF
--- a/config/daemon/systemd.md
+++ b/config/daemon/systemd.md
@@ -57,7 +57,7 @@ To accomplish this, set the following flags in the `daemon.json` file:
 ```none
 {
     "data-root": "/mnt/docker-data",
-    "storage-driver": "overlay"
+    "storage-driver": "overlay2"
 }
 ```
 


### PR DESCRIPTION
### Proposed changes

changed overlay to overlay2 in the description about controlling storage. I blindly followed the recommendation to use overlay and tar stopped working inside the container. 

### Related issues (optional)

I saw an issue similar to this: https://github.com/coreos/bugs/issues/1095

