### PR TITLE
tag and push latest docs to hub on publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,9 @@ pipeline {
             withDockerRegistry(reg) {
               sh """
                 docker build -t docs/docker.github.io:prod-${env.BUILD_NUMBER} .
+                docker tag docs/docker.github.io:prod-${env.BUILD_NUMBER} docs/docker.github.io:latest
                 docker push docs/docker.github.io:prod-${env.BUILD_NUMBER}
+                docker push docs/docker.github.io:latest .
                 unzip -o $UCP_BUNDLE
                 cd ucp-bundle-success_bot
                 export DOCKER_TLS_VERIFY=1


### PR DESCRIPTION
**Summary**
- The docker image `docs/docker.github.io:latest` needs to be up-to-date so that the Docker community can serve up the docs themselves according to to the directions in readme.md.
- Previously this had been done by an automated build but we decided it was best to consolidate this into Jenkins with the other builds.
- These changes ensure that the image is up-to-date by updating it each time there is a push to the `published` branch.

**Changes**
- `docs/docker.github.io:latest` tagged and pushed to Hub on push to `docker.github.io:published`