### PR TITLE
[ucp] agent pause typo in 3.2.0 release notes

### DIFF
--- a/ee/ucp/release-notes.md
+++ b/ee/ucp/release-notes.md
@@ -88,7 +88,7 @@ The following features are deprecated in UCP 3.2:
 - `ucp-agent-pause`
     - `ucp-agent-pause` is no longer supported. To pause UCP reconciliation on a specific node, for example, when repairing unhealthy `etcd` or `rethinkdb` replicas, you can use swarm node labels as shown in the following example:
     ```
-    docker node update --label-add com.docker.ucpagent-pause=true <NODE>
+    docker node update --label-add com.docker.ucp.agent-pause=true <NODE>
     ```
 - Windows 2016 is formally deprecated from Docker Enterprise 3.0. EOL of Windows Server 2016 support will occur in Docker 
 Enterprise 3.1. Upgrade to Windows Server 2019 for continued support on Docker Enterprise.


### PR DESCRIPTION
Source is a UCP 3.2.0 cluster:

```
$ for service in $(docker service ls --format {{.Name}} |grep agent); do docker service inspect $service --format '{{with .Spec}}{{.Name}} {{with .TaskTemplate}}{{.ContainerSpec.Image}} {{.Placement.Constraints}}{{end}}{{end}}'; done |column -t
ucp-cluster-agent       docker/ucp-agent:3.2.0      [node.platform.os==linux    node.platform.arch==x86_64  node.labels.com.docker.ucp.agent-pause!=true  node.role==manager]
ucp-manager-agent       docker/ucp-agent:3.2.0      [node.platform.os==linux    node.platform.arch==x86_64  node.labels.com.docker.ucp.agent-pause!=true  node.role==manager]
ucp-worker-agent-win-x  docker/ucp-agent-win:3.2.0  [node.platform.os==windows  node.platform.arch==x86_64  node.labels.com.docker.ucp.agent-pause!=true  node.role==worker]
ucp-worker-agent-x      docker/ucp-agent:3.2.0      [node.platform.os==linux    node.platform.arch==x86_64  node.labels.com.docker.ucp.agent-pause!=true  node.role==worker]
```