### PR TITLE
Updated Desktop URLs and removed CSP and EE URLs

### DIFF
--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -10,24 +10,18 @@
                     <div class="navbar-collapse collapse">
                         <ul class="primary nav navbar-nav">
                             <li><a href="https://docker.com/why-docker">Why Docker?</a></li>
-                            <li><a href="https://docker.com/get-started">Product</a></li>
+                            <li><a href="https://www.docker.com/products">Products</a></li>
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Get Docker <span class="caret"></span></a>
                                 <ul class="dropdown-menu nav-main">
                                     <h6 class="dropdown-header">For Desktop</h6>
-                                    <li><a href="https://docker.com/products/docker-desktop">Mac & Windows</a></li>
-                                    <h6 class="dropdown-header">For Cloud Providers</h6>
-                                    <li><a href="https://docker.com/partners/aws">AWS</a></li>
-                                    <li><a href="https://docker.com/partners/microsoft">Azure</a></li>
+                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-desktop-mac">Mac</a></li>
+									<li><a href="https://hub.docker.com/editions/community/docker-ce-desktop-windows">Windows</a></li>
                                     <h6 class="dropdown-header">For Servers</h6>
-                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-windows">Windows Server</a></li>
-                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-centos">CentOS</a></li>
+                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-centos">CentOS</a></li>
                                     <li><a href="https://hub.docker.com/editions/community/docker-ce-server-debian">Debian</a></li>
                                     <li><a href="https://hub.docker.com/editions/community/docker-ce-server-fedora">Fedora</a></li>
-                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-oraclelinux">Oracle Enterprise Linux</a></li>
-                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-rhel">RHEL</a></li>
-                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-sles">SLES</a></li>
-                                    <li><a href="https://hub.docker.com/editions/enterprise/docker-ee-server-ubuntu">Ubuntu</a></li>
+                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-ubuntu">Ubuntu</a></li>
                                 </ul>
                             </li>
                             <li><a href="https://docker.com/docker-community">Community</a></li>

--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -9,21 +9,9 @@
                     </div>
                     <div class="navbar-collapse collapse">
                         <ul class="primary nav navbar-nav">
-                            <li><a href="https://docker.com/why-docker">Why Docker?</a></li>
+                            <li><a href="https://www.docker.com/why-docker">Why Docker?</a></li>
+                            <li><a href="https://docs.docker.com/get-started/">Get started</a></li>
                             <li><a href="https://www.docker.com/products">Products</a></li>
-                            <li class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Get Docker <span class="caret"></span></a>
-                                <ul class="dropdown-menu nav-main">
-                                    <h6 class="dropdown-header">For Desktop</h6>
-                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-desktop-mac">Mac</a></li>
-									<li><a href="https://hub.docker.com/editions/community/docker-ce-desktop-windows">Windows</a></li>
-                                    <h6 class="dropdown-header">For Servers</h6>
-                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-centos">CentOS</a></li>
-                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-debian">Debian</a></li>
-                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-fedora">Fedora</a></li>
-                                    <li><a href="https://hub.docker.com/editions/community/docker-ce-server-ubuntu">Ubuntu</a></li>
-                                </ul>
-                            </li>
                             <li><a href="https://docker.com/docker-community">Community</a></li>
                             <li><a href="https://hub.docker.com/signup">Create Docker ID</a></li>
                             <li><a href="https://hub.docker.com/sso/start">Sign In</a></li>


### PR DESCRIPTION
- Removed Get Docker drop-down from top navigation
- Added a link to Get started docs
- Fixed the URL to Docker Products
