### PR TITLE
Re-order Compose TOC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1100,10 +1100,10 @@ manuals:
     title: Getting started
   - path: /compose/swarm/
     title: Using Compose with Swarm
-  - path: /compose/env-file/
-    title: Environment file
   - path: /compose/environment-variables/
     title: Environment variables in Compose
+  - path: /compose/env-file/
+    title: Environment file
   - path: /compose/extends/
     title: Extend services in Compose
   - path: /compose/networking/


### PR DESCRIPTION
### Proposed changes

Re-order Compose TOC:
  - Environment variables in Compose
  - Environment variables in .env file

This makes more sense since environment variables and .env file is first mentioned in the section labelled "Environment variables in Compose"
