### PR TITLE
Remove Mutagen doc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1160,8 +1160,6 @@ manuals:
       title: Stable release notes
     - path: /docker-for-mac/edge-release-notes/
       title: Edge release notes
-    - path: /docker-for-mac/mutagen/
-      title: File synchronization
   - sectiontitle: Windows
     section:
     - path: /docker-for-windows/install/

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -11,6 +11,7 @@ redirect_from:
 - /engine/installation/mac/
 - /docker-for-mac/index/
 - /docker-for-mac/osx/
+- /docker-for-mac/mutagen/
 title: Docker Desktop for Mac user manual
 toc_min: 1
 toc_max: 2


### PR DESCRIPTION
Removing the Mutagen topic from the docs as the feature has been removed from Docker Desktop Edge 2.3.5.0.