### PR TITLE
fix update docker command

### DIFF
--- a/ee/admin/backup/back-up-ucp.md
+++ b/ee/admin/backup/back-up-ucp.md
@@ -87,7 +87,6 @@ Replace `{{ page.ucp_version }}` with the version you are currently running.
 ```bash
 $ docker container run \
     --rm \
-    --interactive \
     --log-driver none \
     --name ucp \
     --volume /var/run/docker.sock:/var/run/docker.sock \
@@ -108,7 +107,6 @@ $ docker container run \
 ```bash
 $ docker container run \
     --rm \
-    --interactive \
     --log-driver none \
     --security-opt label=disable \
     --name ucp \


### PR DESCRIPTION
If you supply the `--interactive` flag to `docker run` the prompt will never come back. That said, if somebody were to run this as a cron job, it would fail as the `ucp-phase2` container name will already exist.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
