### PR TITLE
Engine: reorganize install topic

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -4,7 +4,7 @@ horizontalnav:
   path: /
   node: guides
 - title: Product manuals
-  path: /install/
+  path: /engine/
   node: manuals
 - title: Reference
   path: /reference/
@@ -1023,22 +1023,24 @@ samples:
 manuals:
 - sectiontitle: Docker Engine
   section:
-  - path: /install/
+  - path: /engine/
     title: Overview
-  - sectiontitle: Linux
+  - path: /engine/install/
+    title: Install
+  - sectiontitle: Installation per distro
     section:
-    - path: /install/linux/docker-ce/centos/
-      title: CentOS
-    - path: /install/linux/docker-ce/debian/
-      title: Debian
-    - path: /install/linux/docker-ce/fedora/
-      title: Fedora
-    - path: /install/linux/docker-ce/ubuntu/
-      title: Ubuntu
-    - path: /install/linux/docker-ce/binaries/
-      title: Binaries
-    - path: /install/linux/linux-postinstall/
-      title: Optional Linux post-installation steps
+    - path: /engine/install/centos/
+      title: Install on CentOS
+    - path: /engine/install/debian/
+      title: Install on Debian
+    - path: /engine/install/fedora/
+      title: Install on Fedora
+    - path: /engine/install/ubuntu/
+      title: Install on Ubuntu
+    - path: /engine/install/binaries/
+      title: Install binaries
+    - path: /engine/install/linux-postinstall/
+      title: Optional post-installation steps
   - path: /engine/release-notes/
     title: Release notes
   - sectiontitle: Previous versions
@@ -1077,6 +1079,9 @@ manuals:
       title: Engine 17.03 release notes
     - path: /engine/release-notes/prior-releases/
       title: Engine 1.13 and earlier
+  - path: /engine/deprecated/
+    title: Deprecated features
+
   - path: /app/working-with-app/
     title: Docker App
   - path: /buildx/working-with-buildx/

--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -23,7 +23,7 @@ on {{ linux-dist-long }}:
 Docker Engine - Community is _not_ supported on {{ linux-dist-long }}.
 {% endif %}
 {% if linux-dist == "centos" %}
-For Docker Community Edition on {{ linux-dist-cap }}, see [Get Docker Engine - Community for CentOS](/install/linux/docker-ce/centos.md).
+For Docker Community Edition on {{ linux-dist-cap }}, see [Get Docker Engine - Community for CentOS](/engine/install/centos.md).
 {% endif %}
 
 {% elsif section == "find-ee-repo-url" %}
