### PR TITLE
Improved manual UCP uninstall commands

### DIFF
--- a/ee/ucp/admin/install/uninstall.md
+++ b/ee/ucp/admin/install/uninstall.md
@@ -40,7 +40,7 @@ for any necessary configuration values.
 #Run the following command on one manager node to remove remaining UCP services
 docker service rm $(docker service ls -f name=ucp- -q)
 #Run the following command on each manager node to remove remaining UCP containers
-docker container rm -f $(docker container ps -f name=ucp- -f name=k8s_ -q)
+docker container rm -f $(docker container ps -a -f name=ucp- -f name=k8s_ -q)
 #Run the following command on each manager node to remove remaining UCP volumes
 docker volume rm $(docker volume ls -f name=ucp -q)
 ```

--- a/ee/ucp/admin/install/uninstall.md
+++ b/ee/ucp/admin/install/uninstall.md
@@ -36,10 +36,13 @@ This runs the uninstall command in interactive mode, so that you are prompted
 for any necessary configuration values.
 
 > **Important**: If the `uninstall-ucp` command fails, you can run the following commands to manually uninstall UCP:
-```
-docker service rm ucp-agent-win ucp-agent-s390x ucp-agent
-docker ps -a | grep ucp | awk '{print $1}' | xargs docker rm -f
-docker volume ls | grep ucp | awk '{print $2}' | xargs docker volume rm
+```bash
+#Run the following command on one manager node to remove remaining UCP services
+docker service rm $(docker service ls -f name=ucp- -q)
+#Run the following command on each manager node to remove remaining UCP containers
+docker container rm -f $(docker container ps -f name=ucp- -f name=k8s_ -q)
+#Run the following command on each manager node to remove remaining UCP volumes
+docker volume rm $(docker volume ls -f name=ucp -q)
 ```
 
 The UCP configuration is kept in case you want to reinstall UCP with the same


### PR DESCRIPTION
Current `service rm` command made assumptions about the names of existing services and would fail in some instances. Current `container rm` command would not remove k8s containers. New commands don't rely on grep, awk, or xargs.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
