### PR TITLE
Add redirect until WSL 2 GA

### DIFF
--- a/docker-for-windows/wsl-tech-preview.md
+++ b/docker-for-windows/wsl-tech-preview.md
@@ -1,6 +1,8 @@
 ---
 description: Docker Desktop WSL 2 backend
 keywords: WSL, WSL 2 Tech Preview, Windows Subsystem for Linux, WSL 2 backend Docker
+redirect_from:
+- /docker-for-windows/wsl/
 title: Docker Desktop WSL 2 backend
 toc_min: 2
 toc_max: 3


### PR DESCRIPTION
This PR adds a temporary redirect from an upcoming link to the current tech preview link.
This helps making the output of the WSL helper scripts we've added to be correct, showing a link that works right now and after the GA of WSL 2.
After GA we can merge and deploy #10745 to swap the page and the redirect.
 