### PR TITLE
Updated to use new syntax.

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -48,8 +48,7 @@ services:
       update_config:
         parallelism: 2
         delay: 10s
-      restart_policy:
-        condition: on-failure
+      restart: on-failure
 
   db:
     image: postgres:9.4


### PR DESCRIPTION

### Proposed changes
Updated to use new syntax. without this,  getting the following error:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services.redis: 'restart_policy'

```

```
$ docker-compose --version 
docker-compose version 1.25.5, build 8a1c60f6
```


