### PR TITLE
fix examples.md to match the correct modern APIs

### DIFF
--- a/develop/sdk/examples.md
+++ b/develop/sdk/examples.md
@@ -51,7 +51,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -75,13 +75,10 @@ func main() {
 		panic(err)
 	}
 
-	statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
-	select {
-	case err := <-errCh:
-		if err != nil {
-			panic(err)
-		}
-	case <-statusCh:
+	_, err = cli.ContainerWait(ctx, resp.ID)
+
+	if err != nil {
+		panic(err)
 	}
 
 	out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true})


### PR DESCRIPTION
### Proposed changes

I was trying to get started with docker client development, one of the examples didn't work with due to using old APIs I guess.