### PR TITLE
engine/api: fix incorrect ID on "http" tab

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -659,7 +659,7 @@ print image.id
 
 </div>
 
-<div id="tab-pullimages-curl" class="tab-pane fade" markdown="1">
+<div id="tab-pullimages-auth-curl" class="tab-pane fade" markdown="1">
 
 This example leaves the credentials in your shell's history, so consider
 this a naive implementation. The credentials are passed as a Base-64-encoded


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/11211