### PR TITLE
Hub known issues

### DIFF
--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -2,18 +2,24 @@
 title: Docker Hub release notes
 description: Learn about the new features, bug fixes, and breaking changes for Docker Hub
 keywords: docker hub, whats new, release notes
+toc_min: 1
 toc_max: 2
 ---
 
 Here you can learn about the latest changes, new features, bug fixes, and
 known issues for each Docker Hub release.
 
-## 2019-10-02
+# 2019-10-02
 
 ### Enhancements
-* You can now manage teams and members straight from your [organization page](https://hub.docker.com/orgs). Each organization page now breaks down into these tabs:
-  * **New:** Members - manage your members directly from this page (delete, add, or open their teams)
-  * **New:** Teams - search by team or username, and open up any team page to manage the team
+* You can now manage teams and members straight from your [organization page](https://hub.docker.com/orgs).
+Each organization page now breaks down into these tabs:
+  * **New:** Members - manage your members directly from this page (delete,
+  add, or open their teams)
+  * **New:** Teams - search by team or username, and open up any team page to
+  manage the team
+  * **New:** Invitees (conditional tab, only if an invite exists) - resend or
+  remove invitiations from this tab
   * Repositories
   * Settings
   * Billing
@@ -22,22 +28,34 @@ known issues for each Docker Hub release.
 
 * Fixed an issue where Kinematic could not connect and log in to Docker Hub.
 
+### Known Issues
 
-## 2019-09-19
+* Scan results don't appear for some official images.
+
+
+# 2019-09-19
 
 ### New features
 
 * You can now [create personal access tokens](access-tokens.md) in Docker Hub and use them to authenticate from the Docker CLI. Find them in your account settings, under the new **[Security](https://hub.docker.com/settings/security)** section.
 
+### Known Issues
 
-## 2019-09-16
+* Scan results don't appear for some official images.
+
+
+# 2019-09-16
 
 ### Enhancements
 
 * The [billing page](https://docs.docker.com/docker-hub/upgrade/) for personal accounts has been updated. You can access the page at its new URL: [https://hub.docker.com/billing/plan](https://hub.docker.com/billing/plan).
 
+### Known Issues
 
-## 2019-09-05
+* Scan results don't appear for some official images.
+
+
+# 2019-09-05
 
 ### Enhancements
 


### PR DESCRIPTION
Added Hub known issue with scanning to every release, and added missing "invitees" tab to teams and orgs note

Old link: https://docs.docker.com/docker-hub/release-notes
New link: https://deploy-preview-9625--docsdocker.netlify.com/docker-hub/release-notes/