### PR TITLE
Desktop: update mutagen file sync documentation

### DIFF
--- a/docker-for-mac/mutagen-caching.md
+++ b/docker-for-mac/mutagen-caching.md
@@ -1,7 +1,7 @@
 ---
 description: High-performance two-way file sync for volume mounts
 keywords: mac, mutagen, volumes, file sync,
-title: Mutagen-based caching
+title: Mutagen-based file synchronization
 ---
 
 Docker Desktop for Mac on Edge has a new file sharing feature which performs
@@ -16,7 +16,7 @@ This page contains an example to show how the Mutagen feature should be used to 
 
 > **Important**
 >
-> After completing the caching process, you must delete and re-create any containers which will make use of the cached directories.
+> After completing the synchronizing process, you must delete and re-create any containers which will make use of the synchronized directories.
 
 ## A simple React app
 
@@ -56,7 +56,7 @@ root@95441305251a:/my-app# npm start
 Once the development webserver has started, open [https://localhost:3000/](https://localhost:3000/) in
 your browser and observe the app is running.
 
-Return to the **File sharing** page in the UI and observe the status of the cache toggle located next to the directory name. The status will be
+Return to the **File sharing** page in the UI and observe the status of the synchronize toggle located next to the directory name. The status will be
 updated as file changes are detected and then synchronized between the host
 and the containers.
 
@@ -67,11 +67,58 @@ on the webserver.
 As you edit code on the host, the changes are detected and transferred to the
 container for testing. Changes inside the container (for example, the creation of build artifacts) are detected and transferred back to the host.
 
-## Avoiding synchronizing a subdirectory
+## Adding synchronized directories via the CLI
 
-Although two-way file sync is suitable for many types of files, sometimes containers can generate lots of data which doesn't require copying to the host, for example, debug logs.
+As of Docker Desktop Edge 2.3.2.0 the `:delegated` flag on a shared volume will 
+automatically enable synchronization. This is particularly useful if you want to share
+the synchronization setting with other developers in your team, via your source code.
 
-If your project has a subdirectory that doesn't need to be continuously copied back to the host, then use a named docker volume to bypass the sync.
+## Scripting
+
+Many projects have scripts which modify files in a container and then read them back on
+the host, or the other way around. To support these, Docker Desktop automatically flushes
+file changes around `docker run` calls. Therefore the following will work as expected:
+
+```
+docker run -v ~/foo:/foo:delegated touch /foo/new-file-in-container
+stat ~/foo/new-file-in-container
+```
+
+and
+
+```
+touch ~/foo/new-file-on-host
+docker run -v ~/foo:/foo:delegated stat /foo/new-file-on-host
+```
+
+Note that changes are not flushed around `docker exec` calls, so this will not work as
+expected:
+
+```
+docker exec existing-container touch /foo/new-file-from-existing-container
+stat ~/foo/new-file-from-existing-container # file will not be found
+```
+
+## Bypassing a two-way sync for a volume
+
+By default if a directory has two-way sync enabled, then shared volumes will use the
+sync. However if you want to *avoid* using a two-way file synchronization, choose
+one of the following volume sharing options:
+
+- `:consistent`: this will bypass both the file caching and the two-way sync.
+- `:cached`: this will bypass the two-way sync but still use the file caching.
+
+Note that these options are backwards compatible with older Docker version. Any existing
+projects using `:delegated` to enable file caching can be safely changed to use `:cached`
+without loss of performance.
+
+## Avoiding synchronizing a subdirectory from a container to the host
+
+Although two-way file sync is suitable for many types of files, sometimes containers can
+generate lots of data which doesn't require copying to the host, for example, debug logs.
+
+If your project has a subdirectory that doesn't need to be continuously copied back to
+the host, then use a named docker volume to bypass the sync.
 
 First create a volume using:
 
@@ -89,6 +136,27 @@ $ docker run -it -v ~/workspace/my-app:/my-app -v donotsyncme:/my-app/dontsyncme
 Docker Desktop will sync all changes written by the app to `/my-app` to
 the host, except changes written to `/my-app/dontsyncme` which will be written
 to the named volume instead.
+
+## Avoiding synchronizing a subdirectory in both directions
+
+Although the example in the previous section successfully prevents changes written in
+the container from being copied back to the host, changes written on the host will
+still be written to the container (although hidden by the `docker volume`).
+
+To completely avoid synchronization in both directions, create a
+[global mutagen config file](https://mutagen.io/documentation/introduction/configuration#configuration-files).
+For example create a file `~/.mutagen.yml` containing:
+
+```
+sync:
+  defaults:
+    ignore:
+      paths:
+        - /path1/to/ignore
+        - /path2/to/ignore
+        - ...
+        - /pathN/to/ignore
+```
 
 ## Best practices
 
@@ -110,7 +178,7 @@ To achieve maximum performance when you enable two-way file sync:
 - Avoid changing the same files from both the host and containers. If changes
   are detected on both sides, the host takes precedence and the changes in the containers will be discarded.
 
-- After completing the caching process, you must delete and re-create any containers which will make use of the cached directories.
+- After completing the caching process, you must delete and re-create any containers which will make use of the synchronized directories.
 
 ## Feedback
 

--- a/docker-for-mac/mutagen-caching.md
+++ b/docker-for-mac/mutagen-caching.md
@@ -16,7 +16,8 @@ This page contains an example to show how the Mutagen feature should be used to 
 
 > **Important**
 >
-> After completing the synchronizing process, you must delete and re-create any containers which will make use of the synchronized directories.
+> After completing the synchronizing process, you must delete and re-create any 
+containers which will make use of the synchronized directories.
 
 ## A simple React app
 
@@ -56,7 +57,8 @@ root@95441305251a:/my-app# npm start
 Once the development webserver has started, open [https://localhost:3000/](https://localhost:3000/) in
 your browser and observe the app is running.
 
-Return to the **File sharing** page in the UI and observe the status of the synchronize toggle located next to the directory name. The status will be
+Return to the **File sharing** page in the UI and observe the status of the 
+synchronize toggle located next to the directory name. The status will be
 updated as file changes are detected and then synchronized between the host
 and the containers.
 
@@ -67,17 +69,17 @@ on the webserver.
 As you edit code on the host, the changes are detected and transferred to the
 container for testing. Changes inside the container (for example, the creation of build artifacts) are detected and transferred back to the host.
 
-## Adding synchronized directories via the CLI
+## Adding synchronized directories through the CLI
 
 As of Docker Desktop Edge 2.3.2.0 the `:delegated` flag on a shared volume will 
 automatically enable synchronization. This is particularly useful if you want to share
-the synchronization setting with other developers in your team, via your source code.
+the synchronization setting with other developers in your team, through your source code.
 
 ## Scripting
 
 Many projects have scripts which modify files in a container and then read them back on
 the host, or the other way around. To support these, Docker Desktop automatically flushes
-file changes around `docker run` calls. Therefore the following will work as expected:
+file changes around `docker run` calls. Therefore, the following will work as expected:
 
 ```
 docker run -v ~/foo:/foo:delegated touch /foo/new-file-in-container
@@ -101,14 +103,14 @@ stat ~/foo/new-file-from-existing-container # file will not be found
 
 ## Bypassing a two-way sync for a volume
 
-By default if a directory has two-way sync enabled, then shared volumes will use the
-sync. However if you want to *avoid* using a two-way file synchronization, choose
+By default, if a directory has two-way sync enabled, then shared volumes will use the
+sync. However, if you want to *avoid* using a two-way file synchronization, choose
 one of the following volume sharing options:
 
 - `:consistent`: this will bypass both the file caching and the two-way sync.
-- `:cached`: this will bypass the two-way sync but still use the file caching.
+- `:cached`: this will bypass the two-way sync but still uses the file caching.
 
-Note that these options are backwards compatible with older Docker version. Any existing
+Note that these options are backwards compatible with older Docker versions. Any existing
 projects using `:delegated` to enable file caching can be safely changed to use `:cached`
 without loss of performance.
 
@@ -145,7 +147,7 @@ still be written to the container (although hidden by the `docker volume`).
 
 To completely avoid synchronization in both directions, create a
 [global mutagen config file](https://mutagen.io/documentation/introduction/configuration#configuration-files).
-For example create a file `~/.mutagen.yml` containing:
+For example, create a file `~/.mutagen.yml` containing:
 
 ```
 sync:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Recent edge releases of Docker Desktop have updated the mutagen support. This PR re-synchronises the docs with the code.

The changes are:
- terminology: we use "synchronize" rather than "cache"
- it's possible to configure it via `:delegated`
- it's possible to avoid it via `:cached`
- scripting should work better with `docker run`
- it's possible to use the global mutagen config file to completely exclude directories from the sync (in both directions, not just one direction)

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

This is all released in Edge 2.3.0.2