### PR TITLE
fixed max_replicas_per_node example

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -846,7 +846,8 @@ services:
     deploy:
       mode: replicated
       replicas: 6
-      max_replicas_per_node: 1
+      placement:
+        max_replicas_per_node: 1
 ```
 
 #### resources


### PR DESCRIPTION
### Proposed changes
The example for max_replicas_per_node was not inside the placement dict.
