### PR TITLE
Replace Cube links with YouTube urls

### DIFF
--- a/_includes/landing-page/popular-videos.html
+++ b/_includes/landing-page/popular-videos.html
@@ -8,19 +8,19 @@
     </div>
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-12">
-        <a class="video-item" href="https://docker.events.cube365.net/docker/dockercon/content/Videos/hgMFTyX5kYKmTPWZo" target="_blank">
+        <a class="video-item" href="https://youtu.be/iqqDU2crIEQ?t=30" target="_blank">
           <img class="video-image" src="/images/video.svg" />
           <div class="video-title">How to get started with Docker</div>
         </a>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-12">
-        <a class="video-item" href="https://docker.events.cube365.net/docker/dockercon/content/Videos/NjnEcHsq29HMDbMRn" target="_blank">
+        <a class="video-item" href="https://youtu.be/xmLVNpyJ530?t=30" target="_blank">
           <img class="video-image" src="/images/video.svg" />
           <div class="video-title">How to build and test your Docker images in the Cloud</div>
         </a>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-12">
-        <a class="video-item" href="https://docker.events.cube365.net/docker/dockercon/content/Videos/AG9iBqW3BdXTR9Zfh" target="_blank">
+        <a class="video-item" href="https://youtu.be/QeQ2MH5f_BE?t=31" target="_blank">
           <img class="video-image" src="/images/video.svg" />
           <div class="video-title">Simplify all the things with Docker Compose</div>
         </a>


### PR DESCRIPTION
Replace the Cube links on the homepage with YouTube URLs to allow users to watch the tutorials without having to log into Cube.