### PR TITLE
ci: Upload docs only in upstream repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,10 @@
 .git
 .gitignore
 tests
-Dockerfile
-docker-compose.yml
 _site
+CONTRIBUTING.md
+Dockerfile
+Dockerfile.archive
+docker-compose.yml
 Gemfile.lock
+Jenkinsfile

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -7,10 +7,9 @@ jobs:
   build-static-page:
     name: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       DOCKER_BUILDKIT: '1'
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: print docker info
         run: docker version && docker info
@@ -19,5 +18,13 @@ jobs:
         run: docker build --build-arg=ENABLE_ARCHIVES=true --target=deploy-source --output=./_site .
       - name: upload files to S3 bucket
         run: aws s3 sync --acl public-read _site s3://docs.docker.com-test-us-east-1/ --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        if: github.repository == 'docker/docker.github.io' && github.event_name == 'push'
       - name: invalidate docs website cache
         run: aws --region us-east-1 lambda invoke --function-name arn:aws:lambda:us-east-1:710015040892:function:docs-test-cache-invalidator response.json
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        if: github.repository == 'docker/docker.github.io' && github.event_name == 'push'


### PR DESCRIPTION
Improve the GH actions pipeline to only run the upload and invalidate cache steps in upstream repo.
Otherwise contributors get an error mail from GitHub when they update their `master` branch.

Example:
<img width="983" alt="Screen Shot 2020-03-13 at 10 54 51 AM" src="https://user-images.githubusercontent.com/207759/76610355-12aae980-6519-11ea-9fe8-6227191b4ed1.png">

I first thought what's wrong with the pipeline in upstream, but then I saw that the full workflow ran in my fork I updated my master branch:

```
git fetch upstream
git rebase upstream/master
git push
```
