### PR TITLE
[FIELD-1939] DTR backup fails because of Scheduler Setting

### DIFF
--- a/ee/dtr/admin/install/system-requirements.md
+++ b/ee/dtr/admin/install/system-requirements.md
@@ -46,14 +46,12 @@ These ports are configurable when installing DTR.
 
 ## UCP Configuration
 
-When installing DTR on a UCP cluster, Administrators need to be able to deploy
+When installing or backing up DTR on a UCP cluster, Administrators need to be able to deploy
 containers on "UCP manager nodes or nodes running DTR". This setting can be
 adjusted in the [UCP Settings
-menu](/ee/ucp/admin/configure/restrict-services-to-worker-nodes/). Once the
-installation has complete, and all additional DTR replicas have been deployed
-this UCP setting can be unchecked.
+menu](/ee/ucp/admin/configure/restrict-services-to-worker-nodes/).
 
-The DTR installation will fail with the following error message if
+The DTR installation or backup will fail with the following error message if
 Administrators are unable to deploy on "UCP manager nodes or nodes running
 DTR".
 


### PR DESCRIPTION
This change is proposed because DTR backup will fail in the same way as an installation if Administrators are unable to deploy on "UCP manager nodes or nodes running DTR".  Tracked by FIELD-1939.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.
### Proposed changes

Update documentation to remove advise on unchecking "UCP manager nodes or nodes running DTR" after installing new versions.

### Related issues (optional)
