### PR TITLE
remove Jenkinsfile from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,4 +15,3 @@ Dockerfile.archive
 docker-compose.yml
 Gemfile
 Gemfile.lock
-Jenkinsfile


### PR DESCRIPTION
There's no longer a Jenkinsfile in this repo, so we can remove it
