### PR TITLE
Fix distro name for Ubuntu 18.04

### DIFF
--- a/docker-for-windows/wsl-tech-preview.md
+++ b/docker-for-windows/wsl-tech-preview.md
@@ -36,7 +36,7 @@ Before you install Docker Desktop WSL 2 Tech Preview, you must complete the foll
     `wsl --set-version <distro name> 2`
 5. Set Ubuntu 18.04 as the default distribution.
 
-    `wsl -s ubuntu 18.04`
+    `wsl -s Ubuntu-18.04`
 
 # Download
 


### PR DESCRIPTION
### Proposed changes

As mentioned by @tdaniely in #9244, the command should be `wsl -s Ubuntu-18.04`.
The current command results in an error:
```
> wsl -s ubuntu 18.04
There is no distribution with the supplied name.
```
