### PR TITLE
re-organize + fix global header

### DIFF
--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -10,28 +10,26 @@
                     <div class="navbar-collapse collapse">
                         <ul class="primary nav navbar-nav">
                             <li><a href="https://docker.com/what-docker">What is Docker?</a></li>
-                            <li><a href="https://docker.com/get-docker">Product</a></li>
+                            <li><a href="https://docker.com/get-started">Product</a></li>
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Get Docker <span class="caret"></span></a>
                                 <ul class="dropdown-menu nav-main">
-                                    <h6 class="dropdown-header">For Desktops</h6>
-                                    <li><a href="https://docker.com/docker-mac">Mac</a></li>
-                                    <li><a href="https://docker.com/docker-windows">Windows</a></li>
+                                    <h6 class="dropdown-header">For Desktop</h6>
+                                    <li><a href="https://docker.com/products/docker-desktop">Mac & Windows</a></li>
                                     <h6 class="dropdown-header">For Cloud Providers</h6>
-                                    <li><a href="https://docker.com/docker-aws">AWS</a></li>
-                                    <li><a href="https://docker.com/docker-microsoft-azure">Azure</a></li>
+                                    <li><a href="https://docker.com/partners/aws">AWS</a></li>
+                                    <li><a href="https://docker.com/partners/microsoft">Azure</a></li>
                                     <h6 class="dropdown-header">For Servers</h6>
-                                    <li><a href="https://docker.com/docker-windows-server">Windows Server</a></li>
-                                    <li><a href="https://docker.com/docker-centos">CentOS</a></li>
-                                    <li><a href="https://docker.com/docker-debian">Debian</a></li>
-                                    <li><a href="https://docker.com/docker-fedora">Fedora</a></li>
-                                    <li><a href="https://docker.com/docker-oracle-linux">Oracle Enterprise Linux</a></li>
-                                    <li><a href="https://docker.com/docker-rhel">RHEL</a></li>
-                                    <li><a href="https://docker.com/docker-sles">SLES</a></li>
-                                    <li><a href="https://docker.com/docker-ubuntu">Ubuntu</a></li>
+                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-windows">Windows Server</a></li>
+                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-centos">CentOS</a></li>
+                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-debian">Debian</a></li>
+                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-fedora">Fedora</a></li>
+                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-oraclelinux">Oracle Enterprise Linux</a></li>
+                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-rhel">RHEL</a></li>
+                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-sles">SLES</a></li>
+                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-ubuntu">Ubuntu</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://docs.docker.com">Docs</a></li>
                             <li><a href="https://docker.com/docker-community">Community</a></li>
                             <li><a href="https://hub.docker.com/signup">Create Docker ID</a></li>
                             <li><a href="https://hub.docker.com/sso/start">Sign In</a></li>

--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -9,7 +9,7 @@
                     </div>
                     <div class="navbar-collapse collapse">
                         <ul class="primary nav navbar-nav">
-                            <li><a href="https://docker.com/what-docker">What is Docker?</a></li>
+                            <li><a href="https://docker.com/why-docker">Why Docker?</a></li>
                             <li><a href="https://docker.com/get-started">Product</a></li>
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Get Docker <span class="caret"></span></a>


### PR DESCRIPTION
**Changes**
- Top level menu links changed / fixed according to plans in Figma
  - What is Docker? changed to Why Docker? and link corrected
  - Product points to docker.com/get-started
  - Mac & Windows combined
  - For Cloud Providers links corrected
  - For Servers links corrected
  - Docs menu item removed
