### PR TITLE
apt-key fingerprint does not need sudo

### DIFF
--- a/ee/docker-ee/ubuntu.md
+++ b/ee/docker-ee/ubuntu.md
@@ -143,7 +143,7 @@ and update Docker Engine - Enterprise from the repository.
     because of the variable you set earlier.
 
     ```bash
-    $ sudo apt-key fingerprint 6D085F96
+    $ apt-key fingerprint 6D085F96
 
     pub   4096R/0EBFCD88 2017-02-22
           Key fingerprint = DD91 1E99 5A64 A202 E859  07D6 BC14 F10B 6D08 5F96

--- a/install/linux/docker-ce/debian.md
+++ b/install/linux/docker-ce/debian.md
@@ -107,7 +107,7 @@ from the repository.
     last 8 characters of the fingerprint.
 
     ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
+    $ apt-key fingerprint 0EBFCD88
 
     pub   4096R/0EBFCD88 2017-02-22
           Key fingerprint = 9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88

--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -120,7 +120,7 @@ from the repository.
     last 8 characters of the fingerprint.
 
     ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
+    $ apt-key fingerprint 0EBFCD88
     
     pub   rsa4096 2017-02-22 [SCEA]
           9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88


### PR DESCRIPTION
### Proposed changes

`apt-key fingerprint` does not need `sudo`