### PR TITLE
remove -it from example, as it's not needed for redis

### DIFF
--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -35,7 +35,7 @@ The following example starts a Redis container and configures it to always
 restart unless it is explicitly stopped or Docker is restarted.
 
 ```bash
-$ docker run -dit --restart unless-stopped redis
+$ docker run -d --restart unless-stopped redis
 ```
 
 ### Restart policy details


### PR DESCRIPTION
Adding `-it` on a "detached" (`-d`) container is needed
if the container's main process expects a TTY attached to keep
running.

It's not needed for a redis container, so we can remove it here

fixes https://github.com/docker/docker.github.io/issues/10632