### PR TITLE
Adding links to Docker EULA and DPA

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -8,6 +8,8 @@ title: Install Docker Desktop on Mac
 
 [Download from Docker Hub](https://hub.docker.com/?overlay=onboarding){: .button .outline-btn}
 
+By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
+
 ## What to know before you install
 
 > README FIRST for Docker Toolbox and Docker Machine users

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -11,6 +11,8 @@ You can download Docker Desktop for Windows from Docker Hub.
 Hub](https://hub.docker.com/?overlay=onboarding){:
 .button .outline-btn}
 
+By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
+
 ## What to know before you install
 
 ### System Requirements


### PR DESCRIPTION
### Proposed changes

Adding URLs to Docker EULA and DPA so users can review this information before downloading Docker Desktop. 

This info is also available on the Desktop pages in Docker Hub.

https://hub.docker.com/editions/community/docker-ce-desktop-windows
https://hub.docker.com/editions/community/docker-ce-desktop-mac

### Related issues (optional)

Fixes #9832 