### PR TITLE
Remove pinned version 0.1.4 from ACI integration install docs

### DIFF
--- a/engine/context/aci-integration.md
+++ b/engine/context/aci-integration.md
@@ -160,7 +160,8 @@ curl -L https://github.com/docker/aci-integration-beta/blob/main/scripts/install
 
 ### Manual install
 
-You can download the Docker ACI Integration CLI from [latest release](https://github.com/docker/aci-integration-beta/releases/latest).
+You can download the Docker ACI Integration CLI from the 
+[latest release](https://github.com/docker/aci-integration-beta/releases/latest){: target="_blank" class="_"} page.
 
 You will then need to make it executable:
 

--- a/engine/context/aci-integration.md
+++ b/engine/context/aci-integration.md
@@ -155,16 +155,12 @@ The Docker ACI Integration CLI adds support for running and managing containers 
 You can install the new CLI using the install script:
 
 ```console
-curl -L https://github.com/docker/aci-integration-beta/releases/download/v0.1.4/install.sh | sh
+curl -L https://github.com/docker/aci-integration-beta/blob/main/scripts/install_linux.sh | sh
 ```
 
 ### Manual install
 
-You can download the Docker ACI Integration CLI using the following command:
-
-```console
-curl -Lo docker-aci https://github.com/docker/aci-integration-beta/releases/download/v0.1.4/docker-linux-amd64
-```
+You can download the Docker ACI Integration CLI from [latest release](https://github.com/docker/aci-integration-beta/releases/latest).
 
 You will then need to make it executable:
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

point to latest release, so we don't need to edit this every time we do a relase. 

Depends on https://github.com/docker/aci-integration-beta/pull/17

