### PR TITLE
Typo in command.

### DIFF
--- a/network/network-tutorial-standalone.md
+++ b/network/network-tutorial-standalone.md
@@ -304,7 +304,7 @@ connected to both networks.
 
     $ docker run -dit --name alpine3 alpine ash
 
-    $ docker run -dit --name alpine4 --network alpine-net alpine ash
+    $ docker run -dit --name alpine4 alpine ash
 
     $ docker network connect bridge alpine4
     ```


### PR DESCRIPTION
Because alpine4 is shown as in bridge network. the `--network alpine-net` shouldn't be used with it.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
