### PR TITLE
Add missing dependency to Run a container example

### DIFF
--- a/develop/sdk/examples.md
+++ b/develop/sdk/examples.md
@@ -41,7 +41,7 @@ package main
 
 import (
 	"os"
-
+	"io"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"


### PR DESCRIPTION
### Proposed changes 

The `io` library needs to be imported for the **Run a container** example in [Docker Go SDK examples](https://docs.docker.com/develop/sdk/examples/) to compile successfully. This PR adds `io` lib to the example. 
