### PR TITLE
Remove links to success articles

### DIFF
--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -48,8 +48,6 @@ Nested virtualization scenarios, such as running Docker Desktop on a
 VMWare or Parallels instance might work, but there are no guarantees. For
 more information, see [Running Docker Desktop in nested virtualization scenarios](troubleshoot.md#running-docker-desktop-for-windows-in-nested-virtualization-scenarios).
 
-**Note**: Refer to the [Docker compatibility matrix](https://success.docker.com/article/compatibility-matrix) for complete Docker compatibility information with Windows Server.
-
 ### About Windows containers
 
 Looking for information on using Windows containers?

--- a/engine/release-notes/18.09.md
+++ b/engine/release-notes/18.09.md
@@ -230,7 +230,7 @@ Update your configuration if this command prints a non-empty value for `MountFla
 * Add libseccomp requirement for RPM packages. [docker/docker-ce-packaging#266](https://github.com/docker/docker-ce-packaging/pull/266)
 
 ### Known Issues
-* When upgrading from 18.09.0 to 18.09.1, `containerd` is not upgraded to the correct version on Ubuntu.  [Learn more](https://success.docker.com/article/error-upgrading-to-engine-18091-with-containerd).
+* When upgrading from 18.09.0 to 18.09.1, `containerd` is not upgraded to the correct version on Ubuntu.
 * There are [important changes to the upgrade process](/ee/upgrade) that, if not correctly followed, can have impact on the availability of applications running on the Swarm during upgrades. These constraints impact any upgrades coming from any version before 18.09 to version 18.09 or greater.
 
 ## 18.09.0
@@ -361,8 +361,7 @@ Update your configuration if this command prints a non-empty value for `MountFla
 - Docker has deprecated support for Device Mapper as a storage driver. It will continue to be
 supported at this time, but support will be removed in a future release.
 
-    Docker recommends that existing users
-    [migrate to using Overlay2 for the storage driver](https://success.docker.com/article/how-do-i-migrate-an-existing-ucp-cluster-to-the-overlay2-graph-driver). The [Overlay2 storage driver](https://docs.docker.com/storage/storagedriver/overlayfs-driver/) is now the default for Docker engine implementations.
+    The [Overlay2 storage driver](https://docs.docker.com/storage/storagedriver/overlayfs-driver/) is now the default for Docker engine implementations.
 
 For more information on the list of deprecated flags and APIs, have a look at the [deprecation information](https://docs.docker.com/engine/deprecated/) where you can find the target removal dates.
 

--- a/storage/storagedriver/btrfs-driver.md
+++ b/storage/storagedriver/btrfs-driver.md
@@ -18,19 +18,13 @@ easily combine multiple physical block devices into a single Btrfs filesystem.
 This article refers to Docker's Btrfs storage driver as `btrfs` and the overall
 Btrfs Filesystem as Btrfs.
 
-> **Note**: The `btrfs` storage driver is only supported on Docker Engine - Community on Ubuntu
-> or Debian, and Docker EE / CS Engine on SLES.
+> **Note**: The `btrfs` storage driver is only supported on Docker Engine - Community on Ubuntu or Debian.
 
 ## Prerequisites
 
 `btrfs` is supported if you meet the following prerequisites:
 
 - **Docker Engine - Community**: For Docker Engine - Community, `btrfs` is only recommended on Ubuntu or Debian.
-
-- **Docker EE**: For Docker EE and CS-Engine, `btrfs` is only supported on SLES.
-  See the
-  [Product compatibility matrix](https://success.docker.com/Policies/Compatibility_Matrix)
-  for all supported configurations for commercially-supported Docker.
 
 - Changing the storage driver makes any containers you have already
   created inaccessible on the local system. Use `docker save` to save containers,

--- a/storage/storagedriver/device-mapper-driver.md
+++ b/storage/storagedriver/device-mapper-driver.md
@@ -14,19 +14,16 @@ storage driver as `devicemapper`, and the kernel framework as _Device Mapper_.
 
 For the systems where it is supported, `devicemapper` support is included in
 the Linux kernel. However, specific configuration is required to use it with
-Docker. 
+Docker.
 
 The `devicemapper` driver uses block devices dedicated to Docker and operates at
 the block level, rather than the file level. These devices can be extended by
 adding physical storage to your Docker host, and they perform better than using
-a filesystem at the operating system (OS) level. 
+a filesystem at the operating system (OS) level.
 
 ## Prerequisites
 
-- `devicemapper` storage driver is a supported storage driver for Docker
-  EE on many OS distribution. See the
-  [Product compatibility matrix](https://success.docker.com/article/compatibility-matrix) for details.
-- `devicemapper` is also supported on Docker Engine - Community running on CentOS, Fedora,
+- `devicemapper` is supported on Docker Engine - Community running on CentOS, Fedora,
   Ubuntu, or Debian.
 - `devicemapper` requires the `lvm2` and `device-mapper-persistent-data` packages
   to be installed.

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -78,13 +78,6 @@ In addition, Docker does not recommend any configuration that requires you to
 disable security features of your operating system, such as the need to disable
 `selinux` if you use the `overlay` or `overlay2` driver on CentOS.
 
-### Docker Engine - Enterprise and Docker Enterprise
-
-For Docker Engine - Enterprise and Docker Enterprise, the definitive resource for which
-storage drivers are supported is the
-[Product compatibility matrix](https://success.docker.com/Policies/Compatibility_Matrix).
-To get commercial support from Docker, you must use a supported configuration.
-
 ### Docker Engine - Community
 
 For Docker Engine - Community, only some configurations are tested, and your operating


### PR DESCRIPTION
Removed links to success.docker.com articles that are not applicable anymore. 