### PR TITLE
Moved Windows EE Engine Version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,10 +109,6 @@ defaults:
       toc_max: 3
       tree: true
   - scope:
-      path: "install"
-    values:
-      win_latest_build: "docker-19.03.5"
-  - scope:
       path: "datacenter"
     values:
       enterprise: true
@@ -126,6 +122,7 @@ defaults:
       dtr_repo: "dtr"
       ucp_version: "3.2.4"
       dtr_version: "2.7.4"
+      win_latest_build: "docker-19.03.5"
   # Previous DTR Releases
   - scope:
       path: "datacenter/dtr/2.6"

--- a/_config_authoring.yml
+++ b/_config_authoring.yml
@@ -94,10 +94,6 @@ defaults:
       toc_max: 3
       tree: true
   - scope:
-      path: "install"
-    values:
-      win_latest_build: "docker-19.03.0"
-  - scope:
       path: "datacenter"
     values:
       enterprise: true
@@ -158,6 +154,7 @@ defaults:
       dtr_repo: "dtr"
       ucp_version: "3.1.2"
       dtr_version: "2.6.1"
+      win_latest_build: "docker-19.03.5"
   - scope:
       path: "datacenter/ucp/3.0"
     values:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

It appears this change https://github.com/docker/docker.github.io/pull/9967/, caused the static URL on the Windows EE Engine pages to break.

Dead URL can be found within this section:

```
# On an online machine, download the zip file.
Invoke-WebRequest -UseBasicParsing -OutFile .zip https://download.docker.com/components/engine/windows-server/19.03/.zip
```

 https://docs.docker.com/ee/docker-ee/windows/docker-ee/#use-a-script-to-install-docker-engine---enterprise

Thanks @stevenfollis for reporting 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