@@ -280,7 +280,7 @@ You only need to set up the repository once, after which you can install Docker 
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 
@@ -351,7 +351,7 @@ To manually install Docker Enterprise, download the `.{{ package-format | downca
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 </div>
@@ -394,7 +394,7 @@ To manually install Docker Enterprise, download the `.{{ package-format | downca
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 </div>
@@ -444,7 +444,7 @@ To manually install Docker Enterprise, download the `.{{ package-format | downca
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 {% endif %}
 
@@ -485,7 +485,7 @@ You must delete any edited configuration files manually.
 
 {% elsif section == "linux-install-nextsteps" %}
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md){: target="_blank" class="_" }
+- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md){: target="_blank" class="_" }
 
 - Continue with user guides on [Universal Control Plane (UCP)](/ee/ucp/){: target="_blank" class="_" } and [Docker Trusted Registry (DTR)](/ee/dtr/){: target="_blank" class="_" }
 

--- a/compose/aspnet-mssql-compose.md
+++ b/compose/aspnet-mssql-compose.md
@@ -9,7 +9,7 @@ Compose to set up and run the sample ASP.NET Core application using the
 [.NET Core SDK image](https://hub.docker.com/_/microsoft-dotnet-core-sdk)
 with the
 [SQL Server on Linux image](https://hub.docker.com/_/microsoft-mssql-server).
-You just need to have [Docker Engine](/install/index.md)
+You just need to have [Docker Engine](/get-docker.md)
 and [Docker Compose](/compose/install.md) installed on your
 platform of choice: Linux, Mac or Windows.
 

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -11,7 +11,7 @@ understandable even if you're not familiar with it.
 
 ## Prerequisites
 
-Make sure you have already installed both [Docker Engine](/install/index.md)
+Make sure you have already installed both [Docker Engine](/get-docker.md)
 and [Docker Compose](install.md). You don't need to install Python or Redis, as
 both are provided by Docker images.
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -16,12 +16,12 @@ have Docker Engine installed either locally or remote, depending on your setup.
 included as part of those desktop installs.
 
 - On Linux systems, first install the
-[Docker](/install/index.md#server){: target="_blank" class="_"}
+[Docker Engine](/engine/install/index.md#server){: target="_blank" class="_"}
 for your OS as described on the Get Docker page, then come back here for
 instructions on installing Compose on
 Linux systems.
 
-- To run Compose as a non-root user, see [Manage Docker as a non-root user](/install/linux/linux-postinstall.md).
+- To run Compose as a non-root user, see [Manage Docker as a non-root user](/engine/install/linux-postinstall.md).
 
 ## Install Compose
 

--- a/config/containers/resource_constraints.md
+++ b/config/containers/resource_constraints.md
@@ -24,7 +24,7 @@ WARNING: No swap limit support
 ```
 
 Consult your operating system's documentation for enabling them.
-[Learn more](/install/linux/linux-postinstall.md#your-kernel-does-not-support-cgroup-swap-limit-capabilities).
+[Learn more](/engine/install/linux-postinstall.md#your-kernel-does-not-support-cgroup-swap-limit-capabilities).
 
 ## Memory
 

--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -34,9 +34,9 @@ not manually by a user. This makes it easier to automatically start Docker when
 the machine reboots.
 
 The command to start Docker depends on your operating system. Check the correct
-page under [Install Docker](/install/index.md). To configure Docker
+page under [Install Docker](/engine/install/index.md). To configure Docker
 to start automatically at system boot, see
-[Configure Docker to start on boot](/install/linux/linux-postinstall.md#configure-docker-to-start-on-boot).
+[Configure Docker to start on boot](/engine/install/linux-postinstall.md#configure-docker-to-start-on-boot).
 
 ## Start the daemon manually
 

--- a/config/daemon/systemd.md
+++ b/config/daemon/systemd.md
@@ -34,7 +34,7 @@ do not have `systemctl`, use the `service` command.
 ### Start automatically at system boot
 
 If you want Docker to start at boot, see
-[Configure Docker to start on boot](/install/linux/linux-postinstall.md#configure-docker-to-start-on-boot).
+[Configure Docker to start on boot](/engine/install/linux-postinstall.md#configure-docker-to-start-on-boot).
 
 ## Custom Docker daemon options
 
@@ -155,7 +155,7 @@ you need to add this configuration in the Docker systemd service file.
 ## Configure where the Docker daemon listens for connections
 
 See
-[Configure where the Docker daemon listens for connections](/install/linux/linux-postinstall.md#control-where-the-docker-daemon-listens-for-connections).
+[Configure where the Docker daemon listens for connections](/engine/install/linux-postinstall.md#control-where-the-docker-daemon-listens-for-connections).
 
 ## Manually create the systemd unit files
 

--- a/datacenter/ucp/1.1/installation/system-requirements.md
+++ b/datacenter/ucp/1.1/installation/system-requirements.md
@@ -17,7 +17,7 @@ all nodes must have:
 
 * Linux kernel version 3.10 or higher
 * CS Docker Engine version 1.10 or higher. Learn about the
-[operating systems supported by CS Docker Engine](/install/).
+[operating systems supported by CS Docker Engine](/ee/supported-platforms.md).
 * 2.00 GB of RAM
 * 3.00 GB of available disk space
 * A static IP address

--- a/datacenter/ucp/2.2/guides/admin/install/index.md
+++ b/datacenter/ucp/2.2/guides/admin/install/index.md
@@ -20,7 +20,7 @@ UCP is a containerized application that requires the commercially supported
 Docker Engine to run.
 
 Install Docker Enterprise on each host that you plan to manage with UCP.
-View the [supported platforms](/install/index.md#supported-platforms)
+View the [supported platforms](/ee/supported-platforms.md)
 and click on your platform to get platform-specific instructions for installing
 Docker Enterprise.
 

--- a/datacenter/ucp/2.2/guides/admin/install/system-requirements.md
+++ b/datacenter/ucp/2.2/guides/admin/install/system-requirements.md
@@ -11,7 +11,7 @@ Before installing, be sure your infrastructure has these requirements.
 
 You can install UCP on-premises or on a cloud provider. Common requirements:
 
-* [Docker Enterprise Edition](/install/index.md) version 17.06 or higher
+* [Docker Enterprise Edition](/ee/supported-platforms.md) version 17.06 or higher
 * Linux kernel version 3.10 or higher
 * A static IP address
 

--- a/datacenter/ucp/3.0/guides/admin/install/index.md
+++ b/datacenter/ucp/3.0/guides/admin/install/index.md
@@ -20,7 +20,7 @@ UCP is a containerized application that requires the commercially supported
 Docker Engine to run.
 
 Install Docker EE on each host that you plan to manage with UCP.
-View the [supported platforms](/install/index.md#supported-platforms)
+View the [supported platforms](/ee/supported-platforms.md)
 and click on your platform to get platform-specific instructions for installing
 Docker EE.
 

--- a/datacenter/ucp/3.0/guides/admin/install/system-requirements.md
+++ b/datacenter/ucp/3.0/guides/admin/install/system-requirements.md
@@ -11,7 +11,7 @@ Before installing, be sure your infrastructure has these requirements.
 
 You can install UCP on-premises or on a cloud provider. Common requirements:
 
-* [Docker Enterprise Edition](/install/index.md) version 17.06 or higher
+* [Docker Enterprise Edition](/ee/supported-platforms.md) version 17.06 or higher
 * Linux kernel version 3.10 or higher
 * A static IP address
 

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -48,8 +48,8 @@ Your Mac must meet the following requirements to successfully install Docker Des
 ## What's included in the installer
 
 The Docker Desktop installation includes
-  [Docker Engine](/install/), Docker CLI client,
-  [Docker Compose](/compose/), [Notary](/notary/getting_started/), [Kubernetes](https://github.com/kubernetes/kubernetes/), and [Credential Helper](https://github.com/docker/docker-credential-helpers/).
+  [Docker Engine](/engine/index.md), Docker CLI client,
+  [Docker Compose](/compose/index.md), [Notary](/notary/getting_started/), [Kubernetes](https://github.com/kubernetes/kubernetes/), and [Credential Helper](https://github.com/docker/docker-credential-helpers/).
 
 ## Install and run Docker Desktop on Mac
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -39,7 +39,11 @@ used side-by-side with Docker Desktop. However, you can still use
 
 ### What's included in the installer
 
-The Docker Desktop installation includes [Docker Engine](/install/), Docker CLI client, [Docker Compose](/compose/overview.md), [Notary](/notary/getting_started/), [Kubernetes](https://github.com/kubernetes/kubernetes/), and [Credential Helper](https://github.com/docker/docker-credential-helpers/).
+The Docker Desktop installation includes [Docker Engine](/engine/index.md),
+Docker CLI client, [Docker Compose](/compose/index.md),
+[Notary](/notary/getting_started.md),
+[Kubernetes](https://github.com/kubernetes/kubernetes/),
+and [Credential Helper](https://github.com/docker/docker-credential-helpers/).
 
 Containers and images created with Docker Desktop are shared between all
 user accounts on machines where it is installed. This is because all Windows

--- a/ee/docker-ee/centos.md
+++ b/ee/docker-ee/centos.md
@@ -28,7 +28,8 @@ on {{ linux-dist-long }}:
 Shared between centOS.md, rhel.md, oracle.md
 --->
 
-For Docker Community Edition on {{ linux-dist-cap }}, see [Get Docker Engine - Community for CentOS](/install/linux/docker-ce/centos.md).
+For Docker Community Edition on {{ linux-dist-cap }}, see
+[Install Docker Engine on CentOS](/engine/install/centos.md).
 
 ## Prerequisites
 
@@ -219,7 +220,7 @@ Shared between centOS.md, oracle.md
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 <!---
@@ -281,7 +282,7 @@ Not shared
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 <!---
@@ -332,6 +333,6 @@ Shared between centOS.md, rhel.md, oracle.md
 ## Next steps
 
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md){: target="_blank" class="_" }
+- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md){: target="_blank" class="_" }
 
 - Continue with user guides on [Universal Control Plane (UCP)](/ee/ucp/){: target="_blank" class="_" } and [Docker Trusted Registry (DTR)](/ee/dtr/){: target="_blank" class="_" }

--- a/ee/docker-ee/oracle.md
+++ b/ee/docker-ee/oracle.md
@@ -215,7 +215,7 @@ Shared between centOS.md, oracle.md
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 <!---
@@ -281,7 +281,7 @@ Not shared
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 <!---
@@ -332,6 +332,6 @@ Shared between centOS.md, rhel.md, oracle.md
 ## Next steps
 
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md){: target="_blank" class="_" }
+- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md){: target="_blank" class="_" }
 
 - Continue with user guides on [Universal Control Plane (UCP)](/ee/ucp/){: target="_blank" class="_" } and [Docker Trusted Registry (DTR)](/ee/dtr/){: target="_blank" class="_" }

--- a/ee/docker-ee/release-notes.md
+++ b/ee/docker-ee/release-notes.md
@@ -765,8 +765,8 @@ Update your configuration if this command prints a non-empty value for `MountFla
 
 ### New features for Docker Engine EE
 
-* [FIPS Compliance added for Windows Server 2016 and later](/install/windows/docker-ee)
-* [Docker Content Trust Enforcement](/engine/security/trust/content_trust) for the Enterprise Engine. This allows the Docker Engine - Enterprise to run containers not signed by a specific organization.
+* [FIPS Compliance added for Windows Server 2016 and later](/ee/docker-ee/windows/docker-ee.md)
+* [Docker Content Trust Enforcement](/engine/security/trust/content_trust.md) for the Enterprise Engine. This allows the Docker Engine - Enterprise to run containers not signed by a specific organization.
 
 ### New features
 

--- a/ee/docker-ee/rhel.md
+++ b/ee/docker-ee/rhel.md
@@ -396,7 +396,7 @@ Shared between centOS.md, rhel.md, oracle.md
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 <!---
@@ -479,7 +479,7 @@ Shared between centOS.md, rhel.md, oracle.md
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 </div>
@@ -522,7 +522,7 @@ Shared between centOS.md, rhel.md, oracle.md
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/install/linux/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 </div>
@@ -572,6 +572,6 @@ Shared between centOS.md, rhel.md, oracle.md
 ## Next steps
 
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md){: target="_blank" class="_" }
+- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md){: target="_blank" class="_" }
 
 - Continue with user guides on [Universal Control Plane (UCP)](/ee/ucp/){: target="_blank" class="_" } and [Docker Trusted Registry (DTR)](/ee/dtr/){: target="_blank" class="_" }

--- a/ee/docker-ee/suse.md
+++ b/ee/docker-ee/suse.md
@@ -311,7 +311,7 @@ and update Docker from the repository.
     container runs, it prints an informational message and exits.
 
 Docker Engine - Enterprise is installed and running. You need to use `sudo` to
-run Docker commands. Continue to [Linux postinstall](/install/linux/linux-postinstall.md)
+run Docker commands. Continue to [Linux postinstall](/engine/install/linux-postinstall.md)
 to configure the graph storage driver, allow non-privileged users to run Docker
 commands, and for other optional configuration steps.
 
@@ -391,7 +391,7 @@ manually. You need to download a new file each time you want to upgrade Docker.
     container runs, it prints an informational message and exits.
 
 Docker Engine - Enterprise is installed and running. You need to use `sudo` to
-run Docker commands. Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md)
+run Docker commands. Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md)
 to allow non-privileged users to run Docker commands and for other optional
 configuration steps.
 
@@ -427,6 +427,6 @@ You must delete any edited configuration files manually.
 
 ## Next steps
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md)
+- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md)
 
 - Continue with the [User Guide](/engine/userguide/index.md).

--- a/ee/docker-ee/ubuntu.md
+++ b/ee/docker-ee/ubuntu.md
@@ -16,7 +16,7 @@ toc_max: 4
 > **Important** 
 > 
 > Docker Engine - Community users should go to
-[Get Docker Engine - Community for Ubuntu](/install/linux/docker-ce/ubuntu.md)
+[Get Docker Engine - Community for Ubuntu](/engine/install/ubuntu.md)
 **instead of this topic**. 
 {: .important}
 
@@ -203,7 +203,7 @@ Naturally, to install Docker Engine - Enterprise on a new host machine using the
 
 Docker Engine - Enterprise is installed and running. The `docker` group is
 created but no users are added to it. You need to use `sudo` to run Docker
-commands. Continue to [Linux postinstall](/install/linux/linux-postinstall.md)
+commands. Continue to [Linux postinstall](/engine/install/linux-postinstall.md)
 to allow non-privileged users to run Docker commands and for other optional
 configuration steps.
 
@@ -265,7 +265,7 @@ Engine - Enterprise.
 
 Docker Engine - Enterprise is installed and running. The `docker` group is
 created but no users are added to it. You need to use `sudo` to run Docker
-commands. Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md)
+commands. Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md)
 to allow non-privileged users to run Docker commands and for other optional
 configuration steps.
 
@@ -295,5 +295,5 @@ You must delete any edited configuration files manually.
 
 ## Next steps
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md).
+- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md).
 - Continue with the [User Guide](/engine/userguide/index.md).

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -104,6 +104,6 @@ details on EOL of minor and major versions of Docker Enterprise.
 
 ## Where to go next
 
-- [Install Docker Engine - Enterprise for RHEL](/install/linux/docker-ee/rhel/)
-- [Install Docker Engine - Enterprise for Ubuntu](/install/linux/docker-ee/ubuntu/)
-- [Install Docker Engine - Enterprise for Windows Server](/install/windows/docker-ee/)
+- [Install Docker Engine - Enterprise for RHEL](/ee/docker-ee/rhel.md)
+- [Install Docker Engine - Enterprise for Ubuntu](/ee/docker-ee/ubuntu/)
+- [Install Docker Engine - Enterprise for Windows Server](/ee/docker-ee/windows/docker-ee.md)

--- a/ee/upgrade.md
+++ b/ee/upgrade.md
@@ -216,12 +216,12 @@ $ docker node update --availability drain <node>
 To upgrade a node individually by operating system, please follow the instructions
 listed below:
 
-* [Windows Server](/install/windows/docker-ee/#update-docker-engine---enterprise)
-* [Ubuntu](/install/linux/docker-ee/ubuntu.md#upgrade-docker-engine---enterprise)
-* [RHEL](/install/linux/docker-ee/rhel/#upgrade-from-the-repository)
-* [CentOS](/install/linux/docker-ee/centos/#upgrade-from-the-repository)
-* [Oracle Linux](/install/linux/docker-ee/oracle/#upgrade-from-the-repository)
-* [SLES](/install/linux/docker-ee/suse/#upgrade-docker-engine---enterprise)
+* [Windows Server](/ee/docker-ee/windows/docker-ee.md#update-docker-engine---enterprise)
+* [Ubuntu](/ee/docker-ee/ubuntu.md#upgrade-docker-engine---enterprise)
+* [RHEL](/ee/docker-ee/rhel.md#upgrade-from-the-repository)
+* [CentOS](/ee/docker-ee/centos.md#upgrade-from-the-repository)
+* [Oracle Linux](/ee//oracle.md#upgrade-from-the-repository)
+* [SLES](/ee/docker-ee/suse.md#upgrade-docker-engine---enterprise)
 
 ### Post-Upgrade steps for Docker Engine - Enterprise
 

--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -10,7 +10,7 @@ redirect_from:
 ---
 
 After you
-[install Docker](/install/index.md), you can
+[install Docker](/get-docker.md), you can
 [install the Go or Python SDK](/engine/api/sdk/index.md#install-the-sdks) and
 also try out the Docker Engine API.
 

--- a/engine/examples/apt-cacher-ng.md
+++ b/engine/examples/apt-cacher-ng.md
@@ -6,7 +6,7 @@ title: Dockerize an apt-cacher-ng service
 
 > **Note**:
 > - **If you don't like sudo** then see
->   [*Giving non-root access*](/install/linux/linux-postinstall.md#manage-docker-as-a-non-root-user).
+>   [*Giving non-root access*](/engine/install/linux-postinstall.md#manage-docker-as-a-non-root-user).
 > - **If you're using macOS or docker via TCP** then you shouldn't use sudo.
 
 When you have multiple Docker servers, or build unrelated Docker

--- a/engine/examples/couchdb_data_volumes.md
+++ b/engine/examples/couchdb_data_volumes.md
@@ -5,7 +5,7 @@ title: Dockerize a CouchDB service
 ---
 
 > **Note**:
-> - **If you don't like sudo** then see [*Giving non-root access*](/install/linux/linux-postinstall.md#manage-docker-as-a-non-root-user)
+> - **If you don't like sudo** then see [*Giving non-root access*](/engine/install/linux-postinstall.md#manage-docker-as-a-non-root-user)
 
 Here's an example of using data volumes to share the same data between
 two CouchDB containers. This could be used for hot upgrades, testing

--- a/engine/index.md
+++ b/engine/index.md
@@ -6,90 +6,34 @@ redirect_from:
 - /engine/ce-ee-node-activate/
 - /linux/
 - /edge/
-title: About Docker Engine
+title: Docker Engine overview
 ---
 
-**Develop, Ship and Run Any Application, Anywhere**
+Docker Engine is an open source containerization technology for building and
+containerizing your applications. Docker Engine acts as a client-server
+application with:
 
-[**Docker**](https://www.docker.com) is a platform for developers and sysadmins
-to develop, ship, and run applications.  Docker lets you quickly assemble
-applications from components and eliminates the friction that can come when
-shipping code. Docker lets you get your code tested and deployed into production
-as fast as possible.
+* A server with a long-running daemon process [`dockerd`](/engine/reference/commandline/dockerd).
+* APIs which specify interfaces that programs can use to talk to and
+  instruct the Docker daemon.
+* A command line interface (CLI) client [`docker`](/engine/reference/commandline/cli/).
 
-Docker consists of:
+The CLI uses [Docker APIs](api/index.md) to control or interact with the Docker
+daemon through scripting or direct CLI commands. Many other Docker applications
+use the underlying API and CLI. The daemon creates and manage Docker objects,
+such as images, containers, networks, and volumes.
 
-* The Docker Engine - our lightweight and powerful open source containerization
-  technology combined with a work flow for building and containerizing your
-  applications.
-* [Docker Hub](https://hub.docker.com) - our SaaS service for
-  sharing and managing your application stacks.
+For more details, see [Docker Architecture](/get-started/overview.md#docker-architecture).
 
-## Why Docker?
-
-*Faster delivery of your applications*
-
-* We want your environment to work better. Docker containers,
-      and the work flow that comes with them, help your developers,
-      sysadmins, QA folks, and release engineers work together to get your code
-      into production and make it useful. We've created a standard
-      container format that lets developers care about their applications
-      inside containers while sysadmins and operators can work on running the
-      container in your deployment. This separation of duties streamlines and
-      simplifies the management and deployment of code.
-* We make it easy to build new containers, enable rapid iteration of
-      your applications, and increase the visibility of changes. This
-      helps everyone in your organization understand how an application works
-      and how it is built.
-* Docker containers are lightweight and fast! Containers have
-      sub-second launch times, reducing the cycle
-      time of development, testing, and deployment.
-
-*Deploy and scale more easily*
-
-* Docker containers run (almost) everywhere. You can deploy
-      containers on desktops, physical servers, virtual machines, into
-      data centers, and up to public and private clouds.
-* Since Docker runs on so many platforms, it's easy to move your
-      applications around. You can easily move an application from a
-      testing environment into the cloud and back whenever you need.
-* Docker's lightweight containers also make scaling up and
-      down fast and easy. You can quickly launch more containers when
-      needed and then shut them down easily when they're no longer needed.
-
-*Get higher density and run more workloads*
-
-* Docker containers don't need a hypervisor, so you can pack more of
-      them onto your hosts. This means you get more value out of every
-      server and can potentially reduce what you spend on equipment and
-      licenses.
-
-*Faster deployment makes for easier management*
-
-* As Docker speeds up your work flow, it gets easier to make lots
-      of small changes instead of huge, big bang updates. Smaller
-      changes mean reduced risk and more uptime.
-
-## About this guide
-
-The [Understanding Docker section](understanding-docker.md) helps you:
-
- - See how Docker works at a high level
- - Understand the architecture of Docker
- - Discover Docker's features;
- - See how Docker compares to virtual machines
- - See some common use cases.
-
-### Installation guides
-
-The [installation section](installation/index.md) shows you how to install Docker
-on a variety of platforms.
-
-
-### Docker user guide
+## Docker user guide
 
 To learn about Docker in more detail and to answer questions about usage and
-implementation, check out the [Docker User Guide](userguide/index.md).
+implementation, check out the [overview page in "get started"](/get-started/overview.md).
+
+## Installation guides
+
+The [installation section](install/index.md) shows you how to install Docker
+on a variety of platforms.
 
 ## Release notes
 

--- a/engine/index.md
+++ b/engine/index.md
@@ -4,6 +4,8 @@ keywords: Engine
 redirect_from:
 - /engine/misc/
 - /engine/ce-ee-node-activate/
+- /linux/
+- /edge/
 title: About Docker Engine
 ---
 
@@ -92,7 +94,7 @@ implementation, check out the [Docker User Guide](userguide/index.md).
 ## Release notes
 
 A summary of the changes in each release in the current series can now be found
-on the separate [Release Notes page](/release-notes)
+on the separate [Release Notes page](release-notes/index.md)
 
 ## Feature Deprecation Policy
 

--- a/engine/install/binaries.md
+++ b/engine/install/binaries.md
@@ -1,10 +1,11 @@
 ---
 description: Instructions for installing Docker as a binary. Mostly meant for hackers who want to try out Docker on a variety of environments.
 keywords: binaries, installation, docker, documentation, linux
-title: Install Docker Engine - Community from binaries
+title: Install Docker Engine from binaries
 redirect_from:
 - /engine/installation/binaries/
 - /engine/installation/linux/docker-ce/binaries/
+- /install/linux/docker-ce/binaries/
 ---
 
 > **Note**: You may have been redirected to this page because there is no longer
@@ -79,7 +80,7 @@ instructions for enabling and configuring AppArmor or SELinux.
     [https://download.docker.com/linux/static/stable/](https://download.docker.com/linux/static/stable/)
     (or change `stable` to `nightly` or `test`),
     choose your hardware platform, and download the `.tgz` file relating to the
-    version of Docker Engine - Community you want to install.
+    version of Docker Engine you want to install.
 
 2.  Extract the archive using the `tar` utility. The `dockerd` and `docker`
     binaries are extracted.
@@ -124,7 +125,7 @@ The macOS binary includes the Docker client only. It does not include the
 1.  Download the static binary archive. Go to
     [https://download.docker.com/mac/static/stable/x86_64/](https://download.docker.com/mac/static/stable/x86_64/),
     (or change `stable` to `nightly` or `test`),
-    and download the `.tgz` file relating to the version of Docker Engine - Community you want
+    and download the `.tgz` file relating to the version of Docker Engine you want
     to install.
 
 2.  Extract the archive using the `tar` utility. The `docker` binary is
@@ -155,13 +156,13 @@ The macOS binary includes the Docker client only. It does not include the
 
 ## Upgrade static binaries
 
-To upgrade your manual installation of Docker Engine - Community, first stop any
+To upgrade your manual installation of Docker Engine, first stop any
 `dockerd` or `dockerd.exe`  processes running locally, then follow the
 regular installation steps to install the new version on top of the existing
 version.
 
 ## Next steps
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md).
+- Continue to [Post-installation steps for Linux](linux-postinstall.md).
 - Take a look at the [Get started](/get-started/index.md) training modules to learn  how to build an image and run it as a containerized application.
 - Review the topics in [Develop with Docker](/develop/index.md) to learn how to build new applications using Docker.

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -1,24 +1,25 @@
 ---
-description: Instructions for installing Docker Engine - Community on CentOS
+description: Instructions for installing Docker Engine on CentOS
 keywords: requirements, apt, installation, centos, rpm, install, uninstall, upgrade, update
 redirect_from:
 - /engine/installation/centos/
 - /engine/installation/linux/docker-ce/centos/
 - /install/linux/centos/
+- /install/linux/docker-ce/centos/
 - /engine/installation/linux/centos/
-title: Get Docker Engine - Community for CentOS
+title: Install Docker Engine on CentOS
 toc_max: 4
 ---
 
-To get started with Docker Engine - Community on CentOS, make sure you
+To get started with Docker Engine on CentOS, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker-ce).
+[install Docker](#installation-methods).
 
 ## Prerequisites
 
 ### OS requirements
 
-To install Docker Engine - Community, you need a maintained version of CentOS 7. Archived
+To install Docker Engine, you need a maintained version of CentOS 7. Archived
 versions aren't supported or tested.
 
 The `centos-extras` repository must be enabled. This repository is enabled by
@@ -46,11 +47,11 @@ $ sudo yum remove docker \
 It's OK if `yum` reports that none of these packages are installed.
 
 The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine - Community package is now called `docker-ce`.
+networks, are preserved. The Docker Engine package is now called `docker-ce`.
 
-## Install Docker Engine - Community
+## Installation methods
 
-You can install Docker Engine - Community in different ways, depending on your needs:
+You can install Docker Engine in different ways, depending on your needs:
 
 - Most users
   [set up Docker's repositories](#install-using-the-repository) and install
@@ -67,7 +68,7 @@ You can install Docker Engine - Community in different ways, depending on your n
 
 ### Install using the repository
 
-Before you install Docker Engine - Community for the first time on a new host machine, you need
+Before you install Docker Engine for the first time on a new host machine, you need
 to set up the Docker repository. Afterward, you can install and update Docker
 from the repository.
 
@@ -75,23 +76,16 @@ from the repository.
 
 {% assign download-url-base = "https://download.docker.com/linux/centos" %}
 
-1.  Install required packages. `yum-utils` provides the `yum-config-manager`
-    utility, and `device-mapper-persistent-data` and `lvm2` are required by the
-    `devicemapper` storage driver.
+Install the `yum-utils` package (which provides the `yum-config-manager`
+utility) and set up the **stable** repository.
 
-    ```bash
-    $ sudo yum install -y yum-utils \
-      device-mapper-persistent-data \
-      lvm2
-    ```
+```bash
+$ sudo yum install -y yum-utils
 
-2.  Use the following command to set up the **stable** repository.
-
-    ```bash
-    $ sudo yum-config-manager \
-        --add-repo \
-        {{ download-url-base }}/docker-ce.repo
-    ```
+$ sudo yum-config-manager \
+    --add-repo \
+    {{ download-url-base }}/docker-ce.repo
+```
 
 > **Optional**: Enable the **nightly** or **test** repositories.
 >
@@ -117,11 +111,11 @@ from the repository.
 > $ sudo yum-config-manager --disable docker-ce-nightly
 > ```
 >
-> [Learn about **nightly** and **test** channels](/install/index.md).
+> [Learn about **nightly** and **test** channels](index.md).
 
-#### Install Docker Engine - Community
+#### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine - Community and containerd, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
 
     ```bash
     $ sudo yum install docker-ce docker-ce-cli containerd.io
@@ -139,7 +133,7 @@ from the repository.
 
     Docker is installed but not started. The `docker` group is created, but no users are added to the group.
 
-2.  To install a _specific version_ of Docker Engine - Community, list the available versions
+2.  To install a _specific version_ of Docker Engine, list the available versions
     in the repo, then select and install:
 
     a. List and sort the versions available in your repo. This example sorts
@@ -174,7 +168,7 @@ from the repository.
     $ sudo systemctl start docker
     ```
 
-4.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+4.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -184,31 +178,31 @@ from the repository.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. You need to use `sudo` to run Docker
-commands. Continue to [Linux postinstall](/install/linux/linux-postinstall.md) to allow
+Docker Engine is installed and running. You need to use `sudo` to run Docker
+commands. Continue to [Linux postinstall](linux-postinstall.md) to allow
 non-privileged users to run Docker commands and for other optional configuration
 steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, follow the [installation instructions](#install-docker-ce),
+To upgrade Docker Engine, follow the [installation instructions](#install-using-the-repository),
 choosing the new version you want to install.
 
 ### Install from a package
 
 If you cannot use Docker's repository to install Docker, you can download the
 `.rpm` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker Engine - Community.
+a new file each time you want to upgrade Docker Engine.
 
-1.  Go to
-    [{{ download-url-base }}/7/x86_64/stable/Packages/]({{ download-url-base }}/7/x86_64/stable/Packages/)
+1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" class="_" }
+    and choose your version of CentOS. Then browse to `x86_64/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
 
-    > **Note**: To install a **nightly**  or **test** (pre-release) package,
+    > **Note**: To install a **nightly** or **test** (pre-release) package,
     > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](/install/index.md).
+    > [Learn about **nightly** and **test** channels](index.md).
 
-2.  Install Docker Engine - Community, changing the path below to the path where you downloaded
+2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
     ```bash
@@ -224,7 +218,7 @@ a new file each time you want to upgrade Docker Engine - Community.
     $ sudo systemctl start docker
     ```
 
-4.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+4.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -234,25 +228,25 @@ a new file each time you want to upgrade Docker Engine - Community.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. You need to use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md) to allow
+Docker Engine is installed and running. You need to use `sudo` to run Docker commands.
+Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
 non-privileged users to run Docker commands and for other optional configuration
 steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package file and repeat the
 [installation procedure](#install-from-a-package), using `yum -y upgrade`
 instead of `yum -y install`, and pointing to the new file.
 
 {% include install-script.md %}
 
-## Uninstall Docker Engine - Community
+## Uninstall Docker Engine
 
-1.  Uninstall the Docker package:
+1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
     ```bash
-    $ sudo yum remove docker-ce
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host
@@ -267,5 +261,5 @@ You must delete any edited configuration files manually.
 
 ## Next steps
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md).
+- Continue to [Post-installation steps for Linux](linux-postinstall.md).
 - Review the topics in [Develop with Docker](/develop/index.md) to learn how to build new applications using Docker.

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -22,8 +22,8 @@ To get started with Docker Engine on Debian, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Debian or
 Raspbian versions:
 
-- Buster 10 (stable)
-- Stretch 9 / Raspbian Stretch
+- Ubuntu Buster 10 (stable)
+- Ubuntu Stretch 9 / Raspbian Stretch
 
 Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -1,31 +1,31 @@
 ---
-description: Instructions for installing Docker Engine - Community on Debian
+description: Instructions for installing Docker Engine on Debian
 keywords: requirements, apt, installation, debian, install, uninstall, upgrade, update
 redirect_from:
 - /engine/installation/debian/
 - /engine/installation/linux/raspbian/
 - /engine/installation/linux/debian/
 - /engine/installation/linux/docker-ce/debian/
-title: Get Docker Engine - Community for Debian
+- /install/linux/docker-ce/debian/
+title: Install Docker Engine on Debian
 toc_max: 4
 ---
 
-To get started with Docker Engine - Community on Debian, make sure you
+To get started with Docker Engine on Debian, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker-ce).
+[install Docker](#installation-methods).
 
 ## Prerequisites
- 
 
 ### OS requirements
 
-To install Docker Engine - Community, you need the 64-bit version of one of these Debian or
+To install Docker Engine, you need the 64-bit version of one of these Debian or
 Raspbian versions:
 
 - Buster 10 (stable)
 - Stretch 9 / Raspbian Stretch
 
-Docker Engine - Community is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
+Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
 
 ### Uninstall old versions
 
@@ -39,11 +39,11 @@ $ sudo apt-get remove docker docker-engine docker.io containerd runc
 It's OK if `apt-get` reports that none of these packages are installed.
 
 The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine - Community package is now called `docker-ce`.
+networks, are preserved. The Docker Engine package is now called `docker-ce`.
 
-## Install Docker Engine - Community
+## Installation methods
 
-You can install Docker Engine - Community in different ways, depending on your needs:
+You can install Docker Engine in different ways, depending on your needs:
 
 - Most users
   [set up Docker's repositories](#install-using-the-repository) and install
@@ -61,7 +61,7 @@ You can install Docker Engine - Community in different ways, depending on your n
 
 ### Install using the repository
 
-Before you install Docker Engine - Community for the first time on a new host machine, you need
+Before you install Docker Engine for the first time on a new host machine, you need
 to set up the Docker repository. Afterward, you can install and update Docker
 from the repository.
 
@@ -74,15 +74,12 @@ from the repository.
 
 {% assign download-url-base = "https://download.docker.com/linux/debian" %}
 
-1.  Update the `apt` package index:
+1.  Update the `apt` package index and install packages to allow `apt` to use a
+    repository over HTTPS:
 
     ```bash
     $ sudo apt-get update
-    ```
 
-2.  Install packages to allow `apt` to use a repository over HTTPS:
-
-    ```bash
     $ sudo apt-get install \
         apt-transport-https \
         ca-certificates \
@@ -91,7 +88,7 @@ from the repository.
         software-properties-common
     ```
 
-3.  Add Docker's official GPG key:
+2.  Add Docker's official GPG key:
 
     ```bash
     $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
@@ -110,9 +107,9 @@ from the repository.
     sub   4096R/F273FCD8 2017-02-22
     ```
 
-4.  Use the following command to set up the **stable** repository. To add the
+3.  Use the following command to set up the **stable** repository. To add the
     **nightly** or **test** repository, add the word `nightly` or `test` (or both)
-    after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](/install/index.md).
+    after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](index.md).
 
     > **Note**: The `lsb_release -cs` sub-command below returns the name of your
     > Debian distribution, such as `helium`. Sometimes, in a distribution
@@ -159,20 +156,16 @@ from the repository.
     </div>
     </div> <!-- tab-content -->
 
-#### Install Docker Engine - Community
+#### Install Docker Engine
 
 > **Note**: This procedure works for Debian on `x86_64` / `amd64`, Debian ARM,
 > or Raspbian.
 
-1.  Update the `apt` package index.
+1. Update the `apt` package index, and install the _latest version_ of Docker
+   Engine and containerd, or go to the next step to install a specific version:
 
     ```bash
     $ sudo apt-get update
-    ```
-
-2.  Install the _latest version_ of Docker Engine - Community and containerd, or go to the next step to install a specific version:
-
-    ```bash
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io
     ```
 
@@ -183,7 +176,8 @@ from the repository.
     > `apt-get update` command always installs the highest possible version,
     > which may not be appropriate for your stability needs.
 
-3.  To install a _specific version_ of Docker Engine - Community, list the available versions in the repo, then select and install:
+2.  To install a _specific version_ of Docker Engine, list the available versions
+    in the repo, then select and install:
 
     a. List the versions available in your repo:
 
@@ -204,7 +198,7 @@ from the repository.
     $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
     ```
 
-4.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -214,34 +208,33 @@ from the repository.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. The `docker` group is created but no users
+Docker Engine is installed and running. The `docker` group is created but no users
 are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Linux postinstall](/install/linux/linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+Continue to [Linux postinstall](linux-postinstall.md) to allow non-privileged
+users to run Docker commands and for other optional configuration steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, first run `sudo apt-get update`, then follow the
-[installation instructions](#install-docker-ce), choosing the new version you want
-to install.
+To upgrade Docker Engine, first run `sudo apt-get update`, then follow the
+[installation instructions](#install-using-the-repository), choosing the new
+version you want to install.
 
 ### Install from a package
 
-If you cannot use Docker's repository to install Docker Engine - Community, you can download the
+If you cannot use Docker's repository to install Docker Engine, you can download the
 `.deb` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker.
 
 1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" class="_" },
-    choose your Debian version, browse to `pool/stable/`, choose `amd64`,
-    `armhf`, or `arm64` and download the `.deb` file for the Docker Engine - Community version
+    choose your Debian version, then browse to `pool/stable/`, choose `amd64`,
+    `armhf`, or `arm64` and download the `.deb` file for the Docker version
     you want to install.
 
-    > **Note**: To install a **nightly**  package, change the word
-    > `stable` in the  URL to `nightly`.
-    > [Learn about **nightly** and **test** channels](/install/index.md).
+    > **Note**: To install a **nightly** or **test** (pre-release) package,
+    > change the word `stable` in the above URL to `nightly` or `test`.
+    > [Learn about **nightly** and **test** channels](index.md).
 
-2.  Install Docker Engine - Community, changing the path below to the path where you downloaded
+2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
     ```bash
@@ -250,7 +243,7 @@ a new file each time you want to upgrade Docker.
 
     The Docker daemon starts automatically.
 
-3.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -260,25 +253,25 @@ a new file each time you want to upgrade Docker.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. The `docker` group is created but no users
+Docker Engine is installed and running. The `docker` group is created but no users
 are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md)
-to allow non-privileged users to run Docker commands and for other optional
-configuration steps.
+Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
+non-privileged users to run Docker commands and for other optional configuration
+steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package file and repeat the
 [installation procedure](#install-from-a-package), pointing to the new file.
 
 {% include install-script.md %}
 
-## Uninstall Docker Engine - Community
+## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine - Community package:
+1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
     ```bash
-    $ sudo apt-get purge docker-ce
+    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host
@@ -293,5 +286,5 @@ You must delete any edited configuration files manually.
 
 ## Next steps
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md).
+- Continue to [Post-installation steps for Linux](linux-postinstall.md).
 - Review the topics in [Develop with Docker](/develop/index.md) to learn how to build new applications using Docker.

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -1,27 +1,27 @@
 ---
-description: Instructions for installing Docker Engine - Community on Fedora
+description: Instructions for installing Docker Engine on Fedora
 keywords: requirements, apt, installation, fedora, rpm, install, uninstall, upgrade, update
 redirect_from:
 - /engine/installation/fedora/
 - /engine/installation/linux/fedora/
 - /engine/installation/linux/docker-ce/fedora/
-title: Get Docker Engine - Community for Fedora
+- /install/linux/docker-ce/fedora/
+title: Install Docker Engine on Fedora
 toc_max: 4
 ---
 
-To get started with Docker Engine - Community on Fedora, make sure you
+To get started with Docker Engine on Fedora, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker-ce).
+[install Docker](#installation-methods).
 
 ## Prerequisites
 
-
 ### OS requirements
 
-To install Docker, you need the 64-bit version of one of these Fedora versions:
+To install Docker Engine, you need the 64-bit version of one of these Fedora versions:
 
-- 30
-- 31
+- Fedora 30
+- Fedora 31
 
 ### Uninstall old versions
 
@@ -44,11 +44,11 @@ $ sudo dnf remove docker \
 It's OK if `dnf` reports that none of these packages are installed.
 
 The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine - Community package is now called `docker-ce`.
+networks, are preserved. The Docker Engine package is now called `docker-ce`.
 
-## Install Docker Engine - Community
+## Installation methods
 
-You can install Docker Engine - Community in different ways, depending on your needs:
+You can install Docker Engine in different ways, depending on your needs:
 
 - Most users
   [set up Docker's repositories](#install-using-the-repository) and install
@@ -65,7 +65,7 @@ You can install Docker Engine - Community in different ways, depending on your n
 
 ### Install using the repository
 
-Before you install Docker Engine - Community for the first time on a new host machine, you need
+Before you install Docker Engine for the first time on a new host machine, you need
 to set up the Docker repository. Afterward, you can install and update Docker
 from the repository.
 
@@ -73,20 +73,18 @@ from the repository.
 
 {% assign download-url-base = "https://download.docker.com/linux/fedora" %}
 
-1.  Install the `dnf-plugins-core` package which provides the commands to manage
-    your DNF repositories from the command line.
+Install the `dnf-plugins-core` package (which provides the commands to manage
+your DNF repositories) and set up the **stable** repository.
 
-    ```bash
-    $ sudo dnf -y install dnf-plugins-core
-    ```
+```bash
+$ sudo dnf -y install dnf-plugins-core
 
-2.  Use the following command to set up the **stable** repository.
+$ sudo dnf -y install dnf-plugins-core
 
-    ```bash
-    $ sudo dnf config-manager \
-        --add-repo \
-        {{ download-url-base }}/docker-ce.repo
-    ```
+$ sudo dnf config-manager \
+    --add-repo \
+    {{ download-url-base }}/docker-ce.repo
+```
 
 > **Optional**: Enable the **nightly** or **test** repositories.
 >
@@ -113,11 +111,11 @@ from the repository.
 > $ sudo dnf config-manager --set-disabled docker-ce-nightly
 > ```
 >
-> [Learn about **nightly** and **test** channels](/install/index.md).
+> [Learn about **nightly** and **test** channels](index.md).
 
-#### Install Docker Engine - Community
+#### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine - Community and containerd, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
 
     ```bash
     $ sudo dnf install docker-ce docker-ce-cli containerd.io
@@ -135,7 +133,7 @@ from the repository.
 
     Docker is installed but not started. The `docker` group is created, but no users are added to the group.
 
-2.  To install a _specific version_ of Docker Engine - Community, list the available versions
+2.  To install a _specific version_ of Docker Engine, list the available versions
     in the repo, then select and install:
 
     a. List and sort the versions available in your repo. This example sorts
@@ -179,7 +177,7 @@ from the repository.
     $ sudo systemctl start docker
     ```
 
-5.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+5.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -189,36 +187,39 @@ from the repository.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. You need to use `sudo` to run Docker
-commands. Continue to [Linux postinstall](/install/linux/linux-postinstall.md) to allow
+Docker Engine is installed and running. You need to use `sudo` to run Docker
+commands. Continue to [Linux postinstall](linux-postinstall.md) to allow
 non-privileged users to run Docker commands and for other optional configuration
 steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, follow the [installation instructions](#install-docker-ce),
+To upgrade Docker Engine, follow the [installation instructions](#install-using-the-repository),
 choosing the new version you want to install.
 
 ### Install from a package
 
 If you cannot use Docker's repository to install Docker, you can download the
 `.rpm` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker Engine - Community.
+a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/) and choose your
-    version of Fedora. Go to `x86_64/stable/Packages/`
+1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" class="_" }
+    and choose your version of Fedora. Then browse to `x86_64/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
 
-    > **Note**: To install a **nightly**  or **test** (pre-release) package,
+    > **Note**: To install a **nightly** or **test** (pre-release) package,
     > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](/install/index.md).
+    > [Learn about **nightly** and **test** channels](index.md).
 
-2.  Install Docker Engine - Community, changing the path below to the path where you downloaded
+2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
     ```bash
     $ sudo dnf -y install /path/to/package.rpm
     ```
+
+    Docker is installed but not started. The `docker` group is created, but no
+    users are added to the group.
 
 3.  Start Docker.
 
@@ -226,7 +227,7 @@ a new file each time you want to upgrade Docker Engine - Community.
     $ sudo systemctl start docker
     ```
 
-4.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+4.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -236,25 +237,25 @@ a new file each time you want to upgrade Docker Engine - Community.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. You need to use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md) to allow
+Docker Engine is installed and running. You need to use `sudo` to run Docker commands.
+Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
 non-privileged users to run Docker commands and for other optional configuration
 steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package file and repeat the
 [installation procedure](#install-from-a-package), using `dnf -y upgrade`
 instead of `dnf -y install`, and pointing to the new file.
 
 {% include install-script.md %}
 
-## Uninstall Docker Engine - Community
+## Uninstall Docker Engine
 
-1.  Uninstall the Docker package:
+1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
     ```bash
-    $ sudo dnf remove docker-ce
+    $ sudo dnf remove docker-ce docker-ce-cli containerd.io
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host
@@ -269,5 +270,5 @@ You must delete any edited configuration files manually.
 
 ## Next steps
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md).
+- Continue to [Post-installation steps for Linux](linux-postinstall.md).
 - Review the topics in [Develop with Docker](/develop/index.md) to learn how to build new applications using Docker.

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -1,10 +1,8 @@
 ---
-title: Docker Engine overview
+title: Install Docker Engine
 description: Lists the installation methods
-keywords: docker, installation, install, Docker Engine - Community, Docker Engine - Enterprise, docker editions, stable, edge
+keywords: docker, installation, install, Docker Engine, Docker Engine, docker editions, stable, edge
 redirect_from:
-- /install/overview/
-- /installation/
 - /engine/installation/linux/
 - /engine/installation/linux/frugalware/
 - /engine/installation/frugalware/
@@ -16,8 +14,6 @@ redirect_from:
 - /engine/installation/linux/docker-ee/
 - /engine/installation/
 - /en/latest/installation/
-- /linux/
-- /edge/
 toc_max: 2
 ---
 
@@ -44,31 +40,28 @@ For more information, see [Release channels](#release-channels).
 
 ## Supported platforms
 
-Docker Engine is available on a variety of Linux platforms, [Mac](/docker-for-mac/install/)
-and [Windows](/docker-for-windows/install/) through Docker Desktop, Windows
+Docker Engine is available on a variety of Linux platforms, [Mac](/docker-for-mac/install.md)
+and [Windows](/docker-for-windows/install.md) through Docker Desktop, Windows
 Server, and as a static binary installation. Find your preferred operating
 system below.
 
 #### Desktop
 
-{% assign green-check = '![yes](/install/images/green-check.svg){: style="height: 14px; margin: 0 auto"}' %}
+{% assign yes = '![yes](/install/images/green-check.svg){: style="height: 14px; margin: 0 auto"}' %}
 
-| Platform                                                                    |      x86_64       |
-|:----------------------------------------------------------------------------|:-----------------:|
-| [Docker Desktop for Mac (macOS)](/docker-for-mac/install/)                        | {{ green-check }} |
-| [Docker Desktop for Windows (Microsoft Windows 10)](/docker-for-windows/install/) | {{ green-check }} |
+| Platform                                                     | x86_64 / amd64                              |
+|:-------------------------------------------------------------|:-------------------------------------------:|
+| [Docker Desktop for Mac (macOS)](/docker-for-mac/install.md) | [{{ yes }}](/docker-for-mac/install.md)     |
+| [Docker Desktop for Windows](/docker-for-windows/install.md) | [{{ yes }}](/docker-for-windows/install.md) |
 
 #### Server
 
-{% assign green-check = '![yes](/install/images/green-check.svg){: style="height: 14px; margin: 0 auto"}' %}
-{% assign install-prefix-ce = '/install/linux/docker-ce' %}
-
-| Platform                                    | x86_64 / amd64                                         | ARM                                                    | ARM64 / AARCH64                                        | IBM Power (ppc64le)                                    | IBM Z (s390x)                                          |
-|:--------------------------------------------|:-------------------------------------------------------|:-------------------------------------------------------|:-------------------------------------------------------|:-------------------------------------------------------|:-------------------------------------------------------|
-| [CentOS]({{ install-prefix-ce }}/centos/) | [{{ green-check }}]({{ install-prefix-ce }}/centos/) |                                                        | [{{ green-check }}]({{ install-prefix-ce }}/centos/) |                                                        |                                                        |
-| [Debian]({{ install-prefix-ce }}/debian/) | [{{ green-check }}]({{ install-prefix-ce }}/debian/) | [{{ green-check }}]({{ install-prefix-ce }}/debian/) | [{{ green-check }}]({{ install-prefix-ce }}/debian/) |                                                        |                                                        |
-| [Fedora]({{ install-prefix-ce }}/fedora/) | [{{ green-check }}]({{ install-prefix-ce }}/fedora/) |                                                        | [{{ green-check }}]({{ install-prefix-ce }}/fedora/) |                                                        |                                                        |
-| [Ubuntu]({{ install-prefix-ce }}/ubuntu/) | [{{ green-check }}]({{ install-prefix-ce }}/ubuntu/) | [{{ green-check }}]({{ install-prefix-ce }}/ubuntu/) | [{{ green-check }}]({{ install-prefix-ce }}/ubuntu/) | [{{ green-check }}]({{ install-prefix-ce }}/ubuntu/) | [{{ green-check }}]({{ install-prefix-ce }}/ubuntu/) |
+| Platform              | x86_64 / amd64         | ARM                      | ARM64 / AARCH64        | IBM Power (ppc64le)    | IBM Z (s390x)          |
+|:----------------------|:-----------------------|:-------------------------|:-----------------------|:-----------------------|:-----------------------|
+| [CentOS](centos.md)   | [{{ yes }}](centos.md) |                          | [{{ yes }}](centos.md) |                        |                        |
+| [Debian](debian.md)   | [{{ yes }}](debian.md) | [{{ yes }}](debian.md)   | [{{ yes }}](debian.md) |                        |                        |
+| [Fedora](fedora.md)   | [{{ yes }}](fedora.md) |                          | [{{ yes }}](fedora.md) |                        |                        |
+| [Ubuntu](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) |
 
 ## Release channels
 
@@ -118,8 +111,8 @@ The release channel for these builds is called `nightly`.
 
 ## Support
 
-Docker Engine releases of a year-month branch are supported with patches as needed for 7 months after the first year-month general availability
-release.
+Docker Engine releases of a year-month branch are supported with patches as
+needed for one month after the the next year-month general availability release.
 
 This means bug reports and backports to release branches are assessed
 until the end-of-life date.
@@ -161,4 +154,4 @@ for it.
 ## Get started
 
 After setting up Docker, you can learn the basics with
-[Getting started with Docker](/get-started/).
+[Getting started with Docker](/get-started/index.md).

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -20,10 +20,10 @@ toc_max: 2
 
 ## Supported platforms
 
-Docker Engine is available on a variety of Linux platforms, [Mac](/docker-for-mac/install.md)
-and [Windows](/docker-for-windows/install.md) through Docker Desktop, Windows
-Server, and as a static binary installation. Find your preferred operating
-system below.
+Docker Engine is available on a variety of [Linux platforms](#server),
+[macOS](/docker-for-mac/install.md) and [Windows 10](/docker-for-windows/install.md)
+through Docker Desktop, and as a [static binary installation](binaries.md). Find
+your preferred operating system below.
 
 #### Desktop
 
@@ -36,14 +36,49 @@ system below.
 
 #### Server
 
+Docker provides `.deb` and `.rpm` packages form the following Linux distributions
+and architectures:
+
 | Platform              | x86_64 / amd64         | ARM                      | ARM64 / AARCH64        | IBM Power (ppc64le)    | IBM Z (s390x)          |
 |:----------------------|:-----------------------|:-------------------------|:-----------------------|:-----------------------|:-----------------------|
 | [CentOS](centos.md)   | [{{ yes }}](centos.md) |                          | [{{ yes }}](centos.md) |                        |                        |
 | [Debian](debian.md)   | [{{ yes }}](debian.md) | [{{ yes }}](debian.md)   | [{{ yes }}](debian.md) |                        |                        |
 | [Fedora](fedora.md)   | [{{ yes }}](fedora.md) |                          | [{{ yes }}](fedora.md) |                        |                        |
+| [Raspbian](debian.md) |                        | [{{ yes }}](fedora.md)   | [{{ yes }}](fedora.md) |                        |                        |
 | [Ubuntu](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) |
 
+##### Other Linux distributions
+
+- Users of Debian derivatives such as "BunsenLabs Linux", "Kali Linux" or 
+  "Linux Mint" should follow the installation instructions for [Debian](debian.md),
+  substituting the version of their distro for the corresponding Debian release.
+  Refer to the documentation of your distro to find which Debian release
+  corresponds with your derivative version.
+- Likewise, users of Ubuntu derivatives such as "Kubuntu", "Lubuntu" or "Xubuntu"
+  should follow the installation instructions for [Ubuntu](ubuntu.md),
+  substituting the version of their distro for the corresponding Ubuntu release.
+  Refer to the documentation of your distro to find which Ubuntu release
+  corresponds with your derivative version.
+- Some Linux distributions are providing a package of Docker Engine through their
+  package repositories. These packages are built and maintained by the Linux
+  distribution's package maintainers and may have differences in configuration
+  or built from modified source code. Docker is not involved in releasing these
+  packages and bugs or issues involving these packages should be reported in
+  your Linux distribution's issue tracker.
+
+Docker provides [binaries](binaries.md) for manual installation of Docker Engine.
+These binaries are statically linked and can be used on any Linux distribution.
+
 ## Release channels
+
+Docker Engine has three types of update channels, **stable**, **test**,
+and **nightly**:
+
+* The **Stable** channel gives you latest releases for general availability.
+* The **Test** channel gives pre-releases that are ready for testing before
+  general availability (GA).
+* The **Nightly** channel gives you latest builds of work in progress for the
+  next major release.
 
 ### Stable
 
@@ -63,14 +98,6 @@ such as betas and release candidates are conducted from their respective release
 branches. Patch releases and the corresponding pre-releases are performed
 from within the corresponding release branch.
 
-> **Note:**
-> While pre-releases are done to assist in the stabilization process, no
-> guarantees are provided.
-
-Binaries built for pre-releases are available in the test channel for
-the targeted year-month release using the naming format `test-YY.mm`,
-for example `test-18.09`.
-
 ### Nightly
 
 Nightly builds give you the latest builds of work in progress for the next major
@@ -86,8 +113,6 @@ These builds allow for testing from the latest code on the master branch.
 
 > **Note:**
 > No qualifications or guarantees are made for the nightly builds.
-
-The release channel for these builds is called `nightly`.
 
 ## Support
 

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -17,26 +17,6 @@ redirect_from:
 toc_max: 2
 ---
 
-Docker Engine is an open source containerization technology for building and
-containerizing your applications. Docker Engine acts as a client-server
-application with:
-* A server with a long-running daemon process [`dockerd`](/engine/reference/commandline/dockerd/).
-* APIs which specify interfaces that programs can use to talk to and
-  instruct the Docker daemon.
-* A command line interface (CLI) client [`docker`](/engine/reference/commandline/cli/).
-
-The CLI uses Docker APIs to control or interact with the Docker daemon
-through scripting or direct CLI commands. Many other Docker applications use the
-underlying API and CLI. The daemon creates and manage Docker objects, such as
-images, containers, networks, and volumes.
-
-Docker Engine has three types of update channels, **stable**, **test**, and **nightly**:
-
-* **Stable** gives you latest releases for general availability.
-* **Test** gives pre-releases that are ready for testing before general availability.
-* **Nightly** gives you latest builds of work in progress for the next major release.
-
-For more information, see [Release channels](#release-channels).
 
 ## Supported platforms
 

--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -5,6 +5,7 @@ title: Post-installation steps for Linux
 redirect_from:
 - /engine/installation/linux/docker-ee/linux-postinstall/
 - /engine/installation/linux/linux-postinstall/
+- /install/linux/linux-postinstall/
 ---
 
 This section contains optional procedures for configuring Linux hosts to work

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -1,27 +1,28 @@
 ---
-description: Instructions for installing Docker Engine - Community on Ubuntu
+description: Instructions for installing Docker Engine on Ubuntu
 keywords: requirements, apt, installation, ubuntu, install, uninstall, upgrade, update
 redirect_from:
 - /engine/installation/ubuntulinux/
 - /installation/ubuntulinux/
+- /engine/installation/linux/ubuntu/
 - /engine/installation/linux/ubuntulinux/
 - /engine/installation/linux/docker-ce/ubuntu/
 - /install/linux/ubuntu/
-- /engine/installation/linux/ubuntu/
-title: Get Docker Engine - Community for Ubuntu
+- /install/linux/docker-ce/debian/
+title: Install Docker Engine on Ubuntu
 toc_max: 4
 ---
 
-To get started with Docker Engine - Community on Ubuntu, make sure you
+To get started with Docker Engine on Ubuntu, make sure you
 [meet the prerequisites](#prerequisites), then
-[install Docker](#install-docker-engine---community-1).
+[install Docker](#installation-methods).
 
 ## Prerequisites
 
 ### Docker EE customers
 
 To install Docker Enterprise Edition (Docker EE), go to
-[Get Docker EE for Ubuntu](/install/linux/docker-ee/ubuntu.md)
+[Get Docker EE for Ubuntu](/ee/docker-ee/ubuntu.md)
 **instead of this topic**.
 
 To learn more about Docker EE, see
@@ -29,14 +30,14 @@ To learn more about Docker EE, see
 
 ### OS requirements
 
-To install Docker Engine - Community, you need the 64-bit version of one of these Ubuntu
+To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
 - Eoan 19.10
 - Bionic 18.04 (LTS)
 - Xenial 16.04 (LTS)
 
-Docker Engine - Community is supported on `x86_64` (or `amd64`), `armhf`, `arm64`, `s390x`
+Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, `arm64`, `s390x`
 (IBM Z), and `ppc64le` (IBM Power) architectures.
 
 ### Uninstall old versions
@@ -51,22 +52,19 @@ $ sudo apt-get remove docker docker-engine docker.io containerd runc
 It's OK if `apt-get` reports that none of these packages are installed.
 
 The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine - Community package is now called `docker-ce`.
+networks, are preserved. The Docker Engine package is now called `docker-ce`.
 
 ### Supported storage drivers
 
-Docker Engine - Community on Ubuntu supports `overlay2`, `aufs` and `btrfs` storage drivers.
-> **Note**: In Docker Engine - Enterprise, `btrfs` is only supported on SLES. See the documentation on
-> [btrfs](/engine/userguide/storagedriver/btrfs-driver.md) for more details.
+Docker Engine on Ubuntu supports `overlay2`, `aufs` and `btrfs` storage drivers.
 
-For new installations on version 4 and higher of the Linux kernel, `overlay2`
-is supported and preferred over `aufs`. Docker Engine - Community uses the `overlay2`
-storage driver by default. If you need to use `aufs` instead, you need to
-configure it manually. See [aufs](/engine/userguide/storagedriver/aufs-driver.md)
+Docker Engine uses the `overlay2` storage driver by default. If you need to use
+`aufs` instead, you need to configure it manually.
+See [use the AUFS storage driver](/storage/storagedriver/aufs-driver.md)
 
-## Install Docker Engine - Community
+## Installation methods
 
-You can install Docker Engine - Community in different ways, depending on your needs:
+You can install Docker Engine in different ways, depending on your needs:
 
 - Most users
   [set up Docker's repositories](#install-using-the-repository) and install
@@ -83,7 +81,7 @@ You can install Docker Engine - Community in different ways, depending on your n
 
 ### Install using the repository
 
-Before you install Docker Engine - Community for the first time on a new host machine, you need
+Before you install Docker Engine for the first time on a new host machine, you need
 to set up the Docker repository. Afterward, you can install and update Docker
 from the repository.
 
@@ -91,15 +89,12 @@ from the repository.
 
 {% assign download-url-base = "https://download.docker.com/linux/ubuntu" %}
 
-1.  Update the `apt` package index:
+1.  Update the `apt` package index and install packages to allow `apt` to use a
+    repository over HTTPS:
 
     ```bash
     $ sudo apt-get update
-    ```
 
-2.  Install packages to allow `apt` to use a repository over HTTPS:
-
-    ```bash
     $ sudo apt-get install \
         apt-transport-https \
         ca-certificates \
@@ -108,7 +103,7 @@ from the repository.
         software-properties-common
     ```
 
-3.  Add Docker's official GPG key:
+2.  Add Docker's official GPG key:
 
     ```bash
     $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
@@ -120,16 +115,16 @@ from the repository.
 
     ```bash
     $ sudo apt-key fingerprint 0EBFCD88
-    
+
     pub   rsa4096 2017-02-22 [SCEA]
           9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88
     uid           [ unknown] Docker Release (CE deb) <docker@docker.com>
     sub   rsa4096 2017-02-22 [S]
     ```
 
-4.  Use the following command to set up the **stable** repository. To add the
+3.  Use the following command to set up the **stable** repository. To add the
     **nightly** or **test** repository, add the word `nightly` or `test` (or both)
-    after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](/install/index.md).
+    after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](index.md).
 
     > **Note**: The `lsb_release -cs` sub-command below returns the name of your
     > Ubuntu distribution, such as `xenial`. Sometimes, in a distribution
@@ -137,7 +132,6 @@ from the repository.
     > to your parent Ubuntu distribution. For example, if you are using
     >  `Linux Mint Tessa`, you could use `bionic`. Docker does not offer any guarantees on untested
     > and unsupported Ubuntu distributions.
-
 
     <ul class="nav nav-tabs">
       <li class="active"><a data-toggle="tab" data-target="#x86_64_repo">x86_64 / amd64</a></li>
@@ -199,17 +193,13 @@ from the repository.
     </div>
     </div> <!-- tab-content -->
 
-#### Install Docker Engine - Community
+#### Install Docker Engine
 
-1.  Update the `apt` package index.
+1. Update the `apt` package index, and install the _latest version_ of Docker
+   Engine and containerd, or go to the next step to install a specific version:
 
     ```bash
     $ sudo apt-get update
-    ```
-
-2.  Install the _latest version_ of Docker Engine - Community and containerd, or go to the next step to install a specific version:
-
-    ```bash
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io
     ```
 
@@ -220,7 +210,8 @@ from the repository.
     > `apt-get update` command always installs the highest possible version,
     > which may not be appropriate for your stability needs.
 
-3.  To install a _specific version_ of Docker Engine - Community, list the available versions in the repo, then select and install:
+2.  To install a _specific version_ of Docker Engine, list the available versions
+    in the repo, then select and install:
 
     a. List the versions available in your repo:
 
@@ -241,7 +232,7 @@ from the repository.
     $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
     ```
 
-4.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -251,34 +242,33 @@ from the repository.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. The `docker` group is created but no users
+Docker Engine is installed and running. The `docker` group is created but no users
 are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Linux postinstall](/install/linux/linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+Continue to [Linux postinstall](linux-postinstall.md) to allow non-privileged
+users to run Docker commands and for other optional configuration steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, first run `sudo apt-get update`, then follow the
-[installation instructions](#install-docker-ce), choosing the new version you want
-to install.
+To upgrade Docker Engine, first run `sudo apt-get update`, then follow the
+[installation instructions](#install-using-the-repository), choosing the new
+version you want to install.
 
 ### Install from a package
 
-If you cannot use Docker's repository to install Docker Engine - Community, you can download the
+If you cannot use Docker's repository to install Docker Engine, you can download the
 `.deb` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker.
 
 1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" class="_" },
-    choose your Ubuntu version, browse to `pool/stable/`, choose `amd64`,
+    choose your Ubuntu version, then browse to `pool/stable/`, choose `amd64`,
     `armhf`, `arm64`, `ppc64el`, or `s390x`, and download the `.deb` file for the
-    Docker Engine - Community version you want to install.
+    Docker Engine version you want to install.
 
-    > **Note**: To install a **nightly**  package, change the word
-    > `stable` in the  URL to `nightly`.
-    > [Learn about **nightly** and **test** channels](/install/index.md).
+    > **Note**: To install a **nightly** or **test** (pre-release) package,
+    > change the word `stable` in the above URL to `nightly` or `test`.
+    > [Learn about **nightly** and **test** channels](index.md).
 
-2.  Install Docker Engine - Community, changing the path below to the path where you downloaded
+2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
     ```bash
@@ -287,7 +277,7 @@ a new file each time you want to upgrade Docker.
 
     The Docker daemon starts automatically.
 
-3.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
+3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```bash
@@ -297,25 +287,25 @@ a new file each time you want to upgrade Docker.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints an informational message and exits.
 
-Docker Engine - Community is installed and running. The `docker` group is created but no users
+Docker Engine is installed and running. The `docker` group is created but no users
 are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md)
-to allow non-privileged users to run Docker commands and for other optional
-configuration steps.
+Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
+non-privileged users to run Docker commands and for other optional configuration
+steps.
 
-#### Upgrade Docker Engine - Community
+#### Upgrade Docker Engine
 
-To upgrade Docker Engine - Community, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package file and repeat the
 [installation procedure](#install-from-a-package), pointing to the new file.
 
 {% include install-script.md %}
 
-## Uninstall Docker Engine - Community
+## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine - Community package:
+1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
     ```bash
-    $ sudo apt-get purge docker-ce
+    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host
@@ -330,5 +320,5 @@ You must delete any edited configuration files manually.
 
 ## Next steps
 
-- Continue to [Post-installation steps for Linux](/install/linux/linux-postinstall.md).
+- Continue to [Post-installation steps for Linux](linux-postinstall.md).
 - Review the topics in [Develop with Docker](/develop/index.md) to learn how to build new applications using Docker.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -33,9 +33,9 @@ To learn more about Docker EE, see
 To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
-- Eoan 19.10
-- Bionic 18.04 (LTS)
-- Xenial 16.04 (LTS)
+- Ubuntu Eoan 19.10
+- Ubuntu Bionic 18.04 (LTS)
+- Ubuntu Xenial 16.04 (LTS)
 
 Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, `arm64`, `s390x`
 (IBM Z), and `ppc64le` (IBM Power) architectures.

--- a/engine/release-notes/18.06.md
+++ b/engine/release-notes/18.06.md
@@ -9,14 +9,14 @@ skip_read_time: true
 
 2019-02-19
 
-### Security fixes for Docker Engine - Community
+### Security fixes for Docker Engine
 * Change how the `runc` critical vulnerability patch is applied to include the fix in RPM packages. [docker/engine#156](https://github.com/docker/engine/pull/156)
 
 ## 18.06.2
 
 2019-02-11
 
-### Security fixes for Docker Engine - Community
+### Security fixes for Docker Engine
 * Update `runc` to address a critical vulnerability that allows specially-crafted containers to gain administrative privileges on the host. [CVE-2019-5736](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736)
 * Ubuntu 14.04 customers using a 3.13 kernel will need to upgrade to a supported Ubuntu 4.x kernel
 

--- a/engine/release-notes/index.md
+++ b/engine/release-notes/index.md
@@ -1,6 +1,6 @@
 ---
 title: Docker Engine release notes
-description: Learn about the new features, bug fixes, and breaking changes for Docker Engine - Community
+description: Learn about the new features, bug fixes, and breaking changes for Docker Engine
 keywords: docker, docker engine, ce, whats new, release notes
 toc_min: 1
 toc_max: 2
@@ -11,7 +11,7 @@ redirect_from:
 ---
 
 This document describes the latest changes, additions, known issues, and fixes
-for Docker Engine - Community.
+for Docker Engine.
 
 > **Note:**
 > The client and container runtime are now in separate packages from the daemon

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -5,7 +5,7 @@ title: Swarm mode overview
 ---
 
 To use Docker in swarm mode, install Docker. See
-[installation instructions](/install/index.md) for all operating systems and platforms.
+[installation instructions](/get-docker.md) for all operating systems and platforms.
 
 Current versions of Docker include *swarm mode* for natively managing a cluster
 of Docker Engines called a *swarm*. Use the Docker CLI to create a swarm, deploy

--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -61,8 +61,8 @@ follows:
 #### Install Docker Engine on Linux machines
 
 If you are using Linux based physical computers or cloud-provided computers as
-hosts, simply follow the [Linux install instructions](/install/index.md) for your platform. Spin up the three
-machines, and you are ready. You can test both
+hosts, simply follow the [Linux install instructions](/engine/install/index.md)
+for your platform. Spin up the three machines, and you are ready. You can test both
 single-node and multi-node swarm scenarios on Linux machines.
 
 #### Use Docker Desktop for Mac or Docker Desktop for Windows

--- a/get-docker.md
+++ b/get-docker.md
@@ -3,6 +3,10 @@ description: Home page for Get Docker
 keywords: Docker, download, documentation, manual
 landing: true
 title: Get Docker
+redirect_from:
+- /install/
+- /install/overview/
+- /installation/
 ---
 
 
@@ -36,7 +40,7 @@ You can download and install Docker on multiple platforms. Refer to the followin
                 <div class="component-icon">
                     <a href="install/linux/ubuntu/"> <img src="../images/linux_48.svg" alt="Docker for Linux"> </a>
                 </div>
-                <h3 id="docker-for-linux"><a href="install/linux/ubuntu/">Docker for Linux</a></h3>
+                <h3 id="docker-for-linux"><a href="engine/install/">Docker for Linux</a></h3>
                 <p>Install Docker on a computer which already has a Linux distribution installed.</p>
             </div>
         </div>

--- a/get-started/overview.md
+++ b/get-started/overview.md
@@ -6,6 +6,7 @@ redirect_from:
 - /engine/userguide/basics/
 - /engine/introduction/understanding-docker/
 - /engine/understanding-docker/
+- /engine/docker-overview/
 title: Docker overview
 ---
 
@@ -260,8 +261,6 @@ the future, Docker may support other container formats by integrating with
 technologies such as BSD Jails or Solaris Zones.
 
 ## Next steps
-- Read about [installing Docker](installation/index.md#installation).
-- Get hands-on experience with the [Getting started with Docker](getstarted/index.md)
+- Read about [installing Docker](/get-docker.md).
+- Get hands-on experience with the [Getting started with Docker](index.md)
     tutorial.
-- Check out examples and deep dive topics in the
-    [Docker Engine user guide](userguide/index.md).

--- a/index.md
+++ b/index.md
@@ -63,7 +63,7 @@ containers and automate the development pipeline from a single environment.
 Choose the Edge channel to get access to the latest features, or the Stable
 channel for more predictability.
 
-[Learn more about Docker Engine - Community](/install/){: class="button outline-btn"}
+[Learn more about Docker Engine - Community](/engine/index.md){: class="button outline-btn"}
 
 </div>
 <div markdown="1" class="col-xs-12 col-sm-12 col-md-12 col-lg-6 block">

--- a/storage/storagedriver/aufs-driver.md
+++ b/storage/storagedriver/aufs-driver.md
@@ -24,7 +24,7 @@ potential performance advantages over the `aufs` storage driver.
   Stretch.
 - For Docker EE, AUFS is supported on Ubuntu.
 - If you use Ubuntu, you need to
-  [install extra packages](/install/linux/ubuntu.md#recommended-extra-packages-for-trusty-1404){: target="_blank" class="_"}
+  [install extra packages](/engine/install/ubuntu.md#recommended-extra-packages-for-trusty-1404){: target="_blank" class="_"}
   to add the AUFS module to the kernel. If you do not install these packages,
   you need to use `devicemapper` on Ubuntu 14.04 (which is not recommended),
   or `overlay2` on Ubuntu 16.04 and higher, which is also supported.

--- a/storage/storagedriver/device-mapper-driver.md
+++ b/storage/storagedriver/device-mapper-driver.md
@@ -26,10 +26,10 @@ a filesystem at the operating system (OS) level.
 - `devicemapper` storage driver is a supported storage driver for Docker
   EE on many OS distribution. See the
   [Product compatibility matrix](https://success.docker.com/article/compatibility-matrix) for details.
-
 - `devicemapper` is also supported on Docker Engine - Community running on CentOS, Fedora,
   Ubuntu, or Debian.
-
+- `devicemapper` requires the `lvm2` and `device-mapper-persistent-data` packages
+  to be installed.
 - Changing the storage driver makes any containers you have already
   created inaccessible on the local system. Use `docker save` to save containers,
   and push existing images to Docker Hub or a private repository, so you do

--- a/swarm/install-manual.md
+++ b/swarm/install-manual.md
@@ -109,9 +109,9 @@ To create the instances do the following:
 
 ## Step 3. Install Engine on each node
 
-1.  [Install Docker](/install/){: target="_blank" class="_"} on each
-    host, using the appropriate instructions for your operating system and
-    distribution.
+1.  [Install Docker](/engine/install/index.md){: target="_blank" class="_"}
+    on each host, using the appropriate instructions for your operating system
+    and distribution.
 
 2.  Edit `/etc/docker/daemon.json`. Create it if it does not exist. Assuming the
     file was empty, its contents should be:


### PR DESCRIPTION

- Move getting started overview to /get-started/overview/
- Move engine installation files under /engine/
- Redirect the top-level /install/ to /get-docker/
- Updated titles in left-hand navigation
- Added back some pages to the navigation that were currently not included.
- Move /engine/docker-overview/ to /get-started/overview/
- Reduce some steps in the installation pages
- Move devicemapper prerequisites to the devicemapper storage driver page.
- engine: remove overlap between "overview" and "install" page
- engine: cleanup install page, add info about derivatives

### rewrite the engine "overview" page

This page is currently not a good introduction to the engine, and overlaps with the "global" introduction to Docker / overview in the getting started: http://localhost:4000/engine/docker-overview/

This PR makes some changes to the page to reduce the overlap, but may still need some TLC

~(note that that page's URL is currently under "engine" - probably will fix that in this PR as well, and move it to either `/docker-overview/` or `/get-started/overview/`)~


With this PR, the navigation looks like this:

<img width="294" alt="Screenshot 2020-03-18 at 13 45 50" src="https://user-images.githubusercontent.com/1804568/76962159-fb0ba080-691e-11ea-92b7-551b0b6657c4.png">
