### PR TITLE
Fix CLI commands in UCP / DTR Backup and Restore

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -172,11 +172,12 @@ defaults:
       ucp_org: "docker"
       ucp_repo: "ucp"
       ucp_version: "3.2.0"
-  - scope: # This is a bit of a hack for the get-support.md topic.
+  - scope: # This is a bit of a hack for the get-support.md and /ee/admin/
       path: "ee"
     values:
       ucp_org: "docker"
       ucp_repo: "ucp"
+      dtr_org: "docker"
       dtr_repo: "dtr"
       ucp_version: "3.2.0"
       dtr_version: "2.7.1"

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -3764,7 +3764,7 @@ manuals:
         title: Back up UCP
       - path: /ee/admin/backup/back-up-dtr/
         title: Back up DTR
-      - path: /cluster/reference/backup/
+      - path: /engine/reference/commandline/cluster_backup/
         title: Back up clusters with Docker Cluster
     - sectiontitle: Restore Docker Enterprise
       section:

--- a/ee/admin/backup/back-up-dtr.md
+++ b/ee/admin/backup/back-up-dtr.md
@@ -4,6 +4,8 @@ description: Learn how to create a DTR backup
 keywords: enterprise, backup, dtr, disaster recovery
 redirect_from:
  - /ee/dtr/admin/disaster-recovery/create-a-backup/
+toc_max: 3
+toc_min: 1
 ---
 
 Backups do not cause downtime for DTR.
@@ -36,7 +38,7 @@ restore. If you have not previously performed a backup, the web interface displa
 
 To create a DTR backup, perform the following steps:
 
