### PR TITLE
Fix liquid warnings on reset password pages

### DIFF
--- a/datacenter/ucp/3.1/guides/authorization/reset-user-password.md
+++ b/datacenter/ucp/3.1/guides/authorization/reset-user-password.md
@@ -36,7 +36,9 @@ docker run --net=host -v ucp-auth-api-certs:/tls -it "$(docker inspect --format 
 
 ### With DEBUG Global Log Level
 
+{% raw %}
 If you have DEBUG set as your global log level within UCP, running `$(docker inspect --format '{{ index .Spec.TaskTemplate.ContainerSpec.Args 0 }}` returns `--debug` instead of `--db-addr`. Pass `Args 1` to `$docker inspect` instead to reset your admin password.
+{% endraw %}
 
 {% raw %}
 ```bash

--- a/ee/ucp/authorization/reset-user-password.md
+++ b/ee/ucp/authorization/reset-user-password.md
@@ -36,7 +36,9 @@ docker run --net=host -v ucp-auth-api-certs:/tls -it "$(docker inspect --format 
 
 ### With DEBUG Global Log Level
 
+{% raw %}
 If you have DEBUG set as your global log level within UCP, running `$(docker inspect --format '{{ index .Spec.TaskTemplate.ContainerSpec.Args 0 }}` returns `--debug` instead of `--db-addr`. Pass `Args 1` to `$docker inspect` instead to reset your admin password.
+{% endraw %}
 
 {% raw %}
 ```bash


### PR DESCRIPTION
```
 => => #     Liquid Warning: Liquid syntax error (line 33): Expected end_of_string but found number in "{{ index .Spec.TaskTemplate.ContainerSpec.Args 0 }}" in datacenter/ucp/3.1/guides/authorization/reset-user-password.md
 => => #     Liquid Warning: Liquid syntax error (line 33): Expected end_of_string but found number in "{{ index .Spec.TaskTemplate.ContainerSpec.Args 0 }}" in ee/ucp/authorization/reset-user-password.md
```

ping @adrian-plata PTAL