### PR TITLE
Download Edge version via Docker Hub

### DIFF
--- a/docker-for-windows/wsl-tech-preview.md
+++ b/docker-for-windows/wsl-tech-preview.md
@@ -25,7 +25,7 @@ Before you install Docker Desktop WSL 2 backend, you must complete the following
 
 # Download
 
-Download [Docker Desktop Edge 2.1.6.0](https://download.docker.com/win/edge/40807/Docker%20Desktop%20Installer.exe) or a later release.
+Download [Docker Desktop Edge](https://hub.docker.com/editions/community/docker-ce-desktop-windows/) 2.1.6.0 or a later release.
 
 # Install
 


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

### Proposed changes

Update the link to download the latest Docker Desktop Edge version via Docker Hub. The previous link downloads 2.1.6.0 and we want users to get the current Edge version.
