### PR TITLE
Fix confusing 'log-opt' key in json part of docs

### DIFF
--- a/config/containers/logging/json-file.md
+++ b/config/containers/logging/json-file.md
@@ -20,13 +20,13 @@ only one container.
 ## Usage
 
 To use the `json-file` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
+and `log-opts` keys to appropriate values in the `daemon.json` file, which is
 located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more information about
+`C:\ProgramData\docker\config\` on Windows Server. For more information about
 configuring Docker using `daemon.json`, see
 [daemon.json](/engine/reference/commandline/dockerd.md#daemon-configuration-file).
 
-The following example sets the log driver to `json-file` and sets the `max-size` and 'max-file' options.
+The following example sets the log driver to `json-file` and sets the `max-size` and `max-file` options.
 
 ```json
 {
@@ -37,7 +37,7 @@ The following example sets the log driver to `json-file` and sets the `max-size`
   }
 }
 ```
-**Note**: `log-opt` configuration options in the `daemon.json` configuration		
+**Note**: `log-opts` configuration options in the `daemon.json` configuration		
 file must be provided as strings. Boolean and numeric values (such as the value		
 for `max-file` in the example above) must therefore be enclosed in quotes (`"`).
 


### PR DESCRIPTION
### Proposed changes

I changed the `log-opt` key to `log-opts` in the documentation of logging drivers in the part where `json` configs are used, because this causes confusion which of the keys is the correct one.