### PR TITLE
Changes in part2.md for pip to work with requirements.txt

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -70,7 +70,7 @@ WORKDIR /app
 COPY . /app
 
 # Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
+RUN pip install --trusted-host pypi.python.org -r /app/requirements.txt
 
 # Make port 80 available to the world outside this container
 EXPOSE 80

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -79,7 +79,7 @@ EXPOSE 80
 ENV NAME World
 
 # Run app.py when the container launches
-CMD ["python", "app.py"]
+CMD ["python", "/app/app.py"]
 ```
 
 This `Dockerfile` refers to a couple of files we haven't created yet, namely


### PR DESCRIPTION
As you're copying all the files to /app requirements.txt has to be referenced from the /app folder to work, otherwise it returns ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'app/requirements.txt' (there is a issue on that https://github.com/docker/docker.github.io/issues/8851)

Also first PR ever so sorry in advance if I make a mistake.