### PR TITLE
Install on azure reqs update 081419

### DIFF
--- a/ee/ucp/admin/install/cloudproviders/install-on-azure.md
+++ b/ee/ucp/admin/install/cloudproviders/install-on-azure.md
@@ -45,6 +45,7 @@ to successfully deploy Docker UCP on Azure:
   Configuration](#considerations-for-ipam-configuration).
 - All UCP worker and manager nodes need to be attached to the same Azure
   Subnet.
+- All UCP Nodes NIC's (Network Interface) must have IP forwarding enabled.
 - Internal IP addresses for all nodes should be [set to
   Static](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-static-private-ip-arm-pportal),
   rather than the default of Dynamic.
@@ -69,7 +70,7 @@ objects are being deployed.
 
 ### Azure Configuration File
 
-For Docker UCP to integrate with Microsoft Azure,each UCP node in your cluster
+For Docker UCP to integrate with Microsoft Azure, each UCP node in your cluster that runs `kubelet` component
 needs an Azure configuration file, `azure.json`. Place the file within
 `/etc/kubernetes`. Since the config file is owned by `root`, set its permissions 
 to `0644` to ensure the container user has read access.

--- a/ee/ucp/admin/install/cloudproviders/install-on-azure.md
+++ b/ee/ucp/admin/install/cloudproviders/install-on-azure.md
@@ -69,10 +69,11 @@ objects are being deployed.
 
 ### Azure Configuration File
 
-For Docker UCP to integrate with Microsoft Azure, each Linux UCP node in your cluster that runs `kubelet` component
-needs an Azure configuration file, `azure.json`. Place the file within
-`/etc/kubernetes`. Since the config file is owned by `root`, set its permissions 
-to `0644` to ensure the container user has read access.
+For UCP to integrate with Microsoft Azure, all Linux UCP Manager and Linux UCP
+Worker nodes in your cluster need an identical Azure configuration file,
+`azure.json`.  Place this file within `/etc/kubernetes` on each host. Since the
+configution file is owned by `root`, set its permissions to `0644` to ensure
+the container user has read access.
 
 The following is an example template for `azure.json`. Replace `***` with real values, and leave the other
 parameters as is.

--- a/ee/ucp/admin/install/cloudproviders/install-on-azure.md
+++ b/ee/ucp/admin/install/cloudproviders/install-on-azure.md
@@ -45,7 +45,6 @@ to successfully deploy Docker UCP on Azure:
   Configuration](#considerations-for-ipam-configuration).
 - All UCP worker and manager nodes need to be attached to the same Azure
   Subnet.
-- All UCP Nodes NIC's (Network Interface) must have IP forwarding enabled.
 - Internal IP addresses for all nodes should be [set to
   Static](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-static-private-ip-arm-pportal),
   rather than the default of Dynamic.
@@ -70,7 +69,7 @@ objects are being deployed.
 
 ### Azure Configuration File
 
-For Docker UCP to integrate with Microsoft Azure, each UCP node in your cluster that runs `kubelet` component
+For Docker UCP to integrate with Microsoft Azure, each Linux UCP node in your cluster that runs `kubelet` component
 needs an Azure configuration file, `azure.json`. Place the file within
 `/etc/kubernetes`. Since the config file is owned by `root`, set its permissions 
 to `0644` to ensure the container user has read access.


### PR DESCRIPTION
### Proposed changes

Added line under `Azure Prerequisites` section
- Internal IP addresses for all nodes should be [set to Static](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-static-private-ip-arm-pportal), rather than the default of Dynamic.

Added details to the first sentence under `Azure Configuration File` section
- For Docker UCP to integrate with Microsoft Azure, each Linux UCP node in your cluster that runs `kubelet` component needs an Azure configuration file, `azure.json`.

### Related issues (optional)
this is a revision of PR #9117 