### PR TITLE
Fix "Docker Docker Image" link

### DIFF
--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -96,5 +96,5 @@ $ docker run -d -p 8080:80 --name myapp aspnetapp
 
   - [ASP.NET Core](https://docs.microsoft.com/aspnet/core/)
   - [Microsoft ASP.NET Core on Docker Hub](https://hub.docker.com/r/microsoft/dotnet/)
-  - [Building Docker Docker Images for ASP.NET Core](https://docs.microsoft.com/aspnet/core/host-and-deploy/docker/building-net-docker-images)
+  - [Building Docker Images for ASP.NET Core](https://docs.microsoft.com/aspnet/core/host-and-deploy/docker/building-net-docker-images)
   - [Docker Tools for Visual Studio](https://docs.microsoft.com/dotnet/articles/core/docker/visual-studio-tools-for-docker)


### PR DESCRIPTION
### Proposed changes
Fixed typo "Building **Docker Docker** Images for ASP.NET Core" link to "Building **Docker** Images for ASP.NET Core" in donetcore documentation.