### PR TITLE
Add note on case-sensitive filenames

### DIFF
--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -73,6 +73,7 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 - Fixed a race condition when starting the WSL engine which caused Docker Desktop to incorrectly report that the containers have exited. Fixes [docker/for-win#5607](https://github.com/docker/for-win/issues/5607).
 - Fixed an issue where editing code inside a container resulted in an error. Fixes [docker/for-win#5528](https://github.com/docker/for-win/issues/5528).
 - Fixed a bug where running the command `DockerCli.exe -SharedDrives` failed to display a list of drives that are shared. Fixes [docker/for-win#5625](https://github.com/docker/for-win/issues/5625).
+- Starting with Docker Desktop 2.2.0.3, you must access all shared files using their original case. For example, if you have created a file called `test`, you must open it as `test`. Attempts to open the file as `Test` will fail with the error `No such file or directory`. For more information, see _Tips on shared drives, permissions, and volume mounts_ in [File sharing](/docker-for-windows/index/#file-sharing).
 
 ### Known issues
 


### PR DESCRIPTION
Adding a release note to clarify case-sensitive file naming in Docker Desktop.