### PR TITLE
suse.md: info about sles and docker-ee versions

### DIFF
--- a/install/linux/docker-ee/suse.md
+++ b/install/linux/docker-ee/suse.md
@@ -178,19 +178,21 @@ from the repository.
 
     ```bash
     $ DOCKER_EE_BASE_URL="<DOCKER-EE-URL>"
-    $ DOCKER_EE_URL="${DOCKER_EE_BASE_URL}/sles/12.3/<ARCHITECTURE>/stable-<VERSION>"
+    $ DOCKER_EE_URL="${DOCKER_EE_BASE_URL}/sles/<SLES_VERSION>/<ARCH>/stable-<DOCKER_VERSION>"
     ```
 
     Where:
     * `DOCKER-EE-URL` is the URL from your Docker Hub subscription.
-    * `ARCHITECTURE` is `x86_64`, `s390x`, or `ppc64le`.
-    * `VERSION` is `18.09` 
+    * `SLES_VERSION` is `15` or `12.3`.
+    * `ARCH` is `x86_64`, `s390x`, or `ppc64le`.
+    * `DOCKER_VERSION` is `19.03` or one of the older releases (`18.09`, `18.03`, `17.06` etc.)
 
     As an example your command should look like:
 
     ```bash
 
     DOCKER_EE_BASE_URL="https://storebits.docker.com/ee/sles/sub-555-55-555"
+    DOCKER_EE_URL="${DOCKER_EE_BASE_URL}/sles/15/x86_64/stable-19.03
     
     ```
 


### PR DESCRIPTION
1. `12.3` is not the only SLES version supported.

2. Latest Docker EE version is 19.03

3. Provide a complete example.