### PR TITLE
Commandline reference: add note to "enterprise only" subcommands

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -29,6 +29,15 @@ your client and daemon API versions.
 
 {% endif %}
 
+{% if page.enterprise_only == true %}
+
+> This command is only available on Docker Enterprise Edition.
+>
+> Learn more about [Docker Enterprise products](/ee/supported-platforms/){: target="_blank" class="_"}.
+{: .important }
+
+{% endif %}
+
 {% if site.data[include.datafolder][include.datafile].experimental %}
 
 > This command is experimental.

--- a/engine/reference/commandline/assemble.md
+++ b/engine/reference/commandline/assemble.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble
 title: docker assemble
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend.md
+++ b/engine/reference/commandline/assemble_backend.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend
 title: docker assemble backend
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_cache.md
+++ b/engine/reference/commandline/assemble_backend_cache.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_cache
 title: docker assemble backend cache
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_cache_purge.md
+++ b/engine/reference/commandline/assemble_backend_cache_purge.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_cache_purge
 title: docker assemble backend cache purge
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_cache_usage.md
+++ b/engine/reference/commandline/assemble_backend_cache_usage.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_cache_usage
 title: docker assemble backend cache usage
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_image.md
+++ b/engine/reference/commandline/assemble_backend_image.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_image
 title: docker assemble backend image
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_info.md
+++ b/engine/reference/commandline/assemble_backend_info.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_info
 title: docker assemble backend info
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_logs.md
+++ b/engine/reference/commandline/assemble_backend_logs.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_logs
 title: docker assemble backend logs
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_start.md
+++ b/engine/reference/commandline/assemble_backend_start.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_start
 title: docker assemble backend start
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_backend_stop.md
+++ b/engine/reference/commandline/assemble_backend_stop.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_backend_stop
 title: docker assemble backend stop
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_build.md
+++ b/engine/reference/commandline/assemble_build.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_build
 title: docker assemble build
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/assemble_version.md
+++ b/engine/reference/commandline/assemble_version.md
@@ -2,6 +2,7 @@
 datafolder: assemble
 datafile: docker_assemble_version
 title: docker assemble version
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster.md
+++ b/engine/reference/commandline/cluster.md
@@ -3,6 +3,7 @@ datafolder: cluster
 datafile: docker_cluster
 title: docker cluster
 redirect_from: /cluster/reference/
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_backup.md
+++ b/engine/reference/commandline/cluster_backup.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_backup
 title: docker cluster backup
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_create.md
+++ b/engine/reference/commandline/cluster_create.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_create
 title: docker cluster create
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_inspect.md
+++ b/engine/reference/commandline/cluster_inspect.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_inspect
 title: docker cluster inspect
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_ls.md
+++ b/engine/reference/commandline/cluster_ls.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_ls
 title: docker cluster ls
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_restore.md
+++ b/engine/reference/commandline/cluster_restore.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_restore
 title: docker cluster restore
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_rm.md
+++ b/engine/reference/commandline/cluster_rm.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_rm
 title: docker cluster rm
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_update.md
+++ b/engine/reference/commandline/cluster_update.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_update
 title: docker cluster update
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/cluster_version.md
+++ b/engine/reference/commandline/cluster_version.md
@@ -2,6 +2,7 @@
 datafolder: cluster
 datafile: docker_cluster_version
 title: docker cluster version
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry.md
+++ b/engine/reference/commandline/registry.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry
 title: docker registry
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_events.md
+++ b/engine/reference/commandline/registry_events.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_events
 title: docker registry events
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_history.md
+++ b/engine/reference/commandline/registry_history.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_history
 title: docker registry history
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_info.md
+++ b/engine/reference/commandline/registry_info.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_info
 title: docker registry info
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_inspect.md
+++ b/engine/reference/commandline/registry_inspect.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_inspect
 title: docker registry inspect
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_joblogs.md
+++ b/engine/reference/commandline/registry_joblogs.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_joblogs
 title: docker registry joblogs
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_jobs.md
+++ b/engine/reference/commandline/registry_jobs.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_jobs
 title: docker registry jobs
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_ls.md
+++ b/engine/reference/commandline/registry_ls.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_ls
 title: docker registry ls
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/registry_rmi.md
+++ b/engine/reference/commandline/registry_rmi.md
@@ -2,6 +2,7 @@
 datafolder: registry-cli
 datafile: docker_registry_rmi
 title: docker registry rmi
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template.md
+++ b/engine/reference/commandline/template.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template
 title: docker template
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template_config.md
+++ b/engine/reference/commandline/template_config.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template_config
 title: docker template config
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template_config_set.md
+++ b/engine/reference/commandline/template_config_set.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template_config_set
 title: docker template config set
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template_config_view.md
+++ b/engine/reference/commandline/template_config_view.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template_config_view
 title: docker template config view
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template_inspect.md
+++ b/engine/reference/commandline/template_inspect.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template_inspect
 title: docker template inspect
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template_list.md
+++ b/engine/reference/commandline/template_list.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template_list
 title: docker template list
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template_scaffold.md
+++ b/engine/reference/commandline/template_scaffold.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template_scaffold
 title: docker template scaffold
+enterprise_only: true
 skip_read_time: true
 ---
 <!--

--- a/engine/reference/commandline/template_version.md
+++ b/engine/reference/commandline/template_version.md
@@ -2,6 +2,7 @@
 datafolder: application-template
 datafile: docker_template_version
 title: docker template version
+enterprise_only: true
 skip_read_time: true
 ---
 <!--


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/2217

The `assemble`, `cluster`, `registry`, and `template` subcommands are provided by plugins that only ship with the enterprise engine / cli.

This patch annotates those commands to print a note that they only ship with the enterprise version of docker;

<img width="731" alt="Screenshot 2019-12-11 at 10 20 09" src="https://user-images.githubusercontent.com/1804568/70608497-867ae480-1c00-11ea-8db6-e8ff2880678e.png">
