### PR TITLE
Fix docker logging's options indentation that would cause ScannerError when copied

### DIFF
--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -46,8 +46,8 @@ If you are using Docker Compose, set `awslogs` using the following declaration e
 myservice:
   logging:
     driver: awslogs
-      options:
-        awslogs-region: us-east-1
+    options:
+      awslogs-region: us-east-1
 ```
           
 ## Amazon CloudWatch Logs options


### PR DESCRIPTION
### Proposed changes

Fix docker logging's options incorrect indentation that would cause yaml.scanner.ScannerError when copied directly to `docker-compose.yml` and it might confuse developers.

Link: https://docs.docker.com/config/containers/logging/awslogs/