### PR TITLE
Removing a link to Cloud and replacing with Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ If you are using a version of the documentation that is no longer supported, whi
 
 - By entering your version number and selecting it from the branch selection list for this repo
 - By directly accessing the Github URL for your version. For example, https://github.com/docker/docker.github.io/tree/v1.9 for `v1.9`
-- By running a container of the specific [tag for your documentation version](https://cloud.docker.com/u/docs/repository/docker/docs/docker.github.io/general#read-these-docs-offline)
+- By running a container of the specific [tag for your documentation version](https://hub.docker.com/r/docs/docker.github.io/tags)
 in Docker Hub. For example, run the following to access `v1.9`:
 
  ```bash


### PR DESCRIPTION
No doc preview, changes only in readme