### PR TITLE
TYPO: "daemon reload" should be "daemon-reload"

### DIFF
--- a/machine/drivers/generic.md
+++ b/machine/drivers/generic.md
@@ -69,6 +69,6 @@ docker-machine.  Make sure you don't have any other configuration files in this 
 that override the [ExecStart] setting.
 
 Once you have confirmed any conflicting settings have been removed, run
-`sudo systemctl daemon reload` followed by `sudo systemctl restart docker`
+`sudo systemctl daemon-reload` followed by `sudo systemctl restart docker`
 
 


### PR DESCRIPTION
### Proposed changes

Changed `systemctl daemon reload` to `systemctl daemon-reload` (note the hyphen).