### PR TITLE
Update running_ssh_service.md

### DIFF
--- a/engine/examples/running_ssh_service.md
+++ b/engine/examples/running_ssh_service.md
@@ -25,7 +25,7 @@ FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:THEPASSWORDYOUCREATED' | chpasswd
-RUN sed -i 's/#*PermitRootLogin prohibit-password/\#PermitRootLogin yes/g' /etc/ssh/sshd_config
+RUN sed -i 's/\#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd

--- a/engine/examples/running_ssh_service.md
+++ b/engine/examples/running_ssh_service.md
@@ -25,12 +25,15 @@ FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:THEPASSWORDYOUCREATED' | chpasswd
-RUN sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
+RUN sed -i 's/#*PermitRootLogin prohibit-password/\#PermitRootLogin yes/g' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd
 
+# Demonstration of the correct way to set up an environment variable within the container: 
+# This environment variable is not visible in a users profile
 ENV NOTVISIBLE "in users profile"
+# Whereas this one is.
 RUN echo "export VISIBLE=now" >> /etc/profile
 
 EXPOSE 22


### PR DESCRIPTION
1. The set function to allow root logins is commented by default, and the command here does not remove the comment, so root login would still fail. 
2. Increased clarification on the correct way to set environment variable within SSHd.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
