### PR TITLE
Move WSL page, update to Windows 10, version 2004

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1168,7 +1168,7 @@ manuals:
       title: Stable release notes
     - path: /docker-for-windows/edge-release-notes/
       title: Edge release notes
-    - path: /docker-for-windows/wsl-tech-preview/
+    - path: /docker-for-windows/wsl/
       title: Docker Desktop WSL 2 backend
   - path: /desktop/dashboard/
     title: Dashboard

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -289,7 +289,7 @@ This release contains a Kubernetes upgrade. Note that your local Kubernetes clus
 
   To access the Dashboard UI, select the Docker menu from the system tray and then click **Dashboard**.
 
-- **WSL 2 backend:** The new Docker Desktop WSL 2 backend replaces the Docker Desktop WSL 2 Tech Preview. The WSL 2 backend architecture introduces support for Kubernetes, provides an updated Docker daemon, offers VPN-friendly networking, and additional features. For more information, see [Docker Desktop WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
+- **WSL 2 backend:** The new Docker Desktop WSL 2 backend replaces the Docker Desktop WSL 2 Tech Preview. The WSL 2 backend architecture introduces support for Kubernetes, provides an updated Docker daemon, offers VPN-friendly networking, and additional features. For more information, see [Docker Desktop WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/).
 
 - **New file sharing implementation:** Docker Desktop introduces a new file sharing implementation which uses gRPC, FUSE, and Hypervisor sockets instead of Samba, CIFS, and Hyper-V networking. The new implementation  offers improved I/O performance. Additionally, when using the new file system:
 
@@ -364,7 +364,7 @@ This release contains a Kubernetes upgrade. Note that your local Kubernetes clus
 
 #### New
 
-- [Docker Desktop WSL 2 Tech Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)
+- [Docker Desktop WSL 2 Tech Preview](https://docs.docker.com/docker-for-windows/wsl/)
 
 #### Bug fixes and minor changes
 

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -124,7 +124,7 @@ You can find a tutorial about running Windows containers on Windows Server in
 
 ### Can I install Docker Desktop on Windows 10 Home?
 
-Windows 10 Insider Preview (Windows 10 Home) users can now install [Docker Desktop Edge 2.2.2.0](https://download.docker.com/win/edge/43066/Docker%20Desktop%20Installer.exe) or a later release with the [experimental WSL 2 support](wsl-tech-preview.md). This requires Windows Insider Preview Build 19018 or later.
+Windows 10 Insider Preview (Windows 10 Home) users can now install [Docker Desktop Edge 2.2.2.0](https://download.docker.com/win/edge/43066/Docker%20Desktop%20Installer.exe) or a later release with the [experimental WSL 2 support](wsl.md). This requires Windows Insider Preview Build 19018 or later.
 
 Docker Desktop Stable releases require the Hyper-V feature which is not available in the Windows 10 Home edition.
 

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -124,7 +124,7 @@ You can find a tutorial about running Windows containers on Windows Server in
 
 ### Can I install Docker Desktop on Windows 10 Home?
 
-Windows 10 Insider Preview (Windows 10 Home) users can now install [Docker Desktop Edge 2.2.2.0](https://download.docker.com/win/edge/43066/Docker%20Desktop%20Installer.exe) or a later release with the [experimental WSL 2 support](wsl.md). This requires Windows Insider Preview Build 19018 or later.
+Windows 10 Home, version 2004 users can now install [Docker Desktop Stable 2.3.0.2](https://hub.docker.com/editions/community/docker-ce-desktop-windows/) or a later release with the [WSL 2 backend](wsl.md).
 
 Docker Desktop Stable releases require the Hyper-V feature which is not available in the Windows 10 Home edition.
 

--- a/docker-for-windows/install-windows-home.md
+++ b/docker-for-windows/install-windows-home.md
@@ -29,7 +29,7 @@ For detailed information about WSL 2, see [Docker Desktop WSL 2 backend](/wsl-te
 
 Windows 10 Home machines must meet the following requirements to install Docker Desktop:
 
-  - Install Windows 10 Insider Preview build 19041 or higher.
+  - Install Windows 10, version 2004 or higher.
   - Enable the WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
   - The following hardware prerequisites are required to successfully run
 WSL 2 on Windows 10 Home:

--- a/docker-for-windows/install-windows-home.md
+++ b/docker-for-windows/install-windows-home.md
@@ -30,7 +30,7 @@ For detailed information about WSL 2, see [Docker Desktop WSL 2 backend](/wsl-te
 Windows 10 Home machines must meet the following requirements to install Docker Desktop:
 
   - Install Windows 10 Insider Preview build 19041 or higher.
-  - Enable the WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/windows/wsl/wsl2-install).
+  - Enable the WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
   - The following hardware prerequisites are required to successfully run
 WSL 2 on Windows 10 Home:
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -118,7 +118,7 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 
 ### Known issues
 
-- Some CLI commands fail if you are running Docker Desktop in the experimental Linux Containers on Windows (LCOW) mode. As alternatives, we recommend running either traditional Linux containers, or the experimental [WSL backend](wsl-tech-preview.md).
+- Some CLI commands fail if you are running Docker Desktop in the experimental Linux Containers on Windows (LCOW) mode. As alternatives, we recommend running either traditional Linux containers, or the experimental [WSL backend](wsl.md).
 - It is not possible to resize the disk image using the Docker Desktop **Settings** UI. If you would like to update the size of the disk image (for example, to 128 GB), run the following command in PowerShell:
 
   ```powershell
@@ -184,7 +184,7 @@ Docker Desktop 2.2.0.0 contains a Kubernetes upgrade. Your local Kubernetes clus
 - **Docker Desktop Dashboard:** The new Docker Desktop **Dashboard** provides a user-friendly interface which enables you to interact with containers and applications, and manage the lifecycle of your applications directly from the UI. In addition, it allows you to access the logs, view container details, and monitor resource utilization to explore the container behavior.
 For detailed information about the new Dashboard UI, see [Docker Desktop Dashboard](dashboard.md).
 
-- **WSL 2 backend:** The experimental Docker Desktop WSL 2 backend architecture introduces support for Kubernetes, provides an updated Docker daemon, offers VPN-friendly networking, and additional features. For more information, see [Docker Desktop WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
+- **WSL 2 backend:** The experimental Docker Desktop WSL 2 backend architecture introduces support for Kubernetes, provides an updated Docker daemon, offers VPN-friendly networking, and additional features. For more information, see [Docker Desktop WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/).
 
 - **New file sharing implementation:** Docker Desktop introduces a new file sharing implementation that replaces Samba, CIFS, and Hyper-V networking. The new implementation  offers improved I/O performance. Additionally, when using the new file system:
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -20,7 +20,7 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 
 ### New
 
-- Windows 10 Home users can now use Docker Desktop through WSL 2. This requires Windows 10 Insider Preview build 19041 or higher. For more information, see [Install Docker Desktop on Windows Home](install-windows-home.md).
+- Windows 10 Home users can now use Docker Desktop through WSL 2. This requires Windows 10, version 2004 or higher. For more information, see [Install Docker Desktop on Windows Home](install-windows-home.md).
 - Docker Desktop introduces a new onboarding tutorial upon first startup. The Quick Start tutorial guides users to get started with Docker in a few easy steps. It includes a simple exercise to build an example Docker image, run it as a container, push and save the image to Docker Hub.
 - Docker Desktop now allows sharing individual folders, rather than whole drives, giving more control to users over what is being shared.
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -193,7 +193,7 @@ as described in the [Docker Machine driver example](../machine/drivers/hyper-v.m
 
 #### Virtualization must be enabled
 
-In addition to [Hyper-V](#hyper-v) or [WSL 2](wsl-tech-preview.md), virtualization must be enabled. Check the
+In addition to [Hyper-V](#hyper-v) or [WSL 2](wsl.md), virtualization must be enabled. Check the
 Performance tab on the Task Manager:
 
 ![Task Manager](images/virtualization-enabled.png){:width="700px"}

--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -18,17 +18,17 @@ Additionally, with WSL 2, the time required to start a Docker daemon after a col
 
 Before you install the Docker Desktop WSL 2 backend, you must complete the following steps:
 
-1. Install Windows 10 Insider Preview build 19041 or higher.
+1. Install Windows 10, version 2004 or higher.
 2. Enable WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 3. Download and install the [Linux kernel update package](https://docs.microsoft.com/windows/wsl/wsl2-kernel).
 
 ## Download
 
-Download [Docker Desktop Edge 2.2.3.0](https://download.docker.com/win/edge/Docker%20Desktop%20Installer.exe) or a later release.
+Download [Docker Desktop Stable 2.3.0.2](https://hub.docker.com/editions/community/docker-ce-desktop-windows/) or a later release.
 
 ## Install
 
-Ensure you have completed the steps described in the Prerequisites section **before** installing the Docker Desktop Edge 2.2.3.0 release.
+Ensure you have completed the steps described in the Prerequisites section **before** installing the Docker Desktop Stable 2.3.0.2 release.
 
 1. Follow the usual installation instructions to install Docker Desktop. If you are running a supported system, Docker Desktop prompts you to enable WSL 2 during installation. Read the information displayed on the screen and enable WSL 2 to continue.
 2. Start Docker Desktop from the Windows Start menu.

--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -2,7 +2,7 @@
 description: Docker Desktop WSL 2 backend
 keywords: WSL, WSL 2 Tech Preview, Windows Subsystem for Linux, WSL 2 backend Docker
 redirect_from:
-- /docker-for-windows/wsl/
+- /docker-for-windows/wsl-tech-preview/
 title: Docker Desktop WSL 2 backend
 toc_min: 2
 toc_max: 3
@@ -19,7 +19,7 @@ Additionally, with WSL 2, the time required to start a Docker daemon after a col
 Before you install the Docker Desktop WSL 2 backend, you must complete the following steps:
 
 1. Install Windows 10 Insider Preview build 19041 or higher.
-2. Enable WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/windows/wsl/wsl2-install).
+2. Enable WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 3. Download and install the [Linux kernel update package](https://docs.microsoft.com/windows/wsl/wsl2-kernel).
 
 ## Download


### PR DESCRIPTION
I'm working on a command line script to help WSL users to get the most out of the Docker Desktop WSL 2 integration and therefore want to link to the WSL docs page.

But given that the link still is `wsl-tech-preview` this wouldn't look good ("this is so 2019" :-) ) this PR moves the page to `/docker-for-windows/wsl` and provides a redirect from the old `/docker-for-windows/wsl-tech-preview` via Jekyll.
