### PR TITLE
Add reference to docker/for-mac#4864 in release notes

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -22,7 +22,7 @@ For information about Stable releases, see the [Stable release notes](release-no
 
 ### Bug fixes and minor changes
 
--  Docker Desktop now correctly displays the state of "Use gRPC FUSE for file sharing" in the UI.
+-  Docker Desktop now correctly displays the state of "Use gRPC FUSE for file sharing" in the UI. Fixes [docker/for-mac#4864](https://github.com/docker/for-mac/issues/4864).
 
 ## Docker Desktop Community 2.3.6.0
 2020-09-01


### PR DESCRIPTION
### Proposed changes

Add a missing link to a docker/for-mac issue in a release note.

