### PR TITLE
Not truncating cryptographic fingerprint

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -116,10 +116,10 @@ from the repository.
 
     Verify that you now have the key with the fingerprint
     `9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88`, by searching for the
-    last 8 characters of the fingerprint.
+    key by it's fingerprint.
 
     ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
+    $ sudo apt-key fingerprint "9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88"
     
     pub   rsa4096 2017-02-22 [SCEA]
           9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88


### PR DESCRIPTION
### Proposed changes

I replaced a truncated cryptographic fingerprint with the full fingerprint.  My rationale:

1. As you're providing the apt command for easy copy & paste, there's no good ease-of-use argument for using just part of the fingerprint.
2. It promotes poor security hygiene.
3. Verifying eight hexits just isn't useful.  It's hard to imagine an attacker in a position to provide a different key while not also being in a position to just generate a few billion keys hoping for that much of a hash collision.