### PR TITLE
Added checkmark by DCI for Azure

### DIFF
--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -79,8 +79,8 @@ a CLI plugin for automated deployment and configuration, and third-party ecosyst
 | Platform  | Docker Enterprise support |
 :----------------------------------------------------------------------------------------|:-------------------------:|
 | [Amazon Web Services](..\cluster\aws.md) |  {{ page.green-check }}   |
+| Microsoft Azure  | {{ page.green-check }}  |
 | VMware  |  coming soon  |
-| Microsoft Azure  | coming soon  |
 
 ## Docker Enterprise release cycles
 


### PR DESCRIPTION
Yesterday's release of [Cluster](https://docs.docker.com/cluster/release-notes/#version-110) added support for Azure. Replaced "Coming Soon" with a Checkmark for Azure, and shuffled VMWare to the bottom row