### PR TITLE
Fix broken link in mac FAQs

### DIFF
--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -83,7 +83,7 @@ Yes, you can use the host’s SSH agent inside a container. For more information
 ### How do I add custom CA certificates?
 
 Docker Desktop supports all trusted certificate authorities (CAs) (root or intermediate). For more information on adding server and client side certs, see
-[Add TLS certificates](/docker-for-mac/index/#add-tls-certificates) in the Getting Started topic.
+[Add TLS certificates](/docker-for-mac/#add-tls-certificates) in the Getting Started topic.
 
 ### How do I add client certificates?
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -83,7 +83,7 @@ Yes, you can use the host’s SSH agent inside a container. For more information
 ### How do I add custom CA certificates?
 
 Docker Desktop supports all trusted certificate authorities (CAs) (root or intermediate). For more information on adding server and client side certs, see
-[Add TLS certificates](/docker-for-mac/index/#adding-tls-certificates) in the Getting Started topic.
+[Add TLS certificates](/docker-for-mac/index/#add-tls-certificates) in the Getting Started topic.
 
 ### How do I add client certificates?
 


### PR DESCRIPTION
The title of the linked section has changed to "Add TLS Certificates". The current link goes to the top of the Getting Started page and is confusing because you have to scroll past the Kubernetes section to get to the section you actually need.

### Proposed changes

Fix a link

### Unreleased project version (optional)

N/A

### Related issues (optional)

N/A