### PR TITLE
Add question marks in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,8 +20,8 @@
             <div class="row">
                 <div class="col-xs-12 col-sm-3 col-md-3">
                     <ul class="footer_links">
-                        <li><b><a href="https://www.docker.com/why-docker">Why Docker</a></b></li>
-                        <li><a href="https://www.docker.com/what-container">What is a Container</a></li>
+                        <li><b><a href="https://www.docker.com/why-docker">Why Docker?</a></b></li>
+                        <li><a href="https://www.docker.com/what-container">What is a Container?</a></li>
                     </ul>
                 </div>
                 <div class="col-xs-12 col-sm-3 col-md-3">


### PR DESCRIPTION
### Proposed changes

- "Why Docker" --> "Why Docker?
- "What is a Container" --> "What is a Container?"

The footer links now match the page titles.