### PR TITLE
Missing quote for swarm port from restore docs

### DIFF
--- a/reference/ucp/3.2/cli/restore.md
+++ b/reference/ucp/3.2/cli/restore.md
@@ -68,5 +68,5 @@ Notes:
 | `--host-address` *value*   | The network address to advertise to other nodes. Format: IP address or network interface name |
 | `--passphrase` *value*     | Decrypt the backup tar file with the provided passphrase                                      |
 | `--san` *value*            | Add subject alternative names to certificates (e.g. --san www1.acme.com --san www2.acme.com)  |
-| `--swarm-grpc-port *value* | Port for communication between nodes (default: 2377)                                          |
+| `--swarm-grpc-port` *value* | Port for communication between nodes (default: 2377)                                          |
 | `--unlock-key` *value*     | The unlock key for this swarm-mode cluster, if one exists.                                    |


### PR DESCRIPTION
Missing quote from restore docs

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

cc @DawnWood-Docker 

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
