### PR TITLE
Update log location for Ubuntu 16.04+ and CentOS

### DIFF
--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -224,7 +224,7 @@ subsystem used:
 |:----------------------|:-----------------------------------------------------------------------------------------|
 | RHEL, Oracle Linux    | `/var/log/messages`                                                                      |
 | Debian                | `/var/log/daemon.log`                                                                    |
-| Ubuntu 16.04+, CentOS | Use the command `journalctl -u docker.service`                                           |
+| Ubuntu 16.04+, CentOS | Use the command `journalctl -u docker.service` or `/var/log/syslog`                      |
 | Ubuntu 14.10-         | `/var/log/upstart/docker.log`                                                            |
 | macOS (Docker 18.01+) | `~/Library/Containers/com.docker.docker/Data/vms/0/console-ring`                         |
 | macOS (Docker <18.01) | `~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/console-ring` |


### PR DESCRIPTION
Update log location for Ubuntu 16.04+ and CentOS
Add the /var/log/syslog

### Proposed changes

Added the log location path for Ubuntu 16.04+ and CentOS systems as a option to journald in case needed to read the text based log files

