### PR TITLE
improve description of iptables design, add notes about securing Docker hosts

### DIFF
--- a/network/iptables.md
+++ b/network/iptables.md
@@ -68,6 +68,17 @@ the source and destination. For instance, if the Docker daemon listens on both
 topic. See the [Netfilter.org HOWTO](https://www.netfilter.org/documentation/HOWTO/NAT-HOWTO.html)
 for a lot more information.
 
+## Docker on a router
+
+Docker also sets the policy for the `FORWARD` chain to `DROP`. If your Docker
+host also acts as a router, this will result in that router not forwarding
+any traffic anymore. If you want your system to continue functioning as a
+router, you can add explicit `ACCEPT` rules to the `DOCKER-USER` chain to
+allow it:
+
+```bash
+$ iptables -I DOCKER-USER -i src_if -o dst_if -j ACCEPT
+```
 
 ## Prevent Docker from manipulating iptables
 

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -85,7 +85,7 @@ are not allowed on IPs the service is not bound to), without the necessity
 for disabling the iptables mechanisms altogether, because they do honor this
 setting and do not expose services on IPs they shall not be exposed on.
 
-However, `--ip` is not a _binding_ option: Setting it only changes the _default_,
+However, setting `--ip` only changes the _default_,
 it does not _restrict_ services to that IP. This means that while containers
 deployed via a simple `docker run` command mostly honor this setting (unless
 a `-p` option string explicitly overrides it), other container management

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -37,8 +37,8 @@ when a port gets exposed through Docker, you _must_ add these rules to the
 
 By default, all external source IPs are allowed to connect to the Docker daemon.
 To allow only a specific IP or network to access the containers, insert a
-negated rule at the top of the DOCKER filter chain. For example, the following
-rule restricts external access to all IP addresses except 192.168.1.1:
+negated rule at the top of the `DOCKER-USER` filter chain. For example, the
+following rule restricts external access to all IP addresses except 192.168.1.1:
 
 ```bash
 $ iptables -I DOCKER-USER -i ext_if ! -s 192.168.1.1 -j DROP

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -33,12 +33,12 @@ rules your firewall has configured. If you want those rules to apply even
 when a port gets exposed through Docker, you _must_ add these rules to the
 `DOCKER-USER` chain.
 
-### Restrict connections to the Docker daemon
+### Restrict connections to the Docker host
 
-By default, all external source IPs are allowed to connect to the Docker daemon.
+By default, all external source IPs are allowed to connect to the Docker host.
 To allow only a specific IP or network to access the containers, insert a
 negated rule at the top of the `DOCKER-USER` filter chain. For example, the
-following rule restricts external access to all IP addresses except 192.168.1.1:
+following rule restricts external access from all IP addresses except `192.168.1.1`:
 
 ```bash
 $ iptables -I DOCKER-USER -i ext_if ! -s 192.168.1.1 -j DROP
@@ -46,7 +46,7 @@ $ iptables -I DOCKER-USER -i ext_if ! -s 192.168.1.1 -j DROP
 
 Please note that you will need to change `ext_if` to correspond with your
 host's actual external interface. You could instead allow connections from a
-source subnet. The following rule only allows access from the subnet 192.168.1.0/24:
+source subnet. The following rule only allows access from the subnet `192.168.1.0/24`:
 
 ```bash
 $ iptables -I DOCKER-USER -i ext_if ! -s 192.168.1.0/24 -j DROP
@@ -61,7 +61,7 @@ $ iptables -I DOCKER-USER -m iprange -i ext_if ! --src-range 192.168.1.1-192.168
 
 You can combine `-s` or `--src-range` with `-d` or `--dst-range` to control both
 the source and destination. For instance, if the Docker daemon listens on both
-192.168.1.99 and 10.1.2.3, you can make rules specific to `10.1.2.3` and leave
+`192.168.1.99` and `10.1.2.3`, you can make rules specific to `10.1.2.3` and leave
 `192.168.1.99` open.
 
 `iptables` is complicated and more complicated rules are out of scope for this

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -86,7 +86,7 @@ It is possible to set the `iptables` key to `false` in the Docker engine's confi
 
 For system integrators who wish to build the Docker runtime into other applications, explore the [`moby` project](https://mobyproject.org/).
 
-## Note on the `--ip` option
+## Setting the default bind address for containers
 
 By default, the Docker daemon will expose ports on the `0.0.0.0` address, i.e.
 any address on the host. If you want to change that behavior to only

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -86,7 +86,7 @@ for disabling the iptables mechanisms altogether, because they do honor this
 setting and do not expose services on IPs they shall not be exposed on.
 
 However, `--ip` is not a _binding_ option: Setting it only changes the _default_,
-it does not _restrict_ services to that IP. This means that while containners
+it does not _restrict_ services to that IP. This means that while containers
 deployed via a simple `docker run` command mostly honor this setting (unless
 a `-p` option string explicitly overrides it), other container management
 systems may feel free to ignore this setting (or simply be unaware of it).

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -89,20 +89,10 @@ For system integrators who wish to build the Docker runtime into other applicati
 ## Note on the `--ip` option
 
 By default, the Docker daemon will expose ports on the `0.0.0.0` address, i.e.
-any address on the host. If you want to change that behavior to e.g. only
+any address on the host. If you want to change that behavior to only
 expose ports on an internal IP address, you can use the `--ip` option to
-specify a different IP address. This method heightens security (connections
-are not allowed on IPs the service is not bound to), without the necessity
-for disabling the iptables mechanisms altogether, because they do honor this
-setting and do not expose services on IPs they shall not be exposed on.
-
-However, setting `--ip` only changes the _default_,
-it does not _restrict_ services to that IP. This means that while containers
-deployed via a simple `docker run` command mostly honor this setting (unless
-a `-p` option string explicitly overrides it), other container management
-systems may feel free to ignore this setting (or simply be unaware of it).
-Thus if they specify `0.0.0.0` explicitly, the container will be reachable
-on any interface regardless of the `--ip` option.
+specify a different IP address. However, setting `--ip` only changes the
+_default_, it does not _restrict_ services to that IP.
 
 ## Next steps
 


### PR DESCRIPTION
Hi,

I've added a few paragraphs to [the "Docker and iptables"](https://docs.docker.com/network/iptables/) page that go into the details of how `FORWARD`, `DOCKER-USER` and `DOCKER` relate and how people can secure Docker hosts effectively, without being surprised by their rules being ineffective.

If you have any comments, I'd be happy to address them :)

Cheers,
Michael.