### PR TITLE
Update install/linux/docker-ce/debian.md

### DIFF
--- a/install/linux/docker-ce/debian.md
+++ b/install/linux/docker-ce/debian.md
@@ -22,8 +22,8 @@ To get started with Docker Engine - Community on Debian, make sure you
 To install Docker Engine - Community, you need the 64-bit version of one of these Debian or
 Raspbian versions:
 
-- Buster 10
-- Stretch 9 (stable) / Raspbian Stretch
+- Buster 10 (stable)
+- Stretch 9 / Raspbian Stretch
 
 Docker Engine - Community is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
 

--- a/install/linux/docker-ce/debian.md
+++ b/install/linux/docker-ce/debian.md
@@ -87,7 +87,7 @@ from the repository.
         apt-transport-https \
         ca-certificates \
         curl \
-        gnupg2 \
+        gnupg-agent \
         software-properties-common
     ```
 


### PR DESCRIPTION
### Proposed changes

This PR proposes to update the page https://docs.docker.com/install/linux/docker-ce/debian/ :

* Keep the name of the latest stable distribution up-to-date;
* Mention in the Debian install procedure, the same APT packages as in [Ubuntu's install procedure](https://docs.docker.com/install/linux/docker-ce/ubuntu/) (to be more precise, `gnupg2` was just a transitional package providing symlinks to `gnupg` and depending on `gnupg-agent`, and IINM `gnupg-agent` should be enough for Debian as well :)  
    see also [this commit message](https://github.com/docker/docker.github.io/commit/651ae2d507fac4fa5cad983cdbc0288158164965) for details.