### PR TITLE
Add Networks to extensions table

### DIFF
--- a/ee/ucp/interlock/config/index.md
+++ b/ee/ucp/interlock/config/index.md
@@ -92,6 +92,7 @@ Interlock must contain at least one extension to service traffic. The following 
 | `Image` | string | Name of the Docker Image to use for the extension service |
 | `Args` | []string | Arguments to be passed to the Docker extension service upon creation |
 | `Labels` | map[string]string | Labels to add to the extension service |
+|`Networks` | []string | Allows the administrator to cherry-pick a list of networks that Interlock can connect to. If this option is not specified, the proxy-service can connect to all networks. |
 | `ContainerLabels` | map[string]string | Labels to be added to the extension service tasks |
 | `Constraints` | []string | One or more [constraints](https://docs.docker.com/engine/reference/commandline/service_create/#specify-service-constraints-constraint) to use when scheduling the extension service |
 | `PlacementPreferences` | []string | One or more [placement prefs](https://docs.docker.com/engine/reference/commandline/service_create/#specify-service-placement-preferences-placement-pref) to use when scheduling the extension service |


### PR DESCRIPTION
### Proposed changes
- https://docs.docker.com/ee/ucp/interlock/config/
- Add an entry for `Networks` to the Extension configuration table

### Related issues (optional)
https://github.com/docker/docker.github.io/issues/9748