### PR TITLE
Add space between prompt and command

### DIFF
--- a/engine/swarm/swarm-tutorial/inspect-service.md
+++ b/engine/swarm/swarm-tutorial/inspect-service.md
@@ -111,7 +111,7 @@ the Docker CLI to see details about the service running in the swarm.
     you must ssh to that node.
 
     ```bash
-    [worker2]$docker ps
+    [worker2]$ docker ps
 
     CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
     e609dde94e47        alpine:latest       "ping docker.com"   3 minutes ago       Up 3 minutes                            helloworld.1.8p1vev3fq5zm0mi8g0as41w35


### PR DESCRIPTION

### Proposed changes

When rendered in the actual docs, this will not be highlighted as a reference to a shell variable. Right now, it shows up like this:

<img width="681" alt="Screen Shot 2020-05-23 at 9 05 01 AM" src="https://user-images.githubusercontent.com/26552821/82732700-8402d780-9cd4-11ea-9105-211cee85d737.png">
