### PR TITLE
Fix link to docker-app.yaml and ingress-simple.yaml

### DIFF
--- a/ee/ucp/kubernetes/cluster-ingress/ingress.md
+++ b/ee/ucp/kubernetes/cluster-ingress/ingress.md
@@ -35,7 +35,7 @@ An example Kubernetes manifest file container all 3 deployments can be found [he
   2) Download the sample Kubernetes manifest file
 
   ```
-    $ wget https://github.com/docker/docker.github.io/tree/master/ee/ucp/kubernetes/cluster-ingress/yaml/demo-app.yaml
+  $ wget https://raw.githubusercontent.com/docker/docker.github.io/master/ee/ucp/kubernetes/cluster-ingress/yaml/demo-app.yaml
   ```
 
   3) Deploy the sample Kubernetes manifest file 

--- a/ee/ucp/kubernetes/cluster-ingress/ingress.md
+++ b/ee/ucp/kubernetes/cluster-ingress/ingress.md
@@ -105,7 +105,7 @@ For the sample application, an example manifest file with all 3 objects defined 
   2) Download the sample Kubernetes manifest file
 
   ```
-  $ wget https://github.com/docker/docker.github.io/tree/master/ee/ucp/kubernetes/cluster-ingress/yaml/ingress-simple.yaml
+  $ wget https://raw.githubusercontent.com/docker/docker.github.io/master/ee/ucp/kubernetes/cluster-ingress/yaml/ingress-simple.yaml
   ```
   
   3) Deploy the sample Kubernetes manifest file 


### PR DESCRIPTION
The link to `demo-app.yaml` was to the HTML formatted page; changed to raw format.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
