### PR TITLE
correct typo in bash command

### DIFF
--- a/network/none.md
+++ b/network/none.md
@@ -42,7 +42,7 @@ only the loopback device is created. The following example illustrates this.
     the `--rm` flag.
 
     ```bash
-    $ docker container rm no-net-alpine
+    $ docker stop no-net-alpine
     ```
 
 ## Next steps


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

bash command in docks was incorrect for the given step

