### PR TITLE
updated typo in the command scale missing hiphen

### DIFF
--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -22,7 +22,7 @@ Sets the number of containers to run for a service.
 
 Numbers are specified as arguments in the form `service=num`. For example:
 
-    docker-compose scale web=2 worker=3
+    docker-compose --scale web=2 worker=3
 
 >**Tip**: Alternatively, in
 [Compose file version 3.x](/compose/compose-file/index.md), you can specify


### PR DESCRIPTION
### Proposed changes

fixed typo in the command `scale` for missing hyphen 

in

https://docs.docker.com/compose/reference/scale/
