### PR TITLE
ucp: fix whitespace on node labels doc

### DIFF
--- a/ee/ucp/admin/configure/add-labels-to-cluster-nodes.md
+++ b/ee/ucp/admin/configure/add-labels-to-cluster-nodes.md
@@ -30,13 +30,14 @@ scheduled to run on a node that has the `ssd` label.
 2. Select **Nodes** in the left-hand navigation menu.
 3. In the nodes list, select the node to which you want to apply labels.
 4. In the details pane, select the edit node icon in the upper-right corner to edit the node.
+
     ![](../../images/add-labels-to-cluster-nodes-3.png)
 
 5. In the **Edit Node** page, scroll down to the **Labels** section.
 6. Select **Add Label**.
 7. Add a label with the key `disk` and a value of `ssd`.
 
-![](../../images/add-labels-to-cluster-nodes-2.png){: .with-border}
+   ![](../../images/add-labels-to-cluster-nodes-2.png){: .with-border}
 
 8. Click **Save** then dismiss the **Edit Node** page.
 9. In the node's details pane, select **Labels** to view the labels that are applied to the node.
@@ -60,67 +61,66 @@ service to be scheduled only on nodes that have SSD storage:
 1. Navigate to the **Stacks** page.
 2. Name the new stack "wordpress".
 3. Under **Orchestrator Mode**, select **Swarm Services**.
-
 4. In the **docker-compose.yml** editor, paste the following stack file.
 
-```
-version: "3.1"
+   ```
+   version: "3.1"
 
-services:
-  db:
-    image: mysql:5.7
-    deploy:
-      placement:
-        constraints:
-          - node.labels.disk == ssd
-      restart_policy:
-        condition: on-failure
-    networks:
-      - wordpress-net
-    environment:
-      MYSQL_ROOT_PASSWORD: wordpress
-      MYSQL_DATABASE: wordpress
-      MYSQL_USER: wordpress
-      MYSQL_PASSWORD: wordpress
-  wordpress:
-    depends_on:
-      - db
-    image: wordpress:latest
-    deploy:
-      replicas: 1
-      placement:
-        constraints:
-          - node.labels.disk == ssd
-      restart_policy:
-        condition: on-failure
-        max_attempts: 3
-    networks:
-      - wordpress-net
-    ports:
-      - "8000:80"
-    environment:
-      WORDPRESS_DB_HOST: db:3306
-      WORDPRESS_DB_PASSWORD: wordpress
+   services:
+     db:
+       image: mysql:5.7
+       deploy:
+         placement:
+           constraints:
+             - node.labels.disk == ssd
+         restart_policy:
+           condition: on-failure
+       networks:
+         - wordpress-net
+       environment:
+         MYSQL_ROOT_PASSWORD: wordpress
+         MYSQL_DATABASE: wordpress
+         MYSQL_USER: wordpress
+         MYSQL_PASSWORD: wordpress
+     wordpress:
+       depends_on:
+         - db
+       image: wordpress:latest
+       deploy:
+         replicas: 1
+         placement:
+           constraints:
+             - node.labels.disk == ssd
+         restart_policy:
+           condition: on-failure
+           max_attempts: 3
+       networks:
+         - wordpress-net
+       ports:
+         - "8000:80"
+       environment:
+         WORDPRESS_DB_HOST: db:3306
+         WORDPRESS_DB_PASSWORD: wordpress
 
-networks:
-  wordpress-net:
-```
+   networks:
+     wordpress-net:
+   ```
 
 5. Click **Create** to deploy the stack, and when the stack deploys,
 click **Done**.
 
-![](../../images/use-constraints-in-stack-deployment.png)
+   ![](../../images/use-constraints-in-stack-deployment.png)
 
 6. Navigate to the **Nodes** page, and click the node that has the
 `disk` label. In the details pane, click the **Inspect Resource**
 dropdown and select **Containers**.
 
-![](../../images/use-constraints-in-stack-deployment-2.png)
+   ![](../../images/use-constraints-in-stack-deployment-2.png)
 
-Dismiss the filter and navigate to the **Nodes** page. Click a node that
-doesn't have the `disk` label. In the details pane, click the
-**Inspect Resource** dropdown and select **Containers**. There are no
-WordPress containers scheduled on the node. Dismiss the filter.
+   Dismiss the filter and navigate to the **Nodes** page. Click a node that
+   doesn't have the `disk` label. In the details pane, click the
+   **Inspect Resource** dropdown and select **Containers**. There are no
+   WordPress containers scheduled on the node. Dismiss the filter.
 
 ## Add a constraint to a service by using the UCP web UI
 


### PR DESCRIPTION
what i did:
- fix whitespace so markdown numbering is consistent

how i tested:
1. build docs locally `docker-compose build; docker-compose up -d`
2. verify numbering corrected
3. deploy compose file through UCP 3.2.1 UI to make sure its spacing was
   unaffected\*

\* note: not addressing outdated screenshots with this commit