### PR TITLE
fix COPY failed

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -226,12 +226,12 @@ repository does not contain a `Dockerfile`, or if you want to build with a custo
 `Dockerfile`, without maintaining your own fork of the repository.
 
 The example below builds an image using a `Dockerfile` from `stdin`, and adds
-the `README.md` file from the ["hello-world" Git repository on GitHub](https://github.com/docker-library/hello-world).
+the `hello.c` file from the ["hello-world" Git repository on GitHub](https://github.com/docker-library/hello-world).
 
 ```bash
 docker build -t myimage:latest -f- https://github.com/docker-library/hello-world.git <<EOF
 FROM busybox
-COPY README.md .
+COPY hello.c .
 EOF
 ```
 


### PR DESCRIPTION
since README.md listed in https://github.com/docker-library/hello-world/blob/master/.dockerignore , you will get COPY failed without this change.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
