### PR TITLE
Optimize keywords-list logic in docs layout

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -177,11 +177,16 @@
 							{{ content }}
 							<!-- tags -->
 							{% unless page.notags == true %}
-							{% assign keywords = page.keywords | split:"," %}
-							{% for keyword in keywords %}{% assign strippedKeyword = keyword | strip %}
-							{% capture keywordlist %}{{ keywordlist }}<a href="https://docs.docker.com/search/?q={{strippedKeyword}}">{{strippedKeyword}}</a>{% unless forloop.last %}, {% endunless %}{% endcapture %}
-							{% endfor %}
-							{% if keywordlist.size > 0 %}<span class="glyphicon glyphicon-tags" style="padding-right: 10px"></span><span style="vertical-align: 2px">{{ keywordlist }}</span>{% endif %}
+							{% assign keywords = page.keywords | split:"," -%}
+							{% if keywords.size > 0 -%}
+							  <span class="glyphicon glyphicon-tags" style="padding-right: 10px"></span><span style="vertical-align: 2px">
+							  {%- for keyword in keywords -%}
+							    {%- assign strippedKeyword = keyword | strip -%}
+							    <a href="https://docs.docker.com/search/?q={{ strippedKeyword }}">{{ strippedKeyword }}</a>
+							    {%- unless forloop.last %}, {% endunless -%}
+							  {% endfor -%}
+							  </span>
+							{% endif -%}
 							{% endunless %}
 							<!-- link corrections -->
               <script language="JavaScript">


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The Liquid logic to render a list of keywords for a document consists of using a recursive
`{% capture %}` of words wrapped in an `<a/>` tag. This *recursive capturing* is inefficient both speed-wise and memory-usage-wise.

This pull request refactors the logic by:
- wrapping the core logic in a conditional that checks if `page.keywords | split:","` results in a non-empty array right away.
- using Liquid's whitespace-control feature to conform to whitespace quirks of an HTML `<span />` tag yet nest and indent Liquid markup for readability.
