### PR TITLE
Template: remove "base href" and fix javascript link-fixing

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -19,7 +19,7 @@ your client and daemon API versions.
 
 {% if controller_data.deprecated %}
 
-> This command is [deprecated](/engine/deprecated.md){: target="_blank" class="_"}.
+> This command is [deprecated](/engine/deprecated/){: target="_blank" class="_"}.
 >
 > It may be removed in a future Docker version.
 {: .warning }
@@ -42,7 +42,7 @@ your client and daemon API versions.
 > This command is experimental on the Docker daemon. It should not be used in
 > production environments.
 > To enable experimental features on the Docker daemon, edit the
-> [daemon.json](/engine/reference/commandline/dockerd.md#daemon-configuration-file)
+> [daemon.json](/engine/reference/commandline/dockerd/#daemon-configuration-file)
 > and set `experimental` to `true`.
 >
 > {% include experimental.md %}
@@ -56,7 +56,7 @@ your client and daemon API versions.
 > **It should not be used in production environments.**
 >
 > To enable experimental features in the Docker CLI, edit the
-> [config.json](/engine/reference/commandline/cli.md#configuration-files)
+> [config.json](/engine/reference/commandline/cli/#configuration-files)
 > and set `experimental` to `enabled`. You can go [here](https://docs.docker.com/engine/reference/commandline/cli/#experimental-features)
 > for more information.
 {: .important }
@@ -117,9 +117,9 @@ For example uses of this command, refer to the [examples section](#examples) bel
 <tbody>
 {% for option in alloptions %}
 
-  {% capture deprecated-badge %}{% if option.deprecated %}<a href="/engine/deprecated.md" target="_blank" class="_"><span class="badge badge-danger" data-toggle="tooltip" title="Read the deprecation reference (in a new window).">deprecated</span></a>{% endif %}{% endcapture %}
-  {% capture experimental-daemon-badge %}{% if option.experimental %}<a href="/engine/reference/commandline/dockerd.md#daemon-configuration-file" target="_blank" class="_"><span class="badge badge-warning" data-toggle="tooltip" title="Read about experimental daemon options (in a new window).">experimental (daemon)</span></a>{% endif %}{% endcapture %}
-  {% capture experimental-cli-badge %}{% if option.experimentalcli %}<a href="/engine/reference/commandline/cli.md#configuration-files" target="_blank" class="_"><span class="badge badge-warning"  data-toggle="tooltip" title="Read about experimental CLI options (in a new window).">experimental (CLI)</span></a>{% endif %}{% endcapture %}
+  {% capture deprecated-badge %}{% if option.deprecated %}<a href="/engine/deprecated/" target="_blank" class="_"><span class="badge badge-danger" data-toggle="tooltip" title="Read the deprecation reference (in a new window).">deprecated</span></a>{% endif %}{% endcapture %}
+  {% capture experimental-daemon-badge %}{% if option.experimental %}<a href="/engine/reference/commandline/dockerd/#daemon-configuration-file" target="_blank" class="_"><span class="badge badge-warning" data-toggle="tooltip" title="Read about experimental daemon options (in a new window).">experimental (daemon)</span></a>{% endif %}{% endcapture %}
+  {% capture experimental-cli-badge %}{% if option.experimentalcli %}<a href="/engine/reference/commandline/cli/#configuration-files" target="_blank" class="_"><span class="badge badge-warning"  data-toggle="tooltip" title="Read about experimental CLI options (in a new window).">experimental (CLI)</span></a>{% endif %}{% endcapture %}
   {% capture min-api %}{% if option.min_api_version %}<a href="/engine/api/v{{ option.min_api_version }}/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" ttitle="Open the {{ controller_data.min_api_version }} API reference (in a new window)">API {{ option.min_api_version }}+</span></a>{% endif %}{%endcapture%}
   {% capture flag-orchestrator %}{% if option.swarm %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Swarm orchestrator.">Swarm</span>{% endif %}{% if option.kubernetes %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Kubernetes orchestrator.">Kubernetes</span>{% endif %}{% endcapture %}
 

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -1,6 +1,4 @@
 {% capture tabChar %}	{% endcapture %}<!-- Make sure atom is using hard tabs -->
-{% if include.datafolder and include.datafile %}
-
 {% assign controller_data = site.data[include.datafolder][include.datafile] %}
 
 ## Description
@@ -139,11 +137,6 @@ For example uses of this command, refer to the [examples section](#examples) bel
 ## Examples
 
 {{ controller_data.examples }}
-
-{% endif %}
-{% else %}
-
-The include.datafolder or include.datafile was not set.
 
 {% endif %}
 

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -81,8 +81,8 @@ your client and daemon API versions.
 
 ## Usage
 
-```none
-{{ controller_data.usage | replace: tabChar,"" | strip }}{% if controller_data.cname %} COMMAND{% endif %}
+```console
+{{ controller_data.usage | replace: tabChar, "" | strip }}{% if controller_data.cname %} COMMAND{% endif %}
 ```
 
 {% endif %}
@@ -116,15 +116,12 @@ For example uses of this command, refer to the [examples section](#examples) bel
 </thead>
 <tbody>
 {% for option in alloptions %}
-
   {% capture deprecated-badge %}{% if option.deprecated %}<a href="/engine/deprecated/" target="_blank" class="_"><span class="badge badge-danger" data-toggle="tooltip" title="Read the deprecation reference (in a new window).">deprecated</span></a>{% endif %}{% endcapture %}
   {% capture experimental-daemon-badge %}{% if option.experimental %}<a href="/engine/reference/commandline/dockerd/#daemon-configuration-file" target="_blank" class="_"><span class="badge badge-warning" data-toggle="tooltip" title="Read about experimental daemon options (in a new window).">experimental (daemon)</span></a>{% endif %}{% endcapture %}
   {% capture experimental-cli-badge %}{% if option.experimentalcli %}<a href="/engine/reference/commandline/cli/#configuration-files" target="_blank" class="_"><span class="badge badge-warning"  data-toggle="tooltip" title="Read about experimental CLI options (in a new window).">experimental (CLI)</span></a>{% endif %}{% endcapture %}
   {% capture min-api %}{% if option.min_api_version %}<a href="/engine/api/v{{ option.min_api_version }}/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" ttitle="Open the {{ controller_data.min_api_version }} API reference (in a new window)">API {{ option.min_api_version }}+</span></a>{% endif %}{%endcapture%}
   {% capture flag-orchestrator %}{% if option.swarm %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Swarm orchestrator.">Swarm</span>{% endif %}{% if option.kubernetes %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Kubernetes orchestrator.">Kubernetes</span>{% endif %}{% endcapture %}
-
   {% capture all-badges %}{{ deprecated-badge }}{{ experimental-daemon-badge }}{{ experimental-cli-badge }}{{ min-api }}{{ flag-orchestrator }}{% endcapture %}
-
   {% assign defaults-to-skip = "[],map[],false,0,0s,default,'',\"\"" | split: ',' %}
   {% capture option-default %}{% if option.default_value %}{% unless defaults-to-skip contains option.default_value or defaults-to-skip == blank %}`{{ option.default_value }}`{% endunless %}{% endif %}{% endcapture %}
   <tr>
@@ -132,11 +129,9 @@ For example uses of this command, refer to the [examples section](#examples) bel
     <td markdown="span">{{ option-default }}</td>
     <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip }}</td>
   </tr>
-
 {% endfor %} <!-- end for option -->
 </tbody>
 </table>
-
 {% endif %} <!-- end if options -->
 
 {% if controller_data.examples %}
@@ -157,8 +152,8 @@ The include.datafolder or include.datafile was not set.
 
 ## Parent command
 
-{% capture parentfile %}{{ controller_data.plink | replace: ".yaml", "" | replace: "docker_","" }}{% endcapture %}
-{% capture parentdatafile %}{{ controller_data.plink | replace: ".yaml", "" }}{% endcapture %}
+{% capture parentfile %}{{ controller_data.plink | remove_first: ".yaml" | remove_first: "docker_" }}{% endcapture %}
+{% capture parentdatafile %}{{ controller_data.plink | remove_first: ".yaml" }}{% endcapture %}
 {% capture parentDesc %}{{ site.data[include.datafolder][parentdatafile].short }}{% endcapture %}
 
 | Command | Description |
@@ -181,9 +176,9 @@ The include.datafolder or include.datafile was not set.
 </thead>
 <tbody>
 {% for command in controller_data.cname %}
-  {% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
+  {% capture dataFileName %}{{ command | strip | replace: " ", "_" }}{% endcapture %}
   <tr>
-    <td markdown="span">[{{ command }}]({{ dataFileName | replace: "docker_","" }}/)</td>
+    <td markdown="span">[{{ command }}]({{ dataFileName | remove_first: "docker_" }}/)</td>
     <td markdown="span">{{ site.data[include.datafolder][dataFileName].short }}</td>
   </tr>
 {% endfor %}
@@ -204,9 +199,9 @@ The include.datafolder or include.datafile was not set.
 </thead>
 <tbody>
 {% for command in site.data[include.datafolder][parentdatafile].cname %}
-  {% capture dataFileName %}{{ command | strip | replace: " ","_" }}{% endcapture %}
+  {% capture dataFileName %}{{ command | strip | replace: " ", "_" }}{% endcapture %}
   <tr>
-    <td markdown="span">[{{ command }}]({{ dataFileName | replace: "docker_","" }}/)</td>
+    <td markdown="span">[{{ command }}]({{ dataFileName | remove_first: "docker_" }}/)</td>
     <td markdown="span">{{ site.data[include.datafolder][dataFileName].short }}</td>
   </tr>
 {% endfor %}

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -1,5 +1,6 @@
 {% capture tabChar %}	{% endcapture %}<!-- Make sure atom is using hard tabs -->
 {% assign controller_data = site.data[include.datafolder][include.datafile] %}
+{% assign parentPath = page.path | prepend: "/" | remove: page.name %}
 
 ## Description
 
@@ -151,7 +152,7 @@ For example uses of this command, refer to the [examples section](#examples) bel
 
 | Command | Description |
 | ------- | ----------- |
-| [{{ controller_data.pname }}]({{ parentfile }}) | {{ parentDesc }}|
+| [{{ controller_data.pname }}]({{parentPath}}{{ parentfile }}/) | {{ parentDesc }}|
 
 {% endunless %}
 {% endif %}
@@ -171,7 +172,7 @@ For example uses of this command, refer to the [examples section](#examples) bel
 {% for command in controller_data.cname %}
   {% capture dataFileName %}{{ command | strip | replace: " ", "_" }}{% endcapture %}
   <tr>
-    <td markdown="span">[{{ command }}]({{ dataFileName | remove_first: "docker_" }}/)</td>
+    <td markdown="span">[{{ command }}]({{ parentPath }}{{ dataFileName | remove_first: "docker_" }}/)</td>
     <td markdown="span">{{ site.data[include.datafolder][dataFileName].short }}</td>
   </tr>
 {% endfor %}
@@ -194,7 +195,7 @@ For example uses of this command, refer to the [examples section](#examples) bel
 {% for command in site.data[include.datafolder][parentdatafile].cname %}
   {% capture dataFileName %}{{ command | strip | replace: " ", "_" }}{% endcapture %}
   <tr>
-    <td markdown="span">[{{ command }}]({{ dataFileName | remove_first: "docker_" }}/)</td>
+    <td markdown="span">[{{ command }}]({{ parentPath }}{{ dataFileName | remove_first: "docker_" }}/)</td>
     <td markdown="span">{{ site.data[include.datafolder][dataFileName].short }}</td>
   </tr>
 {% endfor %}

--- a/_includes/content/compose-var-sub.md
+++ b/_includes/content/compose-var-sub.md
@@ -18,7 +18,7 @@ string. In the example above, if `POSTGRES_VERSION` is not set, the value for
 the `image` option is `postgres:`.
 
 You can set default values for environment variables using a
-[`.env` file](../env-file.md), which Compose automatically looks for. Values
+[`.env` file](/compose/env-file/), which Compose automatically looks for. Values
 set in the shell environment override those set in the `.env` file.
 
 > Note when using docker stack deploy
@@ -28,7 +28,7 @@ set in the shell environment override those set in the `.env` file.
 {: .important }
 
 Both `$VARIABLE` and `${VARIABLE}` syntax are supported. Additionally when using
-the [2.1 file format](compose-versioning.md#version-21), it is possible to
+the [2.1 file format](/compose/compose-file/compose-versioning/#version-21), it is possible to
 provide inline default values using typical shell syntax:
 
 - `${VARIABLE:-default}` evaluates to `default` if `VARIABLE` is unset or

--- a/_includes/content/ssh/ssh-overview.md
+++ b/_includes/content/ssh/ssh-overview.md
@@ -1,4 +1,4 @@
-[SSH](/glossary.md#SSH) is a secure protocol for accessing remote machines and applications. It
+[SSH](/glossary/#SSH) is a secure protocol for accessing remote machines and applications. It
 provides authentication and encrypts data communication over insecure networks.
 
 These topics describe how to find existing SSH keys or generate new ones, and

--- a/_includes/docker_ee.md
+++ b/_includes/docker_ee.md
@@ -3,7 +3,7 @@
 |  Capabilities                                                                    | Docker Engine - Enterprise | Docker Enterprise |
 |:---------------------------------------------------------------------|:-------------------------:|:----------------------------:|
 | Container engine and built in orchestration, networking, security | {{green-check}}          | {{green-check}}             |
-| [Certified infrastructure, plugins and ISV containers](../ee/supported-platforms/#docker-enterprise)              | {{green-check}}          | {{green-check}}             |
-| [Image management with Docker Trusted Registry security scanning](../ee/dtr/user/manage-images/scan-images-for-vulnerabilities/)  |                          | {{green-check}}             |
-| [Container app management with Universal Control Plane](../ee/ucp/)              |                          | {{green-check}}             |
-| [Developer solutions with Docker Desktop Enterprise](../ee/desktop/)                           |                        | {{green-check}}             |
+| [Certified infrastructure, plugins and ISV containers](/ee/supported-platforms/#docker-enterprise)              | {{green-check}}          | {{green-check}}             |
+| [Image management with Docker Trusted Registry security scanning](/ee/dtr/user/manage-images/scan-images-for-vulnerabilities/)  |                          | {{green-check}}             |
+| [Container app management with Universal Control Plane](/ee/ucp/)              |                          | {{green-check}}             |
+| [Developer solutions with Docker Desktop Enterprise](/desktop/enterprise/)                           |                        | {{green-check}}             |

--- a/_includes/ee-linux-install-reuse.md
+++ b/_includes/ee-linux-install-reuse.md
@@ -23,7 +23,7 @@ on {{ linux-dist-long }}:
 Docker Engine - Community is _not_ supported on {{ linux-dist-long }}.
 {% endif %}
 {% if linux-dist == "centos" %}
-For Docker Community Edition on {{ linux-dist-cap }}, see [Get Docker Engine - Community for CentOS](/engine/install/centos.md).
+For Docker Community Edition on {{ linux-dist-cap }}, see [Get Docker Engine - Community for CentOS](/engine/install/centos/).
 {% endif %}
 
 {% elsif section == "find-ee-repo-url" %}
@@ -280,7 +280,7 @@ You only need to set up the repository once, after which you can install Docker 
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall/){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 
@@ -351,7 +351,7 @@ To manually install Docker Enterprise, download the `.{{ package-format | downca
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall/){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 </div>
@@ -394,7 +394,7 @@ To manually install Docker Enterprise, download the `.{{ package-format | downca
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall/){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 
 </div>
@@ -444,7 +444,7 @@ To manually install Docker Enterprise, download the `.{{ package-format | downca
     ```
 
     Docker Engine - Enterprise is installed and running. Use `sudo` to run Docker commands. See
-    [Linux postinstall](/engine/install/linux-postinstall.md){: target="_blank" class="_" } to allow
+    [Linux postinstall](/engine/install/linux-postinstall/){: target="_blank" class="_" } to allow
     non-privileged users to run Docker commands.
 {% endif %}
 
@@ -485,7 +485,7 @@ You must delete any edited configuration files manually.
 
 {% elsif section == "linux-install-nextsteps" %}
 
-- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall.md){: target="_blank" class="_" }
+- Continue to [Post-installation steps for Linux](/engine/install/linux-postinstall/){: target="_blank" class="_" }
 
 - Continue with user guides on [Universal Control Plane (UCP)](/ee/ucp/){: target="_blank" class="_" } and [Docker Trusted Registry (DTR)](/ee/dtr/){: target="_blank" class="_" }
 

--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -69,7 +69,7 @@ run Docker commands by default.
 > **Note**:
 >
 > To install Docker without root privileges, see
-> [Run the Docker daemon as a non-root user (Rootless mode)](/engine/security/rootless.md).
+> [Run the Docker daemon as a non-root user (Rootless mode)](/engine/security/rootless/).
 >
 > Rootless mode is currently available as an experimental feature.
 

--- a/_includes/kubernetes-mac-win.md
+++ b/_includes/kubernetes-mac-win.md
@@ -55,7 +55,7 @@ your workloads, in parallel, on Kubernetes, Swarm, and as standalone containers.
 Enabling or disabling the Kubernetes server does not affect your other
 workloads.
 
-See [{{ product }} > Getting started](/docker-for-{{ platform }}/index.md#kubernetes) to
+See [{{ product }} > Getting started](/docker-for-{{ platform }}/#kubernetes) to
 enable Kubernetes and begin testing the deployment of your workloads on
 Kubernetes.
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -161,60 +161,6 @@
                                 </span>
                                 {% endif -%}
                             {% endunless %}
-                            <script>
-                                // This is a horrible hack, and cute little kittens are sacrificed every time it's run, so we
-                                // need to remove it as soon as possible.
-                                //
-                                // Fix up links to markdown pages that weren't resolved by Jekyll (or the "jekyll-relative-links"
-                                // plugin). This is a horrible hack, and should not rely on JavaScript (perhaps be re-implemented
-                                // using Liquid). We need this hack to work around two bugs in the "jekyll-relative-links" plugin;
-                                // 1. As reported in https://github.com/benbalter/jekyll-relative-links/issues/54, (relative) links
-                                //    to markdown pages in includes are not processed by Jekyll. This means that (for example) our
-                                //    reference pages (which use includes) contain broken links. We can work around this by modifying
-                                //    the markdown for those pages to use "absolute" "html" links (/link/to/other/page/#some-anchor),
-                                //    but doing so would render the links broken when viewed on GitHub. Instead, we're fixing them up
-                                //    here, hoping the bug will be fixed, and it's only temporarily.
-                                // 2. As reported in https://github.com/benbalter/jekyll-relative-links/issues/61, (relative) links
-                                //    to markdown pages are not resolved if the link's caption/title is wrapped.
-                                //
-                                Array.prototype.forEach.call(document.querySelectorAll("section.section a:not(.nomunge)"), function (el) {
-                                    let href = el.getAttribute("href");
-                                    if (href.startsWith("/") || href.startsWith("#") || href.includes("://") || !href.includes('.md')) {
-                                        // Don't modify anchor links, absolute links, links to external websites,
-                                        // or links not pointing to a .md file; we assume those were
-                                        // resolved successfully by Jekyll.
-                                        return
-                                    }
-                                    if (href.startsWith("./")) {
-                                        href = href.substr(2)
-                                    }
-                                    if ("{{ page.name }}" !== "index.md") {
-                                        // For non-index pages, things are a bit hairy. For example, for /foo/bar/mypage.md, Jekyll
-                                        // will generate a page named /foo/bar/mypage/index.html. This means that all links relative
-                                        // to mypage.md expect those links to be relative to the /foo/bar/ directory, but end up
-                                        // being relative to /foo/bar/mypage/.
-                                        //
-                                        // For files "next to", or "below" this file, such as "file.md" or "nested/dir/file.md" we
-                                        // prepend the "parent-dir" to the URL.
-                                        //
-                                        // For links to files "up" the directory tree, we prepend
-                                        // "../" to the URL and have the browser handle this. For example, "../file.md" and "../../file.md"
-                                        // become "../../file.md" and "../../../file.md".
-                                        if (href.startsWith("../")) {
-                                            href = "../" + href
-                                        } else {
-                                            // Generate "parentPath" with Liquid, which is used below. Liquid's page.path (and page.dir)
-                                            // are relative to the _generated_ HTML page, not the source page, so we have to remove the
-                                            // last part of the path:
-                                            // {% raw %}{% assign parentPath = page.path | prepend: "/" | remove: page.name %}{% endraw %}
-                                            // {% assign parentPath = page.path | prepend: "/" | remove: page.name %}
-                                            href = "{{ parentPath}}" + href
-                                        }
-                                    }
-                                    // finally, we replace the .md extension for a slash, and update the link's href
-                                    el.setAttribute("href", href.replace(".md", "/"))
-                                });
-                            </script>
                             {% if page.noratings != true %}
                             <div id="ratings-div" style="color:#b9c2cc; text-align: center; margin-top: 150px; visibility: hidden">
                                 <div id="pd_rating_holder_8453675"></div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -161,26 +161,59 @@
                                 </span>
                                 {% endif -%}
                             {% endunless %}
-                            <!-- link corrections -->
                             <script>
-                            var x = document.links.length;
-                            var baseHref = document.getElementsByTagName('base')[0].href
-                            for (i = 0; i < x; i++) {
-                              var munged = false;
-                              var thisHREF = document.links[i].href;
-                              var originalURL = "{{ page.url }}";
-                              if (thisHREF.indexOf(baseHref + "#") > -1) {
-                                // hash fix
-                                //console.log('BEFORE: base:',baseHref,'thisHREF:',thisHREF,'originalURL:',originalURL);
-                                thisHREF = originalURL + thisHREF.replace(baseHref, "");
-                                //console.log('AFTER: base:',baseHref,'thisHREF:',thisHREF,'originalURL:',originalURL);
-                              }
-                              if ((thisHREF.indexOf(window.location.hostname) > -1 || thisHREF.indexOf('http') == -1) && document.links[i].className.indexOf("nomunge") < 0) {
-                                munged = true;
-                                thisHREF = thisHREF.replace(".md", "/").replace("/index/", "/");
-                                document.links[i].setAttribute('href', thisHREF);
-                              }
-                            }
+                                // This is a horrible hack, and cute little kittens are sacrificed every time it's run, so we
+                                // need to remove it as soon as possible.
+                                //
+                                // Fix up links to markdown pages that weren't resolved by Jekyll (or the "jekyll-relative-links"
+                                // plugin). This is a horrible hack, and should not rely on JavaScript (perhaps be re-implemented
+                                // using Liquid). We need this hack to work around two bugs in the "jekyll-relative-links" plugin;
+                                // 1. As reported in https://github.com/benbalter/jekyll-relative-links/issues/54, (relative) links
+                                //    to markdown pages in includes are not processed by Jekyll. This means that (for example) our
+                                //    reference pages (which use includes) contain broken links. We can work around this by modifying
+                                //    the markdown for those pages to use "absolute" "html" links (/link/to/other/page/#some-anchor),
+                                //    but doing so would render the links broken when viewed on GitHub. Instead, we're fixing them up
+                                //    here, hoping the bug will be fixed, and it's only temporarily.
+                                // 2. As reported in https://github.com/benbalter/jekyll-relative-links/issues/61, (relative) links
+                                //    to markdown pages are not resolved if the link's caption/title is wrapped.
+                                //
+                                Array.prototype.forEach.call(document.querySelectorAll("section.section a:not(.nomunge)"), function (el) {
+                                    let href = el.getAttribute("href");
+                                    if (href.startsWith("/") || href.startsWith("#") || href.includes("://") || !href.includes('.md')) {
+                                        // Don't modify anchor links, absolute links, links to external websites,
+                                        // or links not pointing to a .md file; we assume those were
+                                        // resolved successfully by Jekyll.
+                                        return
+                                    }
+                                    if (href.startsWith("./")) {
+                                        href = href.substr(2)
+                                    }
+                                    if ("{{ page.name }}" !== "index.md") {
+                                        // For non-index pages, things are a bit hairy. For example, for /foo/bar/mypage.md, Jekyll
+                                        // will generate a page named /foo/bar/mypage/index.html. This means that all links relative
+                                        // to mypage.md expect those links to be relative to the /foo/bar/ directory, but end up
+                                        // being relative to /foo/bar/mypage/.
+                                        //
+                                        // For files "next to", or "below" this file, such as "file.md" or "nested/dir/file.md" we
+                                        // prepend the "parent-dir" to the URL.
+                                        //
+                                        // For links to files "up" the directory tree, we prepend
+                                        // "../" to the URL and have the browser handle this. For example, "../file.md" and "../../file.md"
+                                        // become "../../file.md" and "../../../file.md".
+                                        if (href.startsWith("../")) {
+                                            href = "../" + href
+                                        } else {
+                                            // Generate "parentPath" with Liquid, which is used below. Liquid's page.path (and page.dir)
+                                            // are relative to the _generated_ HTML page, not the source page, so we have to remove the
+                                            // last part of the path:
+                                            // {% raw %}{% assign parentPath = page.path | prepend: "/" | remove: page.name %}{% endraw %}
+                                            // {% assign parentPath = page.path | prepend: "/" | remove: page.name %}
+                                            href = "{{ parentPath}}" + href
+                                        }
+                                    }
+                                    // finally, we replace the .md extension for a slash, and update the link's href
+                                    el.setAttribute("href", href.replace(".md", "/"))
+                                });
                             </script>
                             {% if page.noratings != true %}
                             <div id="ratings-div" style="color:#b9c2cc; text-align: center; margin-top: 150px; visibility: hidden">

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,21 +1,5 @@
 <!-- Page generated {{ site.time }} -->
-<!-- relative link basehrefs -->
-{% if page.path contains "index.md" %}
-	{% capture basehref %}{{ page.url }}{% endcapture %}
-{% else %}
-	{% assign crumbs = page.url | split: '/' %}
-	{% assign stoppingpoint = crumbs | size | minus: 1 %}
-	{% for crumb in crumbs %}
-		{% if forloop.index == stoppingpoint %}
-			{% capture basehref %}{{basehref}}{{ crumb }}/{% endcapture %}
-			{% break %}
-		{% else %}
-			{% capture basehref %}{{basehref}}{{ crumb }}/{% endcapture %}
-		{% endif %}
-	{% endfor %}
-{% endif %}
-
-<!-- Logic for 'edit this button' -->
+<!-- Logic for 'edit this button'
 {% assign edit_url = "https://github.com/docker/docker.github.io/edit/master/" | append: page.path %}
 {% for entry in site.data.not_edited_here.overrides %}
 	{% if page.path contains entry.path %}
@@ -27,13 +11,9 @@
 	{% break %}
 	{% endif %}
 {% endfor %}
-
-<!-- End of logic for 'edit this button' -->
-
-
+-->
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
 	<base href="{{ basehref }}" />
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -92,18 +72,17 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	<!-- SEO stuff -->
 	<title>{{ page.title }} | Docker Documentation</title>
-<meta property="og:title" content="{{ page.title }}" />
-<meta property="og:locale" content="en_US" />
-<meta name="description" content="{{ page.description }}" />
-<meta property="og:description" content="{{ page.description }}" />
-<link rel="canonical" href="{{ page.url }}" />
-<meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
-<meta property="og:site_name" content="Docker Documentation" />
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
+	<meta property="og:title" content="{{ page.title }}" />
+	<meta property="og:locale" content="en_US" />
+	<meta name="description" content="{{ page.description }}" />
+	<meta property="og:description" content="{{ page.description }}" />
+	<link rel="canonical" href="{{ page.url }}" />
+	<meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
+	<meta property="og:site_name" content="Docker Documentation" />
+	<script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
 	<!-- END SEO STUFF -->
 	{% if page.hide_from_sitemap %}<meta name="robots" content="noindex" />{% endif %}
-	<script language="javascript">
+	<script>
 	// Default to assuming this is an archive and hiding some stuff
 	// See js/archive.js and js/docs.js for logic relating to this
 	var isArchive = true;
@@ -112,9 +91,12 @@
 </head>
 <body ng-app="Docker" ng-controller="DockerController" class="colums">
 	<header>
-		{% if page.landing == true %}{% include global-header.html %}{% endif %} {% if page.landing != true %}{% include header.html %}{% endif %}
+		{% if page.landing == true %}
+			{% include global-header.html %}
+		{% else %}
+			{% include header.html %}
+		{% endif %}
 	</header>
-
 	<div class="{% if page.landing == true %}wrapper{%else%}wrapper right-open{% endif %}">
 		<div class="container-fluid">
 			<div class="row">
@@ -128,45 +110,37 @@
 							<h1>{{ page.title }}</h1>{% endif %} {% if page.advisory %}
 							<blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>{% endif %}{% endif %} {% unless page.tree == false or page.skip_read_time == true %}{% include read_time.html %}{% endunless %}
 							{% if page.enterprise %}{% include ee_dropdown.html %}{% endif %}
-							{% if page.ui_tabs or page.cli_tabs or page.api_tabs %}{% capture content %}
+							{% if page.ui_tabs or page.cli_tabs or page.api_tabs %}
+								{% capture content %}
 
 								{% if page.intro %}{{ page.intro | markdownify }}{% else %}{{ page.description | markdownify }}{% endif %}
 
 								{% if page.ui_tabs %}
-
 								<ul class="nav nav-tabs">{% for tab in page.ui_tabs %}
 								  <li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#ui-{{ tab.version | slugify }}" id="ui-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}{% if tab.orhigher %} (or higher){% endif %}{% if tab.orlower %} (or lower){% endif %}</a></li>{% endfor %}
 								</ul>
 								<div class="tab-content">{% for tab in page.ui_tabs %}
 								  <div id="ui-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version ui="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
 								</div>
-
 								{% endif %}
 								{% if page.cli_tabs %}
-
 								<ul class="nav nav-tabs">{% for tab in page.cli_tabs %}
 								  <li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#cli-{{ tab.version | slugify }}" id="cli-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}</a></li>{% endfor %}
 								</ul>
 								<div class="tab-content">{% for tab in page.cli_tabs %}
 								  <div id="cli-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version cli="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
 								</div>
-
 								{% endif %}
 								{% if page.api_tabs %}
-
 								<ul class="nav nav-tabs">{% for tab in page.api_tabs %}
 									<li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#api-{{ tab.version | slugify }}" id="api-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}</a></li>{% endfor %}
 								</ul>
 								<div class="tab-content">{% for tab in page.api_tabs %}
 									<div id="api-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version api="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
 								</div>
-
 								{% endif %}
-
 								{% if page.next_steps %}
-
 								<h2>Next steps</h2>
-
 								<ul>
 								{% for step in page.next_steps %}  <li><a href="{{ step.path }}">{{ step.title }}</a></li>
 								{% endfor %}
@@ -177,19 +151,19 @@
 							{{ content }}
 							<!-- tags -->
 							{% unless page.notags == true %}
-							{% assign keywords = page.keywords | split:"," -%}
-							{% if keywords.size > 0 -%}
-							  <span class="glyphicon glyphicon-tags" style="padding-right: 10px"></span><span style="vertical-align: 2px">
-							  {%- for keyword in keywords -%}
-							    {%- assign strippedKeyword = keyword | strip -%}
-							    <a href="https://docs.docker.com/search/?q={{ strippedKeyword }}">{{ strippedKeyword }}</a>
-							    {%- unless forloop.last %}, {% endunless -%}
-							  {% endfor -%}
-							  </span>
-							{% endif -%}
+								{% assign keywords = page.keywords | split:"," -%}
+								{% if keywords.size > 0 -%}
+								<span class="glyphicon glyphicon-tags" style="padding-right: 10px"></span><span style="vertical-align: 2px">
+								{%- for keyword in keywords -%}
+								{%- assign strippedKeyword = keyword | strip -%}
+								<a href="https://docs.docker.com/search/?q={{ strippedKeyword }}">{{ strippedKeyword }}</a>
+								{%- unless forloop.last %}, {% endunless -%}
+								{% endfor -%}
+								</span>
+								{% endif -%}
 							{% endunless %}
 							<!-- link corrections -->
-              <script language="JavaScript">
+							<script>
 							var x = document.links.length;
 							var baseHref = document.getElementsByTagName('base')[0].href
 							for (i = 0; i < x; i++) {
@@ -210,7 +184,7 @@
 							}
 							</script>
 							{% if page.noratings != true %}
-						  <div id="ratings-div" style="color:#b9c2cc; text-align: center; margin-top: 150px; visibility: hidden">
+							<div id="ratings-div" style="color:#b9c2cc; text-align: center; margin-top: 150px; visibility: hidden">
 								<div id="pd_rating_holder_8453675"></div>
 								<script type="text/javascript">
 									PDRTJS_settings_8453675 = {
@@ -240,7 +214,7 @@
 						</div>
 					</nav>
 					<div class="col-toc">
-							<div class="sidebar hidden-xs hidden-sm">
+						<div class="sidebar hidden-xs hidden-sm">
 							<div class="toc-nav">
 								<div class="feedback-links">
 									<ul>
@@ -268,10 +242,10 @@
 									</ul>
 								</div>
 								{% unless page.notoc %} {% assign my_min = page.toc_min | default: site.toc_min | default: 2 %} {% assign my_max = page.toc_max | default: site.toc_max | default: 3 %} {% assign my_name = page.url | default: "unnamed" %}
-									<div id="side-toc-title">On this page:</div>
+								<div id="side-toc-title">On this page:</div>
 									{% include toc_pure_liquid.html html=content sanitize=true class="inline_toc" id="my_toc" toc_min=my_min toc_max=my_max page_name=my_name %}
-								</div>
 								{% endunless %}
+							</div>
 						</div>
 					</div>
 				</div>
@@ -280,14 +254,14 @@
 	</div>
 
 	{% if page.path == "404.md" %}
-		<script type="text/javascript">
-			var path = window.location.pathname.replace("#","");
-			var ghIssueQueryString = "https://github.com/docker/docker.github.io/issues/new?" + "title=404%20at%20" + path + "&body=URL%3A%20" + path;
-			document.getElementsByClassName("nomunge")[1].onclick = function() {
-				 document.getElementsByClassName("nomunge")[1].href = ghIssueQueryString;
-				 return true;
-			};
-		</script>
+	<script type="text/javascript">
+		var path = window.location.pathname.replace("#","");
+		var ghIssueQueryString = "https://github.com/docker/docker.github.io/issues/new?" + "title=404%20at%20" + path + "&body=URL%3A%20" + path;
+		document.getElementsByClassName("nomunge")[1].onclick = function() {
+			 document.getElementsByClassName("nomunge")[1].href = ghIssueQueryString;
+			 return true;
+		};
+	</script>
 	{% endif %}
 	<footer class="footer">
 		{% include footer.html %}
@@ -304,7 +278,7 @@
 	<script src="/js/jquery.js"></script>
 	<script src="/js/bootstrap.min.js"></script>
 	<!-- Always include the archive.js, but it doesn't do much unless we are an archive -->
-	<script language="javascript">
+	<script>
 	// Default to assuming this is an archive and hiding some stuff
 	// See js/archive.js and js/docs.js for logic relating to this
 	var isArchive = true;
@@ -312,7 +286,7 @@
 	// In archives, we need to know the page root and we get it from JEKYLL_ENV in the jekyll build command
 	var jekyllEnv = '{{ jekyll.environment }}';
 	// If unset (in non-archive branches), defaults to "development". In that case, reset it to empty
-	if (jekyllEnv == 'development') {
+	if (jekyllEnv === 'development') {
 		jekyllEnv = '';
 	}
 	var pageURL = jekyllEnv + '{{ page.url }}';
@@ -323,11 +297,8 @@
 	<script src="/js/glossary.js"></script>
 	<script defer src="/js/docs.js"></script>
 	<script defer src="/js/toc.js"></script>
-	<script language="javascript">
-	jQuery(document).ready(function(){
-				hookupTOCEvents();
-			});
+	<script>
+	jQuery(document).ready(function(){hookupTOCEvents();});
 	</script>
 </body>
-
 </html>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -2,303 +2,302 @@
 <!-- Logic for 'edit this button'
 {% assign edit_url = "https://github.com/docker/docker.github.io/edit/master/" | append: page.path %}
 {% for entry in site.data.not_edited_here.overrides %}
-	{% if page.path contains entry.path %}
-		{% if entry.source %}
-			{% assign edit_url = entry.source %}
-		{% else %}
-			{% assign edit_url = "" %}
-		{% endif %}
-	{% break %}
-	{% endif %}
+    {% if page.path contains entry.path %}
+        {% if entry.source %}
+            {% assign edit_url = entry.source %}
+        {% else %}
+            {% assign edit_url = "" %}
+        {% endif %}
+    {% break %}
+    {% endif %}
 {% endfor %}
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<base href="{{ basehref }}" />
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-	<style type="text/css">
-		@charset "UTF-8";
-		[ng\:cloak],
-		[ng-cloak],
-		[data-ng-cloak],
-		[x-ng-cloak],
-		.ng-cloak,
-		.x-ng-cloak,
-		.ng-hide:not(.ng-hide-animate) {
-			display: none !important;
-		}
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <style type="text/css">
+        @charset "UTF-8";
+        [ng\:cloak],
+        [ng-cloak],
+        [data-ng-cloak],
+        [x-ng-cloak],
+        .ng-cloak,
+        .x-ng-cloak,
+        .ng-hide:not(.ng-hide-animate) {
+            display: none !important;
+        }
 
-		ng\:form {
-			display: block;
-		}
-	</style>
-	<!-- Google Tag Manager -->
-	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','GTM-WL2QLG5');</script>
-	<!-- End Google Tag Manager -->
-	{% if site.GH_ENV == "gh_pages" %}
-	<meta name="robots" content="noindex">{% endif %}
-	<!-- favicon -->
-	<link rel="icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">
-	<meta name="msapplication-TileImage" content="/favicons/docs@2x.ico">
-	<link rel="apple-touch-icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">
-	<meta property="og:image" content="/favicons/docs@2x.ico"/>
-	<!-- metadata -->
-	<meta property="og:type" content="website"/>
-	<meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
-	<meta property="og:image" itemprop="image primaryImageOfPage" content="/images/docs@2x.png"/>
-	<meta name="twitter:card" content="summary"/>
-	<meta name="twitter:domain" content="docs.docker.com"/>
-	<meta name="twitter:site" content="@docker_docs"/>
-	<meta name="twitter:url" content="https://twitter.com/docker_docs"/>
-	<meta name="twitter:title" itemprop="title name" content="{{ page.title }}"/>
-	<meta name="twitter:description" property="og:description" itemprop="description" content="{{ content | strip_html | truncatewords: 30}}" />
-	<meta name="twitter:image:src" content="/images/docs@2x.png"/>
-	<meta name="twitter:image:alt" content="Docker Documentation"/>
-	<meta property="article:published_time" itemprop="datePublished" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
+        ng\:form {
+            display: block;
+        }
+    </style>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WL2QLG5');</script>
+    <!-- End Google Tag Manager -->
+    {% if site.GH_ENV == "gh_pages" %}
+    <meta name="robots" content="noindex">{% endif %}
+    <!-- favicon -->
+    <link rel="icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">
+    <meta name="msapplication-TileImage" content="/favicons/docs@2x.ico">
+    <link rel="apple-touch-icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">
+    <meta property="og:image" content="/favicons/docs@2x.ico"/>
+    <!-- metadata -->
+    <meta property="og:type" content="website"/>
+    <meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
+    <meta property="og:image" itemprop="image primaryImageOfPage" content="/images/docs@2x.png"/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:domain" content="docs.docker.com"/>
+    <meta name="twitter:site" content="@docker_docs"/>
+    <meta name="twitter:url" content="https://twitter.com/docker_docs"/>
+    <meta name="twitter:title" itemprop="title name" content="{{ page.title }}"/>
+    <meta name="twitter:description" property="og:description" itemprop="description" content="{{ content | strip_html | truncatewords: 30}}" />
+    <meta name="twitter:image:src" content="/images/docs@2x.png"/>
+    <meta name="twitter:image:alt" content="Docker Documentation"/>
+    <meta property="article:published_time" itemprop="datePublished" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
 
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization{% endif %}">
-	<link rel="stylesheet" href="/css/font-awesome.min.css">
-	<link rel="stylesheet" href="/css/bootstrap.min.css">
-	<link id="pygments" rel="stylesheet" href="/css/pygments/perldoc.css">
-	<link id="pagestyle" rel="stylesheet" href="/css/style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization{% endif %}">
+    <link rel="stylesheet" href="/css/font-awesome.min.css">
+    <link rel="stylesheet" href="/css/bootstrap.min.css">
+    <link id="pygments" rel="stylesheet" href="/css/pygments/perldoc.css">
+    <link id="pagestyle" rel="stylesheet" href="/css/style.css">
 
-	<!-- Go get "Open Sans" font from Google -->
-	<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-	<!-- SEO stuff -->
-	<title>{{ page.title }} | Docker Documentation</title>
-	<meta property="og:title" content="{{ page.title }}" />
-	<meta property="og:locale" content="en_US" />
-	<meta name="description" content="{{ page.description }}" />
-	<meta property="og:description" content="{{ page.description }}" />
-	<link rel="canonical" href="{{ page.url }}" />
-	<meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
-	<meta property="og:site_name" content="Docker Documentation" />
-	<script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
-	<!-- END SEO STUFF -->
-	{% if page.hide_from_sitemap %}<meta name="robots" content="noindex" />{% endif %}
-	<script>
-	// Default to assuming this is an archive and hiding some stuff
-	// See js/archive.js and js/docs.js for logic relating to this
-	var isArchive = true;
-	var dockerVersion = 'v{{ site.docker_ce_version }}';
-	</script>
+    <!-- Go get "Open Sans" font from Google -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <!-- SEO stuff -->
+    <title>{{ page.title }} | Docker Documentation</title>
+    <meta property="og:title" content="{{ page.title }}" />
+    <meta property="og:locale" content="en_US" />
+    <meta name="description" content="{{ page.description }}" />
+    <meta property="og:description" content="{{ page.description }}" />
+    <link rel="canonical" href="{{ page.url }}" />
+    <meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
+    <meta property="og:site_name" content="Docker Documentation" />
+    <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
+    <!-- END SEO STUFF -->
+    {% if page.hide_from_sitemap %}<meta name="robots" content="noindex" />{% endif %}
+    <script>
+    // Default to assuming this is an archive and hiding some stuff
+    // See js/archive.js and js/docs.js for logic relating to this
+    var isArchive = true;
+    var dockerVersion = 'v{{ site.docker_ce_version }}';
+    </script>
 </head>
 <body ng-app="Docker" ng-controller="DockerController" class="colums">
-	<header>
-		{% if page.landing == true %}
-			{% include global-header.html %}
-		{% else %}
-			{% include header.html %}
-		{% endif %}
-	</header>
-	<div class="{% if page.landing == true %}wrapper{%else%}wrapper right-open{% endif %}">
-		<div class="container-fluid">
-			<div class="row">
-				<div class="col-body">
-					<main class="col-content {% if page.landing == true %}main-content{%else%}content{% endif %}">
-						<section class="section">
-							{% if page.url == '/' %}
-							<h1>{{ site.name }}</h1>
-							{% else %}
-								{% if page.title %}
-							<h1>{{ page.title }}</h1>{% endif %} {% if page.advisory %}
-							<blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>{% endif %}{% endif %} {% unless page.tree == false or page.skip_read_time == true %}{% include read_time.html %}{% endunless %}
-							{% if page.enterprise %}{% include ee_dropdown.html %}{% endif %}
-							{% if page.ui_tabs or page.cli_tabs or page.api_tabs %}
-								{% capture content %}
+    <header>
+        {% if page.landing == true %}
+            {% include global-header.html %}
+        {% else %}
+            {% include header.html %}
+        {% endif %}
+    </header>
+    <div class="{% if page.landing == true %}wrapper{%else%}wrapper right-open{% endif %}">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-body">
+                    <main class="col-content {% if page.landing == true %}main-content{%else%}content{% endif %}">
+                        <section class="section">
+                            {% if page.url == '/' %}
+                            <h1>{{ site.name }}</h1>
+                            {% else %}
+                                {% if page.title %}
+                            <h1>{{ page.title }}</h1>{% endif %} {% if page.advisory %}
+                            <blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>{% endif %}{% endif %} {% unless page.tree == false or page.skip_read_time == true %}{% include read_time.html %}{% endunless %}
+                            {% if page.enterprise %}{% include ee_dropdown.html %}{% endif %}
+                            {% if page.ui_tabs or page.cli_tabs or page.api_tabs %}
+                                {% capture content %}
 
-								{% if page.intro %}{{ page.intro | markdownify }}{% else %}{{ page.description | markdownify }}{% endif %}
+                                {% if page.intro %}{{ page.intro | markdownify }}{% else %}{{ page.description | markdownify }}{% endif %}
 
-								{% if page.ui_tabs %}
-								<ul class="nav nav-tabs">{% for tab in page.ui_tabs %}
-								  <li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#ui-{{ tab.version | slugify }}" id="ui-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}{% if tab.orhigher %} (or higher){% endif %}{% if tab.orlower %} (or lower){% endif %}</a></li>{% endfor %}
-								</ul>
-								<div class="tab-content">{% for tab in page.ui_tabs %}
-								  <div id="ui-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version ui="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
-								</div>
-								{% endif %}
-								{% if page.cli_tabs %}
-								<ul class="nav nav-tabs">{% for tab in page.cli_tabs %}
-								  <li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#cli-{{ tab.version | slugify }}" id="cli-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}</a></li>{% endfor %}
-								</ul>
-								<div class="tab-content">{% for tab in page.cli_tabs %}
-								  <div id="cli-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version cli="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
-								</div>
-								{% endif %}
-								{% if page.api_tabs %}
-								<ul class="nav nav-tabs">{% for tab in page.api_tabs %}
-									<li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#api-{{ tab.version | slugify }}" id="api-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}</a></li>{% endfor %}
-								</ul>
-								<div class="tab-content">{% for tab in page.api_tabs %}
-									<div id="api-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version api="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
-								</div>
-								{% endif %}
-								{% if page.next_steps %}
-								<h2>Next steps</h2>
-								<ul>
-								{% for step in page.next_steps %}  <li><a href="{{ step.path }}">{{ step.title }}</a></li>
-								{% endfor %}
-								</ul>
-								{% endif %}
-								{% endcapture %}
-							{% endif %}
-							{{ content }}
-							<!-- tags -->
-							{% unless page.notags == true %}
-								{% assign keywords = page.keywords | split:"," -%}
-								{% if keywords.size > 0 -%}
-								<span class="glyphicon glyphicon-tags" style="padding-right: 10px"></span><span style="vertical-align: 2px">
-								{%- for keyword in keywords -%}
-								{%- assign strippedKeyword = keyword | strip -%}
-								<a href="https://docs.docker.com/search/?q={{ strippedKeyword }}">{{ strippedKeyword }}</a>
-								{%- unless forloop.last %}, {% endunless -%}
-								{% endfor -%}
-								</span>
-								{% endif -%}
-							{% endunless %}
-							<!-- link corrections -->
-							<script>
-							var x = document.links.length;
-							var baseHref = document.getElementsByTagName('base')[0].href
-							for (i = 0; i < x; i++) {
-							  var munged = false;
-							  var thisHREF = document.links[i].href;
-							  var originalURL = "{{ page.url }}";
-							  if (thisHREF.indexOf(baseHref + "#") > -1) {
-							    // hash fix
-							    //console.log('BEFORE: base:',baseHref,'thisHREF:',thisHREF,'originalURL:',originalURL);
-							    thisHREF = originalURL + thisHREF.replace(baseHref, "");
-							    //console.log('AFTER: base:',baseHref,'thisHREF:',thisHREF,'originalURL:',originalURL);
-							  }
-							  if ((thisHREF.indexOf(window.location.hostname) > -1 || thisHREF.indexOf('http') == -1) && document.links[i].className.indexOf("nomunge") < 0) {
-							    munged = true;
-							    thisHREF = thisHREF.replace(".md", "/").replace("/index/", "/");
-							    document.links[i].setAttribute('href', thisHREF);
-							  }
-							}
-							</script>
-							{% if page.noratings != true %}
-							<div id="ratings-div" style="color:#b9c2cc; text-align: center; margin-top: 150px; visibility: hidden">
-								<div id="pd_rating_holder_8453675"></div>
-								<script type="text/javascript">
-									PDRTJS_settings_8453675 = {
-										"id": "8453675",
-										"unique_id": "{{ page.path }}",
-										"title": "{{ page.title }}",
-										"permalink": "https://github.com/docker/docker.github.io/blob/master/{{ page.path }}"
-									};
-									(function(d, c, j) {
-										if (!document.getElementById(j)) {
-											var pd = d.createElement(c),
-												s;
-											pd.id = j;
-											pd.src = ('https:' == document.location.protocol) ? 'https://polldaddy.com/js/rating/rating.js' : 'http://i0.poll.fm/js/rating/rating.js';
-											s = document.getElementsByTagName(c)[0];
-											s.parentNode.insertBefore(pd, s);
-										}
-									}(document, 'script', 'pd-rating-js'));
-								</script>
-							</div>
-							{% endif %}
-						</section>
-					</main>
-					<nav class="col-nav">
-						<div id="sidebar-nav" class="sidebar hidden-sm hidden-xs">
-						{% include side-menu.html %}
-						</div>
-					</nav>
-					<div class="col-toc">
-						<div class="sidebar hidden-xs hidden-sm">
-							<div class="toc-nav">
-								<div class="feedback-links">
-									<ul>
-										{% if edit_url != "" %}
-										<li style="visibility: hidden"><a href="{{ edit_url }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit this page</a></li>{% endif %}
-										<li><a href="https://github.com/docker/docker.github.io/issues/new?body=File: [{{ page.path }}](https://docs.docker.com{{ page.url }})"
-															class="nomunge"><i class="fa fa-check" aria-hidden="true"></i> Request docs changes</a></li>
-										<!-- toggle mode -->
-										<li>
-											<div class="toggle-mode">
-												<div class="icon">
-													<i class="fa fa-sun-o" aria-hidden="true"></i>
-												</div>
-												<div class="toggle-switch">
-													<label class="switch">
-														<input type="checkbox" id="switch-style">
-														<div class="slider round"></div>
-												</label>
-												</div>
-												<div class="icon">
-													<i class="fa fa-moon-o" aria-hidden="true"></i>
-												</div>
-											</div>
-										</li>
-									</ul>
-								</div>
-								{% unless page.notoc %} {% assign my_min = page.toc_min | default: site.toc_min | default: 2 %} {% assign my_max = page.toc_max | default: site.toc_max | default: 3 %} {% assign my_name = page.url | default: "unnamed" %}
-								<div id="side-toc-title">On this page:</div>
-									{% include toc_pure_liquid.html html=content sanitize=true class="inline_toc" id="my_toc" toc_min=my_min toc_max=my_max page_name=my_name %}
-								{% endunless %}
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+                                {% if page.ui_tabs %}
+                                <ul class="nav nav-tabs">{% for tab in page.ui_tabs %}
+                                  <li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#ui-{{ tab.version | slugify }}" id="ui-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}{% if tab.orhigher %} (or higher){% endif %}{% if tab.orlower %} (or lower){% endif %}</a></li>{% endfor %}
+                                </ul>
+                                <div class="tab-content">{% for tab in page.ui_tabs %}
+                                  <div id="ui-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version ui="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
+                                </div>
+                                {% endif %}
+                                {% if page.cli_tabs %}
+                                <ul class="nav nav-tabs">{% for tab in page.cli_tabs %}
+                                  <li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#cli-{{ tab.version | slugify }}" id="cli-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}</a></li>{% endfor %}
+                                </ul>
+                                <div class="tab-content">{% for tab in page.cli_tabs %}
+                                  <div id="cli-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version cli="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
+                                </div>
+                                {% endif %}
+                                {% if page.api_tabs %}
+                                <ul class="nav nav-tabs">{% for tab in page.api_tabs %}
+                                    <li{% if forloop.first %} class="active"{% endif %}><a data-toggle="tab" data-target="#api-{{ tab.version | slugify }}" id="api-tabheader-{{ tab.version | slugify }}">{{ site.tablabels[tab.version] }}</a></li>{% endfor %}
+                                </ul>
+                                <div class="tab-content">{% for tab in page.api_tabs %}
+                                    <div id="api-{{ tab.version | slugify }}" class="tab-pane fade{% if forloop.first %} in active{% endif %}">{% capture thistab %}{% include_relative {{ page.path | split: "/" | last }} version=tab.version api="true" %}{% endcapture %}{{ thistab | split: "---" | shift:2 | join: "---" | markdownify }}</div>{% endfor %}
+                                </div>
+                                {% endif %}
+                                {% if page.next_steps %}
+                                <h2>Next steps</h2>
+                                <ul>
+                                {% for step in page.next_steps %}  <li><a href="{{ step.path }}">{{ step.title }}</a></li>
+                                {% endfor %}
+                                </ul>
+                                {% endif %}
+                                {% endcapture %}
+                            {% endif %}
+                            {{ content }}
+                            <!-- tags -->
+                            {% unless page.notags == true %}
+                                {% assign keywords = page.keywords | split:"," -%}
+                                {% if keywords.size > 0 -%}
+                                <span class="glyphicon glyphicon-tags" style="padding-right: 10px"></span><span style="vertical-align: 2px">
+                                {%- for keyword in keywords -%}
+                                {%- assign strippedKeyword = keyword | strip -%}
+                                <a href="https://docs.docker.com/search/?q={{ strippedKeyword }}">{{ strippedKeyword }}</a>
+                                {%- unless forloop.last %}, {% endunless -%}
+                                {% endfor -%}
+                                </span>
+                                {% endif -%}
+                            {% endunless %}
+                            <!-- link corrections -->
+                            <script>
+                            var x = document.links.length;
+                            var baseHref = document.getElementsByTagName('base')[0].href
+                            for (i = 0; i < x; i++) {
+                              var munged = false;
+                              var thisHREF = document.links[i].href;
+                              var originalURL = "{{ page.url }}";
+                              if (thisHREF.indexOf(baseHref + "#") > -1) {
+                                // hash fix
+                                //console.log('BEFORE: base:',baseHref,'thisHREF:',thisHREF,'originalURL:',originalURL);
+                                thisHREF = originalURL + thisHREF.replace(baseHref, "");
+                                //console.log('AFTER: base:',baseHref,'thisHREF:',thisHREF,'originalURL:',originalURL);
+                              }
+                              if ((thisHREF.indexOf(window.location.hostname) > -1 || thisHREF.indexOf('http') == -1) && document.links[i].className.indexOf("nomunge") < 0) {
+                                munged = true;
+                                thisHREF = thisHREF.replace(".md", "/").replace("/index/", "/");
+                                document.links[i].setAttribute('href', thisHREF);
+                              }
+                            }
+                            </script>
+                            {% if page.noratings != true %}
+                            <div id="ratings-div" style="color:#b9c2cc; text-align: center; margin-top: 150px; visibility: hidden">
+                                <div id="pd_rating_holder_8453675"></div>
+                                <script type="text/javascript">
+                                    PDRTJS_settings_8453675 = {
+                                        "id": "8453675",
+                                        "unique_id": "{{ page.path }}",
+                                        "title": "{{ page.title }}",
+                                        "permalink": "https://github.com/docker/docker.github.io/blob/master/{{ page.path }}"
+                                    };
+                                    (function(d, c, j) {
+                                        if (!document.getElementById(j)) {
+                                            var pd = d.createElement(c),
+                                                s;
+                                            pd.id = j;
+                                            pd.src = ('https:' == document.location.protocol) ? 'https://polldaddy.com/js/rating/rating.js' : 'http://i0.poll.fm/js/rating/rating.js';
+                                            s = document.getElementsByTagName(c)[0];
+                                            s.parentNode.insertBefore(pd, s);
+                                        }
+                                    }(document, 'script', 'pd-rating-js'));
+                                </script>
+                            </div>
+                            {% endif %}
+                        </section>
+                    </main>
+                    <nav class="col-nav">
+                        <div id="sidebar-nav" class="sidebar hidden-sm hidden-xs">
+                        {% include side-menu.html %}
+                        </div>
+                    </nav>
+                    <div class="col-toc">
+                        <div class="sidebar hidden-xs hidden-sm">
+                            <div class="toc-nav">
+                                <div class="feedback-links">
+                                    <ul>
+                                        {% if edit_url != "" %}
+                                        <li style="visibility: hidden"><a href="{{ edit_url }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit this page</a></li>{% endif %}
+                                        <li><a href="https://github.com/docker/docker.github.io/issues/new?body=File: [{{ page.path }}](https://docs.docker.com{{ page.url }})"
+                                                            class="nomunge"><i class="fa fa-check" aria-hidden="true"></i> Request docs changes</a></li>
+                                        <!-- toggle mode -->
+                                        <li>
+                                            <div class="toggle-mode">
+                                                <div class="icon">
+                                                    <i class="fa fa-sun-o" aria-hidden="true"></i>
+                                                </div>
+                                                <div class="toggle-switch">
+                                                    <label class="switch">
+                                                        <input type="checkbox" id="switch-style">
+                                                        <div class="slider round"></div>
+                                                </label>
+                                                </div>
+                                                <div class="icon">
+                                                    <i class="fa fa-moon-o" aria-hidden="true"></i>
+                                                </div>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                </div>
+                                {% unless page.notoc %} {% assign my_min = page.toc_min | default: site.toc_min | default: 2 %} {% assign my_max = page.toc_max | default: site.toc_max | default: 3 %} {% assign my_name = page.url | default: "unnamed" %}
+                                <div id="side-toc-title">On this page:</div>
+                                    {% include toc_pure_liquid.html html=content sanitize=true class="inline_toc" id="my_toc" toc_min=my_min toc_max=my_max page_name=my_name %}
+                                {% endunless %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 
-	{% if page.path == "404.md" %}
-	<script type="text/javascript">
-		var path = window.location.pathname.replace("#","");
-		var ghIssueQueryString = "https://github.com/docker/docker.github.io/issues/new?" + "title=404%20at%20" + path + "&body=URL%3A%20" + path;
-		document.getElementsByClassName("nomunge")[1].onclick = function() {
-			 document.getElementsByClassName("nomunge")[1].href = ghIssueQueryString;
-			 return true;
-		};
-	</script>
-	{% endif %}
-	<footer class="footer">
-		{% include footer.html %}
-	</footer>
-	<link rel="stylesheet" href="/css/github.css">
-	{% if page.highlightjs == true %}
-	<script src="/js/highlight.pack.js"></script>
-	<script>
-		hljs.initHighlightingOnLoad();
-	</script>
-	{% endif %}
-	<script defer src="/js/anchorlinks.js"></script>
-	<script defer src="/js/menu.js"></script>
-	<script src="/js/jquery.js"></script>
-	<script src="/js/bootstrap.min.js"></script>
-	<!-- Always include the archive.js, but it doesn't do much unless we are an archive -->
-	<script>
-	// Default to assuming this is an archive and hiding some stuff
-	// See js/archive.js and js/docs.js for logic relating to this
-	var isArchive = true;
-	var dockerVersion = 'v{{ site.docker_ce_version }}';
-	// In archives, we need to know the page root and we get it from JEKYLL_ENV in the jekyll build command
-	var jekyllEnv = '{{ jekyll.environment }}';
-	// If unset (in non-archive branches), defaults to "development". In that case, reset it to empty
-	if (jekyllEnv === 'development') {
-		jekyllEnv = '';
-	}
-	var pageURL = jekyllEnv + '{{ page.url }}';
-	</script>
-	<script src="/js/archive.js"></script>
-	<script src="/js/stickyfill.min.js"></script>
-	<script defer src="/js/metadata.js"></script>
-	<script src="/js/glossary.js"></script>
-	<script defer src="/js/docs.js"></script>
-	<script defer src="/js/toc.js"></script>
-	<script>
-	jQuery(document).ready(function(){hookupTOCEvents();});
-	</script>
+    {% if page.path == "404.md" %}
+    <script type="text/javascript">
+        var path = window.location.pathname.replace("#","");
+        var ghIssueQueryString = "https://github.com/docker/docker.github.io/issues/new?" + "title=404%20at%20" + path + "&body=URL%3A%20" + path;
+        document.getElementsByClassName("nomunge")[1].onclick = function() {
+             document.getElementsByClassName("nomunge")[1].href = ghIssueQueryString;
+             return true;
+        };
+    </script>
+    {% endif %}
+    <footer class="footer">
+        {% include footer.html %}
+    </footer>
+    <link rel="stylesheet" href="/css/github.css">
+    {% if page.highlightjs == true %}
+    <script src="/js/highlight.pack.js"></script>
+    <script>
+        hljs.initHighlightingOnLoad();
+    </script>
+    {% endif %}
+    <script defer src="/js/anchorlinks.js"></script>
+    <script defer src="/js/menu.js"></script>
+    <script src="/js/jquery.js"></script>
+    <script src="/js/bootstrap.min.js"></script>
+    <!-- Always include the archive.js, but it doesn't do much unless we are an archive -->
+    <script>
+    // Default to assuming this is an archive and hiding some stuff
+    // See js/archive.js and js/docs.js for logic relating to this
+    var isArchive = true;
+    var dockerVersion = 'v{{ site.docker_ce_version }}';
+    // In archives, we need to know the page root and we get it from JEKYLL_ENV in the jekyll build command
+    var jekyllEnv = '{{ jekyll.environment }}';
+    // If unset (in non-archive branches), defaults to "development". In that case, reset it to empty
+    if (jekyllEnv === 'development') {
+        jekyllEnv = '';
+    }
+    var pageURL = jekyllEnv + '{{ page.url }}';
+    </script>
+    <script src="/js/archive.js"></script>
+    <script src="/js/stickyfill.min.js"></script>
+    <script defer src="/js/metadata.js"></script>
+    <script src="/js/glossary.js"></script>
+    <script defer src="/js/docs.js"></script>
+    <script defer src="/js/toc.js"></script>
+    <script>
+    jQuery(document).ready(function(){hookupTOCEvents();});
+    </script>
 </body>
 </html>

--- a/js/anchorlinks.js
+++ b/js/anchorlinks.js
@@ -5,7 +5,7 @@
 	for (var i = 0; i < hs.length; i++) {
 		h = hs[i];
 		if (h.id != null && h.id.length > 0) {
-			h.insertAdjacentHTML('beforeend', '<a href="' + window.location.href + '#' + h.id + '" class="anchorLink">🔗</a>')
+			h.insertAdjacentHTML('beforeend', '<a href="#' + h.id + '" class="anchorLink">🔗</a>')
 		}
 	}
 


### PR DESCRIPTION
The base href caused browsers to produce incorrect URLs for anchor links on various pages, for example, pointing to:

    https://docs-test.docker.com/engine/reference/#foreground

Instead of

    https://docs-test.docker.com/engine/reference/run/#foreground

While there might be links generated incorrectly (links including `.md`), we should fix those when generating the HTML instead of trying to fix them up using JavaScript.

Unfortunately, Jekyll doesn't process links to markdown files in includes, so for includes in this repository, these were changed to "absolute" "html" links (not linking to Markdown). After that, the only place we need the JavaScript link fix is within the reference docs.

I rewrite the script to be more efficient, documented each step (sorry, quite verbose on the comments), and limited its scope to only run on the reference docs, and on those, only on links within the "content".


fixes https://github.com/docker/docker.github.io/issues/2655
fixes https://github.com/docker/docker.github.io/issues/10647

relates to https://github.com/docker/docker.github.io/issues/247
relates to https://github.com/docker/docker.github.io/issues/8070
relates to https://github.com/docker/docker.github.io/issues/6772
relates to https://github.com/docker/docker.github.io/issues/5711
relates to https://github.com/docker/docker.github.io/issues/5388
relates to https://github.com/docker/docker.github.io/issues/3952
relates to https://github.com/docker/docker.github.io/issues/2655