### PR TITLE
Update fluentd.md - Corrected default fluentd-max-retries

### DIFF
--- a/config/containers/logging/fluentd.md
+++ b/config/containers/logging/fluentd.md
@@ -123,7 +123,7 @@ How long to wait between retries. Defaults to 1 second.
 
 ### fluentd-max-retries
 
-The maximum number of retries. Defaults to `10`.
+The maximum number of retries. Defaults to `4294967295` (2**32 - 1).
 
 ### fluentd-sub-second-precision
 


### PR DESCRIPTION
### Proposed changes

Corrected default fluentd-max-retries

Reference code: https://github.com/docker/docker-ce/blob/19.03/components/engine/daemon/logger/fluentd/fluentd.go#L49
