### PR TITLE
Don't use sudo with apt-key fingerprint command

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -99,7 +99,7 @@ from the repository.
     last 8 characters of the fingerprint.
 
     ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
+    $ apt-key fingerprint 0EBFCD88
 
     pub   4096R/0EBFCD88 2017-02-22
           Key fingerprint = 9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88


### PR DESCRIPTION

### Proposed changes

We don't need to use `sudo` to list trusted key with fingerprints using apt-key list/fingerprint command. We are unnecessarily allowing apt-key to run in privilege mode.
