### PR TITLE
Add doc for awslogs-endpoint log option

### DIFF
--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -65,6 +65,19 @@ and no region is set, the driver uses the instance's region.
 
     docker run --log-driver=awslogs --log-opt awslogs-region=us-east-1 ...
 
+### awslogs-endpoint
+
+By default, Docker uses either the `awslogs-region` log option or the
+detected region to construct the remote CloudWatch Logs API endpoint.
+Use the `awslogs-endpoint` log option to override the default endpoint
+with the provided endpoint.
+
+> **Note**
+>
+> The `awslogs-region` log option or detected region controls the
+> region used for signing. You may experience signature errors if the
+> endpoint you've specified with `awslogs-endpoint` uses a different region.
+
 ### awslogs-group
 
 You must specify a


### PR DESCRIPTION
forward-port of https://github.com/docker/docker.github.io/pull/7003, which was merged in the `vnext-engine` branch, but the feature (https://github.com/moby/moby/pull/37374) was already included in the current 19.03 release