### PR TITLE
typo last command interlock-proxy name

### DIFF
--- a/ee/ucp/interlock/config/tuning.md
+++ b/ee/ucp/interlock/config/tuning.md
@@ -30,5 +30,5 @@ updates, such as to let a service settle, use the `update-delay` setting.  For e
 thirty (30) seconds between updates, use the following command:
 
 ```bash
-$> docker service update --update-delay=30s interlock=proxy
+$> docker service update --update-delay=30s interlock-proxy
 ```


### PR DESCRIPTION
### Proposed changes

last command has service name `interlock=proxy` but should be `interlock-proxy`
