### PR TITLE
put emphasis on current online gc method

### DIFF
--- a/ee/dtr/admin/configure/garbage-collection.md
+++ b/ee/dtr/admin/configure/garbage-collection.md
@@ -16,11 +16,11 @@ the scheduled time, DTR:
 1. Identifies and marks unused image layers.
 2. Deletes the marked image layers.
 
-Starting in DTR 2.5, we introduced an experimental feature which lets you run garbage collection jobs
-without putting DTR in read-only mode. As of v2.6, online garbage collection is no longer in 
-experimental mode. This means that the registry no longer has to be in read-only mode (or offline) 
-during garbage collection. 
-
+As of v2.6, garbage collection runs without putting DTR into read-only mode.
+This is known as online garbage collection. In previous versions, DTR would be
+put into read-only mode and reject pushes while it ran. Online garbage
+collection was an experimental feature in v2.5 and is the default,
+non-experimental mode in v2.6.
 
 ## Schedule garbage collection
 

--- a/ee/dtr/admin/configure/garbage-collection.md
+++ b/ee/dtr/admin/configure/garbage-collection.md
@@ -16,11 +16,10 @@ the scheduled time, DTR:
 1. Identifies and marks unused image layers.
 2. Deletes the marked image layers.
 
-As of v2.6, garbage collection runs without putting DTR into read-only mode.
-This is known as online garbage collection. In previous versions, DTR would be
-put into read-only mode and reject pushes while it ran. Online garbage
-collection was an experimental feature in v2.5 and is the default,
-non-experimental mode in v2.6.
+As of v2.6, DTR uses online garbage collection. This allows DTR to run garbage
+collection without setting DTR to read-only/offline mode. In previous versions,
+garbage collection would set DTR to read-only/offline mode so DTR would reject
+pushes. Online garbage collection was an experimental feature in v2.5.
 
 ## Schedule garbage collection
 


### PR DESCRIPTION
changed the order of the information to highlight the current behavior, while preserving the past behavior as an afterthought. Calling out the past behavior in the current version of the docs is relevant because many may not know that the behavior changed.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

clarify information about a behavior change for both new and existing users of DTR
