### PR TITLE
docker-compose command manage.py fix

### DIFF
--- a/compose/django.md
+++ b/compose/django.md
@@ -71,7 +71,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
         image: postgres
       web:
         build: .
-        command: python manage.py runserver 0.0.0.0:8000
+        command: python composeexample/manage.py runserver 0.0.0.0:8000
         volumes:
           - .:/code
         ports:


### PR DESCRIPTION
This will result in an error...
command: python manage.py runserver 0.0.0.0:8000

as manage.py is not in the default path but one directory below....
Changed to 
command: python composeexample/manage.py runserver 0.0.0.0:8000
