### PR TITLE
Consistently use docker-desktop for Kube context

### DIFF
--- a/_includes/kubernetes-mac-win.md
+++ b/_includes/kubernetes-mac-win.md
@@ -20,8 +20,8 @@ Usage: {% include kubernetes-mac-win.md platform="mac" %}
 
   {% capture local-kubectl-warning %}
 > If you independently installed the Kubernetes CLI, `kubectl`, make sure that
-> it is pointing to `docker-for-desktop` and not some other context such as
-> `minikube` or a GKE cluster. Run: `kubectl config use-context docker-for-desktop`.
+> it is pointing to `docker-desktop` and not some other context such as
+> `minikube` or a GKE cluster. Run: `kubectl config use-context docker-desktop`.
 > If you experience conflicts with an existing `kubectl` installation, remove `/usr/local/bin/kubectl`.
 
   {% endcapture %}
@@ -130,7 +130,7 @@ You can test the command by listing the available nodes:
 kubectl get nodes
 
 NAME                 STATUS    ROLES     AGE       VERSION
-docker-for-desktop   Ready     master    3h        v1.8.2
+docker-desktop       Ready     master    3h        v1.8.2
 ```
 
 ## Example app

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -262,7 +262,7 @@ that you can test deploying your Docker workloads on Kubernetes.
 The Kubernetes client command, `kubectl`, is included and configured to connect
 to the local Kubernetes server. If you have `kubectl` already installed and
 pointing to some other environment, such as `minikube` or a GKE cluster, be sure
-to change context so that `kubectl` is pointing to `docker-for-desktop`:
+to change context so that `kubectl` is pointing to `docker-desktop`:
 
 ```bash
 $ kubectl config get-contexts

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -371,11 +371,11 @@ Docker Desktop includes a standalone Kubernetes server that runs on your Windows
 The Kubernetes client command, `kubectl`, is included and configured to connect
 to the local Kubernetes server. If you have `kubectl` already installed and
 pointing to some other environment, such as `minikube` or a GKE cluster, be sure
-to change context so that `kubectl` is pointing to `docker-for-desktop`:
+to change context so that `kubectl` is pointing to `docker-desktop`:
 
 ```bash
 > kubectl config get-contexts
-> kubectl config use-context docker-for-desktop
+> kubectl config use-context docker-desktop
 ```
 
  To enable Kubernetes support and install a standalone instance of Kubernetes

--- a/ee/desktop/user/mac-user.md
+++ b/ee/desktop/user/mac-user.md
@@ -238,11 +238,11 @@ that you can test deploying your Docker workloads on Kubernetes.
 The Kubernetes client command, `kubectl`, is included and configured to connect
 to the local Kubernetes server. If you have `kubectl` already installed and
 pointing to some other environment, such as `minikube` or a GKE cluster, be sure
-to change context so that `kubectl` is pointing to `docker-for-desktop`:
+to change context so that `kubectl` is pointing to `docker-desktop`:
 
 ```bash
 $ kubectl config get-contexts
-$ kubectl config use-context docker-for-desktop
+$ kubectl config use-context docker-desktop
 ```
 
 If you installed `kubectl` with Homebrew, or by some other method, and

--- a/ee/desktop/user/windows-user.md
+++ b/ee/desktop/user/windows-user.md
@@ -388,11 +388,11 @@ Docker workloads on Kubernetes.
 The Kubernetes client command, `kubectl`, is included and configured to connect
 to the local Kubernetes server. If you have `kubectl` already installed and
 pointing to some other environment, such as `minikube` or a GKE cluster, be sure
-to change context so that `kubectl` is pointing to `docker-for-desktop`:
+to change context so that `kubectl` is pointing to `docker-desktop`:
 
 ```bash
 > kubectl config get-contexts
-> kubectl config use-context docker-for-desktop
+> kubectl config use-context docker-desktop
 ```
 
 You can also change it through the Docker Desktop Enterprise menu:


### PR DESCRIPTION
This changed and both work, but this is the correct form.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
