### PR TITLE
ubuntu.md: minor update for apt-key usage

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -112,7 +112,7 @@ from the repository.
 3.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key --keyring  /etc/apt/trusted.gpg.d/docker.gpg add -
     ```
 
     Verify that you now have the key with the fingerprint


### PR DESCRIPTION
Please use the  `--keyring  /etc/apt/trusted.gpg.d/docker.gpg` option for apt-key when add a new key. It makes the installation cleaner, instead of modifying system wide binary file it creates a new dedicated one. Easier to clean up as it's enough simple delete the file (apt-key del... works too).


