### PR TITLE
Compose: index.md

### DIFF
--- a/compose/index.md
+++ b/compose/index.md
@@ -71,10 +71,10 @@ Compose has commands for managing the whole lifecycle of your application:
 
 The features of Compose that make it effective are:
 
-* [Multiple isolated environments on a single host](overview.md#Multiple-isolated-environments-on-a-single-host)
-* [Preserve volume data when containers are created](overview.md#preserve-volume-data-when-containers-are-created)
-* [Only recreate containers that have changed](overview.md#only-recreate-containers-that-have-changed)
-* [Variables and moving a composition between environments](overview.md#variables-and-moving-a-composition-between-environments)
+* [Multiple isolated environments on a single host](#multiple-isolated-environments-on-a-single-host)
+* [Preserve volume data when containers are created](#preserve-volume-data-when-containers-are-created)
+* [Only recreate containers that have changed](#only-recreate-containers-that-have-changed)
+* [Variables and moving a composition between environments](#variables-and-moving-a-composition-between-environments)
 
 ### Multiple isolated environments on a single host
 


### PR DESCRIPTION
### Proposed changes

Some link in compose documentation main page are broken.
They try to reach overview page that doesn't existe anymore. The link should target header on the 
