### PR TITLE
Fixing broken links in older DTR versions

### DIFF
--- a/datacenter/dtr/2.0/configure/config-storage.md
+++ b/datacenter/dtr/2.0/configure/config-storage.md
@@ -176,7 +176,7 @@ YAML file (which is discussed further in this document.)
 
 >**Note**: Changing your storage backend requires you to restart the Trusted Registry.
 
-See the [Registry configuration](/registry/configuration.md)
+See the [Docker Registry storage driver](/registry/storage-drivers/)
 documentation for the full options specific to each driver. Storage drivers can
 be customized through the [Docker Registry storage driver
 API](/registry/storage-drivers/index.md#storage-driver-api).
@@ -184,21 +184,21 @@ API](/registry/storage-drivers/index.md#storage-driver-api).
 
 ### Filesystem settings
 
-The [filesystem storage backend](/registry/configuration.md#filesystem)
+The [filesystem storage backend](/registry/storage-drivers/filesystem)
 has only one setting, the "Storage directory".
 
 ### S3 settings
 
-If you select the [S3 storage backend](/registry/configuration.md#s3), then you
+If you select the [S3 storage backend](/registry/storage-drivers/s3), then you
 need to set  "AWS region", "Bucket name", "Access Key", and "Secret Key".
 
 ### Azure settings
 
-Set the "Account name", "Account key", "Container", and "Realm" on the [Azure storage backend](/registry/configuration.md#azure) page.
+Set the "Account name", "Account key", "Container", and "Realm" on the [Azure storage backend](/registry/storage-drivers/azure) page.
 
 ### Openstack Swift settings
 
-View the [Openstack Swift settings](/registry/configuration.md#openstack-swift)
+View the [Openstack Swift settings](/registry/storage-drivers/openstack-swift)
 documentation so that you can set up your storage settings: authurl, username,
 password, container, tenant, tenantid, domain, domainid, insecureskipverify,
 region, chunksize, and prefix.

--- a/datacenter/dtr/2.1/guides/configure/configure-storage.md
+++ b/datacenter/dtr/2.1/guides/configure/configure-storage.md
@@ -60,7 +60,7 @@ adequate space available. To do so, you can run the following commands:
 ### Amazon S3
 
 S3 stores data as objects within “buckets” where you read, write, and delete
-objects in that container. It too, has a `rootdirectory` parameter. If you select this option, there will be some tasks that you need to first perform [on AWS](https://aws.amazon.com/s3/getting-started/).   
+objects in that container. It too, has a `rootdirectory` parameter. If you select this option, there will be some tasks that you need to first perform [on AWS](https://aws.amazon.com/s3/getting-started/).
 
 1. You must create an S3 bucket, and write down its name and the AWS zone it
 runs on.
@@ -155,7 +155,7 @@ YAML file (which is discussed further in this document.)
 
 >**Note**: Changing your storage backend requires you to restart the Trusted Registry.
 
-See the [Registry configuration](/registry/configuration.md)
+See the [Docker Registry storage driver](/registry/storage-drivers/)
 documentation for the full options specific to each driver. Storage drivers can
 be customized through the [Docker Registry storage driver
 API](/registry/storage-drivers/index.md#storage-driver-api).
@@ -163,21 +163,21 @@ API](/registry/storage-drivers/index.md#storage-driver-api).
 
 ### Filesystem settings
 
-The [filesystem storage backend](/registry/configuration.md#filesystem)
+The [filesystem storage backend](/registry/storage-drivers/filesystem)
 has only one setting, the "Storage directory".
 
 ### S3 settings
 
-If you select the [S3 storage backend](/registry/configuration.md#s3), then you
+If you select the [S3 storage backend](/registry/storage-drivers/s3), then you
 need to set  "AWS region", "Bucket name", "Access Key", and "Secret Key".
 
 ### Azure settings
 
-Set the "Account name", "Account key", "Container", and "Realm" on the [Azure storage backend](/registry/configuration.md#azure) page.
+Set the "Account name", "Account key", "Container", and "Realm" on the [Azure storage backend](/registry/storage-drivers/azure) page.
 
 ### Openstack Swift settings
 
-View the [Openstack Swift settings](/registry/configuration.md#openstack-swift)
+View the [Openstack Swift settings](/registry/storage-drivers/openstack-swift)
 documentation so that you can set up your storage settings: authurl, username,
 password, container, tenant, tenantid, domain, domainid, insecureskipverify,
 region, chunksize, and prefix.


### PR DESCRIPTION
Based on issue #9593 

The doc the old links pointed to is maintained in the distribution repo, and it changed a long time ago so that the sections no longer exist. However, we do actually have docs in the current structure that have this info. Updating the old content to avoid confusion.