### PR TITLE
update to docker-compose 1.26.2

### DIFF
--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -6,17 +6,22 @@ notoc: true
 
 ---
 
-```
+```none
 Usage: build [options] [--build-arg key=val...] [SERVICE...]
 
 Options:
+    --build-arg key=val     Set build-time variables for services.
     --compress              Compress the build context using gzip.
     --force-rm              Always remove intermediate containers.
+    -m, --memory MEM        Set memory limit for the build container.
     --no-cache              Do not use cache when building the image.
-    --pull                  Always attempt to pull a newer version of the image.
-    -m, --memory MEM        Sets memory limit for the build container.
-    --build-arg key=val     Set build-time variables for services.
+    --no-rm                 Do not remove intermediate containers after a successful build.
     --parallel              Build images in parallel.
+    --progress string       Set type of progress output (auto, plain, tty).
+                            EXPERIMENTAL flag for native builder.
+                            To enable, run with COMPOSE_DOCKER_CLI_BUILD=1)
+    --pull                  Always attempt to pull a newer version of the image.
+    -q, --quiet             Don't print anything to STDOUT
 ```
 
 Services are built once and then tagged, by default as `project_service`. For

--- a/compose/reference/config.md
+++ b/compose/reference/config.md
@@ -7,18 +7,19 @@ redirect_from:
 - /compose/reference/bundle/
 ---
 
-```
+```none
 Usage: config [options]
 
 Options:
     --resolve-image-digests  Pin image tags to digests.
-    --no-interpolate         Don't interpolate environment variables.
-    -q, --quiet              Only validate the configuration, don't print anything.
+    --no-interpolate         Don't interpolate environment variables
+    -q, --quiet              Only validate the configuration, don't print
+                             anything.
     --services               Print the service names, one per line.
     --volumes                Print the volume names, one per line.
     --hash="*"               Print the service config hash, one per line.
                              Set "service1,service2" for a list of specified services
-                             or use the wildcard symbol to display all services.
+                             or use the wildcard symbol to display all services
 ```
 
 Validate and view the Compose file.

--- a/compose/reference/create.md
+++ b/compose/reference/create.md
@@ -9,9 +9,7 @@ notoc: true
 instead.
 {: .warning }
 
-```
-Creates containers for a service.
-
+```none
 Usage: create [options] [SERVICE...]
 
 Options:

--- a/compose/reference/down.md
+++ b/compose/reference/down.md
@@ -5,7 +5,7 @@ title: docker-compose down
 notoc: true
 ---
 
-```
+```none
 Usage: down [options]
 
 Options:

--- a/compose/reference/events.md
+++ b/compose/reference/events.md
@@ -5,7 +5,7 @@ title: docker-compose events
 notoc: true
 ---
 
-```
+```none
 Usage: events [options] [SERVICE...]
 
 Options:

--- a/compose/reference/exec.md
+++ b/compose/reference/exec.md
@@ -5,7 +5,7 @@ title: docker-compose exec
 notoc: true
 ---
 
-```
+```none
 Usage: exec [options] [-e KEY=VAL...] SERVICE COMMAND [ARGS...]
 
 Options:

--- a/compose/reference/help.md
+++ b/compose/reference/help.md
@@ -5,8 +5,8 @@ title: docker-compose help
 notoc: true
 ---
 
-```
-Usage: help COMMAND
+```none
+Usage: help [COMMAND]
 ```
 
 Displays help and usage instructions for a command.

--- a/compose/reference/images.md
+++ b/compose/reference/images.md
@@ -5,7 +5,7 @@ title: docker-compose images
 notoc: true
 ---
 
-```
+```none
 Usage: images [options] [SERVICE...]
 
 Options:

--- a/compose/reference/kill.md
+++ b/compose/reference/kill.md
@@ -5,7 +5,7 @@ title: docker-compose kill
 notoc: true
 ---
 
-```
+```none
 Usage: kill [options] [SERVICE...]
 
 Options:

--- a/compose/reference/logs.md
+++ b/compose/reference/logs.md
@@ -5,7 +5,7 @@ title: docker-compose logs
 notoc: true
 ---
 
-```
+```none
 Usage: logs [options] [SERVICE...]
 
 Options:

--- a/compose/reference/pause.md
+++ b/compose/reference/pause.md
@@ -5,7 +5,7 @@ title: docker-compose pause
 notoc: true
 ---
 
-```
+```none
 Usage: pause [SERVICE...]
 ```
 

--- a/compose/reference/port.md
+++ b/compose/reference/port.md
@@ -5,7 +5,7 @@ title: docker-compose port
 notoc: true
 ---
 
-```
+```none
 Usage: port [options] SERVICE PRIVATE_PORT
 
 Options:

