### PR TITLE
docker-compose documentation version

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -112,7 +112,7 @@ and the [Dockerfile reference](/engine/reference/builder.md).
 Create a file called `docker-compose.yml` in your project directory and paste
 the following:
 
-    version: '3'
+    version: '2.0'
     services:
       web:
         build: .
@@ -216,7 +216,7 @@ hitting CTRL+C in the original terminal where you started the app.
 
 Edit `docker-compose.yml` in your project directory to add a [bind mount](/engine/admin/volumes/bind-mounts.md) for the `web` service:
 
-    version: '3'
+    version: '2.0'
     services:
       web:
         build: .


### PR DESCRIPTION
hochan@hochan-node:~/Desktop/pfc/dockercompose$ sudo docker-compose up --build
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a version of "2" (or "2.0") and place your service definitions under the services key, or omit the version key and place your service definitions at the root of the file to use version 1.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Due to the evolution of version, '3' no longer matches version in docker-compose.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
docker-compose documentation version #10451
docker-compose documentation version #10450
docker-compose documentation version #10449

docker-compose documentation version #10433 [Merged]
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
