### PR TITLE
better documentation on network organization

### DIFF
--- a/ee/ucp/swarm/deploy-to-collection.md
+++ b/ee/ucp/swarm/deploy-to-collection.md
@@ -111,7 +111,7 @@ To confirm that the service deployed to the `/Shared/wordpress` collection:
 It is important to note that by default Docker Stacks will create a default `overlay`
 network for your stack. It will be
 attached to each container that is deployed. This works if you have full control over
-your Default Collection or are an adminitrator. If your administrators have locked
+your Default Collection or are an administrator. If your administrators have locked
 down UCP to only allow you access to specific collections and you manage multiple
 collections, then it can get very difficult to manage the networks as well and you
 might run into permissions errors. To fix this, you must define a custom network

--- a/ee/ucp/swarm/deploy-to-collection.md
+++ b/ee/ucp/swarm/deploy-to-collection.md
@@ -109,7 +109,7 @@ To confirm that the service deployed to the `/Shared/wordpress` collection:
 ### Notes
 
 It is important to note that by default Docker Stacks will create a default `overlay`
-network for your stack if you expose any ports in any of the services. It will be
+network for your stack. It will be
 attached to each container that is deployed. This works if you have full control over
 your Default Collection or are an adminitrator. If your administrators have locked
 down UCP to only allow you access to specific collections and you manage multiple

--- a/ee/ucp/swarm/deploy-to-collection.md
+++ b/ee/ucp/swarm/deploy-to-collection.md
@@ -109,7 +109,7 @@ To confirm that the service deployed to the `/Shared/wordpress` collection:
 ### Notes
 
 It is important to note that by default Docker Stacks will create a default `overlay`
-network for your stack if you expose any ports in any of the service. It will be
+network for your stack if you expose any ports in any of the services. It will be
 attached to each container that is deployed. This works if you have full control over
 your Default Collection or are an adminitrator. If your administrators have locked
 down UCP to only allow you access to specific collections and you manage multiple

--- a/ee/ucp/swarm/deploy-to-collection.md
+++ b/ee/ucp/swarm/deploy-to-collection.md
@@ -79,7 +79,7 @@ services:
 networks:
   wp:
     driver: overlay
-    lables:
+    labels:
       com.docker.ucp.access.label: /Shared/wordpress
 ```
 

--- a/ee/ucp/swarm/deploy-to-collection.md
+++ b/ee/ucp/swarm/deploy-to-collection.md
@@ -57,20 +57,30 @@ services:
 
   wordpress:
     image: wordpress
+    networks:
+      - wp
     ports:
       - 8080:80
     environment:
       WORDPRESS_DB_PASSWORD: example
-    deploy:  
+    deploy:
       labels:
         com.docker.ucp.access.label: /Shared/wordpress
   mysql:
     image: mysql:5.7
+    networks:
+      - wp
     environment:
       MYSQL_ROOT_PASSWORD: example
-    deploy:  
+    deploy:
       labels:
         com.docker.ucp.access.label: /Shared/wordpress
+
+networks:
+  wp:
+    driver: overlay
+    lables:
+      com.docker.ucp.access.label: /Shared/wordpress
 ```
 
 To deploy the application:
@@ -95,6 +105,21 @@ To confirm that the service deployed to the `/Shared/wordpress` collection:
    make sure that the **Collection** is `/Shared/wordpress`.
 
 ![](../images/deploy-stack-to-collection-2.png){: .with-border}
+
+### Notes
+
+It is important to note that by default Docker Stacks will create a default `overlay`
+network for your stack if you expose any ports in any of the service. It will be
+attached to each container that is deployed. This works if you have full control over
+your Default Collection or are an adminitrator. If your administrators have locked
+down UCP to only allow you access to specific collections and you manage multiple
+collections, then it can get very difficult to manage the networks as well and you
+might run into permissions errors. To fix this, you must define a custom network
+and attach that to each service. The network must have the same `com.docker.ucp.access.label`
+Label as your service. If configured correctly, then your network will correctly
+be grouped with the other resources in your stack.
+
+
 
 ## Where to go next
 


### PR DESCRIPTION
### Proposed changes
Currently in UCP if your administrators use Swarm Collections heavily and do not grant everyone else full administrative privileges, then it can become confusing and cumbersome as users have networks and other stack resources existing in separate collections. For example, let's say we have a new user named `billy` and he has access to several collections:
* `/Swarm/Shared/Private/billy` => View Only access. This is the default set by UCP on the first login of `billy` and we have the default Grant to be `View Only`
* `/Swarm/service1` => Full Control access. This is where Billy and his team deploy one of their services
* `/Swarm/service2` => Full Control access. This is where Billy is creating a new service for his team

The user `billy` has his Default Collection set to the default value of `/Swarm/Shared/Private/billy` and doesn't change it because he manages multiple collections, so a default collection does not mean much to him. 

After he is ready to deploy `service2`, he runs `docker stack deploy -c service1.yaml service2` with the following compose file:
```
version: '3.6'

services:
  web:
    image: nginx:latest
    ports:
      - mode: host
        protocol: tcp
        target: 80
    deploy:
      replicas: 1
      update_config:
        parallelism: 1
        failure_action: rollback
        delay: 30s
      labels:
        com.docker.ucp.access.label: "/service2"
      resources:
        limits:
            memory: 128M
        reservations:
            memory: 128M
```

He then receives an error like this:
```
Creating network service2_default
failed to create network service2_default: Error response from daemon: access denied:
no access to Network Create, on collection swarm/shared/private/billy
```

He is very confused because this is what the documentation says to do [here](https://docs.docker.com/ee/ucp/swarm/deploy-to-collection/). 

...

This scenario (and those like it) is what this documentation PR is trying to solve. I'm not 100% sure the wording is correct, but I want to make it clear that to correctly put networks, and really all resources in a stack, into the expected collection, then the user MUST set the label accordingly. The confusing part currently is that the network is automatically created by the `docker stack deploy...` command, so it can easily go unnoticed by the user until their permissions are locked down further.