### PR TITLE
Landing page touch-ups

### DIFF
--- a/_includes/body-landing.html
+++ b/_includes/body-landing.html
@@ -80,8 +80,7 @@
   <section class="container">
     <div class="row">
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card" href="/get-started/">
-          <img src="/images/rocket.svg" alt="get started" />
+        <a class="card rocket" href="/get-started/">
           <h5 class="title">Get started</h5>
           <p>
             Learn Docker basics and the benefits of containerizing you
@@ -90,11 +89,7 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card" href="/get-docker/">
-          <img
-            src="/images/download-docker.svg"
-            alt="download and install docker"
-          />
+        <a class="card download-docker" href="/get-docker/">
           <h5 class="title">Download and install</h5>
           <p>
             Download and install Docker on your machine in a few easy steps.
@@ -102,8 +97,7 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card" href="/develop/">
-          <img src="/images/guides.svg" alt="guides" />
+        <a class="card guides" href="/develop/">
           <h5 class="title">Guides</h5>
           <p>
             Learn how to set up your Docker environment and start containerizing
@@ -112,8 +106,7 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card" href="/release-notes/">
-          <img src="/images/whats-new.svg" alt="what's new" />
+        <a class="card whats-new" href="/release-notes/">
           <h5 class="title">What's new?</h5>
           <p>
             Learn about the cool new features, updates, and bug fixes.
@@ -121,8 +114,7 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card" href="/engine/">
-          <img src="/images/manuals.svg" alt="products manuals" />
+        <a class="card manuals" href="/engine/">
           <h5 class="title">Product manuals</h5>
           <p>
             Browse through the manuals and learn how to use Docker products.
@@ -130,8 +122,7 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card" href="/reference/">
-          <img src="/images/reference.svg" alt="reference" />
+        <a class="card reference" href="/reference/">
           <h5 class="title">Reference</h5>
           <p>
             Browse through the through the CLI and API reference documentation.

