### PR TITLE
Fixed typo in tmpfs example index.md

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1897,10 +1897,10 @@ Mount a temporary file system inside the container. Size parameter specifies the
 of the tmpfs mount in bytes. Unlimited by default.
 
 ```yaml
- - type: tmpfs
-     target: /app
-     tmpfs:
-       size: 1000
+- type: tmpfs
+  target: /app
+  tmpfs:
+    size: 1000
 ```
 
 ### ulimits


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
tmpfs example has incorrect yaml syntax
<img width="237" alt="Screenshot 2020-06-22 at 10 36 51" src="https://user-images.githubusercontent.com/3237625/85261297-9ce9de80-b474-11ea-96ef-7ee9b8929543.png">

fixed the layout
