### PR TITLE
Fix the effect of `--memory-swap` is unset.

### DIFF
--- a/config/containers/resource_constraints.md
+++ b/config/containers/resource_constraints.md
@@ -111,9 +111,9 @@ Its setting can have complicated effects:
   [Prevent a container from using swap](#prevent-a-container-from-using-swap).
 
 - If `--memory-swap` is unset, and `--memory` is set, the container can use
-  twice as much swap as the `--memory` setting, if the host container has swap
+  as much swap as the `--memory` setting, if the host container has swap
   memory configured. For instance, if `--memory="300m"` and `--memory-swap` is
-  not set, the container can use 300m of memory and 600m of swap.
+  not set, the container can use 600m in total of memory and swap.
 
 - If `--memory-swap` is explicitly set to `-1`, the container is allowed to use
   unlimited swap, up to the amount available on the host system.


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

**Fix the effect of `--memory-swap` is unset.**

If `--memory-swap` is unset, and `--memory` is set, the container can use as much swap as the `--memory` setting, if the host container has swap memory configured.
  For instance, if `--memory="300m"` and `--memory-swap` is not set, the
  container can use 300m of memory and 300m of swap.

The code is here https://github.com/moby/moby/blob/master/daemon/daemon_unix.go#L343-L346
### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Fixed https://github.com/docker/docker.github.io/pull/2854

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->


cc @crosbymichael @mistyhacks 