### PR TITLE
Adding new info to clarify --mount vs -v. Showing that type=volume cr…

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -85,7 +85,8 @@ always created as a directory.**
 
 If you use `--mount` to bind-mount a file or directory that does not
 yet exist on the Docker host, Docker does **not** automatically create it for
-you, but generates an error.
+you, but generates an error. If you use `type=volume`, Docker creates the
+endpoint for you.
 
 ## Start a container with a bind mount
 


### PR DESCRIPTION
…eates the endpoint for the user

### Proposed changes

<!--Just add an info to clarify that --mount flag can create a volume as -v using the type=volume parameter.-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
