### PR TITLE
Added Image Storage Flag into DTR Restore 

### DIFF
--- a/ee/admin/backup/back-up-dtr.md
+++ b/ee/admin/backup/back-up-dtr.md
@@ -117,6 +117,7 @@ documentation](/reference/dtr/2.7/cli/backup/).
 $ docker container run \
   --rm \
   --interactive \
+  --tty \
   --log-driver none \
   --env UCP_PASSWORD=$UCP_PASSWORD \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} backup \

--- a/ee/admin/disaster-recovery.md
+++ b/ee/admin/disaster-recovery.md
@@ -248,6 +248,7 @@ Then use the UCP client bundle to remove the unhealthy replicas:
 $ docker container run \
   --rm \
   --interactive \
+  --tty \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} remove \
   --existing-replica-id <healthy-replica-id> \
   --replica-ids <unhealthy-replica-id> \
@@ -274,6 +275,7 @@ the necessary parameters:
 $ docker container run \
   --rm \
   --interactive \
+  --tty \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} join \
   --ucp-node <ucp-node-name> \
   --ucp-insecure-tls
@@ -358,6 +360,7 @@ Then, use your UCP client bundle to run the emergency repair command:
 $ docker container run \
   --rm \
   --interactive \
+  --tty \
   {{ page.dtr_org }}/{{ page.dtr_repo }}:{{ page.dtr_version }} emergency-repair \
   --ucp-insecure-tls \
   --existing-replica-id <replica-id>

--- a/ee/admin/restore/restore-ucp.md
+++ b/ee/admin/restore/restore-ucp.md
@@ -41,6 +41,7 @@ The following example shows how to restore UCP from an existing backup file, pre
 $ docker container run \
   --rm \
   --interactive \
+  --tty \
   --name ucp \
   --volume /var/run/docker.sock:/var/run/docker.sock  \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} restore < /tmp/backup.tar
@@ -52,6 +53,7 @@ If the backup file is encrypted with a passphrase, provide the passphrase to the
 $ docker container run \
   --rm \
   --interactive \
+  --tty \
   --name ucp \
   --volume /var/run/docker.sock:/var/run/docker.sock  \
   {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} restore --passphrase "secret" < /tmp/backup.tar  
@@ -65,6 +67,7 @@ backup file should be mounted to the container rather than streamed through
 $ docker container run \
   --rm \
   --interactive \
+  --tty \
   --name ucp \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp/backup.tar:/config/backup.tar \


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added tty into most of the commands, this is something I missed on: https://github.com/docker/docker.github.io/pull/9209

Expanded on the DTR restore command around image storage. Fixes: https://github.com/docker/docker.github.io/issues/9264

@trapier As you worked on https://success.docker.com/article/dtr-26-lost-tags-after-reconfiguring-storage where I got most of the goodness from. Do you mind taking a look? Thanks :) 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
