### PR TITLE
Updated Overriding a Vulnerability topic to match DTR 2.5 edit.

### DIFF
--- a/datacenter/dtr/2.5/guides/user/manage-images/override-a-vulnerability.md
+++ b/datacenter/dtr/2.5/guides/user/manage-images/override-a-vulnerability.md
@@ -16,7 +16,7 @@ DTR scans images for vulnerabilities. At times, however, it may report image vul
 
 3. Click **View details** to review the image scan results, and select **Components** to see the vulnerabilities for each component packaged in the image.
 
-4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **hide**.
+4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **Hide**.
 
     ![Vulnerability list](../../images/override-vulnerability-2.png){: .with-border}
 

--- a/datacenter/dtr/2.6/guides/user/manage-images/override-a-vulnerability.md
+++ b/datacenter/dtr/2.6/guides/user/manage-images/override-a-vulnerability.md
@@ -16,7 +16,7 @@ DTR scans images for vulnerabilities. At times, however, it may report image vul
 
 3. Click **View details** to review the image scan results, and select **Components** to see the vulnerabilities for each component packaged in the image.
 
-4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **hide**.
+4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **Hide**.
 
     ![Vulnerability list](../../images/override-vulnerability-2.png){: .with-border}
 

--- a/datacenter/dtr/2.6/guides/user/manage-images/override-a-vulnerability.md
+++ b/datacenter/dtr/2.6/guides/user/manage-images/override-a-vulnerability.md
@@ -5,31 +5,24 @@ description: Learn how to dismiss a vulnerability reported by the security
 keywords: registry, security scanner
 ---
 
-DTR scans your images for vulnerabilities but sometimes it can report that
-your image has vulnerabilities you know have been fixed. If that happens you
-can dismiss the warning.
+DTR scans images for vulnerabilities. At times, however, it may report image vulnerabilities that you know have been fixed, and whenever that happens the warning can be dismissed.
 
-In the **DTR web interface**, navigate to the repository that has been scanned.
+1. Access the DTR web interface.
 
-![](../../images/scan-images-for-vulns-3.png){: .with-border}
+2. Click **Repositories** in the left-hand menu, and locate the repository that has been scanned.
 
-Click **View details** to review the image scan results, and
-choose **Components** to see the vulnerabilities for each component packaged
-in the image.
 
-Select the component with the vulnerability you want to ignore, navigate to the
-vulnerability, and click **hide**.
+    ![](../../images/scan-images-for-vulns-3.png){: .with-border}
 
-![Vulnerability list](../../images/override-vulnerability-2.png){: .with-border}
+3. Click **View details** to review the image scan results, and select **Components** to see the vulnerabilities for each component packaged in the image.
 
-The vulnerability is hidden system-wide and will no longer be reported as a vulnerability
-on affected images with the same layer IDs or digests.
+4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **hide**.
 
-After dismissing a vulnerability, DTR will not reevaluate the promotion policies
-you have set up for the repository.
+    ![Vulnerability list](../../images/override-vulnerability-2.png){: .with-border}
 
-If you want the promotion policy to be reevaluated for the image after hiding
-a particular vulnerability, click **Promote**.
+    Once dismissed, the vulnerability is hidden system-wide and will no longer be reported as a vulnerability on affected images with the same layer IDs or digests. In addition, DTR will not reevaluate the promotion policies that have been set up for the repository.
+
+    If after hiding a particular vulnerability you want the promotion policy for the image to be reevaluated, click **Promote**.
 
 ## Where to go next
 

--- a/ee/dtr/user/manage-images/override-a-vulnerability.md
+++ b/ee/dtr/user/manage-images/override-a-vulnerability.md
@@ -7,31 +7,24 @@ keywords: registry, security scanner
 
 >{% include enterprise_label_shortform.md %}
 
-DTR scans your images for vulnerabilities but sometimes it can report that
-your image has vulnerabilities you know have been fixed. If that happens you
-can dismiss the warning.
+DTR scans images for vulnerabilities. At times, however, it may report image vulnerabilities that you know have been fixed, and whenever that happens the warning can be dismissed.
 
-In the **DTR web interface**, navigate to the repository that has been scanned.
+1. Access the DTR web interface.
 
-![](../../images/scan-images-for-vulns-3.png){: .with-border}
+2. Click **Repositories** in the left-hand menu, and locate the repository that has been scanned.
 
-Click **View details** to review the image scan results, and
-choose **Components** to see the vulnerabilities for each component packaged
-in the image.
 
-Select the component with the vulnerability you want to ignore, navigate to the
-vulnerability, and click **hide**.
+    ![](../../images/scan-images-for-vulns-3.png){: .with-border}
 
-![Vulnerability list](../../images/override-vulnerability-2.png){: .with-border}
+3. Click **View details** to review the image scan results, and select **Components** to see the vulnerabilities for each component packaged in the image.
 
-The vulnerability is hidden system-wide and will no longer be reported as a vulnerability
-on affected images with the same layer IDs or digests.
+4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **hide**.
 
-After dismissing a vulnerability, DTR will not reevaluate the promotion policies
-you have set up for the repository.
+    ![Vulnerability list](../../images/override-vulnerability-2.png){: .with-border}
 
-If you want the promotion policy to be reevaluated for the image after hiding
-a particular vulnerability, click **Promote**.
+    Once dismissed, the vulnerability is hidden system-wide and will no longer be reported as a vulnerability on affected images with the same layer IDs or digests. In addition, DTR will not reevaluate the promotion policies that have been set up for the repository.
+
+    If after hiding a particular vulnerability you want the promotion policy for the image to be reevaluated, click **Promote**.
 
 ## Where to go next
 

--- a/ee/dtr/user/manage-images/override-a-vulnerability.md
+++ b/ee/dtr/user/manage-images/override-a-vulnerability.md
@@ -18,7 +18,7 @@ DTR scans images for vulnerabilities. At times, however, it may report image vul
 
 3. Click **View details** to review the image scan results, and select **Components** to see the vulnerabilities for each component packaged in the image.
 
-4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **hide**.
+4. Select the component with the vulnerability you want to ignore, navigate to the vulnerability, and click **Hide**.
 
     ![Vulnerability list](../../images/override-vulnerability-2.png){: .with-border}
 


### PR DESCRIPTION
The insertion of "Overriding a Vulnerability" into the DTR 2.5 docs resulted in solid text and formatting update, which is now being ported over to DTR 2.6 docs and the current (2.7).