### PR TITLE
Remove `restart` and `stop` from command list.

### DIFF
--- a/reference/ucp/3.2/cli/index.md
+++ b/reference/ucp/3.2/cli/index.md
@@ -41,9 +41,7 @@ docker container run -it --rm \
 | `images`            | Verify the UCP images on this node                        |
 | `install`           | Install UCP on this node                                  |
 | `port-check-server` | Checks the ports on a node before a UCP installation      |
-| `restart`           | Start or restart UCP components running on this node      |
 | `restore`           | Restore a UCP cluster from a backup                       |
-| `stop`              | Stop UCP components running on this node                  |
 | `support`           | Create a support dump for this UCP node                   |
 | `uninstall-ucp`     | Uninstall UCP from this swarm                             |
 | `upgrade`           | Upgrade the UCP cluster                                   |


### PR DESCRIPTION
UCP commands `restart` and `stop` have been deprecated and are no longer available in UCP 3.2.

https://docs.docker.com/ee/ucp/release-notes/#deprecations