### PR TITLE
Removed extraneous sample azure.json entries

### DIFF
--- a/ee/ucp/admin/install/cloudproviders/install-on-azure.md
+++ b/ee/ucp/admin/install/cloudproviders/install-on-azure.md
@@ -86,19 +86,10 @@ parameters as is.
     "aadClientId": "***",
     "aadClientSecret": "***",
     "resourceGroup": "***",
-    "location": "****",
-    "subnetName": "/****",
-    "securityGroupName": "****",
-    "vnetName": "****",
-    "cloudProviderBackoff": false,
-    "cloudProviderBackoffRetries": 0,
-    "cloudProviderBackoffExponent": 0,
-    "cloudProviderBackoffDuration": 0,
-    "cloudProviderBackoffJitter": 0,
-    "cloudProviderRatelimit": false,
-    "cloudProviderRateLimitQPS": 0,
-    "cloudProviderRateLimitBucket": 0,
-    "useManagedIdentityExtension": false,
+    "location": "***",
+    "subnetName": "***",
+    "securityGroupName": "***",
+    "vnetName": "***",
     "useInstanceMetadata": true
 }
 ```


### PR DESCRIPTION
### Proposed changes

Currently we specify quite a few extra lines in the `azure.json` file that are unneeded due to the default values. 

I removed `cloudProviderBackoff` and its extraneous related values, and `useManagedIdentityExtension` since the default value is the same. 

Removing these entries tidies up and simplifies the sample `azure.json` for end users.

I also standardized on 3 `***` placeholder characters, as currently there is an inconsistent mixture of sometimes 3, and sometimes 4. 