### PR TITLE
Removed L7 redirect from archive

### DIFF
--- a/datacenter/ucp/3.0/guides/user/kubernetes/layer-7-routing.md
+++ b/datacenter/ucp/3.0/guides/user/kubernetes/layer-7-routing.md
@@ -4,7 +4,6 @@ description: Learn how to route traffic to your Kubernetes workloads in
   Docker Enterprise Edition.
 keywords: UCP, Kubernetes, ingress, routing
 redirect_from:
-  - /ee/ucp/kubernetes/deploy-ingress-controller/
 ---
 
 When you deploy a Kubernetes application, you may want to make it accessible


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Removed L7 redirect from archive. I noticed this redirect was in twice in the UCP 3.0 and UCP 3.1 page, so this removes the UCP 3.0 link. 

Right now http://docker.com/ucp-9 points to the UCP 3.0 version not UCP 3.1 and I believe this is because of the duplicate redirect. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
