### PR TITLE
Desktop Edge 2.2.2.0 release notes

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -22,6 +22,11 @@ This release contains a Kubernetes upgrade. Note that your local Kubernetes clus
 - [Kubernetes 1.16.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.16.5)
 - [Go 1.13.8](https://golang.org/doc/devel/release.html#go1.13)
 
+### Bug fixes and minor changes
+
+- Docker Desktop now shares `/var/folders` by default as it stores per-user temporary files and caches.
+- Ceph support has been removed from Docker Desktop to save disk space.
+
 ## Docker Desktop Community 2.2.1.0
 2020-02-12
 

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -12,6 +12,16 @@ For information about Stable releases, see the [Stable release
 notes](release-notes). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
+## Docker Desktop Community 2.2.2.0
+2020-02-
+
+This release contains a Kubernetes upgrade. Note that your local Kubernetes cluster will be reset after installing Docker Desktop.
+
+### Upgrades
+
+- [Kubernetes 1.16.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.16.5)
+- [Go 1.13.8](https://golang.org/doc/devel/release.html#go1.13)
+
 ## Docker Desktop Community 2.2.1.0
 2020-02-12
 

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -13,7 +13,9 @@ notes](release-notes). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
 ## Docker Desktop Community 2.2.2.0
-2020-02-
+2020-03-02
+
+> [Download](https://download.docker.com/mac/edge/43066/Docker.dmg)
 
 This release contains a Kubernetes upgrade. Note that your local Kubernetes cluster will be reset after installing Docker Desktop.
 

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -22,9 +22,16 @@ This release contains a Kubernetes upgrade. Note that your local Kubernetes clus
 - [Kubernetes 1.16.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.16.5)
 - [Go 1.13.8](https://golang.org/doc/devel/release.html#go1.13)
 
+### New
+
+- Windows 10 Home users can now use Docker Desktop through the experimental WSL 2 support. This requires Windows Insider Preview Build 19018 or later.
+- Docker Desktop now allows sharing individual folders, rather than whole drives, giving more control to users over what is being shared.
+
 ### Bug fixes and minor changes
 
 - DockerNAT has been removed from Docker Desktop as using an IP address to communicate from the host to a container is not a supported feature. To communicate from a container to the host, you must use the special DNS name `host.docker.internal`. We also recommend using ports to communicate from the host to a container. For more information, see [Networking](/docker-for-win/networking/#use-cases-and-workarounds).
+- Ceph support has been removed from Docker Desktop to save disk space.
+- Fixed an issue that caused the Windows log file archive to grow indefinitely. Fixes [docker/for-win#5113](https://github.com/docker/for-win/issues/5113).
 
 ## Docker Desktop Community 2.2.1.0
 2020-02-12

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -13,7 +13,9 @@ notes](release-notes). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
 ## Docker Desktop Community 2.2.2.0
-2020-02-
+2020-03-02
+
+> [Download](https://download.docker.com/win/edge/43066/Docker%2520Desktop%2520Installer.exe)
 
 This release contains a Kubernetes upgrade. Note that your local Kubernetes cluster will be reset after installing Docker Desktop.
 
@@ -29,6 +31,7 @@ This release contains a Kubernetes upgrade. Note that your local Kubernetes clus
 
 ### Bug fixes and minor changes
 
+- Added a prerequisite check in the installer for the `LanmanServer` service. Fixes [docker/for-win#5150](https://github.com/docker/for-win/issues/5150).
 - DockerNAT has been removed from Docker Desktop as using an IP address to communicate from the host to a container is not a supported feature. To communicate from a container to the host, you must use the special DNS name `host.docker.internal`. We also recommend using ports to communicate from the host to a container. For more information, see [Networking](/docker-for-win/networking/#use-cases-and-workarounds).
 - Ceph support has been removed from Docker Desktop to save disk space.
 - Fixed an issue that caused the Windows log file archive to grow indefinitely. Fixes [docker/for-win#5113](https://github.com/docker/for-win/issues/5113).

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -12,6 +12,20 @@ For information about Stable releases, see the [Stable release
 notes](release-notes). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
+## Docker Desktop Community 2.2.2.0
+2020-02-
+
+This release contains a Kubernetes upgrade. Note that your local Kubernetes cluster will be reset after installing Docker Desktop.
+
+### Upgrades
+
+- [Kubernetes 1.16.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.16.5)
+- [Go 1.13.8](https://golang.org/doc/devel/release.html#go1.13)
+
+### Bug fixes and minor changes
+
+- DockerNAT has been removed from Docker Desktop as using an IP address to communicate from the host to a container is not a supported feature. To communicate from a container to the host, you must use the special DNS name `host.docker.internal`. We also recommend using ports to communicate from the host to a container. For more information, see [Networking](/docker-for-win/networking/#use-cases-and-workarounds).
+
 ## Docker Desktop Community 2.2.1.0
 2020-02-12
 


### PR DESCRIPTION

### Proposed changes

Release notes for Docker Desktop Edge 2.2.2.0

### Unreleased project version (optional)

2.2.2.0

