### PR TITLE
Upload published website to S3

### DIFF
--- a/.github/workflows/build-published.yml
+++ b/.github/workflows/build-published.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - published
+
+jobs:
+  build-static-page:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DOCKER_BUILDKIT: '1'
+    steps:
+      - name: print docker info
+        run: docker version && docker info
+      - uses: actions/checkout@v2
+      - name: build current docs
+        run: docker build --build-arg=ENABLE_ARCHIVES=true --target=deploy-source --output=./_site .
+      - name: upload files to S3 bucket
+        run: aws s3 sync --acl public-read _site s3://docs.docker.com-us-east-1/ --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        if: github.repository == 'docker/docker.github.io' && github.event_name == 'push'
+      - name: invalidate docs website cache
+        run: aws --region us-east-1 lambda invoke --function-name arn:aws:lambda:us-east-1:710015040892:function:docs-cache-invalidator response.json
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        if: github.repository == 'docker/docker.github.io' && github.event_name == 'push'


### PR DESCRIPTION
Similar to #10485, enable the S3 website GH Actions workflow for the `published` branch.

Information for reviewers:
- DNS at this point still is configured to the nginx service, but we already can test the upload and cache invalidation.
- We should merge this PR before switching DNS to have the same content both in the nginx service and in S3.
- We should merge this to `published` branch before switching DNS to have the correct content in the S3 bucket.
