### PR TITLE
Fix typo for empty vs non empty volume

### DIFF
--- a/storage/index.md
+++ b/storage/index.md
@@ -166,7 +166,7 @@ needs to write a large volume of non-persistent state data.
 
 If you use either bind mounts or volumes, keep the following in mind:
 
-- If you mount an **empty volume** into a directory in the container in which files
+- If you mount an **non-empty volume** into a directory in the container in which files
   or directories exist, these files or directories are propagated (copied)
   into the volume. Similarly, if you start a container and specify a volume which
   does not already exist, an empty volume is created for you.


### PR DESCRIPTION
In the following paragraph, it should be `non-empty volume`.

```
If you mount an **empty volume** into a directory in the container in which files
  or directories exist, these files or directories are propagated (copied)
  into the volume.
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
