### PR TITLE
Add link to CLI experimental features

### DIFF
--- a/_includes/experimental.md
+++ b/_includes/experimental.md
@@ -12,3 +12,5 @@ Docker does not offer support for experimental features.
 > **Settings** (**Preferences** on macOS) > **Command Line** and then turn on
 > the **Enable experimental features** toggle. Click **Apply & Restart**.
 {: .important }
+
+For a list of current experimental features in the Docker CLI, see [Docker CLI Experimental features](https://github.com/docker/cli/blob/master/experimental/README.md).


### PR DESCRIPTION
Add link to the Docker CLI experimental features readme which contains a list of the current experimental features.