### PR TITLE
Fix explanation of `rm --force`

### DIFF
--- a/get-started/part2.md
+++ b/get-started/part2.md
@@ -172,7 +172,7 @@ You'll see Docker step through each instruction in your Dockerfile, building up 
     docker rm --force bb
     ```
 
-    The `--force` option removes the running container. If you stop the container running with `docker stop bb` you do not need to use `--force`.
+    The `--force` option stops a running container, so it can be removed. If you stop the container running with `docker stop bb` first, then you do not need to use `--force` to remove it.
 
 ## Conclusion
 


### PR DESCRIPTION
`--force` in `rm --force` claimed to remove the container (which `rm` obviously does). `--force` allows a container to be removed even if it's still running.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
