### PR TITLE
Pointing to new experimental information section

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -51,7 +51,7 @@ your client and daemon API versions.
 >
 > To enable experimental features in the Docker CLI, edit the
 > [config.json](/engine/reference/commandline/cli.md#configuration-files)
-> and set `experimental` to `enabled`. You can go [here](https://github.com/docker/docker.github.io/blob/master/_includes/experimental.md)
+> and set `experimental` to `enabled`. You can go [here](https://docs.docker.com/engine/reference/commandline/cli/#experimental-features)
 > for more information.
 {: .important }
 


### PR DESCRIPTION
Pointing to a new experimental information section.

Current: https://docs.docker.com/engine/reference/commandline/app/
Currently points to: https://github.com/docker/docker.github.io/blob/master/_includes/experimental.md

Change points to: https://docs.docker.com/engine/reference/commandline/cli/#experimental-features

Signed-off-by: Adrian Plata <adrian.plata@docker.com>