### PR TITLE
Use original short forms of Docker commands

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -146,7 +146,7 @@ Docker version 19.03.5, build 633a0ea
 3.  List the `hello-world` container (spawned by the image) which exits after displaying its message. If it is still running, you do not need the `--all` option:
 
     ```shell
-        $ docker container ls --all
+        $ docker ps --all
 
         CONTAINER ID     IMAGE           COMMAND      CREATED            STATUS
         54f4984ed6a8     hello-world     "/hello"     20 seconds ago     Exited (0) 19 seconds ago

--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -141,7 +141,7 @@ Now that you have some source code and a Dockerfile, it's time to build your fir
 Make sure you're in the directory `node-bulletin-board/bulletin-board-app` in a terminal or PowerShell using the `cd` command. Let's build your bulletin board image:
 
 ```script
-docker image build -t bulletinboard:1.0 .
+docker build --tag bulletinboard:1.0 .
 ```
 
 You'll see Docker step through each instruction in your Dockerfile, building up your image as it goes. If successful, the build process should end with a message `Successfully tagged bulletinboard:1.0`.
@@ -153,7 +153,7 @@ You'll see Docker step through each instruction in your Dockerfile, building up 
 1.  Start a container based on your new image:
 
     ```script
-    docker container run --publish 8000:8080 --detach --name bb bulletinboard:1.0
+    docker run --publish 8000:8080 --detach --name bb bulletinboard:1.0
     ```
 
     There are a couple of common flags here:
@@ -169,10 +169,10 @@ You'll see Docker step through each instruction in your Dockerfile, building up 
 3.  Once you're satisfied that your bulletin board container works correctly, you can delete it:
 
     ```script
-    docker container rm --force bb
+    docker rm --force bb
     ```
 
-    The `--force` option removes the running container.
+    The `--force` option removes the running container. If you stop the container running with `docker stop bb` you do not need to use `--force`.
 
 ## Conclusion
 

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -45,13 +45,13 @@ At this point, you've set up your Docker Hub account and have connected it to yo
 3.  Now you are ready to share your image on Docker Hub, but there's one thing you must do first: images must be *namespaced correctly* to share on Docker Hub. Specifically, you must name images like `<Docker ID>/<Repository Name>:<tag>`. You can relabel your `bulletinboard:1.0` image like this (of course, please replace `gordon` with your Docker ID):
 
     ```shell
-    docker image tag bulletinboard:1.0 gordon/bulletinboard:1.0
+    docker tag bulletinboard:1.0 gordon/bulletinboard:1.0
     ```
 
 4.  Finally, push your image to Docker Hub:
 
     ```shell
-    docker image push gordon/bulletinboard:1.0
+    docker push gordon/bulletinboard:1.0
     ```
 
     Visit your repository in Docker Hub, and you'll see your new image there. Remember, Docker Hub repositories are public by default.


### PR DESCRIPTION
The long forms of Docker commands have not caught on. I don't think we
should continue to encourage their use especially in the get started
guide. There is no evidence from online searches that anyone is really
using them. They are overly pedantic and verbose.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
