### PR TITLE
Incorrect key-value set

### DIFF
--- a/ee/admin/backup/back-up-ucp.md
+++ b/ee/admin/backup/back-up-ucp.md
@@ -92,7 +92,7 @@ $ docker container run \
     {{ page.ucp_org }}/{{ page.ucp_repo }}:{{ page.ucp_version }} backup \
     --file mybackup.tar \
     --passphrase "secret12chars" \
-    --include-logs false
+    --include-logs=false
 ```
 
 > **Note**: If you are running with Security-Enhanced Linux (SELinux) enabled,


### PR DESCRIPTION
### Proposed changes
--include-logs switch requires the keyvalue to be set with "="
e.g. --include-logs=false

### Related issues (optional)
https://github.com/docker/docker.github.io/pull/9376
