### PR TITLE
Fix missing "toggle" for right-hand navigation

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -26,4 +26,7 @@
 
         </ul>
     </div>
+    <div class="ctrl-right">
+        <a href="javascript:void(0)" id="menu-toggle"><i class="fa fa-indent" aria-hidden="true"></i></a>
+    </div>
 </div>


### PR DESCRIPTION
This button was accidentally removed when the archives were removed in ba85012f47efdc41e30ad9e9f7a9a579d05f6382 (https://github.com/docker/docker.github.io/pull/11014)

This brings back that toggle button:

<img width="282" alt="Screenshot 2020-07-09 at 12 32 42" src="https://user-images.githubusercontent.com/1804568/87029360-55878000-c1e0-11ea-98e3-b5fa73d1abf2.png">


We should have a look at re-designing this button, as it's not very clear (and easy to be missed), but that's good for a follow-up
