### PR TITLE
Update Machine install info

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -26,7 +26,7 @@ See [Install Docker Desktop](install.md){: target="_blank" class="_"} for downlo
 
 ## Check versions
 
-Ensure your versions of `docker`, `docker-compose`, and `docker-machine` are
+Ensure your versions of `docker` and `docker-compose` are
 up-to-date and compatible with `Docker.app`. Your output may differ if you are
 running different versions.
 
@@ -414,8 +414,7 @@ topics.
 
 ## Install shell completion
 
-Docker Desktop comes with scripts to enable completion for the `docker`,
-`docker-machine`, and `docker-compose` commands. The completion scripts may be
+Docker Desktop comes with scripts to enable completion for the `docker` and `docker-compose` commands. The completion scripts may be
 found inside `Docker.app`, in the `Contents/Resources/etc/` directory and can be
 installed both in Bash and Zsh.
 
@@ -430,12 +429,10 @@ installed bash via [Homebrew](http://brew.sh/):
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc
 ln -s $etc/docker.bash-completion $(brew --prefix)/etc/bash_completion.d/docker
-ln -s $etc/docker-machine.bash-completion $(brew --prefix)/etc/bash_completion.d/docker-machine
 ln -s $etc/docker-compose.bash-completion $(brew --prefix)/etc/bash_completion.d/docker-compose
 ```
 
 Add the following to your `~/.bash_profile`:
-
 
 ```shell
 [ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
@@ -460,7 +457,6 @@ directory. For example, if you installed Zsh via [Homebrew](http://brew.sh/):
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc
 ln -s $etc/docker.zsh-completion /usr/local/share/zsh/site-functions/_docker
-ln -s $etc/docker-machine.zsh-completion /usr/local/share/zsh/site-functions/_docker-machine
 ln -s $etc/docker-compose.zsh-completion /usr/local/share/zsh/site-functions/_docker-compose
 ```
 

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -5,18 +5,12 @@ title: Install Docker Machine
 hide_from_sitemap: true
 ---
 
-On macOS and Windows, Machine is no longer installed along with other Docker products when
-you install the [Docker for Mac](/docker-for-mac/index.md),
-[Docker for Windows](/docker-for-windows/index.md), or
-[Docker Toolbox](/toolbox/overview.md).
-
-If you want Docker Machine, you can install the Machine binaries directly
-by following the instructions in the next section. You can find the latest
+Install Docker Machine binaries by following the instructions in the following section. You can find the latest
 versions of the binaries on the [docker/machine release
 page](https://github.com/docker/machine/releases/){: target="_blank" class="_" }
 on GitHub.
 
-## Install Machine directly
+## Install Docker Machine
 
 1.  Install [Docker](/engine/installation/index.md){: target="_blank" class="_" }.
 


### PR DESCRIPTION
Update Docker Machine installation topic to remove references to Docker Desktop.
Removed references to Docker Machine from Docker for Mac topic as Docker Machine is no longer included in Docker Desktop.