### PR TITLE
fixed port for wordpress docker-compose.yml - "8000:80" => "8080:80"

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -53,7 +53,7 @@ Compose to set up and run WordPress. Before starting, make sure you have
            - db
          image: wordpress:latest
          ports:
-           - "8000:80"
+           - "8080:80"
          restart: always
          environment:
            WORDPRESS_DB_HOST: db:3306


### PR DESCRIPTION
using port 8000 breaks currently. When I change to 8000 I can `docker-compose up` against it and load Wordpress in a browser fine.

Other details:

* Docker Desktop 2.1.1.0 (37260)
* Docker Compose 1.24.1
* OSX 10.14.6

### Proposed changes

updated:

```
     ports:
       - "8000:80"
```
to:

```
     ports:
       - "8000:80"
```

