### PR TITLE
Attempt to fix moby/moby#39723

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -159,6 +159,10 @@ $ docker container stop devtest
 $ docker container rm devtest
 ```
 
+> **Note** A popular way to run Docker in Docker on \*nix machine is to bind mount Docker's socket to itself using an option like `--volume /var/run/docker.sock:/var/run/docker.sock`.
+> However, this method actually allows to run sibling containers, *not* nested ones.
+> An important consequence is that if a directory is bind mounted while starting *container B* from inside *container A*, the directory which is mounted is always the one on the host, *not* the one inside *container A*.
+
 ### Mount into a non-empty directory on the container
 
 If you bind-mount into a non-empty directory on the container, the directory's

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -159,7 +159,7 @@ $ docker container stop devtest
 $ docker container rm devtest
 ```
 
-> **Note** A popular way to run Docker in Docker on \*nix machine is to bind mount Docker's socket to itself using an option like `--volume /var/run/docker.sock:/var/run/docker.sock`.
+> **Note**: A popular way to run Docker in Docker on \*nix machine is to bind mount Docker's socket to itself using an option like `--volume /var/run/docker.sock:/var/run/docker.sock`.
 > However, this method actually allows to run sibling containers, *not* nested ones.
 > An important consequence is that if a directory is bind mounted while starting *container B* from inside *container A*, the directory which is mounted is always the one on the host, *not* the one inside *container A*.
 


### PR DESCRIPTION
### Proposed changes

I added a note to explain what I did not understand when I opened moby/moby#39723, i.e. that when you bind mount from inside a container, you may still bind mount a directory on the host (see the content of the pull request for a clearer explanation). I added the note on the page I read (twice) while trying to figure out what was going on (I read this page twice *before* opening the issue). I found it hard to find a perfect place for the note, but I think the place I choose is a good compromise. 

### Related issues

Fixes moby/moby#39723.