### PR TITLE
Update ubuntu.md

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -25,7 +25,6 @@ To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
 - Ubuntu Focal 20.04 (LTS)
-- Ubuntu Eoan 19.10
 - Ubuntu Bionic 18.04 (LTS)
 - Ubuntu Xenial 16.04 (LTS)
 


### PR DESCRIPTION
### Proposed changes

Remove Ubuntu 19.10 (Eoan) as it is an EOL release. Here is the [official announcement](https://lists.ubuntu.com/archives/ubuntu-security-announce/2020-July/005494.html).

### Unreleased project version (optional)

Doc change only.

### Related issues (optional)

No issues found about removing the EOL release.
