### PR TITLE
Adding redirect

### DIFF
--- a/engine/reference/commandline/run.md
+++ b/engine/reference/commandline/run.md
@@ -3,6 +3,7 @@ datafolder: engine-cli
 datafile: docker_run
 title: docker run
 redirect_from:
+  - /reference/run
   - /edge/engine/reference/commandline/run/
 skip_read_time: true
 ---


### PR DESCRIPTION
Adding a redirect to the run reference.

Current link: https://docs.docker.com/reference/run
Preview: https://deploy-preview-9672--docsdocker.netlify.com/reference/run

Signed-off-by: Adrian Plata <adrian.plata@docker.com>