### PR TITLE
Adding new info to clarify --mount vs -v. Showing that type=volume cr…

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -85,7 +85,8 @@ always created as a directory.**
 
 If you use `--mount` to bind-mount a file or directory that does not
 yet exist on the Docker host, Docker does **not** automatically create it for
-you, but generates an error.
+you, but generates an error. If you use `type=volume`, Docker creates the
+endpoint for you.
 
 ## Start a container with a bind mount
 


### PR DESCRIPTION
Just add an info to clarify that --mount flag can create a volume as -v using the type=volume parameter.
