### PR TITLE
[sec] nginx/compose: Drop aforementioned loophole

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -181,8 +181,6 @@ Review the [requirements](/registry/recipes/index.md#requirements), then follow 
 
     registry:
       image: registry:2
-      ports:
-        - 127.0.0.1:5000:5000
       volumes:
         - ./data:/var/lib/registry
     ```


### PR DESCRIPTION
### Proposed changes

Let me quote from the receipt on nginx as an authentication handler:  

> Note: Docker does not recommend binding your registry to localhost:5000 without authentication. This creates a potential loophole in your Docker Registry security. As a result, anyone who can log on to the server where your Docker Registry is running can push images without authentication

This loophole was added a few lines below. Let's drop it.

### Unreleased project version (optional)

### Related issues (optional)