-1. Run [docker/dtr backup](/reference/dtr/{{site.dtr_version}}/cli/backup/)
+1. Run [DTR Backup command](#run-the-dtr-backup-command-cli)
 2. [Back up DTR image content](#back-up-image-content)
 3. [Back up DTR metadata](#back-up-dtr-metadata)
 4. [Verify your backup](#verify-your-backup)
@@ -58,7 +60,7 @@ From a terminal [using a UCP client bundle]((/ee/ucp/user-access/cli/), run:
 
 {% raw %}
 ```bash
-docker ps --format "{{.Names}}" | grep dtr
+$ docker ps --format "{{.Names}}" | grep dtr
 
 # The list of DTR containers with <node>/<component>-<replicaID>, e.g.
 # node-1/dtr-api-a1640e1c15b6
@@ -72,12 +74,12 @@ Another way to determine the replica ID is to SSH into a DTR node and run the fo
 
 {% raw %}
 ```bash
-REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
+$ REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
 && echo $REPLICA_ID
 ```
 {% endraw %}
 
-#### Back up image content
+### Back up image content
 
 Since you can configure the storage backend that DTR uses to store images,
 the way you back up images depends on the storage backend you're using.
@@ -88,7 +90,7 @@ and creating a tar archive of the [dtr-registry volume](/ee/dtr/architecture/):
 
 {% raw %}
 ```none
-sudo tar -cf {{ image_backup_file }} \
+$ sudo tar -cf {{ image_backup_file }} \
 -C /var/lib/docker/volumes/ dtr-registry-<replica-id>
 ```
 {% endraw %}
@@ -97,20 +99,25 @@ If you're using a different storage backend, follow the best practices
 recommended for that system.
 
 
-#### Back up DTR metadata
+### Back up DTR metadata
 
 To create a DTR backup, load your UCP client bundle, and run the following
 command, replacing the placeholders with real values:
 
 ```bash
-read -sp 'ucp password: ' UCP_PASSWORD;
+$ read -sp 'ucp password: ' UCP_PASSWORD;
 ```
 
-This prompts you for the UCP password. Next, run the following to back up your DTR metadata and save the result into a tar archive. You can learn more about the supported flags in
-the [reference documentation](/reference/dtr/2.6/cli/backup/).
+This prompts you for the UCP password. Next, run the following to back up your
+DTR metadata and save the result into a tar archive. You can learn more about
+the supported flags in the [reference
+documentation](/reference/dtr/2.7/cli/backup/).
 
 ```bash
-docker run --log-driver none -i --rm \
+$ docker container run \
+  --rm \
+  --interactive \
+  --log-driver none \
   --env UCP_PASSWORD=$UCP_PASSWORD \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} backup \
   --ucp-url <ucp-url> \
@@ -124,7 +131,6 @@ Where:
 * `<ucp-url>` is the url you use to access UCP.
 * `<ucp-username>` is the username of a UCP administrator.
 * `<replica-id>` is the id of the DTR replica to backup.
-
 
 By default the backup command doesn't stop the DTR replica being backed up.
 This means you can take frequent backups without affecting your users.
@@ -141,7 +147,6 @@ gpg --symmetric {{ metadata_backup_file }}
 
 This prompts you for a password to encrypt the backup, copies the backup file
 and encrypts it.
-
 
 ## Verify your backup
 
@@ -179,12 +184,5 @@ cluster. Then restore DTR on that new cluster to confirm that everything is
 working as expected.
 
 ### Where to go next
-- [Configure your storage backend](/ee/dtr/admin/configure/external-storage/)
-- [Switch your storage backend](/ee/dtr/admin/configure/external-storage/storage-backend-migration/)
-- [Use NFS](/ee/dtr/admin/configure/external-storage/nfs/)
-- [Use S3](/ee/dtr/admin/configure/external-storage/s3/)
-- CLI reference pages
-  - [docker/dtr install](/reference/dtr/2.6/cli/install/)
-  - [docker/dtr reconfigure](/reference/dtr/2.6/cli/reconfigure/)
-  - [docker/dtr restore](/reference/dtr/2.6/cli/restore/)
+- [Restoring Docker Enterprise](/ee/admin/restore/)
 

--- a/ee/admin/backup/back-up-ucp.md
+++ b/ee/admin/backup/back-up-ucp.md
@@ -71,35 +71,45 @@ There are several options for creating a UCP backup:
 The backup process runs on one manager node.
 
 ### Create a UCP backup using the CLI
-The following example shows how to create a UCP manager node backup, encrypt it by using a passphrase, decrypt it, verify its contents, and store it on `/directory1/directory2/backup.tar`: 
+The following example shows how to create a UCP manager node backup, encrypt it
+by using a passphrase, decrypt it, verify its contents, and store it locally on
+the node at `/tmp/mybackup.tar`:
 
-1. Run the `{{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} backup` command on a single UCP manager and include the `--file` and `--include-logs`options. This creates a tar archive with the contents of all [volumes used by UCP](/ee/ucp-architecture/)
-and streams it to `stdout`. Replace `version` with the version you are currently running.
+1. Run the `{{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }}
+   backup` command on a single UCP manager and include the `--file` and
+`--include-logs`options. This creates a tar archive with the contents of all
+[volumes used by UCP](/ee/ucp-architecture/) and streams it to `stdout`.
+Replace `{{ page.ucp_version }}` with the version you are currently running.
 
 ```bash
-docker container run \
-    --log-driver none --rm \
+$ docker container run \
+    --rm \
     --interactive \
+    --log-driver none \
     --name ucp \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /tmp:/backup \
-    $ORG/ucp:$TAG backup \
-    --file directory1/directory2/mybackup.tar \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    --volume /tmp:/backup \
+    {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} backup \
+    --file mybackup.tar \
     --passphrase "secret12chars" \
     --include-logs false
 ```
 
-> **Note**: If you are running with Security-Enhanced Linux (SELinux) enabled, which is typical for RHEL hosts, you must include `--security-opt label=disable` in the `docker` command (replace `version` with the version you are currently running):
+> **Note**: If you are running with Security-Enhanced Linux (SELinux) enabled,
+> which is typical for RHEL hosts, you must include `--security-opt
+> label=disable` in the `docker` command (replace `version` with the version
+> you are currently running):
 
 ```bash
-docker container run \
+$ docker container run \
     --rm \
-   --log-driver=none \ 
+    --interactive \
+    --log-driver none \
     --security-opt label=disable \
     --name ucp \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    docker/ucp:$version backup \
-    --passphrase "secret12chars" > /directory1/directory2/backup.tar
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} backup \
+    --passphrase "secret12chars" > /tmp/mybackup.tar
  ```   
 
 > To determine whether SELinux is enabled in the engine, view the host’s `/etc/docker/daemon.json` file, and search for the string `"selinux-enabled":"true"`.
@@ -240,5 +250,5 @@ The following table describes the backup schema returned by the `GET` and `LIST`
 
 ### Where to go next
 
-- [Back up DTR](back-up-dtr)
+- [Back up the Docker Trusted Registry](./back-up-dtr/)
  

--- a/ee/admin/backup/index.md
+++ b/ee/admin/backup/index.md
@@ -35,4 +35,4 @@ a fresh installation on a separate infrastructure with the backup. Refer to [Res
 
 ### Where to go next
 
-- [Back up Docker Swarm](back-up-swarm)
+- [Back up Docker Swarm](./back-up-swarm/)

--- a/ee/admin/disaster-recovery.md
+++ b/ee/admin/disaster-recovery.md
@@ -51,7 +51,7 @@ desired number of managers.
 
 ```bash
 # From the node to recover
-docker swarm init --force-new-cluster --advertise-addr node01:2377
+$ docker swarm init --force-new-cluster --advertise-addr node01:2377
 ```
 
 When you run the `docker swarm init` command with the `--force-new-cluster`
@@ -226,7 +226,7 @@ client bundle to run:
 
 {% raw %}
 ```bash
-docker ps --format "{{.Names}}" | grep dtr
+$ docker ps --format "{{.Names}}" | grep dtr
 
 # The list of DTR containers with <node>/<component>-<replicaID>, e.g.
 # node-1/dtr-api-a1640e1c15b6
@@ -237,7 +237,7 @@ Another way to determine the replica ID is to SSH into a DTR node and run the fo
 
 {% raw %}
 ```bash
-REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
+$ REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
 && echo $REPLICA_ID
 ```
 {% endraw %}
@@ -245,7 +245,10 @@ REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) |
 Then use the UCP client bundle to remove the unhealthy replicas:
 
 ```bash
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} remove \
+$ docker container run \
+  --rm \
+  --interactive \
+  {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} remove \
   --existing-replica-id <healthy-replica-id> \
   --replica-ids <unhealthy-replica-id> \
   --ucp-insecure-tls \
@@ -268,7 +271,9 @@ Use your UCP client bundle to run the following command which prompts you for
 the necessary parameters:
 
 ```bash
-docker run -it --rm \
+$ docker container run \
+  --rm \
+  --interactive \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} join \
   --ucp-node <ucp-node-name> \
   --ucp-insecure-tls
@@ -331,7 +336,7 @@ a UCP client bundle to run:
 
 {% raw %}
 ```bash
-docker ps --format "{{.Names}}" | grep dtr
+$ docker ps --format "{{.Names}}" | grep dtr
 
 # The list of DTR containers with <node>/<component>-<replicaID>, e.g.
 # node-1/dtr-api-a1640e1c15b6
@@ -342,7 +347,7 @@ Another way to determine the replica ID is to SSH into a DTR node and run the fo
 
 {% raw %}
 ```bash
-REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
+$ REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) | cut -f 3 -d '-')
 && echo $REPLICA_ID
 ```
 {% endraw %}
@@ -350,7 +355,10 @@ REPLICA_ID=$(docker inspect -f '{{.Name}}' $(docker ps -q -f name=dtr-rethink) |
 Then, use your UCP client bundle to run the emergency repair command:
 
 ```bash
-docker run -it --rm {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} emergency-repair \
+$ docker container run \
+  --rm \
+  --interactive \
+  {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} emergency-repair \
   --ucp-insecure-tls \
   --existing-replica-id <replica-id>
 ```

--- a/ee/admin/restore/restore-dtr.md
+++ b/ee/admin/restore/restore-dtr.md
@@ -35,7 +35,9 @@ to work.
 Start by removing any DTR container that is still running:
 
 ```none
-docker run -it --rm \
+$ docker container run \
+  --rm \
+  --interactive \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} destroy \
   --ucp-insecure-tls
 ```
@@ -65,10 +67,14 @@ placeholders for the real values:
 read -sp 'ucp password: ' UCP_PASSWORD;
 ```
 
-This prompts you for the UCP password. Next, run the following to restore DTR from your backup. You can learn more about the supported flags in [docker/dtr restore](/reference/dtr/2.6/cli/restore).
+This prompts you for the UCP password. Next, run the following to restore DTR
+from your backup. You can learn more about the supported flags in [docker/dtr
+restore](/reference/dtr/2.7/cli/restore).
 
 ```bash
-docker run -i --rm \
+$ docker container run \
+  --rm \
+  --interactive \
   --env UCP_PASSWORD=$UCP_PASSWORD \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} restore \
   --ucp-url <ucp-url> \
@@ -114,5 +120,5 @@ would after a fresh installation. [Learn more](/ee/dtr/admin/configure/set-up-vu
 
 ## Where to go next
 
-- [docker/dtr restore](/reference/dtr/2.6/cli/restore/)
+- [docker/dtr restore](/reference/dtr/2.7/cli/restore/)
 

--- a/ee/admin/restore/restore-ucp.md
+++ b/ee/admin/restore/restore-ucp.md
@@ -38,16 +38,22 @@ Volumes are placed onto the host on which the UCP restore command occurs.
 The following example shows how to restore UCP from an existing backup file, presumed to be located at `/tmp/backup.tar` (replace `<UCP_VERSION>` with the version of your backup):
 
 ```
-$ docker container run --rm -i --name ucp \
-  -v /var/run/docker.sock:/var/run/docker.sock  \
+$ docker container run \
+  --rm \
+  --interactive \
+  --name ucp \
+  --volume /var/run/docker.sock:/var/run/docker.sock  \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} restore < /tmp/backup.tar
 ```
 
 If the backup file is encrypted with a passphrase, provide the passphrase to the restore operation(replace `<UCP_VERSION>` with the version of your backup):
 
 ```
-$ docker container run --rm -i --name ucp \
-  -v /var/run/docker.sock:/var/run/docker.sock  \
+$ docker container run \
+  --rm \
+  --interactive \
+  --name ucp \
+  --volume /var/run/docker.sock:/var/run/docker.sock  \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} restore --passphrase "secret" < /tmp/backup.tar  
 ```
 
@@ -56,8 +62,11 @@ backup file should be mounted to the container rather than streamed through
 `stdin`:
 
 ```none
-docker container run --rm -i --name ucp \
-  -v /var/run/docker.sock:/var/run/docker.sock \
+$ docker container run \
+  --rm \
+  --interactive \
+  --name ucp \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp/backup.tar:/config/backup.tar \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} restore -i
 ```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
The current UCP / DTR backup / restore commands do not work as the variables are not correct. I have fixed the CLI commands and standardised the formatting. 

Fixes: https://github.com/docker/docker.github.io/issues/9193

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
