### PR TITLE
Updating deprecated Kubernetes namespaces link

### DIFF
--- a/ee/ucp/authorization/group-resources.md
+++ b/ee/ucp/authorization/group-resources.md
@@ -24,7 +24,7 @@ and resource quotas for the namespace.
 Each Kubernetes resources can only be in one namespace, and namespaces cannot
 be nested inside one another.
 
-[Learn more about Kubernetes namespaces](https://v1-11.docs.kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
+[Learn more about Kubernetes namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces).
 
 ## Swarm collections
 


### PR DESCRIPTION
### Proposed changes

Updating deprecated link as Kubernetes v1.11 documentation is no longer actively maintained.

### Related issues

https://github.com/docker/docker.github.io/issues/9379
