### PR TITLE
update gettingstarted - docker-compose.yml use existing redis image

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -119,7 +119,7 @@ the following:
         ports:
           - "5000:5000"
       redis:
-        image: "redis:alpine"
+        image: "redis:5.0.6-alpine"
 
 This Compose file defines two services: `web` and `redis`. 
 


### PR DESCRIPTION
original "redis/alpine" does not exist
docker-compose up ends up with "ERROR: pull access denied for redis/alpine, repository does not exist or may require 'docker login': denied: requested access to the resource is denied" (there is nothing in https://hub.docker.com/search?q=redis%2Falpine&type=image)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
