### PR TITLE
Update rails.md grammer

### DIFF
--- a/compose/rails.md
+++ b/compose/rails.md
@@ -10,7 +10,7 @@ a Rails/PostgreSQL app. Before starting, [install Compose](install.md).
 ### Define the project
 
 
-Start by setting up the files needed to build the app. App will run inside a Docker container containing its dependencies. Defining dependencies is done using a file called `Dockerfile`. To begin with, the 
+Start by setting up the files needed to build the app. The app will run inside a Docker container containing its dependencies. Defining dependencies is done using a file called `Dockerfile`. To begin with, the 
 Dockerfile consists of:
 
     FROM ruby:2.5


### PR DESCRIPTION
### Proposed changes

Added "the" in front of "App" on line 13 to read better. It put me off when first reading the documentation as it was in the first few sentences.

This may just be be but it just flows better this way.