### PR TITLE
fix Jenkinsfile error wording

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
   post {
     unsuccessful {
       sh """
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"Error in docker.github.io:published build. Please contact the Customer Success Engineering team for help."}' $SLACK
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"Error in Jenkins build. Please contact the Customer Success Engineering team for help."}' $SLACK
       """
     }
   }


### PR DESCRIPTION
**Changes**
- Just a change in the wording for errors in the Jenkins build - not all errors were happening in the `docker.github.io:published` branch so it shouldn't say that. I think 'Jenkins error' is specific enough.