### PR TITLE
Add notice about port binding and overriding of UFW to compose file reference

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1040,10 +1040,10 @@ on which platform the service's build will be performed.
 
 Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container
 port (an ephemeral host port is chosen).  
-Notice that when using ports which are not bound to the host (i.e. `"127.0.0.1:3000:3000"`)
-these ports will be accessible from the outside. This also applies if you configured 
-UFW to block this specific port, as Docker manages his own iptables rules. 
-[Read more](/network/iptables.md)
+Please be aware that when using ports which are not bound to the host 
+(i.e. `"80:80"` instead of `"127.0.0.1:80:80"`) these ports will be accessible from
+the outside. This also applies if you configured UFW to block this specific port,
+as Docker manages his own iptables rules. [Read more](/network/iptables.md)
 
 > **Note**: When mapping ports in the `HOST:CONTAINER` format, you may experience
 > erroneous results when using a container port lower than 60, because YAML

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1039,7 +1039,11 @@ on which platform the service's build will be performed.
 ### ports
 
 Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container
-port (an ephemeral host port is chosen).
+port (an ephemeral host port is chosen).  
+Notice that when using ports which are not bound to the host (i.e. `"127.0.0.1:3000:3000"`)
+these ports will be accessible from the outside. This also applies if you configured 
+UFW to block this specific port, as Docker manages his own iptables rules. 
+[Read more](/network/iptables.md)
 
 > **Note**: When mapping ports in the `HOST:CONTAINER` format, you may experience
 > erroneous results when using a container port lower than 60, because YAML

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1527,7 +1527,10 @@ Expose ports.
 #### Short syntax
 
 Either specify both ports (`HOST:CONTAINER`), or just the container
-port (an ephemeral host port is chosen).
+port (an ephemeral host port is chosen).  
+Notice that when using ports which are not bound to the host (i.e. `"127.0.0.1:3000:3000"`)
+these ports will be accessible from the outside, even if you configured UFW to block
+this specific port.
 
 > **Note**: When mapping ports in the `HOST:CONTAINER` format, you may experience
 > erroneous results when using a container port lower than 60, because YAML

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1528,9 +1528,10 @@ Expose ports.
 
 Either specify both ports (`HOST:CONTAINER`), or just the container
 port (an ephemeral host port is chosen).  
-Notice that when using ports which are not bound to the host (i.e. `"127.0.0.1:3000:3000"`)
-these ports will be accessible from the outside, even if you configured UFW to block
-this specific port.
+Please be aware that when using ports which are not bound to the host 
+(i.e. `"80:80"` instead of `"127.0.0.1:80:80"`) these ports will be accessible from
+the outside. This also applies if you configured UFW to block this specific port,
+as Docker manages his own iptables rules. [Read more](/network/iptables.md)
 
 > **Note**: When mapping ports in the `HOST:CONTAINER` format, you may experience
 > erroneous results when using a container port lower than 60, because YAML


### PR DESCRIPTION
### Proposed changes

I already work with Docker for a long time, but recently found out that binding ports will override / ignore UFW firewall rules. This leads to unwanted vulnerabilities if you restrict access to a specific port via UFW, add the port to a Docker compose setup and then find out that the whole world could access the app via the port because Docker manages his own iptables rules.
As this may lead to severe vulnerabilities, I added a notice to the `ports` config section of the compose file references. Nothing too heavy, just a short notice that bound port may be accessible even if blocked via UFW.
Currently, the information is kinda buried in the /network/iptables page.