### PR TITLE
toc: move glossary, and reorganize "reference" section

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -324,22 +324,6 @@ guides:
     title: View the docs archives
 
 reference:
-- sectiontitle: File formats
-  section:
-  - title: Dockerfile reference
-    path: /engine/reference/builder/
-  - sectiontitle: Compose file reference
-    section:
-    - path: /compose/compose-file/
-      title: Version 3
-    - path: /compose/compose-file/compose-file-v2/
-      title: Version 2
-    - path: /compose/compose-file/compose-file-v1/
-      title: Version 1
-    - path: /compose/compose-file/compose-versioning/
-      title: About versions and upgrading
-    - path: /compose/faq/
-      title: Frequently asked questions
 - sectiontitle: Command-line reference
   section:
   - sectiontitle: Docker CLI (docker)
@@ -1014,6 +998,22 @@ reference:
     path: /registry/spec/api/
   - title: Template API
     path: /app-template/api-reference/
+- sectiontitle: File formats
+  section:
+    - title: Dockerfile reference
+      path: /engine/reference/builder/
+    - sectiontitle: Compose file reference
+      section:
+        - path: /compose/compose-file/
+          title: Version 3
+        - path: /compose/compose-file/compose-file-v2/
+          title: Version 2
+        - path: /compose/compose-file/compose-file-v1/
+          title: Version 1
+        - path: /compose/compose-file/compose-versioning/
+          title: About versions and upgrading
+        - path: /compose/faq/
+          title: Frequently asked questions
 - sectiontitle: Drivers and specifications
   section:
   - sectiontitle: Registry image manifests

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -6,9 +6,6 @@ horizontalnav:
 - title: Product manuals
   path: /install/
   node: manuals
-- title: Glossary
-  path: /glossary/
-  node: glossary
 - title: Reference
   path: /reference/
   node: reference
@@ -1057,6 +1054,8 @@ reference:
       title: S3 storage driver
     - path: /registry/storage-drivers/swift/
       title: Swift storage driver
+- path: /glossary/
+  title: Glossary
 
 
 

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -340,7 +340,7 @@ reference:
       title: About versions and upgrading
     - path: /compose/faq/
       title: Frequently asked questions
-- sectiontitle: Command-Line Interfaces (CLIs)
+- sectiontitle: Command-line reference
   section:
   - sectiontitle: Docker CLI (docker)
     section:
@@ -948,7 +948,7 @@ reference:
       title: up
   - title: Daemon CLI (dockerd)
     path: /engine/reference/commandline/dockerd/
-- sectiontitle: Application Programming Interfaces (APIs)
+- sectiontitle: API reference
   section:
   - sectiontitle: Docker Engine API
     section:

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -998,22 +998,20 @@ reference:
     path: /registry/spec/api/
   - title: Template API
     path: /app-template/api-reference/
-- sectiontitle: File formats
+- title: Dockerfile reference
+  path: /engine/reference/builder/
+- sectiontitle: Compose file reference
   section:
-    - title: Dockerfile reference
-      path: /engine/reference/builder/
-    - sectiontitle: Compose file reference
-      section:
-        - path: /compose/compose-file/
-          title: Version 3
-        - path: /compose/compose-file/compose-file-v2/
-          title: Version 2
-        - path: /compose/compose-file/compose-file-v1/
-          title: Version 1
-        - path: /compose/compose-file/compose-versioning/
-          title: About versions and upgrading
-        - path: /compose/faq/
-          title: Frequently asked questions
+    - path: /compose/compose-file/
+      title: Version 3
+    - path: /compose/compose-file/compose-file-v2/
+      title: Version 2
+    - path: /compose/compose-file/compose-file-v1/
+      title: Version 1
+    - path: /compose/compose-file/compose-versioning/
+      title: About versions and upgrading
+    - path: /compose/faq/
+      title: Frequently asked questions
 - sectiontitle: Drivers and specifications
   section:
   - sectiontitle: Registry image manifests

