### PR TITLE
Add a note on turning experimental features on

### DIFF
--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -99,7 +99,9 @@ using Edge features that aren't in Stable yet. Keep this in mind as
 you create and work with Edge containers, perhaps in the spirit of a playground
 space where you are prepared to troubleshoot or start over.
 
-To safely switch between Edge and Stable versions, ensure you save images and export the containers you need, then uninstall the current version before installing another. For more information, see the section Save and Restore data below.
+Experimental features are turned on by default on Edge releases. However, when you switch from a Stable to an Edge release, you must turn on the experimental features flag to access experimental features. From the Docker Desktop menu, click **Preferences** > **Command Line** and then turn on the **Enable experimental features** toggle. Click **Apply & Restart** for the changes to take effect.
+
+To safely switch between Edge and Stable versions, ensure you save images and export the containers you need, then uninstall the current version before installing another. For more information, see the section **Save and Restore data** below.
 
 ### Save and restore data
 

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -124,6 +124,8 @@ using Edge features that aren't in Stable yet. Keep this in mind as
 you create and work with Edge containers, perhaps in the spirit of a playground
 space where you are prepared to troubleshoot or start over.
 
+Experimental features are turned on by default on Edge releases. However, when you switch from a Stable to an Edge release, you must turn on the experimental features flag to access experimental features. From the Docker Desktop menu, click **Settings** > **Command Line** and then turn on the **Enable experimental features** toggle. Click **Apply & Restart** for the changes to take effect.
+
 To safely switch between Edge and Stable versions, ensure you save images and export the containers you need, then uninstall the current version before installing another. For more information, see the section _Save and Restore data_ below.
 
 ### Save and restore data

--- a/engine/context/ecs-integration.md
+++ b/engine/context/ecs-integration.md
@@ -29,11 +29,17 @@ To deploy Docker containers on ECS, you must meet the following requirements:
     - [Download for Mac](https://desktop.docker.com/mac/edge/Docker.dmg){: target="_blank" class="_"}
     - [Download for Windows](https://desktop.docker.com/win/edge/Docker%20Desktop%20Installer.exe){: target="_blank" class="_"}
 
-    Alternatively, install the [Docker ECS Integration for Linux](#install-the-docker-ecs-integration-cli-on-linux).
+    Alternatively, install [Docker ECS Integration for Linux](#install-the-docker-ecs-integration-cli-on-linux).
 
 2. Ensure you have an AWS account.
 
-You can check your installation by running the command `docker ecs version`.
+  > **Note**
+  >
+  > If you had previously installed a Docker Desktop Stable release and now switched to Edge, ensure you turn on the experimental features flag. 
+  >
+  > From the Docker Desktop menu, click **Settings** (Preferences on macOS) > **Command Line** and then turn on the **Enable experimental features** toggle. Click **Apply & Restart** for the changes to take effect.
+
+Check your installation by running the command `docker ecs version`.
 
 Docker not only runs multi-container applications locally, but also enables developers to seamlessly deploy Docker containers on Amazon ECS using a Compose file with the `docker ecs compose up` command. The following sections contain instructions on how to deploy your Compose application on Amazon ECS.
 


### PR DESCRIPTION
### Proposed changes

Add a note to specify users must turn on the experimental features flag manually when they switch from stable to edge releases.

### Related issue
https://github.com/docker/ecs-plugin/issues/190