### PR TITLE
Reduce list of archives to supported enterprise versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,7 @@ FROM scratch AS archives-true
 ENV TARGET=/usr/share/nginx/html
 # To add a new archive, add it here and ALSO edit _data/docsarchive/archives.yaml
 # to add it to the drop-down
-COPY --from=docs/docker.github.io:v17.03 ${TARGET} /
 COPY --from=docs/docker.github.io:v17.06 ${TARGET} /
-COPY --from=docs/docker.github.io:v17.09 ${TARGET} /
-COPY --from=docs/docker.github.io:v17.12 ${TARGET} /
 COPY --from=docs/docker.github.io:v18.03 ${TARGET} /
 COPY --from=docs/docker.github.io:v18.09 ${TARGET} /
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ safe: false
 lsi: false
 url: https://docs.docker.com
 # This needs to have all the directories you expect to be in the archives (delivered by docs-base in the Dockerfile)
-keep_files: ["v17.03", "v17.06", "v17.09", "v17.12", "v18.03", "v18.09"]
+keep_files: ["v17.06", "v18.03", "v18.09"]
 exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]
 
 # Component versions -- address like site.docker_ce_version
@@ -81,10 +81,7 @@ tablabels:
   engine-19.03: Docker EE Engine 19.03
   engine-18.09: Docker EE Engine 18.09
   engine-18.03: Docker EE Engine 18.03
-  engine-17.12: Docker EE Engine 17.12
-  engine-17.09: Docker EE Engine 17.09
   engine-17.06: Docker EE Engine 17.06
-  engine-17.03: Docker EE Engine 17.03
   docker-cli-linux: Docker CLI on Mac/Linux
   docker-cli-win: Docker CLI on Windows
   kubectl: Kubernetes CLI

--- a/_config_authoring.yml
+++ b/_config_authoring.yml
@@ -13,7 +13,7 @@ safe: false
 lsi: false
 url: https://docs.docker.com
 # This needs to have all the directories you expect to be in the archives (delivered by docs-base in the Dockerfile)
-keep_files: ["v17.03", "v17.06", "v17.09", "v17.12", "v18.03", "v18.09"]
+keep_files: ["v17.06", "v18.03", "v18.09"]
 exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]
 
 # Component versions -- address like site.docker_ce_version
@@ -85,7 +85,6 @@ tablabels:
   engine-18.09: Docker EE Engine 18.09
   engine-18.03: Docker EE Engine 18.03
   engine-17.06: Docker EE Engine 17.06
-  engine-17.03: Docker EE Engine 17.03
   docker-cli-linux: Docker CLI on Mac/Linux
   docker-cli-win: Docker CLI on Windows
   kubectl: Kubernetes CLI

--- a/_config_authoring.yml
+++ b/_config_authoring.yml
@@ -12,6 +12,9 @@ permalink: pretty
 safe: false
 lsi: false
 url: https://docs.docker.com
+# This needs to have all the directories you expect to be in the archives (delivered by docs-base in the Dockerfile)
+keep_files: ["v17.03", "v17.06", "v17.09", "v17.12", "v18.03", "v18.09"]
+exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]
 
 # Component versions -- address like site.docker_ce_version
 # You can't have - characters in these for non-YAML reasons
@@ -26,14 +29,16 @@ compose_version: "1.25.4"
 compose_file_v3: "3.7"
 compose_file_v2: "2.4"
 machine_version: "0.16.0"
-distribution_version: "2.6"
-dtr_version: "2.6"
-ucp_version: "3.1"
+distribution_version: "2.7"
+dtr_version: "2.7"
+ucp_version: "3.2"
 
 ucp_versions:
-  - version: "3.1"
+  - version: "3.2"
     path: /ee/ucp/
     latest: true
+  - version: "3.1"
+    path: /datacenter/ucp/3.1/guides/
   - version: "3.0"
     path: /datacenter/ucp/3.0/guides/
   - version: "2.2"
@@ -46,9 +51,11 @@ ucp_versions:
     path: /datacenter/ucp/1.1/overview/
 
 dtr_versions:
-  - version: "2.6"
+  - version: "2.7"
     path: /ee/dtr/
     latest: true
+  - version: "2.6"
+    path: /datacenter/dtr/2.6/guides/
   - version: "2.5"
     path: /datacenter/dtr/2.5/guides/
   - version: "2.4"
