### PR TITLE
Add Azure NIC requirement and clarify azure.json requirement

### DIFF
--- a/ee/ucp/admin/install/cloudproviders/install-on-azure.md
+++ b/ee/ucp/admin/install/cloudproviders/install-on-azure.md
@@ -45,6 +45,7 @@ to successfully deploy Docker UCP on Azure:
   Configuration](#considerations-for-ipam-configuration).
 - All UCP worker and manager nodes need to be attached to the same Azure
   Subnet.
+- All UCP Nodes NIC's (Network Interface) must have IP forwarding enabled.
 - Internal IP addresses for all nodes should be [set to
   Static](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-static-private-ip-arm-pportal),
   rather than the default of Dynamic.
@@ -69,7 +70,7 @@ objects are being deployed.
 
 ### Azure Configuration File
 
-For Docker UCP to integrate with Microsoft Azure,each UCP node in your cluster
+For Docker UCP to integrate with Microsoft Azure, each UCP node in your cluster that runs `kubelet` component
 needs an Azure configuration file, `azure.json`. Place the file within
 `/etc/kubernetes`. Since the config file is owned by `root`, set its permissions 
 to `0644` to ensure the container user has read access.


### PR DESCRIPTION
### Proposed changes

Requirements list is missing instruction to enable `IP Forwarding` for each UCP node NIC.

Clarified that `azure.json` is needed only on nodes that run `kubelet` component. At the moment it's not used on Windows workers.