### PR TITLE
Engine: update YAML-docs with latest version from 19.03 branch

### DIFF
--- a/_data/engine-cli/docker.yaml
+++ b/_data/engine-cli/docker.yaml
@@ -1,4 +1,6 @@
 command: docker
+short: The base command for the Docker CLI.
+long: The base command for the Docker CLI.
 cname:
 - docker attach
 - docker build

--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -20,12 +20,13 @@ long: |-
   Local copy gives you the ability to access private repositories using local
   user credentials, VPN's, and so forth.
 
-  > **Note:**
+  > **Note**
+  >
   > If the `URL` parameter contains a fragment the system will recursively clone
   > the repository and its submodules using a `git clone --recursive` command.
 
   Git URLs accept context configuration in their fragment section, separated by a
-  colon `:`.  The first part represents the reference that Git will check out,
+  colon (`:`).  The first part represents the reference that Git will check out,
   and can be either a branch, a tag, or a remote reference. The second part
   represents a subdirectory inside the repository that will be used as a build
   context.
@@ -635,13 +636,13 @@ examples: |-
 
   When `docker build` is run with the `--cgroup-parent` option the containers
   used in the build will be run with the [corresponding `docker run`
-  flag](../run.md#specifying-custom-cgroups).
+  flag](../run.md#specify-custom-cgroups).
 
   ### Set ulimits in container (--ulimit)
 
   Using the `--ulimit` option with `docker build` will cause each build step's
   container to be started using those [`--ulimit`
-  flag values](./run.md#set-ulimits-in-container-ulimit).
+  flag values](run.md#set-ulimits-in-container---ulimit).
 
   ### Set build-time variables (--build-arg)
 
@@ -816,7 +817,9 @@ examples: |-
   vndr
   ```
 
-  > **Note**: This feature requires the BuildKit backend. You can either
+  > **Note**
+  >
+  > This feature requires the BuildKit backend. You can either
   > [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)
   > plugin which provides more output type options.
 
@@ -855,7 +858,9 @@ examples: |-
   $ docker build --cache-from myname/myapp .
   ```
 
-  > **Note**: This feature requires the BuildKit backend. You can either
+  > **Note**
+  >
+  > This feature requires the BuildKit backend. You can either
   > [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)
   > plugin. The previous builder has limited support for reusing cache from
   > pre-pulled images.

--- a/_data/engine-cli/docker_cp.yaml
+++ b/_data/engine-cli/docker_cp.yaml
@@ -66,7 +66,7 @@ long: |-
       `/path/to/file:name.txt` or `./file:name.txt`
 
   It is not possible to copy certain system files such as resources under
-  `/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs-tmpfs), and mounts created by
+  `/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs---tmpfs), and mounts created by
   the user in the container. However, you can still copy such files by manually
   running `tar` in `docker exec`. Both of the following examples do the same thing
   in different ways (consider `SRC_PATH` and `DEST_PATH` are directories):

--- a/_data/engine-cli/docker_history.yaml
+++ b/_data/engine-cli/docker_history.yaml
@@ -89,7 +89,8 @@ examples: |-
   `table` directive, will include column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID` and `CreatedSince` entries separated by a colon for the `busybox` image:
+  `ID` and `CreatedSince` entries separated by a colon (`:`) for the `busybox`
+  image:
 
   ```bash
   $ docker history --format "{{.ID}}: {{.CreatedSince}}" busybox

--- a/_data/engine-cli/docker_image_prune.yaml
+++ b/_data/engine-cli/docker_image_prune.yaml
@@ -201,7 +201,9 @@ examples: |-
   $ docker image prune --filter="label!=maintainer=john"
   ```
 
-  > **Note**: You are prompted for confirmation before the `prune` removes
+  > **Note**
+  >
+  > You are prompted for confirmation before the `prune` removes
   > anything, but you are not shown a list of what will potentially be removed.
   > In addition, `docker image ls` does not support negative filtering, so it
   > difficult to predict what images will actually be removed.

--- a/_data/engine-cli/docker_images.yaml
+++ b/_data/engine-cli/docker_images.yaml
@@ -214,8 +214,7 @@ examples: |-
   511136ea3c5a
   ```
 
-  > **Note**: Docker warns you if any containers exist that are using these
-  > untagged images.
+  Docker warns you if any containers exist that are using these untagged images.
 
 
   #### Show images with a given label
@@ -339,7 +338,7 @@ examples: |-
   `table` directive, will include column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID` and `Repository` entries separated by a colon for all images:
+  `ID` and `Repository` entries separated by a colon (`:`) for all images:
 
   ```bash
   $ docker images --format "{{.ID}}: {{.Repository}}"

--- a/_data/engine-cli/docker_import.yaml
+++ b/_data/engine-cli/docker_import.yaml
@@ -70,7 +70,7 @@ examples: |-
   - Import to docker from a local archive.
 
     ```bash
-      $ docker import /path/to/exampleimage.tgz
+    $ docker import /path/to/exampleimage.tgz
     ```
 
   ### Import from a local directory

--- a/_data/engine-cli/docker_kill.yaml
+++ b/_data/engine-cli/docker_kill.yaml
@@ -6,7 +6,9 @@ long: |-
   specified with the `--signal` option. You can kill a container using the
   container's ID, ID-prefix, or name.
 
-  > **Note**: `ENTRYPOINT` and `CMD` in the *shell* form run as a subcommand of
+  > **Note**
+  >
+  > `ENTRYPOINT` and `CMD` in the *shell* form run as a child process of
   > `/bin/sh -c`, which does not pass signals. This means that the executable is
   > not the container’s PID 1 and does not receive Unix signals.
 usage: docker kill [OPTIONS] CONTAINER [CONTAINER...]

--- a/_data/engine-cli/docker_logs.yaml
+++ b/_data/engine-cli/docker_logs.yaml
@@ -3,8 +3,10 @@ short: Fetch the logs of a container
 long: |-
   The `docker logs` command batch-retrieves logs present at the time of execution.
 
-  > **Note**: this command is only functional for containers that are started with
-  > the `json-file` or `journald` logging driver.
+  > **Note**
+  >
+  > This command is only functional for containers that are started with the
+  > `json-file` or `journald` logging driver.
 
   For more information about selecting and configuring logging drivers, refer to
   [Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).

--- a/_data/engine-cli/docker_manifest.yaml
+++ b/_data/engine-cli/docker_manifest.yaml
@@ -19,7 +19,7 @@ long: |-
 
   ### manifest inspect
 
-  ```
+  ```bash
   manifest inspect --help
 
   Usage:  docker manifest inspect [OPTIONS] [MANIFEST_LIST] MANIFEST
@@ -265,7 +265,9 @@ examples: |-
   $ docker manifest push --insecure myprivateregistry.mycompany.com/repo/image:tag
   ```
 
-  > **Note**: the `--insecure` flag is not required to annotate a manifest list,
+  > **Note**
+  >
+  > The `--insecure` flag is not required to annotate a manifest list,
   > since annotations are to a locally-stored copy of a manifest list. You may also
   > skip the `--insecure` flag if you are performing a `docker manifest inspect`
   > on a locally-stored manifest list. Be sure to keep in mind that locally-stored

--- a/_data/engine-cli/docker_network_disconnect.yaml
+++ b/_data/engine-cli/docker_network_disconnect.yaml
@@ -19,7 +19,7 @@ options:
   swarm: false
 examples: |-
   ```bash
-    $ docker network disconnect multi-host-network container1
+  $ docker network disconnect multi-host-network container1
   ```
 deprecated: false
 min_api_version: "1.21"

--- a/_data/engine-cli/docker_network_ls.yaml
+++ b/_data/engine-cli/docker_network_ls.yaml
@@ -237,7 +237,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID` and `Driver` entries separated by a colon for all networks:
+  `ID` and `Driver` entries separated by a colon (`:`) for all networks:
 
   ```bash
   $ docker network ls --format "{{.ID}}: {{.Driver}}"

--- a/_data/engine-cli/docker_node_demote.yaml
+++ b/_data/engine-cli/docker_node_demote.yaml
@@ -3,7 +3,9 @@ short: Demote one or more nodes from manager in the swarm
 long: |-
   Demotes an existing manager so that it is no longer a manager.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the [Swarm mode
   > section](https://docs.docker.com/engine/swarm/) in the documentation.
 usage: docker node demote NODE [NODE...]

--- a/_data/engine-cli/docker_node_inspect.yaml
+++ b/_data/engine-cli/docker_node_inspect.yaml
@@ -7,9 +7,12 @@ long: |-
   [text/template](http://golang.org/pkg/text/template/) package describes all the
   details of the format.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker node inspect [OPTIONS] self|NODE [NODE...]
 pname: docker node
 plink: docker_node.yaml

--- a/_data/engine-cli/docker_node_ls.yaml
+++ b/_data/engine-cli/docker_node_ls.yaml
@@ -6,9 +6,12 @@ long: |-
   using the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section
   for more information about available filter options.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker node ls [OPTIONS]
 pname: docker node
 plink: docker_node.yaml
@@ -49,10 +52,11 @@ examples: |-
   38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active
   e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
   ```
-  > **Note**:
-  > In the above example output, there is a hidden column of `.Self` that indicates if the
-  > node is the same node as the current docker daemon. A `*` (e.g., `e216jshn25ckzbvmwlnh5jr3g *`)
-  > means this node is the current docker daemon.
+  > **Note**
+  >
+  > In the above example output, there is a hidden column of `.Self` that indicates
+  > if the node is the same node as the current docker daemon. A `*` (e.g.,
+  > `e216jshn25ckzbvmwlnh5jr3g *`) means this node is the current docker daemon.
 
 
   ### Filtering
@@ -62,11 +66,11 @@ examples: |-
 
   The currently supported filters are:
 
-  * [id](node_ls.md#id)
-  * [label](node_ls.md#label)
-  * [membership](node_ls.md#membership)
-  * [name](node_ls.md#name)
-  * [role](node_ls.md#role)
+  * [id](#id)
+  * [label](#label)
+  * [membership](#membership)
+  * [name](#name)
+  * [role](#role)
 
   #### id
 
@@ -156,7 +160,8 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID`, `Hostname`, and `TLS Status` entries separated by a colon for all nodes:
+  `ID`, `Hostname`, and `TLS Status` entries separated by a colon (`:`) for all
+  nodes:
 
   ```bash
   $ docker node ls --format "{{.ID}}: {{.Hostname}} {{.TLSStatus}}"

--- a/_data/engine-cli/docker_node_promote.yaml
+++ b/_data/engine-cli/docker_node_promote.yaml
@@ -3,9 +3,12 @@ short: Promote one or more nodes to manager in the swarm
 long: |-
   Promotes a node to manager. This command can only be executed on a manager node.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker node promote NODE [NODE...]
 pname: docker node
 plink: docker_node.yaml

--- a/_data/engine-cli/docker_node_ps.yaml
+++ b/_data/engine-cli/docker_node_ps.yaml
@@ -5,9 +5,12 @@ long: |-
   `-f` or `--filter` flag. Refer to the [filtering](#filtering) section for more
   information about available filter options.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker node ps [OPTIONS] [NODE...]
 pname: docker node
 plink: docker_node.yaml
@@ -152,7 +155,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `Name` and `Image` entries separated by a colon for all tasks:
+  `Name` and `Image` entries separated by a colon (`:`) for all tasks:
 
   ```bash
   $ docker node ps --format "{{.Name}}: {{.Image}}"

--- a/_data/engine-cli/docker_node_rm.yaml
+++ b/_data/engine-cli/docker_node_rm.yaml
@@ -4,9 +4,12 @@ short: Remove one or more nodes from the swarm
 long: |-
   Removes the specified nodes from a swarm.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker node rm [OPTIONS] NODE [NODE...]
 pname: docker node
 plink: docker_node.yaml

--- a/_data/engine-cli/docker_node_update.yaml
+++ b/_data/engine-cli/docker_node_update.yaml
@@ -3,9 +3,12 @@ short: Update a node
 long: |-
   Update metadata about a node, such as its availability, labels, or roles.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker node update [OPTIONS] NODE
 pname: docker node
 plink: docker_node.yaml
@@ -71,7 +74,7 @@ examples: |-
 
   The labels you set for nodes using `docker node update` apply only to the node
   entity within the swarm. Do not confuse them with the docker daemon labels for
-  [dockerd](https://docs.docker.com/engine/userguide/labels-custom-metadata/#daemon-labels).
+  [dockerd](dockerd.md).
 
   For more information about labels, refer to [apply custom
   metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).

--- a/_data/engine-cli/docker_plugin_inspect.yaml
+++ b/_data/engine-cli/docker_plugin_inspect.yaml
@@ -17,9 +17,17 @@ options:
   kubernetes: false
   swarm: false
 examples: |-
-  ```none
-  $ docker plugin inspect tiborvass/sample-volume-plugin:latest
+  ### Inspect a plugin
 
+  The following example example inspects the `tiborvass/sample-volume-plugin` plugin:
+
+  ```bash
+  $ docker plugin inspect tiborvass/sample-volume-plugin:latest
+  ```
+
+  Output is in JSON format (output below is formatted for readability):
+
+  ```json
   {
     "Id": "8c74c978c434745c3ade82f1bc0acf38d04990eaf494fa507c16d9f1daa99c21",
     "Name": "tiborvass/sample-volume-plugin:latest",
@@ -127,7 +135,6 @@ examples: |-
   }
   ```
 
-  (output formatted for readability)
 
   ### Formatting the output
 

--- a/_data/engine-cli/docker_plugin_ls.yaml
+++ b/_data/engine-cli/docker_plugin_ls.yaml
@@ -91,8 +91,8 @@ examples: |-
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder    | Description
-  ---------------|------------------------------------------------------------------------------------------
+  Placeholder        | Description
+  -------------------|------------------------------------------------------------
   `.ID`              | Plugin ID
   `.Name`            | Plugin name
   `.Description`     | Plugin description
@@ -104,7 +104,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID` and `Name` entries separated by a colon for all plugins:
+  `ID` and `Name` entries separated by a colon (`:`) for all plugins:
 
   ```bash
   $ docker plugin ls --format "{{.ID}}: {{.Name}}"

--- a/_data/engine-cli/docker_plugin_set.yaml
+++ b/_data/engine-cli/docker_plugin_set.yaml
@@ -42,7 +42,9 @@ examples: |-
   /bar
   ```
 
-  > **Note**: Since only `source` is settable in `mymount`,
+  > **Note**
+  >
+  > Since only `source` is settable in `mymount`,
   > `docker plugins set mymount=/bar myplugin` would work too.
 
   ### Change a device path
@@ -62,7 +64,8 @@ examples: |-
   /dev/bar
   ```
 
-  > **Note**: Since only `path` is settable in `mydevice`,
+  > **Note**
+  > Since only `path` is settable in `mydevice`,
   > `docker plugins set mydevice=/dev/bar myplugin` would work too.
 
   ### Change the source of the arguments

--- a/_data/engine-cli/docker_port.yaml
+++ b/_data/engine-cli/docker_port.yaml
@@ -12,16 +12,25 @@ examples: |-
 
   ```bash
   $ docker ps
+
   CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
   b650456536c7        busybox:latest      top                 54 minutes ago      Up 54 minutes       0.0.0.0:1234->9876/tcp, 0.0.0.0:4321->7890/tcp   test
+
   $ docker port test
+
   7890/tcp -> 0.0.0.0:4321
   9876/tcp -> 0.0.0.0:1234
+
   $ docker port test 7890/tcp
+
   0.0.0.0:4321
+
   $ docker port test 7890/udp
+
   2014/06/24 11:53:36 Error: No public port '7890/udp' published for test
+
   $ docker port test 7890
+
   0.0.0.0:4321
   ```
 deprecated: false

--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -113,6 +113,7 @@ examples: |-
 
   ```bash
   $ docker ps -s
+
   CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
   e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours           my_nginx     35.58 kB (virtual 109.2 MB)
   00c6131c5e30   telegraf:1.5   "/entrypoint.sh"         11 weeks ago   Up 11 weeks          my_telegraf  0 B (virtual 209.5 MB)
@@ -351,10 +352,12 @@ examples: |-
 
   ```bash
   $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
+
   CONTAINER ID        MOUNTS
   9c3527ed70ce        remote-volume
 
   $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
+
   CONTAINER ID        MOUNTS
   9c3527ed70ce        remote-volume
   ```
@@ -458,7 +461,7 @@ examples: |-
   column headers as well.
 
   The following example uses a template without headers and outputs the `ID` and
-  `Command` entries separated by a colon for all running containers:
+  `Command` entries separated by a colon (`:`) for all running containers:
 
   ```bash
   $ docker ps --format "{{.ID}}: {{.Command}}"

--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -16,7 +16,7 @@ long: |-
   before open a connect to registry, you may need to configure the Docker
   daemon's proxy settings, using the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
   environment variables. To set these environment variables on a host using
-  `systemd`, refer to the [control and configure Docker with systemd](https://docs.docker.com/engine/admin/systemd/#http-proxy)
+  `systemd`, refer to the [control and configure Docker with systemd](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
   for variables configuration.
 
   ### Concurrent downloads
@@ -122,7 +122,7 @@ examples: |-
   space.
 
   For more information about images, layers, and the content-addressable store,
-  refer to [understand images, containers, and storage drivers](https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/).
+  refer to [understand images, containers, and storage drivers](https://docs.docker.com/storage/storagedriver/).
 
 
   ### Pull an image by digest (immutable identifier)
@@ -184,7 +184,9 @@ examples: |-
   MAINTAINER some maintainer <maintainer@example.com>
   ```
 
-  > **Note**: Using this feature "pins" an image to a specific version in time.
+  > **Note**
+  >
+  > Using this feature "pins" an image to a specific version in time.
   > Docker will therefore not pull updated versions of an image, which may include
   > security updates. If you want to pull an updated image, you need to change the
   > digest accordingly.
@@ -261,10 +263,12 @@ examples: |-
   ^C
   ```
 
-  > **Note**: Technically, the Engine terminates a pull operation when the
-  > connection between the Docker Engine daemon and the Docker Engine client
-  > initiating the pull is lost. If the connection with the Engine daemon is
-  > lost for other reasons than a manual interaction, the pull is also aborted.
+  > **Note**
+  >
+  > The Engine terminates a pull operation when the connection between the Docker
+  > Engine daemon and the Docker Engine client initiating the pull is lost. If the
+  > connection with the Engine daemon is lost for other reasons than a manual
+  > interaction, the pull is also aborted.
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_rm.yaml
+++ b/_data/engine-cli/docker_rm.yaml
@@ -38,8 +38,7 @@ options:
 examples: |-
   ### Remove a container
 
-  This will remove the container referenced under the link
-  `/redis`.
+  This removes the container referenced under the link `/redis`.
 
   ```bash
   $ docker rm /redis
@@ -49,7 +48,7 @@ examples: |-
 
   ### Remove a link specified with `--link` on the default bridge network
 
-  This will remove the underlying link between `/webapp` and the `/redis`
+  This removes the underlying link between `/webapp` and the `/redis`
   containers on the default bridge network, removing all network communication
   between the two containers. This does not apply when `--link` is used with
   user-specified networks.
@@ -62,7 +61,7 @@ examples: |-
 
   ### Force-remove a running container
 
-  This command will force-remove a running container.
+  This command force-removes a running container.
 
   ```bash
   $ docker rm --force redis
@@ -79,10 +78,9 @@ examples: |-
   $ docker rm $(docker ps -a -q)
   ```
 
-  This command will delete all stopped containers. The command
-  `docker ps -a -q` will return all existing container IDs and pass them to
-  the `rm` command which will delete them. Any running containers will not be
-  deleted.
+  This command deletes all stopped containers. The command
+  `docker ps -a -q` above returns all existing container IDs and passes them to
+  the `rm` command which deletes them. Running containers are not deleted.
 
   ### Remove a container and its volumes
 
@@ -91,7 +89,7 @@ examples: |-
   redis
   ```
 
-  This command will remove the container and any volumes associated with it.
+  This command removes the container and any volumes associated with it.
   Note that if a volume was specified with a name, it will not be removed.
 
   ### Remove a container and selectively remove volumes
@@ -99,11 +97,12 @@ examples: |-
   ```bash
   $ docker create -v awesome:/foo -v /bar --name hello redis
   hello
+
   $ docker rm -v hello
   ```
 
-  In this example, the volume for `/foo` will remain intact, but the volume for
-  `/bar` will be removed. The same behavior holds for volumes inherited with
+  In this example, the volume for `/foo` remains intact, but the volume for
+  `/bar` is removed. The same behavior holds for volumes inherited with
   `--volumes-from`.
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -11,7 +11,7 @@ long: |-
   The `docker run` command can be used in combination with `docker commit` to
   [*change the command that a container runs*](commit.md). There is additional detailed information about `docker run` in the [Docker run reference](../run.md).
 
-  For information on connecting a container to a network, see the ["*Docker network overview*"](https://docs.docker.com/engine/userguide/networking/).
+  For information on connecting a container to a network, see the ["*Docker network overview*"](https://docs.docker.com/network/).
 usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker
 plink: docker.yaml
@@ -1025,8 +1025,7 @@ examples: |-
   ```
 
   By bind-mounting the docker unix socket and statically linked docker
-  binary (refer to [get the linux binary](
-  https://docs.docker.com/engine/installation/binaries/#/get-the-linux-binary)),
+  binary (refer to [get the linux binary](https://docs.docker.com/engine/install/binaries/#install-static-binaries)),
   you give the container the full access to create and manipulate the host's
   Docker daemon.
 
@@ -1054,7 +1053,7 @@ examples: |-
   docker run -v c:\foo:c:\existing-directory-with-contents ...
   ```
 
-  For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/engine/tutorials/dockervolumes/)
+  For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/storage/volumes/)
 
 
   ### Add bind mounts or volumes using the --mount flag
@@ -1065,7 +1064,7 @@ examples: |-
   The `--mount` flag supports most options that are supported by the `-v` or the
   `--volume` flag, but uses a different syntax. For in-depth information on the
   `--mount` flag, and a comparison between `--volume` and `--mount`, refer to
-  the [service create command reference](service_create.md#add-bind-mounts-or-volumes).
+  the [service create command reference](service_create.md#add-bind-mounts-volumes-or-memory-filesystems).
 
   Even though there is no plan to deprecate `--volume`, usage of `--mount` is recommended.
 
@@ -1087,7 +1086,7 @@ examples: |-
 
   This binds port `8080` of the container to TCP port `80` on `127.0.0.1` of the host
   machine. You can also specify `udp` and `sctp` ports.
-  The [Docker User Guide](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/)
+  The [Docker User Guide](https://docs.docker.com/network/links/)
   explains in detail how to manipulate ports in Docker.
 
   Note that ports which are not bound to the host (i.e., `-p 80:80` instead of
@@ -1192,8 +1191,8 @@ examples: |-
   You can load multiple label-files by supplying multiple  `--label-file` flags.
 
   For additional information on working with labels, see [*Labels - custom
-  metadata in Docker*](https://docs.docker.com/engine/userguide/labels-custom-metadata/) in the Docker User
-  Guide.
+  metadata in Docker*](https://docs.docker.com/config/labels-custom-metadata/) in
+  the Docker User Guide.
 
   ### Connect a container to a network (--network)
 
@@ -1219,9 +1218,11 @@ examples: |-
   connectivity, containers connected to the same multi-host network but launched
   from different Engines can also communicate in this way.
 
-  > **Note**: Service discovery is unavailable on the default bridge network.
-  > Containers can communicate via their IP addresses by default. To communicate
-  > by name, they must be linked.
+  > **Note**
+  >
+  > Service discovery is unavailable on the default bridge network. Containers can
+  > communicate via their IP addresses by default. To communicate by name, they
+  > must be linked.
 
   You can disconnect a container from a network using the `docker network
   disconnect` command.
@@ -1322,9 +1323,10 @@ examples: |-
   fdisk: unable to open /dev/xvdc: Operation not permitted
   ```
 
-  > **Note**: `--device` cannot be safely used with ephemeral devices. Block devices
-  > that may be removed should not be added to untrusted containers with
-  > `--device`.
+  > **Note**
+  >
+  > The `--device` option cannot be safely used with ephemeral devices. Block devices
+  > that may be removed should not be added to untrusted containers with `--device`.
 
   For Windows, the format of the string passed to the `--device` option is in
   the form of `--device=<IdType>/<Id>`. Beginning with Windows Server 2019
@@ -1344,9 +1346,11 @@ examples: |-
   PS C:\> docker run --device=class/86E0D1E0-8089-11D0-9CE4-08003E301F73 mcr.microsoft.com/windows/servercore:ltsc2019
   ```
 
-  > **Note**: the `--device` option is only supported on process-isolated
-  > Windows containers. This option fails if the container isolation is `hyperv`
-  > or when running Linux Containers on Windows (LCOW).
+  > **Note**
+  >
+  > The `--device` option is only supported on process-isolated Windows containers.
+  > This option fails if the container isolation is `hyperv` or when running Linux
+  > Containers on Windows (LCOW).
 
   ### Access an NVIDIA GPU
 
@@ -1447,9 +1451,11 @@ examples: |-
   1024
   ```
 
-  > **Note**: If you do not provide a `hard limit`, the `soft limit` will be used
-  > for both values. If no `ulimits` are set, they will be inherited from
-  > the default `ulimits` set on the daemon.  `as` option is disabled now.
+  > **Note**
+  >
+  > If you do not provide a `hard limit`, the `soft limit` is used
+  > for both values. If no `ulimits` are set, they are inherited from
+  > the default `ulimits` set on the daemon. The `as` option is disabled now.
   > In other words, the following script is not supported:
   >
   > ```bash
@@ -1587,26 +1593,25 @@ examples: |-
   $ docker run --sysctl net.ipv4.ip_forward=1 someimage
   ```
 
-  > **Note**: Not all sysctls are namespaced. Docker does not support changing sysctls
+  > **Note**
+  >
+  > Not all sysctls are namespaced. Docker does not support changing sysctls
   > inside of a container that also modify the host system. As the kernel
   > evolves we expect to see more sysctls become namespaced.
 
   #### Currently supported sysctls
 
-  - `IPC Namespace`:
+  IPC Namespace:
 
-    ```none
-    kernel.msgmax, kernel.msgmnb, kernel.msgmni, kernel.sem, kernel.shmall, kernel.shmmax, kernel.shmmni, kernel.shm_rmid_forced
-    Sysctls beginning with fs.mqueue.*
-    ```
+  - `kernel.msgmax`, `kernel.msgmnb`, `kernel.msgmni`, `kernel.sem`,
+    `kernel.shmall`, `kernel.shmmax`, `kernel.shmmni`, `kernel.shm_rmid_forced`.
+  - Sysctls beginning with `fs.mqueue.*`
+  - If you use the `--ipc=host` option these sysctls are not allowed.
 
-    If you use the `--ipc=host` option these sysctls will not be allowed.
+  Network Namespace:
 
-  - `Network Namespace`:
-
-    Sysctls beginning with net.*
-
-    If you use the `--network=host` option using these sysctls will not be allowed.
+  - Sysctls beginning with `net.*`
+  - If you use the `--network=host` option using these sysctls are not allowed.
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_search.yaml
+++ b/_data/engine-cli/docker_search.yaml
@@ -1,12 +1,6 @@
 command: docker search
 short: Search the Docker Hub for images
-long: |-
-  Search [Docker Hub](https://hub.docker.com) for images
-
-  See [*Find Public Images on Docker Hub*](https://docs.docker.com/engine/tutorials/dockerrepos/#searching-for-images) for
-  more details on finding shared images from the command line.
-
-  > **Note**: Search queries return a maximum of 25 results.
+long: Search [Docker Hub](https://hub.docker.com) for images
 usage: docker search [OPTIONS] TERM
 pname: docker
 plink: docker.yaml
@@ -126,9 +120,9 @@ examples: |-
 
   The currently supported filters are:
 
-  * stars (int - number of stars the image has)
-  * is-automated (boolean - true or false) - is the image automated or not
-  * is-official (boolean - true or false) - is the image official or not
+  - stars (int - number of stars the image has)
+  - is-automated (boolean - true or false) - is the image automated or not
+  - is-official (boolean - true or false) - is the image official or not
 
   #### stars
 
@@ -190,10 +184,9 @@ examples: |-
   `table` directive, column headers are included as well.
 
   The following example uses a template without headers and outputs the
-  `Name` and `StarCount` entries separated by a colon for all images:
+  `Name` and `StarCount` entries separated by a colon (`:`) for all images:
 
   ```bash
-  {% raw %}
   $ docker search --format "{{.Name}}: {{.StarCount}}" nginx
 
   nginx: 5441
@@ -206,13 +199,11 @@ examples: |-
   evild/alpine-nginx: 14
   million12/nginx: 9
   maxexcloo/nginx: 7
-  {% endraw %}
   ```
 
   This example outputs a table format:
 
   ```bash
-  {% raw %}
   $ docker search --format "table {{.Name}}\t{{.IsAutomated}}\t{{.IsOfficial}}" nginx
 
   NAME                                     AUTOMATED           OFFICIAL
@@ -222,7 +213,6 @@ examples: |-
   jrcs/letsencrypt-nginx-proxy-companion   [OK]
   million12/nginx-php                      [OK]
   webdevops/php-nginx                      [OK]
-  {% endraw %}
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_secret_create.yaml
+++ b/_data/engine-cli/docker_secret_create.yaml
@@ -5,9 +5,12 @@ long: |-
 
   For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker secret create [OPTIONS] SECRET [file|-]
 pname: docker secret
 plink: docker_secret.yaml

--- a/_data/engine-cli/docker_secret_inspect.yaml
+++ b/_data/engine-cli/docker_secret_inspect.yaml
@@ -11,9 +11,12 @@ long: |-
 
   For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker secret inspect [OPTIONS] SECRET [SECRET...]
 pname: docker secret
 plink: docker_secret.yaml

--- a/_data/engine-cli/docker_secret_ls.yaml
+++ b/_data/engine-cli/docker_secret_ls.yaml
@@ -6,9 +6,12 @@ long: |-
 
   For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker secret ls [OPTIONS]
 pname: docker secret
 plink: docker_secret.yaml
@@ -57,9 +60,9 @@ examples: |-
 
   The currently supported filters are:
 
-  * [id](secret_ls.md#id) (secret's ID)
-  * [label](secret_ls.md#label) (`label=<key>` or `label=<key>=<value>`)
-  * [name](secret_ls.md#name) (secret's name)
+  - [id](#id) (secret's ID)
+  - [label](#label) (`label=<key>` or `label=<key>=<value>`)
+  - [name](#name) (secret's name)
 
   #### id
 
@@ -131,7 +134,7 @@ examples: |-
   `table` directive, will include column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID` and `Name` entries separated by a colon for all images:
+  `ID` and `Name` entries separated by a colon (`:`) for all images:
 
   ```bash
   $ docker secret ls --format "{{.ID}}: {{.Name}}"

--- a/_data/engine-cli/docker_secret_rm.yaml
+++ b/_data/engine-cli/docker_secret_rm.yaml
@@ -6,9 +6,12 @@ long: |-
 
   For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker secret rm SECRET [SECRET...]
 pname: docker secret
 plink: docker_secret.yaml
@@ -20,8 +23,10 @@ examples: |-
   sapth4csdo5b6wz2p5uimh5xg
   ```
 
-  > **Warning**: Unlike `docker rm`, this command does not ask for confirmation
-  > before removing a secret.
+  > **Warning**
+  >
+  > Unlike `docker rm`, this command does not ask for confirmation before removing
+  > a secret.
 deprecated: false
 min_api_version: "1.25"
 experimental: false

--- a/_data/engine-cli/docker_service.yaml
+++ b/_data/engine-cli/docker_service.yaml
@@ -3,9 +3,12 @@ short: Manage services
 long: |-
   Manage services.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -3,9 +3,12 @@ short: Create a new service
 long: |-
   Creates a service as described by the specified parameters.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker service
 plink: docker_service.yaml
@@ -815,7 +818,7 @@ examples: |-
   ```
 
   For more information about labels, refer to [apply custom
-  metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
+  metadata](https://docs.docker.com/config/labels-custom-metadata/).
 
   ### Add bind mounts, volumes or memory filesystems
 
@@ -853,7 +856,7 @@ examples: |-
   update the named volume.
 
   For more information about named volumes, see
-  [Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).
+  [Data Volumes](https://docs.docker.com/storage/volumes/).
 
   The following table describes options which apply to both bind mounts and named
   volumes in a service:
@@ -868,14 +871,14 @@ examples: |-
       <td><b>type</b></td>
       <td></td>
       <td>
-        <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, <tt>tmpfs</tt>, or <tt>npipe</tt>. Defaults to <tt>volume</tt> if no type is specified.
+        <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, <tt>tmpfs</tt>, or <tt>npipe</tt>. Defaults to <tt>volume</tt> if no type is specified.</p>
         <ul>
           <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/engine/reference/commandline/volume_create/">managed volume</a>
           into the container.</li> <li><tt>bind</tt>:
           bind-mounts a directory or file from the host into the container.</li>
           <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
           <li><tt>npipe</tt>: mounts named pipe from the host into the container (Windows containers only).</li>
-        </ul></p>
+        </ul>
       </td>
     </tr>
     <tr>
@@ -915,11 +918,11 @@ examples: |-
       <td>
         <p>The Engine mounts binds and volumes <tt>read-write</tt> unless <tt>readonly</tt> option
         is given when mounting the bind or volume. Note that setting <tt>readonly</tt> for a
-        bind-mount does not make its submounts <tt>readonly</tt> on the current Linux implementation. See also <tt>bind-nonrecursive</tt>.
+        bind-mount does not make its submounts <tt>readonly</tt> on the current Linux implementation. See also <tt>bind-nonrecursive</tt>.</p>
         <ul>
           <li><tt>true</tt> or <tt>1</tt> or no value: Mounts the bind or volume read-only.</li>
           <li><tt>false</tt> or <tt>0</tt>: Mounts the bind or volume read-write.</li>
-        </ul></p>
+        </ul>
       </td>
     </tr>
   </table>
@@ -943,14 +946,13 @@ examples: |-
     <tr>
       <td><b>consistency</b></td>
       <td>
-        <p>The consistency requirements for the mount; one of
-           <ul>
-             <li><tt>default</tt>: Equivalent to <tt>consistent</tt>.</li>
-             <li><tt>consistent</tt>: Full consistency.  The container runtime and the host maintain an identical view of the mount at all times.</li>
-             <li><tt>cached</tt>: The host's view of the mount is authoritative.  There may be delays before updates made on the host are visible within a container.</li>
-             <li><tt>delegated</tt>: The container runtime's view of the mount is authoritative.  There may be delays before updates made in a container are visible on the host.</li>
-          </ul>
-       </p>
+        <p>The consistency requirements for the mount; one of </p>
+        <ul>
+         <li><tt>default</tt>: Equivalent to <tt>consistent</tt>.</li>
+         <li><tt>consistent</tt>: Full consistency.  The container runtime and the host maintain an identical view of the mount at all times.</li>
+         <li><tt>cached</tt>: The host's view of the mount is authoritative.  There may be delays before updates made on the host are visible within a container.</li>
+         <li><tt>delegated</tt>: The container runtime's view of the mount is authoritative.  There may be delays before updates made in a container are visible on the host.</li>
+        </ul>
       </td>
     </tr>
     <tr>
@@ -1032,7 +1034,7 @@ examples: |-
         creation. For example,
         <tt>volume-label=mylabel=hello-world,my-other-label=hello-mars</tt>. For more
         information about labels, refer to
-        <a href="https://docs.docker.com/engine/userguide/labels-custom-metadata/">apply custom metadata</a>.
+        <a href="https://docs.docker.com/config/labels-custom-metadata/">apply custom metadata</a>.
       </td>
     </tr>
     <tr>
@@ -1440,7 +1442,7 @@ examples: |-
   The swarm extends my-network to each node running the service.
 
   Containers on the same network can access each other using
-  [service discovery](https://docs.docker.com/engine/swarm/networking/#use-swarm-mode-service-discovery).
+  [service discovery](https://docs.docker.com/network/overlay/#container-discovery).
 
   Long form syntax of `--network` allows to specify list of aliases and driver options:
   `--network name=my-network,alias=web1,driver-opt=field1=value1`
@@ -1450,7 +1452,7 @@ examples: |-
   You can publish service ports to make them available externally to the swarm
   using the `--publish` flag. The `--publish` flag can take two different styles
   of arguments. The short version is positional, and allows you to specify the
-  published port and target port separated by a colon.
+  published port and target port separated by a colon (`:`).
 
   ```bash
   $ docker service create --name my_web --replicas 3 --publish 8080:80 nginx
@@ -1594,9 +1596,10 @@ examples: |-
   service's name, the node's ID and hostname where it sits.
 
   ```bash
-  $ docker service create --name hosttempl \
-                          --hostname="{{.Node.Hostname}}-{{.Node.ID}}-{{.Service.Name}}"\
-                           busybox top
+  $ docker service create \
+      --name hosttempl \
+      --hostname="{{.Node.Hostname}}-{{.Node.ID}}-{{.Service.Name}}"\
+      busybox top
 
   va8ew30grofhjoychbr6iot8c
 
@@ -1631,10 +1634,11 @@ examples: |-
   `--generic-resource` flag (if the nodes advertise these resources):
 
   ```bash
-  $ docker service create --name cuda \
-                          --generic-resource "NVIDIA-GPU=2" \
-                          --generic-resource "SSD=1" \
-                          nvidia/cuda
+  $ docker service create \
+      --name cuda \
+      --generic-resource "NVIDIA-GPU=2" \
+      --generic-resource "SSD=1" \
+      nvidia/cuda
   ```
 deprecated: false
 min_api_version: "1.24"

--- a/_data/engine-cli/docker_service_inspect.yaml
+++ b/_data/engine-cli/docker_service_inspect.yaml
@@ -9,9 +9,12 @@ long: |-
   Go's [text/template](http://golang.org/pkg/text/template/) package
   describes all the details of the format.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service inspect [OPTIONS] SERVICE [SERVICE...]
 pname: docker service
 plink: docker_service.yaml
@@ -50,47 +53,47 @@ examples: |-
   Both `docker service inspect redis`, and `docker service inspect dmu1ept4cxcf`
   produce the same result:
 
-  ```none
+  ```bash
   $ docker service inspect redis
 
   [
-      {
-          "ID": "dmu1ept4cxcfe8k8lhtux3ro3",
-          "Version": {
-              "Index": 12
+    {
+      "ID": "dmu1ept4cxcfe8k8lhtux3ro3",
+      "Version": {
+        "Index": 12
+      },
+      "CreatedAt": "2016-06-17T18:44:02.558012087Z",
+      "UpdatedAt": "2016-06-17T18:44:02.558012087Z",
+      "Spec": {
+        "Name": "redis",
+        "TaskTemplate": {
+          "ContainerSpec": {
+            "Image": "redis:3.0.6"
           },
-          "CreatedAt": "2016-06-17T18:44:02.558012087Z",
-          "UpdatedAt": "2016-06-17T18:44:02.558012087Z",
-          "Spec": {
-              "Name": "redis",
-              "TaskTemplate": {
-                  "ContainerSpec": {
-                      "Image": "redis:3.0.6"
-                  },
-                  "Resources": {
-                      "Limits": {},
-                      "Reservations": {}
-                  },
-                  "RestartPolicy": {
-                      "Condition": "any",
-                      "MaxAttempts": 0
-                  },
-                  "Placement": {}
-              },
-              "Mode": {
-                  "Replicated": {
-                      "Replicas": 1
-                  }
-              },
-              "UpdateConfig": {},
-              "EndpointSpec": {
-                  "Mode": "vip"
-              }
+          "Resources": {
+            "Limits": {},
+            "Reservations": {}
           },
-          "Endpoint": {
-              "Spec": {}
+          "RestartPolicy": {
+            "Condition": "any",
+            "MaxAttempts": 0
+          },
+          "Placement": {}
+        },
+        "Mode": {
+          "Replicated": {
+            "Replicas": 1
           }
+        },
+        "UpdateConfig": {},
+        "EndpointSpec": {
+          "Mode": "vip"
+        }
+      },
+      "Endpoint": {
+        "Spec": {}
       }
+    }
   ]
   ```
 
@@ -98,13 +101,13 @@ examples: |-
   $ docker service inspect dmu1ept4cxcf
 
   [
-      {
-          "ID": "dmu1ept4cxcfe8k8lhtux3ro3",
-          "Version": {
-              "Index": 12
-          },
-          ...
-      }
+    {
+      "ID": "dmu1ept4cxcfe8k8lhtux3ro3",
+      "Version": {
+        "Index": 12
+      },
+      ...
+    }
   ]
   ```
 

--- a/_data/engine-cli/docker_service_logs.yaml
+++ b/_data/engine-cli/docker_service_logs.yaml
@@ -3,20 +3,25 @@ short: Fetch the logs of a service or task
 long: |-
   The `docker service logs` command batch-retrieves logs present at the time of execution.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 
   The `docker service logs` command can be used with either the name or ID of a
   service, or with the ID of a task. If a service is passed, it will display logs
   for all of the containers in that service. If a task is passed, it will only
   display logs from that particular task.
 
-  > **Note**: This command is only functional for services that are started with
+  > **Note**
+  >
+  > This command is only functional for services that are started with
   > the `json-file` or `journald` logging driver.
 
   For more information about selecting and configuring logging drivers, refer to
-  [Configure logging drivers](https://docs.docker.com/engine/admin/logging/overview/).
+  [Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
 
   The `docker service logs --follow` command will continue streaming the new output from
   the service's `STDOUT` and `STDERR`.

--- a/_data/engine-cli/docker_service_ls.yaml
+++ b/_data/engine-cli/docker_service_ls.yaml
@@ -4,9 +4,12 @@ short: List services
 long: |-
   This command lists services are running in the swarm.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service ls [OPTIONS]
 pname: docker service
 plink: docker_service.yaml
@@ -146,7 +149,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID`, `Mode`, and `Replicas` entries separated by a colon for all services:
+  `ID`, `Mode`, and `Replicas` entries separated by a colon (`:`) for all services:
 
   ```bash
   $ docker service ls --format "{{.ID}}: {{.Mode}} {{.Replicas}}"

--- a/_data/engine-cli/docker_service_ps.yaml
+++ b/_data/engine-cli/docker_service_ps.yaml
@@ -3,9 +3,12 @@ short: List the tasks of one or more services
 long: |-
   Lists the tasks that are running as part of the specified services.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service ps [OPTIONS] SERVICE [SERVICE...]
 pname: docker service
 plink: docker_service.yaml
@@ -193,7 +196,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `Name` and `Image` entries separated by a colon for all tasks:
+  `Name` and `Image` entries separated by a colon (`:`) for all tasks:
 
   ```bash
   $ docker service ps --format "{{.Name}}: {{.Image}}" top

--- a/_data/engine-cli/docker_service_rm.yaml
+++ b/_data/engine-cli/docker_service_rm.yaml
@@ -4,9 +4,12 @@ short: Remove one or more services
 long: |-
   Removes the specified services from the swarm.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service rm SERVICE [SERVICE...]
 pname: docker service
 plink: docker_service.yaml
@@ -23,8 +26,10 @@ examples: |-
   ID  NAME  MODE  REPLICAS  IMAGE
   ```
 
-  > **Warning**: Unlike `docker rm`, this command does not ask for confirmation
-  > before removing a running service.
+  > **Warning**
+  >
+  > Unlike `docker rm`, this command does not ask for confirmation before removing
+  > a running service.
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_service_rollback.yaml
+++ b/_data/engine-cli/docker_service_rollback.yaml
@@ -3,9 +3,12 @@ short: Revert changes to a service's configuration
 long: |-
   Roll back a specified service to its previous version from the swarm.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service rollback [OPTIONS] SERVICE
 pname: docker service
 plink: docker_service.yaml

--- a/_data/engine-cli/docker_service_scale.yaml
+++ b/_data/engine-cli/docker_service_scale.yaml
@@ -7,9 +7,12 @@ long: |-
   actual scaling of the service may take some time. To stop all replicas of a
   service while keeping the service active in the swarm you can set the scale to 0.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service scale SERVICE=REPLICAS [SERVICE=REPLICAS...]
 pname: docker service
 plink: docker_service.yaml

--- a/_data/engine-cli/docker_service_update.yaml
+++ b/_data/engine-cli/docker_service_update.yaml
@@ -11,9 +11,12 @@ long: |-
   setting. However, the `--force` flag will cause the tasks to be recreated anyway. This can be used to perform a
   rolling restart without any changes to the service parameters.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker service update [OPTIONS] SERVICE
 pname: docker service
 plink: docker_service.yaml
@@ -806,9 +809,8 @@ examples: |-
   service name.
 
   - The `--mount-add` flag takes the same parameters as the `--mount` flag on
-    `service create`. Refer to the [volumes and
-    bind mounts](service_create.md#volumes-and-bind-mounts-mount) section in the
-    `service create` reference for details.
+    `service create`. Refer to the [volumes and bind mounts](service_create.md#add-bind-mounts-volumes-or-memory-filesystems)
+    section in the `service create` reference for details.
 
   - The `--mount-rm` flag takes the `target` path of the mount.
 
@@ -838,7 +840,7 @@ examples: |-
 
   Use the `--publish-add` or `--publish-rm` flags to add or remove a published
   port for a service. You can use the short or long syntax discussed in the
-  [docker service create](service_create/#publish-service-ports-externally-to-the-swarm)
+  [docker service create](service_create.md#publish-service-ports-externally-to-the-swarm--p---publish)
   reference.
 
   The following example adds a published service port to an existing service.
@@ -853,7 +855,7 @@ examples: |-
 
   Use the `--network-add` or `--network-rm` flags to add or remove a network for
   a service. You can use the short or long syntax discussed in the
-  [docker service create](service_create/#attach-a-service-to-an-existing-network-network)
+  [docker service create](service_create.md#attach-a-service-to-an-existing-network---network)
   reference.
 
   The following example adds a new alias name to an existing service already connected to network my-network:
@@ -947,13 +949,13 @@ examples: |-
   ### Update services using templates
 
   Some flags of `service update` support the use of templating.
-  See [`service create`](./service_create.md#templating) for the reference.
+  See [`service create`](service_create.md#create-services-using-templates) for the reference.
 
 
   ### Specify isolation mode (Windows)
 
   `service update` supports the same `--isolation` flag as `service create`
-  See [`service create`](./service_create.md) for the reference.
+  See [`service create`](service_create.md) for the reference.
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_stack_deploy.yaml
+++ b/_data/engine-cli/docker_stack_deploy.yaml
@@ -4,10 +4,12 @@ short: Deploy a new stack or update an existing stack
 long: |-
   Create and update a stack from a `compose` file on the swarm.
 
-  > **Note**: This is a cluster management command. When using swarm as an orchestrator,
-  > this command must be executed on a swarm manager node. To learn about managers
-  > and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
-  > in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker stack deploy [OPTIONS] STACK
 pname: docker stack
 plink: docker_stack.yaml

--- a/_data/engine-cli/docker_stack_ls.yaml
+++ b/_data/engine-cli/docker_stack_ls.yaml
@@ -4,10 +4,12 @@ short: List stacks
 long: |-
   Lists the stacks.
 
-  > **Note**: This is a cluster management command. When using swarm as an orchestrator,
-  > this command must be executed on a swarm manager node. To learn about managers
-  > and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
-  > in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker stack ls [OPTIONS]
 pname: docker stack
 plink: docker_stack.yaml
@@ -84,7 +86,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `Name` and `Services` entries separated by a colon for all stacks:
+  `Name` and `Services` entries separated by a colon (`:`) for all stacks:
 
   ```bash
   $ docker stack ls --format "{{.Name}}: {{.Services}}"

--- a/_data/engine-cli/docker_stack_ps.yaml
+++ b/_data/engine-cli/docker_stack_ps.yaml
@@ -3,10 +3,12 @@ short: List the tasks in the stack
 long: |-
   Lists the tasks that are running as part of the specified stack.
 
-  > **Note**: This is a cluster management command. When using swarm as an orchestrator,
-  > this command must be executed on a swarm manager node. To learn about managers
-  > and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
-  > in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker stack ps [OPTIONS] STACK
 pname: docker stack
 plink: docker_stack.yaml
@@ -186,7 +188,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `Name` and `Image` entries separated by a colon for all tasks:
+  `Name` and `Image` entries separated by a colon (`:`) for all tasks:
 
   ```bash
   $ docker stack ps --format "{{.Name}}: {{.Image}}" voting

--- a/_data/engine-cli/docker_stack_rm.yaml
+++ b/_data/engine-cli/docker_stack_rm.yaml
@@ -4,10 +4,12 @@ short: Remove one or more stacks
 long: |-
   Remove the stack from the swarm.
 
-  > **Note**: This is a cluster management command. When using swarm as an orchestrator,
-  > this command must be executed on a swarm manager node. To learn about managers
-  > and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
-  > in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker stack rm [OPTIONS] STACK [STACK...]
 pname: docker stack
 plink: docker_stack.yaml

--- a/_data/engine-cli/docker_stack_services.yaml
+++ b/_data/engine-cli/docker_stack_services.yaml
@@ -3,10 +3,12 @@ short: List the services in the stack
 long: |-
   Lists the services that are running as part of the specified stack.
 
-  > **Note**: This is a cluster management command. When using swarm as an orchestrator,
-  > this command must be executed on a swarm manager node. To learn about managers
-  > and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
-  > in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker stack services [OPTIONS] STACK
 pname: docker stack
 plink: docker_stack.yaml
@@ -119,7 +121,7 @@ examples: |-
   Valid placeholders for the Go template are listed below:
 
   Placeholder | Description
-  ------------|------------------------------------------------------------------------------------------
+  ------------|-------------------------------------------------------------------
   `.ID`       | Service ID
   `.Name`     | Service name
   `.Mode`     | Service mode (replicated, global)
@@ -131,7 +133,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `ID`, `Mode`, and `Replicas` entries separated by a colon for all services:
+  `ID`, `Mode`, and `Replicas` entries separated by a colon (`:`) for all services:
 
   ```bash
   $ docker stack services --format "{{.ID}}: {{.Mode}} {{.Replicas}}"

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -1,13 +1,28 @@
 command: docker stats
 short: Display a live stream of container(s) resource usage statistics
 long: |-
-  The `docker stats` command returns a live data stream for running containers. To limit data to one or more specific containers, specify a list of container names or ids separated by a space. You can specify a stopped container but stopped containers do not return any data.
+  The `docker stats` command returns a live data stream for running containers. To
+  limit data to one or more specific containers, specify a list of container names
+  or ids separated by a space. You can specify a stopped container but stopped
+  containers do not return any data.
 
-  If you want more detailed information about a container's resource usage, use the `/containers/(id)/stats` API endpoint.
+  If you need more detailed information about a container's resource usage, use
+  the `/containers/(id)/stats` API endpoint.
 
-  > **Note**: On Linux, the Docker CLI reports memory usage by subtracting page cache usage from the total memory usage. The API does not perform such a calculation but rather provides the total memory usage and the amount from the page cache so that clients can use the data as needed.
+  > **Note**
+  >
+  > On Linux, the Docker CLI reports memory usage by subtracting page cache usage
+  > from the total memory usage. The API does not perform such a calculation but
+  > rather provides the total memory usage and the amount from the page cache so
+  > that clients can use the data as needed.
 
-  > **Note**: The `PIDS` column contains the number of processes and kernel threads created by that container. Threads is the term used by Linux kernel. Other equivalent terms are "lightweight process" or "kernel task", etc. A large number in the `PIDS` column combined with a small number of processes (as reported by `ps` or `top`) may indicate that something in the container is creating many threads.
+  > **Note**
+  >
+  > The `PIDS` column contains the number of processes and kernel threads created
+  > by that container. Threads is the term used by Linux kernel. Other equivalent
+  > terms are "lightweight process" or "kernel task", etc. A large number in the
+  > `PIDS` column combined with a small number of processes (as reported by `ps`
+  > or `top`) may indicate that something in the container is creating many threads.
 usage: docker stats [OPTIONS] [CONTAINER...]
 pname: docker
 plink: docker.yaml
@@ -147,7 +162,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `Container` and `CPUPerc` entries separated by a colon for all images:
+  `Container` and `CPUPerc` entries separated by a colon (`:`) for all images:
 
   ```bash
   $ docker stats --format "{{.Container}}: {{.CPUPerc}}"
@@ -178,10 +193,6 @@ examples: |-
   On Windows:
 
       "table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}"
-
-
-  > **Note**: On Docker 17.09 and older, the `{{.Container}}` column was used,
-  > instead of `{{.ID}}\t{{.Name}}`.
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_swarm_ca.yaml
+++ b/_data/engine-cli/docker_swarm_ca.yaml
@@ -3,9 +3,12 @@ short: Display and rotate the root CA
 long: |-
   View or rotate the current swarm CA certificate.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker swarm ca [OPTIONS]
 pname: docker swarm
 plink: docker_swarm.yaml

--- a/_data/engine-cli/docker_swarm_init.yaml
+++ b/_data/engine-cli/docker_swarm_init.yaml
@@ -167,7 +167,7 @@ examples: |-
   to [swarm join](swarm_join.md).
 
   After you create the swarm, you can display or rotate the token using
-  [swarm join-token](swarm_join_token.md).
+  [swarm join-token](swarm_join-token.md).
 
   ### `--autolock`
 

--- a/_data/engine-cli/docker_swarm_join-token.yaml
+++ b/_data/engine-cli/docker_swarm_join-token.yaml
@@ -7,9 +7,12 @@ long: |-
   [swarm join](swarm_join.md). Nodes use the join token only when they join the
   swarm.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker swarm join-token [OPTIONS] (worker|manager)
 pname: docker swarm
 plink: docker_swarm.yaml
@@ -42,6 +45,7 @@ examples: |-
 
   ```bash
   $ docker swarm join-token worker
+
   To add a worker to this swarm, run the following command:
 
       docker swarm join \
@@ -49,6 +53,7 @@ examples: |-
       172.17.0.2:2377
 
   $ docker swarm join-token manager
+
   To add a manager to this swarm, run the following command:
 
       docker swarm join \
@@ -60,6 +65,7 @@ examples: |-
 
   ```bash
   $ docker swarm join-token --rotate worker
+
   Successfully rotated worker join token.
 
   To add a worker to this swarm, run the following command:

--- a/_data/engine-cli/docker_swarm_leave.yaml
+++ b/_data/engine-cli/docker_swarm_leave.yaml
@@ -28,6 +28,7 @@ examples: |-
 
   ```bash
   $ docker node ls
+
   ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
   7ln70fl22uw2dvjn2ft53m3q5    worker2   Ready   Active
   dkp8vy1dq1kxleu9g4u78tlag    worker1   Ready   Active
@@ -38,6 +39,7 @@ examples: |-
 
   ```bash
   $ docker swarm leave
+
   Node left the default swarm.
   ```
 

--- a/_data/engine-cli/docker_swarm_unlock-key.yaml
+++ b/_data/engine-cli/docker_swarm_unlock-key.yaml
@@ -8,9 +8,12 @@ long: |-
   You can view or rotate the unlock key using `swarm unlock-key`. To view the key,
   run the `docker swarm unlock-key` command without any arguments:
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker swarm unlock-key [OPTIONS]
 pname: docker swarm
 plink: docker_swarm.yaml
@@ -52,6 +55,7 @@ examples: |-
 
   ```bash
   $ docker swarm unlock-key --rotate
+
   Successfully rotated manager unlock key.
 
   To unlock a swarm manager after it restarts, run the `docker swarm unlock`
@@ -67,6 +71,7 @@ examples: |-
 
   ```bash
   $ docker swarm unlock-key -q
+
   SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8
   ```
 

--- a/_data/engine-cli/docker_swarm_unlock.yaml
+++ b/_data/engine-cli/docker_swarm_unlock.yaml
@@ -6,9 +6,12 @@ long: |-
   setting is turned on. The unlock key is printed at the time when autolock is
   enabled, and is also available from the `docker swarm unlock-key` command.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker swarm unlock
 pname: docker swarm
 plink: docker_swarm.yaml

--- a/_data/engine-cli/docker_swarm_update.yaml
+++ b/_data/engine-cli/docker_swarm_update.yaml
@@ -3,9 +3,12 @@ short: Update the swarm
 long: |-
   Updates a swarm with new parameter values.
 
-  > **Note**: This is a cluster management command, and must be executed on a swarm
-  > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > **Note**
+  >
+  > This is a cluster management command, and must be executed on a swarm
+  > manager node. To learn about managers and workers, refer to the
+  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > documentation.
 usage: docker swarm update [OPTIONS]
 pname: docker swarm
 plink: docker_swarm.yaml

--- a/_data/engine-cli/docker_system_df.yaml
+++ b/_data/engine-cli/docker_system_df.yaml
@@ -68,8 +68,9 @@ examples: |-
   * `UNIQUE SIZE` is the amount of space that is only used by a given image
   * `SIZE` is the virtual size of the image, it is the sum of `SHARED SIZE` and `UNIQUE SIZE`
 
-  > **Note**: Network information is not shown because it doesn't consume the disk
-  > space.
+  > **Note**
+  >
+  > Network information is not shown because it does not consume disk space.
 deprecated: false
 min_api_version: "1.25"
 experimental: false

--- a/_data/engine-cli/docker_system_events.yaml
+++ b/_data/engine-cli/docker_system_events.yaml
@@ -190,7 +190,7 @@ examples: |-
 
   **Shell 1: (Again .. now showing events):**
 
-  ```none
+  ```console
   2017-01-05T00:35:58.859401177+08:00 container create 0fdb48addc82871eb34eb23a847cfd033dedd1a0a37bef2e6d9eb3870fc7ff37 (image=alpine:latest, name=test)
   2017-01-05T00:36:04.703631903+08:00 network connect e2e1f5ceda09d4300f3a846f0acfaa9a8bb0d89e775eb744c5acecd60e0529e2 (container=0fdb...ff37, name=bridge, type=bridge)
   2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
@@ -209,6 +209,7 @@ examples: |-
 
   ```bash
   $ docker system events --since 1483283804
+
   2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
   2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
   2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
@@ -219,6 +220,7 @@ examples: |-
   2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
 
   $ docker system events --since '2017-01-05'
+
   2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
   2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
   2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
@@ -229,6 +231,7 @@ examples: |-
   2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
 
   $ docker system events --since '2013-09-03T15:49:29'
+
   2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
   2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
   2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
@@ -239,6 +242,7 @@ examples: |-
   2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
 
   $ docker system events --since '10m'
+
   2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
   2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
   2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
@@ -340,14 +344,14 @@ examples: |-
 
   #### Format as JSON
 
-  ```none
-      $ docker system events --format '{{json .}}'
+  ```bash
+  $ docker system events --format '{{json .}}'
 
-      {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
-      {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
-      {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
-      {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
-      {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+  {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+  {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+  {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
+  {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
+  {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_system_prune.yaml
+++ b/_data/engine-cli/docker_system_prune.yaml
@@ -117,11 +117,13 @@ examples: |-
   Total reclaimed space: 13.5 MB
   ```
 
-  > **Note**: The `--volumes` option was added in Docker 17.06.1. Older versions
-  > of Docker prune volumes by default, along with other Docker objects. On older
-  > versions, run `docker container prune`, `docker network prune`, and
-  > `docker image prune` separately to remove unused containers, networks, and
-  > images, without removing volumes.
+  > **Note**
+  >
+  > The `--volumes` option was added in Docker 17.06.1. Older versions of Docker
+  > prune volumes by default, along with other Docker objects. On older versions,
+  > run `docker container prune`, `docker network prune`, and `docker image prune`
+  > separately to remove unused containers, networks, and images, without removing
+  > volumes.
 
 
   ### Filtering

--- a/_data/engine-cli/docker_tag.yaml
+++ b/_data/engine-cli/docker_tag.yaml
@@ -15,7 +15,7 @@ long: |-
   period or a dash and may contain a maximum of 128 characters.
 
   You can group your images together using names and tags, and then upload them
-  to [*Share Images via Repositories*](https://docs.docker.com/engine/tutorials/dockerrepos/#/contributing-to-docker-hub).
+  to [*Share images on Docker Hub*](https://docs.docker.com/get-started/part3/).
 usage: docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_trust_inspect.yaml
+++ b/_data/engine-cli/docker_trust_inspect.yaml
@@ -143,6 +143,7 @@ examples: |-
 
   ```bash
   $ docker trust inspect unsigned-img
+
   No signatures or cannot access unsigned-img
   ```
 
@@ -151,6 +152,7 @@ examples: |-
 
   ```bash
   $ docker trust inspect alpine:unsigned
+
   [
     {
       "Name": "alpine:unsigned",
@@ -159,17 +161,17 @@ examples: |-
         {
           "Name": "Repository",
           "Keys": [
-              {
-                  "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
-              }
+            {
+              "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
+            }
           ]
         },
         {
           "Name": "Root",
           "Keys": [
-              {
-                  "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
-              }
+            {
+              "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
+            }
           ]
         }
       ]
@@ -184,59 +186,60 @@ examples: |-
 
   ```bash
   $ docker trust inspect alpine
+
   [
-      {
-          "Name": "alpine",
-          "SignedTags": [
-              {
-                  "SignedTag": "3.5",
-                  "Digest": "b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "3.6",
-                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "edge",
-                  "Digest": "23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "latest",
-                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              }
-          ],
-          "Signers": [],
-          "AdministrativeKeys": [
-              {
-                  "Name": "Repository",
-                  "Keys": [
-                      {
-                          "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
-                      }
-                  ]
-              },
-              {
-                  "Name": "Root",
-                  "Keys": [
-                      {
-                          "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
-                      }
-                  ]
-              }
+    {
+      "Name": "alpine",
+      "SignedTags": [
+        {
+          "SignedTag": "3.5",
+          "Digest": "b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c",
+          "Signers": [
+            "Repo Admin"
           ]
-      }
+        },
+        {
+          "SignedTag": "3.6",
+          "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+          "Signers": [
+            "Repo Admin"
+          ]
+        },
+        {
+          "SignedTag": "edge",
+          "Digest": "23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096",
+          "Signers": [
+            "Repo Admin"
+          ]
+        },
+        {
+          "SignedTag": "latest",
+          "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+          "Signers": [
+            "Repo Admin"
+          ]
+        }
+      ],
+      "Signers": [],
+      "AdministrativeKeys": [
+        {
+          "Name": "Repository",
+          "Keys": [
+            {
+              "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
+            }
+          ]
+        },
+        {
+          "Name": "Root",
+          "Keys": [
+            {
+              "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
+            }
+          ]
+        }
+      ]
+    }
   ]
   ```
 
@@ -248,104 +251,105 @@ examples: |-
 
   ```bash
   $ docker trust inspect alpine notary
+
   [
-      {
-          "Name": "alpine",
-          "SignedTags": [
-              {
-                  "SignedTag": "3.5",
-                  "Digest": "b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "3.6",
-                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "edge",
-                  "Digest": "23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "integ-test-base",
-                  "Digest": "3952dc48dcc4136ccdde37fbef7e250346538a55a0366e3fccc683336377e372",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "latest",
-                  "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              }
-          ],
-          "Signers": [],
-          "AdministrativeKeys": [
-              {
-                  "Name": "Repository",
-                  "Keys": [
-                      {
-                          "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
-                      }
-                  ]
-              },
-              {
-                  "Name": "Root",
-                  "Keys": [
-                      {
-                          "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
-                      }
-                  ]
-              }
+    {
+      "Name": "alpine",
+      "SignedTags": [
+        {
+          "SignedTag": "3.5",
+          "Digest": "b007a354427e1880de9cdba533e8e57382b7f2853a68a478a17d447b302c219c",
+          "Signers": [
+            "Repo Admin"
           ]
-      },
-      {
-          "Name": "notary",
-          "SignedTags": [
-              {
-                  "SignedTag": "server",
-                  "Digest": "71f64ab718a3331dee103bc5afc6bc492914738ce37c2d2f127a8133714ecf5c",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              },
-              {
-                  "SignedTag": "signer",
-                  "Digest": "a6122d79b1e74f70b5dd933b18a6d1f99329a4728011079f06b245205f158fe8",
-                  "Signers": [
-                      "Repo Admin"
-                  ]
-              }
-          ],
-          "Signers": [],
-          "AdministrativeKeys": [
-              {
-                  "Name": "Root",
-                  "Keys": [
-                      {
-                          "ID": "8cdcdef5bd039f4ab5a029126951b5985eebf57cabdcdc4d21f5b3be8bb4ce92"
-                      }
-                  ]
-              },
-              {
-                  "Name": "Repository",
-                  "Keys": [
-                      {
-                          "ID": "85bfd031017722f950d480a721f845a2944db26a3dc084040a70f1b0d9bbb3df"
-                      }
-                  ]
-              }
+        },
+        {
+          "SignedTag": "3.6",
+          "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+          "Signers": [
+            "Repo Admin"
           ]
-      }
+        },
+        {
+          "SignedTag": "edge",
+          "Digest": "23e7d843e63a3eee29b6b8cfcd10e23dd1ef28f47251a985606a31040bf8e096",
+          "Signers": [
+            "Repo Admin"
+          ]
+        },
+        {
+          "SignedTag": "integ-test-base",
+          "Digest": "3952dc48dcc4136ccdde37fbef7e250346538a55a0366e3fccc683336377e372",
+          "Signers": [
+            "Repo Admin"
+          ]
+        },
+        {
+          "SignedTag": "latest",
+          "Digest": "d6bfc3baf615dc9618209a8d607ba2a8103d9c8a405b3bd8741d88b4bef36478",
+          "Signers": [
+            "Repo Admin"
+          ]
+        }
+      ],
+      "Signers": [],
+      "AdministrativeKeys": [
+        {
+          "Name": "Repository",
+          "Keys": [
+            {
+              "ID": "5a46c9aaa82ff150bb7305a2d17d0c521c2d784246807b2dc611f436a69041fd"
+            }
+          ]
+        },
+        {
+          "Name": "Root",
+          "Keys": [
+            {
+              "ID": "a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "notary",
+      "SignedTags": [
+        {
+          "SignedTag": "server",
+          "Digest": "71f64ab718a3331dee103bc5afc6bc492914738ce37c2d2f127a8133714ecf5c",
+          "Signers": [
+            "Repo Admin"
+          ]
+        },
+        {
+          "SignedTag": "signer",
+          "Digest": "a6122d79b1e74f70b5dd933b18a6d1f99329a4728011079f06b245205f158fe8",
+          "Signers": [
+            "Repo Admin"
+          ]
+        }
+      ],
+      "Signers": [],
+      "AdministrativeKeys": [
+        {
+          "Name": "Root",
+          "Keys": [
+            {
+              "ID": "8cdcdef5bd039f4ab5a029126951b5985eebf57cabdcdc4d21f5b3be8bb4ce92"
+            }
+          ]
+        },
+        {
+          "Name": "Repository",
+          "Keys": [
+            {
+              "ID": "85bfd031017722f950d480a721f845a2944db26a3dc084040a70f1b0d9bbb3df"
+            }
+          ]
+        }
+      ]
+    }
   ]
   ```
 
@@ -380,6 +384,7 @@ examples: |-
 
   ```bash
   $ docker trust inspect --pretty my-image:purple
+
   SIGNED TAG          DIGEST                                                              SIGNERS
   purple              941d3dba358621ce3c41ef67b47cf80f701ff80cdf46b5cc86587eaebfe45557    alice, bob, carol
 
@@ -413,6 +418,7 @@ examples: |-
 
   ```bash
   $ docker trust inspect --pretty alpine
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   2.6                 9ace551613070689a12857d62c30ef0daa9a376107ec0fff0e34786cedb3399b   (Repo Admin)
   2.7                 9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a   (Repo Admin)
@@ -434,6 +440,7 @@ examples: |-
 
   ```bash
   $ docker trust inspect --pretty my-image
+
   SIGNED TAG          DIGEST                                                              SIGNERS
   red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
   blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob

--- a/_data/engine-cli/docker_trust_revoke.yaml
+++ b/_data/engine-cli/docker_trust_revoke.yaml
@@ -22,7 +22,7 @@ examples: |-
 
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
   SIGNED TAG          DIGEST                                                              SIGNERS
   red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
   blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
@@ -49,7 +49,7 @@ examples: |-
   After revocation, the tag is removed from the list of released tags:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
   SIGNED TAG          DIGEST                                                              SIGNERS
   blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
 
@@ -69,7 +69,7 @@ examples: |-
   When no tag is specified, `docker trust` revokes all signatures that you have a signing key for.
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
   SIGNED TAG          DIGEST                                                              SIGNERS
   red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
   blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
@@ -97,7 +97,7 @@ examples: |-
   All tags that have `alice`'s signature on them are removed from the list of released tags:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
 
   No signatures for example/trust-demo
 

--- a/_data/engine-cli/docker_trust_sign.yaml
+++ b/_data/engine-cli/docker_trust_sign.yaml
@@ -20,7 +20,8 @@ examples: |-
   Given an image:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   v1                  c24134c079c35e698060beabe110bb83ab285d0d978de7d92fed2c8c83570a41   (Repo Admin)
 
@@ -33,6 +34,7 @@ examples: |-
 
   ```bash
   $ docker trust sign example/trust-demo:v2
+
   Signing and pushing trust metadata for example/trust-demo:v2
   The push refers to a repository [docker.io/example/trust-demo]
   eed4e566104a: Layer already exists
@@ -48,10 +50,11 @@ examples: |-
   Successfully signed docker.io/example/trust-demo:v2
   ```
 
-  Use `docker trust view` to list the new signature:
+  Use `docker trust inspect --pretty` to list the new signature:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   v1                  c24134c079c35e698060beabe110bb83ab285d0d978de7d92fed2c8c83570a41   (Repo Admin)
   v2                  8f6f460abf0436922df7eb06d28b3cdf733d2cac1a185456c26debbff0839c56   (Repo Admin)
@@ -66,7 +69,7 @@ examples: |-
   Given an image:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
 
   No signatures for example/trust-demo
 
@@ -86,6 +89,7 @@ examples: |-
 
   ```bash
   $ docker trust sign example/trust-demo:v1
+
   Signing and pushing trust metadata for example/trust-demo:v1
   The push refers to a repository [docker.io/example/trust-demo]
   26b126eb8632: Layer already exists
@@ -99,10 +103,11 @@ examples: |-
   Successfully signed docker.io/example/trust-demo:v1
   ```
 
-  `docker trust view` lists the new signature:
+  `docker trust inspect --pretty` lists the new signature:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   alice
 

--- a/_data/engine-cli/docker_trust_signer_add.yaml
+++ b/_data/engine-cli/docker_trust_signer_add.yaml
@@ -19,7 +19,7 @@ examples: |-
   To add a new signer, `alice`, to this repository:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
 
   No signatures for example/trust-demo
 
@@ -43,10 +43,10 @@ examples: |-
   Successfully added signer: alice to example/trust-demo
   ```
 
-  `docker trust view` now lists `alice` as a valid signer:
+  `docker trust inspect --pretty` now lists `alice` as a valid signer:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
 
   No signatures for example/trust-demo
 

--- a/_data/engine-cli/docker_trust_signer_remove.yaml
+++ b/_data/engine-cli/docker_trust_signer_remove.yaml
@@ -21,7 +21,7 @@ examples: |-
 
   To remove an existing signer, `alice`, from this repository:
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
 
   No signatures for example/trust-demo
 
@@ -47,10 +47,10 @@ examples: |-
   Successfully removed alice from example/trust-demo
   ```
 
-  `docker trust view` now does not list `alice` as a valid signer:
+  `docker trust inspect --pretty` now does not list `alice` as a valid signer:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
 
   No signatures for example/trust-demo
 
@@ -70,7 +70,8 @@ examples: |-
   To remove an existing signer, `alice`, from multiple repositories:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   alice, bob
 
@@ -86,7 +87,8 @@ examples: |-
   ```
 
   ```bash
-  $ docker trust view example/trust-demo2
+  $ docker trust inspect --pretty example/trust-demo2
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   alice, bob
 
@@ -115,11 +117,12 @@ examples: |-
   Successfully removed alice from example/trust-demo2
   ```
 
-  Run `docker trust view` to confirm that `alice` is no longer listed as a valid
+  Run `docker trust inspect --pretty` to confirm that `alice` is no longer listed as a valid
   signer of either `example/trust-demo` or `example/trust-demo2`:
 
   ```bash
-  $ docker trust view example/trust-demo
+  $ docker trust inspect --pretty example/trust-demo
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   bob
 
@@ -134,7 +137,8 @@ examples: |-
   ```
 
   ```bash
-  $ docker trust view example/trust-demo2
+  $ docker trust inspect --pretty example/trust-demo2
+
   SIGNED TAG          DIGEST                                                             SIGNERS
   v1                  74d4bfa917d55d53c7df3d2ab20a8d926874d61c3da5ef6de15dd2654fc467c4   bob
 

--- a/_data/engine-cli/docker_update.yaml
+++ b/_data/engine-cli/docker_update.yaml
@@ -12,8 +12,10 @@ long: |-
   4.6, you can only update `--kernel-memory` on a stopped container or on
   a running container with kernel memory initialized.
 
-  > **Warning**: The `docker update` and `docker container update` commands are
-  > not supported for Windows containers.
+  > **Warning**
+  >
+  > The `docker update` and `docker container update` commands are not supported
+  > for Windows containers.
   {: .warning }
 usage: docker update [OPTIONS] CONTAINER [CONTAINER...]
 pname: docker

--- a/_data/engine-cli/docker_version.yaml
+++ b/_data/engine-cli/docker_version.yaml
@@ -34,20 +34,32 @@ examples: |-
   $ docker version
 
   Client:
-  Version:      1.8.0
-  API version:  1.20
-  Go version:   go1.4.2
-  Git commit:   f5bae0a
-  Built:        Tue Jun 23 17:56:00 UTC 2015
-  OS/Arch:      linux/amd64
+   Version:           19.03.8
+   API version:       1.40
+   Go version:        go1.12.17
+   Git commit:        afacb8b
+   Built:             Wed Mar 11 01:21:11 2020
+   OS/Arch:           darwin/amd64
+   Experimental:      true
 
   Server:
-  Version:      1.8.0
-  API version:  1.20
-  Go version:   go1.4.2
-  Git commit:   f5bae0a
-  Built:        Tue Jun 23 17:56:00 UTC 2015
-  OS/Arch:      linux/amd64
+   Engine:
+    Version:          19.03.8
+    API version:      1.40 (minimum version 1.12)
+    Go version:       go1.12.17
+    Git commit:       afacb8b
+    Built:            Wed Mar 11 01:29:16 2020
+    OS/Arch:          linux/amd64
+    Experimental:     true
+   containerd:
+    Version:          v1.2.13
+    GitCommit:        7ad184331fa3e55e52b890ea95e65ba581ae3429
+   runc:
+    Version:          1.0.0-rc10
+    GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
+   docker-init:
+    Version:          0.18.0
+    GitCommit:        fec3683
   ```
 
   ### Get the server version
@@ -55,7 +67,7 @@ examples: |-
   ```bash
   $ docker version --format '{{.Server.Version}}'
 
-  1.8.0
+  19.03.8
   ```
 
   ### Dump raw JSON data
@@ -63,7 +75,7 @@ examples: |-
   ```bash
   $ docker version --format '{{json .}}'
 
-  {"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
+  {"Client":{"Platform":{"Name":"Docker Engine - Community"},"Version":"19.03.8","ApiVersion":"1.40","DefaultAPIVersion":"1.40","GitCommit":"afacb8b","GoVersion":"go1.12.17","Os":"darwin","Arch":"amd64","BuildTime":"Wed Mar 11 01:21:11 2020","Experimental":true},"Server":{"Platform":{"Name":"Docker Engine - Community"},"Components":[{"Name":"Engine","Version":"19.03.8","Details":{"ApiVersion":"1.40","Arch":"amd64","BuildTime":"Wed Mar 11 01:29:16 2020","Experimental":"true","GitCommit":"afacb8b","GoVersion":"go1.12.17","KernelVersion":"4.19.76-linuxkit","MinAPIVersion":"1.12","Os":"linux"}},{"Name":"containerd","Version":"v1.2.13","Details":{"GitCommit":"7ad184331fa3e55e52b890ea95e65ba581ae3429"}},{"Name":"runc","Version":"1.0.0-rc10","Details":{"GitCommit":"dc9208a3303feef5b3839f4323d9beb36df0a9dd"}},{"Name":"docker-init","Version":"0.18.0","Details":{"GitCommit":"fec3683"}}],"Version":"19.03.8","ApiVersion":"1.40","MinAPIVersion":"1.12","GitCommit":"afacb8b","GoVersion":"go1.12.17","Os":"linux","Arch":"amd64","KernelVersion":"4.19.76-linuxkit","Experimental":true,"BuildTime":"2020-03-11T01:29:16.000000000+00:00"}}
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_volume_inspect.yaml
+++ b/_data/engine-cli/docker_volume_inspect.yaml
@@ -22,19 +22,26 @@ options:
 examples: |-
   ```bash
   $ docker volume create
-  85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
+
+  8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5
+
   $ docker volume inspect 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
+
   [
     {
-        "Name": "85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d",
-        "Driver": "local",
-        "Mountpoint": "/var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data",
-        "Status": null
+      "CreatedAt": "2020-04-19T11:00:21Z",
+      "Driver": "local",
+      "Labels": {},
+      "Mountpoint": "/var/lib/docker/volumes/8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5/_data",
+      "Name": "8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5",
+      "Options": {},
+      "Scope": "local"
     }
   ]
 
-  $ docker volume inspect --format '{{ .Mountpoint }}' 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
-  /var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data
+  $ docker volume inspect --format '{{ .Mountpoint }}' 8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5
+
+  /var/lib/docker/volumes/8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5/_data
   ```
 deprecated: false
 min_api_version: "1.21"

--- a/_data/engine-cli/docker_volume_ls.yaml
+++ b/_data/engine-cli/docker_volume_ls.yaml
@@ -61,10 +61,10 @@ examples: |-
 
   The currently supported filters are:
 
-  * dangling (boolean - true or false, 0 or 1)
-  * driver (a volume driver's name)
-  * label (`label=<key>` or `label=<key>=<value>`)
-  * name (a volume's name)
+  - dangling (boolean - true or false, 0 or 1)
+  - driver (a volume driver's name)
+  - label (`label=<key>` or `label=<key>=<value>`)
+  - name (a volume's name)
 
   #### dangling
 
@@ -175,7 +175,7 @@ examples: |-
   `table` directive, includes column headers as well.
 
   The following example uses a template without headers and outputs the
-  `Name` and `Driver` entries separated by a colon for all volumes:
+  `Name` and `Driver` entries separated by a colon (`:`) for all volumes:
 
   ```bash
   $ docker volume ls --format "{{.Name}}: {{.Driver}}"

--- a/_data/engine-cli/docker_volume_rm.yaml
+++ b/_data/engine-cli/docker_volume_rm.yaml
@@ -19,8 +19,9 @@ options:
   swarm: false
 examples: |-
   ```bash
-    $ docker volume rm hello
-    hello
+  $ docker volume rm hello
+
+  hello
   ```
 deprecated: false
 min_api_version: "1.21"

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -1,16 +1,11 @@
 {% capture tabChar %}	{% endcapture %}<!-- Make sure atom is using hard tabs -->
-{% capture dockerBaseDesc %}The base command for the Docker CLI.{% endcapture %}
 {% if include.datafolder and include.datafile %}
 
 {% assign controller_data = site.data[include.datafolder][include.datafile] %}
 
 ## Description
 
-{% if include.datafile=="docker" %}<!-- docker.yaml is textless, so override -->
-{{ dockerBaseDesc }}
-{% else %}
 {{ controller_data.short }}
-{% endif %}
 
 {% if controller_data.min_api_version %}
 
@@ -164,12 +159,7 @@ The include.datafolder or include.datafile was not set.
 
 {% capture parentfile %}{{ controller_data.plink | replace: ".yaml", "" | replace: "docker_","" }}{% endcapture %}
 {% capture parentdatafile %}{{ controller_data.plink | replace: ".yaml", "" }}{% endcapture %}
-
-{% if controller_data.pname == "docker" %}
-  {% capture parentDesc %}{{ dockerBaseDesc }}{% endcapture %}
-{% else %}
-  {% capture parentDesc %}{{ site.data[include.datafolder][parentdatafile].short }}{% endcapture %}
-{% endif %}
+{% capture parentDesc %}{{ site.data[include.datafolder][parentdatafile].short }}{% endcapture %}
 
 | Command | Description |
 | ------- | ----------- |


### PR DESCRIPTION
With this, we can also remove a special-case in the cli.md template, because that issue was fixed upstream (in https://github.com/docker/cli/pull/2454)

This brings in the changes from https://github.com/docker/cli/pull/2453