### PR TITLE
Simplified EE variables in _config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -116,12 +116,17 @@ defaults:
       path: "datacenter"
     values:
       enterprise: true
+  # Latest Enterprise Platform Release
   - scope:
-      path: "ee/dtr"
+      path: "ee"
     values:
+      ucp_org: "docker"
+      ucp_repo: "ucp"
       dtr_org: "docker"
       dtr_repo: "dtr"
+      ucp_version: "3.2.0"
       dtr_version: "2.7.1"
+  # Previous DTR Releases
   - scope:
       path: "datacenter/dtr/2.6"
     values:
@@ -166,21 +171,7 @@ defaults:
     values:
       ucp_version: "1.1"
       dtr_version: "2.0"
-  - scope:
-      path: "ee/ucp"
-    values:
-      ucp_org: "docker"
-      ucp_repo: "ucp"
-      ucp_version: "3.2.0"
-  - scope: # This is a bit of a hack for the get-support.md and /ee/admin/
-      path: "ee"
-    values:
-      ucp_org: "docker"
-      ucp_repo: "ucp"
-      dtr_org: "docker"
-      dtr_repo: "dtr"
-      ucp_version: "3.2.0"
-      dtr_version: "2.7.1"
+  # Previous UCP Releases
   - scope:
       path: "datacenter/ucp/3.1"
     values:


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Before we had 2 UCP configuration variables. 1 for pages under "ee" and
1 for pages under "ee/ucp". We had the same pattern for DTR. THis commit
removes the variable at the ee/ucp level, in the hope that all files
will take it from the /ee variable.

Will check with the preview to make sure nothing has broken. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
