### PR TITLE
Removed wrong information about container DNS

### DIFF
--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -56,7 +56,7 @@ flag to specify an additional network alias for the container on that network.
 
 ## DNS services
 
-By default, a container inherits the DNS settings of the Docker daemon by copying the config file `/etc/resolv.conf` to the container. The file `/etc/hosts` however, are not inherited. To pass additional hosts into your container, see [run command](../../engine/reference/commandline/run.md##add-entries-to-container-hosts-file---add-host). You can override these
+By default, a container inherits the DNS settings of the Docker daemon by copying the config file `/etc/resolv.conf` to the container. The file `/etc/hosts` however, are not inherited. To pass additional hosts into your container, see [run command](../../engine/reference/commandline/run.md#add-entries-to-container-hosts-file---add-host). You can override these
 settings on a per-container basis.
 
 | Flag           | Description                                                                                                                                                                                                                                                         |

--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -56,8 +56,7 @@ flag to specify an additional network alias for the container on that network.
 
 ## DNS services
 
-By default, a container inherits the DNS settings of the Docker daemon,
-including the `/etc/hosts` and `/etc/resolv.conf`.You can override these
+By default, a container inherits the DNS settings of the Docker daemon by copying the config file `/etc/resolv.conf` to the container. The file `/etc/hosts` however, are not inherited. To pass additional hosts into your container, see [run command](../../engine/reference/commandline/run.md##add-entries-to-container-hosts-file---add-host). You can override these
 settings on a per-container basis.
 
 | Flag           | Description                                                                                                                                                                                                                                                         |

--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -56,7 +56,17 @@ flag to specify an additional network alias for the container on that network.
 
 ## DNS services
 
-By default, a container inherits the DNS settings of the Docker daemon by copying the config file `/etc/resolv.conf` to the container. The file `/etc/hosts` however, are not inherited. To pass additional hosts into your container, see [run command](../../engine/reference/commandline/run.md#add-entries-to-container-hosts-file---add-host). You can override these
+By default, a container inherits the DNS settings of the host, as defined in the
+`/etc/resolv.conf` configuration file. Containers that use the default `bridge`
+network get a copy of this file, whereas containers that use a
+[custom network](../../network/network-tutorial-standalone.md#use-user-defined-bridge-networks)
+use Docker's embedded DNS server, which forwards external DNS lookups to the DNS
+servers configured on the host.
+
+Custom hosts defined in `/etc/hosts` are not inherited. To pass additional hosts
+into your container, refer to [add entries to container hosts file](../../engine/reference/commandline/run.md#add-entries-to-container-hosts-file---add-host)
+in the `docker run` reference documentation. You can override these settings on
+a per-container basis.
 settings on a per-container basis.
 
 | Flag           | Description                                                                                                                                                                                                                                                         |


### PR DESCRIPTION
### Proposed changes

In the docs it says a container will inherit the host /etc/hosts file along with /etc/resolv.conf. While the latter part is correct, /etc/hosts will not actually be inherited.

This PR will update the paragraph to tell reader only the file /etc/resolv.conf will be inherited. In addition to that, some texts have been added to emphasize the fact that /etc/hosts are not inherited

If there's anything wrong with the grammar or the sentence structure, do let me know and I will amend accordingly

### Related issues
https://github.com/moby/moby/issues/39311
