### PR TITLE
Deploy docs-stage to S3 instead of swarm

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - master
+      # TODO remove next line with branch switch-stage-to-s3 before merging PR
+      - switch-stage-to-s3
 
 jobs:
   build-static-page:

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -17,13 +17,13 @@ jobs:
       - name: build current docs
         run: docker build --build-arg=ENABLE_ARCHIVES=true --target=deploy-source --output=./_site .
       - name: upload files to S3 bucket
-        run: aws s3 sync --acl public-read _site s3://docs.docker.com-test-us-east-1/ --delete
+        run: aws s3 sync --acl public-read _site s3://docs.docker.com-stage-us-east-1/ --delete
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.repository == 'docker/docker.github.io' && github.event_name == 'push'
       - name: invalidate docs website cache
-        run: aws --region us-east-1 lambda invoke --function-name arn:aws:lambda:us-east-1:710015040892:function:docs-test-cache-invalidator response.json
+        run: aws --region us-east-1 lambda invoke --function-name arn:aws:lambda:us-east-1:710015040892:function:docs-stage-cache-invalidator response.json
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,24 +20,6 @@ pipeline {
         expression { env.GIT_URL == 'https://github.com/Docker/docker.github.io.git' }
       }
       stages {
-        stage( 'build + push stage image, update stage swarm' ) {
-          when {
-            branch 'master'
-          }
-          steps {
-            sh """
-              cat $SUCCESS_BOT_TOKEN | docker login  $DTR_URL --username 'success_bot' --password-stdin
-              docker build -t $DTR_URL/docker/docker.github.io:stage-${env.BUILD_NUMBER} .
-              docker push $DTR_URL/docker/docker.github.io:stage-${env.BUILD_NUMBER}
-              unzip -o $UCP_BUNDLE
-              export DOCKER_TLS_VERIFY=1
-              export COMPOSE_TLS_VERSION=TLSv1_2
-              export DOCKER_CERT_PATH=${WORKSPACE}/ucp-bundle-success_bot
-              export DOCKER_HOST=$DOCKER_HOST_STRING
-              docker service update --detach=false --force --image $DTR_URL/docker/docker.github.io:stage-${env.BUILD_NUMBER} docs-stage-docker-com_docs --with-registry-auth
-            """
-          }
-        }
         stage( 'build + push prod image, update prod swarm' ) {
           when {
             branch 'published'


### PR DESCRIPTION
This PR changes the pipeline how to deploy master branch to docs-stage.docker.com 
It removes the stage in Jenkins pipeline and activates the S3 upload in the GitHub action workflow.
