### PR TITLE
Jekyll: exclude "tests" directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ safe: false
 lsi: false
 # This needs to have all the directories you expect to be in the archives (delivered by docs-base in the Dockerfile)
 keep_files: ["v17.06", "v18.03", "v18.09"]
-exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]
+exclude: ["_scripts", "tests", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]
 
 # Component versions -- address like site.docker_ce_version
 # You can't have - characters in these for non-YAML reasons

--- a/_config_authoring.yml
+++ b/_config_authoring.yml
@@ -13,7 +13,7 @@ safe: false
 lsi: false
 # This needs to have all the directories you expect to be in the archives (delivered by docs-base in the Dockerfile)
 keep_files: ["v17.06", "v18.03", "v18.09"]
-exclude: ["_scripts", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]
+exclude: ["_scripts", "tests", "apidocs/layouts", "Gemfile", "hooks", "index.html", "404.html"]
 
 # Component versions -- address like site.docker_ce_version
 # You can't have - characters in these for non-YAML reasons


### PR DESCRIPTION
Netlify reported "mixed content" warnings (which means that the website contained links to both HTTPS and HTTP URLs.

Those reports were based on some test-files in the "tests" directory;

```
10:08:07 PM: Finished processing build request in 6m14.58941986s
10:09:14 PM: Mixed content detected in: /tests/src/golang.org/x/net/html/charset/testdata/utf-8-bom-vs-meta-content.html
10:09:15 PM: --> insecure link urls:
10:09:15 PM:   - http://www.w3.org/TR/html5/syntax.html#the-input-byte-stream
10:09:15 PM: --> insecure script urls:
10:09:15 PM:   - http://w3c-test.org/resources/testharness.js
10:09:15 PM:   - http://w3c-test.org/resources/testharnessreport.js
10:09:15 PM: Mixed content detected in: /tests/src/golang.org/x/net/html/charset/testdata/utf-8-bom-vs-meta-charset.html
10:09:15 PM: --> insecure link urls:
10:09:15 PM:   - http://www.w3.org/TR/html5/syntax.html#the-input-byte-stream
10:09:15 PM: --> insecure script urls:
10:09:15 PM:   - http://w3c-test.org/resources/testharness.js
10:09:15 PM:   - http://w3c-test.org/resources/testharnessreport.js
```

We already look to be excluding that directory from our Dockerfile, but possibly Netlify uses the source itself for this detection, so adding `tests` to the `exclude` list in the Jenkyll configuration.


@StefanScherer @usha-mandya PTAL