### PR TITLE
Emphasizing no production environments for experimental features

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -45,10 +45,10 @@ your client and daemon API versions.
 
 {% if site.data[include.datafolder][include.datafile].experimentalcli %}
 
-> This command is experimental.
+> This command is experimental on the Docker client.
 >
-> This command is experimental on the Docker client. It should not be used in
-> production environments.
+> **It should not be used in production environments.**
+>
 > To enable experimental features in the Docker CLI, edit the
 > [config.json](/engine/reference/commandline/cli.md#configuration-files)
 > and set `experimental` to `enabled`. You can go [here](https://github.com/docker/docker.github.io/blob/master/_includes/experimental.md)


### PR DESCRIPTION
Adding bold to emphasize not to use experimental features in production environments.

Live example: https://docs.docker.com/engine/reference/commandline/assemble/
Preview example: 

Signed-off-by: Adrian Plata <adrian.plata@docker.com>

