### PR TITLE
fix description for ptrace in seccomp.md

### DIFF
--- a/engine/security/seccomp.md
+++ b/engine/security/seccomp.md
@@ -93,7 +93,7 @@ the reason each syscall is blocked rather than white-listed.
 | `pivot_root`        | Deny `pivot_root`, should be privileged operation.                                                           |
 | `process_vm_readv`  | Restrict process inspection capabilities, already blocked by dropping `CAP_SYS_PTRACE`.                          |
 | `process_vm_writev` | Restrict process inspection capabilities, already blocked by dropping `CAP_SYS_PTRACE`.                          |
-| `ptrace`            | Tracing/profiling syscall, which could leak a lot of information on the host. Already blocked by dropping `CAP_SYS_PTRACE`. Blocked in Linux kernel versions before 4.8 to avoid seccomp bypass. |
+| `ptrace`            | Tracing/profiling syscall. Blocked in Linux kernel versions before 4.8 to avoid seccomp bypass. Tracing/profiling arbitrary processes is already blocked by dropping `CAP_SYS_PTRACE`, because it could leak a lot of information on the host. |
 | `query_module`      | Deny manipulation and functions on kernel modules. Obsolete.                                                  |
 | `quotactl`          | Quota syscall which could let containers disable their own resource limits or process accounting. Also gated by `CAP_SYS_ADMIN`. |
 | `reboot`            | Don't let containers reboot the host. Also gated by `CAP_SYS_BOOT`.                                           |


### PR DESCRIPTION

### Proposed changes

Fix the description for `ptrace` in `engine/security/seccomp.md`

The existing description leads the reader to believe that dropping CAP_SYS_PTRACE already blocks all ptraces. That is not true, and could give the reader a false view on this aspect of docker security. Dropping CAP_SYS_PTRACE only blocks ptracing arbitrary processes, ptracing child processes is still allowed.

### Unreleased project version (optional)

### Related issues (optional)
