### PR TITLE
ci: Disable netlify-deploy for now

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,13 +14,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: build image
         run: docker build --build-arg=ENABLE_ARCHIVES=false --target=current -t documentation:latest .
-      - name: copy static files
-        if: github.event.pull_request.head.repo.fork == false
-        run: docker run -v ${PWD}:/output documentation:latest cp -r /usr/share/nginx/html /output/_site
-      - uses: ./.github/actions/netlify-deploy
-        if: github.event.pull_request.head.repo.fork == false
-        with:
-          directory: _site
-          netlify_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          netlify_account_slug: ${{ secrets.NETLIFY_ACCOUNT_SLUG }}
-          site_name: "${{ github.repository }}/${{ github.head_ref }}"
+      # Disabled netlify-deploy due to flakey 502 http errors
+      # - name: copy static files
+      #   if: github.event.pull_request.head.repo.fork == false
+      #   run: docker run -v ${PWD}:/output documentation:latest cp -r /usr/share/nginx/html /output/_site
+      # - uses: ./.github/actions/netlify-deploy
+      #   if: github.event.pull_request.head.repo.fork == false
+      #   with:
+      #     directory: _site
+      #     netlify_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      #     netlify_account_slug: ${{ secrets.NETLIFY_ACCOUNT_SLUG }}
+      #     site_name: "${{ github.repository }}/${{ github.head_ref }}"


### PR DESCRIPTION
The `netlify-deploy` action is flakey and often aborts with a 502 HTTP error during the upload.
Disable this action for now.