--- a/_scss/_buttons.scss
+++ b/_scss/_buttons.scss
@@ -27,7 +27,7 @@ a.button.outline-btn.min-hgt {
 
 .button {
     margin: 10px 10px 10px 0;
-    font-family: Geomanist Book;
+    font-family: Geomanist Book, sans-serif;
     padding: 12px 35px 10px;
     min-width: 200px;
     box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.1);
@@ -61,8 +61,7 @@ a.button.outline-btn.min-hgt {
 
 .outline-btn {
     background: #fff;
-    border: 1px solid;
-    border-color: #0087C8;
+    border: 1px solid #0087C8;
     text-decoration: none;
     margin: 0;
 }

--- a/_scss/_content.scss
+++ b/_scss/_content.scss
@@ -72,7 +72,7 @@ pre code {
     padding: 5px 0 10px 20px;
     float: left;
     min-height: 100px;
-    margin: 0px 0 15px 0;
+    margin: 0 0 15px 0;
     width: 100%;
 }
 

--- a/_scss/_github.scss
+++ b/_scss/_github.scss
@@ -24,13 +24,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   font-weight: bold;
 }
 
+/*
 .hljs-number,
 .hljs-literal,
 .hljs-variable,
 .hljs-template-variable,
 .hljs-tag .hljs-attr {
-  // color: #008080;
+   color: #008080;
 }
+*/
 
 .hljs-string,
 .hljs-doctag {
@@ -61,33 +63,37 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   font-weight: normal;
 }
 
+/*
 .hljs-regexp,
 .hljs-link {
-  // color: #009926;
+   color: #009926;
 }
 
 .hljs-symbol,
 .hljs-bullet {
-  // color: #990073;
+   color: #990073;
 }
 
 .hljs-built_in,
 .hljs-builtin-name {
-  // color: #0086b3;
+   color: #0086b3;
 }
+*/
 
 .hljs-meta {
   // color: #999;
   font-weight: bold;
 }
 
+/*
 .hljs-deletion {
-  // background: #fdd;
+   background: #fdd;
 }
 
 .hljs-addition {
-  // background: #dfd;
+   background: #dfd;
 }
+*/
 
 .hljs-emphasis {
   font-style: italic;

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -117,34 +117,41 @@ body#landing {
     padding: 7.5px;
   }
 
+  %icon-card {
+    background-image:  none;
+    background-origin: content-box;
+    background-repeat: no-repeat;
+    background-size:   auto 35px;
+
+    @include sm-width { background-size: auto 40px; min-height: 220px; }
+    @include md-width { background-size: auto 50px }
+    @include lg-width { background-size: auto 60px }
+
+    .title {
+      margin-top: 50px;
+      @include sm-width { margin-top: 60px }
+      @include md-width { margin-top: 72px }
+      @include lg-width { margin-top: 90px }
+    }
+  }
+
+  $icons: rocket, download-docker, guides, whats-new, manuals, reference;
+
   .card {
     background-color: $bg-body;
     box-shadow: 0 3px 6px rgba(11, 33, 74, 0.09),
       0 -2px 2px rgba(11, 33, 74, 0.03);
     padding: 24px 36px;
-    min-height: 200px;
+    min-height: 100px;
 
     @include sm-width {
-      min-height: 230px;
+      min-height: 185px;
     }
 
-    img {
-      height: 35px;
-      margin-bottom: 5px;
-
-      @include sm-width {
-        height: 40px;
-        margin-bottom: 6px;
-      }
-
-      @include md-width {
-        height: 50px;
-        margin-bottom: 8px;
-      }
-
-      @include lg-width {
-        height: 60px;
-        margin-bottom: 10px;
+    @each $icon in $icons {
+      &.#{$icon} {
+        @extend %icon-card;
+        background-image: url("/images/#{$icon}.svg");
       }
     }
 
@@ -190,6 +197,13 @@ body#landing {
     &:hover {
       opacity: 1;
       transform: scale(1.01);
+    }
+
+    &[target=_blank] {
+      background-image:    url(/images/arrow.svg);
+      background-position: top 10px right 10px;
+      background-repeat:   no-repeat;
+      background-size:     15px 15px;
     }
   }
 
@@ -328,30 +342,6 @@ body#landing {
         height: 130px;
         margin-left: auto;
         margin-right: auto;
-      }
-    }
-  }
-
-  #community-resources,
-  #play-with-docker {
-    .card {
-      position: relative;
-      min-height: 200px;
-
-      &::after {
-        content: '';
-        background-image: url(/images/arrow.svg);
-        background-size: contain;
-        background-repeat: no-repeat;
-        position: absolute;
-        top: 10px;
-        right: 10px;
-        width: 15px;
-        height: 15px;
-      }
-
-      @include sm-width {
-        min-height: 185px;
       }
     }
   }

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -13,7 +13,7 @@ body#landing {
   overflow-x: hidden;
 
   h2, h5, h6 {
-    font-family: 'Geomanist Regular';
+    font-family: 'Geomanist Regular', sans-serif;
   }
 
   section {
@@ -119,8 +119,8 @@ body#landing {
 
   .card {
     background-color: $bg-body;
-    box-shadow: 0px 3px 6px rgba(11, 33, 74, 0.09),
-      0px -2px 2px rgba(11, 33, 74, 0.03);
+    box-shadow: 0 3px 6px rgba(11, 33, 74, 0.09),
+      0 -2px 2px rgba(11, 33, 74, 0.03);
     padding: 24px 36px;
     min-height: 200px;
 
@@ -198,7 +198,7 @@ body#landing {
     padding: 24px 36px;
 
     .title {
-      font-family: 'Geomanist Book';
+      font-family: 'Geomanist Book', sans-serif;
       line-height: 22px;
       font-size: 22px;
     }
@@ -238,7 +238,7 @@ body#landing {
       a.btn {
         background-color: #FF3F73;
         color: white;
-        font-family: 'Open Sans';
+        font-family: 'Open Sans', sans-serif;
         font-size: 17px;
         font-weight: bold;
         padding: 20px 60px;
@@ -274,12 +274,12 @@ body#landing {
 
   .help-by-product {
     .title {
-      font-family: 'Geomanist Book';
+      font-family: 'Geomanist Book', sans-serif;
       font-size: 22px;
     }
 
     ul.nav.nav-tabs li a, h5, h6 {
-      font-family: 'Geomanist Regular';
+      font-family: 'Geomanist Regular', sans-serif;
       font-size: 18px;
     }
 

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -128,10 +128,16 @@ body#landing {
     @include lg-width { background-size: auto 60px }
 
     .title {
-      margin-top: 50px;
-      @include sm-width { margin-top: 60px }
-      @include md-width { margin-top: 72px }
-      @include lg-width { margin-top: 90px }
+      margin-top: 0;
+      margin-left: 60px;
+      @include sm-width { margin-left: 0; margin-top: 60px }
+      @include md-width { margin-left: 0; margin-top: 72px }
+      @include lg-width { margin-left: 0; margin-top: 90px }
+    }
+
+    p {
+      margin-left: 60px;
+      @include sm-width { margin-left: 0 }
     }
   }
 

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -308,6 +308,8 @@ body#landing {
 
       li a {
         cursor: pointer;
+        padding: 10px 3px;
+        @include sm-width { padding: 10px 15px; }
       }
 
       li.active a {

--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -26,7 +26,7 @@
     h2,
     h3 {
         margin-top: 10px;
-        margin-bottom: 0px;
+        margin-bottom: 0;
     }
     h1 {
         font-size: 24px;
@@ -100,7 +100,7 @@
     h2,
     h3 {
         margin-top: 10px;
-        margin-bottom: 0px;
+        margin-bottom: 0;
     }
     h1 {
         font-size: 24px;
@@ -124,8 +124,7 @@
         height: 100px;
     }
     .nav-secondary input[type=search] {
-        background: rgb(78, 77, 77) url(/images/search.png) no-repeat;
-        background-position: 10px 9px;
+        background: rgb(78, 77, 77) url(/images/search.png) no-repeat 10px 9px;
     }
     .nav-sidebar a {
         color: #a8a8a8;
@@ -221,7 +220,7 @@
     h2,
     h3 {
         margin-top: 10px;
-        margin-bottom: 0px;
+        margin-bottom: 0;
     }
     h1 {
         font-size: 24px;
@@ -248,7 +247,7 @@
         padding: 120px 20px;
     }
     .main-content {
-        padding: 0px 10px;
+        padding: 0 10px;
     }
     .nav-sidebar a {
         color: #a8a8a8;
@@ -296,7 +295,7 @@
     h2,
     h3 {
         margin-top: 10px;
-        margin-bottom: 0px;
+        margin-bottom: 0;
     }
     h1 {
         font-size: 24px;
@@ -322,8 +321,7 @@
   and (max-device-width: 1024px) 
   and (orientation: portrait) {
     .nav-secondary input[type=search] {
-        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat;
-        background-position: 10px 9px;
+        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px;
     }
 }
 
@@ -343,8 +341,7 @@
         width: 270px;
     }
     .nav-secondary input[type=search] {
-        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat;
-        background-position: 10px 9px;
+        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px;
     }
 }
 

--- a/_scss/_navigation.scss
+++ b/_scss/_navigation.scss
@@ -113,7 +113,7 @@
 
 .nav-sidebar ul {
     list-style: none;
-    padding: 0px;
+    padding: 0;
     text-align: left;
     li {
         display: block;
@@ -121,7 +121,7 @@
 }
 
 .nav-sidebar .nav ul {
-  padding: 0px 0px 0px 15px;
+  padding: 0 0 0 15px;
 }
 
 .nav-sidebar ul li a:hover {
@@ -204,7 +204,7 @@
 
 .toc-nav i.fa {
     font-size: 14px;
-    margin: 0px 8px 0 0;
+    margin: 0 8px 0 0;
     color: #4fa1d0;
 }
 
@@ -371,12 +371,12 @@ input:checked+.slider:before {
 .ctrl-left {
     float: left;
     width: 20px;
-    margin: 3px 0px 0px 0;
+    margin: 3px 0 0 0;
 }
 
 .ctrl-right {
     float: right;
-    padding: 5px 0px;
+    padding: 5px 0;
 }
 
 .ctrl-right .btn-group {

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -44,21 +44,17 @@ body.night {
         background: $bg-secondary-night;
     }
     .nav-secondary input[type=search] {
-        background: rgba(76, 76, 76, 0.47) url(/images/search.png) no-repeat;
-        background-position: 10px 9px;
+        background: rgba(76, 76, 76, 0.47) url(/images/search.png) no-repeat 10px 9px;
         color: $white;
     }
     .nav-secondary-tabs .search-form input[type=search] {
-        background: rgba(16, 28, 41, 0.6) url(/images/search.png) no-repeat;
-        background-position: 10px 9px;
+        background: rgba(16, 28, 41, 0.6) url(/images/search.png) no-repeat 10px 9px;
     }
     .nav-secondary-tabs .search-form input[type=search]:focus {
-        background: rgba(255,255,255,0.17) url(/images/search.png) no-repeat;
-        background-position: 10px 9px;
+        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px;
     }
     .nav-secondary .search-form input[type=search]:focus {
-        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat!important;
-        background-position: 10px 9px!important;
+        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px !important;
     }
     .sidebar-home,
     .sidebar,
@@ -130,7 +126,7 @@ body.night {
         background: #0a121b !important;
     }
     pre>code {
-        padding: 0px;
+        padding: 0;
     }
     .nav-secondary .dropdown-btn {
         color: #d0e8ff;
@@ -175,7 +171,7 @@ body.night {
         background: $bg-search-results-night;
         border: 1px solid $black;
         color: $white;
-        padding: 20px 0 15px 0px;
+        padding: 20px 0 15px 0;
         margin: 10px 0 0 0;
         position: absolute;
         width: 800px;
@@ -328,7 +324,6 @@ body.night {
         cursor: default;
         background-color: #4e6071;
         border: 1px solid transparent;
-        border-bottom-color: transparent;
     }
     .popover {
         color: $black;

--- a/_scss/_overrides.scss
+++ b/_scss/_overrides.scss
@@ -7,7 +7,7 @@
 .nav-secondary-tabs .dropdown-btn {
     background: transparent;
     color: #fff;
-    padding: 5px 11px 0px 0px;
+    padding: 5px 11px 0 0;
     margin-top: 7px;
     border: 0;
     font-size: 12px;
@@ -16,7 +16,7 @@
 .nav-secondary .dropdown-btn {
     background: transparent;
     color: #b4d4e4;
-    padding: 5px 11px 0px 0px;
+    padding: 5px 11px 0 0;
     margin-top: 7px;
     border: 0;
     font-size: 12px;
@@ -68,8 +68,7 @@
 
 .btn-group.open .dropdown-toggle {
     -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
-    box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
-    background: trr;
+    //box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
     background: transparent;
     color: #fff;
     box-shadow: none;
@@ -82,7 +81,7 @@
 .open>.dropdown-toggle.btn-default:hover {
     color: #fff!important;
     background-color: transparent!important;
-    border-color: none!important;
+    border-color: transparent !important;
     box-shadow: none!important
 }
 

--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -64,7 +64,7 @@ i.fa.fa-outdent {
 
 
 .block {
-    padding: 0px 15px 10px 15px;
+    padding: 0 15px 10px 15px;
 }
 
 
@@ -86,14 +86,13 @@ img.inline {
 
 .search-form {
     float: left;
-    margin: 5px 0 0px;
+    margin: 5px 0 0;
     // width: 200px;
     & input[type=text] {
-        background: rgba(0, 0, 0, 0.17) url("/images/search.png") no-repeat;
-        background-position: 10px 9px;
+        background: rgba(0, 0, 0, 0.17) url("/images/search.png") no-repeat 10px 9px;
         border: 0;
         color: #0C5176;
-        border-radius: 0px;
+        border-radius: 0;
         margin: 0;
         transition: all 0.2s ease;
         width: 230px;
@@ -101,8 +100,7 @@ img.inline {
 }
 
 .nav-secondary-tabs .search-form input[type=search] {
-    background: rgba(0, 0, 0, 0.17) url("/images/search.png") no-repeat;
-    background-position: 10px 9px;
+    background: rgba(0, 0, 0, 0.17) url("/images/search.png") no-repeat 10px 9px;
     border: 0;
     box-shadow: none;
     color: #fff;
@@ -111,7 +109,7 @@ img.inline {
     -moz-transition: all 0.2s ease;
     -o-transition: all 0.2s ease;
     transition: all 0.2s ease;
-    padding: 0px 0 0 35px;
+    padding: 0 0 0 35px;
     width: 100%;
 }
 
@@ -128,22 +126,19 @@ input[type=text],
 }
 
 .nav-secondary-tabs .search-form input[type=search]:focus {
-    background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat;
-    background-position: 10px 9px;
+    background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px;
 }
 
 .nav-secondary-tabs.affix input[type=search],
 input[type=text] {
-    background: rgba(0, 0, 0, 0.17) url(/images/search.png) no-repeat;
-    background-position: 10px 9px;
+    background: rgba(0, 0, 0, 0.17) url(/images/search.png) no-repeat 10px 9px;
     border: 1px solid transparent;
     box-shadow: none;
     transition: all 0.2s ease;
 }
 
 .nav-secondary input[type=search] {
-    background: rgba(0, 0, 0, 0.17) url("/images/search.png") no-repeat;
-    background-position: 10px 9px;
+    background: rgba(0, 0, 0, 0.17) url("/images/search.png") no-repeat 10px 9px;
     border: 0;
     box-shadow: none;
     color: #fff;
@@ -152,12 +147,11 @@ input[type=text] {
     -moz-transition: all 0.2s ease;
     -o-transition: all 0.2s ease;
     transition: all 0.2s ease;
-    padding: 0px 0 0 35px;
+    padding: 0 0 0 35px;
 }
 
 .nav-secondary .search-form input[type=search]:focus {
-    background: rgba(255,255,255,0.17) url(/images/search.png) no-repeat;
-    background-position: 10px 9px;
+    background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px;
 }
 
 .search-form input[type=search]::-webkit-input-placeholder {
@@ -214,7 +208,7 @@ div#autocompleteResults {
     background: #E6F5FD;
     border: 1px solid #eee;
     box-shadow: 1px 2px 2px rgba(0, 0, 0, 0.28);
-    padding: 20px 0 15px 0px;
+    padding: 20px 0 15px 0;
     margin: 10px 0 0 0;
     position: absolute;
     width: 600px!important;
@@ -246,9 +240,9 @@ div#autocompleteResults span {
 .autocompleteList {
   list-style-type: none;
   width: 400px;
-/* commented out 0px padding to allow inherit padding, search results on autocompleteList were getting smashed up against left margin due to this */
-/*  padding:0px; */
-  margin-bottom: 0px;
+/* commented out 0 padding to allow inherit padding, search results on autocompleteList were getting smashed up against left margin due to this */
+/*  padding: 0; */
+  margin-bottom: 0;
 }
 
 .autoCompleteResult {
@@ -262,9 +256,9 @@ div#autocompleteResults span {
 
 .autocompleteList li {
   width: 380px;
-  border: 0px;
+  border: 0;
   padding-right: 20px;
-  margin: 0px;
+  margin: 0;
 }
 /*
   *
@@ -308,11 +302,9 @@ input.gsc-search-button, input.gsc-search-button:hover, input.gsc-search-button:
 }
 
 .alert-info {
-    border: 0;
+    border: 0 #bce8f1;
     border-radius: 0;
-    color: #31708f;
     background-color: #3F51B5!important;
-    border-color: #bce8f1;
     text-align: center;
     color: #fff;
     margin-bottom: 0;

--- a/_scss/_variables.scss
+++ b/_scss/_variables.scss
@@ -32,7 +32,7 @@ $bg-body: #fff;
 
 $heading-color: #254356;
 
-$body-text-color: #33444C;//grey #11 in color pallette
+$body-text-color: #33444C;//grey #11 in color palette
 
 $bg-footer: #fff;
 


### PR DESCRIPTION
Some things I was playing with in the weekend for fun, so thought I'd push them in case we think these look good 🤷‍♂️ 

### scss: various small fixes and linting issues

- Add generic font classes where missing (except for FontAwesome cfonts)
- Combined some rules with their shorthand form
- Removed unneeded units (0px -> 0)
- Fix some invalid values
- Commented out empty styles in _github.scss

### Landing page: apply icons using CSS, and remove duplication

This patch:

- removes the icon images from the landing page, instead setting
  them as a background-image through css.
- replaced the "community-resources" and "play-with-docker" styles
  in favor of a conditional style (based on cards linking to external
  websites)
- changes the minimal height of cards for mobile devices (there was
  a big amount of padding on the smallest size, which didn't add
  much value).

Looks of the "community resources" cards before and after:

<img width="252" alt="community-card-before" src="https://user-images.githubusercontent.com/1804568/82306282-24988500-99bf-11ea-87dd-e8d361a5926c.png">
<img width="252" alt="community-card-after" src="https://user-images.githubusercontent.com/1804568/82306289-25c9b200-99bf-11ea-9045-e97fc75c442f.png">

### Landing page: left-align icon on small screen sizes

Reduce the vertical space on small devices by putting the icon at the left of the text, instead of above.

Before and after:

<img width="252" alt="icon-card-before" src="https://user-images.githubusercontent.com/1804568/82306599-8c4ed000-99bf-11ea-9f42-537d85f61fd7.png">
<img width="252" alt="icon-card-after" src="https://user-images.githubusercontent.com/1804568/82306592-8bb63980-99bf-11ea-947c-91f98de1b1e8.png">
 

### Landing page: reduce tab-width to prevent wrapping

The tabs on the "help by project" card were wrapping on iPhone, so reducing the padding to prevent this.

<img width="252" alt="tabs-before" src="https://user-images.githubusercontent.com/1804568/82312094-e1421480-99c6-11ea-9fff-40c64f1dba86.png">
<img width="252" alt="tabs-after" src="https://user-images.githubusercontent.com/1804568/82312100-e3a46e80-99c6-11ea-9494-5659a1febf46.png">
