### PR TITLE
NGINX config: add redirect rules for obsolete archive pages

### DIFF
--- a/_deploy/nginx/default.conf
+++ b/_deploy/nginx/default.conf
@@ -4,8 +4,6 @@ server {
   absolute_redirect off;
   listen 4000;
   error_page 403 404 /404.html;
-  location / {
-    root   /usr/share/nginx/html;
-    index  index.html index.htm;
-  }
+  root   /usr/share/nginx/html;
+  index  index.html;
 }

--- a/_deploy/nginx/default.conf
+++ b/_deploy/nginx/default.conf
@@ -1,5 +1,7 @@
 server {
-  port_in_redirect off;
+  # Use relative redirects to account for situations where a front-end proxy is
+  # used and the container does not know the public domain and port
+  absolute_redirect off;
   listen 4000;
   error_page 403 404 /404.html;
   location / {

--- a/_deploy/nginx/default.conf
+++ b/_deploy/nginx/default.conf
@@ -6,4 +6,7 @@ server {
   error_page 403 404 /404.html;
   root   /usr/share/nginx/html;
   index  index.html;
+
+  # Enable aio for better performance (see https://www.nginx.com/blog/thread-pools-boost-performance-9x/)
+  aio threads;
 }

--- a/_deploy/nginx/default.conf
+++ b/_deploy/nginx/default.conf
@@ -9,4 +9,18 @@ server {
 
   # Enable aio for better performance (see https://www.nginx.com/blog/thread-pools-boost-performance-9x/)
   aio threads;
+
+  location ~ ^/v([\d\.]+)/(.*)$ {
+    # Archive URLs: first try if the given file is still hosted, otherwise
+    # redirect to the same URL in the current version of the docs.
+    try_files $uri $uri/ @redirect_current;
+  }
+
+  location @redirect_current {
+    # Do a 301 (moved permanently) redirect of archive pages we didn't find
+    # to the same location in the current docs. Note that the location redirected
+    # to may not (or no longer) exist, and as such could result in another 301
+    # redirect, or a 404.
+    rewrite ^/v([\d\.]+)/(.*)$ /$2 permanent;
+  }
 }


### PR DESCRIPTION
# NGINX configuration: use relative redirects

Use relative redirects to account for situations where a front-end
proxy is used and the container does not know the public domain and
port.

Before this change, when running locally (on localhost:4000), redirects would omit
the port number, and redirect to localhost _without_ port number:

```bash
curl -v "http://localhost:4000/engine/reference/commandline/run"
* TCP_NODELAY set
* Connected to localhost (::1) port 4000 (#0)
> GET /engine/reference/commandline/run HTTP/1.1
> Host: localhost:4000
> User-Agent: curl/7.65.3
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.17.8
< Date: Fri, 28 Feb 2020 13:46:10 GMT
< Content-Type: text/html
< Content-Length: 169
< Location: http://localhost/engine/reference/commandline/run/
< Connection: keep-alive
```

After this change, redirect will be "relative", so redirecting to the correct location:

```bash
curl -v "http://localhost:4000/engine/reference/commandline/run"
* TCP_NODELAY set
* Connected to localhost (::1) port 4000 (#0)
> GET /engine/reference/commandline/run HTTP/1.1
> Host: localhost:4000
> User-Agent: curl/7.65.3
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.17.8
< Date: Fri, 28 Feb 2020 13:39:02 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: /engine/reference/commandline/run/
```

# NGINX configuration: define "root" and "index" at server level

It's best-practice to not define these inside a "location" block
to prevent having to re-define them for each location.

# NGINX config: enable aio

Enable aio for better performance (see https://www.nginx.com/blog/thread-pools-boost-performance-9x/)

# NGINX config: add redirect rules for obsolete archive pages

This adds redirect rules to redirect URLs for archives that are no longer hosted
to the current documentation.

Some test scenarios below to verify:

First, build the docs with archives enabled:

```bash
DOCKER_BUILDKIT=1 docker build --build-arg=ENABLE_ARCHIVES=true -t docs .
```

Then, run the docs locally:

```bash
docker run -it --rm -p 4000:4000 docs
```

Verify these URL's

Current docs
--------------------------------------------------------------------------------


- http://localhost:4000/engine/reference/commandline/create
    - redirects to http://localhost:4000/engine/reference/commandline/create/ (with trailing slash)
- http://localhost:4000/engine/reference/commandline/create/
- http://localhost:4000/engine/reference/commandline/create/index.html

Archived docs for current archives (e.g. v18.09):
--------------------------------------------------------------------------------

- http://localhost:4000/v18.09/engine/reference/commandline/create
  - ideally this should redirect to http://localhost:4000/v18.09/engine/reference/commandline/create/ (with trailing slash)
- http://localhost:4000/v18.09/engine/reference/commandline/create/
- http://localhost:4000/v18.09/engine/reference/commandline/create/index.html

Non-existing pages
--------------------------------------------------------------------------------

These should produce a 404 (not found)

- http://localhost:4000/no/such/page/
- http://localhost:4000/v18.09/no/such/page/
    - redirects to http://localhost:4000/no/such/page/

URLs for archived versions that are not, or no longer, published
--------------------------------------------------------------------------------
These are not found, because we don't (or no longer) publish these archive versions.
Because they start with `/vXX.XX/`, we redirect them to the same location in the
current docs. Note that the location redirected to may not (or no longer) exist,
and as such could result in another 301 redirect, or a ultimately a 404 ("not found").

Given that these should not re-appear, these redirects use a 301 (permanent). There
is one corner case; URLs for _future_ releases (e.g. `/v20.03/`) will _also_ produce
a 301, which could be cached by browsers / proxies, and effectively "block" the
URL for future use. I don't think this is very problematic, or at least not
something we should care about.

- http://localhost:4000/v17.99/engine/reference/commandline/run
    - redirects to http://localhost:4000/engine/reference/commandline/run/ in the current docs
- http://localhost:4000/v17.99/engine/reference/commandline/run/
    - redirects to http://localhost:4000/engine/reference/commandline/run/ in the current docs
- http://localhost:4000/v17.99/engine/reference/commandline/run/index.html
    - redirects to http://localhost:4000/engine/reference/commandline/run/index.html  in the current docs

Non existing pages in archive paths
--------------------------------------------------------------------------------

- http://localhost:4000/v17.03/no/such/page/
    - redirects to http://localhost:4000/no/such/page/ in the current docs
    - which shows a 404 not found page
