### PR TITLE
examples.md: Actually use `ctx` variable in Go example

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -245,7 +245,7 @@ func main() {
 		panic(err)
 	}
 
-	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Proposed changes

"List and manage containers" Go example:
`ctx := context.Background()` was defined but never used.
Follow the structure of the other examples instead.