--- a/_includes/content/ssh/ssh-overview.md
+++ b/_includes/content/ssh/ssh-overview.md
@@ -1,4 +1,4 @@
-[SSH](/../../../glossary.md#SSH) is a secure protocol for accessing remote machines and applications. It
+[SSH](/glossary.md#SSH) is a secure protocol for accessing remote machines and applications. It
 provides authentication and encrypts data communication over insecure networks.
 
 These topics describe how to find existing SSH keys or generate new ones, and

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -30,7 +30,7 @@ The default path for a Compose file is `./docker-compose.yml`.
 
 >**Tip**: You can use either a `.yml` or `.yaml` extension for this file. They both work.
 
-A [container](/../../glossary.md#container) definition contains configuration which are applied to each
+A [container](/glossary.md#container) definition contains configuration which are applied to each
 container started for that service, much like passing command-line parameters to
 `docker run`. Likewise, network and volume definitions are analogous to
 `docker network create` and `docker volume create`.

--- a/js/docs.js
+++ b/js/docs.js
@@ -16,13 +16,13 @@ if (current[0]) {
 }
 
 function navClicked(sourceLink) {
-    var classString = document.getElementById('#item' + sourceLink).className;
-    if (classString.indexOf(' in') > -1) {
+    var classString = document.getElementById("#item" + sourceLink).className;
+    if (classString.indexOf(" in") > -1) {
         //collapse
-        document.getElementById('#item' + sourceLink).className = classString.replace(' in', '');
+        document.getElementById("#item" + sourceLink).className = classString.replace(" in", "");
     } else {
         //expand
-        document.getElementById('#item' + sourceLink).className = classString.concat(' in');
+        document.getElementById("#item" + sourceLink).className = classString.concat(" in");
     }
 }
 
@@ -62,19 +62,19 @@ function walkTree(tree) {
             } else {
                 outputLetNav.push('class="collapsed" aria-expanded="false"')
             }
-            outputLetNav.push('>' + tree[j].sectiontitle + '<span class="caret arrow"></span></a>');
+            outputLetNav.push(">" + tree[j].sectiontitle + '<span class="caret arrow"></span></a>');
             outputLetNav.push('<ul class="nav collapse');
-            if (sectionHasPath) outputLetNav.push(' in');
+            if (sectionHasPath) outputLetNav.push(" in");
             outputLetNav.push('" id="#item' + totalTopics + '" aria-expanded="');
             if (sectionHasPath) {
-                outputLetNav.push('true');
+                outputLetNav.push("true");
             } else {
-                outputLetNav.push('false');
+                outputLetNav.push("false");
             }
             outputLetNav.push('">');
             var subTree = tree[j].section;
             walkTree(subTree);
-            outputLetNav.push('</ul></li>');
+            outputLetNav.push("</ul></li>");
         } else {
             // just a regular old topic; this is a leaf, not a branch; render a link!
             outputLetNav.push('<li><a href="' + tree[j].path + '"')
@@ -82,13 +82,13 @@ function walkTree(tree) {
                 sectionToHighlight = currentSection;
                 outputLetNav.push('class="active currentPage"')
             }
-            outputLetNav.push('>' + tree[j].title + '</a></li>')
+            outputLetNav.push(">" + tree[j].title + "</a></li>")
         }
     }
 }
 
 function renderNav(docstoc) {
-    for (i = 0; i < docstoc.horizontalnav.length; i++) {
+    for (var i = 0; i < docstoc.horizontalnav.length; i++) {
         if (docstoc.horizontalnav[i].node !== "glossary") {
             currentSection = docstoc.horizontalnav[i].node;
             // build vertical nav
@@ -102,10 +102,10 @@ function renderNav(docstoc) {
         if (docstoc.horizontalnav[i].path === pageURL || docstoc.horizontalnav[i].node === sectionToHighlight) {
             outputHorzTabs.push(' class="active"');
         }
-        outputHorzTabs.push('><a href="' + docstoc.horizontalnav[i].path + '">' + docstoc.horizontalnav[i].title + '</a></li>\n');
+        outputHorzTabs.push('><a href="' + docstoc.horizontalnav[i].path + '">' + docstoc.horizontalnav[i].title + "</a></li>\n");
     }
-    document.getElementById('jsTOCHorizontal').innerHTML = outputHorzTabs.join('');
-    document.getElementById('jsTOCLeftNav').innerHTML = outputLetNav.join('');
+    document.getElementById("jsTOCHorizontal").innerHTML = outputHorzTabs.join("");
+    document.getElementById("jsTOCLeftNav").innerHTML = outputLetNav.join("");
 }
 
 function highlightRightNav(heading) {
@@ -113,7 +113,7 @@ function highlightRightNav(heading) {
         $("#my_toc a.active").removeClass("active");
 
         if (heading !== "title") {
-            $("#my_toc a[href='#" + heading + "']").addClass('active');
+            $("#my_toc a[href='#" + heading + "']").addClass("active");
         }
     }
 }
@@ -158,24 +158,24 @@ function createCookie(name, value, days) {
 
 function readCookie(name) {
     var nameEQ = name + "=";
-    var ca = document.cookie.split(';');
+    var ca = document.cookie.split(";");
     for (var i = 0; i < ca.length; i++) {
         var c = ca[i];
-        while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+        while (c.charAt(0) === " ") c = c.substring(1, c.length);
         if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
     }
     return null;
 }
 
-var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
 var selectedNightTheme = readCookie("night");
 
 if (selectedNightTheme === "true" || (selectedNightTheme === null && prefersDark)) {
     applyNight();
-    $('#switch-style').prop('checked', true);
+    $("#switch-style").prop("checked", true);
 } else {
     applyDay();
-    $('#switch-style').prop('checked', false);
+    $("#switch-style").prop("checked", false);
 }
 
 
@@ -203,26 +203,22 @@ $(".navbar-toggle").click(function () {
     });
 });
 
-var navHeight = $('.navbar').outerHeight(true) + 80;
+var navHeight = $(".navbar").outerHeight(true) + 80;
 
 $(document.body).scrollspy({
-    target: '#leftCol',
+    target: "#leftCol",
     offset: navHeight
 });
 
 function loadHash(hashObj) {
     // Using jQuery's animate() method to add smooth page scroll
     // The optional number (800) specifies the number of milliseconds it takes to scroll to the specified area
-    $('html, body').animate({
-        scrollTop: $(hashObj).offset().top - 80
-    }, 800);
+    $("html, body").animate({scrollTop: $(hashObj).offset().top - 80}, 800);
 }
 
 $(document).ready(function () {
     // Add smooth scrolling to all links
-    // $( ".toc-nav a" ).addClass( "active" );
-    $(".toc-nav a").on('click', function (event) {
-        // $(this).addClass('active');
+    $(".toc-nav a").on("click", function (event) {
         // Make sure this.hash has a value before overriding default behavior
         if (this.hash !== "") {
             // Prevent default anchor click behavior
@@ -244,7 +240,7 @@ $(document).ready(function () {
     $(".sidebar").Stickyfill();
 
     // Add smooth scrolling to all links
-    $(".nav-sidebar ul li a").on('click', function (event) {
+    $(".nav-sidebar ul li a").on("click", function (event) {
 
         // Make sure this.hash has a value before overriding default behavior
         if (this.hash !== "") {
@@ -256,7 +252,7 @@ $(document).ready(function () {
 
             // Using jQuery's animate() method to add smooth page scroll
             // The optional number (800) specifies the number of milliseconds it takes to scroll to the specified area
-            $('html, body').animate({
+            $("html, body").animate({
                 scrollTop: $(hash).offset().top - 80
             }, 800, function () {
                 // Add hash (#) to URL when done scrolling (default click behavior)
@@ -273,10 +269,10 @@ $(document).ready(function () {
  *
  */
 
-$('ul.nav li.dropdown').hover(function () {
-    $(this).find('.dropdown-menu').stop(true, true).delay(200).fadeIn(500);
+$("ul.nav li.dropdown").hover(function () {
+    $(this).find(".dropdown-menu").stop(true, true).delay(200).fadeIn(500);
 }, function () {
-    $(this).find('.dropdown-menu').stop(true, true).delay(200).fadeOut(500);
+    $(this).find(".dropdown-menu").stop(true, true).delay(200).fadeOut(500);
 });
 
 /*
@@ -293,9 +289,8 @@ function applyDay() {
     $("body").removeClass("night");
 }
 
-$('#switch-style').change(function () {
-
-    if ($(this).is(':checked')) {
+$("#switch-style").change(function () {
+    if ($(this).is(":checked")) {
         applyNight();
         createCookie("night", true, 999)
     } else {
@@ -311,13 +306,13 @@ $('#switch-style').change(function () {
  *
  */
 
-$('.nav-sidebar ul li a').click(function () {
-    $(this).addClass('collapse').siblings().toggleClass('in');
+$(".nav-sidebar ul li a").click(function () {
+    $(this).addClass("collapse").siblings().toggleClass("in");
 });
 
-if ($('.nav-sidebar ul a.active').length !== 0) {
-    $('.nav-sidebar ul').click(function () {
-        $(this).addClass('collapse in').siblings;
+if ($(".nav-sidebar ul a.active").length !== 0) {
+    $(".nav-sidebar ul").click(function () {
+        $(this).addClass("collapse in").siblings;
     });
 }
 
@@ -332,25 +327,25 @@ $(function () {
 });
 
 // Enable glossary link popovers
-$('.glossLink').popover();
+$(".glossLink").popover();
 
 // sync tabs with the same data-group
 window.onload = function () {
-    $('.nav-tabs > li > a').click(function (e) {
-        var group = $(this).attr('data-group');
-        $('.nav-tabs > li > a[data-group="' + group + '"]').tab('show');
+    $(".nav-tabs > li > a").click(function (e) {
+        var group = $(this).attr("data-group");
+        $('.nav-tabs > li > a[data-group="' + group + '"]').tab("show");
     });
 
     // isArchive is set by logic in archive.js
     if (isArchive === false) {
         // Hide elements that are not appropriate for archives
         // PollDaddy
-        $('#ratings-div').css("visibility", "visible");
+        $("#ratings-div").css("visibility", "visible");
         // Archive drop-down
-        $('.ctrl-right .btn-group').css("visibility", "visible");
-        // Swarch
-        $('.search-form').css("visibility", "visible");
+        $(".ctrl-right .btn-group").css("visibility", "visible");
+        // Search
+        $(".search-form").css("visibility", "visible");
         // Page edit link
-        $('.feedback-links li').first().css("visibility", "visible");
+        $(".feedback-links li").first().css("visibility", "visible");
     }
 };

--- a/js/docs.js
+++ b/js/docs.js
@@ -1,8 +1,5 @@
 // Right nav highlighting
 var sidebarObj = (document.getElementsByClassName("sidebar")[0]) ? document.getElementsByClassName("sidebar")[0] : document.getElementsByClassName("sidebar-home")[0];
-var sidebarBottom = sidebarObj.getBoundingClientRect().bottom;
-var footerTop = document.getElementsByClassName("footer")[0].getBoundingClientRect().top;
-var headerOffset = document.getElementsByClassName("container-fluid")[0].getBoundingClientRect().bottom;
 
 // ensure that the left nav visibly displays the current topic
 var current = document.getElementsByClassName("active currentPage");
@@ -16,12 +13,6 @@ if (current[0]) {
     if (document.location.pathname.indexOf("/samples/") > -1) {
         $(".currentPage").closest("ul").addClass("in");
     }
-}
-
-function addMyClass(classToAdd) {
-    var classString = this.className; // returns the string of all the classes for myDiv
-    // Adds the class "main__section" to the string (notice the leading space)
-    this.className = newClass; // sets className to the new string
 }
 
 function navClicked(sourceLink) {
@@ -48,11 +39,8 @@ function findMyTopic(tree) {
                 processBranch(branch[k].section);
             } else {
                 if (branch[k].path === pageURL && !branch[k].nosync) {
-                    // console.log(branch[k].path + ' was == ' + pageURL)
                     thisIsIt = true;
                     break;
-                } else {
-                    // console.log(branch[k].path + ' was != ' + pageURL)
                 }
             }
         }
@@ -116,18 +104,6 @@ function renderNav(docstoc) {
         }
         outputHorzTabs.push('><a href="' + docstoc.horizontalnav[i].path + '">' + docstoc.horizontalnav[i].title + '</a></li>\n');
     }
-//  if (outputLetNav.length==0)
-//  {
-//     either glossary was true or no left nav has been built; default to glossary
-//     show pages tagged with term and highlight term in left nav if applicable
-//    renderTagsPage()
-//    for (var i=0;i<glossary.length;i++)
-//    {
-//      var highlightGloss = '';
-//      if (tagToLookup) highlightGloss = (glossary[i].term.toLowerCase()==tagToLookup.toLowerCase()) ? ' class="active currentPage"' : '';
-//      outputLetNav.push('<li><a'+highlightGloss+' href="/glossary/?term=' + glossary[i].term + '">'+glossary[i].term+'</a></li>');
-//    }
-//  }
     document.getElementById('jsTOCHorizontal').innerHTML = outputHorzTabs.join('');
     document.getElementById('jsTOCLeftNav').innerHTML = outputLetNav.join('');
 }
@@ -191,10 +167,6 @@ function readCookie(name) {
     return null;
 }
 
-function eraseCookie(name) {
-    createCookie(name, "", -1);
-}
-
 var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 var selectedNightTheme = readCookie("night");
 
@@ -218,10 +190,12 @@ $("#menu-toggle").click(function (e) {
     $(".wrapper").toggleClass("right-open");
     $(".col-toc").toggleClass("col-toc-hidden");
 });
+
 $("#menu-toggle-left").click(function (e) {
     e.preventDefault();
     $(".col-nav").toggleClass("col-toc-hidden");
 });
+
 $(".navbar-toggle").click(function () {
     $("#sidebar-nav").each(function () {
         $(this).toggleClass("hidden-sm");
@@ -260,8 +234,7 @@ $(document).ready(function () {
 
             // Add hash (#) to URL when done scrolling (default click behavior)
             window.location.hash = hash;
-
-        } // End if
+        }
     });
     if (window.location.hash) loadHash(window.location.hash);
 });
@@ -286,11 +259,10 @@ $(document).ready(function () {
             $('html, body').animate({
                 scrollTop: $(hash).offset().top - 80
             }, 800, function () {
-
                 // Add hash (#) to URL when done scrolling (default click behavior)
                 window.location.hash = hash;
             });
-        } // End if
+        }
     });
 });
 
@@ -312,10 +284,6 @@ $('ul.nav li.dropdown').hover(function () {
  * swapStyleSheet*********************************************************************
  *
  */
-
-// function swapStyleSheet(sheet) {
-//     document.getElementById('pagestyle').setAttribute('href', sheet);
-// }
 
 function applyNight() {
     $("body").addClass("night");
@@ -353,7 +321,6 @@ if ($('.nav-sidebar ul a.active').length !== 0) {
     });
 }
 
-
 /*
  *
  * Components *********************************************************************
@@ -376,21 +343,14 @@ window.onload = function () {
 
     // isArchive is set by logic in archive.js
     if (isArchive === false) {
-        //console.log("Showing content that should only be in the current version.");
         // Hide elements that are not appropriate for archives
         // PollDaddy
         $('#ratings-div').css("visibility", "visible");
-        //console.log("Ratings widget shown.");
         // Archive drop-down
         $('.ctrl-right .btn-group').css("visibility", "visible");
-        //console.log("Archive widget shown.");
         // Swarch
         $('.search-form').css("visibility", "visible");
-        //console.log("Search widget shown.");
         // Page edit link
         $('.feedback-links li').first().css("visibility", "visible");
-        //console.log("Page edit link shown.");
-    } else {
-        //console.log("Keeping non-applicable elements hidden.");
     }
 };

--- a/js/docs.js
+++ b/js/docs.js
@@ -1,5 +1,5 @@
 // Right nav highlighting
-var sidebarObj = (document.getElementsByClassName("sidebar")[0]) ? document.getElementsByClassName("sidebar")[0] : document.getElementsByClassName("sidebar-home")[0]
+var sidebarObj = (document.getElementsByClassName("sidebar")[0]) ? document.getElementsByClassName("sidebar")[0] : document.getElementsByClassName("sidebar-home")[0];
 var sidebarBottom = sidebarObj.getBoundingClientRect().bottom;
 var footerTop = document.getElementsByClassName("footer")[0].getBoundingClientRect().top;
 var headerOffset = document.getElementsByClassName("container-fluid")[0].getBoundingClientRect().bottom;
@@ -28,17 +28,15 @@ function navClicked(sourceLink) {
     var classString = document.getElementById('#item' + sourceLink).className;
     if (classString.indexOf(' in') > -1) {
         //collapse
-        var newClass = classString.replace(' in', '');
-        document.getElementById('#item' + sourceLink).className = newClass;
+        document.getElementById('#item' + sourceLink).className = classString.replace(' in', '');
     } else {
         //expand
-        var newClass = classString.concat(' in');
-        document.getElementById('#item' + sourceLink).className = newClass;
+        document.getElementById('#item' + sourceLink).className = classString.concat(' in');
     }
 }
 
-var outputHorzTabs = new Array();
-var outputLetNav = new Array();
+var outputHorzTabs = [];
+var outputLetNav = [];
 var totalTopics = 0;
 var currentSection;
 var sectionToHighlight;
@@ -49,7 +47,7 @@ function findMyTopic(tree) {
             if (branch[k].section) {
                 processBranch(branch[k].section);
             } else {
-                if (branch[k].path == pageURL && !branch[k].nosync) {
+                if (branch[k].path === pageURL && !branch[k].nosync) {
                     // console.log(branch[k].path + ' was == ' + pageURL)
                     thisIsIt = true;
                     break;
@@ -61,7 +59,7 @@ function findMyTopic(tree) {
     }
 
     var thisIsIt = false;
-    processBranch(tree)
+    processBranch(tree);
     return thisIsIt;
 }
 
@@ -92,7 +90,7 @@ function walkTree(tree) {
         } else {
             // just a regular old topic; this is a leaf, not a branch; render a link!
             outputLetNav.push('<li><a href="' + tree[j].path + '"')
-            if (tree[j].path == pageURL && !tree[j].nosync) {
+            if (tree[j].path === pageURL && !tree[j].nosync) {
                 sectionToHighlight = currentSection;
                 outputLetNav.push('class="active currentPage"')
             }
@@ -103,17 +101,17 @@ function walkTree(tree) {
 
 function renderNav(docstoc) {
     for (i = 0; i < docstoc.horizontalnav.length; i++) {
-        if (docstoc.horizontalnav[i].node != "glossary") {
+        if (docstoc.horizontalnav[i].node !== "glossary") {
             currentSection = docstoc.horizontalnav[i].node;
             // build vertical nav
             var itsHere = findMyTopic(docstoc[docstoc.horizontalnav[i].node]);
-            if (itsHere || docstoc.horizontalnav[i].path == pageURL) {
+            if (itsHere || docstoc.horizontalnav[i].path === pageURL) {
                 walkTree(docstoc[docstoc.horizontalnav[i].node]);
             }
         }
         // build horizontal nav
         outputHorzTabs.push('<li id="' + docstoc.horizontalnav[i].node + '"');
-        if (docstoc.horizontalnav[i].path == pageURL || docstoc.horizontalnav[i].node == sectionToHighlight) {
+        if (docstoc.horizontalnav[i].path === pageURL || docstoc.horizontalnav[i].node === sectionToHighlight) {
             outputHorzTabs.push(' class="active"');
         }
         outputHorzTabs.push('><a href="' + docstoc.horizontalnav[i].path + '">' + docstoc.horizontalnav[i].title + '</a></li>\n');
@@ -146,17 +144,20 @@ function highlightRightNav(heading) {
 
 var currentHeading = "";
 $(window).scroll(function () {
-    var headingPositions = new Array();
+    var headingPositions = [];
     $("h1, h2, h3, h4, h5, h6").each(function () {
-        if (this.id == "") this.id = "title";
+        if (this.id === "") this.id = "title";
         headingPositions[this.id] = this.getBoundingClientRect().top;
     });
     headingPositions.sort();
     // the headings have all been grabbed and sorted in order of their scroll
     // position (from the top of the page). First one is toppermost.
     for (var key in headingPositions) {
+        if (!headingPositions.hasOwnProperty(key)) {
+            continue;
+        }
         if (headingPositions[key] > 0 && headingPositions[key] < 200) {
-            if (currentHeading != key) {
+            if (currentHeading !== key) {
                 // a new heading has scrolled to within 200px of the top of the page.
                 // highlight the right-nav entry and de-highlight the others.
                 highlightRightNav(key);
@@ -184,8 +185,8 @@ function readCookie(name) {
     var ca = document.cookie.split(';');
     for (var i = 0; i < ca.length; i++) {
         var c = ca[i];
-        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+        while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
     }
     return null;
 }
@@ -197,7 +198,7 @@ function eraseCookie(name) {
 var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 var selectedNightTheme = readCookie("night");
 
-if (selectedNightTheme == "true" || (selectedNightTheme === null && prefersDark)) {
+if (selectedNightTheme === "true" || (selectedNightTheme === null && prefersDark)) {
     applyNight();
     $('#switch-style').prop('checked', true);
 } else {
@@ -346,7 +347,7 @@ $('.nav-sidebar ul li a').click(function () {
     $(this).addClass('collapse').siblings().toggleClass('in');
 });
 
-if ($('.nav-sidebar ul a.active').length != 0) {
+if ($('.nav-sidebar ul a.active').length !== 0) {
     $('.nav-sidebar ul').click(function () {
         $(this).addClass('collapse in').siblings;
     });
@@ -361,7 +362,7 @@ if ($('.nav-sidebar ul a.active').length != 0) {
 
 $(function () {
     $('[data-toggle="tooltip"]').tooltip()
-})
+});
 
 // Enable glossary link popovers
 $('.glossLink').popover();
@@ -371,10 +372,10 @@ window.onload = function () {
     $('.nav-tabs > li > a').click(function (e) {
         var group = $(this).attr('data-group');
         $('.nav-tabs > li > a[data-group="' + group + '"]').tab('show');
-    })
+    });
 
     // isArchive is set by logic in archive.js
-    if (isArchive == false) {
+    if (isArchive === false) {
         //console.log("Showing content that should only be in the current version.");
         // Hide elements that are not appropriate for archives
         // PollDaddy

--- a/js/docs.js
+++ b/js/docs.js
@@ -9,35 +9,32 @@ var current = document.getElementsByClassName("active currentPage");
 var body = document.getElementsByClassName("col-content content");
 if (current[0]) {
     if (sidebarObj) {
-      current[0].scrollIntoView(true);
-      body[0].scrollIntoView(true);
+        current[0].scrollIntoView(true);
+        body[0].scrollIntoView(true);
     }
     // library hack
-    if (document.location.pathname.indexOf("/samples/") > -1){
-      $(".currentPage").closest("ul").addClass("in");
+    if (document.location.pathname.indexOf("/samples/") > -1) {
+        $(".currentPage").closest("ul").addClass("in");
     }
-  }
-
-function addMyClass(classToAdd) {
-  var classString = this.className; // returns the string of all the classes for myDiv
-   // Adds the class "main__section" to the string (notice the leading space)
-  this.className = newClass; // sets className to the new string
 }
 
-function navClicked(sourceLink)
-{
-  var classString = document.getElementById('#item' + sourceLink).className;
-  if (classString.indexOf(' in') > -1)
-  {
-    //collapse
-    var newClass = classString.replace(' in','');
-    document.getElementById('#item' + sourceLink).className = newClass;
-  } else {
-    //expand
-    var newClass = classString.concat(' in');
-    document.getElementById('#item' + sourceLink).className = newClass;
-  }
+function addMyClass(classToAdd) {
+    var classString = this.className; // returns the string of all the classes for myDiv
+    // Adds the class "main__section" to the string (notice the leading space)
+    this.className = newClass; // sets className to the new string
+}
 
+function navClicked(sourceLink) {
+    var classString = document.getElementById('#item' + sourceLink).className;
+    if (classString.indexOf(' in') > -1) {
+        //collapse
+        var newClass = classString.replace(' in', '');
+        document.getElementById('#item' + sourceLink).className = newClass;
+    } else {
+        //expand
+        var newClass = classString.concat(' in');
+        document.getElementById('#item' + sourceLink).className = newClass;
+    }
 }
 
 var outputHorzTabs = new Array();
@@ -45,92 +42,82 @@ var outputLetNav = new Array();
 var totalTopics = 0;
 var currentSection;
 var sectionToHighlight;
-function findMyTopic(tree)
-{
-  function processBranch(branch)
-  {
-    for (var k=0;k<branch.length;k++)
-    {
-      if (branch[k].section) {
-        processBranch(branch[k].section);
-      } else {
-        if (branch[k].path == pageURL && !branch[k].nosync)
-        {
-          // console.log(branch[k].path + ' was == ' + pageURL)
-          thisIsIt = true;
-          break;
-        } else {
-          // console.log(branch[k].path + ' was != ' + pageURL)
+
+function findMyTopic(tree) {
+    function processBranch(branch) {
+        for (var k = 0; k < branch.length; k++) {
+            if (branch[k].section) {
+                processBranch(branch[k].section);
+            } else {
+                if (branch[k].path == pageURL && !branch[k].nosync) {
+                    // console.log(branch[k].path + ' was == ' + pageURL)
+                    thisIsIt = true;
+                    break;
+                } else {
+                    // console.log(branch[k].path + ' was != ' + pageURL)
+                }
+            }
         }
-      }
     }
-  }
-  var thisIsIt = false;
-  processBranch(tree)
-  return thisIsIt;
+
+    var thisIsIt = false;
+    processBranch(tree)
+    return thisIsIt;
 }
-function walkTree(tree)
-{
-  for (var j=0;j<tree.length;j++)
-  {
-    totalTopics++;
-    if (tree[j].section)
-    {
-      var sectionHasPath = findMyTopic(tree[j].section);
-      outputLetNav.push('<li><a onclick="navClicked(' + totalTopics +')" data-target="#item' + totalTopics +'" data-toggle="collapse" data-parent="#stacked-menu"')
-      if (sectionHasPath)
-      {
-        outputLetNav.push('aria-expanded="true"')
-      } else {
-        outputLetNav.push('class="collapsed" aria-expanded="false"')
-      }
-      outputLetNav.push('>' + tree[j].sectiontitle + '<span class="caret arrow"></span></a>');
-      outputLetNav.push('<ul class="nav collapse');
-      if (sectionHasPath) outputLetNav.push(' in');
-      outputLetNav.push('" id="#item' + totalTopics + '" aria-expanded="');
-      if (sectionHasPath)
-      {
-        outputLetNav.push('true');
-      } else {
-        outputLetNav.push('false');
-      }
-      outputLetNav.push('">');
-      var subTree = tree[j].section;
-      walkTree(subTree);
-      outputLetNav.push('</ul></li>');
-    } else {
-      // just a regular old topic; this is a leaf, not a branch; render a link!
-      outputLetNav.push('<li><a href="' + tree[j].path + '"')
-      if (tree[j].path == pageURL && !tree[j].nosync)
-      {
-        sectionToHighlight = currentSection;
-        outputLetNav.push('class="active currentPage"')
-      }
-      outputLetNav.push('>'+tree[j].title+'</a></li>')
+
+function walkTree(tree) {
+    for (var j = 0; j < tree.length; j++) {
+        totalTopics++;
+        if (tree[j].section) {
+            var sectionHasPath = findMyTopic(tree[j].section);
+            outputLetNav.push('<li><a onclick="navClicked(' + totalTopics + ')" data-target="#item' + totalTopics + '" data-toggle="collapse" data-parent="#stacked-menu"')
+            if (sectionHasPath) {
+                outputLetNav.push('aria-expanded="true"')
+            } else {
+                outputLetNav.push('class="collapsed" aria-expanded="false"')
+            }
+            outputLetNav.push('>' + tree[j].sectiontitle + '<span class="caret arrow"></span></a>');
+            outputLetNav.push('<ul class="nav collapse');
+            if (sectionHasPath) outputLetNav.push(' in');
+            outputLetNav.push('" id="#item' + totalTopics + '" aria-expanded="');
+            if (sectionHasPath) {
+                outputLetNav.push('true');
+            } else {
+                outputLetNav.push('false');
+            }
+            outputLetNav.push('">');
+            var subTree = tree[j].section;
+            walkTree(subTree);
+            outputLetNav.push('</ul></li>');
+        } else {
+            // just a regular old topic; this is a leaf, not a branch; render a link!
+            outputLetNav.push('<li><a href="' + tree[j].path + '"')
+            if (tree[j].path == pageURL && !tree[j].nosync) {
+                sectionToHighlight = currentSection;
+                outputLetNav.push('class="active currentPage"')
+            }
+            outputLetNav.push('>' + tree[j].title + '</a></li>')
+        }
     }
-  }
 }
+
 function renderNav(docstoc) {
-  for (i=0;i<docstoc.horizontalnav.length;i++)
-  {
-    if (docstoc.horizontalnav[i].node != "glossary")
-    {
-      currentSection = docstoc.horizontalnav[i].node;
-      // build vertical nav
-      var itsHere = findMyTopic(docstoc[docstoc.horizontalnav[i].node]);
-      if (itsHere || docstoc.horizontalnav[i].path == pageURL)
-      {
-        walkTree(docstoc[docstoc.horizontalnav[i].node]);
-      }
+    for (i = 0; i < docstoc.horizontalnav.length; i++) {
+        if (docstoc.horizontalnav[i].node != "glossary") {
+            currentSection = docstoc.horizontalnav[i].node;
+            // build vertical nav
+            var itsHere = findMyTopic(docstoc[docstoc.horizontalnav[i].node]);
+            if (itsHere || docstoc.horizontalnav[i].path == pageURL) {
+                walkTree(docstoc[docstoc.horizontalnav[i].node]);
+            }
+        }
+        // build horizontal nav
+        outputHorzTabs.push('<li id="' + docstoc.horizontalnav[i].node + '"');
+        if (docstoc.horizontalnav[i].path == pageURL || docstoc.horizontalnav[i].node == sectionToHighlight) {
+            outputHorzTabs.push(' class="active"');
+        }
+        outputHorzTabs.push('><a href="' + docstoc.horizontalnav[i].path + '">' + docstoc.horizontalnav[i].title + '</a></li>\n');
     }
-    // build horizontal nav
-    outputHorzTabs.push('<li id="' + docstoc.horizontalnav[i].node + '"');
-    if (docstoc.horizontalnav[i].path==pageURL || docstoc.horizontalnav[i].node==sectionToHighlight)
-    {
-      outputHorzTabs.push(' class="active"');
-    }
-    outputHorzTabs.push('><a href="'+docstoc.horizontalnav[i].path+'">'+docstoc.horizontalnav[i].title+'</a></li>\n');
-  }
 //  if (outputLetNav.length==0)
 //  {
 //     either glossary was true or no left nav has been built; default to glossary
@@ -143,54 +130,50 @@ function renderNav(docstoc) {
 //      outputLetNav.push('<li><a'+highlightGloss+' href="/glossary/?term=' + glossary[i].term + '">'+glossary[i].term+'</a></li>');
 //    }
 //  }
-  document.getElementById('jsTOCHorizontal').innerHTML = outputHorzTabs.join('');
-  document.getElementById('jsTOCLeftNav').innerHTML = outputLetNav.join('');
+    document.getElementById('jsTOCHorizontal').innerHTML = outputHorzTabs.join('');
+    document.getElementById('jsTOCLeftNav').innerHTML = outputLetNav.join('');
 }
 
-function highlightRightNav(heading)
-{
-  if (document.location.pathname.indexOf("/glossary/") < 0){
-    $("#my_toc a.active").removeClass("active");
+function highlightRightNav(heading) {
+    if (document.location.pathname.indexOf("/glossary/") < 0) {
+        $("#my_toc a.active").removeClass("active");
 
-    if (heading !== "title") {
-      $("#my_toc a[href='#" + heading + "']").addClass('active');
+        if (heading !== "title") {
+            $("#my_toc a[href='#" + heading + "']").addClass('active');
+        }
     }
-  }
 }
 
 var currentHeading = "";
-$(window).scroll(function(){
-  var headingPositions = new Array();
-  $("h1, h2, h3, h4, h5, h6").each(function(){
-    if (this.id == "") this.id="title";
-    headingPositions[this.id]=this.getBoundingClientRect().top;
-  });
-  headingPositions.sort();
-  // the headings have all been grabbed and sorted in order of their scroll
-  // position (from the top of the page). First one is toppermost.
-  for(var key in headingPositions)
-  {
-    if (headingPositions[key] > 0 && headingPositions[key] < 200)
-    {
-      if (currentHeading != key)
-      {
-        // a new heading has scrolled to within 200px of the top of the page.
-        // highlight the right-nav entry and de-highlight the others.
-        highlightRightNav(key);
-        currentHeading = key;
-      }
-      break;
+$(window).scroll(function () {
+    var headingPositions = new Array();
+    $("h1, h2, h3, h4, h5, h6").each(function () {
+        if (this.id == "") this.id = "title";
+        headingPositions[this.id] = this.getBoundingClientRect().top;
+    });
+    headingPositions.sort();
+    // the headings have all been grabbed and sorted in order of their scroll
+    // position (from the top of the page). First one is toppermost.
+    for (var key in headingPositions) {
+        if (headingPositions[key] > 0 && headingPositions[key] < 200) {
+            if (currentHeading != key) {
+                // a new heading has scrolled to within 200px of the top of the page.
+                // highlight the right-nav entry and de-highlight the others.
+                highlightRightNav(key);
+                currentHeading = key;
+            }
+            break;
+        }
     }
-  }
 });
 
 
 // Cookie functions
-function createCookie(name,value,days) {
+function createCookie(name, value, days) {
     var expires = "";
     if (days) {
         var date = new Date();
-        date.setTime(date.getTime() + (days*24*60*60*1000));
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
         expires = "; expires=" + date.toUTCString();
     }
     document.cookie = name + "=" + value + expires + "; path=/";
@@ -199,29 +182,28 @@ function createCookie(name,value,days) {
 function readCookie(name) {
     var nameEQ = name + "=";
     var ca = document.cookie.split(';');
-    for(var i=0;i < ca.length;i++) {
+    for (var i = 0; i < ca.length; i++) {
         var c = ca[i];
-        while (c.charAt(0)==' ') c = c.substring(1,c.length);
-        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
     }
     return null;
 }
 
 function eraseCookie(name) {
-    createCookie(name,"",-1);
+    createCookie(name, "", -1);
 }
 
 var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 var selectedNightTheme = readCookie("night");
 
 if (selectedNightTheme == "true" || (selectedNightTheme === null && prefersDark)) {
-  applyNight();
-  $('#switch-style').prop('checked', true);
+    applyNight();
+    $('#switch-style').prop('checked', true);
 } else {
-  applyDay();
-  $('#switch-style').prop('checked', false);
+    applyDay();
+    $('#switch-style').prop('checked', false);
 }
-
 
 
 /*
@@ -230,86 +212,85 @@ if (selectedNightTheme == "true" || (selectedNightTheme === null && prefersDark)
  *
  */
 
-$("#menu-toggle").click(function(e) {
-        e.preventDefault();
-        $(".wrapper").toggleClass("right-open");
-        $(".col-toc").toggleClass("col-toc-hidden");
+$("#menu-toggle").click(function (e) {
+    e.preventDefault();
+    $(".wrapper").toggleClass("right-open");
+    $(".col-toc").toggleClass("col-toc-hidden");
+});
+$("#menu-toggle-left").click(function (e) {
+    e.preventDefault();
+    $(".col-nav").toggleClass("col-toc-hidden");
+});
+$(".navbar-toggle").click(function () {
+    $("#sidebar-nav").each(function () {
+        $(this).toggleClass("hidden-sm");
+        $(this).toggleClass("hidden-xs");
     });
-$("#menu-toggle-left").click(function(e) {
-        e.preventDefault();
-        $(".col-nav").toggleClass("col-toc-hidden");
-    });
-$(".navbar-toggle").click(function(){
-  $("#sidebar-nav").each(function(){
-    $(this).toggleClass("hidden-sm");
-    $(this).toggleClass("hidden-xs");
-  });
 });
 
 var navHeight = $('.navbar').outerHeight(true) + 80;
 
 $(document.body).scrollspy({
-	target: '#leftCol',
-	offset: navHeight
+    target: '#leftCol',
+    offset: navHeight
 });
 
-function loadHash(hashObj)
-{
-  // Using jQuery's animate() method to add smooth page scroll
-  // The optional number (800) specifies the number of milliseconds it takes to scroll to the specified area
-  $('html, body').animate({
-    scrollTop: $(hashObj).offset().top-80
-  }, 800);
+function loadHash(hashObj) {
+    // Using jQuery's animate() method to add smooth page scroll
+    // The optional number (800) specifies the number of milliseconds it takes to scroll to the specified area
+    $('html, body').animate({
+        scrollTop: $(hashObj).offset().top - 80
+    }, 800);
 }
 
-$(document).ready(function(){
-  // Add smooth scrolling to all links
-  // $( ".toc-nav a" ).addClass( "active" );
-  $(".toc-nav a").on('click', function(event) {
-    // $(this).addClass('active');
-    // Make sure this.hash has a value before overriding default behavior
-    if (this.hash !== "") {
-      // Prevent default anchor click behavior
-      event.preventDefault();
+$(document).ready(function () {
+    // Add smooth scrolling to all links
+    // $( ".toc-nav a" ).addClass( "active" );
+    $(".toc-nav a").on('click', function (event) {
+        // $(this).addClass('active');
+        // Make sure this.hash has a value before overriding default behavior
+        if (this.hash !== "") {
+            // Prevent default anchor click behavior
+            event.preventDefault();
 
-      // Store hash
-      var hash = this.hash;
-      loadHash(hash);
+            // Store hash
+            var hash = this.hash;
+            loadHash(hash);
 
-      // Add hash (#) to URL when done scrolling (default click behavior)
-      window.location.hash = hash;
+            // Add hash (#) to URL when done scrolling (default click behavior)
+            window.location.hash = hash;
 
-    } // End if
-  });
-  if (window.location.hash) loadHash(window.location.hash);
+        } // End if
+    });
+    if (window.location.hash) loadHash(window.location.hash);
 });
 
 
-$(document).ready(function(){
-  $(".sidebar").Stickyfill();
+$(document).ready(function () {
+    $(".sidebar").Stickyfill();
 
-  // Add smooth scrolling to all links
-  $(".nav-sidebar ul li a").on('click', function(event) {
+    // Add smooth scrolling to all links
+    $(".nav-sidebar ul li a").on('click', function (event) {
 
-    // Make sure this.hash has a value before overriding default behavior
-    if (this.hash !== "") {
-      // Prevent default anchor click behavior
-      event.preventDefault();
+        // Make sure this.hash has a value before overriding default behavior
+        if (this.hash !== "") {
+            // Prevent default anchor click behavior
+            event.preventDefault();
 
-      // Store hash
-      var hash = this.hash;
+            // Store hash
+            var hash = this.hash;
 
-      // Using jQuery's animate() method to add smooth page scroll
-      // The optional number (800) specifies the number of milliseconds it takes to scroll to the specified area
-      $('html, body').animate({
-        scrollTop: $(hash).offset().top-80
-      }, 800, function(){
+            // Using jQuery's animate() method to add smooth page scroll
+            // The optional number (800) specifies the number of milliseconds it takes to scroll to the specified area
+            $('html, body').animate({
+                scrollTop: $(hash).offset().top - 80
+            }, 800, function () {
 
-        // Add hash (#) to URL when done scrolling (default click behavior)
-        window.location.hash = hash;
-      });
-    } // End if
-  });
+                // Add hash (#) to URL when done scrolling (default click behavior)
+                window.location.hash = hash;
+            });
+        } // End if
+    });
 });
 
 
@@ -319,10 +300,10 @@ $(document).ready(function(){
  *
  */
 
-$('ul.nav li.dropdown').hover(function() {
-  $(this).find('.dropdown-menu').stop(true, true).delay(200).fadeIn(500);
-}, function() {
-  $(this).find('.dropdown-menu').stop(true, true).delay(200).fadeOut(500);
+$('ul.nav li.dropdown').hover(function () {
+    $(this).find('.dropdown-menu').stop(true, true).delay(200).fadeIn(500);
+}, function () {
+    $(this).find('.dropdown-menu').stop(true, true).delay(200).fadeOut(500);
 });
 
 /*
@@ -336,21 +317,21 @@ $('ul.nav li.dropdown').hover(function() {
 // }
 
 function applyNight() {
-  $( "body" ).addClass( "night" );
+    $("body").addClass("night");
 }
 
 function applyDay() {
-  $( "body" ).removeClass( "night" );
+    $("body").removeClass("night");
 }
 
-$('#switch-style').change(function() {
+$('#switch-style').change(function () {
 
     if ($(this).is(':checked')) {
         applyNight();
-        createCookie("night",true,999)
+        createCookie("night", true, 999)
     } else {
         applyDay();
-        createCookie("night",false,999);
+        createCookie("night", false, 999);
     }
 });
 
@@ -361,15 +342,14 @@ $('#switch-style').change(function() {
  *
  */
 
-$('.nav-sidebar ul li a').click(function() {
+$('.nav-sidebar ul li a').click(function () {
     $(this).addClass('collapse').siblings().toggleClass('in');
 });
 
-if($('.nav-sidebar ul a.active').length != 0)
-{
-  $('.nav-sidebar ul').click(function() {
-      $(this).addClass('collapse in').siblings;
-  });
+if ($('.nav-sidebar ul a.active').length != 0) {
+    $('.nav-sidebar ul').click(function () {
+        $(this).addClass('collapse in').siblings;
+    });
 }
 
 
@@ -380,36 +360,36 @@ if($('.nav-sidebar ul a.active').length != 0)
  */
 
 $(function () {
-  $('[data-toggle="tooltip"]').tooltip()
+    $('[data-toggle="tooltip"]').tooltip()
 })
 
 // Enable glossary link popovers
 $('.glossLink').popover();
 
 // sync tabs with the same data-group
-window.onload = function() {
-  $('.nav-tabs > li > a').click(function(e) {
-    var group = $(this).attr('data-group');
-    $('.nav-tabs > li > a[data-group="'+ group +'"]').tab('show');
-  })
+window.onload = function () {
+    $('.nav-tabs > li > a').click(function (e) {
+        var group = $(this).attr('data-group');
+        $('.nav-tabs > li > a[data-group="' + group + '"]').tab('show');
+    })
 
-  // isArchive is set by logic in archive.js
-  if ( isArchive == false ) {
-    //console.log("Showing content that should only be in the current version.");
-    // Hide elements that are not appropriate for archives
-    // PollDaddy
-    $('#ratings-div').css("visibility","visible");
-    //console.log("Ratings widget shown.");
-    // Archive drop-down
-    $('.ctrl-right .btn-group').css("visibility","visible");
-    //console.log("Archive widget shown.");
-    // Swarch
-    $('.search-form').css("visibility","visible");
-    //console.log("Search widget shown.");
-    // Page edit link
-    $('.feedback-links li').first().css("visibility","visible");
-    //console.log("Page edit link shown.");
-  } else {
-    //console.log("Keeping non-applicable elements hidden.");
-  }
+    // isArchive is set by logic in archive.js
+    if (isArchive == false) {
+        //console.log("Showing content that should only be in the current version.");
+        // Hide elements that are not appropriate for archives
+        // PollDaddy
+        $('#ratings-div').css("visibility", "visible");
+        //console.log("Ratings widget shown.");
+        // Archive drop-down
+        $('.ctrl-right .btn-group').css("visibility", "visible");
+        //console.log("Archive widget shown.");
+        // Swarch
+        $('.search-form').css("visibility", "visible");
+        //console.log("Search widget shown.");
+        // Page edit link
+        $('.feedback-links li').first().css("visibility", "visible");
+        //console.log("Page edit link shown.");
+    } else {
+        //console.log("Keeping non-applicable elements hidden.");
+    }
 };


### PR DESCRIPTION
With these changes, the reference section navigation looks like this:

<img width="283" alt="Screenshot 2020-03-13 at 16 54 43" src="https://user-images.githubusercontent.com/1804568/76637702-82d26300-654b-11ea-9cbe-7221e5587758.png">


Moving the "file formats" lower is just a suggestion, not sure yet if it's more logical, so open to feedback, and happy to change the position back 👍 