### PR TITLE
Pip fails due to MTU mismatch

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -213,6 +213,21 @@ be something like `--tag=friendlyhello:v0.0.1`.
 > `sudo service docker restart`
 >
 > Once fixed, retry to run the `build` command.
+>
+> _MTU settings_
+>
+> If the MTU(default is 1500) on the default bridge network is greater than the MTU of the host external network then `pip` > will fail. Set the MTU of the docker bridge network to match that of the host by editing (or creating) the configuration  > file at `/etc/docker/daemon.json` with the `mtu` key, as following:
+>
+> ```json
+>{
+>   "mtu": 1450
+>}
+> ```
+> Once corrected, restart the docker service.
+>
+> `sudo systemctl restart docker`
+>
+> Re-run the `build` command.
 
 ## Run the app
 

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -216,14 +216,14 @@ be something like `--tag=friendlyhello:v0.0.1`.
 >
 > _MTU settings_
 >
-> If the MTU(default is 1500) on the default bridge network is greater than the MTU of the host external network then `pip` will fail. Set the MTU of the docker bridge network to match that of the host by editing (or creating) the configuration file at `/etc/docker/daemon.json` with the `mtu` key, as following:
+> If the MTU (default is 1500) on the default bridge network is greater than the MTU of the host external network, then `pip` fails. Set the MTU of the docker bridge network to match that of the host by editing (or creating) the configuration file at `/etc/docker/daemon.json` with the `mtu` key, as follows:
 >
 > ```json
 >{
 >   "mtu": 1450
 >}
 > ```
-> Once corrected, restart the docker service.
+> Before proceeding, save `daemon.json` and restart the docker service.
 >
 > `sudo systemctl restart docker`
 >

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -216,7 +216,7 @@ be something like `--tag=friendlyhello:v0.0.1`.
 >
 > _MTU settings_
 >
-> If the MTU(default is 1500) on the default bridge network is greater than the MTU of the host external network then `pip` > will fail. Set the MTU of the docker bridge network to match that of the host by editing (or creating) the configuration  > file at `/etc/docker/daemon.json` with the `mtu` key, as following:
+> If the MTU(default is 1500) on the default bridge network is greater than the MTU of the host external network then `pip` will fail. Set the MTU of the docker bridge network to match that of the host by editing (or creating) the configuration file at `/etc/docker/daemon.json` with the `mtu` key, as following:
 >
 > ```json
 >{


### PR DESCRIPTION
When building a container, pip fails if MTU of the host external network is less than 1500. It throws the following error:

WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.org', port=443): Read timed out. (read timeout=15)",)': /simple/flask
ERROR: Could not find a version that satisfies the requirement Flask (from -r requirements.txt (line 1)) (from versions: none)
ERROR: No matching distribution found for Flask (from -r requirements.txt (line 1))
The command '/bin/sh -c pip install --trusted-host pypi.python.org -r requirements.txt' returned a non-zero code: 1

To fix it, the MTU of the docker bridge network should either be less than or equal to that of the host.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
