### PR TITLE
Added wp-content to the docker-compose Wordpress example

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -52,6 +52,8 @@ Compose to set up and run WordPress. Before starting, make sure you have
          depends_on:
            - db
          image: wordpress:latest
+         volumes:
+           - wp-content:/var/www/html/wp-content
          ports:
            - "8000:80"
          restart: always
@@ -62,6 +64,7 @@ Compose to set up and run WordPress. Before starting, make sure you have
            WORDPRESS_DB_NAME: wordpress
     volumes:
         db_data: {}
+        wp-content: {}
     ```
 
    > **Notes**:


### PR DESCRIPTION
Hi! I can't think of any reason someone wouldn't want wp-content as a volume - whether for development or production.

Let me know your thoughts. I could understand why you wouldn't include `/var/www/html` as a whole - because there's a lot of wp core files, but wp-content  is something people would want to keep. Even if not for development purposes, for backup purposes.

From here, I think the user would have a pretty safe and usable Wordpress setup.
