### PR TITLE
Add note on Desktop installer size reduction

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -31,6 +31,7 @@ Docker Desktop introduces a new onboarding tutorial upon first startup. The Quic
 
 ### Bug fixes and minor changes
 
+- Reduced the size of the Docker Desktop installer from 708 MB to 456 MB.
 - Fixed bug where containers disappeared from the UI when Kubernetes context is invalid. Fixes [docker/for-win#6037](https://github.com/docker/for-win/issues/6037).
 - Fixed a file descriptor leak in `vpnkit-bridge`. Fixes [docker/for-win#5841](https://github.com/docker/for-win/issues/5841).
 - Added a link to the Edge channel from the UI.

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -54,6 +54,7 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 
 **Other fixes**
 
+- Reduced the size of the Docker Desktop installer from 960 MB to 409 MB.
 - Added an option to delete data from the Troubleshoot screen.
 - Fixed a bug where containers disappeared from the UI when Kubernetes context is invalid. Fixed [docker/for-win#6037](https://github.com/docker/for-win/issues/6037).
 - Fixed Windows event logs filtering when copying them to the Docker Desktop log files. Fixed [docker/for-win#6258](https://github.com/docker/for-win/issues/6258).


### PR DESCRIPTION
Added a note in Desktop 2.3.0.2 release notes about the reduction in the Desktop installer size.