### PR TITLE
engine/install: fix rasbian links on "check" icons

### DIFF
--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -44,7 +44,7 @@ and architectures:
 | [CentOS](centos.md)   | [{{ yes }}](centos.md) |                          | [{{ yes }}](centos.md) |                        |                        |
 | [Debian](debian.md)   | [{{ yes }}](debian.md) | [{{ yes }}](debian.md)   | [{{ yes }}](debian.md) |                        |                        |
 | [Fedora](fedora.md)   | [{{ yes }}](fedora.md) |                          | [{{ yes }}](fedora.md) |                        |                        |
-| [Raspbian](debian.md) |                        | [{{ yes }}](fedora.md)   | [{{ yes }}](fedora.md) |                        |                        |
+| [Raspbian](debian.md) |                        | [{{ yes }}](debian.md)   | [{{ yes }}](debian.md) |                        |                        |
 | [Ubuntu](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) |
 
 ##### Other Linux distributions


### PR DESCRIPTION
as noticed by @jinnko in https://github.com/docker/docker.github.io/issues/10648#issuecomment-615212731 (whoops!)