### PR TITLE
Change ignored directory to forward slash

### DIFF
--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -65,8 +65,8 @@ ENTRYPOINT ["dotnet", "aspnetapp.dll"]
    to your project folder and copy the following into it.
 
 ```dockerignore
-bin\
-obj\
+bin/
+obj/
 ```
 
 ## Build and run the Docker image


### PR DESCRIPTION
When using the backward slash I think it will only use on Windows? 

In my case I was on MacOS and the folders weren't ignored until I changed the slashes to be forward slash.
