### PR TITLE
Update example to use newer Ubuntu LTS

### DIFF
--- a/engine/examples/running_ssh_service.md
+++ b/engine/examples/running_ssh_service.md
@@ -20,7 +20,7 @@ quick access to a test container. Make the following substitutions:
 - With `RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config`, use `without-password` instead of `prohibit-password` for Ubuntu 14.04.
 
 ```dockerfile
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd


### PR DESCRIPTION
### Proposed changes

Update example to use newer LTS release of Ubuntu image. 
I've tested running the Dockerfile with the updated ubuntu LTS (20.04) and the example still works.

### Related issues (optional)

Closes #11252 
