### PR TITLE
Auto-restart of Docker rootless on boot requires an additional command

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -167,9 +167,10 @@ Use `systemctl --user` to manage the lifecycle of the daemon:
 $ systemctl --user start docker
 ```
 
-To launch the daemon on system startup, enable systemd lingering:
+To launch the daemon on system startup, enable the systemd service and lingering:
 
 ```console
+$ systemctl --user enable docker
 $ sudo loginctl enable-linger $(whoami)
 ```
 


### PR DESCRIPTION
### Proposed changes

In `Usage > Daemon` : Docker rootless, in order to execute the `~/.config/systemd/user/docker.service` file need to be enabled by systemctl.

So on top of the `sudo loginctl enable-linger $(whoami)` command, the user has to execute :

```bash
systemctl --user enable docker
```

Then it works perfectly fine.

### Related issues (optional)

Related to issue [#10770](https://github.com/docker/docker.github.io/issues/10770)