--- a/compose/reference/pull.md
+++ b/compose/reference/pull.md
@@ -5,7 +5,7 @@ title: docker-compose pull
 notoc: true
 ---
 
-```
+```none
 Usage: pull [options] [SERVICE...]
 
 Options:

--- a/compose/reference/push.md
+++ b/compose/reference/push.md
@@ -5,7 +5,7 @@ title: docker-compose push
 notoc: true
 ---
 
-```
+```none
 Usage: push [options] [SERVICE...]
 
 Options:

--- a/compose/reference/restart.md
+++ b/compose/reference/restart.md
@@ -5,7 +5,7 @@ title: docker-compose restart
 notoc: true
 ---
 
-```
+```none
 Usage: restart [options] [SERVICE...]
 
 Options:

--- a/compose/reference/rm.md
+++ b/compose/reference/rm.md
@@ -12,6 +12,7 @@ Options:
     -f, --force   Don't ask to confirm removal
     -s, --stop    Stop the containers, if required, before removing
     -v            Remove any anonymous volumes attached to containers
+    -a, --all     Deprecated - no effect.
 ```
 
 Removes stopped service containers.

--- a/compose/reference/run.md
+++ b/compose/reference/run.md
@@ -5,7 +5,7 @@ title: docker-compose run
 notoc: true
 ---
 
-```
+```none
 Usage:
     run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l KEY=VALUE...]
         SERVICE [COMMAND] [ARGS...]

--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -11,7 +11,7 @@ notoc: true
   the `scale` command, as it incorporates the behaviour of the `up` command.
   {: .warning }
 
-```
+```none
 Usage: scale [options] [SERVICE=NUM...]
 
 Options:

--- a/compose/reference/start.md
+++ b/compose/reference/start.md
@@ -5,7 +5,7 @@ title: docker-compose start
 notoc: true
 ---
 
-```
+```none
 Usage: start [SERVICE...]
 ```
 

--- a/compose/reference/stop.md
+++ b/compose/reference/stop.md
@@ -5,7 +5,7 @@ title: docker-compose stop
 notoc: true
 ---
 
-```
+```none
 Usage: stop [options] [SERVICE...]
 
 Options:

--- a/compose/reference/top.md
+++ b/compose/reference/top.md
@@ -7,7 +7,6 @@ notoc: true
 
 ```none
 Usage: top [SERVICE...]
-
 ```
 
 Displays the running processes.

--- a/compose/reference/unpause.md
+++ b/compose/reference/unpause.md
@@ -5,7 +5,7 @@ title: docker-compose unpause
 notoc: true
 ---
 
-```
+```none
 Usage: unpause [SERVICE...]
 ```
 

--- a/compose/reference/up.md
+++ b/compose/reference/up.md
@@ -5,7 +5,7 @@ title: docker-compose up
 notoc: true
 ---
 
-```
+```none
 Usage: up [options] [--scale SERVICE=NUM...] [SERVICE...]
 
 Options:
@@ -26,6 +26,7 @@ Options:
     --build                    Build images before starting containers.
     --abort-on-container-exit  Stops all containers if any container was
                                stopped. Incompatible with -d.
+    --attach-dependencies      Attach to dependent containers
     -t, --timeout TIMEOUT      Use this timeout in seconds for container
                                shutdown when attached or when containers are
                                already running. (default: 10)


### PR DESCRIPTION
### Proposed changes

Update docker-compose CLI reference to 1.26.2. 

I updated it with the following script:

```python
#!/usr/bin/env python3

import glob
import os.path
import re
import subprocess

USAGE_RE = re.compile(r"```.*?\nUsage:.*?```", re.MULTILINE | re.DOTALL)
USAGE_IN_CMD_RE = re.compile(r"^Usage:.*", re.MULTILINE | re.DOTALL)

HELP_CMD = "docker run --rm docker/compose:latest %s --help"

for file in glob.glob("compose/reference/*.md"):
    with open(file, "r") as f:
        data = f.read()
    if not USAGE_RE.search(data):
        print("Not a command:", file)
        continue
    subcmd = os.path.basename(file).replace(".md", "")
    if subcmd == "overview":
        continue
    print(f"Found {subcmd}: {file}")
    help_cmd = HELP_CMD % subcmd
    help = subprocess.check_output(help_cmd.split())
    help = help.decode("utf-8")
    help = USAGE_IN_CMD_RE.findall(help)[0]
    help = help.strip()
    data = USAGE_RE.sub(f"```none\n{help}\n```", data)
    with open(file, "w") as f:
        f.write(data)
```

Note that the change is slightly destructive, since it reverts some grammar fixes that were done directly to this documentation. It would be a good thing to fix these in the actual docker-compose help commands.

### Related issues (optional)

Fixes #11163