### PR TITLE
Mention Docker 19.03 and its compose file version - and add max_repli…

### DIFF
--- a/_includes/content/compose-matrix.md
+++ b/_includes/content/compose-matrix.md
@@ -2,6 +2,7 @@ This table shows which Compose file versions support specific Docker releases.
 
 | **Compose file format** | **Docker Engine release** |
 |  -------------------    |    ------------------     |
+|      3.8                |       19.03.0+            |
 |      3.7                |       18.06.0+            |
 |      3.6                |       18.02.0+            |
 |      3.5                |       17.12.0+            |

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -796,6 +796,29 @@ services:
       replicas: 6
 ```
 
+#### max_replicas_per_node
+
+If the service is `replicated` (which is the default), [limit the number of replicas](/engine/reference/commandline/service_create.md#specify-maximum-replicas-per-node---replicas-max-per-node)
+that can run on an node at any time.
+
+> **[Version 3.8](compose-versioning.md#version-3) and above.**
+
+When there are more tasks requested than running nodes, an error `no suitable node (max replicas per node limit exceed)` is raised.
+
+```yaml
+version: "{{ site.compose_file_v3 }}"
+services:
+  worker:
+    image: dockersamples/examplevotingapp_worker
+    networks:
+      - frontend
+      - backend
+    deploy:
+      mode: replicated
+      replicas: 6
+      max_replicas_per_node: 1
+```
+
 #### resources
 
 Configures resource constraints.


### PR DESCRIPTION
it looks to me like 19.03's effect on swarm more compose wasn't documented.

this is an attempt at starting