### PR TITLE
Update to Posgtres instructions

### DIFF
--- a/compose/rails.md
+++ b/compose/rails.md
@@ -74,6 +74,8 @@ to link them together and expose the web app's port.
         image: postgres
         volumes:
           - ./tmp/db:/var/lib/postgresql/data
+        environment:
+          POSTGRES_PASSWORD: password
       web:
         build: .
         command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
@@ -156,7 +158,7 @@ default: &default
   encoding: unicode
   host: db
   username: postgres
-  password:
+  password: password
   pool: 5
 
 development:


### PR DESCRIPTION
### Proposed changes

**Why**
Newer upstream PostgreSQL Docker images, now require a password for use. If you were previously using passwordless access to a PostgreSQL DB, it will fail with this error.

<img width="666" alt="error-image" src="https://user-images.githubusercontent.com/13186900/84262871-07795100-ab3c-11ea-868d-aeffce18c1e9.png">


Based on the [team members thoughts](https://github.com/docker-library/postgres/issues/681#issuecomment-586517154) it looks like increased security was the major reason for this breaking change happening in a minor update.

**Changes**
The [postgres docker page](https://hub.docker.com/_/postgres) gives instructions on how to use the new image : 

There seems to be two different options we can take here :
- Implement a password using the environment variable
- Revert back to old behavior of having no password requirement

I opted to use the first option of implementing a password as increased security of a DB is generally a win for every one in most cases and this seems to be the intended default behavior meant by the maintainers.

For this change I added :
`environment:
      POSTGRES_PASSWORD: password` to the docker-compose.yml file section to set a password

`password: password` - Was added to the database.yml section of the rails code base

Since this configuration is loaded for local, test and development environments in rails there should not be any issues that arise from this change.

### Related issues (optional)
Github issue discussing the change in behavior - https://github.com/docker-library/postgres/issues/681
