### PR TITLE
Update to move Google Tag Manager lower on the page.

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -53,13 +53,6 @@
 			display: block;
 		}
 	</style>
-	<!-- Google Tag Manager -->
-	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','GTM-WL2QLG5');</script>
-	<!-- End Google Tag Manager -->
 	{% if site.GH_ENV == "gh_pages" %}
 	<meta name="robots" content="noindex">{% endif %}
 	<!-- favicon -->
@@ -325,6 +318,13 @@
 				hookupTOCEvents();
 			});
 	</script>
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-WL2QLG5');</script>
+	<!-- End Google Tag Manager -->
 </body>
 
 </html>


### PR DESCRIPTION
### Proposed changes

Hi Team,

We are seeing an issue with docs.docker.com's javascript re-writing the window.location value as the page is loading.  This change is to move GTM to the bottom of the page to allow the window.location function to run before GTM is loaded.

Please let me know the staging url once the changes are built so we can test.

Thanks for the help,

Erik