### PR TITLE
Engine API: remove per-branch fetching of API docs

### DIFF
--- a/_data/not_edited_here.yaml
+++ b/_data/not_edited_here.yaml
@@ -11,14 +11,11 @@
 # Make sure directories have the trailing slash, keep the list alphabetical
 
 overrides:
-- path: /apidocs/
-  description: "Auto-generated API docs for DTR and UCP. File an issue."
-
 - path: /engine/api/
   description: "ReDoc/Swagger API specs"
-  source: https://github.com/docker/docker-ce/tree/master/components/engine/api
+  source: https://github.com/docker/docker/tree/master/docs/api
 
-- path: /engine/deprecated.md
+- path: /engine/deprecated/
   description: Docker Engine deprecation reference
   source: https://github.com/docker/cli/tree/master/docs/deprecated.md
 
@@ -32,7 +29,7 @@ overrides:
 
 - path: /notary/reference/
   description: Reference docs for Docker Notary
-  source: https://github.com/docker/notary/tree/master/docs/reference/
+  source: https://github.com/theupdateframework/notary/tree/master/docs/reference/
 
 - path: /registry/configuration/
   description: Reference docs for configuring Docker Registry

--- a/_scripts/fetch-upstream-resources.sh
+++ b/_scripts/fetch-upstream-resources.sh
@@ -26,18 +26,6 @@ svn co "https://github.com/mirantis/compliance/trunk/docs/compliance"           
 # Cleanup svn directories
 find . -name ".svn" -print0 | xargs -0 /bin/rm -rf
 
-# Get the Engine APIs that are in Swagger
-# Add a new engine/api/<version>.md file to add a new API version page.
-# @TODO stop fetching individual files, onces all API docs are unified upstream in moby/moby
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v17.06.2-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.30.yaml || (echo "Failed 1.30 swagger download" && exit 1)
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v17.07.0-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.31.yaml || (echo "Failed 1.31 swagger download" && exit 1)
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v17.09.1-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.32.yaml || (echo "Failed 1.32 swagger download" && exit 1)
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v17.10.0-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.33.yaml || (echo "Failed 1.33 swagger download" && exit 1)
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v17.11.0-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.34.yaml || (echo "Failed 1.34 swagger download" && exit 1)
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v17.12.1-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.35.yaml || (echo "Failed 1.35 swagger download" && exit 1)
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v18.02.0-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.36.yaml || (echo "Failed 1.36 swagger download" && exit 1)
-wget --quiet --directory-prefix=./engine/api/ https://raw.githubusercontent.com/docker/docker-ce/v18.03.1-ce/components/engine/api/swagger.yaml; mv ./engine/api/swagger.yaml ./engine/api/v1.37.yaml || (echo "Failed 1.37 swagger download" && exit 1)
-
 # Get a few one-off files that we use directly from upstream
 wget --quiet --directory-prefix=./engine/                       "https://raw.githubusercontent.com/docker/cli/${ENGINE_BRANCH}/docs/deprecated.md"                    || (echo "Failed engine/deprecated.md download" && exit 1)
 wget --quiet --directory-prefix=./engine/reference/             "https://raw.githubusercontent.com/docker/cli/${ENGINE_BRANCH}/docs/reference/builder.md"             || (echo "Failed engine/reference/builder.md download" && exit 1)


### PR DESCRIPTION
now that all API versions are unified in both the "master" https://github.com/moby/moby/pull/40778) and release branches (https://github.com/moby/moby/pull/40779), we can fetch then all at once with svn.

