### PR TITLE
Add missing image to `docker run` GPU example command

### DIFF
--- a/config/containers/resource_constraints.md
+++ b/config/containers/resource_constraints.md
@@ -327,7 +327,7 @@ $ docker run -it --rm --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a ubu
 Exposes that specific GPU.
 
 ```bash
-$ docker run -it --rm --gpus device=0,2 nvidia-smi
+$ docker run -it --rm --gpus device=0,2 ubuntu nvidia-smi
 ```
 
 Exposes the first and third GPUs.


### PR DESCRIPTION
### Proposed changes

Hey team- just noticed that one of the example commands in [`resource_constraints.md`](https://github.com/docker/docker.github.io/blob/master/config/containers/resource_constraints.md) is missing the image (namely `ubuntu`). This PR simply corrects the example command.