### PR TITLE
Update layout of reference pages

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -96,6 +96,11 @@ your client and daemon API versions.
 {{ site.data[include.datafolder][include.datafile].long }}
 
 {% endunless %}
+
+{% if site.data[include.datafolder][include.datafile].examples %}
+For example uses of this command, refer to the [examples section](#examples) below.
+{% endif %}
+
 {% if site.data[include.datafolder][include.datafile].options %}
   {% if site.data[include.datafolder][include.datafile].inherited_options %}
     {% assign alloptions = site.data[include.datafolder][include.datafile].options | concat:site.data[include.datafolder][include.datafile].inherited_options %}

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -130,27 +130,25 @@ your client and daemon API versions.
 
 {% endif %} <!-- end if options -->
 
-{% if site.data[include.datafolder][include.datafile].cname %}
+{% unless site.data[include.datafolder][include.datafile].long == site.data[include.datafolder][include.datafile].short %}
 
-## Child commands
+## Extended description
 
-<table>
-<thead>
-  <tr>
-    <td>Command</td>
-    <td>Description</td>
-  </tr>
-</thead>
-<tbody>
-{% for command in site.data[include.datafolder][include.datafile].cname %}
-  {% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
-  <tr>
-    <td markdown="span">[{{ command }}]({{ dataFileName | replace: "docker_","" }}/)</td>
-    <td markdown="span">{{ site.data[include.datafolder][dataFileName].short }}</td>
-  </tr>
-{% endfor %}
-</tbody>
-</table>
+{{ site.data[include.datafolder][include.datafile].long }}
+
+{% endunless %}
+
+{% if site.data[include.datafolder][include.datafile].examples %}
+
+## Examples
+
+{{ site.data[include.datafolder][include.datafile].examples }}
+
+{% endif %}
+{% else %}
+
+The include.datafolder or include.datafile was not set.
+
 {% endif %}
 
 {% if site.data[include.datafolder][include.datafile].pname %}
@@ -172,6 +170,29 @@ your client and daemon API versions.
 | [{{ site.data[include.datafolder][include.datafile].pname }}]({{ parentfile }}) | {{ parentDesc }}|
 
 {% endunless %}
+{% endif %}
+
+{% if site.data[include.datafolder][include.datafile].cname %}
+
+## Child commands
+
+<table>
+<thead>
+  <tr>
+    <td>Command</td>
+    <td>Description</td>
+  </tr>
+</thead>
+<tbody>
+{% for command in site.data[include.datafolder][include.datafile].cname %}
+  {% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
+  <tr>
+    <td markdown="span">[{{ command }}]({{ dataFileName | replace: "docker_","" }}/)</td>
+    <td markdown="span">{{ site.data[include.datafolder][dataFileName].short }}</td>
+  </tr>
+{% endfor %}
+</tbody>
+</table>
 {% endif %}
 
 {% unless site.data[include.datafolder][include.datafile].pname == "docker" or site.data[include.datafolder][include.datafile].pname == "dockerd" or include.datafile=="docker" %}
@@ -197,24 +218,3 @@ your client and daemon API versions.
 </table>
 
 {% endunless %}
-
-{% unless site.data[include.datafolder][include.datafile].long == site.data[include.datafolder][include.datafile].short %}
-
-## Extended description
-
-{{ site.data[include.datafolder][include.datafile].long }}
-
-{% endunless %}
-
-{% if site.data[include.datafolder][include.datafile].examples %}
-
-## Examples
-
-{{ site.data[include.datafolder][include.datafile].examples }}
-
-{% endif %}
-{% else %}
-
-The include.datafolder or include.datafile was not set.
-
-{% endif %}

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -89,6 +89,13 @@ your client and daemon API versions.
 ```
 
 {% endif %}
+{% unless site.data[include.datafolder][include.datafile].long == site.data[include.datafolder][include.datafile].short %}
+
+## Extended description
+
+{{ site.data[include.datafolder][include.datafile].long }}
+
+{% endunless %}
 {% if site.data[include.datafolder][include.datafile].options %}
   {% if site.data[include.datafolder][include.datafile].inherited_options %}
     {% assign alloptions = site.data[include.datafolder][include.datafile].options | concat:site.data[include.datafolder][include.datafile].inherited_options %}
@@ -129,14 +136,6 @@ your client and daemon API versions.
 </table>
 
 {% endif %} <!-- end if options -->
-
-{% unless site.data[include.datafolder][include.datafile].long == site.data[include.datafolder][include.datafile].short %}
-
-## Extended description
-
-{{ site.data[include.datafolder][include.datafile].long }}
-
-{% endunless %}
 
 {% if site.data[include.datafolder][include.datafile].examples %}
 


### PR DESCRIPTION
- Reference: move "parent", "child", and "related" commands to bottom
  For some commands, the list of "related" commands is lenghty, therefore hiding the extended description and examples below the fold, which is not ideal. This patch moves the "parent command", "child commands", and "related commands" sections to the bottom of the page.
- Reference: move "extended description" above "options"
  The extended description usually provides a good introduction to the command, which likely is useful to read before heading to more detailed information (such as "what options does this command have?")
- Reference: add anchor-link to examples section
  Some commands provide a long list of options, which may "hide" the examples section. To help discoverability, add an anchor-link to the examples section (if present).