### PR TITLE
Add info on ssh agent usage

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -78,24 +78,7 @@ For more information and examples, see
 
 ### Can I use an SSH agent inside a container?
 
-Yes, you can use the host’s SSH agent inside a container. To do this:
-
-1. Bind mount the SSH agent socket by adding the following parameter to your `docker run` command:
-
-    `-v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock`
-
-1. Add the `SSH_AUTH_SOCK` environment variable in your container:
-
-    `-e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"`
-
-To enable the SSH agent in Docker Compose, add the following flags to your service:
-
- ```
-    volumes:
-      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
-    environment:
-      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
- ```
+Yes, you can use the host’s SSH agent inside a container. For more information, see [SSH agent forwarding](/docker-for-mac/networking/#ssh-agent-forwarding).
 
 ### How do I add custom CA certificates?
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -76,10 +76,32 @@ We recommend that you publish a port, or connect from another container. You can
 For more information and examples, see
 [I want to connect to a container from the Mac](networking.md#i-want-to-connect-to-a-container-from-the-mac) in the [Networking](/docker-for-mac/networking/) topic.
 
+### Can I use an SSH agent inside a container?
+
+Yes, you can use the host’s SSH agent inside a container. To do this:
+
+1. Bind mount the SSH agent socket by adding the following parameter to your `docker run` command:
+
+    `-v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock`
+
+1. Add the `SSH_AUTH_SOCK` environment variable in your container:
+
+    `-e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"`
+
+To enable the SSH agent in Docker Compose, add the following flags to your service:
+
+ ```
+    volumes:
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+ ```
+
 ### How do I add custom CA certificates?
 
 Docker Desktop supports all trusted certificate authorities (CAs) (root or intermediate). For more information on adding server and client side certs, see
 [Add TLS certificates](/docker-for-mac/index/#adding-tls-certificates) in the Getting Started topic.
+
 
 ### How do I add client certificates?
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -78,7 +78,7 @@ For more information and examples, see
 
 ### Can I use an SSH agent inside a container?
 
-Yes, you can use the host’s SSH agent inside a container. For more information, see [SSH agent forwarding](/docker-for-mac/networking/#ssh-agent-forwarding).
+Yes, you can use the host’s SSH agent inside a container. For more information, see [SSH agent forwarding](/docker-for-mac/osxfs/#ssh-agent-forwarding).
 
 ### How do I add custom CA certificates?
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -85,7 +85,6 @@ Yes, you can use the host’s SSH agent inside a container. For more information
 Docker Desktop supports all trusted certificate authorities (CAs) (root or intermediate). For more information on adding server and client side certs, see
 [Add TLS certificates](/docker-for-mac/index/#adding-tls-certificates) in the Getting Started topic.
 
-
 ### How do I add client certificates?
 
 For information on adding client certificates, see

--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -39,27 +39,6 @@ $ docker run -p 8000:80 -d nginx
 Now, connections to `localhost:8000` are sent to port 80 in the container. The
 syntax for `-p` is `HOST_PORT:CLIENT_PORT`.
 
-### SSH agent forwarding
-
-Docker Desktop for {{Arch}} allows you to use the host’s SSH agent inside a container. To do this:
-
-1. Bind mount the SSH agent socket by adding the following parameter to your `docker run` command:
-
-    `-v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock`
-
-1. Add the `SSH_AUTH_SOCK` environment variable in your container:
-
-    `-e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"`
-
-To enable the SSH agent in Docker Compose, add the following flags to your service:
-
- ```
-    volumes:
-      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
-    environment:
-      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
- ```
-
 ### HTTP/HTTPS Proxy Support
 
 See [Proxies](/docker-for-mac/index/#proxies).

--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -39,9 +39,30 @@ $ docker run -p 8000:80 -d nginx
 Now, connections to `localhost:8000` are sent to port 80 in the container. The
 syntax for `-p` is `HOST_PORT:CLIENT_PORT`.
 
+### SSH agent forwarding
+
+Docker Desktop for {{Arch}} allows you to use the host’s SSH agent inside a container. To do this:
+
+1. Bind mount the SSH agent socket by adding the following parameter to your `docker run` command:
+
+    `-v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock`
+
+1. Add the `SSH_AUTH_SOCK` environment variable in your container:
+
+    `-e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"`
+
+To enable the SSH agent in Docker Compose, add the following flags to your service:
+
+ ```
+    volumes:
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+ ```
+
 ### HTTP/HTTPS Proxy Support
 
-See [Proxies](index#proxies).
+See [Proxies](/docker-for-mac/index/#proxies).
 
 ## Known limitations, use cases, and workarounds
 

--- a/docker-for-mac/osxfs.md
+++ b/docker-for-mac/osxfs.md
@@ -153,6 +153,32 @@ Extended attributes are not yet supported.
 `osxfs` does not use OSXFUSE. `osxfs` does not run under, inside, or
 between macOS userspace processes and the macOS kernel.
 
+### SSH agent forwarding
+
+Docker Desktop for Mac allows you to use the host’s SSH agent inside a container. To do this:
+
+1. Bind mount the SSH agent socket by adding the following parameter to your `docker run` command:
+
+    `--mount type=bind,src=/run/host-services/ssh-auth.sock,target=/run/host-services/ssh-auth.sock`
+
+1. Add the `SSH_AUTH_SOCK` environment variable in your container:
+
+    `-e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"`
+
+To enable the SSH agent in Docker Compose, add the following flags to your service:
+
+ ```yaml
+services:
+  web:
+    image: nginx:alpine
+    volumes:
+      - type: bind
+        source: /run/host-services/ssh-auth.sock
+        target: /run/host-services/ssh-auth.sock
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+ ```
+
 ### Performance issues, solutions, and roadmap
 
 > See **[Performance tuning for volume mounts (shared filesystems)](osxfs-caching.md)**


### PR DESCRIPTION
### Proposed changes

Added info on how users can access the host's SSH agent inside containers.

### Related issues (optional)

https://docker.atlassian.net/browse/DESKTOP-1928
