### PR TITLE
Updating apt-key command for the Linux Installation Guide

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -115,11 +115,10 @@ from the repository.
     ```
 
     Verify that you now have the key with the fingerprint
-    `9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88`, by searching for the
-    last 8 characters of the fingerprint.
+    `9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88`, by searching in the apt-key interface for the docker fingerprint.
 
     ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
+    $ sudo apt-key fingerprint docker
     
     pub   rsa4096 2017-02-22 [SCEA]
           9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88


### PR DESCRIPTION
### Proposed changes

Updated the apt-key command for Ubuntu as the one provided wasn't working well. You need to pass the name docker rather than the last 8 characters of the FingerPrint.