### PR TITLE
Introduce Buildkit to AutoBuilds

### DIFF
--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -277,7 +277,7 @@ You could also use capture groups to build and label images that come from vario
 
 `/(alice|bob)-v([0-9.]+)/` -->
 
-### Build image with Buildkit
+### Build images with BuildKit
 
 You can enable the Buildkit builder by setting the environment variable `DOCKER_BUILDKIT=1`([enviroment variables](index.md#environment-variables-for-builds)) in the Configure automated build section ([configure builds](index.md#configure-automated-build-settings)).
 For more information on Buildkit please see [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/).

--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -277,6 +277,11 @@ You could also use capture groups to build and label images that come from vario
 
 `/(alice|bob)-v([0-9.]+)/` -->
 
+### Build image with Buildkit
+
+You can enable the Buildkit builder by setting the environment variable `DOCKER_BUILDKIT=1`([enviroment variables](index.md#environment-variables-for-builds)) in the Configure automated build section ([configure builds](index.md#configure-automated-build-settings)).
+For more information on Buildkit please see [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+
 ## Build repositories with linked private submodules
 
 Docker Hub sets up a deploy key in your source code repository that allows it

--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -282,7 +282,8 @@ You could also use capture groups to build and label images that come from vario
 You can enable the BuildKit builder by setting the `DOCKER_BUILDKIT=1`
 [environment variable](#environment-variables-for-builds) in the
 [Configure automated build settings](#configure-automated-build-settings) section.
-For more information on Buildkit please see [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+Refer to the [build images with BuildKit](../../develop/develop-images/build_enhancements.md)
+page for more information on BuildKit.
 
 ## Build repositories with linked private submodules
 

--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -279,7 +279,9 @@ You could also use capture groups to build and label images that come from vario
 
 ### Build images with BuildKit
 
-You can enable the Buildkit builder by setting the environment variable `DOCKER_BUILDKIT=1`([enviroment variables](index.md#environment-variables-for-builds)) in the Configure automated build section ([configure builds](index.md#configure-automated-build-settings)).
+You can enable the BuildKit builder by setting the `DOCKER_BUILDKIT=1`
+[environment variable](#environment-variables-for-builds) in the
+[Configure automated build settings](#configure-automated-build-settings) section.
 For more information on Buildkit please see [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/).
 
 ## Build repositories with linked private submodules


### PR DESCRIPTION
Add a section on explaining how to enable builds to use the Docker Buildkit builder by the Autobuild service
