### PR TITLE
Update content_trust.md

### DIFF
--- a/engine/security/trust/content_trust.md
+++ b/engine/security/trust/content_trust.md
@@ -244,9 +244,9 @@ Engine Signature Verification prevents the following:
 
 DCT does not verify that a running container’s filesystem has not been altered
 from what was in the image. For example, it does not prevent a container from
-writing to the filesystem, once the container is running, nor does it prevent
-the container’s filesystem from being altered on disk. DCT will also not prevent
-unsigned images from being imported, loaded, or created.
+writing to the filesystem, once the container is running. Furthermore, it does 
+not prevent the image's or container’s filesystem from being altered on disk. 
+DCT will also not prevent unsigned images from being imported, loaded, or created.
 
 ### Enabling DCT within the Docker Enterprise Engine
 


### PR DESCRIPTION
To make it clear that DCT does not protect against image layer tampering.

### Proposed changes

The documentation suggests that DCT protects against changes to images on the local disk. However, it does not. DCT only protects against compromised repositories, but not against attacks on the local filesystem. So far, there was a warning saying that DCT does not protect RUNNING containers. However, it does not even protect any containers or images locally. This should be clear so people do not make wrong assumptions leading to security issues.

### Unreleased project version (optional)

-

### Related issues (optional)

-
