### PR TITLE
Update pricing FAQ URLs

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1226,8 +1226,6 @@ manuals:
       title: Add seats
     - path: /docker-hub/billing/remove-seats/
       title: Remove seats
-    - path: /docker-hub/billing/faq/
-      title: Billing FAQ
   - path: /docker-hub/orgs/
     title: Teams and organizations
   - path: /docker-hub/repos/

--- a/docker-hub/billing/downgrade.md
+++ b/docker-hub/billing/downgrade.md
@@ -17,7 +17,7 @@ The following sections contain instructions on how to downgrade from Pro and Tea
 >**Note:**
 >
 > - It is not possible to offer prorated refunds when you downgrade an annual plan that’s already paid for and is still active. After you have downgraded, you can choose to reinstate your annual plan if it hasn't expired.
-> - Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+> - Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 {: .important }
 
 To downgrade from a Pro plan to a Free plan:
@@ -45,7 +45,7 @@ To downgrade from a Pro plan to a Free plan:
 >**Note:**
 >
 > - It is not possible to offer prorated refunds when you downgrade an annual plan that’s already paid for and is still active. After you have downgraded, you can choose to reinstate your annual plan if it hasn't expired.
-> - Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+> - Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 {: .important }
 
 To downgrade to a Free Team plan from a Team plan:

--- a/docker-hub/billing/faq.md
+++ b/docker-hub/billing/faq.md
@@ -20,7 +20,7 @@ Immediately available for **Individuals** and **Teams**:
 
 ### How can I compare which features are in each plan?
 
-You can see pricing and a full list of features for each product at [Docker Hub pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+You can see pricing and a full list of features for each product at [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 
 ### What is the difference between a legacy plan and these new announced plans?
 
@@ -64,13 +64,13 @@ When you downgrade your existing plan, changes are applied at the end of your bi
 
 ### How do I downgrade from a Team plan to a Free plan?
 
-Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 
 For information on how to downgrade from a Team plan to a Free plan, see [Downgrade from Team to a Free plan](/downgrade.md#downgrade-from-team-to-a-free-plan).
 
 ### How do I downgrade from Pro to a Free plan?
 
-Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 
 For information on how to downgrade from Pro to a Free plan, see [Downgrade from Pro to a Free plan](/downgrade.md#downgrade-from-pro-to-a-free-plan).
 
@@ -92,7 +92,7 @@ For information on how to add a member to a team, see [Add a member to a team](.
 
 Yes, both the Pro and Team plans are available through annual subscriptions and include a discount from the monthly subscription price.
 
-You can view the annual subscription pricing for each product at [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+You can view the annual subscription pricing for each product at [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 
 ### Are legacy plans eligible for annual pricing?
 

--- a/docker-hub/billing/index.md
+++ b/docker-hub/billing/index.md
@@ -2,6 +2,8 @@
 description: Docker Billing overview
 keywords: Docker, pricing, billing, Pro, Team, subscription, plans,
 title: Docker Billing overview
+redirect_from:
+- /docker-hub/billing/faq/
 ---
 
 On May 14, 2020, Docker announced a new, per-seat pricing model that aligns with Docker’s [product strategy](https://www.docker.com/blog/docker-strategy-helping-devs-build-and-ship-faster/){: target="_blank" class="_"} to accelerate developer workflows for cloud-native development. The previous private repository/parallel autobuild-based plans have been replaced with new **Pro** and **Team** plans that include unlimited private repositories.
@@ -24,9 +26,9 @@ The **Team** plan includes unlimited public and unlimited private repositories s
 
 The **Free Team** plan includes unlimited public repositories at no cost per month. This plan also offers advanced collaboration and management tools, including organization and team management with role-based access controls which are limited to 1 team and 3 team members.
 
-For detailed information about the features available in each plan, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+For detailed information about the features available in each plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 
-For frequently asked questions about pricing, see [Docker billing FAQ](faq.md).
+For frequently asked questions about pricing, see [Docker pricing FAQ](https://www.docker.com/pricing/faq){: target="_blank" class="_"}.
 
 ### Purchase a Pro plan
 

--- a/docker-hub/billing/upgrade.md
+++ b/docker-hub/billing/upgrade.md
@@ -6,7 +6,7 @@ redirect_from:
 - /docker-hub/upgrade/
 ---
 
-You can upgrade to a Pro or a Team plan from a Free plan, or from your current legacy plan. When you upgrade to a Pro or a Team plan, you will be able to immediately use all the features and entitlements offered in your new plan. For detailed information on features available in each plan, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+You can upgrade to a Pro or a Team plan from a Free plan, or from your current legacy plan. When you upgrade to a Pro or a Team plan, you will be able to immediately use all the features and entitlements offered in your new plan. For detailed information on features available in each plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 
 >**Note:**
 >

--- a/docker-hub/convert-account.md
+++ b/docker-hub/convert-account.md
@@ -46,7 +46,7 @@ Before you convert a user account to an organization, ensure that you have compl
 >
 > When you convert a Pro or a legacy individual repository plan to an organization, the account
 will be migrated to a Team plan and will be charged $35 per month for 5 seats. For more information,
-see [Docker Hub Pricing](https://hub.docker.com/pricing).
+see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
 
 1. Ensure you have removed your user account from all teams and organizations and that you have a new Docker ID before you convert an account. See the [Prerequisites](#prerequisites) section for details.
 


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Updated the Pricing FAQ URLs to point to WWW page.
Added a redirect from the docs FAQ page to the index page
Updated 'Docker Hub pricing' references to 'Docker pricing' for consistency.

The FAQ page itself hasn't been deleted in case we want to repurpose this in future.