### PR TITLE
Update path to Docker.raw file

### DIFF
--- a/docker-for-mac/space.md
+++ b/docker-for-mac/space.md
@@ -79,7 +79,7 @@ To query the actual size of the file on the host from a terminal, run:
 
 ```bash
 $ cd ~/Library/Containers/com.docker.docker/Data
-$ cd vms/0/data
+$ cd vms/0
 $ ls -klsh Docker.raw
 2333548 -rw-r--r--@ 1 username  staff    64G Dec 13 17:42 Docker.raw
 ```


### PR DESCRIPTION
I'm running Docker Desktop for Mac version 2.3.0.3(45519). When I tried to query the actual size of the file on the host from a terminal the command 
```bash
$ cd ~/Library/Containers/com.docker.docker/Data
$ cd vms/0/data
```
gives error: 
`-bash: cd: vms/0/data: No such file or directory`
Instead, it should be `cd vms/0`. 
I hope it helps.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
