### PR TITLE
Removed enterprise note from Engine Community relnotes

### DIFF
--- a/engine/release-notes.md
+++ b/engine/release-notes.md
@@ -9,8 +9,6 @@ redirect_from:
  - /release-notes/docker-ce/
 ---
 
->{% include enterprise_label_shortform.md %}
-
 This document describes the latest changes, additions, known issues, and fixes
 for Docker Engine - Community.
 


### PR DESCRIPTION
### Proposed changes

Removed the Enterprise banner which was incorrectly added to the Engine Community release notes page
