### PR TITLE
Update links on where to download Docker

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -10,7 +10,7 @@ title: Frequently asked questions (FAQ)
 
 ### How do I get the Stable or the Edge version of Docker Desktop?
 
-You can download the Stable version of Docker Desktop from [Docker Hub](https://hub.docker.com/?overlay=onboarding). To download the Edge version, see the [Edge release notes](/docker-for-mac/edge-release-notes/).
+You can download the Stable version of Docker Desktop from [Docker Hub](https://hub.docker.com/editions/community/docker-ce-desktop-mac). To download the Edge version, see the [Edge release notes](/docker-for-mac/edge-release-notes/).
 
 For installation instructions, see [Install Docker Desktop on Mac](install.md){: target="_blank" class="_"}.
 

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -6,7 +6,7 @@ title: Install Docker Desktop on Mac
 
   To download Docker Desktop, go to Docker Hub and sign in with your Docker ID.
 
-[Download from Docker Hub](https://hub.docker.com/?overlay=onboarding){: .button .outline-btn}
+[Download from Docker Hub](https://hub.docker.com/editions/community/docker-ce-desktop-mac){: .button .outline-btn}
 
 By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
 

--- a/docker-for-mac/multi-arch.md
+++ b/docker-for-mac/multi-arch.md
@@ -37,7 +37,7 @@ For more information about the Buildx CLI command, see [Buildx](/buildx/working-
 
 ### Install
 
-1. Download the latest version of [Docker Desktop](https://hub.docker.com/?overlay=onboarding).
+1. Download the latest version of [Docker Desktop](https://hub.docker.com/editions/community/docker-ce-desktop-mac).
 
 1. Follow the on-screen instructions to complete the installation process. After you have successfully installed Docker Desktop, you will see the Docker icon in your task tray.
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -16,7 +16,7 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 ## Docker Desktop Community 2.2.0.0
 2020-01-21
 
-> [Download](https://hub.docker.com/?overlay=onboarding)
+> [Download](https://hub.docker.com/editions/community/docker-ce-desktop-mac)
 >
 > You must sign in to Docker Hub to download Docker Desktop.
 

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -8,7 +8,7 @@ title: Frequently asked questions (FAQ)
 
 ### How do I get the Stable or the Edge version of Docker Desktop?
 
-A. You can download the Stable version of Docker Desktop from [Docker Hub](https://hub.docker.com/?overlay=onboarding). To download the Edge version, see the [Edge release notes](/docker-for-windows/edge-release-notes/).
+A. You can download the Stable version of Docker Desktop from [Docker Hub](https://hub.docker.com/editions/community/docker-ce-desktop-windows). To download the Edge version, see the [Edge release notes](/docker-for-windows/edge-release-notes/).
 
 For installation instructions, see [Install Docker Desktop on Windows](install.md){: target="_blank" class="_"}.
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -8,7 +8,7 @@ Docker Desktop for Windows is the [Community](https://www.docker.com/community-e
 You can download Docker Desktop for Windows from Docker Hub.
 
 [Download from Docker
-Hub](https://hub.docker.com/?overlay=onboarding){:
+Hub](https://hub.docker.com/editions/community/docker-ce-desktop-windows){:
 .button .outline-btn}
 
 By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
@@ -70,7 +70,7 @@ Looking for information on using Windows containers?
 1. Double-click **Docker Desktop Installer.exe** to run the installer.
 
     If you haven't already downloaded the installer (`Docker Desktop Installer.exe`), you can get it from
-    [**Docker Hub**](https://hub.docker.com/?overlay=onboarding).
+    [**Docker Hub**](https://hub.docker.com/editions/community/docker-ce-desktop-windows).
     It typically downloads to your `Downloads` folder, or you can run it from
     the recent downloads bar at the bottom of your web browser.
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -16,7 +16,7 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 ## Docker Desktop Community 2.2.0.0
 2020-01-21
 
-> [Download](https://hub.docker.com/?overlay=onboarding)
+> [Download](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 >
 > You must sign in to Docker Hub to download Docker Desktop.
 


### PR DESCRIPTION
Since the hub Onboarding overlay links back to the docs, it just becomes a logical loop.

I've updated the links to link to each product's edition on the hub, rather than the onboarding overlay

