### PR TITLE
bridge.md

### DIFF
--- a/network/bridge.md
+++ b/network/bridge.md
@@ -133,7 +133,7 @@ $ docker network rm my-net
 
 ## Connect a container to a user-defined bridge
 
-When you create a new container, you can specify one or more `--network` flags.
+When you create a new container, you can specify only one `--network` flag.
 This example connects a Nginx container to the `my-net` network. It also
 publishes port 80 in the container to port 8080 on the Docker host, so external
 clients can access that port. Any other container connected to the `my-net`


### PR DESCRIPTION
In another part of the documentation it is said that : When the container starts, it can only be connected to a single network, using --network (https://docs.docker.com/config/containers/container-networking/). That one seems to be true.
