### PR TITLE
Added example command for `docker context import`

### DIFF
--- a/ee/ucp/user-access/cli.md
+++ b/ee/ucp/user-access/cli.md
@@ -85,10 +85,19 @@ and the `DOCKER_CERT_PATH` environment variable to use the client certificates
 that are included in the client bundle you downloaded. The utility scripts also
 run the `kubectl config` command to configure kubectl.
 
-> **Note**: In Docker Enterprise 3.0, new files are contained in the UCP bundle. These changes support 
-the use of `.zip` files with `docker context import` and allow you to directly change your context 
-using the bundle `.zip` file. Refer to [Working with Contexts](/engine/context/working-with-contexts/) 
-for more information.
+### Use client certificates with Docker contexts
+
+In Docker Enterprise 3.0, new files are contained in the UCP bundle. These changes support 
+the use of `.zip` files with `docker context import` and allow you to directly change 
+your context using the bundle `.zip` file. Navigate to the directory where you downloaded 
+the user bundle and use `docker context import` to add the new context:
+
+```bash
+cd client-bundle && docker context import myucp ucp-bundle-$USER.zip"
+```
+
+> **Note**: Refer to [Working with Contexts](/engine/context/working-with-contexts/) 
+for more information on using Docker contexts.
 
 To confirm that your client tools are now communicating with UCP, run:
 


### PR DESCRIPTION
Added an actual `docker context import` command since the use of this command in conjunction with client bundles was not present in this or the `docker context` documentation. Also increased the emphasis of using `docker context import` vs. prior methods by pulling the new feature out of the note. This information is important and was not obvious enough in the note.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
