### PR TITLE
interlock: Default update failure action is now rollback

### DIFF
--- a/ee/ucp/interlock/config/index.md
+++ b/ee/ucp/interlock/config/index.md
@@ -38,15 +38,15 @@ service and save it to a file:
      ucp-interlock
    ```
 
-By default, the `ucp-interlock` service is configured to pause if you provide an
-invalid configuration. The service will not restart without manual intervention.
+By default, the `ucp-interlock` service is configured to roll back to
+a previous stable configuration if you provide an invalid configuration.
 
-If you want the service to automatically rollback to a previous stable
-configuration, you can update it with the following command:
+If you want the service to pause instead of rolling back, you can update
+it with the following command:
 
 ```bash
 docker service update \
-  --update-failure-action rollback \
+  --update-failure-action pause \
   ucp-interlock
 ```
 


### PR DESCRIPTION
This behaviour changed in Interlock 2.3.0, which was backported to all
active UCP versions.

The change was tracked by ENGCORE-117.

Signed-off-by: Euan Harris <euan.harris@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
