### PR TITLE
Revert "Added build command explanation"

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -161,7 +161,6 @@ name using the `--tag` option. Use `-t` if you want to use the shorter option.
 ```shell
 docker build --tag=friendlyhello .
 ```
-The trailing .(dot) in the docker build command is to represent that the docker file is in the current directory.
 
 Where is your built image? It's in your machine's local Docker image registry:
 


### PR DESCRIPTION
Reverts docker/docker.github.io#8975

Reverting as the statement is incorrect.