### PR TITLE
Update ipv6.md

### DIFF
--- a/config/daemon/ipv6.md
+++ b/config/daemon/ipv6.md
@@ -13,11 +13,13 @@ either IPv4 or IPv6 (or both) with any container, service, or network.
 > **Note**: IPv6 networking is only supported on Docker daemons running on Linux
 > hosts.
 
-1.  Edit `/etc/docker/daemon.json` and set the `ipv6` key to `true`.
+1.  Edit `/etc/docker/daemon.json`, set the `ipv6` key to `true` and the `fixed-cidr-v6` key
+    to your IPv6 subnet. In this example we are setting it to `2001:db8:1::/64`.
 
     ```json
     {
       "ipv6": true
+      "fixed-cidr-v6": "2001:db8:1::/64"
     }
     ```
 

--- a/config/daemon/ipv6.md
+++ b/config/daemon/ipv6.md
@@ -18,7 +18,7 @@ either IPv4 or IPv6 (or both) with any container, service, or network.
 
     ```json
     {
-      "ipv6": true
+      "ipv6": true,
       "fixed-cidr-v6": "2001:db8:1::/64"
     }
     ```


### PR DESCRIPTION
Update the `ipv6` daemon config to include the fixed-cidr-v6 (IPv6 Subnet) key

Fixes: https://github.com/docker/docker.github.io/issues/11143
