### PR TITLE
Remove "product manuals landingpage" placeholder

### DIFF
--- a/engine/index.md
+++ b/engine/index.md
@@ -6,6 +6,7 @@ redirect_from:
 - /engine/ce-ee-node-activate/
 - /linux/
 - /edge/
+- /manuals/ # TODO remove this redirect after we've created a landing page for the product manuals section
 title: Docker Engine overview
 ---
 

--- a/manuals/index.md
+++ b/manuals/index.md
@@ -1,7 +1,0 @@
----
-title: Product Manuals
-description: Learn about Docker Engine - Community
-keywords: Docker Engine - Community, Docker Community
----
-
-Landing page for the Docker Community product manuals


### PR DESCRIPTION
This removes the placeholder in favor of a redirect to the first product manual in the section, so that `/manuals/` redirects users to a sensible location.
