### PR TITLE
config: remove docs.docker.com as site URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ incremental: true
 permalink: pretty
 safe: false
 lsi: false
-url: https://docs.docker.com
 # This needs to have all the directories you expect to be in the archives (delivered by docs-base in the Dockerfile)
 keep_files: ["v17.06", "v18.03", "v18.09"]
 exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]

--- a/_config_authoring.yml
+++ b/_config_authoring.yml
@@ -11,7 +11,6 @@ incremental: false
 permalink: pretty
 safe: false
 lsi: false
-url: https://docs.docker.com
 # This needs to have all the directories you expect to be in the archives (delivered by docs-base in the Dockerfile)
 keep_files: ["v17.06", "v18.03", "v18.09"]
 exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]


### PR DESCRIPTION
extracting this from https://github.com/docker/docker.github.io/pull/10471

Having this variable set causes redirects to always redirect to https://docs.docker.com, which makes it not possible to preview redirects locally, or to host them on a different domain (e.g. on a staging domain).
