### PR TITLE
Install: add Ubuntu Eoan, and remove old non-LTS versions

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -32,8 +32,7 @@ To learn more about Docker EE, see
 To install Docker Engine - Community, you need the 64-bit version of one of these Ubuntu
 versions:
 
-- Disco 19.04
-- Cosmic 18.10
+- Eoan 19.10
 - Bionic 18.04 (LTS)
 - Xenial 16.04 (LTS)
 


### PR DESCRIPTION
Eoan (Ubuntu 19.10) packages are now up; remove old non-LTS versions
from the list, as they reached EOL, and packages may now be outdated.


fixes https://github.com/docker/docker.github.io/issues/8891
fixes https://github.com/docker/docker.github.io/issues/10037


