### PR TITLE
Missing link to Getting Started w/ Compose

### DIFF
--- a/compose/index.md
+++ b/compose/index.md
@@ -59,6 +59,7 @@ Compose has commands for managing the whole lifecycle of your application:
 ## Compose documentation
 
 - [Installing Compose](install.md)
+- [Getting Started with Compose](gettingstarted.md)
 - [Get started with Django](django.md)
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)

--- a/compose/index.md
+++ b/compose/index.md
@@ -59,7 +59,7 @@ Compose has commands for managing the whole lifecycle of your application:
 ## Compose documentation
 
 - [Installing Compose](install.md)
-- [Getting Started with Compose](gettingstarted.md)
+- [Getting started with Compose](gettingstarted.md)
 - [Get started with Django](django.md)
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)


### PR DESCRIPTION
### Proposed changes

Added a link to [Getting Started with Compose](https://docs.docker.com/compose/gettingstarted/).

The [Getting Started with Compose](https://docs.docker.com/compose/gettingstarted/) page is not linked from the [Installing Docker Compose](https://docs.docker.com/compose/install/) page (unlike the specific sample apps for [Django](https://docs.docker.com/compose/django/), [Rails](https://docs.docker.com/compose/rails/), and [WordPress](https://docs.docker.com/compose/wordpress/)---which seem to follow after the [Getting Started](https://docs.docker.com/compose/gettingstarted/) page..).  This made (re-)finding the main Getting Started page difficult...
