### PR TITLE
more redirects for classic swarm

### DIFF
--- a/_data/advisories.yaml
+++ b/_data/advisories.yaml
@@ -9,13 +9,7 @@
 
 texts:
   experimental: "The functionality described on this page is marked as Experimental, and as such, may change before it becomes generally available."
-  rc: "The Swarm mode feature included in Docker Engine 1.12 is a release candidate feature and might be subject to non backward-compatible changes. Some functionality may change before the feature becomes generally available."
-  docker4mac-beta: "Docker Desktop for Mac is currently in public beta. Some functionality may change before the product becomes generally available."
-  docker4win-beta: "Docker Desktop for Windows is currently in public beta. Some functionality may change before the product becomes generally available."
   kitematic: "**Legacy desktop solution.** Kitematic is a legacy solution, bundled with [Docker Toolbox](/toolbox/overview/). We recommend updating to [Docker Desktop for Mac](/docker-for-mac/) or [Docker Desktop for Windows](/docker-for-windows/) if your system meets the requirements for one of those applications."
-  swarm: "See [Swarm mode overview](/engine/swarm/) for the orchestration features introduced in Docker Engine 1.12. Only refer to the Docker Swarm documents below for information on the standalone Swarm product."
-  swarm-standalone: "**You are viewing docs for legacy standalone Swarm.** These topics describe standalone Docker Swarm. In Docker 1.12 and higher, [Swarm mode](/engine/swarm/) is integrated with Docker Engine. Most users should use integrated Swarm mode &#8212; a good place to start is [Getting started with swarm mode](/engine/swarm/swarm-tutorial/), [Swarm mode CLI commands](/engine/swarm/#swarm-mode-cli-commands), and the [Get started with Docker walkthrough](/get-started/)). Standalone Docker Swarm is not integrated into the Docker Engine API and CLI commands."
-  engine: "This site contains documentation for the v1.12 release candidate version of Docker Engine. For the Docker Engine v1.11 docs, see [https://docs.docker.com/v1.11/](https://docs.docker.com/v1.11/). Docker Desktop for Mac and Docker Desktop for Windows are currently in Beta."
 
 
 # URL based advisories

--- a/compose/index.md
+++ b/compose/index.md
@@ -3,6 +3,7 @@ description: Introduction and Overview of Compose
 keywords: documentation, docs, docker, compose, orchestration, containers
 title: Overview of Docker Compose
 redirect_from:
+ - /compose/networking/swarm/
  - /compose/overview/
  - /compose/swarm/
 ---

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -86,11 +86,12 @@ See the [links reference](compose-file/compose-file-v2.md#links) for more inform
 
 ## Multi-host networking
 
-> **Note**: The instructions in this section refer to [legacy Docker Swarm](swarm.md) operations, and only work when targeting a legacy Swarm cluster. For instructions on deploying a compose project to the newer integrated swarm mode, consult the [Docker Stacks](../engine/reference/commandline/stack_deploy.md) documentation.
+When deploying a Compose application on an Docker Engine with [Swarm mode enabled](../engine/swarm/index.md),
+you can make use of the built-in `overlay` driver to enable multi-host communication.
 
-When [deploying a Compose application to a Swarm cluster](swarm.md), you can make use of the built-in `overlay` driver to enable multi-host communication between containers with no changes to your Compose file or application code.
-
-Consult the [Getting started with multi-host networking](../network/network-tutorial-overlay.md) to see how to set up a Swarm cluster. The cluster uses the `overlay` driver by default, but you can specify it explicitly if you prefer - see below for how to do this.
+Consult the [Swarm mode section](../engine/swarm/index.md), to see how to set up
+a Swarm cluster, and the [Getting started with multi-host networking](../network/network-tutorial-overlay.md)
+to learn about multi-host overlay networks.
 
 ## Specify custom networks
 

--- a/compose/production.md
+++ b/compose/production.md
@@ -61,15 +61,6 @@ appropriately.
 Once you've set up your environment variables, all the normal `docker-compose`
 commands work with no further configuration.
 
-### Running Compose on a Swarm cluster
-
-[Docker Swarm](../swarm/overview.md), a Docker-native clustering
-system, exposes the same API as a single Docker host, which means you can use
-Compose against a Swarm instance and run your apps across multiple hosts.
-
-Read more about the Compose/Swarm integration in the
-[integration guide](swarm.md).
-
 ## Compose documentation
 
 - [User guide](index.md)

--- a/engine/swarm/index.md
+++ b/engine/swarm/index.md
@@ -3,34 +3,46 @@ description: Docker Engine swarm mode overview
 keywords: docker, container, cluster, swarm
 title: Swarm mode overview
 redirect_from:
-- /swarm/overview/
+- /api/swarm-api/
+- /engine/userguide/networking/overlay-standalone-swarm/
+- /network/overlay-standalone.swarm/
+- /release-notes/docker-swarm/
+- /swarm/
+- /swarm/api/
+- /swarm/configure-tls/
+- /swarm/discovery/
 - /swarm/get-swarm/
-- /swarm/release-notes/
-- /swarm/install-w-machine/
-- /swarm/plan-for-production/
 - /swarm/install-manual/
-- /swarm/swarm_at_scale/about/
-- /swarm/swarm_at_scale/deploy-infra/
-- /swarm/swarm_at_scale/deploy-app/
-- /swarm/swarm_at_scale/troubleshoot/
+- /swarm/install-w-machine/
+- /swarm/multi-host-networking/
 - /swarm/multi-manager-setup/
 - /swarm/networking/
-- /swarm/multi-host-networking/
-- /swarm/discovery/
+- /swarm/overview/
+- /swarm/plan-for-production/
 - /swarm/provision-with-machine/
-- /swarm/scheduler/filter/
-- /swarm/scheduler/rescheduling/
-- /swarm/scheduler/strategy/
-- /swarm/secure-swarm-tls/
-- /swarm/configure-tls/
+- /swarm/reference/
 - /swarm/reference/create/
 - /swarm/reference/help/
 - /swarm/reference/join/
 - /swarm/reference/list/
 - /swarm/reference/manage/
 - /swarm/reference/swarm/
+- /swarm/release-notes/
+- /swarm/scheduler/
+- /swarm/scheduler/filter/
+- /swarm/scheduler/rescheduling/
+- /swarm/scheduler/strategy/
+- /swarm/secure-swarm-tls/
 - /swarm/status-code-comparison-to-docker/
--  /swarm/swarm-api/
+- /swarm/swarm-api/
+- /swarm/swarm_at_scale/
+- /swarm/swarm_at_scale/02-deploy-infra/
+- /swarm/swarm_at_scale/03-create-cluster/
+- /swarm/swarm_at_scale/04-deploy-app/
+- /swarm/swarm_at_scale/about/
+- /swarm/swarm_at_scale/deploy-app/
+- /swarm/swarm_at_scale/deploy-infra/
+- /swarm/swarm_at_scale/troubleshoot/
 ---
 
 To use Docker in swarm mode, install Docker. See


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/11554
fixes https://github.com/docker/docker.github.io/issues/11575
fixes https://github.com/docker/docker.github.io/issues/11561
fixes https://github.com/docker/docker.github.io/issues/11567
fixes https://github.com/docker/docker.github.io/issues/11588

- The index pages were not in the redirect (they were not in the TOC,
  but were published before, so could be indexed).
- Added "redirect_from" pages that were in the pages that were removed.
- Sorted the list alphabetically
