### PR TITLE
Redirect Docker EE docs to Mirantis

### DIFF
--- a/_website-config-docs-stage.json
+++ b/_website-config-docs-stage.json
@@ -1,180 +1,349 @@
 {
- "ErrorDocument": {
-  "Key": "404.html"
- },
- "IndexDocument": {
-  "Suffix": "index.html"
- },
- "RedirectAllRequestsTo": null,
- "RoutingRules": [
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.4/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
+  "ErrorDocument": {
+    "Key": "404.html"
   },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.5/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
+  "IndexDocument": {
+    "Suffix": "index.html"
   },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.6/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.7/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.8/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.9/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.10/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.11/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.12/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.13/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v17.03/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v17.09/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v17.12/"
-   },
-   "Redirect": {
-    "HostName": "docs-stage.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  }
- ]
+  "RedirectAllRequestsTo": null,
+  "RoutingRules": [
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.4/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.5/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.6/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.7/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.8/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.9/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.10/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.11/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.12/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.13/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.03/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.09/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.12/"
+      },
+      "Redirect": {
+        "HostName": "docs-stage.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/licensing/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/licensing.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/get-support/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/get-support.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/cluster/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/cluster.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/supported-platforms/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/dee-intro.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/ucp/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/ucp.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/dtr/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/dtr.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "compliance/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/compliance.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "datacenter/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v2.1/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.09/ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v2.1/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.03/ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v18.03/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.06/enterprise/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v2.0/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/docker-ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/docker-engine-enterprise/dee-linux.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/index.html"
+      }
+    }
+  ]
 }

--- a/_website-config-docs.json
+++ b/_website-config-docs.json
@@ -1,180 +1,349 @@
 {
- "ErrorDocument": {
-  "Key": "404.html"
- },
- "IndexDocument": {
-  "Suffix": "index.html"
- },
- "RedirectAllRequestsTo": null,
- "RoutingRules": [
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.4/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
+  "ErrorDocument": {
+    "Key": "404.html"
   },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.5/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
+  "IndexDocument": {
+    "Suffix": "index.html"
   },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.6/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.7/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.8/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.9/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.10/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.11/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.12/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v1.13/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v17.03/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v17.09/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  },
-  {
-   "Condition": {
-    "HttpErrorCodeReturnedEquals": null,
-    "KeyPrefixEquals": "v17.12/"
-   },
-   "Redirect": {
-    "HostName": "docs.docker.com",
-    "HttpRedirectCode": null,
-    "Protocol": "https",
-    "ReplaceKeyPrefixWith": "",
-    "ReplaceKeyWith": null
-   }
-  }
- ]
+  "RedirectAllRequestsTo": null,
+  "RoutingRules": [
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.4/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.5/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.6/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.7/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.8/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.9/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.10/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.11/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.12/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.13/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.03/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.09/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.12/"
+      },
+      "Redirect": {
+        "HostName": "docs.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/licensing/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/licensing.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/get-support/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/get-support.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/cluster/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/cluster.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/supported-platforms/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/dee-intro.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/ucp/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/ucp.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/dtr/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/dtr.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "compliance/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/compliance.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "datacenter/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v2.1/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.09/ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v2.1/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.03/ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v18.03/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.06/enterprise/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v2.0/"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/docker-ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/docker-engine-enterprise/dee-linux.html"
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/"
+      },
+      "Redirect": {
+        "HostName": "docs.mirantis.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": "docker-enterprise/v3.0/dockeree-products/index.html"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds redirect rules to redirect all Docker EE related pages to the Mirantis docs.
The redirect rules work independently from actual removing the docs from our repo, the cleanup can be done in a separate PR.
So, once we want to redirect, we can merge this PR and merge it to published branch to have the redirect rules go live.
