### PR TITLE
Add Packet to the machine drivers index

### DIFF
--- a/machine/AVAILABLE_DRIVER_PLUGINS.md
+++ b/machine/AVAILABLE_DRIVER_PLUGINS.md
@@ -312,10 +312,10 @@ with Docker Inc.  Use 3rd party plugins at your own risk.
         "https://github.com/packethost/docker-machine-driver-packet">https://github.com/packethost/docker-machine-driver-packet</a>
       </td>
       <td>
-        <a href="https://github.com/crunchywelch">crunchywelch</a>
+        <a href="https://github.com/packethost">Packet, an Equinix Company</a>
       </td>
       <td>
-        <a href="mailto:welch@packet.net">welch@packet.net</a>
+        <a href="mailto:support@packet.com">support@packet.com</a>
       </td>
     </tr>
     <tr>

--- a/machine/drivers/index.md
+++ b/machine/drivers/index.md
@@ -25,3 +25,4 @@ hide_from_sitemap: true
 -   [Scaleway](https://github.com/scaleway/docker-machine-driver-scaleway) (unofficial plugin, not supported by Docker)
 -   [Hetzner Cloud](https://github.com/JonasProgrammer/docker-machine-driver-hetzner) (unofficial plugin, not supported by Docker)
 -   [ArvanCloud](https://github.com/satrobit/docker-machine-driver-arvan) (unofficial plugin, not supported by Docker)
+-   [Packet](https://github.com/packethost/docker-machine-driver-packet) (unofficial plugin, not supported by Docker)


### PR DESCRIPTION
Adds a link to the Packet docker machine driver:
<https://github.com/packethost/docker-machine-driver-packet>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
