### PR TITLE
Fixed doc about networking

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2288,7 +2288,6 @@ services:
 networks:
   hostnet:
     external: true
-    name: host
 ```
 
 ```yaml
@@ -2312,7 +2311,6 @@ services:
 networks:
   nonet:
     external: true
-    name: none
 ```
 
 ### driver_opts


### PR DESCRIPTION
### Proposed changes

I removed a key that is not supported:
```
networks.foobar_default value Additional properties are not allowed ('name' was unexpected)
```
with this config:
```yaml
networks:
  foobar_default:
    external: true
    name: foobar
```
Version:
```
docker-compose version
docker-compose version 1.24.1, build 4667896b
docker-py version: 3.7.3
CPython version: 3.6.8
OpenSSL version: OpenSSL 1.1.0j  20 Nov 2018
```
