### PR TITLE
Move cloud deployment docs to the Guides section

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -53,6 +53,12 @@ guides:
       title: Manage images
     - path: /develop/develop-images/baseimages/
       title: Create your own base image (advanced)
+- sectiontitle: Deploy your app to the cloud
+  section:
+  - path: /engine/context/aci-integration/
+    title: Docker and ACI (Beta)
+  - path: /engine/context/ecs-integration/
+    title: Docker and ECS (Beta)
 - sectiontitle: Run your app in production
   section:
   - sectiontitle: Orchestration
@@ -1091,10 +1097,7 @@ manuals:
     title: Docker Buildx
   - path: /engine/context/working-with-contexts/
     title: Docker Context
-  - path: /engine/context/aci-integration/
-    title: Docker and ACI (Beta)
-  - path: /engine/context/ecs-integration/
-    title: Docker and ECS (Beta)
+
 - sectiontitle: Docker Compose
   section:
   - path: /compose/

--- a/engine/context/working-with-contexts.md
+++ b/engine/context/working-with-contexts.md
@@ -13,6 +13,8 @@ A single Docker CLI can have multiple contexts. Each context contains all of the
 
 As an example, a single Docker client on your company laptop might be configured with two contexts; **dev-k8s** and **prod-swarm**. **dev-k8s** contains the endpoint data and security credentials to configure and manage a Kubernetes cluster in a development environment. **prod-swarm** contains everything required to manage a Swarm cluster in a production environment. Once these contexts are configured, you can use the top-level `docker context use <context-name>` to easily switch between them.
 
+For information on using Docker Context to deploy your apps to the cloud, see [Deploying Docker containers on Azure](aci-integration.md) and [Deploying Docker containers on ECS](ecs-integration.md).
+
 ## Prerequisites
 
 To follow the examples in this guide, you'll need:


### PR DESCRIPTION
The Cloud deployment guides for Azure and ECS were originally published in the Product Manuals section. Moving this to the Guides section as these docs cover a specific scenario on how to use Docker Context to deploy containers/apps to cloud. 

Also added a link to these docs from the Docker Context product manual for those users who arrive on this page for looking for information on using Docker context to deploy containers to cloud.