### PR TITLE
remove landing option on get-docker page

### DIFF
--- a/get-docker.md
+++ b/get-docker.md
@@ -1,7 +1,6 @@
 ---
 description: Home page for Get Docker
 keywords: Docker, download, documentation, manual
-landing: true
 title: Get Docker
 redirect_from:
 - /install/


### PR DESCRIPTION
### Proposed changes

Remove landing option on get-docker page to fix redirection