### PR TITLE
Broken links to OS specific upgrade pages

### DIFF
--- a/ee/upgrade.md
+++ b/ee/upgrade.md
@@ -216,12 +216,12 @@ $ docker node update --availability drain <node>
 To upgrade a node individually by operating system, please follow the instructions
 listed below:
 
-* [Windows Server](/ee/docker-ee/windows/docker-ee.md#update-docker-engine---enterprise)
-* [Ubuntu](/ee/docker-ee/ubuntu.md#upgrade-docker-engine---enterprise)
-* [RHEL](/ee/docker-ee/rhel.md#upgrade-from-the-repository)
-* [CentOS](/ee/docker-ee/centos.md#upgrade-from-the-repository)
-* [Oracle Linux](/ee//oracle.md#upgrade-from-the-repository)
-* [SLES](/ee/docker-ee/suse.md#upgrade-docker-engine---enterprise)
+* [Windows Server](/ee/docker-ee/windows/docker-ee/#update-docker-engine---enterprise)
+* [Ubuntu](/ee/docker-ee/ubuntu/#upgrade-docker-engine---enterprise)
+* [RHEL](/ee/docker-ee/rhel/#upgrade-from-the-repository)
+* [CentOS](/ee/docker-ee/centos/#upgrade-from-the-repository)
+* [Oracle Linux](/ee//oracle/#upgrade-from-the-repository)
+* [SLES](/ee/docker-ee/suse/#upgrade-docker-engine---enterprise)
 
 ### Post-Upgrade steps for Docker Engine - Enterprise
 


### PR DESCRIPTION
Appears the target prevented the redirect to the correct page. Removing the .md manually directs to correct page.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
