### PR TITLE
Update to standardize Segment in to Google Tag Manager.

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -53,12 +53,13 @@
 			display: block;
 		}
 	</style>
-	<script type="text/javascript">
-	  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
-	  analytics.load("IWj9D0UpZHZdZUZX9jl98PcpBFWBnBMy");
-	  analytics.page();
-	  }}();
-	</script>
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-WL2QLG5');</script>
+	<!-- End Google Tag Manager -->
 	{% if site.GH_ENV == "gh_pages" %}
 	<meta name="robots" content="noindex">{% endif %}
 	<!-- favicon -->


### PR DESCRIPTION
### Proposed changes

Replaced JavaScript call to Segment in document head with new call to our standardized google tag manager container.  GTM allows us to add additional dimensions to Segment and Google Analytics on page load.  GTM also makes adding and removing scripts across the Docker domains easier.

Please let me know where I can test the proposed changes.

Thanks,

Erik  