### PR TITLE
add a note for non existence daemon.json

### DIFF
--- a/config/containers/logging/configure.md
+++ b/config/containers/logging/configure.md
@@ -24,9 +24,9 @@ implement and use [logging driver plugins](plugins.md).
 To configure the Docker daemon to default to a specific logging driver, set the
 value of `log-driver` to the name of the logging driver in the `daemon.json`
 file, which is located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\` on Windows server hosts. The default logging
-driver is `json-file`. The following example explicitly sets the default
-logging driver to `syslog`:
+`C:\ProgramData\docker\config\` on Windows server hosts. Note that you should create `daemon.json`
+file, if the file does not exist. 
+The default logging driver is `json-file`. The following example explicitly sets the default logging driver to `syslog`:
 
 ```json
 {


### PR DESCRIPTION
As `daemon.json` file does not exist in new installations , it's important to give a hint about adding one.