### PR TITLE
Add brew services instructions

### DIFF
--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -354,8 +354,17 @@ each shell session, you can embed `eval $(docker-machine env default)` in your
 shell profiles, by adding it to the `~/.bash_profile` file or the equivalent
 configuration file for your shell. However, this fails if a machine called
 `default` is not running. You can configure your system to start the `default`
-machine automatically. The following example shows how to do this in macOS.
+machine automatically. The following examples show how to do this in macOS.
 
+### If you are using Homebrew
+
+`brew services` is available by default in any [Homebrew installation](https://brew.sh/). It is a convenience wrapper around `launchd`.
+
+`brew services start docker-machine`
+
+### Using launchd
+
+`launchd` comes with macOS by default, so it is not necessary to install anything.
 
 Create a file called `com.docker.machine.default.plist` in the
 `~/Library/LaunchAgents/` directory, with the following content:


### PR DESCRIPTION
### Proposed changes

Added `brew services` instructions. I think Homebrew is common enough among developers on macOS to include here, and `brew services` makes starting local machines on startup very easy, especially for people not familiar with how `launchd` works.

### Unreleased project version (optional)
None

### Related issues (optional)
None