### PR TITLE
machine: update default image for Rackspace driver

### DIFF
--- a/machine/drivers/rackspace.md
+++ b/machine/drivers/rackspace.md
@@ -24,7 +24,7 @@ Create machines on [Rackspace cloud](http://www.rackspace.com/cloud)
 -   `--rackspace-ssh-user`: SSH user for the newly booted machine.
 -   `--rackspace-username`: **required** Rackspace account username.
 
-The Rackspace driver uses `821ba5f4-712d-4ec8-9c65-a3fa4bc500f9` (Ubuntu 16.04 LTS) by default.
+The Rackspace driver uses `498bfa38-d288-4e37-b975-a4acb77f8557` (Ubuntu 18.04 LTS) by default.
 
 #### Environment variables and default values
 
@@ -35,7 +35,7 @@ The Rackspace driver uses `821ba5f4-712d-4ec8-9c65-a3fa4bc500f9` (Ubuntu 16.04 L
 | `--rackspace-docker-install` | -                    | `true`                                 |
 | `--rackspace-endpoint-type`  | `OS_ENDPOINT_TYPE`   | `publicURL`                            |
 | `--rackspace-flavor-id`      | `OS_FLAVOR_ID`       | `general1-1`                           |
-| `--rackspace-image-id`       | `OS_IMAGE_ID`        | `821ba5f4-712d-4ec8-9c65-a3fa4bc500f9` |
+| `--rackspace-image-id`       | `OS_IMAGE_ID`        | `498bfa38-d288-4e37-b975-a4acb77f8557` |
 | **`--rackspace-region`**     | `OS_REGION_NAME`     | `IAD` (Northern Virginia)              |
 | `--rackspace-ssh-port`       | `OS_SSH_PORT`        | `22`                                   |
 | `--rackspace-ssh-user`       | `OS_SSH_USER`        | `root`                                 |


### PR DESCRIPTION
Updated the documented default image for the Rackspace driver because the prior image is deprecated and can no longer be used. This goes hand in hand with the change in https://github.com/docker/machine/pull/4786
