### PR TITLE
Fix hello-world for Windows Server 2016

### DIFF
--- a/install/windows/docker-ee.md
+++ b/install/windows/docker-ee.md
@@ -60,9 +60,21 @@ To install the Docker Engine - Enterprise on your hosts, Docker provides a
 3.  Test your Docker Engine - Enterprise installation by running the 
     `hello-world` container.
 
+    **Windows Server 2019**
+
     ```powershell
     docker run hello-world:nanoserver
+    ```
 
+    **Windows Server 2016**
+
+    ```powershell
+    docker run hello-world:nanoserver-sac2016
+    ```
+
+    The container starts, prints the hello message, and then exits.
+
+    ```
     Unable to find image 'hello-world:nanoserver' locally
     nanoserver: Pulling from library/hello-world
     bce2fbc256ea: Pull complete
@@ -187,8 +199,16 @@ manually, via a script, or on air-gapped systems.
 
 3.  Test your Docker EE installation by running the `hello-world` container.
 
+    **Windows Server 2019**
+
     ```powershell
     docker container run hello-world:nanoserver
+    ```
+
+    **Windows Server 2016**
+
+    ```powershell
+    docker container run hello-world:nanoserver-sac2016
     ```
 
 ## Install a specific version


### PR DESCRIPTION
### Proposed changes

Improve the documentation for first time users on Windows Server 2016. On Windows Server 2016 the users have to run hello-world:nanoserver-sac2016 instead of hello-world:nanoserver as the official images no longer have the old 2016 nanoserver image in the manifest list.

Inspired by the documentation https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server#windows-server-2019 which also lists two different commands for Windows Server 2019 and 2016.

### Related issues (optional)
- docker/for-win#2695
- docker-library/hello-world#56
