### PR TITLE
add DNS names used by DTR

### DIFF
--- a/ee/dtr/admin/configure/use-a-web-proxy.md
+++ b/ee/dtr/admin/configure/use-a-web-proxy.md
@@ -41,6 +41,15 @@ docker run -it --rm \
 
 > **Note**: DTR will hide the password portion of the URL, when it is displayed in the DTR UI.
 
+## DNS names used by DTR
+
+When proxy is configured to allow access only to whitelisted DNS names, make sure to whitelist these DNS names:
+
+```text
+dss-cve-updates.docker.com
+license.enterprise.docker.com
+```
+
 ## Where to go next
 
 - [Configure garbage collection](garbage-collection.md)


### PR DESCRIPTION
### Proposed changes

added list of DNS names that DTR calls to page `ee/dtr/admin/configure/use-a-web-proxy`. These DNS names should be whitelisted if proxy only works with whitelisted domains.