@@ -63,11 +70,20 @@ dtr_versions:
     path: /datacenter/dtr/2.0/
 
 tablabels:
+  dee-3.0: Docker Enterprise Edition 3.0
+  dee-2.1: Docker Enterprise Edition 2.1
   dee-2.0: Docker Enterprise Edition 2.0
+  ucp-3.2: Universal Control Plane 3.2
+  ucp-3.1: Universal Control Plane 3.1
   ucp-3.0: Universal Control Plane 3.0
   ucp-2.2: Universal Control Plane 2.2
+  dtr-2.7: Docker Trusted Registry 2.7
+  dtr-2.6: Docker Trusted Registry 2.6
   dtr-2.5: Docker Trusted Registry 2.5
   dtr-2.4: Docker Trusted Registry 2.4
+  engine-19.03: Docker EE Engine 19.03
+  engine-18.09: Docker EE Engine 18.09
+  engine-18.03: Docker EE Engine 18.03
   engine-17.06: Docker EE Engine 17.06
   engine-17.03: Docker EE Engine 17.03
   docker-cli-linux: Docker CLI on Mac/Linux
@@ -97,33 +113,46 @@ defaults:
       path: "datacenter"
     values:
       enterprise: true
+  # Latest Enterprise Platform Release
   - scope:
-      path: "ee/dtr"
+      path: "ee"
     values:
+      ucp_org: "docker"
+      ucp_repo: "ucp"
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.6.1"
+      ucp_version: "3.2.5"
+      dtr_version: "2.7.5"
+      win_latest_build: "docker-19.03.5"
+  # Previous DTR Releases
+  - scope:
+      path: "datacenter/dtr/2.6"
+    values:
+      hide_from_sitemap: true
+      dtr_org: "docker"
+      dtr_repo: "dtr"
+      dtr_version: "2.6.12"
   - scope:
       path: "datacenter/dtr/2.5"
     values:
       hide_from_sitemap: true
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.5.7"
+      dtr_version: "2.5.16"
   - scope:
       path: "datacenter/dtr/2.4"
     values:
       hide_from_sitemap: true
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.4.8"
+      dtr_version: "2.4.14"
   - scope:
       path: "datacenter/dtr/2.3"
     values:
       hide_from_sitemap: true
       dtr_org: "docker"
       dtr_repo: "dtr"
-      dtr_version: "2.3.10"
+      dtr_version: "2.3.11"
   - scope:
       path: "datacenter/dtr/2.2"
     values:
@@ -140,35 +169,28 @@ defaults:
     values:
       ucp_version: "1.1"
       dtr_version: "2.0"
+  # Previous UCP Releases
   - scope:
-      path: "ee/ucp"
+      path: "datacenter/ucp/3.1"
     values:
+      hide_from_sitemap: true
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "3.1.2"
-  - scope: # This is a bit of a hack for the get-support.md topic.
-      path: "ee"
-    values:
-      ucp_org: "docker"
-      ucp_repo: "ucp"
-      dtr_repo: "dtr"
-      ucp_version: "3.1.2"
-      dtr_version: "2.6.1"
-      win_latest_build: "docker-19.03.5"
+      ucp_version: "3.1.12"
   - scope:
       path: "datacenter/ucp/3.0"
     values:
       hide_from_sitemap: true
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "3.0.8"
+      ucp_version: "3.0.16"
   - scope:
       path: "datacenter/ucp/2.2"
     values:
       hide_from_sitemap: true
       ucp_org: "docker"
       ucp_repo: "ucp"
-      ucp_version: "2.2.15"
+      ucp_version: "2.2.22"
   - scope:
       path: "datacenter/ucp/2.1"
     values:

--- a/_data/docsarchive/archives.yaml
+++ b/_data/docsarchive/archives.yaml
@@ -11,14 +11,5 @@
   name: v18.03
   image: docs/docker.github.io:v18.03
 - archive:
-  name: v17.12
-  image: docs/docker.github.io:v17.12
-- archive:
-  name: v17.09
-  image: docs/docker.github.io:v17.09
-- archive:
   name: v17.06
   image: docs/docker.github.io:v17.06
-- archive:
-  name: v17.03
-  image: docs/docker.github.io:v17.03


### PR DESCRIPTION
Docker Enterprise actively supports the 17.06, 18.03, 18.09 and 19.03 versions, with 17.06 and 18.03 reaching EOL soon.