### PR TITLE
add-ubuntu-disco-to-the-supported-list

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -32,6 +32,7 @@ To learn more about Docker EE, see
 To install Docker Engine - Community, you need the 64-bit version of one of these Ubuntu
 versions:
 
+- Disco 19.04
 - Cosmic 18.10
 - Bionic 18.04 (LTS)
 - Xenial 16.04 (LTS)


### PR DESCRIPTION
### Proposed changes

Since the latest docker release, 19.03.0 there are stable packages available for Ubuntu 19.04 (Disco). Sadly the are not mentioned in the official documentation yet.

I've added Ubuntu 19.04 to the supported list.
