### PR TITLE
Update release notes with a reference to CVE-2019-13139

### DIFF
--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -106,7 +106,7 @@ consistency and compatibility reasons.
 
 ### Builder
 
-* Added validation for `git ref` to avoid misinterpretation as a flag. [moby/moby#38944](https://github.com/moby/moby/pull/38944)
+* Fixed [CVE-2019-13139](https://nvd.nist.gov/vuln/detail/CVE-2019-13139) by adding validation for `git ref` to avoid misinterpretation as a flag. [moby/moby#38944](https://github.com/moby/moby/pull/38944)
 
 ### Runtime
 


### PR DESCRIPTION
### Proposed changes

Update the release notes to reflect that 18.09.4 included a fix for CVE-2019-13139. 

_Note:_ the link 404's at the moment. Once the CVE is listed in the release notes Mitre will change the CVE state from RESERVED, and the link will become active. 🐔  and 🥚 situation.

### Unreleased project version (optional)

### Related issues (optional)

https://github.com/moby/moby/pull/38944 (merged)