### PR TITLE
Fixed links that pointed to the wrong pages in the DTR section of the ToC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -2600,9 +2600,9 @@ manuals:
         - path: /ee/dtr/admin/configure/use-your-own-tls-certificates/
           title: Use your own TLS certificates
         - path: /ee/dtr/admin/configure/enable-single-sign-on/
-          title: Disable persistent cookies
-        - path: /ee/dtr/admin/configure/disable-persistent-cookies/
           title: Enable single sign-on
+        - path: /ee/dtr/admin/configure/disable-persistent-cookies/
+          title: Disable persistent cookies
         - sectiontitle: External storage
           section:
           - path: /ee/dtr/admin/configure/external-storage/


### PR DESCRIPTION
Old topics: https://docs.docker.com/ee/dtr/admin/configure/enable-single-sign-on/
https://docs.docker.com/ee/dtr/admin/configure/disable-persistent-cookies/

New preview: https://deploy-preview-9601--docsdocker.netlify.com/ee/dtr/admin/configure/enable-single-sign-on/
https://deploy-preview-9601--docsdocker.netlify.com/ee/dtr/admin/configure/disable-persistent-cookies/