### PR TITLE
Add usage command to see cache contents

### DIFF
--- a/assemble/adv-backend-manage.md
+++ b/assemble/adv-backend-manage.md
@@ -85,6 +85,6 @@ Pulling image «…»: Success
 Started container "docker-assemble-backend-username" (74476d3fdea7)
 ```
 
-For information regarding the current cache contents, run the command `docker assemble backend cache`.
+For information regarding the current cache contents, run the command `docker assemble backend cache usage`.
 
-To clean the cache, run`docker assemble backend cache purge`.
+To clean the cache, run `docker assemble backend cache purge`.


### PR DESCRIPTION
To see cache contents the command is `docker assemble backend cache usage` and not `docker assemble backend cache`.
Added a missing space between words.