### PR TITLE
Re-enable "anchorlink" script

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -295,7 +295,7 @@
 		hljs.initHighlightingOnLoad();
 	</script>
 	{% endif %}
-	<!-- <script src="/js/anchorlinks.js"></script> -->
+	<script defer src="/js/anchorlinks.js"></script>
 	<script defer src="/js/menu.js"></script>
 	<script src="/js/jquery.js"></script>
 	<script src="/js/bootstrap.min.js"></script>

--- a/_scss/_content.scss
+++ b/_scss/_content.scss
@@ -116,8 +116,16 @@ pre code {
 }
 
 a.anchorLink {
+    font-size: 0.5em;
     margin-left: 5px;
     visibility: hidden;
+}
+
+h1:hover > a.anchorLink,
+h2:hover > a.anchorLink,
+h3:hover > a.anchorLink
+{
+    visibility: visible;
 }
 
 a.glossary {

--- a/js/anchorlinks.js
+++ b/js/anchorlinks.js
@@ -1,11 +1,11 @@
 (function(d) {
 	"use strict";
-	var hs = d.getElementById("DocumentationText").querySelectorAll("H1, H2, H3"), h;
+	var hs = d.querySelectorAll("H1, H2, H3"), h;
 
 	for (var i = 0; i < hs.length; i++) {
 		h = hs[i];
 		if (h.id != null && h.id.length > 0) {
-			h.insertAdjacentHTML('beforeend', '<a href="' + window.location.href + '#' + h.id + '" class="anchorLink">¶</a>')
+			h.insertAdjacentHTML('beforeend', '<a href="' + window.location.href + '#' + h.id + '" class="anchorLink">🔗</a>')
 		}
 	}
 


### PR DESCRIPTION
This allows for easier sharing of links to specific sections on a page.

With this change, hovering over H1, H2, or H3 headings will reveal a small "anchor" icon/link, which can be used to copy/paste to reference that section (e.g. https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-from-a-package):

<img width="625" alt="Screenshot 2020-02-13 at 13 46 45" src="https://user-images.githubusercontent.com/1804568/74436951-9bc1f880-4e67-11ea-9f54-ca27a1d29505.png">
