### PR TITLE
btrfs-driver.md: remove unneeded use of sudo and cat

### DIFF
--- a/storage/storagedriver/btrfs-driver.md
+++ b/storage/storagedriver/btrfs-driver.md
@@ -42,7 +42,7 @@ Btrfs Filesystem as Btrfs.
   command:
 
   ```bash
-  $ sudo cat /proc/filesystems | grep btrfs
+  $ grep btrfs /proc/filesystems
 
   btrfs
   ```


### PR DESCRIPTION
### Proposed changes

Remove unnecessary use of `sudo` and `cat` commands.