### PR TITLE
Added fish-shell auto completion to docker for mac installation guide.

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -470,18 +470,18 @@ class="_"}. To activate completion for Docker commands,
 these files need to be copied or symlinked to your Fish-shell `completions/`
 directory.
 
-Create at first the `completions` directory if not exist:
+Create the `completions` directory:
 
 ```bash
-mkdir ~/.config/fish/completions
+mkdir -p ~/.config/fish/completions
 ```
 
 Now add fish completions from docker.
 
 ```bash
 set etc /Applications/Docker.app/Contents/Resources/etc
-ln -s $etc/docker.fish-completion ~/.config/fish/completions/docker.fish
-ln -s $etc/docker-compose.fish-completion ~/.config/fish/completions/docker-compose.fish
+ln -shi /Applications/Docker.app/Contents/Resources/etc/docker.fish-completion ~/.config/fish/completions/docker.fish
+ln -shi /Applications/Docker.app/Contents/Resources/etc/docker-compose.fish-completion ~/.config/fish/completions/docker-compose.fish
 ```
 
 ## Give feedback and get help

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -462,6 +462,28 @@ ln -s $etc/docker.zsh-completion /usr/local/share/zsh/site-functions/_docker
 ln -s $etc/docker-compose.zsh-completion /usr/local/share/zsh/site-functions/_docker-compose
 ```
 
+### Fish-Shell
+
+Fish-shell also supports tab completion [completion
+system](https://fishshell.com/docs/current/#tab-completion){:target="_blank"
+class="_"}. To activate completion for Docker commands,
+these files need to be copied or symlinked to your Fish-shell `completions/`
+directory.
+
+Create at first the `completions` directory if not exist:
+
+```bash
+mkdir ~/.config/fish/completions
+```
+
+Now add fish completions from docker.
+
+```bash
+set etc /Applications/Docker.app/Contents/Resources/etc
+ln -s $etc/docker.fish-completion ~/.config/fish/completions/docker.fish
+ln -s $etc/docker-compose.fish-completion ~/.config/fish/completions/docker-compose.fish
+```
+
 ## Give feedback and get help
 
 To get help from the community, review current user topics, join or start a

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -479,7 +479,6 @@ mkdir -p ~/.config/fish/completions
 Now add fish completions from docker.
 
 ```bash
-set etc /Applications/Docker.app/Contents/Resources/etc
 ln -shi /Applications/Docker.app/Contents/Resources/etc/docker.fish-completion ~/.config/fish/completions/docker.fish
 ln -shi /Applications/Docker.app/Contents/Resources/etc/docker-compose.fish-completion ~/.config/fish/completions/docker-compose.fish
 ```


### PR DESCRIPTION
### Proposed changes

I added fish-shell auto completion installation information for mac.

### Related issues (optional)

#10785 
