### PR TITLE
Fix broken link to Using routing labels section

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1512,7 +1512,7 @@ manuals:
           - title: Specifying a routing mode
             path: /ee/ucp/interlock/usage/interlock-vip-mode/
           - title: Using routing labels
-            path: /ee/ucp/interlock/usage/labels-reference.md/
+            path: /ee/ucp/interlock/usage/labels-reference/
           - title: Implementing redirects
             path: /ee/ucp/interlock/usage/redirects/
           - title: Implementing a service cluster


### PR DESCRIPTION
### Proposed changes

The link to https://docs.docker.com/ee/ucp/interlock/usage/labels-reference.md/ is broken in the left-hand nav from docs.docker.com. 

### Related issues (optional)

https://docker.atlassian.net/browse/ENGDOCS-195
