### PR TITLE
Update navigation for Guides

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1,7 +1,7 @@
 
 horizontalnav:
 - title: Guides
-  path: /
+  path: /develop/
   node: guides
 - title: Product manuals
   path: /engine/


### PR DESCRIPTION
Clicking on the Guides tab redirects users to the homepage. This PR fixes this issue by redirecting users to /develop/ when they click on the Guides tab.