### PR TITLE
Fix broken link to contribution guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ help. If a reviewer realizes you have based your work on the wrong branch, we'll
 let you know so that you can rebase it.
 
 >**Note**: To contribute code to Docker projects, see the
-[Contribution guidelines](opensource/).
+[Contribution guidelines](/opensource/).
 
 ### Files not edited here
 


### PR DESCRIPTION
Added missing forward slash

### Proposed changes

The link was broken. Displayed the github directory rather than the index file.