### PR TITLE
Added HTML to explicitly include a non-breaking spaces

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -110,7 +110,7 @@ from the repository.
     ```
 
     Verify that you now have the key with the fingerprint
-    `9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88`, by searching for the
+    <span><code>9DC8 5822 9FC7 DD38 854A&nbsp;&nbsp;E2D8 8D81 803C 0EBF CD88</code></span>, by searching for the
     last 8 characters of the fingerprint.
 
     ```bash


### PR DESCRIPTION
… preserve the two spaces by including html span, code tag and two &nbsp characters;

### Problem
As is the markdown compiler was collapsing the spaces in between the fingerprint key.  There are two spaces between the fifth and sixth hextet.  

### Proposed Change
Changed to include HTML to explicitly include a non-breaking space.

**Before:**
![4E26596C-CDCC-4967-BB3C-BCDEDD719BCB_4_5005_c](https://user-images.githubusercontent.com/30410670/78624615-e85dfa80-783e-11ea-8e5c-26d48316909a.jpeg)

**After:**
![10ED75A2-67B0-4708-A435-5FD34E9B900D](https://user-images.githubusercontent.com/30410670/78624611-e5fba080-783e-11ea-8474-59bfd912c728.jpeg)

resolves #10585