### PR TITLE
fix: replace non printable characters

### DIFF
--- a/config/containers/logging/syslog.md
+++ b/config/containers/logging/syslog.md
@@ -64,7 +64,7 @@ You can set the logging driver for a specific container by using the
 
 ```bash
 docker run \
-      -–log-driver syslog –-log-opt syslog-address=udp://1.2.3.4:1111 \
+      --log-driver syslog --log-opt syslog-address=udp://1.2.3.4:1111 \
       alpine echo hello world
 ```
 


### PR DESCRIPTION
The command example sould not contains non printable character. 

If we copied the command, the docker client gave us this:

```
unknown shorthand flag: 'â' in -–log-driver
See 'docker run --help'.
```
