### PR TITLE
Update engine cli reference to fix some missing descriptions

### DIFF
--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -299,8 +299,8 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
-  min_api_version: "1.32"
-  experimental: true
+  min_api_version: "1.38"
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -428,266 +428,562 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Build with PATH\n\n```bash\n$ docker build .\n\nUploading context 10240
-  bytes\nStep 1/3 : FROM busybox\nPulling repository busybox\n ---> e9aa60c60128MB/2.284
-  MB (100%) endpoint: https://cdn-registry-1.docker.io/v1/\nStep 2/3 : RUN ls -lh
-  /\n ---> Running in 9c9e81692ae9\ntotal 24\ndrwxr-xr-x    2 root     root        4.0K
-  Mar 12  2013 bin\ndrwxr-xr-x    5 root     root        4.0K Oct 19 00:19 dev\ndrwxr-xr-x
-  \   2 root     root        4.0K Oct 19 00:19 etc\ndrwxr-xr-x    2 root     root
-  \       4.0K Nov 15 23:34 lib\nlrwxrwxrwx    1 root     root           3 Mar 12
-  \ 2013 lib64 -> lib\ndr-xr-xr-x  116 root     root           0 Nov 15 23:34 proc\nlrwxrwxrwx
-  \   1 root     root           3 Mar 12  2013 sbin -> bin\ndr-xr-xr-x   13 root     root
-  \          0 Nov 15 23:34 sys\ndrwxr-xr-x    2 root     root        4.0K Mar 12
-  \ 2013 tmp\ndrwxr-xr-x    2 root     root        4.0K Nov 15 23:34 usr\n ---> b35f4035db3f\nStep
-  3/3 : CMD echo Hello world\n ---> Running in 02071fceb21b\n ---> f52f38b7823e\nSuccessfully
-  built f52f38b7823e\nRemoving intermediate container 9c9e81692ae9\nRemoving intermediate
-  container 02071fceb21b\n```\n\nThis example specifies that the `PATH` is `.`, and
-  so all the files in the\nlocal directory get `tar`d and sent to the Docker daemon.
-  The `PATH` specifies\nwhere to find the files for the \"context\" of the build on
-  the Docker daemon.\nRemember that the daemon could be running on a remote machine
-  and that no\nparsing of the Dockerfile happens at the client side (where you're
-  running\n`docker build`). That means that *all* the files at `PATH` get sent, not
-  just\nthe ones listed to [*ADD*](../builder.md#add) in the Dockerfile.\n\nThe transfer
-  of context from the local machine to the Docker daemon is what the\n`docker` client
-  means when you see the \"Sending build context\" message.\n\nIf you wish to keep
-  the intermediate containers after the build is complete,\nyou must use `--rm=false`.
-  This does not affect the build cache.\n\n### Build with URL\n\n```bash\n$ docker
-  build github.com/creack/docker-firefox\n```\n\nThis will clone the GitHub repository
-  and use the cloned repository as context.\nThe Dockerfile at the root of the repository
-  is used as Dockerfile. You can\nspecify an arbitrary Git repository by using the
-  `git://` or `git@` scheme.\n\n```bash\n$ docker build -f ctx/Dockerfile http://server/ctx.tar.gz\n\nDownloading
-  context: http://server/ctx.tar.gz [===================>]    240 B/240 B\nStep 1/3
-  : FROM busybox\n ---> 8c2e06607696\nStep 2/3 : ADD ctx/container.cfg /\n ---> e7829950cee3\nRemoving
-  intermediate container b35224abf821\nStep 3/3 : CMD /bin/ls\n ---> Running in fbc63d321d73\n
-  ---> 3286931702ad\nRemoving intermediate container fbc63d321d73\nSuccessfully built
-  377c409b35e4\n```\n\nThis sends the URL `http://server/ctx.tar.gz` to the Docker
-  daemon, which\ndownloads and extracts the referenced tarball. The `-f ctx/Dockerfile`\nparameter
-  specifies a path inside `ctx.tar.gz` to the `Dockerfile` that is used\nto build
-  the image. Any `ADD` commands in that `Dockerfile` that refers to local\npaths must
-  be relative to the root of the contents inside `ctx.tar.gz`. In the\nexample above,
-  the tarball contains a directory `ctx/`, so the `ADD\nctx/container.cfg /` operation
-  works as expected.\n\n### Build with -\n\n```bash\n$ docker build - < Dockerfile\n```\n\nThis
-  will read a Dockerfile from `STDIN` without context. Due to the lack of a\ncontext,
-  no contents of any local directory will be sent to the Docker daemon.\nSince there
-  is no context, a Dockerfile `ADD` only works if it refers to a\nremote URL.\n\n```bash\n$
-  docker build - < context.tar.gz\n```\n\nThis will build an image for a compressed
-  context read from `STDIN`.  Supported\nformats are: bzip2, gzip and xz.\n\n### Use
-  a .dockerignore file\n\n```bash\n$ docker build .\n\nUploading context 18.829 MB\nUploading
-  context\nStep 1/2 : FROM busybox\n ---> 769b9341d937\nStep 2/2 : CMD echo Hello
-  world\n ---> Using cache\n ---> 99cc1ad10469\nSuccessfully built 99cc1ad10469\n$
-  echo \".git\" > .dockerignore\n$ docker build .\nUploading context  6.76 MB\nUploading
-  context\nStep 1/2 : FROM busybox\n ---> 769b9341d937\nStep 2/2 : CMD echo Hello
-  world\n ---> Using cache\n ---> 99cc1ad10469\nSuccessfully built 99cc1ad10469\n```\n\nThis
-  example shows the use of the `.dockerignore` file to exclude the `.git`\ndirectory
-  from the context. Its effect can be seen in the changed size of the\nuploaded context.
-  The builder reference contains detailed information on\n[creating a .dockerignore
-  file](../builder.md#dockerignore-file).\n\nWhen using the [BuildKit backend](../builder.md#buildkit),
-  `docker build` searches\nfor a `.dockerignore` file relative to the Dockerfile name.
-  For example, running\n`docker build -f myapp.Dockerfile .` will first look for an
-  ignore file named\n`myapp.Dockerfile.dockerignore`. If such a file is not found,
-  the `.dockerignore`\nfile is used if present. Using a Dockerfile based `.dockerignore`
-  is useful if a\nproject contains multiple Dockerfiles that expect to ignore different
-  sets of\nfiles.\n\n\n### Tag an image (-t)\n\n```bash\n$ docker build -t vieux/apache:2.0
-  .\n```\n\nThis will build like the previous example, but it will then tag the resulting\nimage.
-  The repository name will be `vieux/apache` and the tag will be `2.0`.\n[Read more
-  about valid tags](tag.md).\n\nYou can apply multiple tags to an image. For example,
-  you can apply the `latest`\ntag to a newly built image and add another tag that
-  references a specific\nversion.\nFor example, to tag an image both as `whenry/fedora-jboss:latest`
-  and\n`whenry/fedora-jboss:v2.1`, use the following:\n\n```bash\n$ docker build -t
-  whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .\n```\n\n### Specify a Dockerfile
-  (-f)\n\n```bash\n$ docker build -f Dockerfile.debug .\n```\n\nThis will use a file
-  called `Dockerfile.debug` for the build instructions\ninstead of `Dockerfile`.\n\n```bash\n$
-  curl example.com/remote/Dockerfile | docker build -f - .\n```\n\nThe above command
-  will use the current directory as the build context and read\na Dockerfile from
-  stdin.\n\n```bash\n$ docker build -f dockerfiles/Dockerfile.debug -t myapp_debug
-  .\n$ docker build -f dockerfiles/Dockerfile.prod  -t myapp_prod .\n```\n\nThe above
-  commands will build the current build context (as specified by the\n`.`) twice,
-  once using a debug version of a `Dockerfile` and once using a\nproduction version.\n\n```bash\n$
-  cd /home/me/myapp/some/dir/really/deep\n$ docker build -f /home/me/myapp/dockerfiles/debug
-  /home/me/myapp\n$ docker build -f ../../../../dockerfiles/debug /home/me/myapp\n```\n\nThese
-  two `docker build` commands do the exact same thing. They both use the\ncontents
-  of the `debug` file instead of looking for a `Dockerfile` and will use\n`/home/me/myapp`
-  as the root of the build context. Note that `debug` is in the\ndirectory structure
-  of the build context, regardless of how you refer to it on\nthe command line.\n\n>
-  **Note:**\n> `docker build` will return a `no such file or directory` error if the\n>
-  file or directory does not exist in the uploaded context. This may\n> happen if
-  there is no context, or if you specify a file that is\n> elsewhere on the Host system.
-  The context is limited to the current\n> directory (and its children) for security
-  reasons, and to ensure\n> repeatable builds on remote Docker hosts. This is also
-  the reason why\n> `ADD ../file` will not work.\n\n### Use a custom parent cgroup
-  (--cgroup-parent)\n\nWhen `docker build` is run with the `--cgroup-parent` option
-  the containers\nused in the build will be run with the [corresponding `docker run`\nflag](../run.md#specifying-custom-cgroups).\n\n###
-  Set ulimits in container (--ulimit)\n\nUsing the `--ulimit` option with `docker
-  build` will cause each build step's\ncontainer to be started using those [`--ulimit`\nflag
-  values](./run.md#set-ulimits-in-container-ulimit).\n\n### Set build-time variables
-  (--build-arg)\n\nYou can use `ENV` instructions in a Dockerfile to define variable\nvalues.
-  These values persist in the built image. However, often\npersistence is not what
-  you want. Users want to specify variables differently\ndepending on which host they
-  build an image on.\n\nA good example is `http_proxy` or source versions for pulling
-  intermediate\nfiles. The `ARG` instruction lets Dockerfile authors define values
-  that users\ncan set at build-time using the  `--build-arg` flag:\n\n```bash\n$ docker
-  build --build-arg HTTP_PROXY=http://10.20.30.2:1234 --build-arg FTP_PROXY=http://40.50.60.5:4567
-  .\n```\n\nThis flag allows you to pass the build-time variables that are\naccessed
-  like regular environment variables in the `RUN` instruction of the\nDockerfile.
-  Also, these values don't persist in the intermediate or final images\nlike `ENV`
-  values do.   You must add `--build-arg` for each build argument.  \n\nUsing this
-  flag will not alter the output you see when the `ARG` lines from the\nDockerfile
-  are echoed during the build process.\n\nFor detailed information on using `ARG`
-  and `ENV` instructions, see the\n[Dockerfile reference](../builder.md).\n\nYou may
-  also use the `--build-arg` flag without a value, in which case the value\nfrom the
-  local environment will be propagated into the Docker container being\nbuilt:\n\n```bash\n$
-  export HTTP_PROXY=http://10.20.30.2:1234\n$ docker build --build-arg HTTP_PROXY
-  .\n```\n\nThis is similar to how `docker run -e` works. Refer to the [`docker run`
-  documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)\nfor
-  more information.\n\n### Optional security options (--security-opt)\n\nThis flag
-  is only supported on a daemon running on Windows, and only supports\nthe `credentialspec`
-  option. The `credentialspec` must be in the format\n`file://spec.txt` or `registry://keyname`.\n\n###
-  Specify isolation technology for container (--isolation)\n\nThis option is useful
-  in situations where you are running Docker containers on\nWindows. The `--isolation=<value>`
-  option sets a container's isolation\ntechnology. On Linux, the only supported is
-  the `default` option which uses\nLinux namespaces. On Microsoft Windows, you can
-  specify these values:\n\n\n| Value     | Description                                                                                                                                                   |\n|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|\n|
-  `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the
-  `daemon` does not specify an isolation technology, Microsoft Windows uses `process`
-  as its default value.  |\n| `process` | Namespace isolation only.                                                                                                                                     |\n|
-  `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                 |\n\nSpecifying
-  the `--isolation` flag without a value is the same as setting `--isolation=\"default\"`.\n\n###
-  Add entries to container hosts file (--add-host)\n\nYou can add other hosts into
-  a container's `/etc/hosts` file by using one or\nmore `--add-host` flags. This example
-  adds a static address for a host named\n`docker`:\n\n    $ docker build --add-host=docker:10.180.0.1
-  .\n\n### Specifying target build stage (--target)\n\nWhen building a Dockerfile
-  with multiple build stages, `--target` can be used to\nspecify an intermediate build
-  stage by name as a final stage for the resulting\nimage. Commands after the target
-  stage will be skipped.\n\n```Dockerfile\nFROM debian AS build-env\n...\n\nFROM alpine
-  AS production-env\n...\n```\n\n```bash\n$ docker build -t mybuildimage --target
-  build-env .\n```\n\n### Custom build outputs\n\nBy default, a local container image
-  is created from the build result. The\n`--output` (or `-o`) flag allows you to override
-  this behavior, and a specify a\ncustom exporter. For example, custom exporters allow
-  you to export the build\nartifacts as files on the local filesystem instead of a
-  Docker image, which can\nbe useful for generating local binaries, code generation
-  etc.\n\nThe value for `--output` is a CSV-formatted string defining the exporter
-  type\nand options. Currently, `local` and `tar` exporters are supported. The `local`\nexporter
-  writes the resulting build files to a directory on the client side. The\n`tar` exporter
-  is similar but writes the files as a single tarball (`.tar`).\n\nIf no type is specified,
-  the value defaults to the output directory of the local\nexporter. Use a hyphen
-  (`-`) to write the output tarball to standard output\n(`STDOUT`).\n\nThe following
-  example builds an image using the current directory (`.`) as build\ncontext, and
-  exports the files to a directory named `out` in the current directory.\nIf the directory
-  does not exist, Docker creates the directory automatically:\n\n```bash\n$ docker
-  build -o out .\n```\n\nThe example above uses the short-hand syntax, omitting the
-  `type` options, and\nthus uses the default (`local`) exporter. The example below
-  shows the equivalent\nusing the long-hand CSV syntax, specifying both `type` and
-  `dest` (destination\npath):\n\n```bash\n$ docker build --output type=local,dest=out
-  .\n```\n\nUse the `tar` type to export the files as a `.tar` archive: \n\n```bash\n$
-  docker build --output type=tar,dest=out.tar .\n```\n\nThe example below shows the
-  equivalent when using the short-hand syntax. In this\ncase, `-` is specified as
-  destination, which automatically selects the `tar` type,\nand writes the output
-  tarball to standard output, which is then redirected to\nthe `out.tar` file:\n\n```bash\ndocker
-  build -o - . > out.tar\n```\n\nThe `--output` option exports all files from the
-  target stage. A common pattern\nfor exporting only specific files is to do multi-stage
-  builds and to copy the\ndesired files to a new scratch stage with [`COPY --from`](../builder.md#copy).\n\nThe
-  example `Dockerfile` below uses a separate stage to collect the\nbuild-artifacts
-  for exporting:\n\n```Dockerfile\nFROM golang AS build-stage\nRUN go get -u github.com/LK4D4/vndr\n\nFROM
-  scratch AS export-stage\nCOPY --from=build-stage /go/bin/vndr /\n```\n\nWhen building
-  the Dockerfile with the `-o` option, only the files from the final\nstage are exported
-  to the `out` directory, in this case, the `vndr` binary:\n\n```bash\n$ docker build
-  -o out .\n\n[+] Building 2.3s (7/7) FINISHED\n => [internal] load build definition
-  from Dockerfile                                                                          0.1s\n
-  => => transferring dockerfile: 176B                                                                                          0.0s\n
-  => [internal] load .dockerignore                                                                                             0.0s\n
-  => => transferring context: 2B                                                                                               0.0s\n
-  => [internal] load metadata for docker.io/library/golang:latest                                                              1.6s\n
-  => [build-stage 1/2] FROM docker.io/library/golang@sha256:2df96417dca0561bf1027742dcc5b446a18957cd28eba6aa79269f23f1846d3f
-  \  0.0s\n => => resolve docker.io/library/golang@sha256:2df96417dca0561bf1027742dcc5b446a18957cd28eba6aa79269f23f1846d3f
-  \              0.0s\n => CACHED [build-stage 2/2] RUN go get -u github.com/LK4D4/vndr
-  \                                                             0.0s\n => [export-stage
-  1/1] COPY --from=build-stage /go/bin/vndr /                                                                 0.2s\n
-  => exporting to client                                                                                                       0.4s\n
-  => => copying files 10.30MB                                                                                                  0.3s\n\n$
-  ls ./out\nvndr\n```\n\n> **Note**: This feature requires the BuildKit backend. You
-  can either\n> [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)\n>
-  plugin which provides more output type options.\n\n### Specifying external cache
-  sources\n\nIn addition to local build cache, the builder can reuse the cache generated
-  from\nprevious builds with the `--cache-from` flag pointing to an image in the registry.\n\nTo
-  use an image as a cache source, cache metadata needs to be written into the\nimage
-  on creation. This can be done by setting `--build-arg BUILDKIT_INLINE_CACHE=1`\nwhen
-  building the image. After that, the built image can be used as a cache source\nfor
-  subsequent builds.\n\nUpon importing the cache, the builder will only pull the JSON
-  metadata from the\nregistry and determine possible cache hits based on that information.
-  If there\nis a cache hit, the matched layers are pulled into the local environment.\n\nIn
-  addition to images, the cache can also be pulled from special cache manifests\ngenerated
-  by [`buildx`](https://github.com/docker/buildx) or the BuildKit CLI\n(`buildctl`).
-  These manifests (when built with the `type=registry` and `mode=max`\noptions) allow
-  pulling layer data for intermediate stages in multi-stage builds.\n\nThe following
-  example builds an image with inline-cache metadata and pushes it\nto a registry,
-  then uses the image as a cache source on another machine:\n\n```bash\n$ docker build
-  -t myname/myapp --build-arg BUILDKIT_INLINE_CACHE=1 .\n$ docker push myname/myapp\n```\n\nAfter
-  pushing the image, the image is used as cache source on another machine.\nBuildKit
-  automatically pulls the image from the registry if needed.\n\n```bash\n# on another
-  machine\n$ docker build --cache-from myname/myapp .\n```\n\n> **Note**: This feature
-  requires the BuildKit backend. You can either\n> [enable BuildKit](../builder.md#buildkit)
-  or use the [buildx](https://github.com/docker/buildx)\n> plugin. The previous builder
-  has limited support for reusing cache from\n> pre-pulled images.\n\n### Squash an
-  image's layers (--squash) (experimental)\n\n#### Overview\n\nOnce the image is built,
-  squash the new layers into a new image with a single\nnew layer. Squashing does
-  not destroy any existing image, rather it creates a new\nimage with the content
-  of the squashed layers. This effectively makes it look\nlike all `Dockerfile` commands
-  were created with a single layer. The build\ncache is preserved with this method.\n\nThe
-  `--squash` option is an experimental feature, and should not be considered\nstable.\n\n\nSquashing
-  layers can be beneficial if your Dockerfile produces multiple layers\nmodifying
-  the same files, for example, files that are created in one step, and\nremoved in
-  another step. For other use-cases, squashing images may actually have\na negative
-  impact on performance; when pulling an image consisting of multiple\nlayers, layers
-  can be pulled in parallel, and allows sharing layers between\nimages (saving space).\n\nFor
-  most use cases, multi-stage builds are a better alternative, as they give more\nfine-grained
-  control over your build, and can take advantage of future\noptimizations in the
-  builder. Refer to the [use multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)\nsection
-  in the userguide for more information.\n\n\n#### Known limitations\n\nThe `--squash`
-  option has a number of known limitations:\n\n- When squashing layers, the resulting
-  image cannot take advantage of layer\n  sharing with other images, and may use significantly
-  more space. Sharing the\n  base image is still supported.\n- When using this option
-  you may see significantly more space used due to\n  storing two copies of the image,
-  one for the build cache with all the cache\n  layers in tact, and one for the squashed
-  version.\n- While squashing layers may produce smaller images, it may have a negative\n
-  \ impact on performance, as a single layer takes longer to extract, and\n  downloading
-  a single layer cannot be parallelized.\n- When attempting to squash an image that
-  does not make changes to the\n  filesystem (for example, the Dockerfile only contains
-  `ENV` instructions),\n  the squash step will fail (see [issue #33823](https://github.com/moby/moby/issues/33823)).\n\n####
-  Prerequisites\n\nThe example on this page is using experimental mode in Docker 1.13.\n\nExperimental
-  mode can be enabled by using the `--experimental` flag when starting the Docker
-  daemon or setting `experimental: true` in the `daemon.json` configuration file.\n\nBy
-  default, experimental mode is disabled. To see the current configuration, use the
-  `docker version` command.\n\n```none\nServer:\n Version:      1.13.1\n API version:
-  \ 1.26 (minimum version 1.12)\n Go version:   go1.7.5\n Git commit:   092cba3\n
-  Built:        Wed Feb  8 06:35:24 2017\n OS/Arch:      linux/amd64\n Experimental:
-  false\n\n [...]\n```\n\nTo enable experimental mode, users need to restart the docker
-  daemon with the experimental flag enabled.\n\n#### Enable Docker experimental\n\nExperimental
-  features are now included in the standard Docker binaries as of version 1.13.0.
-  For enabling experimental features, you need to start the Docker daemon with `--experimental`
-  flag. You can also enable the daemon flag via /etc/docker/daemon.json. e.g.\n\n```json\n{\n
-  \   \"experimental\": true\n}\n```\n\nThen make sure the experimental flag is enabled:\n\n```bash\n$
-  docker version -f '{{.Server.Experimental}}'\ntrue\n```\n\n#### Build an image with
-  `--squash` argument\n\nThe following is an example of docker build with `--squash`
-  argument\n\n```Dockerfile\nFROM busybox\nRUN echo hello > /hello\nRUN echo world
-  >> /hello\nRUN touch remove_me /remove_me\nENV HELLO world\nRUN rm /remove_me\n```\n\nAn
-  image named `test` is built with `--squash` argument.\n\n```bash\n$ docker build
-  --squash -t test .\n\n[...]\n```\n\nIf everything is right, the history will look
-  like this:\n\n```bash\n$ docker history test\n\nIMAGE               CREATED             CREATED
-  BY                                      SIZE                COMMENT\n4e10cb5b4cac
-  \       3 seconds ago                                                       12 B
-  \               merge sha256:88a7b0112a41826885df0e7072698006ee8f621c6ab99fca7fe9151d7b599702
-  to sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb\n<missing>
-  \          5 minutes ago       /bin/sh -c rm /remove_me                        0
-  B\n<missing>           5 minutes ago       /bin/sh -c #(nop) ENV HELLO=world               0
-  B\n<missing>           5 minutes ago       /bin/sh -c touch remove_me /remove_me
-  \          0 B\n<missing>           5 minutes ago       /bin/sh -c echo world >>
-  /hello                 0 B\n<missing>           6 minutes ago       /bin/sh -c echo
-  hello > /hello                  0 B\n<missing>           7 weeks ago         /bin/sh
-  -c #(nop) CMD [\"sh\"]                    0 B\n<missing>           7 weeks ago         /bin/sh
-  -c #(nop) ADD file:47ca6e777c36a4cfff   1.113 MB\n```\n\nWe could find that all
-  layer's name is `<missing>`, and there is a new layer with COMMENT `merge`.\n\nTest
-  the image, check for `/remove_me` being gone, make sure `hello\\nworld` is in `/hello`,
-  make sure the `HELLO` envvar's value is `world`."
+examples: |-
+  ### Build with PATH
+
+  ```bash
+  $ docker build .
+
+  Uploading context 10240 bytes
+  Step 1/3 : FROM busybox
+  Pulling repository busybox
+   ---> e9aa60c60128MB/2.284 MB (100%) endpoint: https://cdn-registry-1.docker.io/v1/
+  Step 2/3 : RUN ls -lh /
+   ---> Running in 9c9e81692ae9
+  total 24
+  drwxr-xr-x    2 root     root        4.0K Mar 12  2013 bin
+  drwxr-xr-x    5 root     root        4.0K Oct 19 00:19 dev
+  drwxr-xr-x    2 root     root        4.0K Oct 19 00:19 etc
+  drwxr-xr-x    2 root     root        4.0K Nov 15 23:34 lib
+  lrwxrwxrwx    1 root     root           3 Mar 12  2013 lib64 -> lib
+  dr-xr-xr-x  116 root     root           0 Nov 15 23:34 proc
+  lrwxrwxrwx    1 root     root           3 Mar 12  2013 sbin -> bin
+  dr-xr-xr-x   13 root     root           0 Nov 15 23:34 sys
+  drwxr-xr-x    2 root     root        4.0K Mar 12  2013 tmp
+  drwxr-xr-x    2 root     root        4.0K Nov 15 23:34 usr
+   ---> b35f4035db3f
+  Step 3/3 : CMD echo Hello world
+   ---> Running in 02071fceb21b
+   ---> f52f38b7823e
+  Successfully built f52f38b7823e
+  Removing intermediate container 9c9e81692ae9
+  Removing intermediate container 02071fceb21b
+  ```
+
+  This example specifies that the `PATH` is `.`, and so all the files in the
+  local directory get `tar`d and sent to the Docker daemon. The `PATH` specifies
+  where to find the files for the "context" of the build on the Docker daemon.
+  Remember that the daemon could be running on a remote machine and that no
+  parsing of the Dockerfile happens at the client side (where you're running
+  `docker build`). That means that *all* the files at `PATH` get sent, not just
+  the ones listed to [*ADD*](../builder.md#add) in the Dockerfile.
+
+  The transfer of context from the local machine to the Docker daemon is what the
+  `docker` client means when you see the "Sending build context" message.
+
+  If you wish to keep the intermediate containers after the build is complete,
+  you must use `--rm=false`. This does not affect the build cache.
+
+  ### Build with URL
+
+  ```bash
+  $ docker build github.com/creack/docker-firefox
+  ```
+
+  This will clone the GitHub repository and use the cloned repository as context.
+  The Dockerfile at the root of the repository is used as Dockerfile. You can
+  specify an arbitrary Git repository by using the `git://` or `git@` scheme.
+
+  ```bash
+  $ docker build -f ctx/Dockerfile http://server/ctx.tar.gz
+
+  Downloading context: http://server/ctx.tar.gz [===================>]    240 B/240 B
+  Step 1/3 : FROM busybox
+   ---> 8c2e06607696
+  Step 2/3 : ADD ctx/container.cfg /
+   ---> e7829950cee3
+  Removing intermediate container b35224abf821
+  Step 3/3 : CMD /bin/ls
+   ---> Running in fbc63d321d73
+   ---> 3286931702ad
+  Removing intermediate container fbc63d321d73
+  Successfully built 377c409b35e4
+  ```
+
+  This sends the URL `http://server/ctx.tar.gz` to the Docker daemon, which
+  downloads and extracts the referenced tarball. The `-f ctx/Dockerfile`
+  parameter specifies a path inside `ctx.tar.gz` to the `Dockerfile` that is used
+  to build the image. Any `ADD` commands in that `Dockerfile` that refers to local
+  paths must be relative to the root of the contents inside `ctx.tar.gz`. In the
+  example above, the tarball contains a directory `ctx/`, so the `ADD
+  ctx/container.cfg /` operation works as expected.
+
+  ### Build with -
+
+  ```bash
+  $ docker build - < Dockerfile
+  ```
+
+  This will read a Dockerfile from `STDIN` without context. Due to the lack of a
+  context, no contents of any local directory will be sent to the Docker daemon.
+  Since there is no context, a Dockerfile `ADD` only works if it refers to a
+  remote URL.
+
+  ```bash
+  $ docker build - < context.tar.gz
+  ```
+
+  This will build an image for a compressed context read from `STDIN`.  Supported
+  formats are: bzip2, gzip and xz.
+
+  ### Use a .dockerignore file
+
+  ```bash
+  $ docker build .
+
+  Uploading context 18.829 MB
+  Uploading context
+  Step 1/2 : FROM busybox
+   ---> 769b9341d937
+  Step 2/2 : CMD echo Hello world
+   ---> Using cache
+   ---> 99cc1ad10469
+  Successfully built 99cc1ad10469
+  $ echo ".git" > .dockerignore
+  $ docker build .
+  Uploading context  6.76 MB
+  Uploading context
+  Step 1/2 : FROM busybox
+   ---> 769b9341d937
+  Step 2/2 : CMD echo Hello world
+   ---> Using cache
+   ---> 99cc1ad10469
+  Successfully built 99cc1ad10469
+  ```
+
+  This example shows the use of the `.dockerignore` file to exclude the `.git`
+  directory from the context. Its effect can be seen in the changed size of the
+  uploaded context. The builder reference contains detailed information on
+  [creating a .dockerignore file](../builder.md#dockerignore-file).
+
+  When using the [BuildKit backend](../builder.md#buildkit), `docker build` searches
+  for a `.dockerignore` file relative to the Dockerfile name. For example, running
+  `docker build -f myapp.Dockerfile .` will first look for an ignore file named
+  `myapp.Dockerfile.dockerignore`. If such a file is not found, the `.dockerignore`
+  file is used if present. Using a Dockerfile based `.dockerignore` is useful if a
+  project contains multiple Dockerfiles that expect to ignore different sets of
+  files.
+
+
+  ### Tag an image (-t)
+
+  ```bash
+  $ docker build -t vieux/apache:2.0 .
+  ```
+
+  This will build like the previous example, but it will then tag the resulting
+  image. The repository name will be `vieux/apache` and the tag will be `2.0`.
+  [Read more about valid tags](tag.md).
+
+  You can apply multiple tags to an image. For example, you can apply the `latest`
+  tag to a newly built image and add another tag that references a specific
+  version.
+  For example, to tag an image both as `whenry/fedora-jboss:latest` and
+  `whenry/fedora-jboss:v2.1`, use the following:
+
+  ```bash
+  $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
+  ```
+
+  ### Specify a Dockerfile (-f)
+
+  ```bash
+  $ docker build -f Dockerfile.debug .
+  ```
+
+  This will use a file called `Dockerfile.debug` for the build instructions
+  instead of `Dockerfile`.
+
+  ```bash
+  $ curl example.com/remote/Dockerfile | docker build -f - .
+  ```
+
+  The above command will use the current directory as the build context and read
+  a Dockerfile from stdin.
+
+  ```bash
+  $ docker build -f dockerfiles/Dockerfile.debug -t myapp_debug .
+  $ docker build -f dockerfiles/Dockerfile.prod  -t myapp_prod .
+  ```
+
+  The above commands will build the current build context (as specified by the
+  `.`) twice, once using a debug version of a `Dockerfile` and once using a
+  production version.
+
+  ```bash
+  $ cd /home/me/myapp/some/dir/really/deep
+  $ docker build -f /home/me/myapp/dockerfiles/debug /home/me/myapp
+  $ docker build -f ../../../../dockerfiles/debug /home/me/myapp
+  ```
+
+  These two `docker build` commands do the exact same thing. They both use the
+  contents of the `debug` file instead of looking for a `Dockerfile` and will use
+  `/home/me/myapp` as the root of the build context. Note that `debug` is in the
+  directory structure of the build context, regardless of how you refer to it on
+  the command line.
+
+  > **Note:**
+  > `docker build` will return a `no such file or directory` error if the
+  > file or directory does not exist in the uploaded context. This may
+  > happen if there is no context, or if you specify a file that is
+  > elsewhere on the Host system. The context is limited to the current
+  > directory (and its children) for security reasons, and to ensure
+  > repeatable builds on remote Docker hosts. This is also the reason why
+  > `ADD ../file` will not work.
+
+  ### Use a custom parent cgroup (--cgroup-parent)
+
+  When `docker build` is run with the `--cgroup-parent` option the containers
+  used in the build will be run with the [corresponding `docker run`
+  flag](../run.md#specifying-custom-cgroups).
+
+  ### Set ulimits in container (--ulimit)
+
+  Using the `--ulimit` option with `docker build` will cause each build step's
+  container to be started using those [`--ulimit`
+  flag values](./run.md#set-ulimits-in-container-ulimit).
+
+  ### Set build-time variables (--build-arg)
+
+  You can use `ENV` instructions in a Dockerfile to define variable
+  values. These values persist in the built image. However, often
+  persistence is not what you want. Users want to specify variables differently
+  depending on which host they build an image on.
+
+  A good example is `http_proxy` or source versions for pulling intermediate
+  files. The `ARG` instruction lets Dockerfile authors define values that users
+  can set at build-time using the  `--build-arg` flag:
+
+  ```bash
+  $ docker build --build-arg HTTP_PROXY=http://10.20.30.2:1234 --build-arg FTP_PROXY=http://40.50.60.5:4567 .
+  ```
+
+  This flag allows you to pass the build-time variables that are
+  accessed like regular environment variables in the `RUN` instruction of the
+  Dockerfile. Also, these values don't persist in the intermediate or final images
+  like `ENV` values do.   You must add `--build-arg` for each build argument.
+
+  Using this flag will not alter the output you see when the `ARG` lines from the
+  Dockerfile are echoed during the build process.
+
+  For detailed information on using `ARG` and `ENV` instructions, see the
+  [Dockerfile reference](../builder.md).
+
+  You may also use the `--build-arg` flag without a value, in which case the value
+  from the local environment will be propagated into the Docker container being
+  built:
+
+  ```bash
+  $ export HTTP_PROXY=http://10.20.30.2:1234
+  $ docker build --build-arg HTTP_PROXY .
+  ```
+
+  This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
+  for more information.
+
+  ### Optional security options (--security-opt)
+
+  This flag is only supported on a daemon running on Windows, and only supports
+  the `credentialspec` option. The `credentialspec` must be in the format
+  `file://spec.txt` or `registry://keyname`.
+
+  ### Specify isolation technology for container (--isolation)
+
+  This option is useful in situations where you are running Docker containers on
+  Windows. The `--isolation=<value>` option sets a container's isolation
+  technology. On Linux, the only supported is the `default` option which uses
+  Linux namespaces. On Microsoft Windows, you can specify these values:
+
+
+  | Value     | Description                                                                                                                                                   |
+  |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value.  |
+  | `process` | Namespace isolation only.                                                                                                                                     |
+  | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                 |
+
+  Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
+
+  ### Add entries to container hosts file (--add-host)
+
+  You can add other hosts into a container's `/etc/hosts` file by using one or
+  more `--add-host` flags. This example adds a static address for a host named
+  `docker`:
+
+      $ docker build --add-host=docker:10.180.0.1 .
+
+  ### Specifying target build stage (--target)
+
+  When building a Dockerfile with multiple build stages, `--target` can be used to
+  specify an intermediate build stage by name as a final stage for the resulting
+  image. Commands after the target stage will be skipped.
+
+  ```Dockerfile
+  FROM debian AS build-env
+  ...
+
+  FROM alpine AS production-env
+  ...
+  ```
+
+  ```bash
+  $ docker build -t mybuildimage --target build-env .
+  ```
+
+  ### Custom build outputs
+
+  By default, a local container image is created from the build result. The
+  `--output` (or `-o`) flag allows you to override this behavior, and a specify a
+  custom exporter. For example, custom exporters allow you to export the build
+  artifacts as files on the local filesystem instead of a Docker image, which can
+  be useful for generating local binaries, code generation etc.
+
+  The value for `--output` is a CSV-formatted string defining the exporter type
+  and options. Currently, `local` and `tar` exporters are supported. The `local`
+  exporter writes the resulting build files to a directory on the client side. The
+  `tar` exporter is similar but writes the files as a single tarball (`.tar`).
+
+  If no type is specified, the value defaults to the output directory of the local
+  exporter. Use a hyphen (`-`) to write the output tarball to standard output
+  (`STDOUT`).
+
+  The following example builds an image using the current directory (`.`) as build
+  context, and exports the files to a directory named `out` in the current directory.
+  If the directory does not exist, Docker creates the directory automatically:
+
+  ```bash
+  $ docker build -o out .
+  ```
+
+  The example above uses the short-hand syntax, omitting the `type` options, and
+  thus uses the default (`local`) exporter. The example below shows the equivalent
+  using the long-hand CSV syntax, specifying both `type` and `dest` (destination
+  path):
+
+  ```bash
+  $ docker build --output type=local,dest=out .
+  ```
+
+  Use the `tar` type to export the files as a `.tar` archive:
+
+  ```bash
+  $ docker build --output type=tar,dest=out.tar .
+  ```
+
+  The example below shows the equivalent when using the short-hand syntax. In this
+  case, `-` is specified as destination, which automatically selects the `tar` type,
+  and writes the output tarball to standard output, which is then redirected to
+  the `out.tar` file:
+
+  ```bash
+  docker build -o - . > out.tar
+  ```
+
+  The `--output` option exports all files from the target stage. A common pattern
+  for exporting only specific files is to do multi-stage builds and to copy the
+  desired files to a new scratch stage with [`COPY --from`](../builder.md#copy).
+
+  The example `Dockerfile` below uses a separate stage to collect the
+  build-artifacts for exporting:
+
+  ```Dockerfile
+  FROM golang AS build-stage
+  RUN go get -u github.com/LK4D4/vndr
+
+  FROM scratch AS export-stage
+  COPY --from=build-stage /go/bin/vndr /
+  ```
+
+  When building the Dockerfile with the `-o` option, only the files from the final
+  stage are exported to the `out` directory, in this case, the `vndr` binary:
+
+  ```bash
+  $ docker build -o out .
+
+  [+] Building 2.3s (7/7) FINISHED
+   => [internal] load build definition from Dockerfile                                                                          0.1s
+   => => transferring dockerfile: 176B                                                                                          0.0s
+   => [internal] load .dockerignore                                                                                             0.0s
+   => => transferring context: 2B                                                                                               0.0s
+   => [internal] load metadata for docker.io/library/golang:latest                                                              1.6s
+   => [build-stage 1/2] FROM docker.io/library/golang@sha256:2df96417dca0561bf1027742dcc5b446a18957cd28eba6aa79269f23f1846d3f   0.0s
+   => => resolve docker.io/library/golang@sha256:2df96417dca0561bf1027742dcc5b446a18957cd28eba6aa79269f23f1846d3f               0.0s
+   => CACHED [build-stage 2/2] RUN go get -u github.com/LK4D4/vndr                                                              0.0s
+   => [export-stage 1/1] COPY --from=build-stage /go/bin/vndr /                                                                 0.2s
+   => exporting to client                                                                                                       0.4s
+   => => copying files 10.30MB                                                                                                  0.3s
+
+  $ ls ./out
+  vndr
+  ```
+
+  > **Note**: This feature requires the BuildKit backend. You can either
+  > [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)
+  > plugin which provides more output type options.
+
+  ### Specifying external cache sources
+
+  In addition to local build cache, the builder can reuse the cache generated from
+  previous builds with the `--cache-from` flag pointing to an image in the registry.
+
+  To use an image as a cache source, cache metadata needs to be written into the
+  image on creation. This can be done by setting `--build-arg BUILDKIT_INLINE_CACHE=1`
+  when building the image. After that, the built image can be used as a cache source
+  for subsequent builds.
+
+  Upon importing the cache, the builder will only pull the JSON metadata from the
+  registry and determine possible cache hits based on that information. If there
+  is a cache hit, the matched layers are pulled into the local environment.
+
+  In addition to images, the cache can also be pulled from special cache manifests
+  generated by [`buildx`](https://github.com/docker/buildx) or the BuildKit CLI
+  (`buildctl`). These manifests (when built with the `type=registry` and `mode=max`
+  options) allow pulling layer data for intermediate stages in multi-stage builds.
+
+  The following example builds an image with inline-cache metadata and pushes it
+  to a registry, then uses the image as a cache source on another machine:
+
+  ```bash
+  $ docker build -t myname/myapp --build-arg BUILDKIT_INLINE_CACHE=1 .
+  $ docker push myname/myapp
+  ```
+
+  After pushing the image, the image is used as cache source on another machine.
+  BuildKit automatically pulls the image from the registry if needed.
+
+  ```bash
+  # on another machine
+  $ docker build --cache-from myname/myapp .
+  ```
+
+  > **Note**: This feature requires the BuildKit backend. You can either
+  > [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)
+  > plugin. The previous builder has limited support for reusing cache from
+  > pre-pulled images.
+
+  ### Squash an image's layers (--squash) (experimental)
+
+  #### Overview
+
+  Once the image is built, squash the new layers into a new image with a single
+  new layer. Squashing does not destroy any existing image, rather it creates a new
+  image with the content of the squashed layers. This effectively makes it look
+  like all `Dockerfile` commands were created with a single layer. The build
+  cache is preserved with this method.
+
+  The `--squash` option is an experimental feature, and should not be considered
+  stable.
+
+
+  Squashing layers can be beneficial if your Dockerfile produces multiple layers
+  modifying the same files, for example, files that are created in one step, and
+  removed in another step. For other use-cases, squashing images may actually have
+  a negative impact on performance; when pulling an image consisting of multiple
+  layers, layers can be pulled in parallel, and allows sharing layers between
+  images (saving space).
+
+  For most use cases, multi-stage builds are a better alternative, as they give more
+  fine-grained control over your build, and can take advantage of future
+  optimizations in the builder. Refer to the [use multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)
+  section in the userguide for more information.
+
+
+  #### Known limitations
+
+  The `--squash` option has a number of known limitations:
+
+  - When squashing layers, the resulting image cannot take advantage of layer
+    sharing with other images, and may use significantly more space. Sharing the
+    base image is still supported.
+  - When using this option you may see significantly more space used due to
+    storing two copies of the image, one for the build cache with all the cache
+    layers in tact, and one for the squashed version.
+  - While squashing layers may produce smaller images, it may have a negative
+    impact on performance, as a single layer takes longer to extract, and
+    downloading a single layer cannot be parallelized.
+  - When attempting to squash an image that does not make changes to the
+    filesystem (for example, the Dockerfile only contains `ENV` instructions),
+    the squash step will fail (see [issue #33823](https://github.com/moby/moby/issues/33823)).
+
+  #### Prerequisites
+
+  The example on this page is using experimental mode in Docker 1.13.
+
+  Experimental mode can be enabled by using the `--experimental` flag when starting the Docker daemon or setting `experimental: true` in the `daemon.json` configuration file.
+
+  By default, experimental mode is disabled. To see the current configuration, use the `docker version` command.
+
+  ```none
+  Server:
+   Version:      1.13.1
+   API version:  1.26 (minimum version 1.12)
+   Go version:   go1.7.5
+   Git commit:   092cba3
+   Built:        Wed Feb  8 06:35:24 2017
+   OS/Arch:      linux/amd64
+   Experimental: false
+
+   [...]
+  ```
+
+  To enable experimental mode, users need to restart the docker daemon with the experimental flag enabled.
+
+  #### Enable Docker experimental
+
+  Experimental features are now included in the standard Docker binaries as of version 1.13.0. For enabling experimental features, you need to start the Docker daemon with `--experimental` flag. You can also enable the daemon flag via /etc/docker/daemon.json. e.g.
+
+  ```json
+  {
+      "experimental": true
+  }
+  ```
+
+  Then make sure the experimental flag is enabled:
+
+  ```bash
+  $ docker version -f '{{.Server.Experimental}}'
+  true
+  ```
+
+  #### Build an image with `--squash` argument
+
+  The following is an example of docker build with `--squash` argument
+
+  ```Dockerfile
+  FROM busybox
+  RUN echo hello > /hello
+  RUN echo world >> /hello
+  RUN touch remove_me /remove_me
+  ENV HELLO world
+  RUN rm /remove_me
+  ```
+
+  An image named `test` is built with `--squash` argument.
+
+  ```bash
+  $ docker build --squash -t test .
+
+  [...]
+  ```
+
+  If everything is right, the history will look like this:
+
+  ```bash
+  $ docker history test
+
+  IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+  4e10cb5b4cac        3 seconds ago                                                       12 B                merge sha256:88a7b0112a41826885df0e7072698006ee8f621c6ab99fca7fe9151d7b599702 to sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb
+  <missing>           5 minutes ago       /bin/sh -c rm /remove_me                        0 B
+  <missing>           5 minutes ago       /bin/sh -c #(nop) ENV HELLO=world               0 B
+  <missing>           5 minutes ago       /bin/sh -c touch remove_me /remove_me           0 B
+  <missing>           5 minutes ago       /bin/sh -c echo world >> /hello                 0 B
+  <missing>           6 minutes ago       /bin/sh -c echo hello > /hello                  0 B
+  <missing>           7 weeks ago         /bin/sh -c #(nop) CMD ["sh"]                    0 B
+  <missing>           7 weeks ago         /bin/sh -c #(nop) ADD file:47ca6e777c36a4cfff   1.113 MB
+  ```
+
+  We could find that all layer's name is `<missing>`, and there is a new layer with COMMENT `merge`.
+
+  Test the image, check for `/remove_me` being gone, make sure `hello\nworld` is in `/hello`, make sure the `HELLO` envvar's value is `world`.
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_builder_build.yaml
+++ b/_data/engine-cli/docker_builder_build.yaml
@@ -197,8 +197,8 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
-  min_api_version: "1.32"
-  experimental: true
+  min_api_version: "1.38"
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_builder_prune.yaml
+++ b/_data/engine-cli/docker_builder_prune.yaml
@@ -9,7 +9,7 @@ options:
   shorthand: a
   value_type: bool
   default_value: "false"
-  description: Remove all unused images, not just dangling ones
+  description: Remove all unused build cache, not just dangling ones
   deprecated: false
   experimental: false
   experimentalcli: false
@@ -17,7 +17,7 @@ options:
   swarm: false
 - option: filter
   value_type: filter
-  description: Provide filter values (e.g. 'unused-for=24h')
+  description: Provide filter values (e.g. 'until=24h')
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_events.yaml
+++ b/_data/engine-cli/docker_events.yaml
@@ -1,58 +1,184 @@
 command: docker events
 short: Get real time events from the server
-long: "Use `docker events` to get real-time events from the server. These events differ\nper
-  Docker object type. Different event types have different scopes. Local \nscoped
-  events are only seen on the node they take place on, and swarm scoped \nevents are
-  seen on all managers.\n\nOnly the last 1000 log events are returned. You can use
-  filters to further limit \nthe number of events returned.\n\n### Object types\n\n####
-  Containers\n\nDocker containers report the following events:\n\n- `attach`\n- `commit`\n-
-  `copy`\n- `create`\n- `destroy`\n- `detach`\n- `die`\n- `exec_create`\n- `exec_detach`\n-
-  `exec_die`\n- `exec_start`\n- `export`\n- `health_status`\n- `kill`\n- `oom`\n-
-  `pause`\n- `rename`\n- `resize`\n- `restart`\n- `start`\n- `stop`\n- `top`\n- `unpause`\n-
-  `update`\n\n#### Images\n\nDocker images report the following events:\n\n- `delete`\n-
-  `import`\n- `load`\n- `pull`\n- `push`\n- `save`\n- `tag`\n- `untag`\n\n#### Plugins\n\nDocker
-  plugins report the following events:\n\n- `enable`\n- `disable`\n- `install`\n-
-  `remove`\n\n#### Volumes\n\nDocker volumes report the following events:\n\n- `create`\n-
-  `destroy`\n- `mount`\n- `unmount`\n\n#### Networks\n\nDocker networks report the
-  following events:\n\n- `create`\n- `connect`\n- `destroy`\n- `disconnect`\n- `remove`\n\n####
-  Daemons\n\nDocker daemons report the following events:\n\n- `reload`\n\n#### Services\n\nDocker
-  services report the following events:\n\n- `create`\n- `remove`\n- `update`\n\n####
-  Nodes\n\nDocker nodes report the following events:\n\n- `create`\n- `remove`\n-
-  `update`\n\n#### Secrets\n\nDocker secrets report the following events:\n\n- `create`\n-
-  `remove`\n- `update`\n\n#### Configs\n\nDocker configs report the following events:\n\n-
-  `create`\n- `remove`\n- `update`\n\n### Limiting, filtering, and formatting the
-  output\n\n#### Limit events by time\n\nThe `--since` and `--until` parameters can
-  be Unix timestamps, date formatted\ntimestamps, or Go duration strings (e.g. `10m`,
-  `1h30m`) computed\nrelative to the client machine’s time. If you do not provide
-  the `--since` option,\nthe command returns only new and/or live events.  Supported
-  formats for date\nformatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,\n`2006-01-02T15:04:05.999999999`,
-  `2006-01-02Z07:00`, and `2006-01-02`. The local\ntimezone on the client will be
-  used if you do not provide either a `Z` or a\n`+-00:00` timezone offset at the end
-  of the timestamp.  When providing Unix\ntimestamps enter seconds[.nanoseconds],
-  where seconds is the number of seconds\nthat have elapsed since January 1, 1970
-  (midnight UTC/GMT), not counting leap\nseconds (aka Unix epoch or Unix time), and
-  the optional .nanoseconds field is a\nfraction of a second no more than nine digits
-  long.\n\nOnly the last 1000 log events are returned. You can use filters to further
-  limit \nthe number of events returned.\n\n#### Filtering\n\nThe filtering flag (`-f`
-  or `--filter`) format is of \"key=value\". If you would\nlike to use multiple filters,
-  pass multiple flags (e.g.,\n`--filter \"foo=bar\" --filter \"bif=baz\"`)\n\nUsing
-  the same filter multiple times will be handled as a *OR*; for example\n`--filter
-  container=588a23dac085 --filter container=a8f7720b8c22` will display\nevents for
-  container 588a23dac085 *OR* container a8f7720b8c22\n\nUsing multiple filters will
-  be handled as a *AND*; for example\n`--filter container=588a23dac085 --filter event=start`
-  will display events for\ncontainer container 588a23dac085 *AND* the event type is
-  *start*\n\nThe currently supported filters are:\n\n* config (`config=<name or id>`)\n*
-  container (`container=<name or id>`)\n* daemon (`daemon=<name or id>`)\n* event
-  (`event=<event action>`)\n* image (`image=<repository or tag>`)\n* label (`label=<key>`
-  or `label=<key>=<value>`)\n* network (`network=<name or id>`)\n* node (`node=<id>`)\n*
-  plugin (`plugin=<name or id>`)\n* scope (`scope=<local or swarm>`)\n* secret (`secret=<name
-  or id>`)\n* service (`service=<name or id>`)\n* type (`type=<container or image
-  or volume or network or daemon or plugin or service or node or secret or config>`)\n*
-  volume (`volume=<name>`)\n\n#### Format\n\nIf a format (`--format`) is specified,
-  the given template will be executed\ninstead of the default\nformat. Go's [text/template](http://golang.org/pkg/text/template/)
-  package\ndescribes all the details of the format.\n\nIf a format is set to `{{json
-  .}}`, the events are streamed as valid JSON\nLines. For information about JSON Lines,
-  please refer to http://jsonlines.org/ ."
+long: |-
+  Use `docker events` to get real-time events from the server. These events differ
+  per Docker object type. Different event types have different scopes. Local
+  scoped events are only seen on the node they take place on, and swarm scoped
+  events are seen on all managers.
+
+  Only the last 1000 log events are returned. You can use filters to further limit
+  the number of events returned.
+
+  ### Object types
+
+  #### Containers
+
+  Docker containers report the following events:
+
+  - `attach`
+  - `commit`
+  - `copy`
+  - `create`
+  - `destroy`
+  - `detach`
+  - `die`
+  - `exec_create`
+  - `exec_detach`
+  - `exec_die`
+  - `exec_start`
+  - `export`
+  - `health_status`
+  - `kill`
+  - `oom`
+  - `pause`
+  - `rename`
+  - `resize`
+  - `restart`
+  - `start`
+  - `stop`
+  - `top`
+  - `unpause`
+  - `update`
+
+  #### Images
+
+  Docker images report the following events:
+
+  - `delete`
+  - `import`
+  - `load`
+  - `pull`
+  - `push`
+  - `save`
+  - `tag`
+  - `untag`
+
+  #### Plugins
+
+  Docker plugins report the following events:
+
+  - `enable`
+  - `disable`
+  - `install`
+  - `remove`
+
+  #### Volumes
+
+  Docker volumes report the following events:
+
+  - `create`
+  - `destroy`
+  - `mount`
+  - `unmount`
+
+  #### Networks
+
+  Docker networks report the following events:
+
+  - `create`
+  - `connect`
+  - `destroy`
+  - `disconnect`
+  - `remove`
+
+  #### Daemons
+
+  Docker daemons report the following events:
+
+  - `reload`
+
+  #### Services
+
+  Docker services report the following events:
+
+  - `create`
+  - `remove`
+  - `update`
+
+  #### Nodes
+
+  Docker nodes report the following events:
+
+  - `create`
+  - `remove`
+  - `update`
+
+  #### Secrets
+
+  Docker secrets report the following events:
+
+  - `create`
+  - `remove`
+  - `update`
+
+  #### Configs
+
+  Docker configs report the following events:
+
+  - `create`
+  - `remove`
+  - `update`
+
+  ### Limiting, filtering, and formatting the output
+
+  #### Limit events by time
+
+  The `--since` and `--until` parameters can be Unix timestamps, date formatted
+  timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
+  relative to the client machine’s time. If you do not provide the `--since` option,
+  the command returns only new and/or live events.  Supported formats for date
+  formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
+  `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+  timezone on the client will be used if you do not provide either a `Z` or a
+  `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
+  timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
+  that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
+  seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
+  fraction of a second no more than nine digits long.
+
+  Only the last 1000 log events are returned. You can use filters to further limit
+  the number of events returned.
+
+  #### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
+  like to use multiple filters, pass multiple flags (e.g.,
+  `--filter "foo=bar" --filter "bif=baz"`)
+
+  Using the same filter multiple times will be handled as a *OR*; for example
+  `--filter container=588a23dac085 --filter container=a8f7720b8c22` will display
+  events for container 588a23dac085 *OR* container a8f7720b8c22
+
+  Using multiple filters will be handled as a *AND*; for example
+  `--filter container=588a23dac085 --filter event=start` will display events for
+  container container 588a23dac085 *AND* the event type is *start*
+
+  The currently supported filters are:
+
+  * config (`config=<name or id>`)
+  * container (`container=<name or id>`)
+  * daemon (`daemon=<name or id>`)
+  * event (`event=<event action>`)
+  * image (`image=<repository or tag>`)
+  * label (`label=<key>` or `label=<key>=<value>`)
+  * network (`network=<name or id>`)
+  * node (`node=<id>`)
+  * plugin (`plugin=<name or id>`)
+  * scope (`scope=<local or swarm>`)
+  * secret (`secret=<name or id>`)
+  * service (`service=<name or id>`)
+  * type (`type=<container or image or volume or network or daemon or plugin or service or node or secret or config>`)
+  * volume (`volume=<name>`)
+
+  #### Format
+
+  If a format (`--format`) is specified, the given template will be executed
+  instead of the default
+  format. Go's [text/template](http://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+
+  If a format is set to `{{json .}}`, the events are streamed as valid JSON
+  Lines. For information about JSON Lines, please refer to http://jsonlines.org/.
 usage: docker events [OPTIONS]
 pname: docker
 plink: docker.yaml
@@ -290,14 +416,14 @@ examples: |-
 
   #### Format as JSON
 
-  ```none
-      $ docker events --format '{{json .}}'
+  ```bash
+  $ docker events --format '{{json .}}'
 
-      {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
-      {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
-      {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
-      {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
-      {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+  {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+  {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+  {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
+  {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
+  {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_exec.yaml
+++ b/_data/engine-cli/docker_exec.yaml
@@ -94,28 +94,80 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Run `docker exec` on a running container\n\nFirst, start a container.\n\n```bash\n$
-  docker run --name ubuntu_bash --rm -i -t ubuntu bash\n```\n\nThis will create a
-  container named `ubuntu_bash` and start a Bash session.\n\nNext, execute a command
-  on the container.\n\n```bash\n$ docker exec -d ubuntu_bash touch /tmp/execWorks\n```\n\nThis
-  will create a new file `/tmp/execWorks` inside the running container\n`ubuntu_bash`,
-  in the background.\n\nNext, execute an interactive `bash` shell on the container.\n\n```bash\n$
-  docker exec -it ubuntu_bash bash\n```\n\nThis will create a new Bash session in
-  the container `ubuntu_bash`.\n\nNext, set an environment variable in the current
-  bash session.\n\n```bash\n$ docker exec -it -e VAR=1 ubuntu_bash bash\n```\n\nThis
-  will create a new Bash session in the container `ubuntu_bash` with environment \nvariable
-  `$VAR` set to \"1\". Note that this environment variable will only be valid \non
-  the current Bash session.\n\nBy default `docker exec` command runs in the same working
-  directory set when container was created.\n\n```bash\n$ docker exec -it ubuntu_bash
-  pwd\n/\n```\n\nYou can select working directory for the command to execute into\n\n```bash\n$
-  docker exec -it -w /root ubuntu_bash pwd\n/root\n```\n\n\n### Try to run `docker
-  exec` on a paused container\n\nIf the container is paused, then the `docker exec`
-  command will fail with an error:\n\n```bash\n$ docker pause test\n\ntest\n\n$ docker
-  ps\n\nCONTAINER ID        IMAGE               COMMAND             CREATED             STATUS
-  \                  PORTS               NAMES\n1ae3b36715d2        ubuntu:latest
-  \      \"bash\"              17 seconds ago      Up 16 seconds (Paused)                       test\n\n$
-  docker exec test ls\n\nFATA[0000] Error response from daemon: Container test is
-  paused, unpause the container before exec\n\n$ echo $?\n1\n```"
+examples: |-
+  ### Run `docker exec` on a running container
+
+  First, start a container.
+
+  ```bash
+  $ docker run --name ubuntu_bash --rm -i -t ubuntu bash
+  ```
+
+  This will create a container named `ubuntu_bash` and start a Bash session.
+
+  Next, execute a command on the container.
+
+  ```bash
+  $ docker exec -d ubuntu_bash touch /tmp/execWorks
+  ```
+
+  This will create a new file `/tmp/execWorks` inside the running container
+  `ubuntu_bash`, in the background.
+
+  Next, execute an interactive `bash` shell on the container.
+
+  ```bash
+  $ docker exec -it ubuntu_bash bash
+  ```
+
+  This will create a new Bash session in the container `ubuntu_bash`.
+
+  Next, set an environment variable in the current bash session.
+
+  ```bash
+  $ docker exec -it -e VAR=1 ubuntu_bash bash
+  ```
+
+  This will create a new Bash session in the container `ubuntu_bash` with environment
+  variable `$VAR` set to "1". Note that this environment variable will only be valid
+  on the current Bash session.
+
+  By default `docker exec` command runs in the same working directory set when container was created.
+
+  ```bash
+  $ docker exec -it ubuntu_bash pwd
+  /
+  ```
+
+  You can select working directory for the command to execute into
+
+  ```bash
+  $ docker exec -it -w /root ubuntu_bash pwd
+  /root
+  ```
+
+
+  ### Try to run `docker exec` on a paused container
+
+  If the container is paused, then the `docker exec` command will fail with an error:
+
+  ```bash
+  $ docker pause test
+
+  test
+
+  $ docker ps
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                   PORTS               NAMES
+  1ae3b36715d2        ubuntu:latest       "bash"              17 seconds ago      Up 16 seconds (Paused)                       test
+
+  $ docker exec test ls
+
+  FATA[0000] Error response from daemon: Container test is paused, unpause the container before exec
+
+  $ echo $?
+  1
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_image_build.yaml
+++ b/_data/engine-cli/docker_image_build.yaml
@@ -197,8 +197,8 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
-  min_api_version: "1.32"
-  experimental: true
+  min_api_version: "1.38"
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_info.yaml
+++ b/_data/engine-cli/docker_info.yaml
@@ -31,66 +31,209 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Show output\n\nThe example below shows the output for a daemon running
-  on Red Hat Enterprise Linux,\nusing the `devicemapper` storage driver. As can be
-  seen in the output, additional\ninformation about the `devicemapper` storage driver
-  is shown:\n\n```bash\n$ docker info\nClient:\n Debug Mode: false\n\nServer:\n Containers:
-  14\n  Running: 3\n  Paused: 1\n  Stopped: 10\n Images: 52\n Server Version: 1.10.3\n
-  Storage Driver: devicemapper\n  Pool Name: docker-202:2-25583803-pool\n  Pool Blocksize:
-  65.54 kB\n  Base Device Size: 10.74 GB\n  Backing Filesystem: xfs\n  Data file:
-  /dev/loop0\n  Metadata file: /dev/loop1\n  Data Space Used: 1.68 GB\n  Data Space
-  Total: 107.4 GB\n  Data Space Available: 7.548 GB\n  Metadata Space Used: 2.322
-  MB\n  Metadata Space Total: 2.147 GB\n  Metadata Space Available: 2.145 GB\n  Udev
-  Sync Supported: true\n  Deferred Removal Enabled: false\n  Deferred Deletion Enabled:
-  false\n  Deferred Deleted Device Count: 0\n  Data loop file: /var/lib/docker/devicemapper/devicemapper/data\n
-  \ Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata\n  Library
-  Version: 1.02.107-RHEL7 (2015-12-01)\n Execution Driver: native-0.2\n Logging Driver:
-  json-file\n Plugins:\n  Volume: local\n  Network: null host bridge\n Kernel Version:
-  3.10.0-327.el7.x86_64\n Operating System: Red Hat Enterprise Linux Server 7.2 (Maipo)\n
-  OSType: linux\n Architecture: x86_64\n CPUs: 1\n Total Memory: 991.7 MiB\n Name:
-  ip-172-30-0-91.ec2.internal\n ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S\n
-  Docker Root Dir: /var/lib/docker\n Debug Mode: false\n Username: gordontheturtle\n
-  Registry: https://index.docker.io/v1/\n Insecure registries:\n  myinsecurehost:5000\n
-  \ 127.0.0.0/8\n```\n \n### Show debugging output\n\nHere is a sample output for
-  a daemon running on Ubuntu, using the overlay2\nstorage driver and a node that is
-  part of a 2-node swarm:\n\n```bash\n$ docker -D info\nClient:\n Debug Mode: true\n\nServer:\n
-  Containers: 14\n  Running: 3\n  Paused: 1\n  Stopped: 10\n Images: 52\n Server Version:
-  1.13.0\n Storage Driver: overlay2\n  Backing Filesystem: extfs\n  Supports d_type:
-  true\n  Native Overlay Diff: false\n Logging Driver: json-file\n Cgroup Driver:
-  cgroupfs\n Plugins:\n  Volume: local\n  Network: bridge host macvlan null overlay\n
-  Swarm: active\n  NodeID: rdjq45w1op418waxlairloqbm\n  Is Manager: true\n  ClusterID:
-  te8kdyw33n36fqiz74bfjeixd\n  Managers: 1\n  Nodes: 2\n  Orchestration:\n   Task
-  History Retention Limit: 5\n  Raft:\n   Snapshot Interval: 10000\n   Number of Old
-  Snapshots to Retain: 0\n   Heartbeat Tick: 1\n   Election Tick: 3\n  Dispatcher:\n
-  \  Heartbeat Period: 5 seconds\n  CA Configuration:\n   Expiry Duration: 3 months\n
-  \ Root Rotation In Progress: false\n  Node Address: 172.16.66.128 172.16.66.129\n
-  \ Manager Addresses:\n   172.16.66.128:2477\n Runtimes: runc\n Default Runtime:
-  runc\n Init Binary: docker-init\n containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531\n
-  runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2\n init version: N/A (expected:
-  v0.13.0)\n Security Options:\n  apparmor\n  seccomp\n   Profile: default\n Kernel
-  Version: 4.4.0-31-generic\n Operating System: Ubuntu 16.04.1 LTS\n OSType: linux\n
-  Architecture: x86_64\n CPUs: 2\n Total Memory: 1.937 GiB\n Name: ubuntu\n ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326\n
-  Docker Root Dir: /var/lib/docker\n Debug Mode: true\n  File Descriptors: 30\n  Goroutines:
-  123\n  System Time: 2016-11-12T17:24:37.955404361-08:00\n  EventsListeners: 0\n
-  Http Proxy: http://test:test@proxy.example.com:8080\n Https Proxy: https://test:test@proxy.example.com:8080\n
-  No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com\n Registry: https://index.docker.io/v1/\n
-  WARNING: No swap limit support\n Labels:\n  storage=ssd\n  staging=true\n Experimental:
-  false\n Insecure Registries:\n  127.0.0.0/8\n Registry Mirrors:\n   http://192.168.1.2/\n
-  \  http://registry-mirror.example.com:5000/\n Live Restore Enabled: false\n```\n\nThe
-  global `-D` option causes all `docker` commands to output debug information.\n\n###
-  Format the output\n\nYou can also specify the output format:\n\n```bash\n$ docker
-  info --format '{{json .}}'\n\n{\"ID\":\"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S\",\"Containers\":14,
-  ...}\n```\n\n### Run `docker info` on Windows\n\nHere is a sample output for a daemon
-  running on Windows Server 2016:\n\n```none\nE:\\docker>docker info\nClient:\n Debug
-  Mode: false\n\nServer:\n Containers: 1\n  Running: 0\n  Paused: 0\n  Stopped: 1\n
-  Images: 17\n Server Version: 1.13.0\n Storage Driver: windowsfilter\n  Windows:\n
-  Logging Driver: json-file\n Plugins:\n  Volume: local\n  Network: nat null overlay\n
-  Swarm: inactive\n Default Isolation: process\n Kernel Version: 10.0 14393 (14393.206.amd64fre.rs1_release.160912-1937)\n
-  Operating System: Windows Server 2016 Datacenter\n OSType: windows\n Architecture:
-  x86_64\n CPUs: 8\n Total Memory: 3.999 GiB\n Name: WIN-V0V70C0LU5P\n ID: NYMS:B5VK:UMSL:FVDZ:EWB5:FKVK:LPFL:FJMQ:H6FT:BZJ6:L2TD:XH62\n
-  Docker Root Dir: C:\\control\n Debug Mode: false\n Registry: https://index.docker.io/v1/\n
-  Insecure Registries:\n  127.0.0.0/8\n Registry Mirrors:\n   http://192.168.1.2/\n
-  \  http://registry-mirror.example.com:5000/\n Live Restore Enabled: false\n```"
+examples: |-
+  ### Show output
+
+  The example below shows the output for a daemon running on Red Hat Enterprise Linux,
+  using the `devicemapper` storage driver. As can be seen in the output, additional
+  information about the `devicemapper` storage driver is shown:
+
+  ```bash
+  $ docker info
+  Client:
+   Debug Mode: false
+
+  Server:
+   Containers: 14
+    Running: 3
+    Paused: 1
+    Stopped: 10
+   Images: 52
+   Server Version: 1.10.3
+   Storage Driver: devicemapper
+    Pool Name: docker-202:2-25583803-pool
+    Pool Blocksize: 65.54 kB
+    Base Device Size: 10.74 GB
+    Backing Filesystem: xfs
+    Data file: /dev/loop0
+    Metadata file: /dev/loop1
+    Data Space Used: 1.68 GB
+    Data Space Total: 107.4 GB
+    Data Space Available: 7.548 GB
+    Metadata Space Used: 2.322 MB
+    Metadata Space Total: 2.147 GB
+    Metadata Space Available: 2.145 GB
+    Udev Sync Supported: true
+    Deferred Removal Enabled: false
+    Deferred Deletion Enabled: false
+    Deferred Deleted Device Count: 0
+    Data loop file: /var/lib/docker/devicemapper/devicemapper/data
+    Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
+    Library Version: 1.02.107-RHEL7 (2015-12-01)
+   Execution Driver: native-0.2
+   Logging Driver: json-file
+   Plugins:
+    Volume: local
+    Network: null host bridge
+   Kernel Version: 3.10.0-327.el7.x86_64
+   Operating System: Red Hat Enterprise Linux Server 7.2 (Maipo)
+   OSType: linux
+   Architecture: x86_64
+   CPUs: 1
+   Total Memory: 991.7 MiB
+   Name: ip-172-30-0-91.ec2.internal
+   ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+   Docker Root Dir: /var/lib/docker
+   Debug Mode: false
+   Username: gordontheturtle
+   Registry: https://index.docker.io/v1/
+   Insecure registries:
+    myinsecurehost:5000
+    127.0.0.0/8
+  ```
+
+  ### Show debugging output
+
+  Here is a sample output for a daemon running on Ubuntu, using the overlay2
+  storage driver and a node that is part of a 2-node swarm:
+
+  ```bash
+  $ docker -D info
+  Client:
+   Debug Mode: true
+
+  Server:
+   Containers: 14
+    Running: 3
+    Paused: 1
+    Stopped: 10
+   Images: 52
+   Server Version: 1.13.0
+   Storage Driver: overlay2
+    Backing Filesystem: extfs
+    Supports d_type: true
+    Native Overlay Diff: false
+   Logging Driver: json-file
+   Cgroup Driver: cgroupfs
+   Plugins:
+    Volume: local
+    Network: bridge host macvlan null overlay
+   Swarm: active
+    NodeID: rdjq45w1op418waxlairloqbm
+    Is Manager: true
+    ClusterID: te8kdyw33n36fqiz74bfjeixd
+    Managers: 1
+    Nodes: 2
+    Orchestration:
+     Task History Retention Limit: 5
+    Raft:
+     Snapshot Interval: 10000
+     Number of Old Snapshots to Retain: 0
+     Heartbeat Tick: 1
+     Election Tick: 3
+    Dispatcher:
+     Heartbeat Period: 5 seconds
+    CA Configuration:
+     Expiry Duration: 3 months
+    Root Rotation In Progress: false
+    Node Address: 172.16.66.128 172.16.66.129
+    Manager Addresses:
+     172.16.66.128:2477
+   Runtimes: runc
+   Default Runtime: runc
+   Init Binary: docker-init
+   containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531
+   runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2
+   init version: N/A (expected: v0.13.0)
+   Security Options:
+    apparmor
+    seccomp
+     Profile: default
+   Kernel Version: 4.4.0-31-generic
+   Operating System: Ubuntu 16.04.1 LTS
+   OSType: linux
+   Architecture: x86_64
+   CPUs: 2
+   Total Memory: 1.937 GiB
+   Name: ubuntu
+   ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326
+   Docker Root Dir: /var/lib/docker
+   Debug Mode: true
+    File Descriptors: 30
+    Goroutines: 123
+    System Time: 2016-11-12T17:24:37.955404361-08:00
+    EventsListeners: 0
+   Http Proxy: http://test:test@proxy.example.com:8080
+   Https Proxy: https://test:test@proxy.example.com:8080
+   No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com
+   Registry: https://index.docker.io/v1/
+   WARNING: No swap limit support
+   Labels:
+    storage=ssd
+    staging=true
+   Experimental: false
+   Insecure Registries:
+    127.0.0.0/8
+   Registry Mirrors:
+     http://192.168.1.2/
+     http://registry-mirror.example.com:5000/
+   Live Restore Enabled: false
+  ```
+
+  The global `-D` option causes all `docker` commands to output debug information.
+
+  ### Format the output
+
+  You can also specify the output format:
+
+  ```bash
+  $ docker info --format '{{json .}}'
+
+  {"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}
+  ```
+
+  ### Run `docker info` on Windows
+
+  Here is a sample output for a daemon running on Windows Server 2016:
+
+  ```none
+  E:\docker>docker info
+  Client:
+   Debug Mode: false
+
+  Server:
+   Containers: 1
+    Running: 0
+    Paused: 0
+    Stopped: 1
+   Images: 17
+   Server Version: 1.13.0
+   Storage Driver: windowsfilter
+    Windows:
+   Logging Driver: json-file
+   Plugins:
+    Volume: local
+    Network: nat null overlay
+   Swarm: inactive
+   Default Isolation: process
+   Kernel Version: 10.0 14393 (14393.206.amd64fre.rs1_release.160912-1937)
+   Operating System: Windows Server 2016 Datacenter
+   OSType: windows
+   Architecture: x86_64
+   CPUs: 8
+   Total Memory: 3.999 GiB
+   Name: WIN-V0V70C0LU5P
+   ID: NYMS:B5VK:UMSL:FVDZ:EWB5:FKVK:LPFL:FJMQ:H6FT:BZJ6:L2TD:XH62
+   Docker Root Dir: C:\control
+   Debug Mode: false
+   Registry: https://index.docker.io/v1/
+   Insecure Registries:
+    127.0.0.0/8
+   Registry Mirrors:
+     http://192.168.1.2/
+     http://registry-mirror.example.com:5000/
+   Live Restore Enabled: false
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_login.yaml
+++ b/_data/engine-cli/docker_login.yaml
@@ -1,73 +1,6 @@
 command: docker login
 short: Log in to a Docker registry
-long: "Login to a registry.\n\n### Login to a self-hosted registry\n\nIf you want
-  to login to a self-hosted registry you can specify this by\nadding the server name.\n\n```bash\n$
-  docker login localhost:8080\n```\n\n### Provide a password using STDIN\n\nTo run
-  the `docker login` command non-interactively, you can set the\n`--password-stdin`
-  flag to provide a password through `STDIN`. Using\n`STDIN` prevents the password
-  from ending up in the shell's history,\nor log-files.\n\nThe following example reads
-  a password from a file, and passes it to the\n`docker login` command using `STDIN`:\n\n```bash\n$
-  cat ~/my_password.txt | docker login --username foo --password-stdin\n```\n\n###
-  Privileged user requirement\n\n`docker login` requires user to use `sudo` or be
-  `root`, except when:\n\n1.  connecting to a remote daemon, such as a `docker-machine`
-  provisioned `docker engine`.\n2.  user is added to the `docker` group.  This will
-  impact the security of your system; the `docker` group is `root` equivalent.  See
-  [Docker Daemon Attack Surface](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface)
-  for details.\n\nYou can log into any public or private repository for which you
-  have\ncredentials.  When you log in, the command stores credentials in\n`$HOME/.docker/config.json`
-  on Linux or `%USERPROFILE%/.docker/config.json` on\nWindows, via the procedure described
-  below.\n\n### Credentials store\n\nThe Docker Engine can keep user credentials in
-  an external credentials store,\nsuch as the native keychain of the operating system.
-  Using an external store\nis more secure than storing credentials in the Docker configuration
-  file.\n\nTo use a credentials store, you need an external helper program to interact\nwith
-  a specific keychain or external store. Docker requires the helper\nprogram to be
-  in the client's host `$PATH`.\n\nThis is the list of currently available credentials
-  helpers and where\nyou can download them from:\n\n- D-Bus Secret Service: https://github.com/docker/docker-credential-helpers/releases\n-
-  Apple macOS keychain: https://github.com/docker/docker-credential-helpers/releases\n-
-  Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases\n-
-  [pass](https://www.passwordstore.org/): https://github.com/docker/docker-credential-helpers/releases\n\n####
-  Configure the credentials store\n\nYou need to specify the credentials store in
-  `$HOME/.docker/config.json`\nto tell the docker engine to use it. The value of the
-  config property should be\nthe suffix of the program to use (i.e. everything after
-  `docker-credential-`).\nFor example, to use `docker-credential-osxkeychain`:\n\n```json\n{\n\t\"credsStore\":
-  \"osxkeychain\"\n}\n```\n\nIf you are currently logged in, run `docker logout` to
-  remove\nthe credentials from the file and run `docker login` again.\n\n#### Default
-  behavior\n\nBy default, Docker looks for the native binary on each of the platforms,
-  i.e.\n\"osxkeychain\" on macOS, \"wincred\" on windows, and \"pass\" on Linux. A
-  special\ncase is that on Linux, Docker will fall back to the \"secretservice\" binary
-  if\nit cannot find the \"pass\" binary. If none of these binaries are present, it\nstores
-  the credentials (i.e. password) in base64 encoding in the config files\ndescribed
-  above.\n\n#### Credential helper protocol\n\nCredential helpers can be any program
-  or script that follows a very simple protocol.\nThis protocol is heavily inspired
-  by Git, but it differs in the information shared.\n\nThe helpers always use the
-  first argument in the command to identify the action.\nThere are only three possible
-  values for that argument: `store`, `get`, and `erase`.\n\nThe `store` command takes
-  a JSON payload from the standard input. That payload carries\nthe server address,
-  to identify the credential, the user name, and either a password\nor an identity
-  token.\n\n```json\n{\n\t\"ServerURL\": \"https://index.docker.io/v1\",\n\t\"Username\":
-  \"david\",\n\t\"Secret\": \"passw0rd1\"\n}\n```\n\nIf the secret being stored is
-  an identity token, the Username should be set to\n`<token>`.\n\nThe `store` command
-  can write error messages to `STDOUT` that the docker engine\nwill show if there
-  was an issue.\n\nThe `get` command takes a string payload from the standard input.
-  That payload carries\nthe server address that the docker engine needs credentials
-  for. This is\nan example of that payload: `https://index.docker.io/v1`.\n\nThe `get`
-  command writes a JSON payload to `STDOUT`. Docker reads the user name\nand password
-  from this payload:\n\n```json\n{\n\t\"Username\": \"david\",\n\t\"Secret\": \"passw0rd1\"\n}\n```\n\nThe
-  `erase` command takes a string payload from `STDIN`. That payload carries\nthe server
-  address that the docker engine wants to remove credentials for. This is\nan example
-  of that payload: `https://index.docker.io/v1`.\n\nThe `erase` command can write
-  error messages to `STDOUT` that the docker engine\nwill show if there was an issue.\n\n###
-  Credential helpers\n\nCredential helpers are similar to the credential store above,
-  but act as the\ndesignated programs to handle credentials for *specific registries*.
-  The default\ncredential store (`credsStore` or the config file itself) will not
-  be used for\noperations concerning credentials of the specified registries.\n\n####
-  Configure credential helpers\n\nIf you are currently logged in, run `docker logout`
-  to remove\nthe credentials from the default store.\n\nCredential helpers are specified
-  in a similar way to `credsStore`, but\nallow for multiple helpers to be configured
-  at a time. Keys specify the\nregistry domain, and values specify the suffix of the
-  program to use\n(i.e. everything after `docker-credential-`).\nFor example:\n\n```json\n{\n
-  \ \"credHelpers\": {\n    \"registry.example.com\": \"registryhelper\",\n    \"awesomereg.example.org\":
-  \"hip-star\",\n    \"unicorn.example.io\": \"vcbait\"\n  }\n}\n```"
+long: Login to a registry.
 usage: docker login [OPTIONS] [SERVER]
 pname: docker
 plink: docker.yaml
@@ -99,6 +32,159 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  ### Login to a self-hosted registry
+
+  If you want to login to a self-hosted registry you can specify this by
+  adding the server name.
+
+  ```bash
+  $ docker login localhost:8080
+  ```
+
+  ### Provide a password using STDIN
+
+  To run the `docker login` command non-interactively, you can set the
+  `--password-stdin` flag to provide a password through `STDIN`. Using
+  `STDIN` prevents the password from ending up in the shell's history,
+  or log-files.
+
+  The following example reads a password from a file, and passes it to the
+  `docker login` command using `STDIN`:
+
+  ```bash
+  $ cat ~/my_password.txt | docker login --username foo --password-stdin
+  ```
+
+  ### Privileged user requirement
+
+  `docker login` requires user to use `sudo` or be `root`, except when:
+
+  1.  connecting to a remote daemon, such as a `docker-machine` provisioned `docker engine`.
+  2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface) for details.
+
+  You can log into any public or private repository for which you have
+  credentials.  When you log in, the command stores credentials in
+  `$HOME/.docker/config.json` on Linux or `%USERPROFILE%/.docker/config.json` on
+  Windows, via the procedure described below.
+
+  ### Credentials store
+
+  The Docker Engine can keep user credentials in an external credentials store,
+  such as the native keychain of the operating system. Using an external store
+  is more secure than storing credentials in the Docker configuration file.
+
+  To use a credentials store, you need an external helper program to interact
+  with a specific keychain or external store. Docker requires the helper
+  program to be in the client's host `$PATH`.
+
+  This is the list of currently available credentials helpers and where
+  you can download them from:
+
+  - D-Bus Secret Service: https://github.com/docker/docker-credential-helpers/releases
+  - Apple macOS keychain: https://github.com/docker/docker-credential-helpers/releases
+  - Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases
+  - [pass](https://www.passwordstore.org/): https://github.com/docker/docker-credential-helpers/releases
+
+  #### Configure the credentials store
+
+  You need to specify the credentials store in `$HOME/.docker/config.json`
+  to tell the docker engine to use it. The value of the config property should be
+  the suffix of the program to use (i.e. everything after `docker-credential-`).
+  For example, to use `docker-credential-osxkeychain`:
+
+  ```json
+  {
+    "credsStore": "osxkeychain"
+  }
+  ```
+
+  If you are currently logged in, run `docker logout` to remove
+  the credentials from the file and run `docker login` again.
+
+  #### Default behavior
+
+  By default, Docker looks for the native binary on each of the platforms, i.e.
+  "osxkeychain" on macOS, "wincred" on windows, and "pass" on Linux. A special
+  case is that on Linux, Docker will fall back to the "secretservice" binary if
+  it cannot find the "pass" binary. If none of these binaries are present, it
+  stores the credentials (i.e. password) in base64 encoding in the config files
+  described above.
+
+  #### Credential helper protocol
+
+  Credential helpers can be any program or script that follows a very simple protocol.
+  This protocol is heavily inspired by Git, but it differs in the information shared.
+
+  The helpers always use the first argument in the command to identify the action.
+  There are only three possible values for that argument: `store`, `get`, and `erase`.
+
+  The `store` command takes a JSON payload from the standard input. That payload carries
+  the server address, to identify the credential, the user name, and either a password
+  or an identity token.
+
+  ```json
+  {
+    "ServerURL": "https://index.docker.io/v1",
+    "Username": "david",
+    "Secret": "passw0rd1"
+  }
+  ```
+
+  If the secret being stored is an identity token, the Username should be set to
+  `<token>`.
+
+  The `store` command can write error messages to `STDOUT` that the docker engine
+  will show if there was an issue.
+
+  The `get` command takes a string payload from the standard input. That payload carries
+  the server address that the docker engine needs credentials for. This is
+  an example of that payload: `https://index.docker.io/v1`.
+
+  The `get` command writes a JSON payload to `STDOUT`. Docker reads the user name
+  and password from this payload:
+
+  ```json
+  {
+    "Username": "david",
+    "Secret": "passw0rd1"
+  }
+  ```
+
+  The `erase` command takes a string payload from `STDIN`. That payload carries
+  the server address that the docker engine wants to remove credentials for. This is
+  an example of that payload: `https://index.docker.io/v1`.
+
+  The `erase` command can write error messages to `STDOUT` that the docker engine
+  will show if there was an issue.
+
+  ### Credential helpers
+
+  Credential helpers are similar to the credential store above, but act as the
+  designated programs to handle credentials for *specific registries*. The default
+  credential store (`credsStore` or the config file itself) will not be used for
+  operations concerning credentials of the specified registries.
+
+  #### Configure credential helpers
+
+  If you are currently logged in, run `docker logout` to remove
+  the credentials from the default store.
+
+  Credential helpers are specified in a similar way to `credsStore`, but
+  allow for multiple helpers to be configured at a time. Keys specify the
+  registry domain, and values specify the suffix of the program to use
+  (i.e. everything after `docker-credential-`).
+  For example:
+
+  ```json
+  {
+    "credHelpers": {
+      "registry.example.com": "registryhelper",
+      "awesomereg.example.org": "hip-star",
+      "unicorn.example.io": "vcbait"
+    }
+  }
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_manifest.yaml
+++ b/_data/engine-cli/docker_manifest.yaml
@@ -1,43 +1,91 @@
 command: docker manifest
 short: Manage Docker image manifests and manifest lists
-long: "The `docker manifest` command by itself performs no action. In order to operate\non
-  a manifest or manifest list, one of the subcommands must be used.\n\nA single manifest
-  is information about an image, such as layers, size, and digest.\nThe docker manifest
-  command also gives users additional information such as the os\nand architecture
-  an image was built for.\n\nA manifest list is a list of image layers that is created
-  by specifying one or\nmore (ideally more than one) image names. It can then be used
-  in the same way as\nan image name in `docker pull` and `docker run` commands, for
-  example.\n\nIdeally a manifest list is created from images that are identical in
-  function for\ndifferent os/arch combinations. For this reason, manifest lists are
-  often referred to as\n\"multi-arch images\". However, a user could create a manifest
-  list that points\nto two images -- one for windows on amd64, and one for darwin
-  on amd64.\n\n### manifest inspect\n\n```\nmanifest inspect --help\n\nUsage:  docker
-  manifest inspect [OPTIONS] [MANIFEST_LIST] MANIFEST\n\nDisplay an image manifest,
-  or manifest list\n\nOptions:\n      --help       Print usage\n      --insecure   Allow
-  communication with an insecure registry\n  -v, --verbose    Output additional info
-  including layers and platform\n```\n\n### manifest create \n\n```bash\nUsage:  docker
-  manifest create MANIFEST_LIST MANIFEST [MANIFEST...]\n\nCreate a local manifest
-  list for annotating and pushing to a registry\n\nOptions:\n  -a, --amend      Amend
-  an existing manifest list\n      --insecure   Allow communication with an insecure
-  registry\n      --help       Print usage\n```\n\n### manifest annotate\n```bash\nUsage:
-  \ docker manifest annotate [OPTIONS] MANIFEST_LIST MANIFEST\n\nAdd additional information
-  to a local image manifest\n\nOptions:\n      --arch string               Set architecture\n
-  \     --help                      Print usage\n      --os string                 Set
-  operating system\n      --os-features stringSlice   Set operating system feature\n
-  \     --variant string            Set architecture variant\n\n```\n\n### manifest
-  push\n```bash\nUsage:  docker manifest push [OPTIONS] MANIFEST_LIST\n\nPush a manifest
-  list to a repository\n\nOptions:\n      --help       Print usage\n      --insecure
-  \  Allow push to an insecure registry\n  -p, --purge      Remove the local manifest
-  list after push\n```\n\n### Working with insecure registries\n\nThe manifest command
-  interacts solely with a Docker registry. Because of this, it has no way to query
-  the engine for the list of allowed insecure registries. To allow the CLI to interact
-  with an insecure registry, some `docker manifest` commands have an `--insecure`
-  flag. For each transaction, such as a `create`, which queries a registry, the `--insecure`
-  flag must be specified. This flag tells the CLI that this registry call may ignore
-  security concerns like missing or self-signed certificates. Likewise, on a `manifest
-  push` to an insecure registry, the `--insecure` flag must be specified. If this
-  is not used with an insecure registry, the manifest command fails to find a registry
-  that meets the default requirements."
+long: |-
+  The `docker manifest` command by itself performs no action. In order to operate
+  on a manifest or manifest list, one of the subcommands must be used.
+
+  A single manifest is information about an image, such as layers, size, and digest.
+  The docker manifest command also gives users additional information such as the os
+  and architecture an image was built for.
+
+  A manifest list is a list of image layers that is created by specifying one or
+  more (ideally more than one) image names. It can then be used in the same way as
+  an image name in `docker pull` and `docker run` commands, for example.
+
+  Ideally a manifest list is created from images that are identical in function for
+  different os/arch combinations. For this reason, manifest lists are often referred
+  to as "multi-arch images". However, a user could create a manifest list that points
+  to two images -- one for windows on amd64, and one for darwin on amd64.
+
+  ### manifest inspect
+
+  ```
+  manifest inspect --help
+
+  Usage:  docker manifest inspect [OPTIONS] [MANIFEST_LIST] MANIFEST
+
+  Display an image manifest, or manifest list
+
+  Options:
+        --help       Print usage
+        --insecure   Allow communication with an insecure registry
+    -v, --verbose    Output additional info including layers and platform
+  ```
+
+  ### manifest create
+
+  ```bash
+  Usage:  docker manifest create MANIFEST_LIST MANIFEST [MANIFEST...]
+
+  Create a local manifest list for annotating and pushing to a registry
+
+  Options:
+    -a, --amend      Amend an existing manifest list
+        --insecure   Allow communication with an insecure registry
+        --help       Print usage
+  ```
+
+  ### manifest annotate
+
+  ```bash
+  Usage:  docker manifest annotate [OPTIONS] MANIFEST_LIST MANIFEST
+
+  Add additional information to a local image manifest
+
+  Options:
+        --arch string               Set architecture
+        --help                      Print usage
+        --os string                 Set operating system
+        --os-features stringSlice   Set operating system feature
+        --variant string            Set architecture variant
+
+  ```
+
+  ### manifest push
+
+  ```bash
+  Usage:  docker manifest push [OPTIONS] MANIFEST_LIST
+
+  Push a manifest list to a repository
+
+  Options:
+        --help       Print usage
+        --insecure   Allow push to an insecure registry
+    -p, --purge      Remove the local manifest list after push
+  ```
+
+  ### Working with insecure registries
+
+  The manifest command interacts solely with a Docker registry. Because of this,
+  it has no way to query the engine for the list of allowed insecure registries.
+  To allow the CLI to interact with an insecure registry, some `docker manifest`
+  commands have an `--insecure` flag. For each transaction, such as a `create`,
+  which queries a registry, the `--insecure` flag must be specified. This flag
+  tells the CLI that this registry call may ignore security concerns like missing
+  or self-signed certificates. Likewise, on a `manifest push` to an insecure
+  registry, the `--insecure` flag must be specified. If this is not used with an
+  insecure registry, the manifest command fails to find a registry that meets the
+  default requirements.
 usage: docker manifest COMMAND
 pname: docker
 plink: docker.yaml
@@ -51,80 +99,177 @@ clink:
 - docker_manifest_create.yaml
 - docker_manifest_inspect.yaml
 - docker_manifest_push.yaml
-examples: "### Inspect an image's manifest object\n \n```bash\n$ docker manifest inspect
-  hello-world\n{\n        \"schemaVersion\": 2,\n        \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n
-  \       \"config\": {\n                \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\n
-  \               \"size\": 1520,\n                \"digest\": \"sha256:1815c82652c03bfd8644afda26fb184f2ed891d921b20a0703b46768f9755c57\"\n
-  \       },\n        \"layers\": [\n                {\n                        \"mediaType\":
-  \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\n                        \"size\":
-  972,\n                        \"digest\": \"sha256:b04784fba78d739b526e27edc02a5a8cd07b1052e9283f5fc155828f4b614c28\"\n
-  \               }\n        ]\n}\n```\n\n### Inspect an image's manifest and get
-  the os/arch info\n\nThe `docker manifest inspect` command takes an optional `--verbose`
-  flag\nthat gives you the image's name (Ref), and architecture and os (Platform).\n\nJust
-  as with other docker commands that take image names, you can refer to an image with
-  or\nwithout a tag, or by digest (e.g. hello-world@sha256:f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f).\n\nHere
-  is an example of inspecting an image's manifest with the `--verbose` flag:\n\n```bash\n$
-  docker manifest inspect --verbose hello-world\n{\n        \"Ref\": \"docker.io/library/hello-world:latest\",\n
-  \       \"Digest\": \"sha256:f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f\",\n
-  \       \"SchemaV2Manifest\": {\n                \"schemaVersion\": 2,\n                \"mediaType\":
-  \"application/vnd.docker.distribution.manifest.v2+json\",\n                \"config\":
-  {\n                        \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\n
-  \                       \"size\": 1520,\n                        \"digest\": \"sha256:1815c82652c03bfd8644afda26fb184f2ed891d921b20a0703b46768f9755c57\"\n
-  \               },\n                \"layers\": [\n                        {\n                                \"mediaType\":
-  \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\n                                \"size\":
-  972,\n                                \"digest\": \"sha256:b04784fba78d739b526e27edc02a5a8cd07b1052e9283f5fc155828f4b614c28\"\n
-  \                       }\n                ]\n        },\n        \"Platform\":
-  {\n                \"architecture\": \"amd64\",\n                \"os\": \"linux\"\n
-  \       }\n}\n```\n\n### Create and push a manifest list\n\nTo create a manifest
-  list, you first `create` the manifest list locally by specifying the constituent
-  images you would\nlike to have included in your manifest list. Keep in mind that
-  this is pushed to a registry, so if you want to push\nto a registry other than the
-  docker registry, you need to create your manifest list with the registry name or
-  IP and port.\nThis is similar to tagging an image and pushing it to a foreign registry.\n\nAfter
-  you have created your local copy of the manifest list, you may optionally\n`annotate`
-  it. Annotations allowed are the architecture and operating system (overriding the
-  image's current values),\nos features, and an architecture variant. \n\nFinally,
-  you need to `push` your manifest list to the desired registry. Below are descriptions
-  of these three commands,\nand an example putting them all together.\n\n```bash\n$
-  docker manifest create 45.55.81.106:5000/coolapp:v1 \\\n    45.55.81.106:5000/coolapp-ppc64le-linux:v1
-  \\\n    45.55.81.106:5000/coolapp-arm-linux:v1 \\\n    45.55.81.106:5000/coolapp-amd64-linux:v1
-  \\\n    45.55.81.106:5000/coolapp-amd64-windows:v1\nCreated manifest list 45.55.81.106:5000/coolapp:v1\n```\n\n```bash\n$
-  docker manifest annotate 45.55.81.106:5000/coolapp:v1 45.55.81.106:5000/coolapp-arm-linux
-  --arch arm\n```\n\n```bash\n$ docker manifest push 45.55.81.106:5000/coolapp:v1\nPushed
-  manifest 45.55.81.106:5000/coolapp@sha256:9701edc932223a66e49dd6c894a11db8c2cf4eccd1414f1ec105a623bf16b426
-  with digest: sha256:f67dcc5fc786f04f0743abfe0ee5dae9bd8caf8efa6c8144f7f2a43889dc513b\nPushed
-  manifest 45.55.81.106:5000/coolapp@sha256:f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f
-  with digest: sha256:b64ca0b60356a30971f098c92200b1271257f100a55b351e6bbe985638352f3a\nPushed
-  manifest 45.55.81.106:5000/coolapp@sha256:39dc41c658cf25f33681a41310372f02728925a54aac3598310bfb1770615fc9
-  with digest: sha256:df436846483aff62bad830b730a0d3b77731bcf98ba5e470a8bbb8e9e346e4e8\nPushed
-  manifest 45.55.81.106:5000/coolapp@sha256:f91b1145cd4ac800b28122313ae9e88ac340bb3f1e3a4cd3e59a3648650f3275
-  with digest: sha256:5bb8e50aa2edd408bdf3ddf61efb7338ff34a07b762992c9432f1c02fc0e5e62\nsha256:050b213d49d7673ba35014f21454c573dcbec75254a08f4a7c34f66a47c06aba\n\n```\n\n###
-  Inspect a manifest list\n\n```bash\n$ docker manifest inspect coolapp:v1\n{\n   \"schemaVersion\":
-  2,\n   \"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\",\n
-  \  \"manifests\": [\n      {\n         \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n
-  \        \"size\": 424,\n         \"digest\": \"sha256:f67dcc5fc786f04f0743abfe0ee5dae9bd8caf8efa6c8144f7f2a43889dc513b\",\n
-  \        \"platform\": {\n            \"architecture\": \"arm\",\n            \"os\":
-  \"linux\"\n         }\n      },\n      {\n         \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n
-  \        \"size\": 424,\n         \"digest\": \"sha256:b64ca0b60356a30971f098c92200b1271257f100a55b351e6bbe985638352f3a\",\n
-  \        \"platform\": {\n            \"architecture\": \"amd64\",\n            \"os\":
-  \"linux\"\n         }\n      },\n      {\n         \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n
-  \        \"size\": 425,\n         \"digest\": \"sha256:df436846483aff62bad830b730a0d3b77731bcf98ba5e470a8bbb8e9e346e4e8\",\n
-  \        \"platform\": {\n            \"architecture\": \"ppc64le\",\n            \"os\":
-  \"linux\"\n         }\n      },\n      {\n         \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n
-  \        \"size\": 425,\n         \"digest\": \"sha256:5bb8e50aa2edd408bdf3ddf61efb7338ff34a07b762992c9432f1c02fc0e5e62\",\n
-  \        \"platform\": {\n            \"architecture\": \"s390x\",\n            \"os\":
-  \"linux\"\n         }\n      }\n   ]\n}\n```\n\n### Push to an insecure registry\n\nHere
-  is an example of creating and pushing a manifest list using a known insecure registry.\n\n```\n$
-  docker manifest create --insecure myprivateregistry.mycompany.com/repo/image:1.0
-  \\\n    myprivateregistry.mycompany.com/repo/image-linux-ppc64le:1.0 \\\n    myprivateregistry.mycompany.com/repo/image-linux-s390x:1.0
-  \\\n    myprivateregistry.mycompany.com/repo/image-linux-arm:1.0 \\\n    myprivateregistry.mycompany.com/repo/image-linux-armhf:1.0
-  \\\n    myprivateregistry.mycompany.com/repo/image-windows-amd64:1.0 \\\n    myprivateregistry.mycompany.com/repo/image-linux-amd64:1.0\n```\n```\n$
-  docker manifest push --insecure myprivateregistry.mycompany.com/repo/image:tag\n```\n\nNote
-  that the `--insecure` flag is not required to annotate a manifest list, since annotations
-  are to a locally-stored copy of a manifest list. You may also skip the `--insecure`
-  flag if you are performing a `docker manifest inspect` on a locally-stored manifest
-  list. Be sure to keep in mind that locally-stored manifest lists are never used
-  by the engine on a `docker pull`."
+examples: |-
+  ### Inspect an image's manifest object
+
+  ```bash
+  $ docker manifest inspect hello-world
+  {
+          "schemaVersion": 2,
+          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+          "config": {
+                  "mediaType": "application/vnd.docker.container.image.v1+json",
+                  "size": 1520,
+                  "digest": "sha256:1815c82652c03bfd8644afda26fb184f2ed891d921b20a0703b46768f9755c57"
+          },
+          "layers": [
+                  {
+                          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                          "size": 972,
+                          "digest": "sha256:b04784fba78d739b526e27edc02a5a8cd07b1052e9283f5fc155828f4b614c28"
+                  }
+          ]
+  }
+  ```
+
+  ### Inspect an image's manifest and get the os/arch info
+
+  The `docker manifest inspect` command takes an optional `--verbose` flag
+  that gives you the image's name (Ref), and architecture and os (Platform).
+
+  Just as with other docker commands that take image names, you can refer to an image with or
+  without a tag, or by digest (e.g. `hello-world@sha256:f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f`).
+
+  Here is an example of inspecting an image's manifest with the `--verbose` flag:
+
+  ```bash
+  $ docker manifest inspect --verbose hello-world
+  {
+          "Ref": "docker.io/library/hello-world:latest",
+          "Digest": "sha256:f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f",
+          "SchemaV2Manifest": {
+                  "schemaVersion": 2,
+                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                  "config": {
+                          "mediaType": "application/vnd.docker.container.image.v1+json",
+                          "size": 1520,
+                          "digest": "sha256:1815c82652c03bfd8644afda26fb184f2ed891d921b20a0703b46768f9755c57"
+                  },
+                  "layers": [
+                          {
+                                  "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                                  "size": 972,
+                                  "digest": "sha256:b04784fba78d739b526e27edc02a5a8cd07b1052e9283f5fc155828f4b614c28"
+                          }
+                  ]
+          },
+          "Platform": {
+                  "architecture": "amd64",
+                  "os": "linux"
+          }
+  }
+  ```
+
+  ### Create and push a manifest list
+
+  To create a manifest list, you first `create` the manifest list locally by
+  specifying the constituent images you would like to have included in your
+  manifest list. Keep in mind that this is pushed to a registry, so if you want to
+  push to a registry other than the docker registry, you need to create your
+  manifest list with the registry name or IP and port.
+  This is similar to tagging an image and pushing it to a foreign registry.
+
+  After you have created your local copy of the manifest list, you may optionally
+  `annotate` it. Annotations allowed are the architecture and operating system
+  (overriding the image's current values), os features, and an architecture variant.
+
+  Finally, you need to `push` your manifest list to the desired registry. Below are
+  descriptions of these three commands, and an example putting them all together.
+
+  ```bash
+  $ docker manifest create 45.55.81.106:5000/coolapp:v1 \
+      45.55.81.106:5000/coolapp-ppc64le-linux:v1 \
+      45.55.81.106:5000/coolapp-arm-linux:v1 \
+      45.55.81.106:5000/coolapp-amd64-linux:v1 \
+      45.55.81.106:5000/coolapp-amd64-windows:v1
+
+  Created manifest list 45.55.81.106:5000/coolapp:v1
+  ```
+
+  ```bash
+  $ docker manifest annotate 45.55.81.106:5000/coolapp:v1 45.55.81.106:5000/coolapp-arm-linux --arch arm
+  ```
+
+  ```bash
+  $ docker manifest push 45.55.81.106:5000/coolapp:v1
+  Pushed manifest 45.55.81.106:5000/coolapp@sha256:9701edc932223a66e49dd6c894a11db8c2cf4eccd1414f1ec105a623bf16b426 with digest: sha256:f67dcc5fc786f04f0743abfe0ee5dae9bd8caf8efa6c8144f7f2a43889dc513b
+  Pushed manifest 45.55.81.106:5000/coolapp@sha256:f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f with digest: sha256:b64ca0b60356a30971f098c92200b1271257f100a55b351e6bbe985638352f3a
+  Pushed manifest 45.55.81.106:5000/coolapp@sha256:39dc41c658cf25f33681a41310372f02728925a54aac3598310bfb1770615fc9 with digest: sha256:df436846483aff62bad830b730a0d3b77731bcf98ba5e470a8bbb8e9e346e4e8
+  Pushed manifest 45.55.81.106:5000/coolapp@sha256:f91b1145cd4ac800b28122313ae9e88ac340bb3f1e3a4cd3e59a3648650f3275 with digest: sha256:5bb8e50aa2edd408bdf3ddf61efb7338ff34a07b762992c9432f1c02fc0e5e62
+  sha256:050b213d49d7673ba35014f21454c573dcbec75254a08f4a7c34f66a47c06aba
+
+  ```
+
+  ### Inspect a manifest list
+
+  ```bash
+  $ docker manifest inspect coolapp:v1
+  {
+     "schemaVersion": 2,
+     "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+     "manifests": [
+        {
+           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+           "size": 424,
+           "digest": "sha256:f67dcc5fc786f04f0743abfe0ee5dae9bd8caf8efa6c8144f7f2a43889dc513b",
+           "platform": {
+              "architecture": "arm",
+              "os": "linux"
+           }
+        },
+        {
+           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+           "size": 424,
+           "digest": "sha256:b64ca0b60356a30971f098c92200b1271257f100a55b351e6bbe985638352f3a",
+           "platform": {
+              "architecture": "amd64",
+              "os": "linux"
+           }
+        },
+        {
+           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+           "size": 425,
+           "digest": "sha256:df436846483aff62bad830b730a0d3b77731bcf98ba5e470a8bbb8e9e346e4e8",
+           "platform": {
+              "architecture": "ppc64le",
+              "os": "linux"
+           }
+        },
+        {
+           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+           "size": 425,
+           "digest": "sha256:5bb8e50aa2edd408bdf3ddf61efb7338ff34a07b762992c9432f1c02fc0e5e62",
+           "platform": {
+              "architecture": "s390x",
+              "os": "linux"
+           }
+        }
+     ]
+  }
+  ```
+
+  ### Push to an insecure registry
+
+  Here is an example of creating and pushing a manifest list using a known
+  insecure registry.
+
+  ```bash
+  $ docker manifest create --insecure myprivateregistry.mycompany.com/repo/image:1.0 \
+      myprivateregistry.mycompany.com/repo/image-linux-ppc64le:1.0 \
+      myprivateregistry.mycompany.com/repo/image-linux-s390x:1.0 \
+      myprivateregistry.mycompany.com/repo/image-linux-arm:1.0 \
+      myprivateregistry.mycompany.com/repo/image-linux-armhf:1.0 \
+      myprivateregistry.mycompany.com/repo/image-windows-amd64:1.0 \
+      myprivateregistry.mycompany.com/repo/image-linux-amd64:1.0
+
+  $ docker manifest push --insecure myprivateregistry.mycompany.com/repo/image:tag
+  ```
+
+  > **Note**: the `--insecure` flag is not required to annotate a manifest list,
+  > since annotations are to a locally-stored copy of a manifest list. You may also
+  > skip the `--insecure` flag if you are performing a `docker manifest inspect`
+  > on a locally-stored manifest list. Be sure to keep in mind that locally-stored
+  > manifest lists are never used by the engine on a `docker pull`.
 deprecated: false
 experimental: false
 experimentalcli: true

--- a/_data/engine-cli/docker_network_ls.yaml
+++ b/_data/engine-cli/docker_network_ls.yaml
@@ -44,86 +44,207 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### List all networks\n\n```bash\n$ sudo docker network ls\nNETWORK ID
-  \         NAME                DRIVER          SCOPE\n7fca4eb8c647        bridge
-  \             bridge          local\n9f904ee27bf5        none                null
-  \           local\ncf03ee007fb4        host                host            local\n78b03ee04fc4
-  \       multi-host          overlay         swarm\n```\n\nUse the `--no-trunc` option
-  to display the full network id:\n\n```bash\n$ docker network ls --no-trunc\nNETWORK
-  ID                                                         NAME                DRIVER
-  \          SCOPE\n18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3
-  \  none                null             local\nc288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47
-  \  host                host             local\n7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185
-  \  bridge              bridge           local\n95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd
-  \  foo                 bridge           local\n63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161
-  \  dev                 bridge           local\n```\n\n### Filtering\n\nThe filtering
-  flag (`-f` or `--filter`) format is a `key=value` pair. If there\nis more than one
-  filter, then pass multiple flags (e.g. `--filter \"foo=bar\" --filter \"bif=baz\"`).\nMultiple
-  filter flags are combined as an `OR` filter. For example,\n`-f type=custom -f type=builtin`
-  returns both `custom` and `builtin` networks.\n\nThe currently supported filters
-  are:\n\n* driver\n* id (network's id)\n* label (`label=<key>` or `label=<key>=<value>`)\n*
-  name (network's name)\n* scope (`swarm|global|local`)\n* type (`custom|builtin`)\n\n####
-  Driver\n\nThe `driver` filter matches networks based on their driver.\n\nThe following
-  example matches networks with the `bridge` driver:\n\n```bash\n$ docker network
-  ls --filter driver=bridge\nNETWORK ID          NAME                DRIVER            SCOPE\ndb9db329f835
-  \       test1               bridge            local\nf6e212da9dfd        test2               bridge
-  \           local\n```\n\n#### ID\n\nThe `id` filter matches on all or part of a
-  network's ID.\n\nThe following filter matches all networks with an ID containing
-  the\n`63d1ff1f77b0...` string.\n\n```bash\n$ docker network ls --filter id=63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161\nNETWORK
-  ID          NAME                DRIVER           SCOPE\n63d1ff1f77b0        dev
-  \                bridge           local\n```\n\nYou can also filter for a substring
-  in an ID as this shows:\n\n```bash\n$ docker network ls --filter id=95e74588f40d\nNETWORK
-  ID          NAME                DRIVER          SCOPE\n95e74588f40d        foo                 bridge
-  \         local\n\n$ docker network ls --filter id=95e\nNETWORK ID          NAME
-  \               DRIVER          SCOPE\n95e74588f40d        foo                 bridge
-  \         local\n```\n\n#### Label\n\nThe `label` filter matches networks based
-  on the presence of a `label` alone or a `label` and a\nvalue.\n\nThe following filter
-  matches networks with the `usage` label regardless of its value.\n\n```bash\n$ docker
-  network ls -f \"label=usage\"\nNETWORK ID          NAME                DRIVER         SCOPE\ndb9db329f835
-  \       test1               bridge         local\nf6e212da9dfd        test2               bridge
-  \        local\n```\n\nThe following filter matches networks with the `usage` label
-  with the `prod` value.\n\n```bash\n$ docker network ls -f \"label=usage=prod\"\nNETWORK
-  ID          NAME                DRIVER        SCOPE\nf6e212da9dfd        test2               bridge
-  \       local\n```\n\n#### Name\n\nThe `name` filter matches on all or part of a
-  network's name.\n\nThe following filter matches all networks with a name containing
-  the `foobar` string.\n\n```bash\n$ docker network ls --filter name=foobar\nNETWORK
-  ID          NAME                DRIVER       SCOPE\n06e7eef0a170        foobar              bridge
-  \      local\n```\n\nYou can also filter for a substring in a name as this shows:\n\n```bash\n$
-  docker network ls --filter name=foo\nNETWORK ID          NAME                DRIVER
-  \      SCOPE\n95e74588f40d        foo                 bridge       local\n06e7eef0a170
-  \       foobar              bridge       local\n```\n\n#### Scope\n\nThe `scope`
-  filter matches networks based on their scope.\n\nThe following example matches networks
-  with the `swarm` scope:\n\n```bash\n$ docker network ls --filter scope=swarm\nNETWORK
-  ID          NAME                DRIVER              SCOPE\nxbtm0v4f1lfh        ingress
-  \            overlay             swarm\nic6r88twuu92        swarmnet            overlay
-  \            swarm\n```\n\nThe following example matches networks with the `local`
-  scope:\n\n```bash\n$ docker network ls --filter scope=local\nNETWORK ID          NAME
-  \               DRIVER              SCOPE\ne85227439ac7        bridge              bridge
-  \             local\n0ca0e19443ed        host                host                local\nca13cc149a36
-  \       localnet            bridge              local\nf9e115d2de35        none
-  \               null                local\n```\n\n#### Type\n\nThe `type` filter
-  supports two values; `builtin` displays predefined networks\n(`bridge`, `none`,
-  `host`), whereas `custom` displays user defined networks.\n\nThe following filter
-  matches all user defined networks:\n\n```bash\n$ docker network ls --filter type=custom\nNETWORK
-  ID          NAME                DRIVER       SCOPE\n95e74588f40d        foo                 bridge
-  \      local  \n63d1ff1f77b0        dev                 bridge       local\n```\n\nBy
-  having this flag it allows for batch cleanup. For example, use this filter\nto delete
-  all user defined networks:\n\n```bash\n$ docker network rm `docker network ls --filter
-  type=custom -q`\n```\n\nA warning will be issued when trying to remove a network
-  that has containers\nattached.\n\n### Formatting\n\nThe formatting options (`--format`)
-  pretty-prints networks output\nusing a Go template.\n\nValid placeholders for the
-  Go template are listed below:\n\nPlaceholder  | Description\n-------------|------------------------------------------------------------------------------------------\n`.ID`
-  \       | Network ID\n`.Name`      | Network name\n`.Driver`    | Network driver\n`.Scope`
-  \    | Network scope (local, global)\n`.IPv6`      | Whether IPv6 is enabled on
-  the network or not.\n`.Internal`  | Whether the network is internal or not.\n`.Labels`
-  \   | All labels assigned to the network.\n`.Label`     | Value of a specific label
-  for this network. For example `{{.Label \"project.version\"}}`\n`.CreatedAt` | Time
-  when the network was created\n\nWhen using the `--format` option, the `network ls`
-  command will either\noutput the data exactly as the template declares or, when using
-  the\n`table` directive, includes column headers as well.\n\nThe following example
-  uses a template without headers and outputs the\n`ID` and `Driver` entries separated
-  by a colon for all networks:\n\n```bash\n$ docker network ls --format \"{{.ID}}:
-  {{.Driver}}\"\nafaaab448eb2: bridge\nd1584f8dc718: host\n391df270dc66: null\n```"
+examples: |-
+  ### List all networks
+
+  ```bash
+  $ sudo docker network ls
+  NETWORK ID          NAME                DRIVER          SCOPE
+  7fca4eb8c647        bridge              bridge          local
+  9f904ee27bf5        none                null            local
+  cf03ee007fb4        host                host            local
+  78b03ee04fc4        multi-host          overlay         swarm
+  ```
+
+  Use the `--no-trunc` option to display the full network id:
+
+  ```bash
+  $ docker network ls --no-trunc
+  NETWORK ID                                                         NAME                DRIVER           SCOPE
+  18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3   none                null             local
+  c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host                host             local
+  7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185   bridge              bridge           local
+  95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd   foo                 bridge           local
+  63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge           local
+  ```
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
+  is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
+  Multiple filter flags are combined as an `OR` filter. For example,
+  `-f type=custom -f type=builtin` returns both `custom` and `builtin` networks.
+
+  The currently supported filters are:
+
+  * driver
+  * id (network's id)
+  * label (`label=<key>` or `label=<key>=<value>`)
+  * name (network's name)
+  * scope (`swarm|global|local`)
+  * type (`custom|builtin`)
+
+  #### Driver
+
+  The `driver` filter matches networks based on their driver.
+
+  The following example matches networks with the `bridge` driver:
+
+  ```bash
+  $ docker network ls --filter driver=bridge
+  NETWORK ID          NAME                DRIVER            SCOPE
+  db9db329f835        test1               bridge            local
+  f6e212da9dfd        test2               bridge            local
+  ```
+
+  #### ID
+
+  The `id` filter matches on all or part of a network's ID.
+
+  The following filter matches all networks with an ID containing the
+  `63d1ff1f77b0...` string.
+
+  ```bash
+  $ docker network ls --filter id=63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161
+  NETWORK ID          NAME                DRIVER           SCOPE
+  63d1ff1f77b0        dev                 bridge           local
+  ```
+
+  You can also filter for a substring in an ID as this shows:
+
+  ```bash
+  $ docker network ls --filter id=95e74588f40d
+  NETWORK ID          NAME                DRIVER          SCOPE
+  95e74588f40d        foo                 bridge          local
+
+  $ docker network ls --filter id=95e
+  NETWORK ID          NAME                DRIVER          SCOPE
+  95e74588f40d        foo                 bridge          local
+  ```
+
+  #### Label
+
+  The `label` filter matches networks based on the presence of a `label` alone or a `label` and a
+  value.
+
+  The following filter matches networks with the `usage` label regardless of its value.
+
+  ```bash
+  $ docker network ls -f "label=usage"
+  NETWORK ID          NAME                DRIVER         SCOPE
+  db9db329f835        test1               bridge         local
+  f6e212da9dfd        test2               bridge         local
+  ```
+
+  The following filter matches networks with the `usage` label with the `prod` value.
+
+  ```bash
+  $ docker network ls -f "label=usage=prod"
+  NETWORK ID          NAME                DRIVER        SCOPE
+  f6e212da9dfd        test2               bridge        local
+  ```
+
+  #### Name
+
+  The `name` filter matches on all or part of a network's name.
+
+  The following filter matches all networks with a name containing the `foobar` string.
+
+  ```bash
+  $ docker network ls --filter name=foobar
+  NETWORK ID          NAME                DRIVER       SCOPE
+  06e7eef0a170        foobar              bridge       local
+  ```
+
+  You can also filter for a substring in a name as this shows:
+
+  ```bash
+  $ docker network ls --filter name=foo
+  NETWORK ID          NAME                DRIVER       SCOPE
+  95e74588f40d        foo                 bridge       local
+  06e7eef0a170        foobar              bridge       local
+  ```
+
+  #### Scope
+
+  The `scope` filter matches networks based on their scope.
+
+  The following example matches networks with the `swarm` scope:
+
+  ```bash
+  $ docker network ls --filter scope=swarm
+  NETWORK ID          NAME                DRIVER              SCOPE
+  xbtm0v4f1lfh        ingress             overlay             swarm
+  ic6r88twuu92        swarmnet            overlay             swarm
+  ```
+
+  The following example matches networks with the `local` scope:
+
+  ```bash
+  $ docker network ls --filter scope=local
+  NETWORK ID          NAME                DRIVER              SCOPE
+  e85227439ac7        bridge              bridge              local
+  0ca0e19443ed        host                host                local
+  ca13cc149a36        localnet            bridge              local
+  f9e115d2de35        none                null                local
+  ```
+
+  #### Type
+
+  The `type` filter supports two values; `builtin` displays predefined networks
+  (`bridge`, `none`, `host`), whereas `custom` displays user defined networks.
+
+  The following filter matches all user defined networks:
+
+  ```bash
+  $ docker network ls --filter type=custom
+  NETWORK ID          NAME                DRIVER       SCOPE
+  95e74588f40d        foo                 bridge       local
+  63d1ff1f77b0        dev                 bridge       local
+  ```
+
+  By having this flag it allows for batch cleanup. For example, use this filter
+  to delete all user defined networks:
+
+  ```bash
+  $ docker network rm `docker network ls --filter type=custom -q`
+  ```
+
+  A warning will be issued when trying to remove a network that has containers
+  attached.
+
+  ### Formatting
+
+  The formatting options (`--format`) pretty-prints networks output
+  using a Go template.
+
+  Valid placeholders for the Go template are listed below:
+
+  Placeholder  | Description
+  -------------|------------------------------------------------------------------------------------------
+  `.ID`        | Network ID
+  `.Name`      | Network name
+  `.Driver`    | Network driver
+  `.Scope`     | Network scope (local, global)
+  `.IPv6`      | Whether IPv6 is enabled on the network or not.
+  `.Internal`  | Whether the network is internal or not.
+  `.Labels`    | All labels assigned to the network.
+  `.Label`     | Value of a specific label for this network. For example `{{.Label "project.version"}}`
+  `.CreatedAt` | Time when the network was created
+
+  When using the `--format` option, the `network ls` command will either
+  output the data exactly as the template declares or, when using the
+  `table` directive, includes column headers as well.
+
+  The following example uses a template without headers and outputs the
+  `ID` and `Driver` entries separated by a colon for all networks:
+
+  ```bash
+  $ docker network ls --format "{{.ID}}: {{.Driver}}"
+  afaaab448eb2: bridge
+  d1584f8dc718: host
+  391df270dc66: null
+  ```
 deprecated: false
 min_api_version: "1.21"
 experimental: false

--- a/_data/engine-cli/docker_node_inspect.yaml
+++ b/_data/engine-cli/docker_node_inspect.yaml
@@ -32,42 +32,134 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Inspect a node\n\n```none\n$ docker node inspect swarm-manager\n\n[\n{\n
-  \   \"ID\": \"e216jshn25ckzbvmwlnh5jr3g\",\n    \"Version\": {\n        \"Index\":
-  10\n    },\n    \"CreatedAt\": \"2017-05-16T22:52:44.9910662Z\",\n    \"UpdatedAt\":
-  \"2017-05-16T22:52:45.230878043Z\",\n    \"Spec\": {\n        \"Role\": \"manager\",\n
-  \       \"Availability\": \"active\"\n    },\n    \"Description\": {\n        \"Hostname\":
-  \"swarm-manager\",\n        \"Platform\": {\n            \"Architecture\": \"x86_64\",\n
-  \           \"OS\": \"linux\"\n        },\n        \"Resources\": {\n            \"NanoCPUs\":
-  1000000000,\n            \"MemoryBytes\": 1039843328\n        },\n        \"Engine\":
-  {\n            \"EngineVersion\": \"17.06.0-ce\",\n            \"Plugins\": [\n
-  \               {\n                    \"Type\": \"Volume\",\n                    \"Name\":
-  \"local\"\n                },\n                {\n                    \"Type\":
-  \"Network\",\n                    \"Name\": \"overlay\"\n                },\n                {\n
-  \                   \"Type\": \"Network\",\n                    \"Name\": \"null\"\n
-  \               },\n                {\n                    \"Type\": \"Network\",\n
-  \                   \"Name\": \"host\"\n                },\n                {\n
-  \                   \"Type\": \"Network\",\n                    \"Name\": \"bridge\"\n
-  \               },\n                {\n                    \"Type\": \"Network\",\n
-  \                   \"Name\": \"overlay\"\n                }\n            ]\n        },\n
-  \       \"TLSInfo\": {\n            \"TrustRoot\": \"-----BEGIN CERTIFICATE-----\\nMIIBazCCARCgAwIBAgIUOzgqU4tA2q5Yv1HnkzhSIwGyIBswCgYIKoZIzj0EAwIw\\nEzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNTAyMDAyNDAwWhcNMzcwNDI3MDAy\\nNDAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH\\nA0IABMbiAmET+HZyve35ujrnL2kOLBEQhFDZ5MhxAuYs96n796sFlfxTxC1lM/2g\\nAh8DI34pm3JmHgZxeBPKUURJHKWjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB\\nAf8EBTADAQH/MB0GA1UdDgQWBBS3sjTJOcXdkls6WSY2rTx1KIJueTAKBggqhkjO\\nPQQDAgNJADBGAiEAoeVWkaXgSUAucQmZ3Yhmx22N/cq1EPBgYHOBZmHt0NkCIQC3\\nzONcJ/+WA21OXtb+vcijpUOXtNjyHfcox0N8wsLDqQ==\\n-----END
-  CERTIFICATE-----\\n\",\n            \"CertIssuerSubject\": \"MBMxETAPBgNVBAMTCHN3YXJtLWNh\",\n
-  \           \"CertIssuerPublicKey\": \"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExuICYRP4dnK97fm6OucvaQ4sERCEUNnkyHEC5iz3qfv3qwWV/FPELWUz/aACHwMjfimbcmYeBnF4E8pRREkcpQ==\"\n
-  \       }\n    },\n    \"Status\": {\n        \"State\": \"ready\",\n        \"Addr\":
-  \"168.0.32.137\"\n    },\n    \"ManagerStatus\": {\n        \"Leader\": true,\n
-  \       \"Reachability\": \"reachable\",\n        \"Addr\": \"168.0.32.137:2377\"\n
-  \   }\n}\n]\n```\n\n### Specify an output format\n\n```none\n$ docker node inspect
-  --format '{{ .ManagerStatus.Leader }}' self\n\nfalse\n\n$ docker node inspect --pretty
-  self\nID:                     e216jshn25ckzbvmwlnh5jr3g\nHostname:               swarm-manager\nJoined
-  at:              2017-05-16 22:52:44.9910662 +0000 utc\nStatus:\n State:                 Ready\n
-  Availability:          Active\n Address:               172.17.0.2\nManager Status:\n
-  Address:               172.17.0.2:2377\n Raft Status:           Reachable\n Leader:
-  \               Yes\nPlatform:\n Operating System:      linux\n Architecture:          x86_64\nResources:\n
-  CPUs:                  4\n Memory:                7.704 GiB\nPlugins:\n  Network:
-  \             overlay, bridge, null, host, overlay\n  Volume:               local\nEngine
-  Version:         17.06.0-ce\nTLS Info:\n TrustRoot:\n-----BEGIN CERTIFICATE-----\nMIIBazCCARCgAwIBAgIUOzgqU4tA2q5Yv1HnkzhSIwGyIBswCgYIKoZIzj0EAwIw\nEzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNTAyMDAyNDAwWhcNMzcwNDI3MDAy\nNDAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABMbiAmET+HZyve35ujrnL2kOLBEQhFDZ5MhxAuYs96n796sFlfxTxC1lM/2g\nAh8DI34pm3JmHgZxeBPKUURJHKWjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB\nAf8EBTADAQH/MB0GA1UdDgQWBBS3sjTJOcXdkls6WSY2rTx1KIJueTAKBggqhkjO\nPQQDAgNJADBGAiEAoeVWkaXgSUAucQmZ3Yhmx22N/cq1EPBgYHOBZmHt0NkCIQC3\nzONcJ/+WA21OXtb+vcijpUOXtNjyHfcox0N8wsLDqQ==\n-----END
-  CERTIFICATE-----\n\n Issuer Public Key:\tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExuICYRP4dnK97fm6OucvaQ4sERCEUNnkyHEC5iz3qfv3qwWV/FPELWUz/aACHwMjfimbcmYeBnF4E8pRREkcpQ==\n
-  Issuer Subject:\tMBMxETAPBgNVBAMTCHN3YXJtLWNh\n```"
+examples: |-
+  ### Inspect a node
+
+  ```bash
+  $ docker node inspect swarm-manager
+  ```
+
+  ```json
+  [
+    {
+      "ID": "e216jshn25ckzbvmwlnh5jr3g",
+      "Version": {
+        "Index": 10
+      },
+      "CreatedAt": "2017-05-16T22:52:44.9910662Z",
+      "UpdatedAt": "2017-05-16T22:52:45.230878043Z",
+      "Spec": {
+        "Role": "manager",
+        "Availability": "active"
+      },
+      "Description": {
+        "Hostname": "swarm-manager",
+        "Platform": {
+          "Architecture": "x86_64",
+          "OS": "linux"
+        },
+        "Resources": {
+          "NanoCPUs": 1000000000,
+          "MemoryBytes": 1039843328
+        },
+        "Engine": {
+          "EngineVersion": "17.06.0-ce",
+          "Plugins": [
+            {
+              "Type": "Volume",
+              "Name": "local"
+            },
+            {
+              "Type": "Network",
+              "Name": "overlay"
+            },
+            {
+              "Type": "Network",
+              "Name": "null"
+            },
+            {
+              "Type": "Network",
+              "Name": "host"
+            },
+            {
+              "Type": "Network",
+              "Name": "bridge"
+            },
+            {
+              "Type": "Network",
+              "Name": "overlay"
+            }
+          ]
+        },
+        "TLSInfo": {
+          "TrustRoot": "-----BEGIN CERTIFICATE-----\nMIIBazCCARCgAwIBAgIUOzgqU4tA2q5Yv1HnkzhSIwGyIBswCgYIKoZIzj0EAwIw\nEzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNTAyMDAyNDAwWhcNMzcwNDI3MDAy\nNDAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABMbiAmET+HZyve35ujrnL2kOLBEQhFDZ5MhxAuYs96n796sFlfxTxC1lM/2g\nAh8DI34pm3JmHgZxeBPKUURJHKWjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB\nAf8EBTADAQH/MB0GA1UdDgQWBBS3sjTJOcXdkls6WSY2rTx1KIJueTAKBggqhkjO\nPQQDAgNJADBGAiEAoeVWkaXgSUAucQmZ3Yhmx22N/cq1EPBgYHOBZmHt0NkCIQC3\nzONcJ/+WA21OXtb+vcijpUOXtNjyHfcox0N8wsLDqQ==\n-----END CERTIFICATE-----\n",
+          "CertIssuerSubject": "MBMxETAPBgNVBAMTCHN3YXJtLWNh",
+          "CertIssuerPublicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExuICYRP4dnK97fm6OucvaQ4sERCEUNnkyHEC5iz3qfv3qwWV/FPELWUz/aACHwMjfimbcmYeBnF4E8pRREkcpQ=="
+        }
+      },
+      "Status": {
+        "State": "ready",
+        "Addr": "168.0.32.137"
+      },
+      "ManagerStatus": {
+        "Leader": true,
+        "Reachability": "reachable",
+        "Addr": "168.0.32.137:2377"
+      }
+    }
+  ]
+  ```
+
+  ### Specify an output format
+
+  ```bash
+  $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self
+
+  false
+  ```
+
+  Use `--format=pretty` or the `--pretty` shorthand to pretty-print the output:
+
+  ```bash
+  $ docker node inspect --format=pretty self
+
+  ID:                     e216jshn25ckzbvmwlnh5jr3g
+  Hostname:               swarm-manager
+  Joined at:              2017-05-16 22:52:44.9910662 +0000 utc
+  Status:
+   State:                 Ready
+   Availability:          Active
+   Address:               172.17.0.2
+  Manager Status:
+   Address:               172.17.0.2:2377
+   Raft Status:           Reachable
+   Leader:                Yes
+  Platform:
+   Operating System:      linux
+   Architecture:          x86_64
+  Resources:
+   CPUs:                  4
+   Memory:                7.704 GiB
+  Plugins:
+    Network:              overlay, bridge, null, host, overlay
+    Volume:               local
+  Engine Version:         17.06.0-ce
+  TLS Info:
+   TrustRoot:
+  -----BEGIN CERTIFICATE-----
+  MIIBazCCARCgAwIBAgIUOzgqU4tA2q5Yv1HnkzhSIwGyIBswCgYIKoZIzj0EAwIw
+  EzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNTAyMDAyNDAwWhcNMzcwNDI3MDAy
+  NDAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+  A0IABMbiAmET+HZyve35ujrnL2kOLBEQhFDZ5MhxAuYs96n796sFlfxTxC1lM/2g
+  Ah8DI34pm3JmHgZxeBPKUURJHKWjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+  Af8EBTADAQH/MB0GA1UdDgQWBBS3sjTJOcXdkls6WSY2rTx1KIJueTAKBggqhkjO
+  PQQDAgNJADBGAiEAoeVWkaXgSUAucQmZ3Yhmx22N/cq1EPBgYHOBZmHt0NkCIQC3
+  zONcJ/+WA21OXtb+vcijpUOXtNjyHfcox0N8wsLDqQ==
+  -----END CERTIFICATE-----
+
+   Issuer Public Key: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExuICYRP4dnK97fm6OucvaQ4sERCEUNnkyHEC5iz3qfv3qwWV/FPELWUz/aACHwMjfimbcmYeBnF4E8pRREkcpQ==
+   Issuer Subject:    MBMxETAPBgNVBAMTCHN3YXJtLWNh
+  ```
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_node_ls.yaml
+++ b/_data/engine-cli/docker_node_ls.yaml
@@ -40,54 +40,129 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "```bash\n$ docker node ls\n\nID                           HOSTNAME        STATUS
-  \ AVAILABILITY  MANAGER STATUS\n1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready
-  \  Active\n38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active\ne216jshn25ckzbvmwlnh5jr3g
-  *  swarm-manager1  Ready   Active        Leader\n```\n> **Note**:\n> In the above
-  example output, there is a hidden column of `.Self` that indicates if the\n> node
-  is the same node as the current docker daemon. A `*` (e.g., `e216jshn25ckzbvmwlnh5jr3g
-  *`)\n> means this node is the current docker daemon.\n\n\n### Filtering\n\nThe filtering
-  flag (`-f` or `--filter`) format is of \"key=value\". If there is more\nthan one
-  filter, then pass multiple flags (e.g., `--filter \"foo=bar\" --filter \"bif=baz\"`)\n\nThe
-  currently supported filters are:\n\n* [id](node_ls.md#id)\n* [label](node_ls.md#label)\n*
-  [membership](node_ls.md#membership)\n* [name](node_ls.md#name)\n* [role](node_ls.md#role)\n\n####
-  id\n\nThe `id` filter matches all or part of a node's id.\n\n```bash\n$ docker node
-  ls -f id=1\n\nID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER
-  STATUS\n1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active\n```\n\n#### label\n\nThe
-  `label` filter matches nodes based on engine labels and on the presence of a `label`
-  alone or a `label` and a value. Node labels are currently not used for filtering.\n\nThe
-  following filter matches nodes with the `foo` label regardless of its value.\n\n```bash\n$
-  docker node ls -f \"label=foo\"\n\nID                         HOSTNAME       STATUS
-  \ AVAILABILITY  MANAGER STATUS\n1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready
-  \  Active\n```\n\n#### membership\n\nThe `membership` filter matches nodes based
-  on the presence of a `membership` and a value\n`accepted` or `pending`.\n\nThe following
-  filter matches nodes with the `membership` of `accepted`.\n\n```bash\n$ docker node
-  ls -f \"membership=accepted\"\n\nID                           HOSTNAME        STATUS
-  \ AVAILABILITY  MANAGER STATUS\n1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready
-  \  Active\n38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active\n```\n\n####
-  name\n\nThe `name` filter matches on all or part of a node hostname.\n\nThe following
-  filter matches the nodes with a name equal to `swarm-master` string.\n\n```bash\n$
-  docker node ls -f name=swarm-manager1\n\nID                           HOSTNAME        STATUS
-  \ AVAILABILITY  MANAGER STATUS\ne216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready
-  \  Active        Leader\n```\n\n#### role\n\nThe `role` filter matches nodes based
-  on the presence of a `role` and a value `worker` or `manager`.\n\nThe following
-  filter matches nodes with the `manager` role.\n\n```bash\n$ docker node ls -f \"role=manager\"\n\nID
-  \                          HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS\ne216jshn25ckzbvmwlnh5jr3g
-  *  swarm-manager1  Ready   Active        Leader\n```\n\n### Formatting\n\nThe formatting
-  options (`--format`) pretty-prints nodes output\nusing a Go template.\n\nValid placeholders
-  for the Go template are listed below:\n\nPlaceholder      | Description\n-----------------|------------------------------------------------------------------------------------------\n`.ID`
-  \           | Node ID\n`.Self`          | Node of the daemon (`true/false`, `true`indicates
-  that the node is the same as current docker daemon)\n`.Hostname`      | Node hostname\n`.Status`
-  \       | Node status\n`.Availability`  | Node availability (\"active\", \"pause\",
-  or \"drain\")\n`.ManagerStatus` | Manager status of the node\n`.TLSStatus`     |
-  TLS status of the node (\"Ready\", or \"Needs Rotation\" has TLS certificate signed
-  by an old CA)\n`.EngineVersion` | Engine version\n\nWhen using the `--format` option,
-  the `node ls` command will either\noutput the data exactly as the template declares
-  or, when using the\n`table` directive, includes column headers as well.\n\nThe following
-  example uses a template without headers and outputs the\n`ID`, `Hostname`, and `TLS
-  Status` entries separated by a colon for all nodes:\n\n```bash\n$ docker node ls
-  --format \"{{.ID}}: {{.Hostname}} {{.TLSStatus}}\"\ne216jshn25ckzbvmwlnh5jr3g: swarm-manager1
-  Ready\n35o6tiywb700jesrt3dmllaza: swarm-worker1 Needs Rotation  \n```"
+examples: |-
+  ```bash
+  $ docker node ls
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready   Active
+  38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active
+  e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+  ```
+  > **Note**:
+  > In the above example output, there is a hidden column of `.Self` that indicates if the
+  > node is the same node as the current docker daemon. A `*` (e.g., `e216jshn25ckzbvmwlnh5jr3g *`)
+  > means this node is the current docker daemon.
+
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * [id](node_ls.md#id)
+  * [label](node_ls.md#label)
+  * [membership](node_ls.md#membership)
+  * [name](node_ls.md#name)
+  * [role](node_ls.md#role)
+
+  #### id
+
+  The `id` filter matches all or part of a node's id.
+
+  ```bash
+  $ docker node ls -f id=1
+
+  ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active
+  ```
+
+  #### label
+
+  The `label` filter matches nodes based on engine labels and on the presence of a `label` alone or a `label` and a value. Node labels are currently not used for filtering.
+
+  The following filter matches nodes with the `foo` label regardless of its value.
+
+  ```bash
+  $ docker node ls -f "label=foo"
+
+  ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active
+  ```
+
+  #### membership
+
+  The `membership` filter matches nodes based on the presence of a `membership` and a value
+  `accepted` or `pending`.
+
+  The following filter matches nodes with the `membership` of `accepted`.
+
+  ```bash
+  $ docker node ls -f "membership=accepted"
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready   Active
+  38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active
+  ```
+
+  #### name
+
+  The `name` filter matches on all or part of a node hostname.
+
+  The following filter matches the nodes with a name equal to `swarm-master` string.
+
+  ```bash
+  $ docker node ls -f name=swarm-manager1
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+  ```
+
+  #### role
+
+  The `role` filter matches nodes based on the presence of a `role` and a value `worker` or `manager`.
+
+  The following filter matches nodes with the `manager` role.
+
+  ```bash
+  $ docker node ls -f "role=manager"
+
+  ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+  e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+  ```
+
+  ### Formatting
+
+  The formatting options (`--format`) pretty-prints nodes output
+  using a Go template.
+
+  Valid placeholders for the Go template are listed below:
+
+  Placeholder      | Description
+  -----------------|------------------------------------------------------------------------------------------
+  `.ID`            | Node ID
+  `.Self`          | Node of the daemon (`true/false`, `true`indicates that the node is the same as current docker daemon)
+  `.Hostname`      | Node hostname
+  `.Status`        | Node status
+  `.Availability`  | Node availability ("active", "pause", or "drain")
+  `.ManagerStatus` | Manager status of the node
+  `.TLSStatus`     | TLS status of the node ("Ready", or "Needs Rotation" has TLS certificate signed by an old CA)
+  `.EngineVersion` | Engine version
+
+  When using the `--format` option, the `node ls` command will either
+  output the data exactly as the template declares or, when using the
+  `table` directive, includes column headers as well.
+
+  The following example uses a template without headers and outputs the
+  `ID`, `Hostname`, and `TLS Status` entries separated by a colon for all nodes:
+
+  ```bash
+  $ docker node ls --format "{{.ID}}: {{.Hostname}} {{.TLSStatus}}"
+  e216jshn25ckzbvmwlnh5jr3g: swarm-manager1 Ready
+  35o6tiywb700jesrt3dmllaza: swarm-worker1 Needs Rotation
+  ```
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -81,222 +81,405 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Prevent truncating output\n\nRunning `docker ps --no-trunc` showing
-  2 linked containers.\n\n```bash\n$ docker ps\n\nCONTAINER ID        IMAGE                        COMMAND
-  \               CREATED              STATUS              PORTS               NAMES\n4c01db0b339c
-  \       ubuntu:12.04                 bash                   17 seconds ago       Up
-  16 seconds       3300-3310/tcp       webapp\nd7886598dbe2        crosbymichael/redis:latest
-  \  /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db\n```\n\n###
-  Show both running and stopped containers\n\nThe `docker ps` command only shows running
-  containers by default. To see all\ncontainers, use the `-a` (or `--all`) flag:\n\n```bash\n$
-  docker ps -a\n```\n\n`docker ps` groups exposed ports into a single range if possible.
-  E.g., a\ncontainer that exposes TCP ports `100, 101, 102` displays `100-102/tcp`
-  in\nthe `PORTS` column.\n\n### Show disk usage by container\n\nThe `docker ps -s`
-  command displays two different on-disk-sizes for each container:\n\n```bash\n$ docker
-  ps -s\nCONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS
-  \      PORTS   NAMES        SIZE                                                                                      SIZE\ne90b8831a4b8
-  \  nginx          \"/bin/bash -c 'mkdir \"   11 weeks ago   Up 4 hours           my_nginx
-  \    35.58 kB (virtual 109.2 MB)\n00c6131c5e30   telegraf:1.5   \"/entrypoint.sh\"
-  \        11 weeks ago   Up 11 weeks          my_telegraf  0 B (virtual 209.5 MB)\n```\n
-  \ * The \"size\" information shows the amount of data (on disk) that is used for
-  the _writable_ layer of each container\n  * The \"virtual size\" is the total amount
-  of disk-space used for the read-only _image_ data used by the container and the
-  writable layer.\n  \nFor more information, refer to the [container size on disk](https://docs.docker.com/storage/storagedriver/#container-size-on-disk)
-  section.\n\n\n### Filtering\n\nThe filtering flag (`-f` or `--filter`) format is
-  a `key=value` pair. If there is more\nthan one filter, then pass multiple flags
-  (e.g. `--filter \"foo=bar\" --filter \"bif=baz\"`)\n\nThe currently supported filters
-  are:\n\n| Filter                | Description                                                                                                                          |\n|:----------------------|:-------------------------------------------------------------------------------------------------------------------------------------|\n|
-  `id`                  | Container's ID                                                                                                                       |\n|
-  `name`                | Container's name                                                                                                                     |\n|
-  `label`               | An arbitrary string representing either a key or a key-value
-  pair. Expressed as `<key>` or `<key>=<value>`                           |\n| `exited`
-  \             | An integer representing the container's exit code. Only useful with
-  `--all`.                                                         |\n| `status`              |
-  One of `created`, `restarting`, `running`, `removing`, `paused`, `exited`, or `dead`
-  \                                                |\n| `ancestor`            | Filters
-  containers which share a given image as an ancestor. Expressed as `<image-name>[:<tag>]`,
-  \ `<image id>`, or `<image@digest>` |\n| `before` or `since`   | Filters containers
-  created before or after a given container ID or name                                                              |\n|
-  `volume`              | Filters running containers which have mounted a given volume
-  or bind mount.                                                          |\n| `network`
-  \            | Filters running containers connected to a given network.                                                                             |\n|
-  `publish` or `expose` | Filters containers which publish or expose a given port.
-  Expressed as `<port>[/<proto>]` or `<startport-endport>/[<proto>]`          |\n|
-  `health`              | Filters containers based on their healthcheck status. One
-  of `starting`, `healthy`, `unhealthy` or `none`.                           |\n|
-  `isolation`           | Windows daemon only. One of `default`, `process`, or `hyperv`.
-  \                                                                      |\n| `is-task`
-  \            | Filters containers that are a \"task\" for a service. Boolean option
-  (`true` or `false`)                                               |\n\n\n#### label\n\nThe
-  `label` filter matches containers based on the presence of a `label` alone or a
-  `label` and a\nvalue.\n\nThe following filter matches containers with the `color`
-  label regardless of its value.\n\n```bash\n$ docker ps --filter \"label=color\"\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED             STATUS              PORTS
-  \              NAMES\n673394ef1d4c        busybox             \"top\"               47
-  seconds ago      Up 45 seconds                           nostalgic_shockley\nd85756f57265
-  \       busybox             \"top\"               52 seconds ago      Up 51 seconds
-  \                          high_albattani\n```\n\nThe following filter matches containers
-  with the `color` label with the `blue` value.\n\n```bash\n$ docker ps --filter \"label=color=blue\"\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED              STATUS              PORTS
-  \              NAMES\nd85756f57265        busybox             \"top\"               About
-  a minute ago   Up About a minute                       high_albattani\n```\n\n####
-  name\n\nThe `name` filter matches on all or part of a container's name.\n\nThe following
-  filter matches all containers with a name containing the `nostalgic_stallman` string.\n\n```bash\n$
-  docker ps --filter \"name=nostalgic_stallman\"\n\nCONTAINER ID        IMAGE               COMMAND
-  \            CREATED             STATUS              PORTS               NAMES\n9b6247364a03
-  \       busybox             \"top\"               2 minutes ago       Up 2 minutes
-  \                           nostalgic_stallman\n```\n\nYou can also filter for a
-  substring in a name as this shows:\n\n```bash\n$ docker ps --filter \"name=nostalgic\"\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED             STATUS              PORTS
-  \              NAMES\n715ebfcee040        busybox             \"top\"               3
-  seconds ago       Up 1 second                             i_am_nostalgic\n9b6247364a03
-  \       busybox             \"top\"               7 minutes ago       Up 7 minutes
-  \                           nostalgic_stallman\n673394ef1d4c        busybox             \"top\"
-  \              38 minutes ago      Up 38 minutes                           nostalgic_shockley\n```\n\n####
-  exited\n\nThe `exited` filter matches containers by exist status code. For example,
-  to\nfilter for containers that have exited successfully:\n\n```bash\n$ docker ps
-  -a --filter 'exited=0'\n\nCONTAINER ID        IMAGE             COMMAND                CREATED
-  \            STATUS                   PORTS                      NAMES\nea09c3c82f6e
-  \       registry:latest   /srv/run.sh            2 weeks ago         Exited (0)
-  2 weeks ago   127.0.0.1:5000->5000/tcp   desperate_leakey\n106ea823fe4e        fedora:latest
-  \    /bin/sh -c 'bash -l'   2 weeks ago         Exited (0) 2 weeks ago                              determined_albattani\n48ee228c9464
-  \       fedora:20         bash                   2 weeks ago         Exited (0)
-  2 weeks ago                              tender_torvalds\n```\n\n#### Filter by
-  exit signal\n\nYou can use a filter to locate containers that exited with status
-  of `137`\nmeaning a `SIGKILL(9)` killed them.\n\n```none\n$ docker ps -a --filter
-  'exited=137'\n\nCONTAINER ID        IMAGE               COMMAND                CREATED
-  \            STATUS                       PORTS               NAMES\nb3e1c0ed5bfe
-  \       ubuntu:latest       \"sleep 1000\"           12 seconds ago      Exited
-  (137) 5 seconds ago                       grave_kowalevski\na2eb5558d669        redis:latest
-  \       \"/entrypoint.sh redi   2 hours ago         Exited (137) 2 hours ago                         sharp_lalande\n```\n\nAny
-  of these events result in a `137` status:\n\n* the `init` process of the container
-  is killed manually\n* `docker kill` kills the container\n* Docker daemon restarts
-  which kills all running containers\n\n#### status\n\nThe `status` filter matches
-  containers by status. You can filter using\n`created`, `restarting`, `running`,
-  `removing`, `paused`, `exited` and `dead`. For example,\nto filter for `running`
-  containers:\n\n```bash\n$ docker ps --filter status=running\n\nCONTAINER ID        IMAGE
-  \                 COMMAND             CREATED             STATUS              PORTS
-  \              NAMES\n715ebfcee040        busybox                \"top\"               16
-  minutes ago      Up 16 minutes                           i_am_nostalgic\nd5c976d3c462
-  \       busybox                \"top\"               23 minutes ago      Up 23 minutes
-  \                          top\n9b6247364a03        busybox                \"top\"
-  \              24 minutes ago      Up 24 minutes                           nostalgic_stallman\n```\n\nTo
-  filter for `paused` containers:\n\n```bash\n$ docker ps --filter status=paused\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED             STATUS                      PORTS
-  \              NAMES\n673394ef1d4c        busybox             \"top\"               About
-  an hour ago   Up About an hour (Paused)                       nostalgic_shockley\n```\n\n####
-  ancestor\n\nThe `ancestor` filter matches containers based on its image or a descendant
-  of\nit. The filter supports the following image representation:\n\n- `image`\n-
-  `image:tag`\n- `image:tag@digest`\n- `short-id`\n- `full-id`\n\nIf you don't specify
-  a `tag`, the `latest` tag is used. For example, to filter\nfor containers that use
-  the latest `ubuntu` image:\n\n```bash\n$ docker ps --filter ancestor=ubuntu\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED              STATUS              PORTS
-  \              NAMES\n919e1179bdb8        ubuntu-c1           \"top\"               About
-  a minute ago   Up About a minute                       admiring_lovelace\n5d1e4a540723
-  \       ubuntu-c2           \"top\"               About a minute ago   Up About
-  a minute                       admiring_sammet\n82a598284012        ubuntu              \"top\"
-  \              3 minutes ago        Up 3 minutes                            sleepy_bose\nbab2a34ba363
-  \       ubuntu              \"top\"               3 minutes ago        Up 3 minutes
-  \                           focused_yonath\n```\n\nMatch containers based on the
-  `ubuntu-c1` image which, in this case, is a child\nof `ubuntu`:\n\n```bash\n$ docker
-  ps --filter ancestor=ubuntu-c1\n\nCONTAINER ID        IMAGE               COMMAND
-  \            CREATED              STATUS              PORTS               NAMES\n919e1179bdb8
-  \       ubuntu-c1           \"top\"               About a minute ago   Up About
-  a minute                       admiring_lovelace\n```\n\nMatch containers based
-  on the `ubuntu` version `12.04.5` image:\n\n```bash\n$ docker ps --filter ancestor=ubuntu:12.04.5\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED              STATUS              PORTS
-  \              NAMES\n82a598284012        ubuntu:12.04.5      \"top\"               3
-  minutes ago        Up 3 minutes                            sleepy_bose\n```\n\nThe
-  following matches containers based on the layer `d0e008c6cf02` or an image\nthat
-  have this layer in its layer stack.\n\n```bash\n$ docker ps --filter ancestor=d0e008c6cf02\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED              STATUS              PORTS
-  \              NAMES\n82a598284012        ubuntu:12.04.5      \"top\"               3
-  minutes ago        Up 3 minutes                            sleepy_bose\n```\n\n####
-  Create time\n\n##### before\n\nThe `before` filter shows only containers created
-  before the container with\ngiven id or name. For example, having these containers
-  created:\n\n```bash\n$ docker ps\n\nCONTAINER ID        IMAGE       COMMAND       CREATED
-  \             STATUS              PORTS              NAMES\n9c3527ed70ce        busybox
-  \    \"top\"         14 seconds ago       Up 15 seconds                          desperate_dubinsky\n4aace5031105
-  \       busybox     \"top\"         48 seconds ago       Up 49 seconds                          focused_hamilton\n6e63f6ff38b0
-  \       busybox     \"top\"         About a minute ago   Up About a minute                      distracted_fermat\n```\n\nFiltering
-  with `before` would give:\n\n```bash\n$ docker ps -f before=9c3527ed70ce\n\nCONTAINER
-  ID        IMAGE       COMMAND       CREATED              STATUS              PORTS
-  \             NAMES\n4aace5031105        busybox     \"top\"         About a minute
-  ago   Up About a minute                      focused_hamilton\n6e63f6ff38b0        busybox
-  \    \"top\"         About a minute ago   Up About a minute                      distracted_fermat\n```\n\n#####
-  since\n\nThe `since` filter shows only containers created since the container with
-  given\nid or name. For example, with the same containers as in `before` filter:\n\n```bash\n$
-  docker ps -f since=6e63f6ff38b0\n\nCONTAINER ID        IMAGE       COMMAND       CREATED
-  \            STATUS              PORTS               NAMES\n9c3527ed70ce        busybox
-  \    \"top\"         10 minutes ago      Up 10 minutes                           desperate_dubinsky\n4aace5031105
-  \       busybox     \"top\"         10 minutes ago      Up 10 minutes                           focused_hamilton\n```\n\n####
-  volume\n\nThe `volume` filter shows only containers that mount a specific volume
-  or have\na volume mounted in a specific path:\n\n```bash\n$ docker ps --filter volume=remote-volume
-  --format \"table {{.ID}}\\t{{.Mounts}}\"\nCONTAINER ID        MOUNTS\n9c3527ed70ce
-  \       remote-volume\n\n$ docker ps --filter volume=/data --format \"table {{.ID}}\\t{{.Mounts}}\"\nCONTAINER
-  ID        MOUNTS\n9c3527ed70ce        remote-volume\n```\n\n#### network\n\nThe
-  `network` filter shows only containers that are connected to a network with\na given
-  name or id.\n\nThe following filter matches all containers that are connected to
-  a network\nwith a name containing `net1`.\n\n```bash\n$ docker run -d --net=net1
-  --name=test1 ubuntu top\n$ docker run -d --net=net2 --name=test2 ubuntu top\n\n$
-  docker ps --filter network=net1\n\nCONTAINER ID        IMAGE       COMMAND       CREATED
-  \            STATUS              PORTS               NAMES\n9d4893ed80fe        ubuntu
-  \     \"top\"         10 minutes ago      Up 10 minutes                           test1\n```\n\nThe
-  network filter matches on both the network's name and id. The following\nexample
-  shows all containers that are attached to the `net1` network, using\nthe network
-  id as a filter;\n\n```bash\n$ docker network inspect --format \"{{.ID}}\" net1\n\n8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5\n\n$
-  docker ps --filter network=8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5\n\nCONTAINER
-  ID        IMAGE       COMMAND       CREATED             STATUS              PORTS
-  \              NAMES\n9d4893ed80fe        ubuntu      \"top\"         10 minutes
-  ago      Up 10 minutes                           test1\n```\n\n#### publish and
-  expose\n\nThe `publish` and `expose` filters show only containers that have published
-  or exposed port with a given port\nnumber, port range, and/or protocol. The default
-  protocol is `tcp` when not specified.\n\nThe following filter matches all containers
-  that have published port of 80:\n\n```bash\n$ docker run -d --publish=80 busybox
-  top\n$ docker run -d --expose=8080 busybox top\n\n$ docker ps -a\n\nCONTAINER ID
-  \       IMAGE               COMMAND             CREATED             STATUS              PORTS
-  \                  NAMES\n9833437217a5        busybox             \"top\"               5
-  seconds ago       Up 4 seconds        8080/tcp                dreamy_mccarthy\nfc7e477723b7
-  \       busybox             \"top\"               50 seconds ago      Up 50 seconds
-  \      0.0.0.0:32768->80/tcp   admiring_roentgen\n\n$ docker ps --filter publish=80\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED              STATUS              PORTS
-  \                  NAMES\nfc7e477723b7        busybox             \"top\"               About
-  a minute ago   Up About a minute   0.0.0.0:32768->80/tcp   admiring_roentgen\n```\n\nThe
-  following filter matches all containers that have exposed TCP port in the range
-  of `8000-8080`:\n```bash\n$ docker ps --filter expose=8000-8080/tcp\n\nCONTAINER
-  ID        IMAGE               COMMAND             CREATED             STATUS              PORTS
-  \              NAMES\n9833437217a5        busybox             \"top\"               21
-  seconds ago      Up 19 seconds       8080/tcp            dreamy_mccarthy\n```\n\nThe
-  following filter matches all containers that have exposed UDP port `80`:\n```bash\n$
-  docker ps --filter publish=80/udp\n\nCONTAINER ID        IMAGE               COMMAND
-  \            CREATED             STATUS              PORTS               NAMES\n```\n\n###
-  Formatting\n\nThe formatting option (`--format`) pretty-prints container output
-  using a Go\ntemplate.\n\nValid placeholders for the Go template are listed below:\n\n|
-  Placeholder   | Description                                                                                     |\n|:--------------|:------------------------------------------------------------------------------------------------|\n|
-  `.ID`         | Container ID                                                                                    |\n|
-  `.Image`      | Image ID                                                                                        |\n|
-  `.Command`    | Quoted command                                                                                  |\n|
-  `.CreatedAt`  | Time when the container was created.                                                            |\n|
-  `.RunningFor` | Elapsed time since the container was started.                                                   |\n|
-  `.Ports`      | Exposed ports.                                                                                  |\n|
-  `.Status`     | Container status.                                                                               |\n|
-  `.Size`       | Container disk size.                                                                            |\n|
-  `.Names`      | Container names.                                                                                |\n|
-  `.Labels`     | All labels assigned to the container.                                                           |\n|
-  `.Label`      | Value of a specific label for this container. For example `'{{.Label
-  \"com.docker.swarm.cpu\"}}'` |\n| `.Mounts`     | Names of the volumes mounted in
-  this container.                                                 |\n| `.Networks`
-  \  | Names of the networks attached to this container.                                               |\n\nWhen
-  using the `--format` option, the `ps` command will either output the data\nexactly
-  as the template declares or, when using the `table` directive, includes\ncolumn
-  headers as well.\n\nThe following example uses a template without headers and outputs
-  the `ID` and\n`Command` entries separated by a colon for all running containers:\n\n```bash\n$
-  docker ps --format \"{{.ID}}: {{.Command}}\"\n\na87ecb4f327c: /bin/sh -c #(nop)
-  MA\n01946d9d34d8: /bin/sh -c #(nop) MA\nc1d3b0166030: /bin/sh -c yum -y up\n41d50ecd2f57:
-  /bin/sh -c #(nop) MA\n```\n\nTo list all running containers with their labels in
-  a table format you can use:\n\n```bash\n$ docker ps --format \"table {{.ID}}\\t{{.Labels}}\"\n\nCONTAINER
-  ID        LABELS\na87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd\n01946d9d34d8\nc1d3b0166030
-  \       com.docker.swarm.node=debian,com.docker.swarm.cpu=6\n41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd\n```"
+examples: |-
+  ### Prevent truncating output
+
+  Running `docker ps --no-trunc` showing 2 linked containers.
+
+  ```bash
+  $ docker ps
+
+  CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
+  4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
+  d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
+  ```
+
+  ### Show both running and stopped containers
+
+  The `docker ps` command only shows running containers by default. To see all
+  containers, use the `-a` (or `--all`) flag:
+
+  ```bash
+  $ docker ps -a
+  ```
+
+  `docker ps` groups exposed ports into a single range if possible. E.g., a
+  container that exposes TCP ports `100, 101, 102` displays `100-102/tcp` in
+  the `PORTS` column.
+
+  ### Show disk usage by container
+
+  The `docker ps -s` command displays two different on-disk-sizes for each container:
+
+  ```bash
+  $ docker ps -s
+  CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
+  e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours           my_nginx     35.58 kB (virtual 109.2 MB)
+  00c6131c5e30   telegraf:1.5   "/entrypoint.sh"         11 weeks ago   Up 11 weeks          my_telegraf  0 B (virtual 209.5 MB)
+  ```
+    * The "size" information shows the amount of data (on disk) that is used for the _writable_ layer of each container
+    * The "virtual size" is the total amount of disk-space used for the read-only _image_ data used by the container and the writable layer.
+
+  For more information, refer to the [container size on disk](https://docs.docker.com/storage/storagedriver/#container-size-on-disk) section.
+
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
+  than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  | Filter                | Description                                                                                                                          |
+  |:----------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+  | `id`                  | Container's ID                                                                                                                       |
+  | `name`                | Container's name                                                                                                                     |
+  | `label`               | An arbitrary string representing either a key or a key-value pair. Expressed as `<key>` or `<key>=<value>`                           |
+  | `exited`              | An integer representing the container's exit code. Only useful with `--all`.                                                         |
+  | `status`              | One of `created`, `restarting`, `running`, `removing`, `paused`, `exited`, or `dead`                                                 |
+  | `ancestor`            | Filters containers which share a given image as an ancestor. Expressed as `<image-name>[:<tag>]`,  `<image id>`, or `<image@digest>` |
+  | `before` or `since`   | Filters containers created before or after a given container ID or name                                                              |
+  | `volume`              | Filters running containers which have mounted a given volume or bind mount.                                                          |
+  | `network`             | Filters running containers connected to a given network.                                                                             |
+  | `publish` or `expose` | Filters containers which publish or expose a given port. Expressed as `<port>[/<proto>]` or `<startport-endport>/[<proto>]`          |
+  | `health`              | Filters containers based on their healthcheck status. One of `starting`, `healthy`, `unhealthy` or `none`.                           |
+  | `isolation`           | Windows daemon only. One of `default`, `process`, or `hyperv`.                                                                       |
+  | `is-task`             | Filters containers that are a "task" for a service. Boolean option (`true` or `false`)                                               |
+
+
+  #### label
+
+  The `label` filter matches containers based on the presence of a `label` alone or a `label` and a
+  value.
+
+  The following filter matches containers with the `color` label regardless of its value.
+
+  ```bash
+  $ docker ps --filter "label=color"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  673394ef1d4c        busybox             "top"               47 seconds ago      Up 45 seconds                           nostalgic_shockley
+  d85756f57265        busybox             "top"               52 seconds ago      Up 51 seconds                           high_albattani
+  ```
+
+  The following filter matches containers with the `color` label with the `blue` value.
+
+  ```bash
+  $ docker ps --filter "label=color=blue"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  d85756f57265        busybox             "top"               About a minute ago   Up About a minute                       high_albattani
+  ```
+
+  #### name
+
+  The `name` filter matches on all or part of a container's name.
+
+  The following filter matches all containers with a name containing the `nostalgic_stallman` string.
+
+  ```bash
+  $ docker ps --filter "name=nostalgic_stallman"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  9b6247364a03        busybox             "top"               2 minutes ago       Up 2 minutes                            nostalgic_stallman
+  ```
+
+  You can also filter for a substring in a name as this shows:
+
+  ```bash
+  $ docker ps --filter "name=nostalgic"
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  715ebfcee040        busybox             "top"               3 seconds ago       Up 1 second                             i_am_nostalgic
+  9b6247364a03        busybox             "top"               7 minutes ago       Up 7 minutes                            nostalgic_stallman
+  673394ef1d4c        busybox             "top"               38 minutes ago      Up 38 minutes                           nostalgic_shockley
+  ```
+
+  #### exited
+
+  The `exited` filter matches containers by exist status code. For example, to
+  filter for containers that have exited successfully:
+
+  ```bash
+  $ docker ps -a --filter 'exited=0'
+
+  CONTAINER ID        IMAGE             COMMAND                CREATED             STATUS                   PORTS                      NAMES
+  ea09c3c82f6e        registry:latest   /srv/run.sh            2 weeks ago         Exited (0) 2 weeks ago   127.0.0.1:5000->5000/tcp   desperate_leakey
+  106ea823fe4e        fedora:latest     /bin/sh -c 'bash -l'   2 weeks ago         Exited (0) 2 weeks ago                              determined_albattani
+  48ee228c9464        fedora:20         bash                   2 weeks ago         Exited (0) 2 weeks ago                              tender_torvalds
+  ```
+
+  #### Filter by exit signal
+
+  You can use a filter to locate containers that exited with status of `137`
+  meaning a `SIGKILL(9)` killed them.
+
+  ```none
+  $ docker ps -a --filter 'exited=137'
+
+  CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                       PORTS               NAMES
+  b3e1c0ed5bfe        ubuntu:latest       "sleep 1000"           12 seconds ago      Exited (137) 5 seconds ago                       grave_kowalevski
+  a2eb5558d669        redis:latest        "/entrypoint.sh redi   2 hours ago         Exited (137) 2 hours ago                         sharp_lalande
+  ```
+
+  Any of these events result in a `137` status:
+
+  * the `init` process of the container is killed manually
+  * `docker kill` kills the container
+  * Docker daemon restarts which kills all running containers
+
+  #### status
+
+  The `status` filter matches containers by status. You can filter using
+  `created`, `restarting`, `running`, `removing`, `paused`, `exited` and `dead`. For example,
+  to filter for `running` containers:
+
+  ```bash
+  $ docker ps --filter status=running
+
+  CONTAINER ID        IMAGE                  COMMAND             CREATED             STATUS              PORTS               NAMES
+  715ebfcee040        busybox                "top"               16 minutes ago      Up 16 minutes                           i_am_nostalgic
+  d5c976d3c462        busybox                "top"               23 minutes ago      Up 23 minutes                           top
+  9b6247364a03        busybox                "top"               24 minutes ago      Up 24 minutes                           nostalgic_stallman
+  ```
+
+  To filter for `paused` containers:
+
+  ```bash
+  $ docker ps --filter status=paused
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                      PORTS               NAMES
+  673394ef1d4c        busybox             "top"               About an hour ago   Up About an hour (Paused)                       nostalgic_shockley
+  ```
+
+  #### ancestor
+
+  The `ancestor` filter matches containers based on its image or a descendant of
+  it. The filter supports the following image representation:
+
+  - `image`
+  - `image:tag`
+  - `image:tag@digest`
+  - `short-id`
+  - `full-id`
+
+  If you don't specify a `tag`, the `latest` tag is used. For example, to filter
+  for containers that use the latest `ubuntu` image:
+
+  ```bash
+  $ docker ps --filter ancestor=ubuntu
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  919e1179bdb8        ubuntu-c1           "top"               About a minute ago   Up About a minute                       admiring_lovelace
+  5d1e4a540723        ubuntu-c2           "top"               About a minute ago   Up About a minute                       admiring_sammet
+  82a598284012        ubuntu              "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  bab2a34ba363        ubuntu              "top"               3 minutes ago        Up 3 minutes                            focused_yonath
+  ```
+
+  Match containers based on the `ubuntu-c1` image which, in this case, is a child
+  of `ubuntu`:
+
+  ```bash
+  $ docker ps --filter ancestor=ubuntu-c1
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  919e1179bdb8        ubuntu-c1           "top"               About a minute ago   Up About a minute                       admiring_lovelace
+  ```
+
+  Match containers based on the `ubuntu` version `12.04.5` image:
+
+  ```bash
+  $ docker ps --filter ancestor=ubuntu:12.04.5
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  ```
+
+  The following matches containers based on the layer `d0e008c6cf02` or an image
+  that have this layer in its layer stack.
+
+  ```bash
+  $ docker ps --filter ancestor=d0e008c6cf02
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
+  82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  ```
+
+  #### Create time
+
+  ##### before
+
+  The `before` filter shows only containers created before the container with
+  given id or name. For example, having these containers created:
+
+  ```bash
+  $ docker ps
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS              PORTS              NAMES
+  9c3527ed70ce        busybox     "top"         14 seconds ago       Up 15 seconds                          desperate_dubinsky
+  4aace5031105        busybox     "top"         48 seconds ago       Up 49 seconds                          focused_hamilton
+  6e63f6ff38b0        busybox     "top"         About a minute ago   Up About a minute                      distracted_fermat
+  ```
+
+  Filtering with `before` would give:
+
+  ```bash
+  $ docker ps -f before=9c3527ed70ce
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS              PORTS              NAMES
+  4aace5031105        busybox     "top"         About a minute ago   Up About a minute                      focused_hamilton
+  6e63f6ff38b0        busybox     "top"         About a minute ago   Up About a minute                      distracted_fermat
+  ```
+
+  ##### since
+
+  The `since` filter shows only containers created since the container with given
+  id or name. For example, with the same containers as in `before` filter:
+
+  ```bash
+  $ docker ps -f since=6e63f6ff38b0
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+  9c3527ed70ce        busybox     "top"         10 minutes ago      Up 10 minutes                           desperate_dubinsky
+  4aace5031105        busybox     "top"         10 minutes ago      Up 10 minutes                           focused_hamilton
+  ```
+
+  #### volume
+
+  The `volume` filter shows only containers that mount a specific volume or have
+  a volume mounted in a specific path:
+
+  ```bash
+  $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
+  CONTAINER ID        MOUNTS
+  9c3527ed70ce        remote-volume
+
+  $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
+  CONTAINER ID        MOUNTS
+  9c3527ed70ce        remote-volume
+  ```
+
+  #### network
+
+  The `network` filter shows only containers that are connected to a network with
+  a given name or id.
+
+  The following filter matches all containers that are connected to a network
+  with a name containing `net1`.
+
+  ```bash
+  $ docker run -d --net=net1 --name=test1 ubuntu top
+  $ docker run -d --net=net2 --name=test2 ubuntu top
+
+  $ docker ps --filter network=net1
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+  9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+  ```
+
+  The network filter matches on both the network's name and id. The following
+  example shows all containers that are attached to the `net1` network, using
+  the network id as a filter;
+
+  ```bash
+  $ docker network inspect --format "{{.ID}}" net1
+
+  8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
+
+  $ docker ps --filter network=8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
+
+  CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+  9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+  ```
+
+  #### publish and expose
+
+  The `publish` and `expose` filters show only containers that have published or exposed port with a given port
+  number, port range, and/or protocol. The default protocol is `tcp` when not specified.
+
+  The following filter matches all containers that have published port of 80:
+
+  ```bash
+  $ docker run -d --publish=80 busybox top
+  $ docker run -d --expose=8080 busybox top
+
+  $ docker ps -a
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                   NAMES
+  9833437217a5        busybox             "top"               5 seconds ago       Up 4 seconds        8080/tcp                dreamy_mccarthy
+  fc7e477723b7        busybox             "top"               50 seconds ago      Up 50 seconds       0.0.0.0:32768->80/tcp   admiring_roentgen
+
+  $ docker ps --filter publish=80
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS                   NAMES
+  fc7e477723b7        busybox             "top"               About a minute ago   Up About a minute   0.0.0.0:32768->80/tcp   admiring_roentgen
+  ```
+
+  The following filter matches all containers that have exposed TCP port in the range of `8000-8080`:
+  ```bash
+  $ docker ps --filter expose=8000-8080/tcp
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  9833437217a5        busybox             "top"               21 seconds ago      Up 19 seconds       8080/tcp            dreamy_mccarthy
+  ```
+
+  The following filter matches all containers that have exposed UDP port `80`:
+  ```bash
+  $ docker ps --filter publish=80/udp
+
+  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+  ```
+
+  ### Formatting
+
+  The formatting option (`--format`) pretty-prints container output using a Go
+  template.
+
+  Valid placeholders for the Go template are listed below:
+
+  | Placeholder   | Description                                                                                     |
+  |:--------------|:------------------------------------------------------------------------------------------------|
+  | `.ID`         | Container ID                                                                                    |
+  | `.Image`      | Image ID                                                                                        |
+  | `.Command`    | Quoted command                                                                                  |
+  | `.CreatedAt`  | Time when the container was created.                                                            |
+  | `.RunningFor` | Elapsed time since the container was started.                                                   |
+  | `.Ports`      | Exposed ports.                                                                                  |
+  | `.Status`     | Container status.                                                                               |
+  | `.Size`       | Container disk size.                                                                            |
+  | `.Names`      | Container names.                                                                                |
+  | `.Labels`     | All labels assigned to the container.                                                           |
+  | `.Label`      | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'` |
+  | `.Mounts`     | Names of the volumes mounted in this container.                                                 |
+  | `.Networks`   | Names of the networks attached to this container.                                               |
+
+  When using the `--format` option, the `ps` command will either output the data
+  exactly as the template declares or, when using the `table` directive, includes
+  column headers as well.
+
+  The following example uses a template without headers and outputs the `ID` and
+  `Command` entries separated by a colon for all running containers:
+
+  ```bash
+  $ docker ps --format "{{.ID}}: {{.Command}}"
+
+  a87ecb4f327c: /bin/sh -c #(nop) MA
+  01946d9d34d8: /bin/sh -c #(nop) MA
+  c1d3b0166030: /bin/sh -c yum -y up
+  41d50ecd2f57: /bin/sh -c #(nop) MA
+  ```
+
+  To list all running containers with their labels in a table format you can use:
+
+  ```bash
+  $ docker ps --format "table {{.ID}}\t{{.Labels}}"
+
+  CONTAINER ID        LABELS
+  a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd
+  01946d9d34d8
+  c1d3b0166030        com.docker.swarm.node=debian,com.docker.swarm.cpu=6
+  41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_push.yaml
+++ b/_data/engine-cli/docker_push.yaml
@@ -1,17 +1,27 @@
 command: docker push
 short: Push an image or a repository to a registry
-long: "Use `docker push` to share your images to the [Docker Hub](https://hub.docker.com)\nregistry
-  or to a self-hosted one.\n\nRefer to the [`docker tag`](tag.md) reference for more
-  information about valid\nimage and tag names.\n\nKilling the `docker push` process,
-  for example by pressing `CTRL-c` while it is\nrunning in a terminal, terminates
-  the push operation.\n\nProgress bars are shown during docker push, which show the
-  uncompressed size. The \nactual amount of data that's pushed will be compressed
-  before sending, so the uploaded\n size will not be reflected by the progress bar.
-  \n\nRegistry credentials are managed by [docker login](login.md).\n\n### Concurrent
-  uploads\n\nBy default the Docker daemon will push five layers of an image at a time.\nIf
-  you are on a low bandwidth connection this may cause timeout issues and you may
-  want to lower\nthis via the `--max-concurrent-uploads` daemon option. See the\n[daemon
-  documentation](dockerd.md) for more details."
+long: |-
+  Use `docker push` to share your images to the [Docker Hub](https://hub.docker.com)
+  registry or to a self-hosted one.
+
+  Refer to the [`docker tag`](tag.md) reference for more information about valid
+  image and tag names.
+
+  Killing the `docker push` process, for example by pressing `CTRL-c` while it is
+  running in a terminal, terminates the push operation.
+
+  Progress bars are shown during docker push, which show the uncompressed size.
+  The actual amount of data that's pushed will be compressed before sending, so
+  the uploaded size will not be reflected by the progress bar.
+
+  Registry credentials are managed by [docker login](login.md).
+
+  ### Concurrent uploads
+
+  By default the Docker daemon will push five layers of an image at a time.
+  If you are on a low bandwidth connection this may cause timeout issues and you may want to lower
+  this via the `--max-concurrent-uploads` daemon option. See the
+  [daemon documentation](dockerd.md) for more details.
 usage: docker push [OPTIONS] NAME[:TAG]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_search.yaml
+++ b/_data/engine-cli/docker_search.yaml
@@ -65,87 +65,165 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Search images by name\n\nThis example displays images with a name containing
-  'busybox':\n\n```none\n$ docker search busybox\n\nNAME                             DESCRIPTION
-  \                                    STARS     OFFICIAL   AUTOMATED\nbusybox                          Busybox
-  base image.                             316       [OK]       \nprogrium/busybox
-  \                                                                50                   [OK]\nradial/busyboxplus
-  \              Full-chain, Internet enabled, busybox made...   8                    [OK]\nodise/busybox-python
-  \                                                            2                    [OK]\nazukiapp/busybox
-  \                This image is meant to be used as the base...   2                    [OK]\nofayau/busybox-jvm
-  \              Prepare busybox to install a 32 bits JVM.       1                    [OK]\nshingonoide/archlinux-busybox
-  \   Arch Linux, a lightweight and flexible Lin...   1                    [OK]\nodise/busybox-curl
-  \                                                              1                    [OK]\nofayau/busybox-libc32
-  \           Busybox with 32 bits (and 64 bits) libs         1                    [OK]\npeelsky/zulu-openjdk-busybox
-  \                                                    1                    [OK]\nskomma/busybox-data
-  \             Docker image suitable for data volume cont...   1                    [OK]\nelektritter/busybox-teamspeak
-  \   Lightweight teamspeak3 container based on...    1                    [OK]\nsocketplane/busybox
-  \                                                             1                    [OK]\noveits/docker-nginx-busybox
-  \     This is a tiny NginX docker image based on...   0                    [OK]\nggtools/busybox-ubuntu
-  \          Busybox ubuntu version with extra goodies       0                    [OK]\nnikfoundas/busybox-confd
-  \        Minimal busybox based distribution of confd     0                    [OK]\nopenshift/busybox-http-app
-  \                                                      0                    [OK]\njllopis/busybox
-  \                                                                 0                    [OK]\nswyckoff/busybox
-  \                                                                0                    [OK]\npowellquiring/busybox
-  \                                                           0                    [OK]\nwilliamyeh/busybox-sh
-  \           Docker image for BusyBox's sh                   0                    [OK]\nsimplexsys/busybox-cli-powered
-  \  Docker busybox images, with a few often us...   0                    [OK]\nfhisamoto/busybox-java
-  \          Busybox java                                    0                    [OK]\nscottabernethy/busybox
-  \                                                          0                    [OK]\nmarclop/busybox-solr\n```\n\n###
-  Display non-truncated description (--no-trunc)\n\nThis example displays images with
-  a name containing 'busybox',\nat least 3 stars and the description isn't truncated
-  in the output:\n\n```bash\n$ docker search --filter=stars=3 --no-trunc busybox\nNAME
-  \                DESCRIPTION                                                                               STARS
-  \    OFFICIAL   AUTOMATED\nbusybox              Busybox base image.                                                                       325
-  \      [OK]       \nprogrium/busybox                                                                                               50
-  \                  [OK]\nradial/busyboxplus   Full-chain, Internet enabled, busybox
-  made from scratch. Comes in git and cURL flavors.   8                    [OK]\n```\n\n###
-  Limit search results (--limit)\n\nThe flag `--limit` is the maximum number of results
-  returned by a search. This value could\nbe in the range between 1 and 100. The default
-  value of `--limit` is 25.\n\n### Filtering\n\nThe filtering flag (`-f` or `--filter`)
-  format is a `key=value` pair. If there is more\nthan one filter, then pass multiple
-  flags (e.g. `--filter is-automated=true --filter stars=3`)\n\nThe currently supported
-  filters are:\n\n* stars (int - number of stars the image has)\n* is-automated (boolean
-  - true or false) - is the image automated or not\n* is-official (boolean - true
-  or false) - is the image official or not\n\n#### stars\n\nThis example displays
-  images with a name containing 'busybox' and at\nleast 3 stars:\n\n```bash\n$ docker
-  search --filter stars=3 busybox\n\nNAME                 DESCRIPTION                                     STARS
-  \    OFFICIAL   AUTOMATED\nbusybox              Busybox base image.                             325
-  \      [OK]       \nprogrium/busybox                                                     50
-  \                  [OK]\nradial/busyboxplus   Full-chain, Internet enabled, busybox
-  made...   8                    [OK]\n```\n\n#### is-automated\n\nThis example displays
-  images with a name containing 'busybox'\nand are automated builds:\n\n```bash\n$
-  docker search --filter is-automated=true busybox\n\nNAME                 DESCRIPTION
-  \                                    STARS     OFFICIAL   AUTOMATED\nprogrium/busybox
-  \                                                    50                   [OK]\nradial/busyboxplus
-  \  Full-chain, Internet enabled, busybox made...   8                    [OK]\n```\n\n####
-  is-official\n\nThis example displays images with a name containing 'busybox', at
-  least\n3 stars and are official builds:\n\n```bash\n$ docker search --filter is-official=true
-  --filter stars=3 busybox\n\nNAME                 DESCRIPTION                                     STARS
-  \    OFFICIAL   AUTOMATED\nprogrium/busybox                                                     50
-  \                  [OK]\nradial/busyboxplus   Full-chain, Internet enabled, busybox
-  made...   8                    [OK]\n```\n\n### Format the output\n\nThe formatting
-  option (`--format`) pretty-prints search output\nusing a Go template.\n\nValid placeholders
-  for the Go template are:\n\n| Placeholder    | Description                       |\n|
-  -------------- | --------------------------------- |\n| `.Name`        | Image Name
-  \                       |\n| `.Description` | Image description                 |\n|
-  `.StarCount`   | Number of stars for the image     |\n| `.IsOfficial`  | \"OK\"
-  if image is official         |\n| `.IsAutomated` | \"OK\" if image build was automated
-  |\n\nWhen you use the `--format` option, the `search` command will\noutput the data
-  exactly as the template declares. If you use the\n`table` directive, column headers
-  are included as well.\n\nThe following example uses a template without headers and
-  outputs the\n`Name` and `StarCount` entries separated by a colon for all images:\n\n```bash\n{%
-  raw %}\n$ docker search --format \"{{.Name}}: {{.StarCount}}\" nginx\n\nnginx: 5441\njwilder/nginx-proxy:
-  953\nricharvey/nginx-php-fpm: 353\nmillion12/nginx-php: 75\nwebdevops/php-nginx:
-  70\nh3nrik/nginx-ldap: 35\nbitnami/nginx: 23\nevild/alpine-nginx: 14\nmillion12/nginx:
-  9\nmaxexcloo/nginx: 7\n{% endraw %}\n```\n\nThis example outputs a table format:\n\n```bash\n{%
-  raw %}\n$ docker search --format \"table {{.Name}}\\t{{.IsAutomated}}\\t{{.IsOfficial}}\"
-  nginx\n\nNAME                                     AUTOMATED           OFFICIAL\nnginx
-  \                                                       [OK]\njwilder/nginx-proxy
-  \                     [OK]                \nricharvey/nginx-php-fpm                  [OK]
-  \               \njrcs/letsencrypt-nginx-proxy-companion   [OK]                \nmillion12/nginx-php
-  \                     [OK]                \nwebdevops/php-nginx                      [OK]
-  \               \n{% endraw %}\n```"
+examples: |-
+  ### Search images by name
+
+  This example displays images with a name containing 'busybox':
+
+  ```none
+  $ docker search busybox
+
+  NAME                             DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+  busybox                          Busybox base image.                             316       [OK]
+  progrium/busybox                                                                 50                   [OK]
+  radial/busyboxplus               Full-chain, Internet enabled, busybox made...   8                    [OK]
+  odise/busybox-python                                                             2                    [OK]
+  azukiapp/busybox                 This image is meant to be used as the base...   2                    [OK]
+  ofayau/busybox-jvm               Prepare busybox to install a 32 bits JVM.       1                    [OK]
+  shingonoide/archlinux-busybox    Arch Linux, a lightweight and flexible Lin...   1                    [OK]
+  odise/busybox-curl                                                               1                    [OK]
+  ofayau/busybox-libc32            Busybox with 32 bits (and 64 bits) libs         1                    [OK]
+  peelsky/zulu-openjdk-busybox                                                     1                    [OK]
+  skomma/busybox-data              Docker image suitable for data volume cont...   1                    [OK]
+  elektritter/busybox-teamspeak    Lightweight teamspeak3 container based on...    1                    [OK]
+  socketplane/busybox                                                              1                    [OK]
+  oveits/docker-nginx-busybox      This is a tiny NginX docker image based on...   0                    [OK]
+  ggtools/busybox-ubuntu           Busybox ubuntu version with extra goodies       0                    [OK]
+  nikfoundas/busybox-confd         Minimal busybox based distribution of confd     0                    [OK]
+  openshift/busybox-http-app                                                       0                    [OK]
+  jllopis/busybox                                                                  0                    [OK]
+  swyckoff/busybox                                                                 0                    [OK]
+  powellquiring/busybox                                                            0                    [OK]
+  williamyeh/busybox-sh            Docker image for BusyBox's sh                   0                    [OK]
+  simplexsys/busybox-cli-powered   Docker busybox images, with a few often us...   0                    [OK]
+  fhisamoto/busybox-java           Busybox java                                    0                    [OK]
+  scottabernethy/busybox                                                           0                    [OK]
+  marclop/busybox-solr
+  ```
+
+  ### Display non-truncated description (--no-trunc)
+
+  This example displays images with a name containing 'busybox',
+  at least 3 stars and the description isn't truncated in the output:
+
+  ```bash
+  $ docker search --filter=stars=3 --no-trunc busybox
+  NAME                 DESCRIPTION                                                                               STARS     OFFICIAL   AUTOMATED
+  busybox              Busybox base image.                                                                       325       [OK]
+  progrium/busybox                                                                                               50                   [OK]
+  radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
+  ```
+
+  ### Limit search results (--limit)
+
+  The flag `--limit` is the maximum number of results returned by a search. This value could
+  be in the range between 1 and 100. The default value of `--limit` is 25.
+
+  ### Filtering
+
+  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
+  than one filter, then pass multiple flags (e.g. `--filter is-automated=true --filter stars=3`)
+
+  The currently supported filters are:
+
+  * stars (int - number of stars the image has)
+  * is-automated (boolean - true or false) - is the image automated or not
+  * is-official (boolean - true or false) - is the image official or not
+
+  #### stars
+
+  This example displays images with a name containing 'busybox' and at
+  least 3 stars:
+
+  ```bash
+  $ docker search --filter stars=3 busybox
+
+  NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+  busybox              Busybox base image.                             325       [OK]
+  progrium/busybox                                                     50                   [OK]
+  radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+  ```
+
+  #### is-automated
+
+  This example displays images with a name containing 'busybox'
+  and are automated builds:
+
+  ```bash
+  $ docker search --filter is-automated=true busybox
+
+  NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+  progrium/busybox                                                     50                   [OK]
+  radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+  ```
+
+  #### is-official
+
+  This example displays images with a name containing 'busybox', at least
+  3 stars and are official builds:
+
+  ```bash
+  $ docker search --filter is-official=true --filter stars=3 busybox
+
+  NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+  progrium/busybox                                                     50                   [OK]
+  radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+  ```
+
+  ### Format the output
+
+  The formatting option (`--format`) pretty-prints search output
+  using a Go template.
+
+  Valid placeholders for the Go template are:
+
+  | Placeholder    | Description                       |
+  | -------------- | --------------------------------- |
+  | `.Name`        | Image Name                        |
+  | `.Description` | Image description                 |
+  | `.StarCount`   | Number of stars for the image     |
+  | `.IsOfficial`  | "OK" if image is official         |
+  | `.IsAutomated` | "OK" if image build was automated |
+
+  When you use the `--format` option, the `search` command will
+  output the data exactly as the template declares. If you use the
+  `table` directive, column headers are included as well.
+
+  The following example uses a template without headers and outputs the
+  `Name` and `StarCount` entries separated by a colon for all images:
+
+  ```bash
+  {% raw %}
+  $ docker search --format "{{.Name}}: {{.StarCount}}" nginx
+
+  nginx: 5441
+  jwilder/nginx-proxy: 953
+  richarvey/nginx-php-fpm: 353
+  million12/nginx-php: 75
+  webdevops/php-nginx: 70
+  h3nrik/nginx-ldap: 35
+  bitnami/nginx: 23
+  evild/alpine-nginx: 14
+  million12/nginx: 9
+  maxexcloo/nginx: 7
+  {% endraw %}
+  ```
+
+  This example outputs a table format:
+
+  ```bash
+  {% raw %}
+  $ docker search --format "table {{.Name}}\t{{.IsAutomated}}\t{{.IsOfficial}}" nginx
+
+  NAME                                     AUTOMATED           OFFICIAL
+  nginx                                                        [OK]
+  jwilder/nginx-proxy                      [OK]
+  richarvey/nginx-php-fpm                  [OK]
+  jrcs/letsencrypt-nginx-proxy-companion   [OK]
+  million12/nginx-php                      [OK]
+  webdevops/php-nginx                      [OK]
+  {% endraw %}
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -616,463 +616,1026 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Create a service\n\n```bash\n$ docker service create --name redis redis:3.0.6\n\ndmu1ept4cxcfe8k8lhtux3ro3\n\n$
-  docker service create --mode global --name redis2 redis:3.0.6\n\na8q9dasaafudfs8q8w32udass\n\n$
-  docker service ls\n\nID            NAME    MODE        REPLICAS  IMAGE\ndmu1ept4cxcf
-  \ redis   replicated  1/1       redis:3.0.6\na8q9dasaafud  redis2  global      1/1
-  \      redis:3.0.6\n```\n\n#### Create a service using an image on a private registry\n\nIf
-  your image is available on a private registry which requires login, use the\n`--with-registry-auth`
-  flag with `docker service create`, after logging in. If\nyour image is stored on
-  `registry.example.com`, which is a private registry, use\na command like the following:\n\n```bash\n$
-  docker login registry.example.com\n\n$ docker service  create \\\n  --with-registry-auth
-  \\\n  --name my_service \\\n  registry.example.com/acme/my_image:latest\n```\n\nThis
-  passes the login token from your local client to the swarm nodes where the\nservice
-  is deployed, using the encrypted WAL logs. With this information, the\nnodes are
-  able to log into the registry and pull the image.\n\n### Create a service with 5
-  replica tasks (--replicas)\n\nUse the `--replicas` flag to set the number of replica
-  tasks for a replicated\nservice. The following command creates a `redis` service
-  with `5` replica tasks:\n\n```bash\n$ docker service create --name redis --replicas=5
-  redis:3.0.6\n\n4cdgfyky7ozwh3htjfw0d12qv\n```\n\nThe above command sets the *desired*
-  number of tasks for the service. Even\nthough the command returns immediately, actual
-  scaling of the service may take\nsome time. The `REPLICAS` column shows both the
-  *actual* and *desired* number\nof replica tasks for the service.\n\nIn the following
-  example the desired state is  `5` replicas, but the current\nnumber of `RUNNING`
-  tasks is `3`:\n\n```bash\n$ docker service ls\n\nID            NAME   MODE        REPLICAS
-  \ IMAGE\n4cdgfyky7ozw  redis  replicated  3/5       redis:3.0.7\n```\n\nOnce all
-  the tasks are created and `RUNNING`, the actual number of tasks is\nequal to the
-  desired number:\n\n```bash\n$ docker service ls\n\nID            NAME   MODE        REPLICAS
-  \ IMAGE\n4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7\n```\n\n### Create
-  a service with secrets\n\nUse the `--secret` flag to give a container access to
-  a\n[secret](secret_create.md).\n\nCreate a service specifying a secret:\n\n```bash\n$
-  docker service create --name redis --secret secret.json redis:3.0.6\n\n4cdgfyky7ozwh3htjfw0d12qv\n```\n\nCreate
-  a service specifying the secret, target, user/group ID, and mode:\n\n```bash\n$
-  docker service create --name redis \\\n    --secret source=ssh-key,target=ssh \\\n
-  \   --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 \\\n    redis:3.0.6\n\n4cdgfyky7ozwh3htjfw0d12qv\n```\n\nTo
-  grant a service access to multiple secrets, use multiple `--secret` flags.\n\nSecrets
-  are located in `/run/secrets` in the container if no target is specified.\nIf no
-  target is specified, the name of the secret is used as the in memory file\nin the
-  container. If a target is specified, that is used as the filename. In the\nexample
-  above, two files are created: `/run/secrets/ssh` and\n`/run/secrets/app` for each
-  of the secret targets specified.\n\n### Create a service with configs\n\nUse the
-  `--config` flag to give a container access to a\n[config](config_create.md).\n\nCreate
-  a service with a config. The config will be mounted into `redis-config`,\nbe owned
-  by the user who runs the command inside the container (often `root`),\nand have
-  file mode `0444` or world-readable. You can specify the `uid` and `gid`\nas numerical
-  IDs or names. When using names, the provided group/user names must\npre-exist in
-  the container. The `mode` is specified as a 4-number sequence such\nas `0755`.\n\n```bash\n$
-  docker service create --name=redis --config redis-conf redis:3.0.6\n```\n\nCreate
-  a service with a config and specify the target location and file mode:\n\n```bash\n$
-  docker service create --name redis \\\n  --config source=redis-conf,target=/etc/redis/redis.conf,mode=0400
-  redis:3.0.6\n```\n\nTo grant a service access to multiple configs, use multiple
-  `--config` flags.\n\nConfigs are located in `/` in the container if no target is
-  specified. If no\ntarget is specified, the name of the config is used as the name
-  of the file in\nthe container. If a target is specified, that is used as the filename.\n\n###
-  Create a service with a rolling update policy\n\n```bash\n$ docker service create
-  \\\n  --replicas 10 \\\n  --name redis \\\n  --update-delay 10s \\\n  --update-parallelism
-  2 \\\n  redis:3.0.6\n```\n\nWhen you run a [service update](service_update.md),
-  the scheduler updates a\nmaximum of 2 tasks at a time, with `10s` between updates.
-  For more information,\nrefer to the [rolling updates\ntutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).\n\n###
-  Set environment variables (-e, --env)\n\nThis sets an environment variable for all
-  tasks in a service. For example:\n\n```bash\n$ docker service create \\\n  --name
-  redis_2 \\\n  --replicas 5 \\\n  --env MYVAR=foo \\\n  redis:3.0.6\n```\n\nTo specify
-  multiple environment variables, specify multiple `--env` flags, each\nwith a separate
-  key-value pair.\n\n```bash\n$ docker service create \\\n  --name redis_2 \\\n  --replicas
-  5 \\\n  --env MYVAR=foo \\\n  --env MYVAR2=bar \\\n  redis:3.0.6\n```\n\n### Create
-  a service with specific hostname (--hostname)\n\nThis option sets the docker service
-  containers hostname to a specific string.\nFor example:\n\n```bash\n$ docker service
-  create --name redis --hostname myredis redis:3.0.6\n```\n\n### Set metadata on a
-  service (-l, --label)\n\nA label is a `key=value` pair that applies metadata to
-  a service. To label a\nservice with two labels:\n\n```bash\n$ docker service create
-  \\\n  --name redis_2 \\\n  --label com.example.foo=\"bar\"\n  --label bar=baz \\\n
-  \ redis:3.0.6\n```\n\nFor more information about labels, refer to [apply custom\nmetadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).\n\n###
-  Add bind mounts, volumes or memory filesystems\n\nDocker supports three different
-  kinds of mounts, which allow containers to read\nfrom or write to files or directories,
-  either on the host operating system, or\non memory filesystems. These types are
-  _data volumes_ (often referred to simply\nas volumes), _bind mounts_, _tmpfs_, and
-  _named pipes_.\n\nA **bind mount** makes a file or directory on the host available
-  to the\ncontainer it is mounted within. A bind mount may be either read-only or\nread-write.
-  For example, a container might share its host's DNS information by\nmeans of a bind
-  mount of the host's `/etc/resolv.conf` or a container might\nwrite logs to its host's
-  `/var/log/myContainerLogs` directory. If you use\nbind mounts and your host and
-  containers have different notions of permissions,\naccess controls, or other such
-  details, you will run into portability issues.\n\nA **named volume** is a mechanism
-  for decoupling persistent data needed by your\ncontainer from the image used to
-  create the container and from the host machine.\nNamed volumes are created and managed
-  by Docker, and a named volume persists\neven when no container is currently using
-  it. Data in named volumes can be\nshared between a container and the host machine,
-  as well as between multiple\ncontainers. Docker uses a _volume driver_ to create,
-  manage, and mount volumes.\nYou can back up or restore volumes using Docker commands.\n\nA
-  **tmpfs** mounts a tmpfs inside a container for volatile data.\n\nA **npipe** mounts
-  a named pipe from the host into the container.\n\nConsider a situation where your
-  image starts a lightweight web server. You could\nuse that image as a base image,
-  copy in your website's HTML files, and package\nthat into another image. Each time
-  your website changed, you'd need to update\nthe new image and redeploy all of the
-  containers serving your website. A better\nsolution is to store the website in a
-  named volume which is attached to each of\nyour web server containers when they
-  start. To update the website, you just\nupdate the named volume.\n\nFor more information
-  about named volumes, see\n[Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).\n\nThe
-  following table describes options which apply to both bind mounts and named\nvolumes
-  in a service:\n\n<table>\n  <tr>\n    <th>Option</th>\n    <th>Required</th>\n    <th>Description</th>\n
-  \ </tr>\n  <tr>\n    <td><b>type</b></td>\n    <td></td>\n    <td>\n      <p>The
-  type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, <tt>tmpfs</tt>, or
-  <tt>npipe</tt>. Defaults to <tt>volume</tt> if no type is specified.\n      <ul>\n
-  \       <li><tt>volume</tt>: mounts a <a href=\"https://docs.docker.com/engine/reference/commandline/volume_create/\">managed
-  volume</a>\n        into the container.</li> <li><tt>bind</tt>:\n        bind-mounts
-  a directory or file from the host into the container.</li>\n        <li><tt>tmpfs</tt>:
-  mount a tmpfs in the container</li>\n        <li><tt>npipe</tt>: mounts named pipe
-  from the host into the container (Windows containers only).</li>\n      </ul></p>\n
-  \   </td>\n  </tr>\n  <tr>\n    <td><b>src</b> or <b>source</b></td>\n    <td>for
-  <tt>type=bind</tt> and <tt>type=npipe</tt></td>\n    <td>\n      <ul>\n        <li>\n
-  \        <tt>type=volume</tt>: <tt>src</tt> is an optional way to specify the name
-  of the volume (for example, <tt>src=my-volume</tt>).\n          If the named volume
-  does not exist, it is automatically created. If no <tt>src</tt> is specified, the
-  volume is\n          assigned a random name which is guaranteed to be unique on
-  the host, but may not be unique cluster-wide.\n          A randomly-named volume
-  has the same lifecycle as its container and is destroyed when the <i>container</i>\n
-  \         is destroyed (which is upon <tt>service update</tt>, or when scaling or
-  re-balancing the service)\n        </li>\n        <li>\n          <tt>type=bind</tt>:
-  <tt>src</tt> is required, and specifies an absolute path to the file or directory
-  to bind-mount\n          (for example, <tt>src=/path/on/host/</tt>). An error is
-  produced if the file or directory does not exist.\n        </li>\n        <li>\n
-  \         <tt>type=tmpfs</tt>: <tt>src</tt> is not supported.\n        </li>\n      </ul>\n
-  \   </td>\n  </tr>\n  <tr>\n    <td><p><b>dst</b> or <b>destination</b> or <b>target</b></p></td>\n
-  \   <td>yes</td>\n    <td>\n      <p>Mount path inside the container, for example
-  <tt>/some/path/in/container/</tt>.\n      If the path does not exist in the container's
-  filesystem, the Engine creates\n      a directory at the specified location before
-  mounting the volume or bind mount.</p>\n    </td>\n  </tr>\n  <tr>\n    <td><p><b>readonly</b>
-  or <b>ro</b></p></td>\n    <td></td>\n    <td>\n      <p>The Engine mounts binds
-  and volumes <tt>read-write</tt> unless <tt>readonly</tt> option\n      is given
-  when mounting the bind or volume. Note that setting <tt>readonly</tt> for a\n      bind-mount
-  does not make its submounts <tt>readonly</tt> on the current Linux implementation.
-  See also <tt>bind-nonrecursive</tt>.\n      <ul>\n        <li><tt>true</tt> or <tt>1</tt>
-  or no value: Mounts the bind or volume read-only.</li>\n        <li><tt>false</tt>
-  or <tt>0</tt>: Mounts the bind or volume read-write.</li>\n      </ul></p>\n    </td>\n
-  \ </tr>\n</table>\n\n#### Options for Bind Mounts\n\nThe following options can only
-  be used for bind mounts (`type=bind`):\n\n\n<table>\n  <tr>\n    <th>Option</th>\n
-  \   <th>Description</th>\n  </tr>\n  <tr>\n    <td><b>bind-propagation</b></td>\n
-  \   <td>\n      <p>See the <a href=\"#bind-propagation\">bind propagation section</a>.</p>\n
-  \   </td>\n  </tr>\n  <tr>\n    <td><b>consistency</b></td>\n    <td>\n      <p>The
-  consistency requirements for the mount; one of\n         <ul>\n           <li><tt>default</tt>:
-  Equivalent to <tt>consistent</tt>.</li>\n           <li><tt>consistent</tt>: Full
-  consistency.  The container runtime and the host maintain an identical view of the
-  mount at all times.</li>\n           <li><tt>cached</tt>: The host's view of the
-  mount is authoritative.  There may be delays before updates made on the host are
-  visible within a container.</li>\n           <li><tt>delegated</tt>: The container
-  runtime's view of the mount is authoritative.  There may be delays before updates
-  made in a container are visible on the host.</li>\n        </ul>\n     </p>\n    </td>\n
-  \ </tr>\n  <tr>\n    <td><b>bind-nonrecursive</b></td>\n    <td>\n      By default,
-  submounts are recursively bind-mounted as well. However, this behavior can be confusing
-  when a\n      bind mount is configured with <tt>readonly</tt> option, because submounts
-  are not mounted as read-only.\n      Set <tt>bind-nonrecursive</tt> to disable recursive
-  bind-mount.<br />\n      <br />\n      A value is optional:<br />\n      <br />\n
-  \     <ul>\n        <li><tt>true</tt> or <tt>1</tt>: Disables recursive bind-mount.</li>\n
-  \       <li><tt>false</tt> or <tt>0</tt>: Default if you do not provide a value.
-  Enables recursive bind-mount.</li>\n      </ul>\n    </td>\n  </tr>\n</table>\n\n#####
-  Bind propagation\n\nBind propagation refers to whether or not mounts created within
-  a given\nbind mount or named volume can be propagated to replicas of that mount.
-  Consider\na mount point `/mnt`, which is also mounted on `/tmp`. The propagation
-  settings\ncontrol whether a mount on `/tmp/a` would also be available on `/mnt/a`.
-  Each\npropagation setting has a recursive counterpoint. In the case of recursion,\nconsider
-  that `/tmp/a` is also mounted as `/foo`. The propagation settings\ncontrol whether
-  `/mnt/a` and/or `/tmp/a` would exist.\n\nThe `bind-propagation` option defaults
-  to `rprivate` for both bind mounts and\nvolume mounts, and is only configurable
-  for bind mounts. In other words, named\nvolumes do not support bind propagation.\n\n-
-  **`shared`**: Sub-mounts of the original mount are exposed to replica mounts,\n
-  \               and sub-mounts of replica mounts are also propagated to the\n                original
-  mount.\n- **`slave`**: similar to a shared mount, but only in one direction. If
-  the\n               original mount exposes a sub-mount, the replica mount can see
-  it.\n               However, if the replica mount exposes a sub-mount, the original\n
-  \              mount cannot see it.\n- **`private`**: The mount is private. Sub-mounts
-  within it are not exposed to\n                 replica mounts, and sub-mounts of
-  replica mounts are not\n                 exposed to the original mount.\n- **`rshared`**:
-  The same as shared, but the propagation also extends to and from\n                 mount
-  points nested within any of the original or replica mount\n                 points.\n-
-  **`rslave`**: The same as `slave`, but the propagation also extends to and from\n
-  \                mount points nested within any of the original or replica mount\n
-  \                points.\n- **`rprivate`**: The default. The same as `private`,
-  meaning that no mount points\n                  anywhere within the original or
-  replica mount points propagate\n                  in either direction.\n\nFor more
-  information about bind propagation, see the\n[Linux kernel documentation for shared
-  subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).\n\n####
-  Options for named volumes\n\nThe following options can only be used for named volumes
-  (`type=volume`):\n\n\n<table>\n  <tr>\n    <th>Option</th>\n    <th>Description</th>\n
-  \ </tr>\n  <tr>\n    <td><b>volume-driver</b></td>\n    <td>\n      <p>Name of the
-  volume-driver plugin to use for the volume. Defaults to\n      <tt>\"local\"</tt>,
-  to use the local volume driver to create the volume if the\n      volume does not
-  exist.</p>\n    </td>\n  </tr>\n  <tr>\n    <td><b>volume-label</b></td>\n    <td>\n
-  \     One or more custom metadata (\"labels\") to apply to the volume upon\n      creation.
-  For example,\n      <tt>volume-label=mylabel=hello-world,my-other-label=hello-mars</tt>.
-  For more\n      information about labels, refer to\n      <a href=\"https://docs.docker.com/engine/userguide/labels-custom-metadata/\">apply
-  custom metadata</a>.\n    </td>\n  </tr>\n  <tr>\n    <td><b>volume-nocopy</b></td>\n
-  \   <td>\n      By default, if you attach an empty volume to a container, and files
-  or\n      directories already existed at the mount-path in the container (<tt>dst</tt>),\n
-  \     the Engine copies those files and directories into the volume, allowing\n
-  \     the host to access them. Set <tt>volume-nocopy</tt> to disable copying files\n
-  \     from the container's filesystem to the volume and mount the empty volume.<br
-  />\n      <br />\n      A value is optional:<br />\n      <br />\n      <ul>\n        <li><tt>true</tt>
-  or <tt>1</tt>: Default if you do not provide a value. Disables copying.</li>\n        <li><tt>false</tt>
-  or <tt>0</tt>: Enables copying.</li>\n      </ul>\n    </td>\n  </tr>\n  <tr>\n
-  \   <td><b>volume-opt</b></td>\n    <td>\n      Options specific to a given volume
-  driver, which will be passed to the\n      driver when creating the volume. Options
-  are provided as a comma-separated\n      list of key/value pairs, for example,\n
-  \     <tt>volume-opt=some-option=some-value,volume-opt=some-other-option=some-other-value</tt>.\n
-  \     For available options for a given driver, refer to that driver's\n      documentation.\n
-  \   </td>\n  </tr>\n</table>\n\n\n#### Options for tmpfs\n\nThe following options
-  can only be used for tmpfs mounts (`type=tmpfs`);\n\n\n<table>\n  <tr>\n    <th>Option</th>\n
-  \   <th>Description</th>\n  </tr>\n  <tr>\n    <td><b>tmpfs-size</b></td>\n    <td>Size
-  of the tmpfs mount in bytes. Unlimited by default in Linux.</td>\n  </tr>\n  <tr>\n
-  \   <td><b>tmpfs-mode</b></td>\n    <td>File mode of the tmpfs in octal. (e.g. <tt>\"700\"</tt>
-  or <tt>\"0700\"</tt>.) Defaults to <tt>\"1777\"</tt> in Linux.</td>\n  </tr>\n</table>\n\n\n####
-  Differences between \"--mount\" and \"--volume\"\n\nThe `--mount` flag supports
-  most options that are supported by the `-v`\nor `--volume` flag for `docker run`,
-  with some important exceptions:\n\n- The `--mount` flag allows you to specify a
-  volume driver and volume driver\n  options *per volume*, without creating the volumes
-  in advance. In contrast,\n  `docker run` allows you to specify a single volume driver
-  which is shared\n  by all volumes, using the `--volume-driver` flag.\n\n- The `--mount`
-  flag allows you to specify custom metadata (\"labels\") for a volume,\n  before
-  the volume is created.\n\n- When you use `--mount` with `type=bind`, the host-path
-  must refer to an *existing*\n  path on the host. The path will not be created for
-  you and the service will fail\n  with an error if the path does not exist.\n\n-
-  The `--mount` flag does not allow you to relabel a volume with `Z` or `z` flags,\n
-  \ which are used for `selinux` labeling.\n\n#### Create a service using a named
-  volume\n\nThe following example creates a service that uses a named volume:\n\n```bash\n$
-  docker service create \\\n  --name my-service \\\n  --replicas 3 \\\n  --mount type=volume,source=my-volume,destination=/path/in/container,volume-label=\"color=red\",volume-label=\"shape=round\"
-  \\\n  nginx:alpine\n```\n\nFor each replica of the service, the engine requests
-  a volume named \"my-volume\"\nfrom the default (\"local\") volume driver where the
-  task is deployed. If the\nvolume does not exist, the engine creates a new volume
-  and applies the \"color\"\nand \"shape\" labels.\n\nWhen the task is started, the
-  volume is mounted on `/path/in/container/` inside\nthe container.\n\nBe aware that
-  the default (\"local\") volume is a locally scoped volume driver.\nThis means that
-  depending on where a task is deployed, either that task gets a\n*new* volume named
-  \"my-volume\", or shares the same \"my-volume\" with other tasks\nof the same service.
-  Multiple containers writing to a single shared volume can\ncause data corruption
-  if the software running inside the container is not\ndesigned to handle concurrent
-  processes writing to the same location. Also take\ninto account that containers
-  can be re-scheduled by the Swarm orchestrator and\nbe deployed on a different node.\n\n####
-  Create a service that uses an anonymous volume\n\nThe following command creates
-  a service with three replicas with an anonymous\nvolume on `/path/in/container`:\n\n```bash\n$
-  docker service create \\\n  --name my-service \\\n  --replicas 3 \\\n  --mount type=volume,destination=/path/in/container
-  \\\n  nginx:alpine\n```\n\nIn this example, no name (`source`) is specified for
-  the volume, so a new volume\nis created for each task. This guarantees that each
-  task gets its own volume,\nand volumes are not shared between tasks. Anonymous volumes
-  are removed after\nthe task using them is complete.\n\n#### Create a service that
-  uses a bind-mounted host directory\n\nThe following example bind-mounts a host directory
-  at `/path/in/container` in\nthe containers backing the service:\n\n```bash\n$ docker
-  service create \\\n  --name my-service \\\n  --mount type=bind,source=/path/on/host,destination=/path/in/container
-  \\\n  nginx:alpine\n```\n\n### Set service mode (--mode)\n\nThe service mode determines
-  whether this is a _replicated_ service or a _global_\nservice. A replicated service
-  runs as many tasks as specified, while a global\nservice runs on each active node
-  in the swarm.\n\nThe following command creates a global service:\n\n```bash\n$ docker
-  service create \\\n --name redis_2 \\\n --mode global \\\n redis:3.0.6\n```\n\n###
-  Specify service constraints (--constraint)\n\nYou can limit the set of nodes where
-  a task can be scheduled by defining\nconstraint expressions. Constraint expressions
-  can either use a _match_ (`==`)\nor _exclude_ (`!=`) rule. Multiple constraints
-  find nodes that satisfy every\nexpression (AND match). Constraints can match node
-  or Docker Engine labels as\nfollows:\n\nnode attribute       | matches                        |
-  example\n---------------------|--------------------------------|-----------------------------------------------\n`node.id`
-  \           | Node ID                        | `node.id==2ivku8v2gvtg4`\n`node.hostname`
-  \     | Node hostname                  | `node.hostname!=node-2`\n`node.role`          |
-  Node role (`manager`/`worker`) | `node.role==manager`\n`node.platform.os`   | Node
-  operating system          | `node.platform.os==windows`\n`node.platform.arch` |
-  Node architecture              | `node.platform.arch==x86_64`\n`node.labels`        |
-  User-defined node labels       | `node.labels.security==high`\n`engine.labels`      |
-  Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`\n\n\n`engine.labels`
-  apply to Docker Engine labels like operating system, drivers,\netc. Swarm administrators
-  add `node.labels` for operational purposes by using\nthe [`docker node update`](node_update.md)
-  command.\n\nFor example, the following limits tasks for the redis service to nodes
-  where the\nnode type label equals queue:\n\n```bash\n$ docker service create \\\n
-  \ --name redis_2 \\\n  --constraint node.platform.os==linux \\\n  --constraint node.labels.type==queue
-  \\\n  redis:3.0.6\n```\n\nIf the service constraints exclude all nodes in the cluster,
-  a message is printed\nthat no suitable node is found, but the scheduler will start
-  a reconciliation\nloop and deploy the service once a suitable node becomes available.\n\nIn
-  the example below, no node satisfying the constraint was found, causing the\nservice
-  to not reconcile with the desired state:\n\n```bash\n$ docker service create \\\n
-  \ --name web \\\n  --constraint node.labels.region==east \\\n  nginx:alpine\n\nlx1wrhhpmbbu0wuk0ybws30bc\noverall
-  progress: 0 out of 1 tasks\n1/1: no suitable node (scheduling constraints not satisfied
-  on 5 nodes)\n\n$ docker service ls\nID                  NAME     MODE         REPLICAS
-  \  IMAGE               PORTS\nb6lww17hrr4e        web      replicated   0/1        nginx:alpine\n```\n\nAfter
-  adding the `region=east` label to a node in the cluster, the service\nreconciles,
-  and the desired number of replicas are deployed:\n\n```bash\n$ docker node update
-  --label-add region=east yswe2dm4c5fdgtsrli1e8ya5l \nyswe2dm4c5fdgtsrli1e8ya5l\n\n$
-  docker service ls\nID                  NAME     MODE         REPLICAS   IMAGE               PORTS\nb6lww17hrr4e
-  \       web      replicated   1/1        nginx:alpine\n```\n\n### Specify service
-  placement preferences (--placement-pref)\n\nYou can set up the service to divide
-  tasks evenly over different categories of\nnodes. One example of where this can
-  be useful is to balance tasks over a set\nof datacenters or availability zones.
-  The example below illustrates this:\n\n```bash\n$ docker service create \\\n  --replicas
-  9 \\\n  --name redis_2 \\\n  --placement-pref spread=node.labels.datacenter \\\n
-  \ redis:3.0.6\n```\n\nThis uses `--placement-pref` with a `spread` strategy (currently
-  the only\nsupported strategy) to spread tasks evenly over the values of the `datacenter`\nnode
-  label. In this example, we assume that every node has a `datacenter` node\nlabel
-  attached to it. If there are three different values of this label among\nnodes in
-  the swarm, one third of the tasks will be placed on the nodes\nassociated with each
-  value. This is true even if there are more nodes with one\nvalue than another. For
-  example, consider the following set of nodes:\n\n- Three nodes with `node.labels.datacenter=east`\n-
-  Two nodes with `node.labels.datacenter=south`\n- One node with `node.labels.datacenter=west`\n\nSince
-  we are spreading over the values of the `datacenter` label and the\nservice has
-  9 replicas, 3 replicas will end up in each datacenter. There are\nthree nodes associated
-  with the value `east`, so each one will get one of the\nthree replicas reserved
-  for this value. There are two nodes with the value\n`south`, and the three replicas
-  for this value will be divided between them,\nwith one receiving two replicas and
-  another receiving just one. Finally, `west`\nhas a single node that will get all
-  three replicas reserved for `west`.\n\nIf the nodes in one category (for example,
-  those with\n`node.labels.datacenter=south`) can't handle their fair share of tasks
-  due to\nconstraints or resource limitations, the extra tasks will be assigned to
-  other\nnodes instead, if possible.\n\nBoth engine labels and node labels are supported
-  by placement preferences. The\nexample above uses a node label, because the label
-  is referenced with\n`node.labels.datacenter`. To spread over the values of an engine
-  label, use\n`--placement-pref spread=engine.labels.<labelname>`.\n\nIt is possible
-  to add multiple placement preferences to a service. This\nestablishes a hierarchy
-  of preferences, so that tasks are first divided over\none category, and then further
-  divided over additional categories. One example\nof where this may be useful is
-  dividing tasks fairly between datacenters, and\nthen splitting the tasks within
-  each datacenter over a choice of racks. To add\nmultiple placement preferences,
-  specify the `--placement-pref` flag multiple\ntimes. The order is significant, and
-  the placement preferences will be applied\nin the order given when making scheduling
-  decisions.\n\nThe following example sets up a service with multiple placement preferences.\nTasks
-  are spread first over the various datacenters, and then over racks\n(as indicated
-  by the respective labels):\n\n```bash\n$ docker service create \\\n  --replicas
-  9 \\\n  --name redis_2 \\\n  --placement-pref 'spread=node.labels.datacenter' \\\n
-  \ --placement-pref 'spread=node.labels.rack' \\\n  redis:3.0.6\n```\n\nWhen updating
-  a service with `docker service update`, `--placement-pref-add`\nappends a new placement
-  preference after all existing placement preferences.\n`--placement-pref-rm` removes
-  an existing placement preference that matches the\nargument.\n\n### Specify memory
-  requirements and constraints for a service (--reserve-memory and --limit-memory)\n\nIf
-  your service needs a minimum amount of memory in order to run correctly,\nyou can
-  use `--reserve-memory` to specify that the service should only be\nscheduled on
-  a node with this much memory available to reserve. If no node is\navailable that
-  meets the criteria, the task is not scheduled, but remains in a\npending state.\n\nThe
-  following example requires that 4GB of memory be available and reservable\non a
-  given node before scheduling the service to run on that node.\n\n```bash\n$ docker
-  service create --reserve-memory=4GB --name=too-big nginx:alpine\n```\n\nThe managers
-  won't schedule a set of containers on a single node whose combined\nreservations
-  exceed the memory available on that node.\n\nAfter a task is scheduled and running,
-  `--reserve-memory` does not enforce a\nmemory limit. Use `--limit-memory` to ensure
-  that a task uses no more than a\ngiven amount of memory on a node. This example
-  limits the amount of memory used\nby the task to 4GB. The task will be scheduled
-  even if each of your nodes has\nonly 2GB of memory, because `--limit-memory` is
-  an upper limit.\n\n```bash\n$ docker service create --limit-memory=4GB --name=too-big
-  nginx:alpine\n```\n\nUsing `--reserve-memory` and `--limit-memory` does not guarantee
-  that Docker\nwill not use more memory on your host than you want. For instance,
-  you could\ncreate many services, the sum of whose memory usage could exhaust the
-  available\nmemory.\n\nYou can prevent this scenario from exhausting the available
-  memory by taking\ninto account other (non-containerized) software running on the
-  host as well. If\n`--reserve-memory` is greater than or equal to `--limit-memory`,
-  Docker won't\nschedule a service on a host that doesn't have enough memory. `--limit-memory`\nwill
-  limit the service's memory to stay within that limit, so if every service\nhas a
-  memory-reservation and limit set, Docker services will be less likely to\nsaturate
-  the host. Other non-service containers or applications running directly\non the
-  Docker host could still exhaust memory.\n\nThere is a downside to this approach.
-  Reserving memory also means that you may\nnot make optimum use of the memory available
-  on the node. Consider a service\nthat under normal circumstances uses 100MB of memory,
-  but depending on load can\n\"peak\" at 500MB. Reserving 500MB for that service (to
-  guarantee can have 500MB\nfor those \"peaks\") results in 400MB of memory being
-  wasted most of the time.\n\nIn short, you can take a more conservative or more flexible
-  approach:\n\n- **Conservative**: reserve 500MB, and limit to 500MB. Basically you're
-  now\n  treating the service containers as VMs, and you may be losing a big advantage\n
-  \ containers, which is greater density of services per host.\n\n- **Flexible**:
-  limit to 500MB in the assumption that if the service requires\n  more than 500MB,
-  it is malfunctioning. Reserve something between the 100MB\n  \"normal\" requirement
-  and the 500MB \"peak\" requirement\". This assumes that when\n  this service is
-  at \"peak\", other services or non-container workloads probably\n  won't be.\n\nThe
-  approach you take depends heavily on the memory-usage patterns of your\nworkloads.
-  You should test under normal and peak conditions before settling\non an approach.\n\nOn
-  Linux, you can also limit a service's overall memory footprint on a given\nhost
-  at the level of the host operating system, using `cgroups` or other\nrelevant operating
-  system tools.\n\n### Specify maximum replicas per node (--replicas-max-per-node)\n\nUse
-  the `--replicas-max-per-node` flag to set the maximum number of replica tasks that
-  can run on a node.\nThe following command creates a nginx service with 2 replica
-  tasks but only one replica task per node.\n\nOne example where this can be useful
-  is to balance tasks over a set of data centers together with `--placement-pref`\nand
-  let `--replicas-max-per-node` setting make sure that replicas are not migrated to
-  another datacenter during\nmaintenance or datacenter failure.\n\nThe example below
-  illustrates this:\n\n```bash\n$ docker service create \\\n  --name nginx \\\n  --replicas
-  2 \\\n  --replicas-max-per-node 1 \\\n  --placement-pref 'spread=node.labels.datacenter'
-  \\\n  nginx\n```\n\n### Attach a service to an existing network (--network)\n\nYou
-  can use overlay networks to connect one or more services within the swarm.\n\nFirst,
-  create an overlay network on a manager node the docker network create\ncommand:\n\n```bash\n$
-  docker network create --driver overlay my-network\n\netjpu59cykrptrgw0z0hk5snf\n```\n\nAfter
-  you create an overlay network in swarm mode, all manager nodes have\naccess to the
-  network.\n\nWhen you create a service and pass the `--network` flag to attach the
-  service to\nthe overlay network:\n\n```bash\n$ docker service create \\\n  --replicas
-  3 \\\n  --network my-network \\\n  --name my-web \\\n  nginx\n\n716thylsndqma81j6kkkb5aus\n```\n\nThe
-  swarm extends my-network to each node running the service.\n\nContainers on the
-  same network can access each other using\n[service discovery](https://docs.docker.com/engine/swarm/networking/#use-swarm-mode-service-discovery).\n\nLong
-  form syntax of `--network` allows to specify list of aliases and driver options:
-  \ \n`--network name=my-network,alias=web1,driver-opt=field1=value1`\n\n### Publish
-  service ports externally to the swarm (-p, --publish)\n\nYou can publish service
-  ports to make them available externally to the swarm\nusing the `--publish` flag.
-  The `--publish` flag can take two different styles\nof arguments. The short version
-  is positional, and allows you to specify the\npublished port and target port separated
-  by a colon.\n\n```bash\n$ docker service create --name my_web --replicas 3 --publish
-  8080:80 nginx\n```\n\nThere is also a long format, which is easier to read and allows
-  you to specify\nmore options. The long format is preferred. You cannot specify the
-  service's\nmode when using the short format. Here is an example of using the long
-  format\nfor the same service as above:\n\n```bash\n$ docker service create --name
-  my_web --replicas 3 --publish published=8080,target=80 nginx\n```\n\nThe options
-  you can specify are:\n\n<table>\n<thead>\n<tr>\n  <th>Option</th>\n  <th>Short syntax</th>\n
-  \ <th>Long syntax</th>\n  <th>Description</th>\n</tr>\n</thead>\n<tr>\n  <td>published
-  and target port</td>\n  <td><tt>--publish 8080:80</tt></td>\n  <td><tt>--publish
-  published=8080,target=80</tt></td>\n  <td><p>\n    The target port within the container
-  and the port to map it to on the\n    nodes, using the routing mesh (<tt>ingress</tt>)
-  or host-level networking.\n    More options are available, later in this table.
-  The key-value syntax is\n    preferred, because it is somewhat self-documenting.\n
-  \ </p></td>\n</tr>\n<tr>\n  <td>mode</td>\n  <td>Not possible to set using short
-  syntax.</td>\n  <td><tt>--publish published=8080,target=80,mode=host</tt></td>\n
-  \ <td><p>\n    The mode to use for binding the port, either <tt>ingress</tt> or
-  <tt>host</tt>.\n    Defaults to <tt>ingress</tt> to use the routing mesh.\n  </p></td>\n</tr>\n<tr>\n
-  \ <td>protocol</td>\n  <td><tt>--publish 8080:80/tcp</tt></td>\n  <td><tt>--publish
-  published=8080,target=80,protocol=tcp</tt></td>\n  <td><p>\n    The protocol to
-  use, <tt>tcp</tt> , <tt>udp</tt>, or <tt>sctp</tt>. Defaults to\n    <tt>tcp</tt>.
-  To bind a port for both protocols, specify the <tt>-p</tt> or\n    <tt>--publish</tt>
-  flag twice.\n  </p></td>\n</tr>\n</table>\n\nWhen you publish a service port using
-  `ingress` mode, the swarm routing mesh\nmakes the service accessible at the published
-  port on every node regardless if\nthere is a task for the service running on the
-  node. If you use `host` mode,\nthe port is only bound on nodes where the service
-  is running, and a given port\non a node can only be bound once. You can only set
-  the publication mode using\nthe long syntax. For more information refer to\n[Use
-  swarm mode routing mesh](https://docs.docker.com/engine/swarm/ingress/).\n\n###
-  Provide credential specs for managed service accounts (Windows only)\n\nThis option
-  is only used for services using Windows containers. The\n`--credential-spec` must
-  be in the format `file://<filename>` or\n`registry://<value-name>`.\n\nWhen using
-  the `file://<filename>` format, the referenced file must be\npresent in the `CredentialSpecs`
-  subdirectory in the docker data directory,\nwhich defaults to `C:\\ProgramData\\Docker\\`
-  on Windows. For example,\nspecifying `file://spec.json` loads `C:\\ProgramData\\Docker\\CredentialSpecs\\spec.json`.\n\nWhen
-  using the `registry://<value-name>` format, the credential spec is\nread from the
-  Windows registry on the daemon's host. The specified\nregistry value must be located
-  in:\n\n    HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\Containers\\CredentialSpecs\n\n\n###
-  Create services using templates\n\nYou can use templates for some flags of `service
-  create`, using the syntax\nprovided by the Go's [text/template](http://golang.org/pkg/text/template/)
-  package.\n\nThe supported flags are the following :\n\n- `--hostname`\n- `--mount`\n-
-  `--env`\n\nValid placeholders for the Go template are listed below:\n\n\n<table>\n
-  \ <tr>\n    <th>Placeholder</th>\n    <th>Description</th>\n  </tr>\n  <tr>\n    <td><tt>.Service.ID</tt></td>\n
-  \   <td>Service ID</td>\n  </tr>\n  <tr>\n    <td><tt>.Service.Name</tt></td>\n
-  \   <td>Service name</td>\n  </tr>\n  <tr>\n    <td><tt>.Service.Labels</tt></td>\n
-  \   <td>Service labels</td>\n  </tr>\n  <tr>\n    <td><tt>.Node.ID</tt></td>\n    <td>Node
-  ID</td>\n  </tr>\n  <tr>\n    <td><tt>.Node.Hostname</tt></td>\n    <td>Node Hostname</td>\n
-  \ </tr>\n  <tr>\n    <td><tt>.Task.ID</tt></td>\n    <td>Task ID</td>\n  </tr>\n
-  \ <tr>\n    <td><tt>.Task.Name</tt></td>\n    <td>Task name</td>\n  </tr>\n  <tr>\n
-  \   <td><tt>.Task.Slot</tt></td>\n    <td>Task slot</td>\n  </tr>\n</table>\n\n\n####
-  Template example\n\nIn this example, we are going to set the template of the created
-  containers based on the\nservice's name, the node's ID and hostname where it sits.\n\n```bash\n$
-  docker service create --name hosttempl \\\n                        --hostname=\"{{.Node.Hostname}}-{{.Node.ID}}-{{.Service.Name}}\"\\\n
-  \                        busybox top\n\nva8ew30grofhjoychbr6iot8c\n\n$ docker service
-  ps va8ew30grofhjoychbr6iot8c\n\nID            NAME         IMAGE                                                                                   NODE
-  \         DESIRED STATE  CURRENT STATE               ERROR  PORTS\nwo41w8hg8qan
-  \ hosttempl.1  busybox:latest@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912
-  \ 2e7a8a9c4da2  Running        Running about a minute ago\n\n$ docker inspect --format=\"{{.Config.Hostname}}\"
-  2e7a8a9c4da2-wo41w8hg8qanxwjwsg4kxpprj-hosttempl\n\nx3ti0erg11rjpg64m75kej2mz-hosttempl\n```\n\n###
-  Specify isolation mode (Windows)\n\nBy default, tasks scheduled on Windows nodes
-  are run using the default isolation mode\nconfigured for this particular node. To
-  force a specific isolation mode, you can use\nthe `--isolation` flag:\n\n```bash\n$
-  docker service create --name myservice --isolation=process microsoft/nanoserver\n```\n\nSupported
-  isolation modes on Windows are:\n- `default`: use default settings specified on
-  the node running the task\n- `process`: use process isolation (Windows server only)\n-
-  `hyperv`: use Hyper-V isolation\n\n### Create services requesting Generic Resources\n\nYou
-  can narrow the kind of nodes your task can land on through the using the\n`--generic-resource`
-  flag (if the nodes advertise these resources):\n\n```bash\n$ docker service create
-  --name cuda \\\n                        --generic-resource \"NVIDIA-GPU=2\" \\\n
-  \                       --generic-resource \"SSD=1\" \\\n                        nvidia/cuda\n```"
+examples: |-
+  ### Create a service
+
+  ```bash
+  $ docker service create --name redis redis:3.0.6
+
+  dmu1ept4cxcfe8k8lhtux3ro3
+
+  $ docker service create --mode global --name redis2 redis:3.0.6
+
+  a8q9dasaafudfs8q8w32udass
+
+  $ docker service ls
+
+  ID            NAME    MODE        REPLICAS  IMAGE
+  dmu1ept4cxcf  redis   replicated  1/1       redis:3.0.6
+  a8q9dasaafud  redis2  global      1/1       redis:3.0.6
+  ```
+
+  #### Create a service using an image on a private registry
+
+  If your image is available on a private registry which requires login, use the
+  `--with-registry-auth` flag with `docker service create`, after logging in. If
+  your image is stored on `registry.example.com`, which is a private registry, use
+  a command like the following:
+
+  ```bash
+  $ docker login registry.example.com
+
+  $ docker service  create \
+    --with-registry-auth \
+    --name my_service \
+    registry.example.com/acme/my_image:latest
+  ```
+
+  This passes the login token from your local client to the swarm nodes where the
+  service is deployed, using the encrypted WAL logs. With this information, the
+  nodes are able to log into the registry and pull the image.
+
+  ### Create a service with 5 replica tasks (--replicas)
+
+  Use the `--replicas` flag to set the number of replica tasks for a replicated
+  service. The following command creates a `redis` service with `5` replica tasks:
+
+  ```bash
+  $ docker service create --name redis --replicas=5 redis:3.0.6
+
+  4cdgfyky7ozwh3htjfw0d12qv
+  ```
+
+  The above command sets the *desired* number of tasks for the service. Even
+  though the command returns immediately, actual scaling of the service may take
+  some time. The `REPLICAS` column shows both the *actual* and *desired* number
+  of replica tasks for the service.
+
+  In the following example the desired state is  `5` replicas, but the current
+  number of `RUNNING` tasks is `3`:
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME   MODE        REPLICAS  IMAGE
+  4cdgfyky7ozw  redis  replicated  3/5       redis:3.0.7
+  ```
+
+  Once all the tasks are created and `RUNNING`, the actual number of tasks is
+  equal to the desired number:
+
+  ```bash
+  $ docker service ls
+
+  ID            NAME   MODE        REPLICAS  IMAGE
+  4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
+  ```
+
+  ### Create a service with secrets
+
+  Use the `--secret` flag to give a container access to a
+  [secret](secret_create.md).
+
+  Create a service specifying a secret:
+
+  ```bash
+  $ docker service create --name redis --secret secret.json redis:3.0.6
+
+  4cdgfyky7ozwh3htjfw0d12qv
+  ```
+
+  Create a service specifying the secret, target, user/group ID, and mode:
+
+  ```bash
+  $ docker service create --name redis \
+      --secret source=ssh-key,target=ssh \
+      --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 \
+      redis:3.0.6
+
+  4cdgfyky7ozwh3htjfw0d12qv
+  ```
+
+  To grant a service access to multiple secrets, use multiple `--secret` flags.
+
+  Secrets are located in `/run/secrets` in the container if no target is specified.
+  If no target is specified, the name of the secret is used as the in memory file
+  in the container. If a target is specified, that is used as the filename. In the
+  example above, two files are created: `/run/secrets/ssh` and
+  `/run/secrets/app` for each of the secret targets specified.
+
+  ### Create a service with configs
+
+  Use the `--config` flag to give a container access to a
+  [config](config_create.md).
+
+  Create a service with a config. The config will be mounted into `redis-config`,
+  be owned by the user who runs the command inside the container (often `root`),
+  and have file mode `0444` or world-readable. You can specify the `uid` and `gid`
+  as numerical IDs or names. When using names, the provided group/user names must
+  pre-exist in the container. The `mode` is specified as a 4-number sequence such
+  as `0755`.
+
+  ```bash
+  $ docker service create --name=redis --config redis-conf redis:3.0.6
+  ```
+
+  Create a service with a config and specify the target location and file mode:
+
+  ```bash
+  $ docker service create --name redis \
+    --config source=redis-conf,target=/etc/redis/redis.conf,mode=0400 redis:3.0.6
+  ```
+
+  To grant a service access to multiple configs, use multiple `--config` flags.
+
+  Configs are located in `/` in the container if no target is specified. If no
+  target is specified, the name of the config is used as the name of the file in
+  the container. If a target is specified, that is used as the filename.
+
+  ### Create a service with a rolling update policy
+
+  ```bash
+  $ docker service create \
+    --replicas 10 \
+    --name redis \
+    --update-delay 10s \
+    --update-parallelism 2 \
+    redis:3.0.6
+  ```
+
+  When you run a [service update](service_update.md), the scheduler updates a
+  maximum of 2 tasks at a time, with `10s` between updates. For more information,
+  refer to the [rolling updates
+  tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
+
+  ### Set environment variables (-e, --env)
+
+  This sets an environment variable for all tasks in a service. For example:
+
+  ```bash
+  $ docker service create \
+    --name redis_2 \
+    --replicas 5 \
+    --env MYVAR=foo \
+    redis:3.0.6
+  ```
+
+  To specify multiple environment variables, specify multiple `--env` flags, each
+  with a separate key-value pair.
+
+  ```bash
+  $ docker service create \
+    --name redis_2 \
+    --replicas 5 \
+    --env MYVAR=foo \
+    --env MYVAR2=bar \
+    redis:3.0.6
+  ```
+
+  ### Create a service with specific hostname (--hostname)
+
+  This option sets the docker service containers hostname to a specific string.
+  For example:
+
+  ```bash
+  $ docker service create --name redis --hostname myredis redis:3.0.6
+  ```
+
+  ### Set metadata on a service (-l, --label)
+
+  A label is a `key=value` pair that applies metadata to a service. To label a
+  service with two labels:
+
+  ```bash
+  $ docker service create \
+    --name redis_2 \
+    --label com.example.foo="bar"
+    --label bar=baz \
+    redis:3.0.6
+  ```
+
+  For more information about labels, refer to [apply custom
+  metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
+
+  ### Add bind mounts, volumes or memory filesystems
+
+  Docker supports three different kinds of mounts, which allow containers to read
+  from or write to files or directories, either on the host operating system, or
+  on memory filesystems. These types are _data volumes_ (often referred to simply
+  as volumes), _bind mounts_, _tmpfs_, and _named pipes_.
+
+  A **bind mount** makes a file or directory on the host available to the
+  container it is mounted within. A bind mount may be either read-only or
+  read-write. For example, a container might share its host's DNS information by
+  means of a bind mount of the host's `/etc/resolv.conf` or a container might
+  write logs to its host's `/var/log/myContainerLogs` directory. If you use
+  bind mounts and your host and containers have different notions of permissions,
+  access controls, or other such details, you will run into portability issues.
+
+  A **named volume** is a mechanism for decoupling persistent data needed by your
+  container from the image used to create the container and from the host machine.
+  Named volumes are created and managed by Docker, and a named volume persists
+  even when no container is currently using it. Data in named volumes can be
+  shared between a container and the host machine, as well as between multiple
+  containers. Docker uses a _volume driver_ to create, manage, and mount volumes.
+  You can back up or restore volumes using Docker commands.
+
+  A **tmpfs** mounts a tmpfs inside a container for volatile data.
+
+  A **npipe** mounts a named pipe from the host into the container.
+
+  Consider a situation where your image starts a lightweight web server. You could
+  use that image as a base image, copy in your website's HTML files, and package
+  that into another image. Each time your website changed, you'd need to update
+  the new image and redeploy all of the containers serving your website. A better
+  solution is to store the website in a named volume which is attached to each of
+  your web server containers when they start. To update the website, you just
+  update the named volume.
+
+  For more information about named volumes, see
+  [Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).
+
+  The following table describes options which apply to both bind mounts and named
+  volumes in a service:
+
+  <table>
+    <tr>
+      <th>Option</th>
+      <th>Required</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><b>type</b></td>
+      <td></td>
+      <td>
+        <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, <tt>tmpfs</tt>, or <tt>npipe</tt>. Defaults to <tt>volume</tt> if no type is specified.
+        <ul>
+          <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/engine/reference/commandline/volume_create/">managed volume</a>
+          into the container.</li> <li><tt>bind</tt>:
+          bind-mounts a directory or file from the host into the container.</li>
+          <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
+          <li><tt>npipe</tt>: mounts named pipe from the host into the container (Windows containers only).</li>
+        </ul></p>
+      </td>
+    </tr>
+    <tr>
+      <td><b>src</b> or <b>source</b></td>
+      <td>for <tt>type=bind</tt> and <tt>type=npipe</tt></td>
+      <td>
+        <ul>
+          <li>
+           <tt>type=volume</tt>: <tt>src</tt> is an optional way to specify the name of the volume (for example, <tt>src=my-volume</tt>).
+            If the named volume does not exist, it is automatically created. If no <tt>src</tt> is specified, the volume is
+            assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide.
+            A randomly-named volume has the same lifecycle as its container and is destroyed when the <i>container</i>
+            is destroyed (which is upon <tt>service update</tt>, or when scaling or re-balancing the service)
+          </li>
+          <li>
+            <tt>type=bind</tt>: <tt>src</tt> is required, and specifies an absolute path to the file or directory to bind-mount
+            (for example, <tt>src=/path/on/host/</tt>). An error is produced if the file or directory does not exist.
+          </li>
+          <li>
+            <tt>type=tmpfs</tt>: <tt>src</tt> is not supported.
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><p><b>dst</b> or <b>destination</b> or <b>target</b></p></td>
+      <td>yes</td>
+      <td>
+        <p>Mount path inside the container, for example <tt>/some/path/in/container/</tt>.
+        If the path does not exist in the container's filesystem, the Engine creates
+        a directory at the specified location before mounting the volume or bind mount.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><p><b>readonly</b> or <b>ro</b></p></td>
+      <td></td>
+      <td>
+        <p>The Engine mounts binds and volumes <tt>read-write</tt> unless <tt>readonly</tt> option
+        is given when mounting the bind or volume. Note that setting <tt>readonly</tt> for a
+        bind-mount does not make its submounts <tt>readonly</tt> on the current Linux implementation. See also <tt>bind-nonrecursive</tt>.
+        <ul>
+          <li><tt>true</tt> or <tt>1</tt> or no value: Mounts the bind or volume read-only.</li>
+          <li><tt>false</tt> or <tt>0</tt>: Mounts the bind or volume read-write.</li>
+        </ul></p>
+      </td>
+    </tr>
+  </table>
+
+  #### Options for Bind Mounts
+
+  The following options can only be used for bind mounts (`type=bind`):
+
+
+  <table>
+    <tr>
+      <th>Option</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><b>bind-propagation</b></td>
+      <td>
+        <p>See the <a href="#bind-propagation">bind propagation section</a>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><b>consistency</b></td>
+      <td>
+        <p>The consistency requirements for the mount; one of
+           <ul>
+             <li><tt>default</tt>: Equivalent to <tt>consistent</tt>.</li>
+             <li><tt>consistent</tt>: Full consistency.  The container runtime and the host maintain an identical view of the mount at all times.</li>
+             <li><tt>cached</tt>: The host's view of the mount is authoritative.  There may be delays before updates made on the host are visible within a container.</li>
+             <li><tt>delegated</tt>: The container runtime's view of the mount is authoritative.  There may be delays before updates made in a container are visible on the host.</li>
+          </ul>
+       </p>
+      </td>
+    </tr>
+    <tr>
+      <td><b>bind-nonrecursive</b></td>
+      <td>
+        By default, submounts are recursively bind-mounted as well. However, this behavior can be confusing when a
+        bind mount is configured with <tt>readonly</tt> option, because submounts are not mounted as read-only.
+        Set <tt>bind-nonrecursive</tt> to disable recursive bind-mount.<br />
+        <br />
+        A value is optional:<br />
+        <br />
+        <ul>
+          <li><tt>true</tt> or <tt>1</tt>: Disables recursive bind-mount.</li>
+          <li><tt>false</tt> or <tt>0</tt>: Default if you do not provide a value. Enables recursive bind-mount.</li>
+        </ul>
+      </td>
+    </tr>
+  </table>
+
+  ##### Bind propagation
+
+  Bind propagation refers to whether or not mounts created within a given
+  bind mount or named volume can be propagated to replicas of that mount. Consider
+  a mount point `/mnt`, which is also mounted on `/tmp`. The propagation settings
+  control whether a mount on `/tmp/a` would also be available on `/mnt/a`. Each
+  propagation setting has a recursive counterpoint. In the case of recursion,
+  consider that `/tmp/a` is also mounted as `/foo`. The propagation settings
+  control whether `/mnt/a` and/or `/tmp/a` would exist.
+
+  The `bind-propagation` option defaults to `rprivate` for both bind mounts and
+  volume mounts, and is only configurable for bind mounts. In other words, named
+  volumes do not support bind propagation.
+
+  - **`shared`**: Sub-mounts of the original mount are exposed to replica mounts,
+                  and sub-mounts of replica mounts are also propagated to the
+                  original mount.
+  - **`slave`**: similar to a shared mount, but only in one direction. If the
+                 original mount exposes a sub-mount, the replica mount can see it.
+                 However, if the replica mount exposes a sub-mount, the original
+                 mount cannot see it.
+  - **`private`**: The mount is private. Sub-mounts within it are not exposed to
+                   replica mounts, and sub-mounts of replica mounts are not
+                   exposed to the original mount.
+  - **`rshared`**: The same as shared, but the propagation also extends to and from
+                   mount points nested within any of the original or replica mount
+                   points.
+  - **`rslave`**: The same as `slave`, but the propagation also extends to and from
+                   mount points nested within any of the original or replica mount
+                   points.
+  - **`rprivate`**: The default. The same as `private`, meaning that no mount points
+                    anywhere within the original or replica mount points propagate
+                    in either direction.
+
+  For more information about bind propagation, see the
+  [Linux kernel documentation for shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
+
+  #### Options for named volumes
+
+  The following options can only be used for named volumes (`type=volume`):
+
+
+  <table>
+    <tr>
+      <th>Option</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><b>volume-driver</b></td>
+      <td>
+        <p>Name of the volume-driver plugin to use for the volume. Defaults to
+        <tt>"local"</tt>, to use the local volume driver to create the volume if the
+        volume does not exist.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><b>volume-label</b></td>
+      <td>
+        One or more custom metadata ("labels") to apply to the volume upon
+        creation. For example,
+        <tt>volume-label=mylabel=hello-world,my-other-label=hello-mars</tt>. For more
+        information about labels, refer to
+        <a href="https://docs.docker.com/engine/userguide/labels-custom-metadata/">apply custom metadata</a>.
+      </td>
+    </tr>
+    <tr>
+      <td><b>volume-nocopy</b></td>
+      <td>
+        By default, if you attach an empty volume to a container, and files or
+        directories already existed at the mount-path in the container (<tt>dst</tt>),
+        the Engine copies those files and directories into the volume, allowing
+        the host to access them. Set <tt>volume-nocopy</tt> to disable copying files
+        from the container's filesystem to the volume and mount the empty volume.<br />
+        <br />
+        A value is optional:<br />
+        <br />
+        <ul>
+          <li><tt>true</tt> or <tt>1</tt>: Default if you do not provide a value. Disables copying.</li>
+          <li><tt>false</tt> or <tt>0</tt>: Enables copying.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><b>volume-opt</b></td>
+      <td>
+        Options specific to a given volume driver, which will be passed to the
+        driver when creating the volume. Options are provided as a comma-separated
+        list of key/value pairs, for example,
+        <tt>volume-opt=some-option=some-value,volume-opt=some-other-option=some-other-value</tt>.
+        For available options for a given driver, refer to that driver's
+        documentation.
+      </td>
+    </tr>
+  </table>
+
+
+  #### Options for tmpfs
+
+  The following options can only be used for tmpfs mounts (`type=tmpfs`);
+
+
+  <table>
+    <tr>
+      <th>Option</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><b>tmpfs-size</b></td>
+      <td>Size of the tmpfs mount in bytes. Unlimited by default in Linux.</td>
+    </tr>
+    <tr>
+      <td><b>tmpfs-mode</b></td>
+      <td>File mode of the tmpfs in octal. (e.g. <tt>"700"</tt> or <tt>"0700"</tt>.) Defaults to <tt>"1777"</tt> in Linux.</td>
+    </tr>
+  </table>
+
+
+  #### Differences between "--mount" and "--volume"
+
+  The `--mount` flag supports most options that are supported by the `-v`
+  or `--volume` flag for `docker run`, with some important exceptions:
+
+  - The `--mount` flag allows you to specify a volume driver and volume driver
+    options *per volume*, without creating the volumes in advance. In contrast,
+    `docker run` allows you to specify a single volume driver which is shared
+    by all volumes, using the `--volume-driver` flag.
+
+  - The `--mount` flag allows you to specify custom metadata ("labels") for a volume,
+    before the volume is created.
+
+  - When you use `--mount` with `type=bind`, the host-path must refer to an *existing*
+    path on the host. The path will not be created for you and the service will fail
+    with an error if the path does not exist.
+
+  - The `--mount` flag does not allow you to relabel a volume with `Z` or `z` flags,
+    which are used for `selinux` labeling.
+
+  #### Create a service using a named volume
+
+  The following example creates a service that uses a named volume:
+
+  ```bash
+  $ docker service create \
+    --name my-service \
+    --replicas 3 \
+    --mount type=volume,source=my-volume,destination=/path/in/container,volume-label="color=red",volume-label="shape=round" \
+    nginx:alpine
+  ```
+
+  For each replica of the service, the engine requests a volume named "my-volume"
+  from the default ("local") volume driver where the task is deployed. If the
+  volume does not exist, the engine creates a new volume and applies the "color"
+  and "shape" labels.
+
+  When the task is started, the volume is mounted on `/path/in/container/` inside
+  the container.
+
+  Be aware that the default ("local") volume is a locally scoped volume driver.
+  This means that depending on where a task is deployed, either that task gets a
+  *new* volume named "my-volume", or shares the same "my-volume" with other tasks
+  of the same service. Multiple containers writing to a single shared volume can
+  cause data corruption if the software running inside the container is not
+  designed to handle concurrent processes writing to the same location. Also take
+  into account that containers can be re-scheduled by the Swarm orchestrator and
+  be deployed on a different node.
+
+  #### Create a service that uses an anonymous volume
+
+  The following command creates a service with three replicas with an anonymous
+  volume on `/path/in/container`:
+
+  ```bash
+  $ docker service create \
+    --name my-service \
+    --replicas 3 \
+    --mount type=volume,destination=/path/in/container \
+    nginx:alpine
+  ```
+
+  In this example, no name (`source`) is specified for the volume, so a new volume
+  is created for each task. This guarantees that each task gets its own volume,
+  and volumes are not shared between tasks. Anonymous volumes are removed after
+  the task using them is complete.
+
+  #### Create a service that uses a bind-mounted host directory
+
+  The following example bind-mounts a host directory at `/path/in/container` in
+  the containers backing the service:
+
+  ```bash
+  $ docker service create \
+    --name my-service \
+    --mount type=bind,source=/path/on/host,destination=/path/in/container \
+    nginx:alpine
+  ```
+
+  ### Set service mode (--mode)
+
+  The service mode determines whether this is a _replicated_ service or a _global_
+  service. A replicated service runs as many tasks as specified, while a global
+  service runs on each active node in the swarm.
+
+  The following command creates a global service:
+
+  ```bash
+  $ docker service create \
+   --name redis_2 \
+   --mode global \
+   redis:3.0.6
+  ```
+
+  ### Specify service constraints (--constraint)
+
+  You can limit the set of nodes where a task can be scheduled by defining
+  constraint expressions. Constraint expressions can either use a _match_ (`==`)
+  or _exclude_ (`!=`) rule. Multiple constraints find nodes that satisfy every
+  expression (AND match). Constraints can match node or Docker Engine labels as
+  follows:
+
+  node attribute       | matches                        | example
+  ---------------------|--------------------------------|-----------------------------------------------
+  `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`
+  `node.hostname`      | Node hostname                  | `node.hostname!=node-2`
+  `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`
+  `node.platform.os`   | Node operating system          | `node.platform.os==windows`
+  `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`
+  `node.labels`        | User-defined node labels       | `node.labels.security==high`
+  `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`
+
+
+  `engine.labels` apply to Docker Engine labels like operating system, drivers,
+  etc. Swarm administrators add `node.labels` for operational purposes by using
+  the [`docker node update`](node_update.md) command.
+
+  For example, the following limits tasks for the redis service to nodes where the
+  node type label equals queue:
+
+  ```bash
+  $ docker service create \
+    --name redis_2 \
+    --constraint node.platform.os==linux \
+    --constraint node.labels.type==queue \
+    redis:3.0.6
+  ```
+
+  If the service constraints exclude all nodes in the cluster, a message is printed
+  that no suitable node is found, but the scheduler will start a reconciliation
+  loop and deploy the service once a suitable node becomes available.
+
+  In the example below, no node satisfying the constraint was found, causing the
+  service to not reconcile with the desired state:
+
+  ```bash
+  $ docker service create \
+    --name web \
+    --constraint node.labels.region==east \
+    nginx:alpine
+
+  lx1wrhhpmbbu0wuk0ybws30bc
+  overall progress: 0 out of 1 tasks
+  1/1: no suitable node (scheduling constraints not satisfied on 5 nodes)
+
+  $ docker service ls
+  ID                  NAME     MODE         REPLICAS   IMAGE               PORTS
+  b6lww17hrr4e        web      replicated   0/1        nginx:alpine
+  ```
+
+  After adding the `region=east` label to a node in the cluster, the service
+  reconciles, and the desired number of replicas are deployed:
+
+  ```bash
+  $ docker node update --label-add region=east yswe2dm4c5fdgtsrli1e8ya5l
+  yswe2dm4c5fdgtsrli1e8ya5l
+
+  $ docker service ls
+  ID                  NAME     MODE         REPLICAS   IMAGE               PORTS
+  b6lww17hrr4e        web      replicated   1/1        nginx:alpine
+  ```
+
+  ### Specify service placement preferences (--placement-pref)
+
+  You can set up the service to divide tasks evenly over different categories of
+  nodes. One example of where this can be useful is to balance tasks over a set
+  of datacenters or availability zones. The example below illustrates this:
+
+  ```bash
+  $ docker service create \
+    --replicas 9 \
+    --name redis_2 \
+    --placement-pref spread=node.labels.datacenter \
+    redis:3.0.6
+  ```
+
+  This uses `--placement-pref` with a `spread` strategy (currently the only
+  supported strategy) to spread tasks evenly over the values of the `datacenter`
+  node label. In this example, we assume that every node has a `datacenter` node
+  label attached to it. If there are three different values of this label among
+  nodes in the swarm, one third of the tasks will be placed on the nodes
+  associated with each value. This is true even if there are more nodes with one
+  value than another. For example, consider the following set of nodes:
+
+  - Three nodes with `node.labels.datacenter=east`
+  - Two nodes with `node.labels.datacenter=south`
+  - One node with `node.labels.datacenter=west`
+
+  Since we are spreading over the values of the `datacenter` label and the
+  service has 9 replicas, 3 replicas will end up in each datacenter. There are
+  three nodes associated with the value `east`, so each one will get one of the
+  three replicas reserved for this value. There are two nodes with the value
+  `south`, and the three replicas for this value will be divided between them,
+  with one receiving two replicas and another receiving just one. Finally, `west`
+  has a single node that will get all three replicas reserved for `west`.
+
+  If the nodes in one category (for example, those with
+  `node.labels.datacenter=south`) can't handle their fair share of tasks due to
+  constraints or resource limitations, the extra tasks will be assigned to other
+  nodes instead, if possible.
+
+  Both engine labels and node labels are supported by placement preferences. The
+  example above uses a node label, because the label is referenced with
+  `node.labels.datacenter`. To spread over the values of an engine label, use
+  `--placement-pref spread=engine.labels.<labelname>`.
+
+  It is possible to add multiple placement preferences to a service. This
+  establishes a hierarchy of preferences, so that tasks are first divided over
+  one category, and then further divided over additional categories. One example
+  of where this may be useful is dividing tasks fairly between datacenters, and
+  then splitting the tasks within each datacenter over a choice of racks. To add
+  multiple placement preferences, specify the `--placement-pref` flag multiple
+  times. The order is significant, and the placement preferences will be applied
+  in the order given when making scheduling decisions.
+
+  The following example sets up a service with multiple placement preferences.
+  Tasks are spread first over the various datacenters, and then over racks
+  (as indicated by the respective labels):
+
+  ```bash
+  $ docker service create \
+    --replicas 9 \
+    --name redis_2 \
+    --placement-pref 'spread=node.labels.datacenter' \
+    --placement-pref 'spread=node.labels.rack' \
+    redis:3.0.6
+  ```
+
+  When updating a service with `docker service update`, `--placement-pref-add`
+  appends a new placement preference after all existing placement preferences.
+  `--placement-pref-rm` removes an existing placement preference that matches the
+  argument.
+
+  ### Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
+
+  If your service needs a minimum amount of memory in order to run correctly,
+  you can use `--reserve-memory` to specify that the service should only be
+  scheduled on a node with this much memory available to reserve. If no node is
+  available that meets the criteria, the task is not scheduled, but remains in a
+  pending state.
+
+  The following example requires that 4GB of memory be available and reservable
+  on a given node before scheduling the service to run on that node.
+
+  ```bash
+  $ docker service create --reserve-memory=4GB --name=too-big nginx:alpine
+  ```
+
+  The managers won't schedule a set of containers on a single node whose combined
+  reservations exceed the memory available on that node.
+
+  After a task is scheduled and running, `--reserve-memory` does not enforce a
+  memory limit. Use `--limit-memory` to ensure that a task uses no more than a
+  given amount of memory on a node. This example limits the amount of memory used
+  by the task to 4GB. The task will be scheduled even if each of your nodes has
+  only 2GB of memory, because `--limit-memory` is an upper limit.
+
+  ```bash
+  $ docker service create --limit-memory=4GB --name=too-big nginx:alpine
+  ```
+
+  Using `--reserve-memory` and `--limit-memory` does not guarantee that Docker
+  will not use more memory on your host than you want. For instance, you could
+  create many services, the sum of whose memory usage could exhaust the available
+  memory.
+
+  You can prevent this scenario from exhausting the available memory by taking
+  into account other (non-containerized) software running on the host as well. If
+  `--reserve-memory` is greater than or equal to `--limit-memory`, Docker won't
+  schedule a service on a host that doesn't have enough memory. `--limit-memory`
+  will limit the service's memory to stay within that limit, so if every service
+  has a memory-reservation and limit set, Docker services will be less likely to
+  saturate the host. Other non-service containers or applications running directly
+  on the Docker host could still exhaust memory.
+
+  There is a downside to this approach. Reserving memory also means that you may
+  not make optimum use of the memory available on the node. Consider a service
+  that under normal circumstances uses 100MB of memory, but depending on load can
+  "peak" at 500MB. Reserving 500MB for that service (to guarantee can have 500MB
+  for those "peaks") results in 400MB of memory being wasted most of the time.
+
+  In short, you can take a more conservative or more flexible approach:
+
+  - **Conservative**: reserve 500MB, and limit to 500MB. Basically you're now
+    treating the service containers as VMs, and you may be losing a big advantage
+    containers, which is greater density of services per host.
+
+  - **Flexible**: limit to 500MB in the assumption that if the service requires
+    more than 500MB, it is malfunctioning. Reserve something between the 100MB
+    "normal" requirement and the 500MB "peak" requirement". This assumes that when
+    this service is at "peak", other services or non-container workloads probably
+    won't be.
+
+  The approach you take depends heavily on the memory-usage patterns of your
+  workloads. You should test under normal and peak conditions before settling
+  on an approach.
+
+  On Linux, you can also limit a service's overall memory footprint on a given
+  host at the level of the host operating system, using `cgroups` or other
+  relevant operating system tools.
+
+  ### Specify maximum replicas per node (--replicas-max-per-node)
+
+  Use the `--replicas-max-per-node` flag to set the maximum number of replica tasks that can run on a node.
+  The following command creates a nginx service with 2 replica tasks but only one replica task per node.
+
+  One example where this can be useful is to balance tasks over a set of data centers together with `--placement-pref`
+  and let `--replicas-max-per-node` setting make sure that replicas are not migrated to another datacenter during
+  maintenance or datacenter failure.
+
+  The example below illustrates this:
+
+  ```bash
+  $ docker service create \
+    --name nginx \
+    --replicas 2 \
+    --replicas-max-per-node 1 \
+    --placement-pref 'spread=node.labels.datacenter' \
+    nginx
+  ```
+
+  ### Attach a service to an existing network (--network)
+
+  You can use overlay networks to connect one or more services within the swarm.
+
+  First, create an overlay network on a manager node the docker network create
+  command:
+
+  ```bash
+  $ docker network create --driver overlay my-network
+
+  etjpu59cykrptrgw0z0hk5snf
+  ```
+
+  After you create an overlay network in swarm mode, all manager nodes have
+  access to the network.
+
+  When you create a service and pass the `--network` flag to attach the service to
+  the overlay network:
+
+  ```bash
+  $ docker service create \
+    --replicas 3 \
+    --network my-network \
+    --name my-web \
+    nginx
+
+  716thylsndqma81j6kkkb5aus
+  ```
+
+  The swarm extends my-network to each node running the service.
+
+  Containers on the same network can access each other using
+  [service discovery](https://docs.docker.com/engine/swarm/networking/#use-swarm-mode-service-discovery).
+
+  Long form syntax of `--network` allows to specify list of aliases and driver options:
+  `--network name=my-network,alias=web1,driver-opt=field1=value1`
+
+  ### Publish service ports externally to the swarm (-p, --publish)
+
+  You can publish service ports to make them available externally to the swarm
+  using the `--publish` flag. The `--publish` flag can take two different styles
+  of arguments. The short version is positional, and allows you to specify the
+  published port and target port separated by a colon.
+
+  ```bash
+  $ docker service create --name my_web --replicas 3 --publish 8080:80 nginx
+  ```
+
+  There is also a long format, which is easier to read and allows you to specify
+  more options. The long format is preferred. You cannot specify the service's
+  mode when using the short format. Here is an example of using the long format
+  for the same service as above:
+
+  ```bash
+  $ docker service create --name my_web --replicas 3 --publish published=8080,target=80 nginx
+  ```
+
+  The options you can specify are:
+
+  <table>
+  <thead>
+  <tr>
+    <th>Option</th>
+    <th>Short syntax</th>
+    <th>Long syntax</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tr>
+    <td>published and target port</td>
+    <td><tt>--publish 8080:80</tt></td>
+    <td><tt>--publish published=8080,target=80</tt></td>
+    <td><p>
+      The target port within the container and the port to map it to on the
+      nodes, using the routing mesh (<tt>ingress</tt>) or host-level networking.
+      More options are available, later in this table. The key-value syntax is
+      preferred, because it is somewhat self-documenting.
+    </p></td>
+  </tr>
+  <tr>
+    <td>mode</td>
+    <td>Not possible to set using short syntax.</td>
+    <td><tt>--publish published=8080,target=80,mode=host</tt></td>
+    <td><p>
+      The mode to use for binding the port, either <tt>ingress</tt> or <tt>host</tt>.
+      Defaults to <tt>ingress</tt> to use the routing mesh.
+    </p></td>
+  </tr>
+  <tr>
+    <td>protocol</td>
+    <td><tt>--publish 8080:80/tcp</tt></td>
+    <td><tt>--publish published=8080,target=80,protocol=tcp</tt></td>
+    <td><p>
+      The protocol to use, <tt>tcp</tt> , <tt>udp</tt>, or <tt>sctp</tt>. Defaults to
+      <tt>tcp</tt>. To bind a port for both protocols, specify the <tt>-p</tt> or
+      <tt>--publish</tt> flag twice.
+    </p></td>
+  </tr>
+  </table>
+
+  When you publish a service port using `ingress` mode, the swarm routing mesh
+  makes the service accessible at the published port on every node regardless if
+  there is a task for the service running on the node. If you use `host` mode,
+  the port is only bound on nodes where the service is running, and a given port
+  on a node can only be bound once. You can only set the publication mode using
+  the long syntax. For more information refer to
+  [Use swarm mode routing mesh](https://docs.docker.com/engine/swarm/ingress/).
+
+  ### Provide credential specs for managed service accounts (Windows only)
+
+  This option is only used for services using Windows containers. The
+  `--credential-spec` must be in the format `file://<filename>` or
+  `registry://<value-name>`.
+
+  When using the `file://<filename>` format, the referenced file must be
+  present in the `CredentialSpecs` subdirectory in the docker data directory,
+  which defaults to `C:\ProgramData\Docker\` on Windows. For example,
+  specifying `file://spec.json` loads `C:\ProgramData\Docker\CredentialSpecs\spec.json`.
+
+  When using the `registry://<value-name>` format, the credential spec is
+  read from the Windows registry on the daemon's host. The specified
+  registry value must be located in:
+
+      HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Containers\CredentialSpecs
+
+
+  ### Create services using templates
+
+  You can use templates for some flags of `service create`, using the syntax
+  provided by the Go's [text/template](http://golang.org/pkg/text/template/) package.
+
+  The supported flags are the following :
+
+  - `--hostname`
+  - `--mount`
+  - `--env`
+
+  Valid placeholders for the Go template are listed below:
+
+
+  <table>
+    <tr>
+      <th>Placeholder</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><tt>.Service.ID</tt></td>
+      <td>Service ID</td>
+    </tr>
+    <tr>
+      <td><tt>.Service.Name</tt></td>
+      <td>Service name</td>
+    </tr>
+    <tr>
+      <td><tt>.Service.Labels</tt></td>
+      <td>Service labels</td>
+    </tr>
+    <tr>
+      <td><tt>.Node.ID</tt></td>
+      <td>Node ID</td>
+    </tr>
+    <tr>
+      <td><tt>.Node.Hostname</tt></td>
+      <td>Node Hostname</td>
+    </tr>
+    <tr>
+      <td><tt>.Task.ID</tt></td>
+      <td>Task ID</td>
+    </tr>
+    <tr>
+      <td><tt>.Task.Name</tt></td>
+      <td>Task name</td>
+    </tr>
+    <tr>
+      <td><tt>.Task.Slot</tt></td>
+      <td>Task slot</td>
+    </tr>
+  </table>
+
+
+  #### Template example
+
+  In this example, we are going to set the template of the created containers based on the
+  service's name, the node's ID and hostname where it sits.
+
+  ```bash
+  $ docker service create --name hosttempl \
+                          --hostname="{{.Node.Hostname}}-{{.Node.ID}}-{{.Service.Name}}"\
+                           busybox top
+
+  va8ew30grofhjoychbr6iot8c
+
+  $ docker service ps va8ew30grofhjoychbr6iot8c
+
+  ID            NAME         IMAGE                                                                                   NODE          DESIRED STATE  CURRENT STATE               ERROR  PORTS
+  wo41w8hg8qan  hosttempl.1  busybox:latest@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912  2e7a8a9c4da2  Running        Running about a minute ago
+
+  $ docker inspect --format="{{.Config.Hostname}}" 2e7a8a9c4da2-wo41w8hg8qanxwjwsg4kxpprj-hosttempl
+
+  x3ti0erg11rjpg64m75kej2mz-hosttempl
+  ```
+
+  ### Specify isolation mode (Windows)
+
+  By default, tasks scheduled on Windows nodes are run using the default isolation mode
+  configured for this particular node. To force a specific isolation mode, you can use
+  the `--isolation` flag:
+
+  ```bash
+  $ docker service create --name myservice --isolation=process microsoft/nanoserver
+  ```
+
+  Supported isolation modes on Windows are:
+  - `default`: use default settings specified on the node running the task
+  - `process`: use process isolation (Windows server only)
+  - `hyperv`: use Hyper-V isolation
+
+  ### Create services requesting Generic Resources
+
+  You can narrow the kind of nodes your task can land on through the using the
+  `--generic-resource` flag (if the nodes advertise these resources):
+
+  ```bash
+  $ docker service create --name cuda \
+                          --generic-resource "NVIDIA-GPU=2" \
+                          --generic-resource "SSD=1" \
+                          nvidia/cuda
+  ```
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_service_inspect.yaml
+++ b/_data/engine-cli/docker_service_inspect.yaml
@@ -34,37 +34,125 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Inspect a service by name or ID\n\nYou can inspect a service, either
-  by its *name*, or *ID*\n\nFor example, given the following service;\n\n```bash\n$
-  docker service ls\nID            NAME   MODE        REPLICAS  IMAGE\ndmu1ept4cxcf
-  \ redis  replicated  3/3       redis:3.0.6\n```\n\nBoth `docker service inspect
-  redis`, and `docker service inspect dmu1ept4cxcf`\nproduce the same result:\n\n```none\n$
-  docker service inspect redis\n\n[\n    {\n        \"ID\": \"dmu1ept4cxcfe8k8lhtux3ro3\",\n
-  \       \"Version\": {\n            \"Index\": 12\n        },\n        \"CreatedAt\":
-  \"2016-06-17T18:44:02.558012087Z\",\n        \"UpdatedAt\": \"2016-06-17T18:44:02.558012087Z\",\n
-  \       \"Spec\": {\n            \"Name\": \"redis\",\n            \"TaskTemplate\":
-  {\n                \"ContainerSpec\": {\n                    \"Image\": \"redis:3.0.6\"\n
-  \               },\n                \"Resources\": {\n                    \"Limits\":
-  {},\n                    \"Reservations\": {}\n                },\n                \"RestartPolicy\":
-  {\n                    \"Condition\": \"any\",\n                    \"MaxAttempts\":
-  0\n                },\n                \"Placement\": {}\n            },\n            \"Mode\":
-  {\n                \"Replicated\": {\n                    \"Replicas\": 1\n                }\n
-  \           },\n            \"UpdateConfig\": {},\n            \"EndpointSpec\":
-  {\n                \"Mode\": \"vip\"\n            }\n        },\n        \"Endpoint\":
-  {\n            \"Spec\": {}\n        }\n    }\n]\n```\n\n```bash\n$ docker service
-  inspect dmu1ept4cxcf\n\n[\n    {\n        \"ID\": \"dmu1ept4cxcfe8k8lhtux3ro3\",\n
-  \       \"Version\": {\n            \"Index\": 12\n        },\n        ...\n    }\n]\n```\n\n###
-  Formatting\n\nYou can print the inspect output in a human-readable format instead
-  of the default\nJSON output, by using the `--pretty` option:\n\n```bash\n$ docker
-  service inspect --pretty frontend\n\nID:\t\tc8wgl7q4ndfd52ni6qftkvnnp\nName:\t\tfrontend\nLabels:\n
-  - org.example.projectname=demo-app\nService Mode:\tREPLICATED\n Replicas:\t\t5\nPlacement:\nUpdateConfig:\n
-  Parallelism:\t0\n On failure:\tpause\n Max failure ratio:\t0\nContainerSpec:\n Image:\t\tnginx:alpine\nResources:\nNetworks:\tnet1\nEndpoint
-  Mode:  vip\nPorts:\n PublishedPort = 4443\n  Protocol = tcp\n  TargetPort = 443\n
-  \ PublishMode = ingress\n```\n\nYou can also use `--format pretty` for the same
-  effect.\n\n\n#### Find the number of tasks running as part of a service\n\nThe `--format`
-  option can be used to obtain specific information about a\nservice. For example,
-  the following command outputs the number of replicas\nof the \"redis\" service.\n\n```bash\n$
-  docker service inspect --format='{{.Spec.Mode.Replicated.Replicas}}' redis\n\n10\n```"
+examples: |-
+  ### Inspect a service by name or ID
+
+  You can inspect a service, either by its *name*, or *ID*
+
+  For example, given the following service;
+
+  ```bash
+  $ docker service ls
+  ID            NAME   MODE        REPLICAS  IMAGE
+  dmu1ept4cxcf  redis  replicated  3/3       redis:3.0.6
+  ```
+
+  Both `docker service inspect redis`, and `docker service inspect dmu1ept4cxcf`
+  produce the same result:
+
+  ```none
+  $ docker service inspect redis
+
+  [
+      {
+          "ID": "dmu1ept4cxcfe8k8lhtux3ro3",
+          "Version": {
+              "Index": 12
+          },
+          "CreatedAt": "2016-06-17T18:44:02.558012087Z",
+          "UpdatedAt": "2016-06-17T18:44:02.558012087Z",
+          "Spec": {
+              "Name": "redis",
+              "TaskTemplate": {
+                  "ContainerSpec": {
+                      "Image": "redis:3.0.6"
+                  },
+                  "Resources": {
+                      "Limits": {},
+                      "Reservations": {}
+                  },
+                  "RestartPolicy": {
+                      "Condition": "any",
+                      "MaxAttempts": 0
+                  },
+                  "Placement": {}
+              },
+              "Mode": {
+                  "Replicated": {
+                      "Replicas": 1
+                  }
+              },
+              "UpdateConfig": {},
+              "EndpointSpec": {
+                  "Mode": "vip"
+              }
+          },
+          "Endpoint": {
+              "Spec": {}
+          }
+      }
+  ]
+  ```
+
+  ```bash
+  $ docker service inspect dmu1ept4cxcf
+
+  [
+      {
+          "ID": "dmu1ept4cxcfe8k8lhtux3ro3",
+          "Version": {
+              "Index": 12
+          },
+          ...
+      }
+  ]
+  ```
+
+  ### Formatting
+
+  You can print the inspect output in a human-readable format instead of the default
+  JSON output, by using the `--pretty` option:
+
+  ```bash
+  $ docker service inspect --pretty frontend
+
+  ID:     c8wgl7q4ndfd52ni6qftkvnnp
+  Name:   frontend
+  Labels:
+   - org.example.projectname=demo-app
+  Service Mode:   REPLICATED
+   Replicas:      5
+  Placement:
+  UpdateConfig:
+   Parallelism:   0
+   On failure:    pause
+   Max failure ratio: 0
+  ContainerSpec:
+   Image:     nginx:alpine
+  Resources:
+  Networks:   net1
+  Endpoint Mode:  vip
+  Ports:
+   PublishedPort = 4443
+    Protocol = tcp
+    TargetPort = 443
+    PublishMode = ingress
+  ```
+
+  You can also use `--format pretty` for the same effect.
+
+
+  #### Find the number of tasks running as part of a service
+
+  The `--format` option can be used to obtain specific information about a
+  service. For example, the following command outputs the number of replicas
+  of the "redis" service.
+
+  ```bash
+  $ docker service inspect --format='{{.Spec.Mode.Replicated.Replicas}}' redis
+
+  10
+  ```
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_swarm_init.yaml
+++ b/_data/engine-cli/docker_swarm_init.yaml
@@ -148,77 +148,153 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "```bash\n$ docker swarm init --advertise-addr 192.168.99.121\nSwarm initialized:
-  current node (bvz81updecsj6wjz393c09vti) is now a manager.\n\nTo add a worker to
-  this swarm, run the following command:\n\n    docker swarm join \\\n    --token
-  SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx
-  \\\n    172.17.0.2:2377\n\nTo add a manager to this swarm, run 'docker swarm join-token
-  manager' and follow the instructions.\n```\n\n`docker swarm init` generates two
-  random tokens, a worker token and a manager token. When you join\na new node to
-  the swarm, the node joins as a worker or manager node based upon the token you pass\nto
-  [swarm join](swarm_join.md).\n\nAfter you create the swarm, you can display or rotate
-  the token using\n[swarm join-token](swarm_join_token.md).\n\n### `--autolock`\n\nThis
-  flag enables automatic locking of managers with an encryption key. The\nprivate
-  keys and data stored by all managers will be protected by the\nencryption key printed
-  in the output, and will not be accessible without it.\nThus, it is very important
-  to store this key in order to activate a manager\nafter it restarts. The key can
-  be passed to `docker swarm unlock` to reactivate\nthe manager. Autolock can be disabled
-  by running\n`docker swarm update --autolock=false`. After disabling it, the encryption
-  key\nis no longer required to start the manager, and it will start up on its own\nwithout
-  user intervention.\n\n### `--cert-expiry`\n\nThis flag sets the validity period
-  for node certificates.\n\n### `--dispatcher-heartbeat`\n\nThis flag sets the frequency
-  with which nodes are told to use as a\nperiod to report their health.\n\n### `--external-ca`\n\nThis
-  flag sets up the swarm to use an external CA to issue node certificates. The value
-  takes\nthe form `protocol=X,url=Y`. The value for `protocol` specifies what protocol
-  should be used\nto send signing requests to the external CA. Currently, the only
-  supported value is `cfssl`.\nThe URL specifies the endpoint where signing requests
-  should be submitted.\n\n### `--force-new-cluster`\n\nThis flag forces an existing
-  node that was part of a quorum that was lost to restart as a single node Manager
-  without losing its data.\n\n### `--listen-addr`\n\nThe node listens for inbound
-  swarm manager traffic on this address. The default is to listen on\n0.0.0.0:2377.
-  It is also possible to specify a network interface to listen on that interface's\naddress;
-  for example `--listen-addr eth0:2377`.\n\nSpecifying a port is optional. If the
-  value is a bare IP address or interface\nname, the default port 2377 will be used.\n\n###
-  `--advertise-addr`\n\nThis flag specifies the address that will be advertised to
-  other members of the\nswarm for API access and overlay networking. If unspecified,
-  Docker will check\nif the system has a single IP address, and use that IP address
-  with the\nlistening port (see `--listen-addr`). If the system has multiple IP addresses,\n`--advertise-addr`
-  must be specified so that the correct address is chosen for\ninter-manager communication
-  and overlay networking.\n\nIt is also possible to specify a network interface to
-  advertise that interface's address;\nfor example `--advertise-addr eth0:2377`.\n\nSpecifying
-  a port is optional. If the value is a bare IP address or interface\nname, the default
-  port 2377 will be used.\n\n### `--data-path-addr`\n\nThis flag specifies the address
-  that global scope network drivers will publish towards\nother nodes in order to
-  reach the containers running on this node.\nUsing this parameter it is then possible
-  to separate the container's data traffic from the\nmanagement traffic of the cluster.\nIf
-  unspecified, Docker will use the same IP address or interface that is used for the\nadvertise
-  address.\n\n### `--data-path-port`\n\nThis flag allows you to configure the UDP
-  port number to use for data path\ntraffic. The provided port number must be within
-  the 1024 - 49151 range. If\nthis flag is not set or is set to 0, the default port
-  number 4789 is used.\nThe data path port can only be configured when initializing
-  the swarm, and\napplies to all nodes that join the swarm.\nThe following example
-  initializes a new Swarm, and configures the data path\nport to UDP port 7777;\n\n```bash\ndocker
-  swarm init --data-path-port=7777\n```\nAfter the swarm is initialized, use the `docker
-  info` command to verify that\nthe port is configured:\n\n```bash\ndocker info\n\t...\n\tClusterID:
-  9vs5ygs0gguyyec4iqf2314c0\n\tManagers: 1\n\tNodes: 1\n\tData Path Port: 7777\n\t...\n```\n\n###
-  `--default-addr-pool`\nThis flag specifies default subnet pools for global scope
-  networks.\nFormat example is `--default-addr-pool 30.30.0.0/16 --default-addr-pool
-  40.40.0.0/16`\n\n### `--default-addr-pool-mask-length`\nThis flag specifies default
-  subnet pools mask length for default-addr-pool.\nFormat example is `--default-addr-pool-mask-length
-  24`\n\n### `--task-history-limit`\n\nThis flag sets up task history retention limit.\n\n###
-  `--max-snapshots`\n\nThis flag sets the number of old Raft snapshots to retain in
-  addition to the\ncurrent Raft snapshots. By default, no old snapshots are retained.
-  This option\nmay be used for debugging, or to store old snapshots of the swarm state
-  for\ndisaster recovery purposes.\n\n### `--snapshot-interval`\n\nThis flag specifies
-  how many log entries to allow in between Raft snapshots.\nSetting this to a higher
-  number will trigger snapshots less frequently.\nSnapshots compact the Raft log and
-  allow for more efficient transfer of the\nstate to new managers. However, there
-  is a performance cost to taking snapshots\nfrequently.\n\n### `--availability`\n\nThis
-  flag specifies the availability of the node at the time the node joins a master.\nPossible
-  availability values are `active`, `pause`, or `drain`.\n\nThis flag is useful in
-  certain situations. For example, a cluster may want to have\ndedicated manager nodes
-  that are not served as worker nodes. This could be achieved\nby passing `--availability=drain`
-  to `docker swarm init`."
+examples: |-
+  ```bash
+  $ docker swarm init --advertise-addr 192.168.99.121
+  Swarm initialized: current node (bvz81updecsj6wjz393c09vti) is now a manager.
+
+  To add a worker to this swarm, run the following command:
+
+      docker swarm join \
+      --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx \
+      172.17.0.2:2377
+
+  To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
+  ```
+
+  `docker swarm init` generates two random tokens, a worker token and a manager token. When you join
+  a new node to the swarm, the node joins as a worker or manager node based upon the token you pass
+  to [swarm join](swarm_join.md).
+
+  After you create the swarm, you can display or rotate the token using
+  [swarm join-token](swarm_join_token.md).
+
+  ### `--autolock`
+
+  This flag enables automatic locking of managers with an encryption key. The
+  private keys and data stored by all managers will be protected by the
+  encryption key printed in the output, and will not be accessible without it.
+  Thus, it is very important to store this key in order to activate a manager
+  after it restarts. The key can be passed to `docker swarm unlock` to reactivate
+  the manager. Autolock can be disabled by running
+  `docker swarm update --autolock=false`. After disabling it, the encryption key
+  is no longer required to start the manager, and it will start up on its own
+  without user intervention.
+
+  ### `--cert-expiry`
+
+  This flag sets the validity period for node certificates.
+
+  ### `--dispatcher-heartbeat`
+
+  This flag sets the frequency with which nodes are told to use as a
+  period to report their health.
+
+  ### `--external-ca`
+
+  This flag sets up the swarm to use an external CA to issue node certificates. The value takes
+  the form `protocol=X,url=Y`. The value for `protocol` specifies what protocol should be used
+  to send signing requests to the external CA. Currently, the only supported value is `cfssl`.
+  The URL specifies the endpoint where signing requests should be submitted.
+
+  ### `--force-new-cluster`
+
+  This flag forces an existing node that was part of a quorum that was lost to restart as a single node Manager without losing its data.
+
+  ### `--listen-addr`
+
+  The node listens for inbound swarm manager traffic on this address. The default is to listen on
+  0.0.0.0:2377. It is also possible to specify a network interface to listen on that interface's
+  address; for example `--listen-addr eth0:2377`.
+
+  Specifying a port is optional. If the value is a bare IP address or interface
+  name, the default port 2377 will be used.
+
+  ### `--advertise-addr`
+
+  This flag specifies the address that will be advertised to other members of the
+  swarm for API access and overlay networking. If unspecified, Docker will check
+  if the system has a single IP address, and use that IP address with the
+  listening port (see `--listen-addr`). If the system has multiple IP addresses,
+  `--advertise-addr` must be specified so that the correct address is chosen for
+  inter-manager communication and overlay networking.
+
+  It is also possible to specify a network interface to advertise that interface's address;
+  for example `--advertise-addr eth0:2377`.
+
+  Specifying a port is optional. If the value is a bare IP address or interface
+  name, the default port 2377 will be used.
+
+  ### `--data-path-addr`
+
+  This flag specifies the address that global scope network drivers will publish towards
+  other nodes in order to reach the containers running on this node.
+  Using this parameter it is then possible to separate the container's data traffic from the
+  management traffic of the cluster.
+  If unspecified, Docker will use the same IP address or interface that is used for the
+  advertise address.
+
+  ### `--data-path-port`
+
+  This flag allows you to configure the UDP port number to use for data path
+  traffic. The provided port number must be within the 1024 - 49151 range. If
+  this flag is not set or is set to 0, the default port number 4789 is used.
+  The data path port can only be configured when initializing the swarm, and
+  applies to all nodes that join the swarm.
+  The following example initializes a new Swarm, and configures the data path
+  port to UDP port 7777;
+
+  ```bash
+  docker swarm init --data-path-port=7777
+  ```
+  After the swarm is initialized, use the `docker info` command to verify that
+  the port is configured:
+
+  ```bash
+  docker info
+  ...
+  ClusterID: 9vs5ygs0gguyyec4iqf2314c0
+  Managers: 1
+  Nodes: 1
+  Data Path Port: 7777
+  ...
+  ```
+
+  ### `--default-addr-pool`
+  This flag specifies default subnet pools for global scope networks.
+  Format example is `--default-addr-pool 30.30.0.0/16 --default-addr-pool 40.40.0.0/16`
+
+  ### `--default-addr-pool-mask-length`
+  This flag specifies default subnet pools mask length for default-addr-pool.
+  Format example is `--default-addr-pool-mask-length 24`
+
+  ### `--task-history-limit`
+
+  This flag sets up task history retention limit.
+
+  ### `--max-snapshots`
+
+  This flag sets the number of old Raft snapshots to retain in addition to the
+  current Raft snapshots. By default, no old snapshots are retained. This option
+  may be used for debugging, or to store old snapshots of the swarm state for
+  disaster recovery purposes.
+
+  ### `--snapshot-interval`
+
+  This flag specifies how many log entries to allow in between Raft snapshots.
+  Setting this to a higher number will trigger snapshots less frequently.
+  Snapshots compact the Raft log and allow for more efficient transfer of the
+  state to new managers. However, there is a performance cost to taking snapshots
+  frequently.
+
+  ### `--availability`
+
+  This flag specifies the availability of the node at the time the node joins a master.
+  Possible availability values are `active`, `pause`, or `drain`.
+
+  This flag is useful in certain situations. For example, a cluster may want to have
+  dedicated manager nodes that are not served as worker nodes. This could be achieved
+  by passing `--availability=drain` to `docker swarm init`.
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_swarm_join-token.yaml
+++ b/_data/engine-cli/docker_swarm_join-token.yaml
@@ -1,6 +1,15 @@
 command: docker swarm join-token
 short: Manage join tokens
-long: Manage join tokens
+long: |-
+  Join tokens are secrets that allow a node to join the swarm. There are two
+  different join tokens available, one for the worker role and one for the manager
+  role. You pass the token using the `--token` flag when you run
+  [swarm join](swarm_join.md). Nodes use the join token only when they join the
+  swarm.
+
+  > **Note**: This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the [Swarm mode
+  > section](https://docs.docker.com/engine/swarm/) in the documentation.
 usage: docker swarm join-token [OPTIONS] (worker|manager)
 pname: docker swarm
 plink: docker_swarm.yaml
@@ -24,6 +33,74 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  You can view or rotate the join tokens using `swarm join-token`.
+
+  As a convenience, you can pass `worker` or `manager` as an argument to
+  `join-token` to print the full `docker swarm join` command to join a new node to
+  the swarm:
+
+  ```bash
+  $ docker swarm join-token worker
+  To add a worker to this swarm, run the following command:
+
+      docker swarm join \
+      --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx \
+      172.17.0.2:2377
+
+  $ docker swarm join-token manager
+  To add a manager to this swarm, run the following command:
+
+      docker swarm join \
+      --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2 \
+      172.17.0.2:2377
+  ```
+
+  Use the `--rotate` flag to generate a new join token for the specified role:
+
+  ```bash
+  $ docker swarm join-token --rotate worker
+  Successfully rotated worker join token.
+
+  To add a worker to this swarm, run the following command:
+
+      docker swarm join \
+      --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-b30ljddcqhef9b9v4rs7mel7t \
+      172.17.0.2:2377
+  ```
+
+  After using `--rotate`, only the new token will be valid for joining with the specified role.
+
+  The `-q` (or `--quiet`) flag only prints the token:
+
+  ```bash
+  $ docker swarm join-token -q worker
+
+  SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-b30ljddcqhef9b9v4rs7mel7t
+  ```
+
+  ### `--rotate`
+
+  Because tokens allow new nodes to join the swarm, you should keep them secret.
+  Be particularly careful with manager tokens since they allow new manager nodes
+  to join the swarm. A rogue manager has the potential to disrupt the operation of
+  your swarm.
+
+  Rotate your swarm's join token if a token gets checked-in to version control,
+  stolen, or a node is compromised. You may also want to periodically rotate the
+  token to ensure any unknown token leaks do not allow a rogue node to join
+  the swarm.
+
+  To rotate the join token and print the newly generated token, run
+  `docker swarm join-token --rotate` and pass the role: `manager` or `worker`.
+
+  Rotating a join-token means that no new nodes will be able to join the swarm
+  using the old token. Rotation does not affect existing nodes in the swarm
+  because the join token is only used for authorizing new nodes joining the swarm.
+
+  ### `--quiet`
+
+  Only print the token. Do not print a complete command for joining.
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_swarm_unlock-key.yaml
+++ b/_data/engine-cli/docker_swarm_unlock-key.yaml
@@ -1,6 +1,16 @@
 command: docker swarm unlock-key
 short: Manage the unlock key
-long: Manage the unlock key
+long: |-
+  An unlock key is a secret key needed to unlock a manager after its Docker daemon
+  restarts. These keys are only used when the autolock feature is enabled for the
+  swarm.
+
+  You can view or rotate the unlock key using `swarm unlock-key`. To view the key,
+  run the `docker swarm unlock-key` command without any arguments:
+
+  > **Note**: This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the [Swarm mode
+  > section](https://docs.docker.com/engine/swarm/) in the documentation.
 usage: docker swarm unlock-key [OPTIONS]
 pname: docker swarm
 plink: docker_swarm.yaml
@@ -24,6 +34,50 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  ```bash
+  $ docker swarm unlock-key
+
+  To unlock a swarm manager after it restarts, run the `docker swarm unlock`
+  command and provide the following key:
+
+      SWMKEY-1-fySn8TY4w5lKcWcJPIpKufejh9hxx5KYwx6XZigx3Q4
+
+  Please remember to store this key in a password manager, since without it you
+  will not be able to restart the manager.
+  ```
+
+  Use the `--rotate` flag to rotate the unlock key to a new, randomly-generated
+  key:
+
+  ```bash
+  $ docker swarm unlock-key --rotate
+  Successfully rotated manager unlock key.
+
+  To unlock a swarm manager after it restarts, run the `docker swarm unlock`
+  command and provide the following key:
+
+      SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8
+
+  Please remember to store this key in a password manager, since without it you
+  will not be able to restart the manager.
+  ```
+
+  The `-q` (or `--quiet`) flag only prints the key:
+
+  ```bash
+  $ docker swarm unlock-key -q
+  SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8
+  ```
+
+  ### `--rotate`
+
+  This flag rotates the unlock key, replacing it with a new randomly-generated
+  key. The old unlock key will no longer be accepted.
+
+  ### `--quiet`
+
+  Only print the unlock key, without instructions.
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_trust_inspect.yaml
+++ b/_data/engine-cli/docker_trust_inspect.yaml
@@ -17,154 +17,442 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Get low-level details about signatures for a single image tag\n\nUse
-  the `docker trust inspect` to get trust information about an image. The\nfollowing
-  example prints trust information for the `alpine:latest` image:\n\n```bash\n$ docker
-  trust inspect alpine:latest\n[\n  {\n    \"Name\": \"alpine:latest\",\n    \"SignedTags\":
-  [\n      {\n        \"SignedTag\": \"latest\",\n        \"Digest\": \"d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478\",\n
-  \       \"Signers\": [\n          \"Repo Admin\"\n        ]\n      }\n    ],\n    \"Signers\":
-  [],\n    \"AdministrativeKeys\": [\n      {\n        \"Name\": \"Repository\",\n
-  \       \"Keys\": [\n            {\n                \"ID\": \"5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd\"\n
-  \           }\n        ]\n      },\n      {\n        \"Name\": \"Root\",\n        \"Keys\":
-  [\n            {\n                \"ID\": \"a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce\"\n
-  \           }\n        ]\n      }\n    ]\n  }\n]\n```\n\nThe `SignedTags` key will
-  list the `SignedTag` name, its `Digest`,\nand the `Signers` responsible for the
-  signature.\n\n`AdministrativeKeys` will list the `Repository` and `Root` keys.\n\nIf
-  signers are set up for the repository via other `docker trust`\ncommands, `docker
-  trust inspect` includes a `Signers` key:\n\n```bash\n$ docker trust inspect my-image:purple\n[\n
-  \ {\n    \"Name\": \"my-image:purple\",\n    \"SignedTags\": [\n      {\n        \"SignedTag\":
-  \"purple\",\n        \"Digest\": \"941d3dba358621ce3c41ef67b47cf80f701ff80cdf46b5cc86587eaebfe45557\",\n
-  \       \"Signers\": [\n          \"alice\",\n          \"bob\",\n          \"carol\"\n
-  \       ]\n      }\n    ],\n    \"Signers\": [\n      {\n        \"Name\": \"alice\",\n
-  \       \"Keys\": [\n            {\n                \"ID\": \"04dd031411ed671ae1e12f47ddc8646d98f135090b01e54c3561e843084484a3\"\n
-  \           },\n            {\n                \"ID\": \"6a11e4898a4014d400332ab0e096308c844584ff70943cdd1d6628d577f45fd8\"\n
-  \           }\n        ]\n      },\n      {\n        \"Name\": \"bob\",\n        \"Keys\":
-  [\n            {\n                \"ID\": \"433e245c656ae9733cdcc504bfa560f90950104442c4528c9616daa45824ccba\"\n
-  \           }\n        ]\n      },\n      {\n        \"Name\": \"carol\",\n        \"Keys\":
-  [\n            {\n                \"ID\": \"d32fa8b5ca08273a2880f455fcb318da3dc80aeae1a30610815140deef8f30d9\"\n
-  \           },\n            {\n                \"ID\": \"9a8bbec6ba2af88a5fad6047d428d17e6d05dbdd03d15b4fc8a9a0e8049cd606\"\n
-  \           }\n        ]\n      }\n    ],\n    \"AdministrativeKeys\": [\n      {\n
-  \       \"Name\": \"Repository\",\n        \"Keys\": [\n            {\n                \"ID\":
-  \"27df2c8187e7543345c2e0bf3a1262e0bc63a72754e9a7395eac3f747ec23a44\"\n            }\n
-  \       ]\n      },\n      {\n        \"Name\": \"Root\",\n        \"Keys\": [\n
-  \           {\n                \"ID\": \"40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f\"\n
-  \           }\n        ]\n      }\n    ]\n  }\n]\n```\n\nIf the image tag is unsigned
-  or unavailable, `docker trust inspect` does not\ndisplay any signed tags.\n\n```bash\n$
-  docker trust inspect unsigned-img\nNo signatures or cannot access unsigned-img\n```\n\nHowever,
-  if other tags are signed in the same image repository,\n`docker trust inspect` reports
-  relevant key information:\n\n```bash\n$ docker trust inspect alpine:unsigned\n[\n
-  \ {\n    \"Name\": \"alpine:unsigned\",\n    \"Signers\": [],\n    \"AdministrativeKeys\":
-  [\n      {\n        \"Name\": \"Repository\",\n        \"Keys\": [\n            {\n
-  \               \"ID\": \"5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd\"\n
-  \           }\n        ]\n      },\n      {\n        \"Name\": \"Root\",\n        \"Keys\":
-  [\n            {\n                \"ID\": \"a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce\"\n
-  \           }\n        ]\n      }\n    ]\n  }\n]\n```\n\n### Get details about signatures
-  for all image tags in a repository\n\nIf no tag is specified, `docker trust inspect`
-  will report details for all\nsigned tags in the repository:\n\n```bash\n$ docker
-  trust inspect alpine\n[\n    {\n        \"Name\": \"alpine\",\n        \"SignedTags\":
-  [\n            {\n                \"SignedTag\": \"3.5\",\n                \"Digest\":
-  \"b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c\",\n                \"Signers\":
-  [\n                    \"Repo Admin\"\n                ]\n            },\n            {\n
-  \               \"SignedTag\": \"3.6\",\n                \"Digest\": \"d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478\",\n
-  \               \"Signers\": [\n                    \"Repo Admin\"\n                ]\n
-  \           },\n            {\n                \"SignedTag\": \"edge\",\n                \"Digest\":
-  \"23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096\",\n                \"Signers\":
-  [\n                    \"Repo Admin\"\n                ]\n            },\n            {\n
-  \               \"SignedTag\": \"latest\",\n                \"Digest\": \"d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478\",\n
-  \               \"Signers\": [\n                    \"Repo Admin\"\n                ]\n
-  \           }\n        ],\n        \"Signers\": [],\n        \"AdministrativeKeys\":
-  [\n            {\n                \"Name\": \"Repository\",\n                \"Keys\":
-  [\n                    {\n                        \"ID\": \"5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd\"\n
-  \                   }\n                ]\n            },\n            {\n                \"Name\":
-  \"Root\",\n                \"Keys\": [\n                    {\n                        \"ID\":
-  \"a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce\"\n                    }\n
-  \               ]\n            }\n        ]\n    }\n]\n```\n\n\n### Get details
-  about signatures for multiple images\n\n`docker trust inspect` can take multiple
-  repositories and images as arguments,\nand reports the results in an ordered list:\n\n```bash\n$
-  docker trust inspect alpine notary\n[\n    {\n        \"Name\": \"alpine\",\n        \"SignedTags\":
-  [\n            {\n                \"SignedTag\": \"3.5\",\n                \"Digest\":
-  \"b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c\",\n                \"Signers\":
-  [\n                    \"Repo Admin\"\n                ]\n            },\n            {\n
-  \               \"SignedTag\": \"3.6\",\n                \"Digest\": \"d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478\",\n
-  \               \"Signers\": [\n                    \"Repo Admin\"\n                ]\n
-  \           },\n            {\n                \"SignedTag\": \"edge\",\n                \"Digest\":
-  \"23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096\",\n                \"Signers\":
-  [\n                    \"Repo Admin\"\n                ]\n            },\n            {\n
-  \               \"SignedTag\": \"integ-test-base\",\n                \"Digest\":
-  \"3952dc48dcc4136ccdde37fbef7e250346538a55a0366e3fccc683336377e372\",\n                \"Signers\":
-  [\n                    \"Repo Admin\"\n                ]\n            },\n            {\n
-  \               \"SignedTag\": \"latest\",\n                \"Digest\": \"d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478\",\n
-  \               \"Signers\": [\n                    \"Repo Admin\"\n                ]\n
-  \           }\n        ],\n        \"Signers\": [],\n        \"AdministrativeKeys\":
-  [\n            {\n                \"Name\": \"Repository\",\n                \"Keys\":
-  [\n                    {\n                        \"ID\": \"5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd\"\n
-  \                   }\n                ]\n            },\n            {\n                \"Name\":
-  \"Root\",\n                \"Keys\": [\n                    {\n                        \"ID\":
-  \"a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce\"\n                    }\n
-  \               ]\n            }\n        ]\n    },\n    {\n        \"Name\": \"notary\",\n
-  \       \"SignedTags\": [\n            {\n                \"SignedTag\": \"server\",\n
-  \               \"Digest\": \"71f64ab718a3331dee103bc5afc6bc492914738ce37c2d2f127a8133714ecf5c\",\n
-  \               \"Signers\": [\n                    \"Repo Admin\"\n                ]\n
-  \           },\n            {\n                \"SignedTag\": \"signer\",\n                \"Digest\":
-  \"a6122d79b1e74f70b5dd933b18a6d1f99329a4728011079f06b245205f158fe8\",\n                \"Signers\":
-  [\n                    \"Repo Admin\"\n                ]\n            }\n        ],\n
-  \       \"Signers\": [],\n        \"AdministrativeKeys\": [\n            {\n                \"Name\":
-  \"Root\",\n                \"Keys\": [\n                    {\n                        \"ID\":
-  \"8cdcdef5bd039f4ab5a029126951b5985eebf57cabdcdc4d21f5b3be8bb4ce92\"\n                    }\n
-  \               ]\n            },\n            {\n                \"Name\": \"Repository\",\n
-  \               \"Keys\": [\n                    {\n                        \"ID\":
-  \"85bfd031017722f950d480a721f845a2944db26a3dc084040a70f1b0d9bbb3df\"\n                    }\n
-  \               ]\n            }\n        ]\n    }\n]\n```\n\n### Formatting\n\nYou
-  can print the inspect output in a human-readable format instead of the default\nJSON
-  output, by using the `--pretty` option:\n\n### Get details about signatures for
-  a single image tag\n\n```bash\n$ docker trust inspect --pretty alpine:latest\n\nSIGNED
-  TAG          DIGEST                                                             SIGNERS\nlatest
-  \             1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe   (Repo
-  Admin)\n\nAdministrative keys for alpine:latest:\nRepository Key:\t5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd\nRoot
-  Key:\ta2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce\n```\n\nThe
-  `SIGNED TAG` is the signed image tag with a unique content-addressable\n`DIGEST`.
-  `SIGNERS` lists all entities who have signed.\n\nThe administrative keys listed
-  specify the root key of trust, as well as\nthe administrative repository key. These
-  keys are responsible for modifying\nsigners, and rotating keys for the signed repository.\n\nIf
-  signers are set up for the repository via other `docker trust` commands,\n`docker
-  trust inspect --pretty` displays them appropriately as a `SIGNER`\nand specify their
-  `KEYS`:\n\n```bash\n$ docker trust inspect --pretty my-image:purple\nSIGNED TAG
-  \         DIGEST                                                              SIGNERS\npurple
-  \             941d3dba358621ce3c41ef67b47cf80f701ff80cdf46b5cc86587eaebfe45557    alice,
-  bob, carol\n\nList of signers and their keys:\n\nSIGNER              KEYS\nalice
-  \              47caae5b3e61, a85aab9d20a4\nbob                 034370bcbd77, 82a66673242c\ncarol
-  \              b6f9f8e1aab0\n\nAdministrative keys for my-image:\nRepository Key:\t27df2c8187e7543345c2e0bf3a1262e0bc63a72754e9a7395eac3f747ec23a44\nRoot
-  Key:\t40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f\n```\n\nHowever,
-  if other tags are signed in the same image repository,\n`docker trust inspect` reports
-  relevant key information.\n\n```bash\n$ docker trust inspect --pretty alpine:unsigned\n\nNo
-  signatures for alpine:unsigned\n\n\nAdministrative keys for alpine:unsigned:\nRepository
-  Key:\t5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd\nRoot Key:\ta2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce\n```\n\n###
-  Get details about signatures for all image tags in a repository\n\n```bash\n$ docker
-  trust inspect --pretty alpine\nSIGNED TAG          DIGEST                                                             SIGNERS\n2.6
-  \                9ace551613070689a12857d62c30ef0daa9a376107ec0fff0e34786cedb3399b
-  \  (Repo Admin)\n2.7                 9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a
-  \  (Repo Admin)\n3.1                 d9477888b78e8c6392e0be8b2e73f8c67e2894ff9d4b8e467d1488fcceec21c8
-  \  (Repo Admin)\n3.2                 19826d59171c2eb7e90ce52bfd822993bef6a6fe3ae6bb4a49f8c1d0a01e99c7
-  \  (Repo Admin)\n3.3                 8fd4b76819e1e5baac82bd0a3d03abfe3906e034cc5ee32100d12aaaf3956dc7
-  \  (Repo Admin)\n3.4                 833ad81ace8277324f3ca8c91c02bdcf1d13988d8ecf8a3f97ecdd69d0390ce9
-  \  (Repo Admin)\n3.5                 af2a5bd2f8de8fc1ecabf1c76611cdc6a5f1ada1a2bdd7d3816e121b70300308
-  \  (Repo Admin)\n3.6                 1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
-  \  (Repo Admin)\nedge                79d50d15bd7ea48ea00cf3dd343b0e740c1afaa8e899bee475236ef338e1b53b
-  \  (Repo Admin)\nlatest              1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
-  \  (Repo Admin)\n\nAdministrative keys for alpine:\nRepository Key:\t5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd\nRoot
-  Key:\ta2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce\n```\n\nHere's
-  an example with signers that are set up by `docker trust` commands:\n\n```bash\n$
-  docker trust inspect --pretty my-image\nSIGNED TAG          DIGEST                                                              SIGNERS\nred
-  \                852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943
-  \   alice\nblue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197
-  \   alice, bob\ngreen               cae8fedc840f90c8057e1c24637d11865743ab1e61a972c1c9da06ec2de9a139
-  \   alice, bob\nyellow              9cc65fc3126790e683d1b92f307a71f48f75fa7dd47a7b03145a123eaf0b45ba
-  \   carol\npurple              941d3dba358621ce3c41ef67b47cf80f701ff80cdf46b5cc86587eaebfe45557
-  \   alice, bob, carol\norange              d6c271baa6d271bcc24ef1cbd65abf39123c17d2e83455bdab545a1a9093fc1c
-  \   alice\n\nList of signers and their keys for my-image:\n\nSIGNER              KEYS\nalice
-  \              47caae5b3e61, a85aab9d20a4\nbob                 034370bcbd77, 82a66673242c\ncarol
-  \              b6f9f8e1aab0\n\nAdministrative keys for my-image:\nRepository Key:\t27df2c8187e7543345c2e0bf3a1262e0bc63a72754e9a7395eac3f747ec23a44\nRoot
-  Key:\t40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f\n```"
+examples: |-
+  ### Get low-level details about signatures for a single image tag
+
+  Use the `docker trust inspect` to get trust information about an image. The
+  following example prints trust information for the `alpine:latest` image:
+
+  ```bash
+  $ docker trust inspect alpine:latest
+  [
+    {
+      "Name": "alpine:latest",
+      "SignedTags": [
+        {
+          "SignedTag": "latest",
+          "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+          "Signers": [
+            "Repo Admin"
+          ]
+        }
+      ],
+      "Signers": [],
+      "AdministrativeKeys": [
+        {
+          "Name": "Repository",
+          "Keys": [
+              {
+                  "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
+              }
+          ]
+        },
+        {
+          "Name": "Root",
+          "Keys": [
+              {
+                  "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
+              }
+          ]
+        }
+      ]
+    }
+  ]
+  ```
+
+  The `SignedTags` key will list the `SignedTag` name, its `Digest`,
+  and the `Signers` responsible for the signature.
+
+  `AdministrativeKeys` will list the `Repository` and `Root` keys.
+
+  If signers are set up for the repository via other `docker trust`
+  commands, `docker trust inspect` includes a `Signers` key:
+
+  ```bash
+  $ docker trust inspect my-image:purple
+  [
+    {
+      "Name": "my-image:purple",
+      "SignedTags": [
+        {
+          "SignedTag": "purple",
+          "Digest": "941d3dba358621ce3c41ef67b47cf80f701ff80cdf46b5cc86587eaebfe45557",
+          "Signers": [
+            "alice",
+            "bob",
+            "carol"
+          ]
+        }
+      ],
+      "Signers": [
+        {
+          "Name": "alice",
+          "Keys": [
+              {
+                  "ID": "04dd031411ed671ae1e12f47ddc8646d98f135090b01e54c3561e843084484a3"
+              },
+              {
+                  "ID": "6a11e4898a4014d400332ab0e096308c844584ff70943cdd1d6628d577f45fd8"
+              }
+          ]
+        },
+        {
+          "Name": "bob",
+          "Keys": [
+              {
+                  "ID": "433e245c656ae9733cdcc504bfa560f90950104442c4528c9616daa45824ccba"
+              }
+          ]
+        },
+        {
+          "Name": "carol",
+          "Keys": [
+              {
+                  "ID": "d32fa8b5ca08273a2880f455fcb318da3dc80aeae1a30610815140deef8f30d9"
+              },
+              {
+                  "ID": "9a8bbec6ba2af88a5fad6047d428d17e6d05dbdd03d15b4fc8a9a0e8049cd606"
+              }
+          ]
+        }
+      ],
+      "AdministrativeKeys": [
+        {
+          "Name": "Repository",
+          "Keys": [
+              {
+                  "ID": "27df2c8187e7543345c2e0bf3a1262e0bc63a72754e9a7395eac3f747ec23a44"
+              }
+          ]
+        },
+        {
+          "Name": "Root",
+          "Keys": [
+              {
+                  "ID": "40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f"
+              }
+          ]
+        }
+      ]
+    }
+  ]
+  ```
+
+  If the image tag is unsigned or unavailable, `docker trust inspect` does not
+  display any signed tags.
+
+  ```bash
+  $ docker trust inspect unsigned-img
+  No signatures or cannot access unsigned-img
+  ```
+
+  However, if other tags are signed in the same image repository,
+  `docker trust inspect` reports relevant key information:
+
+  ```bash
+  $ docker trust inspect alpine:unsigned
+  [
+    {
+      "Name": "alpine:unsigned",
+      "Signers": [],
+      "AdministrativeKeys": [
+        {
+          "Name": "Repository",
+          "Keys": [
+              {
+                  "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
+              }
+          ]
+        },
+        {
+          "Name": "Root",
+          "Keys": [
+              {
+                  "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
+              }
+          ]
+        }
+      ]
+    }
+  ]
+  ```
+
+  ### Get details about signatures for all image tags in a repository
+
+  If no tag is specified, `docker trust inspect` will report details for all
+  signed tags in the repository:
+
+  ```bash
+  $ docker trust inspect alpine
+  [
+      {
+          "Name": "alpine",
+          "SignedTags": [
+              {
+                  "SignedTag": "3.5",
+                  "Digest": "b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "3.6",
+                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "edge",
+                  "Digest": "23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "latest",
+                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              }
+          ],
+          "Signers": [],
+          "AdministrativeKeys": [
+              {
+                  "Name": "Repository",
+                  "Keys": [
+                      {
+                          "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
+                      }
+                  ]
+              },
+              {
+                  "Name": "Root",
+                  "Keys": [
+                      {
+                          "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
+                      }
+                  ]
+              }
+          ]
+      }
+  ]
+  ```
+
+
+  ### Get details about signatures for multiple images
+
+  `docker trust inspect` can take multiple repositories and images as arguments,
+  and reports the results in an ordered list:
+
+  ```bash
+  $ docker trust inspect alpine notary
+  [
+      {
+          "Name": "alpine",
+          "SignedTags": [
+              {
+                  "SignedTag": "3.5",
+                  "Digest": "b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "3.6",
+                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "edge",
+                  "Digest": "23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "integ-test-base",
+                  "Digest": "3952dc48dcc4136ccdde37fbef7e250346538a55a0366e3fccc683336377e372",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "latest",
+                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              }
+          ],
+          "Signers": [],
+          "AdministrativeKeys": [
+              {
+                  "Name": "Repository",
+                  "Keys": [
+                      {
+                          "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
+                      }
+                  ]
+              },
+              {
+                  "Name": "Root",
+                  "Keys": [
+                      {
+                          "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "Name": "notary",
+          "SignedTags": [
+              {
+                  "SignedTag": "server",
+                  "Digest": "71f64ab718a3331dee103bc5afc6bc492914738ce37c2d2f127a8133714ecf5c",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              },
+              {
+                  "SignedTag": "signer",
+                  "Digest": "a6122d79b1e74f70b5dd933b18a6d1f99329a4728011079f06b245205f158fe8",
+                  "Signers": [
+                      "Repo Admin"
+                  ]
+              }
+          ],
+          "Signers": [],
+          "AdministrativeKeys": [
+              {
+                  "Name": "Root",
+                  "Keys": [
+                      {
+                          "ID": "8cdcdef5bd039f4ab5a029126951b5985eebf57cabdcdc4d21f5b3be8bb4ce92"
+                      }
+                  ]
+              },
+              {
+                  "Name": "Repository",
+                  "Keys": [
+                      {
+                          "ID": "85bfd031017722f950d480a721f845a2944db26a3dc084040a70f1b0d9bbb3df"
+                      }
+                  ]
+              }
+          ]
+      }
+  ]
+  ```
+
+  ### Formatting
+
+  You can print the inspect output in a human-readable format instead of the default
+  JSON output, by using the `--pretty` option:
+
+  ### Get details about signatures for a single image tag
+
+  ```bash
+  $ docker trust inspect --pretty alpine:latest
+
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  latest              1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe   (Repo Admin)
+
+  Administrative keys for alpine:latest:
+  Repository Key: 5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd
+  Root Key:       a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce
+  ```
+
+  The `SIGNED TAG` is the signed image tag with a unique content-addressable
+  `DIGEST`. `SIGNERS` lists all entities who have signed.
+
+  The administrative keys listed specify the root key of trust, as well as
+  the administrative repository key. These keys are responsible for modifying
+  signers, and rotating keys for the signed repository.
+
+  If signers are set up for the repository via other `docker trust` commands,
+  `docker trust inspect --pretty` displays them appropriately as a `SIGNER`
+  and specify their `KEYS`:
+
+  ```bash
+  $ docker trust inspect --pretty my-image:purple
+  SIGNED TAG          DIGEST                                                              SIGNERS
+  purple              941d3dba358621ce3c41ef67b47cf80f701ff80cdf46b5cc86587eaebfe45557    alice, bob, carol
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  alice               47caae5b3e61, a85aab9d20a4
+  bob                 034370bcbd77, 82a66673242c
+  carol               b6f9f8e1aab0
+
+  Administrative keys for my-image:
+  Repository Key: 27df2c8187e7543345c2e0bf3a1262e0bc63a72754e9a7395eac3f747ec23a44
+  Root Key:       40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f
+  ```
+
+  However, if other tags are signed in the same image repository,
+  `docker trust inspect` reports relevant key information.
+
+  ```bash
+  $ docker trust inspect --pretty alpine:unsigned
+
+  No signatures for alpine:unsigned
+
+
+  Administrative keys for alpine:unsigned:
+  Repository Key: 5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd
+  Root Key:       a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce
+  ```
+
+  ### Get details about signatures for all image tags in a repository
+
+  ```bash
+  $ docker trust inspect --pretty alpine
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  2.6                 9ace551613070689a12857d62c30ef0daa9a376107ec0fff0e34786cedb3399b   (Repo Admin)
+  2.7                 9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a   (Repo Admin)
+  3.1                 d9477888b78e8c6392e0be8b2e73f8c67e2894ff9d4b8e467d1488fcceec21c8   (Repo Admin)
+  3.2                 19826d59171c2eb7e90ce52bfd822993bef6a6fe3ae6bb4a49f8c1d0a01e99c7   (Repo Admin)
+  3.3                 8fd4b76819e1e5baac82bd0a3d03abfe3906e034cc5ee32100d12aaaf3956dc7   (Repo Admin)
+  3.4                 833ad81ace8277324f3ca8c91c02bdcf1d13988d8ecf8a3f97ecdd69d0390ce9   (Repo Admin)
+  3.5                 af2a5bd2f8de8fc1ecabf1c76611cdc6a5f1ada1a2bdd7d3816e121b70300308   (Repo Admin)
+  3.6                 1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe   (Repo Admin)
+  edge                79d50d15bd7ea48ea00cf3dd343b0e740c1afaa8e899bee475236ef338e1b53b   (Repo Admin)
+  latest              1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe   (Repo Admin)
+
+  Administrative keys for alpine:
+  Repository Key: 5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd
+  Root Key:       a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce
+  ```
+
+  Here's an example with signers that are set up by `docker trust` commands:
+
+  ```bash
+  $ docker trust inspect --pretty my-image
+  SIGNED TAG          DIGEST                                                              SIGNERS
+  red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
+  blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
+  green               cae8fedc840f90c8057e1c24637d11865743ab1e61a972c1c9da06ec2de9a139    alice, bob
+  yellow              9cc65fc3126790e683d1b92f307a71f48f75fa7dd47a7b03145a123eaf0b45ba    carol
+  purple              941d3dba358621ce3c41ef67b47cf80f701ff80cdf46b5cc86587eaebfe45557    alice, bob, carol
+  orange              d6c271baa6d271bcc24ef1cbd65abf39123c17d2e83455bdab545a1a9093fc1c    alice
+
+  List of signers and their keys for my-image:
+
+  SIGNER              KEYS
+  alice               47caae5b3e61, a85aab9d20a4
+  bob                 034370bcbd77, 82a66673242c
+  carol               b6f9f8e1aab0
+
+  Administrative keys for my-image:
+  Repository Key: 27df2c8187e7543345c2e0bf3a1262e0bc63a72754e9a7395eac3f747ec23a44
+  Root Key:       40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_trust_key_generate.yaml
+++ b/_data/engine-cli/docker_trust_key_generate.yaml
@@ -1,6 +1,8 @@
 command: docker trust key generate
 short: Generate and load a signing key-pair
-long: Generate and load a signing key-pair
+long: |-
+  `docker trust key generate` generates a key-pair to be used with signing,
+   and loads the private key into the local docker trust keystore.
 usage: docker trust key generate NAME
 pname: docker trust key
 plink: docker_trust_key.yaml
@@ -13,6 +15,38 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  ### Generate a key-pair
+
+  ```bash
+  $ docker trust key generate alice
+
+  Generating key for alice...
+  Enter passphrase for new alice key with ID 17acf3c:
+  Repeat passphrase for new alice key with ID 17acf3c:
+  Successfully generated and loaded private key. Corresponding public key available: alice.pub
+  $ ls
+  alice.pub
+  ```
+
+  The private signing key is encrypted by the passphrase and loaded into the docker trust keystore.
+  All passphrase requests to sign with the key will be referred to by the provided `NAME`.
+
+  The public key component `alice.pub` will be available in the current working directory, and can
+  be used directly by `docker trust signer add`.
+
+  Provide the `--dir` argument to specify a directory to generate the key in:
+
+  ```bash
+  $ docker trust key generate alice --dir /foo
+
+  Generating key for alice...
+  Enter passphrase for new alice key with ID 17acf3c:
+  Repeat passphrase for new alice key with ID 17acf3c:
+  Successfully generated and loaded private key. Corresponding public key available: alice.pub
+  $ ls /foo
+  alice.pub
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_trust_key_load.yaml
+++ b/_data/engine-cli/docker_trust_key_load.yaml
@@ -1,6 +1,9 @@
 command: docker trust key load
 short: Load a private key file for signing
-long: Load a private key file for signing
+long: |-
+  `docker trust key load` adds private keys to the local docker trust keystore.
+
+  To add a signer to a repository use `docker trust signer add`.
 usage: docker trust key load [OPTIONS] KEYFILE
 pname: docker trust key
 plink: docker_trust_key.yaml
@@ -14,6 +17,30 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  ### Load a single private key
+
+  For a private key `alice.pem` with permissions `-rw-------`
+
+  ```bash
+  $ docker trust key load alice.pem
+
+  Loading key from "alice.pem"...
+  Enter passphrase for new signer key with ID f8097df:
+  Repeat passphrase for new signer key with ID f8097df:
+  Successfully imported key from alice.pem
+  ```
+
+  To specify a name use the `--name` flag:
+
+  ```bash
+  $ docker trust key load --name alice-key alice.pem
+
+  Loading key from "alice.pem"...
+  Enter passphrase for new alice-key key with ID f8097df:
+  Repeat passphrase for new alice-key key with ID f8097df:
+  Successfully imported key from alice.pem
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_trust_revoke.yaml
+++ b/_data/engine-cli/docker_trust_revoke.yaml
@@ -15,44 +15,103 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Revoke signatures from a signed tag\n\nHere's an example of a repo
-  with two signed tags:\n\n\n```bash\n$ docker trust view example/trust-demo\nSIGNED
-  TAG          DIGEST                                                              SIGNERS\nred
-  \                852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943
-  \   alice\nblue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197
-  \   alice, bob\n\nList of signers and their keys for example/trust-demo:\n\nSIGNER
-  \             KEYS\nalice               05e87edcaecb\nbob                 5600f5ab76a2\n\nAdministrative
-  keys for example/trust-demo:\nRepository Key:\tecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e\nRoot
-  Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```\n\nWhen
-  `alice`, one of the signers, runs `docker trust revoke`:\n\n```bash\n$ docker trust
-  revoke example/trust-demo:red\nEnter passphrase for delegation key with ID 27d42a8:\nSuccessfully
-  deleted signature for example/trust-demo:red\n```\n\nAfter revocation, the tag is
-  removed from the list of released tags:\n\n```bash\n$ docker trust view example/trust-demo\nSIGNED
-  TAG          DIGEST                                                              SIGNERS\nblue
-  \               f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197
-  \   alice, bob\n\nList of signers and their keys for example/trust-demo:\n\nSIGNER
-  \             KEYS\nalice               05e87edcaecb\nbob                 5600f5ab76a2\n\nAdministrative
-  keys for example/trust-demo:\nRepository Key:\tecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e\nRoot
-  Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```\n\n###
-  Revoke signatures on all tags in a repository\n\nWhen no tag is specified, `docker
-  trust` revokes all signatures that you have a signing key for.\n\n```bash\n$ docker
-  trust view example/trust-demo\nSIGNED TAG          DIGEST                                                              SIGNERS\nred
-  \                852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943
-  \   alice\nblue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197
-  \   alice, bob\n\nList of signers and their keys for example/trust-demo:\n\nSIGNER
-  \             KEYS\nalice               05e87edcaecb\nbob                 5600f5ab76a2\n\nAdministrative
-  keys for example/trust-demo:\nRepository Key:\tecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e\nRoot
-  Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```\n\nWhen
-  `alice`, one of the signers, runs `docker trust revoke`:\n\n```bash\n$ docker trust
-  revoke example/trust-demo\nPlease confirm you would like to delete all signature
-  data for example/trust-demo? [y/N] y\nEnter passphrase for delegation key with ID
-  27d42a8:\nSuccessfully deleted signature for example/trust-demo\n```\n\nAll tags
-  that have `alice`'s signature on them are removed from the list of released tags:\n\n```bash\n$
-  docker trust view example/trust-demo\n\nNo signatures for example/trust-demo\n\n\nList
-  of signers and their keys for example/trust-demo:\n\nSIGNER              KEYS\nalice
-  \              05e87edcaecb\nbob                 5600f5ab76a2\n\nAdministrative
-  keys for example/trust-demo:\nRepository Key:\tecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e\nRoot
-  Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```"
+examples: |-
+  ### Revoke signatures from a signed tag
+
+  Here's an example of a repo with two signed tags:
+
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                              SIGNERS
+  red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
+  blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
+
+  List of signers and their keys for example/trust-demo:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  When `alice`, one of the signers, runs `docker trust revoke`:
+
+  ```bash
+  $ docker trust revoke example/trust-demo:red
+  Enter passphrase for delegation key with ID 27d42a8:
+  Successfully deleted signature for example/trust-demo:red
+  ```
+
+  After revocation, the tag is removed from the list of released tags:
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                              SIGNERS
+  blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
+
+  List of signers and their keys for example/trust-demo:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  ### Revoke signatures on all tags in a repository
+
+  When no tag is specified, `docker trust` revokes all signatures that you have a signing key for.
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                              SIGNERS
+  red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
+  blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
+
+  List of signers and their keys for example/trust-demo:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  When `alice`, one of the signers, runs `docker trust revoke`:
+
+  ```bash
+  $ docker trust revoke example/trust-demo
+  Please confirm you would like to delete all signature data for example/trust-demo? [y/N] y
+  Enter passphrase for delegation key with ID 27d42a8:
+  Successfully deleted signature for example/trust-demo
+  ```
+
+  All tags that have `alice`'s signature on them are removed from the list of released tags:
+
+  ```bash
+  $ docker trust view example/trust-demo
+
+  No signatures for example/trust-demo
+
+
+  List of signers and their keys for example/trust-demo:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_trust_sign.yaml
+++ b/_data/engine-cli/docker_trust_sign.yaml
@@ -14,44 +14,108 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: "### Sign a tag as a repo admin\n\nGiven an image:\n\n```bash\n$ docker
-  trust view example/trust-demo\nSIGNED TAG          DIGEST                                                             SIGNERS\nv1
-  \                 c24134c079c35e698060beabe110bb83ab285d0d978de7d92fed2c8c83570a41
-  \  (Repo Admin)\n\nAdministrative keys for example/trust-demo:\nRepository Key:\t36d4c3601102fa7c5712a343c03b94469e5835fb27c191b529c06fd19c14a942\nRoot
-  Key:\t246d360f7c53a9021ee7d4259e3c5692f3f1f7ad4737b1ea8c7b8da741ad980b\n```\n\nSign
-  a new tag with `docker trust sign`:\n\n```bash\n$ docker trust sign example/trust-demo:v2\nSigning
-  and pushing trust metadata for example/trust-demo:v2\nThe push refers to a repository
-  [docker.io/example/trust-demo]\need4e566104a: Layer already exists\n77edfb6d1e3c:
-  Layer already exists\nc69f806905c2: Layer already exists\n582f327616f1: Layer already
-  exists\na3fbb648f0bd: Layer already exists\n5eac2de68a97: Layer already exists\n8d4d1ab5ff74:
-  Layer already exists\nv2: digest: sha256:8f6f460abf0436922df7eb06d28b3cdf733d2cac1a185456c26debbff0839c56
-  size: 1787\nSigning and pushing trust metadata\nEnter passphrase for repository
-  key with ID 36d4c36:\nSuccessfully signed docker.io/example/trust-demo:v2\n```\n\n`docker
-  trust view` lists the new signature:\n\n```bash\n$ docker trust view example/trust-demo\nSIGNED
-  TAG          DIGEST                                                             SIGNERS\nv1
-  \                 c24134c079c35e698060beabe110bb83ab285d0d978de7d92fed2c8c83570a41
-  \  (Repo Admin)\nv2                  8f6f460abf0436922df7eb06d28b3cdf733d2cac1a185456c26debbff0839c56
-  \  (Repo Admin)\n\nAdministrative keys for example/trust-demo:\nRepository Key:\t36d4c3601102fa7c5712a343c03b94469e5835fb27c191b529c06fd19c14a942\nRoot
-  Key:\t246d360f7c53a9021ee7d4259e3c5692f3f1f7ad4737b1ea8c7b8da741ad980b\n```\n\n###
-  Sign a tag as a signer\n\nGiven an image:\n\n```bash\n$ docker trust view example/trust-demo\n\nNo
-  signatures for example/trust-demo\n\n\nList of signers and their keys for example/trust-demo:\n\nSIGNER
-  \             KEYS\nalice               05e87edcaecb\nbob                 5600f5ab76a2\n\nAdministrative
-  keys for example/trust-demo:\nRepository Key:\tecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e\nRoot
-  Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```\n\nSign
-  a new tag with `docker trust sign`:\n\n```bash\n$ docker trust sign example/trust-demo:v1\nSigning
-  and pushing trust metadata for example/trust-demo:v1\nThe push refers to a repository
-  [docker.io/example/trust-demo]\n26b126eb8632: Layer already exists\n220d34b5f6c9:
-  Layer already exists\n8a5132998025: Layer already exists\naca233ed29c3: Layer already
-  exists\ne5d2f035d7a4: Layer already exists\nv1: digest: sha256:74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4
-  size: 1357\nSigning and pushing trust metadata\nEnter passphrase for delegation
-  key with ID 27d42a8:\nSuccessfully signed docker.io/example/trust-demo:v1\n```\n\n`docker
-  trust view` lists the new signature:\n\n```bash\n$ docker trust view example/trust-demo\nSIGNED
-  TAG          DIGEST                                                             SIGNERS\nv1
-  \                 74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4
-  \  alice\n\nList of signers and their keys for example/trust-demo:\n\nSIGNER              KEYS\nalice
-  \              05e87edcaecb\nbob                 5600f5ab76a2\n\nAdministrative
-  keys for example/trust-demo:\nRepository Key:\tecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e\nRoot
-  Key:\t3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949\n```"
+examples: |-
+  ### Sign a tag as a repo admin
+
+  Given an image:
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  v1                  c24134c079c35e698060beabe110bb83ab285d0d978de7d92fed2c8c83570a41   (Repo Admin)
+
+  Administrative keys for example/trust-demo:
+  Repository Key: 36d4c3601102fa7c5712a343c03b94469e5835fb27c191b529c06fd19c14a942
+  Root Key:       246d360f7c53a9021ee7d4259e3c5692f3f1f7ad4737b1ea8c7b8da741ad980b
+  ```
+
+  Sign a new tag with `docker trust sign`:
+
+  ```bash
+  $ docker trust sign example/trust-demo:v2
+  Signing and pushing trust metadata for example/trust-demo:v2
+  The push refers to a repository [docker.io/example/trust-demo]
+  eed4e566104a: Layer already exists
+  77edfb6d1e3c: Layer already exists
+  c69f806905c2: Layer already exists
+  582f327616f1: Layer already exists
+  a3fbb648f0bd: Layer already exists
+  5eac2de68a97: Layer already exists
+  8d4d1ab5ff74: Layer already exists
+  v2: digest: sha256:8f6f460abf0436922df7eb06d28b3cdf733d2cac1a185456c26debbff0839c56 size: 1787
+  Signing and pushing trust metadata
+  Enter passphrase for repository key with ID 36d4c36:
+  Successfully signed docker.io/example/trust-demo:v2
+  ```
+
+  Use `docker trust view` to list the new signature:
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  v1                  c24134c079c35e698060beabe110bb83ab285d0d978de7d92fed2c8c83570a41   (Repo Admin)
+  v2                  8f6f460abf0436922df7eb06d28b3cdf733d2cac1a185456c26debbff0839c56   (Repo Admin)
+
+  Administrative keys for example/trust-demo:
+  Repository Key: 36d4c3601102fa7c5712a343c03b94469e5835fb27c191b529c06fd19c14a942
+  Root Key:       246d360f7c53a9021ee7d4259e3c5692f3f1f7ad4737b1ea8c7b8da741ad980b
+  ```
+
+  ### Sign a tag as a signer
+
+  Given an image:
+
+  ```bash
+  $ docker trust view example/trust-demo
+
+  No signatures for example/trust-demo
+
+
+  List of signers and their keys for example/trust-demo:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  Sign a new tag with `docker trust sign`:
+
+  ```bash
+  $ docker trust sign example/trust-demo:v1
+  Signing and pushing trust metadata for example/trust-demo:v1
+  The push refers to a repository [docker.io/example/trust-demo]
+  26b126eb8632: Layer already exists
+  220d34b5f6c9: Layer already exists
+  8a5132998025: Layer already exists
+  aca233ed29c3: Layer already exists
+  e5d2f035d7a4: Layer already exists
+  v1: digest: sha256:74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4 size: 1357
+  Signing and pushing trust metadata
+  Enter passphrase for delegation key with ID 27d42a8:
+  Successfully signed docker.io/example/trust-demo:v1
+  ```
+
+  `docker trust view` lists the new signature:
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   alice
+
+  List of signers and their keys for example/trust-demo:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_trust_signer_add.yaml
+++ b/_data/engine-cli/docker_trust_signer_add.yaml
@@ -1,6 +1,6 @@
 command: docker trust signer add
 short: Add a signer
-long: Add a signer
+long: '`docker trust signer add` adds signers to signed repositories.'
 usage: 'docker trust signer add OPTIONS NAME REPOSITORY [REPOSITORY...] '
 pname: docker trust signer
 plink: docker_trust_signer.yaml
@@ -13,6 +13,54 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  ### Add a signer to a repo
+
+  To add a new signer, `alice`, to this repository:
+
+  ```bash
+  $ docker trust view example/trust-demo
+
+  No signatures for example/trust-demo
+
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: 642692c14c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  Add `alice` with `docker trust signer add`:
+
+  ```bash
+  $ docker trust signer add alice example/trust-demo --key alice.crt
+    Adding signer "alice" to example/trust-demo...
+    Enter passphrase for repository key with ID 642692c:
+  Successfully added signer: alice to example/trust-demo
+  ```
+
+  `docker trust view` now lists `alice` as a valid signer:
+
+  ```bash
+  $ docker trust view example/trust-demo
+
+  No signatures for example/trust-demo
+
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: 642692c14c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_trust_signer_remove.yaml
+++ b/_data/engine-cli/docker_trust_signer_remove.yaml
@@ -1,6 +1,6 @@
 command: docker trust signer remove
 short: Remove a signer
-long: Remove a signer
+long: '`docker trust signer remove` removes signers from signed repositories.'
 usage: docker trust signer remove [OPTIONS] NAME REPOSITORY [REPOSITORY...]
 pname: docker trust signer
 plink: docker_trust_signer.yaml
@@ -16,6 +16,154 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  ### Remove a signer from a repo
+
+  To remove an existing signer, `alice`, from this repository:
+  ```bash
+  $ docker trust view example/trust-demo
+
+  No signatures for example/trust-demo
+
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  Remove `alice` with `docker trust signer remove`:
+
+  ```bash
+  $ docker trust signer remove alice example/trust-demo
+
+  Removing signer "alice" from image example/trust-demo...
+  Enter passphrase for repository key with ID 642692c:
+  Successfully removed alice from example/trust-demo
+  ```
+
+  `docker trust view` now does not list `alice` as a valid signer:
+
+  ```bash
+  $ docker trust view example/trust-demo
+
+  No signatures for example/trust-demo
+
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  ### Remove a signer from multiple repos
+
+  To remove an existing signer, `alice`, from multiple repositories:
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   alice, bob
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: 95b9e5514c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  ```bash
+  $ docker trust view example/trust-demo2
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   alice, bob
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  alice               05e87edcaecb
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo2:
+  Repository Key: ece554f14c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4553d2ab20a8d9268
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  Remove `alice` from both images with a single `docker trust signer remove` command:
+
+  ```bash
+  $ docker trust signer remove alice example/trust-demo example/trust-demo2
+
+  Removing signer "alice" from image example/trust-demo...
+  Enter passphrase for repository key with ID 95b9e55:
+  Successfully removed alice from example/trust-demo
+
+  Removing signer "alice" from image example/trust-demo2...
+  Enter passphrase for repository key with ID ece554f:
+  Successfully removed alice from example/trust-demo2
+  ```
+
+  Run `docker trust view` to confirm that `alice` is no longer listed as a valid
+  signer of either `example/trust-demo` or `example/trust-demo2`:
+
+  ```bash
+  $ docker trust view example/trust-demo
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   bob
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo:
+  Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  ```bash
+  $ docker trust view example/trust-demo2
+  SIGNED TAG          DIGEST                                                             SIGNERS
+  v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   bob
+
+  List of signers and their keys:
+
+  SIGNER              KEYS
+  bob                 5600f5ab76a2
+
+  Administrative keys for example/trust-demo2:
+  Repository Key: ece554f14c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4553d2ab20a8d9268
+  Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
+  ```
+
+  `docker trust signer remove` removes signers to repositories on a best effort
+  basis, so it will continue to remove the signer from subsequent repositories if
+  one attempt fails:
+
+  ```bash
+  $ docker trust signer remove alice example/unauthorized example/authorized
+
+  Removing signer "alice" from image example/unauthorized...
+  No signer alice for image example/unauthorized
+
+  Removing signer "alice" from image example/authorized...
+  Enter passphrase for repository key with ID c6772a0:
+  Successfully removed alice from example/authorized
+
+  Error removing signer from: example/unauthorized
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false


### PR DESCRIPTION
Regenerated the yaml files after fixing a bug in the generator script that caused some extended descriptions and examples to not be included (using the code in https://github.com/docker/cli/pull/2391).

Also fixes the generated YAML to use the "long form" format, instead of the compact format (where newlines were encoded as `\n`). This makes the YAML more "human readable", and makes reviewing updates easier.


An example of the pages that are fixed, is the `docker swarm join-token` reference, which is currently missing the extended description and examples section: https://docs.docker.com/engine/reference/commandline/swarm_join-token/

Which is included when trying this PR http://localhost:4000/engine/reference/commandline/swarm_join-token/
