### PR TITLE
change link from ucp 2.2 to layer 7

### DIFF
--- a/network/index.md
+++ b/network/index.md
@@ -105,7 +105,7 @@ your Docker services using Universal Control Plane (UCP):
   services. UCP routes the traffic to the appropriate service using the
   combination of hostname and port, as requested from the client.
 
-- [Session stickiness](/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services/#sticky-sessions) allows you to specify information in the HTTP header
+- [Session stickiness](/ee/ucp/interlock/usage/sessions/) allows you to specify information in the HTTP header
   which UCP uses to route subsequent requests to the same service task, for
   applications which require stateful sessions.
 

--- a/network/index.md
+++ b/network/index.md
@@ -100,7 +100,7 @@ exist by default, and provide core networking functionality:
 The following two features are only possible when using Docker EE and managing
 your Docker services using Universal Control Plane (UCP):
 
-- The [HTTP routing mesh](/datacenter/ucp/2.2/guides/admin/configure/use-domain-names-to-access-services/)
+- The [HTTP routing mesh](/ee/ucp/interlock)
   allows you to share the same network IP address and port among multiple
   services. UCP routes the traffic to the appropriate service using the
   combination of hostname and port, as requested from the client.


### PR DESCRIPTION
link routes to old documentation http routing mesh is now interlock/layer 7

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
