### PR TITLE
Cleanup WSL tech preview links

### DIFF
--- a/_includes/body-landing.html
+++ b/_includes/body-landing.html
@@ -371,7 +371,7 @@
                 Popular articles
               </h6>
               <p class="only-win">
-                <a href="/docker-for-windows/wsl-tech-preview/">
+                <a href="/docker-for-windows/wsl/">
                   Docker Desktop WSL 2 backend
                 </a>
               </p>

--- a/docker-for-windows/install-windows-home.md
+++ b/docker-for-windows/install-windows-home.md
@@ -21,7 +21,7 @@ Docker Desktop on Windows Home offers the following benefits:
 - Dynamic resource and memory allocation
 - Networking stack, support for http proxy settings, and trusted CA synchronization
 
-For detailed information about WSL 2, see [Docker Desktop WSL 2 backend](/wsl-tech-preview.md)
+For detailed information about WSL 2, see [Docker Desktop WSL 2 backend](wsl.md)
 
 ## What to know before you install
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -75,7 +75,7 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 
 ### Known issues
 
-- Some CLI commands fail if you are running Docker Desktop in the experimental Linux Containers on Windows (LCOW) mode. As alternatives, we recommend running either traditional Linux containers, or the experimental [WSL backend](wsl-tech-preview.md).
+- Some CLI commands fail if you are running Docker Desktop in the experimental Linux Containers on Windows (LCOW) mode. As alternatives, we recommend running either traditional Linux containers, or the [WSL 2 backend](wsl.md).
 
 **WSL 2**
 


### PR DESCRIPTION
Cleanup remaining links to `wsl-tech-preview.md` and use the existing `wsl.md` file. This fixes the link on page https://docs.docker.com/docker-for-windows/install-windows-home/ -> For detailed information about WSL 2, see Docker Desktop WSL 2 backend.

We still have a forward for the old https://docs.docker.com/docker-for-windows/wsl-tech-preview link for older installations and blog posts.

### Related issues (optional)

Fixes #10882
