### PR TITLE
fix the background color of the sidebar on 'medium' sized devices

### DIFF
--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -61,6 +61,7 @@
         position: fixed;
         width: 100%;
         z-index: 100;
+        background-color: $bg-sidebar;
     }
     .main-content {
         padding: 22px 35px 25px 30px;
@@ -117,16 +118,10 @@
     .header {
         height: 100px;
     }
-    .nav-secondary-tabs,
-    .nav-secondary {
-        background-color: $black;
-    }
-    .nav-secondary input[type=search] {
-        background: rgb(78, 77, 77) url(/images/search.png) no-repeat 10px 9px;
-    }
+    /*.nav-secondary-tabs,
     .nav-sidebar a {
         color: #a8a8a8;
-    }
+    }*/
     .tabs {
         float: left;
         margin: 0;
@@ -147,8 +142,8 @@
     }
     .sidebar,
     .sidebar-home {
-        background-color: #15212e;
-        border-right: 1px solid rgba(204,204,204,0.29);
+        background-color: $bg-sidebar;
+        /*border-right: 1px solid rgba(204,204,204,0.29);*/
         top: 51px;
         left: 0;
         display: block;
@@ -246,13 +241,12 @@
     .main-content {
         padding: 0 10px;
     }
-    .nav-sidebar a {
+    /*.nav-sidebar a {
         color: #a8a8a8;
-    }
+    }*/
     .sidebar,
     .sidebar-home {
-        background-color: #15212e;
-        border-right: 1px solid rgba(204,204,204,0.29);
+        background-color: $bg-sidebar;
         top: 51px;
         left: 0;
         display: block;

--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -231,10 +231,6 @@
     .nav-secondary-tabs {
         height: 100px;
     }
-    .nav-secondary {
-        background: $bg-sidebar;
-        height: 100px;
-    }
     .content {
         padding: 120px 20px;
     }

--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -310,6 +310,9 @@
     .toc-nav a {
         font-size: 11px;
     }
+    .sidebar {
+        background-color: $bg-sidebar;
+    }
 }
 
 /* Portrait */

--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -232,7 +232,7 @@
         height: 100px;
     }
     .nav-secondary {
-        background: $black;
+        background: $bg-sidebar;
         height: 100px;
     }
     .content {
@@ -309,16 +309,6 @@
     }
 }
 
-/* Portrait */
-@media only screen
-  and (min-device-width: 768px)
-  and (max-device-width: 1024px)
-  and (orientation: portrait) {
-    .nav-secondary input[type=search] {
-        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px;
-    }
-}
-
 /* Landscape */
 @media only screen
   and (min-device-width: 768px)
@@ -333,9 +323,6 @@
 
     .sidebar, .sidebar.affix {
         width: 270px;
-    }
-    .nav-secondary input[type=search] {
-        background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px;
     }
 }
 
@@ -355,8 +342,8 @@
 
 @media (max-width: 1024px) {
     .nav-secondary-tabs.affix-top {
-        // background-color: $bg-secondary;
-        background-color: rgba(0,0,0,.05);
+        /*background-color: $bg-secondary;
+        background-color: rgba(0,0,0,.05); */
         position: fixed;
         top: 0;
     }

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -55,6 +55,7 @@ body.night {
     .nav-secondary .search-form input[type=search]:focus {
         background: rgba(255, 255, 255, 0.17) url(/images/search.png) no-repeat 10px 9px !important;
     }
+    .sidebar,
     .sidebar-home,
     #sidebar-wrapper,
     #sidebar-wrapper-home,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
This fixes #11366 by adding the background color for the correct class name. It
seems that `.sidebar-home` used to be used a lot, but I couldn't find its usage
anywhere (when loading up the docs app), so I stuck to using `.sidebar`, which
seemed to work :smile:


### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Fixes #11366

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
