### PR TITLE
granting cluster-admin to normal users

### DIFF
--- a/ee/ucp/authorization/index.md
+++ b/ee/ucp/authorization/index.md
@@ -103,7 +103,12 @@ For cluster security, only UCP admin users and service accounts that are
 granted the `cluster-admin` ClusterRole for all Kubernetes namespaces via a
 ClusterRoleBinding can deploy pods with privileged options. This prevents a
 platform user from being able to bypass the Universal Control Plane Security
-Model. These privileged options include:
+Model. 
+
+> Note: Granting the `cluster admin` ClusterRole to normal users does not allow 
+> them to deploy privilaged pods. 
+
+These privileged options include:
 
 Pods with any of the following defined in the Pod Specification:
 

--- a/ee/ucp/authorization/index.md
+++ b/ee/ucp/authorization/index.md
@@ -90,7 +90,7 @@ together.
 Only an administrator can manage grants, subjects, roles, and access to
 resources.
 
-> About administrators
+> Note
 >
 > An administrator is a user who creates subjects, groups resources by moving them
 > into collections or namespaces, defines roles by selecting allowable operations,
@@ -105,8 +105,10 @@ ClusterRoleBinding can deploy pods with privileged options. This prevents a
 platform user from being able to bypass the Universal Control Plane Security
 Model. 
 
-> Note: Granting the `cluster admin` ClusterRole to normal users does not allow 
-> them to deploy privilaged pods. 
+> Note
+> 
+> Granting the `cluster admin` ClusterRole to normal users does not allow 
+> them to deploy privileged pods. 
 
 These privileged options include:
 


### PR DESCRIPTION
Added note to clarify results of granting cluster-admin to normal users. This question was raised by a customer in support case# 100567

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
