### PR TITLE
Refer to read-only layer instead of write only layer.

### DIFF
--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -18,8 +18,8 @@ Storage drivers allow you to create data in the writable layer of your container
 The files won't be persisted after the container is deleted, and both read and
 write speeds are lower than native file system performance. 
 
- > **Note**: Operations that are known to be problematic include write-intensive database storage, 
-particularly when pre-existing data exists in the write-only layer. More details are provided in this document.
+ > **Note**: Operations that are known to be problematic include write-intensive database storage,
+particularly when pre-existing data exists in the read-only layer. More details are provided in this document.
 
 [Learn how to use volumes](../volumes.md) to persist data and improve performance.
 


### PR DESCRIPTION
### Proposed changes

Correcting what I think is a small mistake in the documentation related to storage drivers on the writable layer. The documentation refers to the "write-only layer" when describing potential problems of write intensive operations. I'm not aware of such a concept... I think they were trying to refer to the read only layer.
