### PR TITLE
adding additional linux ubuntu install instructions

### DIFF
--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -269,8 +269,8 @@ Engine - Enterprise.
     $ sudo dpkg -i /path/to/package.deb
     ```
 
-    Or, if you downloaded the three `.deb` files, install them in the following
-    order:
+    Or, if you downloaded the three `.deb` files, **you must** install them in
+    the following order:
 
     ```bash
     $ sudo dpkg -i /path/to/docker-ee-cli_<version>.deb

--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -258,7 +258,7 @@ Engine - Enterprise.
     to install.
 
     > **Note:**
-    > Starting with 19.03, you will download three `.deb` files. They
+    > Starting with 19.03, you have to download three `.deb` files. They
     > are `docker-ee-cli_<version>.deb`, `containerd.io_<version>.deb`, and
     > `docker-ee_<version>.deb`.
 

--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -247,19 +247,35 @@ To upgrade Docker Engine - Enterprise, follow the steps below:
 ### Install from a package
 
 If you cannot use Docker's repository to install Docker Engine - Enterprise, you
-can download the `.deb` file for your release and install it manually. You need
-to download a new file each time you want to upgrade Docker Engine - Enterprise.
+can download the `.deb` files for your release and install them manually. You
+need to download a new file or set of files each time you want to upgrade Docker
+Engine - Enterprise.
 
 1.  Go to the Docker Engine - Enterprise repository URL associated with your
     trial or subscription in your browser. Go to
-    `ubuntu/x86_64/stable-<VERSION>` and download the `.deb` file for the
-    Docker Engine - Enterprise version and architecture you want to install.
+    `ubuntu/dists/<distribution>/pool/stable-<VERSION>` and download the `.deb`
+    file(s) for the Docker Engine - Enterprise version and architecture you want
+    to install.
+
+    > **Note:**
+    > For newer versions of Docker, you will download three files. They
+    > are `docker-ee-cli_<version>.deb`, `containerd.io_<version>.deb`, and
+    > `docker-ee_<version>.deb`.
 
 2.  Install Docker, changing the path below to the path where you downloaded
     the Docker Engine - Enterprise package.
 
     ```bash
     $ sudo dpkg -i /path/to/package.deb
+    ```
+
+    Or, if you downloaded the three `.deb` files, install them in the following
+    order:
+
+    ```bash
+    $ sudo dpkg -i /path/to/docker-ee-cli_<version>.deb
+    $ sudo dpkg -i /path/to/containerd.io_<version>.deb
+    $ sudo dpkg -i /path/to/docker-ee_<version>.deb
     ```
 
     The Docker daemon starts automatically.

--- a/install/linux/docker-ee/ubuntu.md
+++ b/install/linux/docker-ee/ubuntu.md
@@ -258,7 +258,7 @@ Engine - Enterprise.
     to install.
 
     > **Note:**
-    > For newer versions of Docker, you will download three files. They
+    > Starting with 19.03, you will download three `.deb` files. They
     > are `docker-ee-cli_<version>.deb`, `containerd.io_<version>.deb`, and
     > `docker-ee_<version>.deb`.
 


### PR DESCRIPTION
Live: https://docs.docker.com/install/linux/docker-ee/ubuntu/#install-from-a-package
Preview: https://deploy-preview-9934--docsdocker.netlify.com/install/linux/docker-ee/ubuntu/#install-from-a-package

Signed-off-by: Adrian Plata <adrian.plata@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
