### PR TITLE
Desktop: updates about IPv6

### DIFF
--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -256,17 +256,6 @@ in the Apple documentation, and Docker Desktop [Mac system requirements](install
 
 * IPv6 is not (yet) supported on Docker Desktop.
 
-  A workaround is provided that auto-filters out the IPv6 addresses in DNS
-  server lists and enables successful network access.  For example,
-  `2001:4860:4860::8888` would become `8.8.8.8`.  To learn more, see these
-  issues on GitHub and Docker Desktop forums:
-
-  * [Network timeout when top two DNS servers in /etc/resolv.conf are IPv6
-    addresses](https://github.com/docker/for-mac/issues/9)
-
-  * [ERROR: Network timed out while trying to connect to
-    index.docker.io](https://forums.docker.com/t/error-network-timed-out-while-trying-to-connect-to-index-docker-io/17206)
-
 * You might encounter errors when using `docker-compose up` with Docker Desktop
   (`ValueError: Extra Data`). We've identified this is likely related to data
   and/or events being passed all at once rather than one by one, so sometimes

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -375,6 +375,8 @@ Discussion thread on GitHub at [Docker for Windows issue
 
 ### Networking issues
 
+IPv6 is not (yet) supported on Docker Desktop.
+
 Some users have reported problems connecting to Docker Hub on the Docker Desktop stable version. (See GitHub issue
 [22567](https://github.com/moby/moby/issues/22567).)
 


### PR DESCRIPTION

### Proposed changes

1. there was a note about IPv6 not being supported in the troubleshooting guide on Mac but not on Windows. I've added it to Windows for symmetry.
2. there was an out-of-date note about DNS and IPv6 in the Mac troubleshooting which I've removed since Desktop doesn't contact the upstream servers directly, so it doesn't matter which protocols are used there.

<!--Tell us what you did and why-->

### Unreleased project version (optional)

This applies to the current released edge and stable versions.
