### PR TITLE
Correct proxies documentation for Docker Desktop (mac)

### DIFF
--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -193,7 +193,8 @@ HOME=/root
 HTTP_PROXY=http://proxy.example.com:3128
 ```
 
-For more information on setting environment variables for running containers see [Set environment variables](/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
+For more information on setting environment variables for running containers,
+see [Set environment variables](/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
 
 #### Network
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -175,28 +175,25 @@ For more information, see:
 #### Proxies
 
 Docker Desktop detects HTTP/HTTPS Proxy Settings from macOS and automatically
-propagates these to Docker and to your containers. For example, if you set your
+propagates these to Docker. For example, if you set your
 proxy settings to `http://proxy.example.com`, Docker uses this proxy when
 pulling containers.
 
-When you start a container, your proxy settings propagate into the containers.
-For example:
+Your proxy settings, however, will not be propagated into the containers you start.
+If you wish to set the proxy settings for your containers, you need to define
+environment variables for them, just like you would do on Linux, for example:
 
 ```
-$ docker run -it alpine env
+$ docker run -e HTTP_PROXY=http://proxy.example.com:3128 alpine env
+
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOSTNAME=b7edf988b2b5
 TERM=xterm
 HOME=/root
 HTTP_PROXY=http://proxy.example.com:3128
-http_proxy=http://proxy.example.com:3128
-no_proxy=*.local, 169.254/16
 ```
 
-You can see from the above output that the `HTTP_PROXY`, `http_proxy`, and
-`no_proxy` environment variables are set. When your proxy configuration changes,
-Docker restarts automatically to pick up the new settings. If you have any
-containers that you would like to keep running across restarts, you should consider using [restart policies](/engine/reference/run/#restart-policies-restart).
+For more information on setting environment variables for running containers see [Set environment variables](/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
 
 #### Network
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The proxies set in the Docker Desktop settings are actually not propagated in the containers automatically.
The rationale being that we want the same UX on Windows/Mac and as on Linux.

### Related issues (optional)

#10890

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
