### PR TITLE
Updating install instructions for Fedora 31

### DIFF
--- a/install/linux/docker-ce/fedora.md
+++ b/install/linux/docker-ce/fedora.md
@@ -171,6 +171,8 @@ from the repository.
     $ sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
     ```
 
+    Reboot the system before moving onto next step
+
 4.  Start Docker
 
     ```bash


### PR DESCRIPTION
### Proposed changes

It is necessary to reboot the system after installation before running the verification step otherwise it may lead to verification errors by throwing a cgroups exception.

### Related issues (optional)

issues: #10255 