### PR TITLE
Update Docker Desktop release notes for 2.3.6.1

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -22,7 +22,7 @@ For information about Stable releases, see the [Stable release notes](release-no
 
 ### Bug fixes and minor changes
 
--  Docker Desktop now correctly displays the default state of "Use gRPC FUSE for file sharing" in the UI.
+-  Docker Desktop now correctly displays the state of "Use gRPC FUSE for file sharing" in the UI.
 
 ## Docker Desktop Community 2.3.6.0
 2020-09-01

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -11,6 +11,15 @@ This page contains information about Docker Desktop Edge releases. Edge releases
 For information about Stable releases, see the [Stable release notes](release-notes.md). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
+## Docker Desktop Community 2.3.6.1
+2020-09-07
+
+> [Download](https://desktop.docker.com/mac/edge/47757/Docker.dmg)
+
+### Bug fixes and minor changes
+
+-  Docker Desktop now correctly displays the default state of "Use gRPC FUSE for file sharing" in the UI.
+
 ## Docker Desktop Community 2.3.6.0
 2020-09-01
 

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -12,9 +12,13 @@ For information about Stable releases, see the [Stable release notes](release-no
 [What to know before you install](install.md#what-to-know-before-you-install).
 
 ## Docker Desktop Community 2.3.6.1
-2020-09-07
+2020-09-08
 
-> [Download](https://desktop.docker.com/mac/edge/47757/Docker.dmg)
+> [Download](https://desktop.docker.com/mac/edge/47792/Docker.dmg)
+
+### Upgrades
+
+- [Docker Compose 1.27.0](https://github.com/docker/compose/releases/tag/1.27.0)
 
 ### Bug fixes and minor changes
 

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -11,6 +11,15 @@ This page contains information about Docker Desktop Edge releases. Edge releases
 For information about Stable releases, see the [Stable release notes](release-notes.md). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
+## Docker Desktop Community 2.3.6.1
+2020-09-07
+
+> [Download](https://desktop.docker.com/win/edge/47757/Docker%20Desktop%20Installer.exe)
+
+### Bug fixes and minor changes
+
+- Fixed an issue with mount shadowing in WSL 2. See [docker/for-win#8183](https://github.com/docker/for-win/issues/8183) and [docker/for-win#8316](https://github.com/docker/for-win/issues/8316).
+
 ## Docker Desktop Community 2.3.6.0
 2020-09-01
 

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -12,9 +12,13 @@ For information about Stable releases, see the [Stable release notes](release-no
 [What to know before you install](install.md#what-to-know-before-you-install).
 
 ## Docker Desktop Community 2.3.6.1
-2020-09-07
+2020-09-08
 
-> [Download](https://desktop.docker.com/win/edge/47757/Docker%20Desktop%20Installer.exe)
+> [Download](https://desktop.docker.com/win/edge/47792/Docker%20Desktop%20Installer.exe)
+
+### Upgrades
+
+- [Docker Compose 1.27.0](https://github.com/docker/compose/releases/tag/1.27.0)
 
 ### Bug fixes and minor changes
 


### PR DESCRIPTION
## Proposed changes

We're about to release an edge version of Desktop: 2.3.6.1

