### PR TITLE
ci: Add name to GH Actions workflow

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,3 +1,5 @@
+name: deploy stage website from master branch
+
 on:
   push:
     branches:

--- a/.github/workflows/build-published.yml
+++ b/.github/workflows/build-published.yml
@@ -1,3 +1,5 @@
+name: deploy website from published branch
+
 on:
   push:
     branches:


### PR DESCRIPTION
This PR adds a name to the GitHub Actions workflows.
At the moment the file names are displayed:
![docs-github-actions](https://user-images.githubusercontent.com/207759/77409304-4f989b00-6db9-11ea-903f-b7c6f8dc826f.jpg)

With this PR the names "deploy stage website from master branch" and "deploy website from published branch" will appear instead.
