### PR TITLE
Update references to the get-started pages

### DIFF
--- a/develop/index.md
+++ b/develop/index.md
@@ -15,8 +15,8 @@ most benefits from Docker.
 - Learn to [build an image from a Dockerfile](/get-started/part2.md){: target="_blank" class="_"}
 - Use [multistage builds](/engine/userguide/eng-image/multistage-build.md){: target="_blank" class="_"} to keep your images lean
 - Manage application data using [volumes](/engine/admin/volumes/volumes.md) and [bind mounts](/engine/admin/volumes/bind-mounts.md){: target="_blank" class="_"}
-- [Scale your app](/get-started/part3.md){: target="_blank" class="_"} as a swarm service
-- [Define your app stack](/get-started/part5.md){: target="_blank" class="_"} using a compose file
+- [Scale your app](/get-started/part3.md){: target="_blank" class="_"} with kubernetes
+- [Scale your app](/get-started/part4.md){: target="_blank" class="_"} as a swarm service
 - General application development best practices
 
 ## Learn about language-specific app development with Docker


### PR DESCRIPTION
### Proposed changes

Update the develop section references to the get-started section, since the get-started was updated.

### Related issues (optional)
I didn't create an issue, but here is the problem I found.

Some changes to the get-started section (#9608, #9609, #9623) led the develop section to be outdated.

> Scale your app as a swarm service

is referring to the `get-started/part3.md` which after the changes reflect the kubernetes deployment instead of the swarm. Scaling the swarm service is now described on the `get-started/part4.md`.

Also,
> Define your app stack using a compose file

which before the changes was the `get-started/part5.md` now is not part of the scope of the get-started anymore.
