### PR TITLE
log-opts is a JSON object not an array in daemon.json

### DIFF
--- a/config/containers/logging/configure.md
+++ b/config/containers/logging/configure.md
@@ -35,7 +35,7 @@ logging driver to `syslog`:
 ```
 
 If the logging driver has configurable options, you can set them in the
-`daemon.json` file as a JSON array with the key `log-opts`. The following
+`daemon.json` file as a JSON object with the key `log-opts`. The following
 example sets two configurable options on the `json-file` logging driver:
 
 ```json


### PR DESCRIPTION
### Proposed changes

"log-opts" is a JSON object not an array in daemon.json
