### PR TITLE
Fix broken link to ucp install cmd docs

### DIFF
--- a/ee/ucp/admin/install/index.md
+++ b/ee/ucp/admin/install/index.md
@@ -83,7 +83,7 @@ To install UCP:
     This runs the install command in interactive mode, so that you're prompted
     for any necessary configuration values.  To find what other options are
     available in the install command, including how to install UCP on a system
-    with SELinux enabled, check the [reference documentation](/reference/ucp/3.2/cli/install.md).
+    with SELinux enabled, check the [reference documentation](/reference/ucp/3.2/cli/install/).
 
 > Note
 >


### PR DESCRIPTION
The link in question, currently leads to https://docs.docker.com/reference/ucp/3.2/cli/install.md
which shows the 404 page.

The actual docs are located at https://docs.docker.com/reference/ucp/3.2/cli/install/

Fixes #10857
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

This PR replaces the wrong link with the right one
