### PR TITLE
compose-file: add some options that were missing in changes

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -324,6 +324,14 @@ build:
   network: custom_network_1
 ```
 
+Use `none` to disable networking during build:
+
+```yaml
+build:
+  context: .
+  network: none
+```
+
 #### shm_size
 
 > Added in [version 2.3](compose-versioning.md#version-23) file format

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -217,15 +217,16 @@ Introduces the following additional parameters:
 - [`link_local_ips`](compose-file-v2.md#link_local_ips)
 - [`isolation`](compose-file-v2.md#isolation) in build configurations and
   service definitions
-- `labels` for [volumes](compose-file-v2.md#volume-configuration-reference) and
-  [networks](compose-file-v2.md#network-configuration-reference)
+- `labels` for [volumes](compose-file-v2.md#volume-configuration-reference),
+  [networks](compose-file-v2.md#network-configuration-reference), and
+  [build](index.md#build)
 - `name` for [volumes](compose-file-v2.md#volume-configuration-reference)
 - [`userns_mode`](compose-file-v2.md#userns_mode)
 - [`healthcheck`](compose-file-v2.md#healthcheck)
 - [`sysctls`](compose-file-v2.md#sysctls)
 - [`pids_limit`](compose-file-v2.md#pids_limit)
 - [`oom_kill_disable`](compose-file-v2.md#cpu-and-other-resources)
-- [`cpu_period`](compose-file-v2.md)
+- [`cpu_period`](compose-file-v2.md#cpu-and-other-resources)
 
 ### Version 2.2
 
@@ -239,6 +240,7 @@ Introduces the following additional parameters:
 - [`init`](compose-file-v2.md#init)
 - [`scale`](compose-file-v2.md#scale)
 - [`cpu_rt_runtime` and `cpu_rt_period`](compose-file-v2.md#cpu_rt_runtime-cpu_rt_period)
+- [`network`](compose-file-v2.md#network) for [build configurations](compose-file-v2.md#build)
 
 ### Version 2.3
 
@@ -295,6 +297,28 @@ the [upgrading](#upgrading) guide for how to migrate away from these.
 > version: "3.0"
 > ```
 
+### Version 3.1
+
+An upgrade of [version 3](#version-3) that introduces new parameters only
+available with Docker Engine version **1.13.1+**, and higher.
+
+Introduces the following additional parameters:
+
+- [`secrets`](index.md#secrets)
+
+### Version 3.2
+
+An upgrade of [version 3](#version-3) that introduces new parameters only
+available with Docker Engine version **17.04.0+**, and higher.
+
+Introduces the following additional parameters:
+
+- [`cache_from`](index.md#cache_from) in [build configurations](index.md#build)
+- Long syntax for [ports](index.md#ports) and [volume mounts](index.md#volumes)
+- [`attachable`](index.md#attachable) network driver option
+- [deploy `endpoint_mode`](index.md#endpoint_mode)
+- [deploy placement `preference`](index.md#placement)
+
 ### Version 3.3
 
 An upgrade of [version 3](#version-3) that introduces new parameters only
@@ -305,7 +329,6 @@ Introduces the following additional parameters:
 - [build `labels`](index.md#build)
 - [`credential_spec`](index.md#credential_spec)
 - [`configs`](index.md#configs)
-- [deploy `endpoint_mode`](index.md#endpoint_mode)
 
 ### Version 3.4
 
@@ -314,7 +337,8 @@ only available with Docker Engine version **17.09.0** and higher.
 
 Introduces the following additional parameters:
 
-- `target` and `network` in [build configurations](index.md#build)
+- [`target`](index.md#target) and [`network`](index.md#network) in
+  [build configurations](index.md#build)
 - `start_period` for [`healthchecks`](index.md#healthcheck)
 - `order` for [update configurations](index.md#update_config)
 - `name` for [volumes](index.md#volume-configuration-reference)

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -340,6 +340,33 @@ build:
     - "com.example.label-with-empty-value"
 ```
 
+#### network
+
+> Added in [version 3.4](compose-versioning.md#version-34) file format
+
+Set the network containers connect to for the `RUN` instructions during
+build.
+
+```yaml
+build:
+  context: .
+  network: host
+```
+
+```yaml
+build:
+  context: .
+  network: custom_network_1
+```
+
+Use `none` to disable networking during build:
+
+```yaml
+build:
+  context: .
+  network: none
+```
+
 #### shm_size
 
 > Added in [version 3.5](compose-versioning.md#version-35) file format
@@ -656,7 +683,7 @@ Several sub-options are available:
 
 #### endpoint_mode
 
-> Added in [version 3.3](compose-versioning.md#version-33) file format.
+> Added in [version 3.2](compose-versioning.md#version-32) file format.
 
 Specify a service discovery method for external clients connecting to a swarm.
 
@@ -762,7 +789,10 @@ services:
 
 #### placement
 
-Specify placement of constraints and preferences. See the docker service create documentation for a full description of the syntax and available types of [constraints](/engine/reference/commandline/service_create.md#specify-service-constraints-constraint) and [preferences](/engine/reference/commandline/service_create.md#specify-service-placement-preferences-placement-pref).
+Specify placement of constraints and preferences. See the docker service create
+documentation for a full description of the syntax and available types of
+[constraints](../../engine/reference/commandline/service_create.md#specify-service-constraints---constraint)
+and [preferences](../../engine/reference/commandline/service_create.md#specify-service-placement-preferences---placement-pref).
 
 ```yaml
 version: "{{ site.compose_file_v3 }}"


### PR DESCRIPTION
I noticed the `network` option for build was not documented, which was added in compose-file 2.2 (https://github.com/docker/compose/pull/4997) and 3.4 (https://github.com/docker/cli/pull/430), then saw some missing entries for the v3.1 and v3.2 format, so added those (probably more changes may be needed, but it didn't go through all versions)

@usha-mandya @ulyssessouza PTAL