### PR TITLE
Clarify the min WSL 2 Windows OS version 2004 for Stable and 1903 for Edge

### DIFF
--- a/docker-for-windows/install-windows-home.md
+++ b/docker-for-windows/install-windows-home.md
@@ -33,7 +33,7 @@ For detailed information about WSL 2, see [Docker Desktop WSL 2 backend](wsl.md)
 
 Windows 10 Home machines must meet the following requirements to install Docker Desktop:
 
-  - Install Windows 10, version 1903 or higher.
+  - Install Windows 10, version 2004 or higher. The Docker Desktop Edge release also supports Windows 10, version 1903 or higher.
   - Enable the WSL 2 feature on Windows. For detailed instructions, refer to the
     [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
   - The following hardware prerequisites are required to successfully run

--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -18,7 +18,7 @@ Additionally, with WSL 2, the time required to start a Docker daemon after a col
 
 Before you install the Docker Desktop WSL 2 backend, you must complete the following steps:
 
-1. Install Windows 10, version 1903 or higher.
+1. Install Windows 10, version 2004 or higher. The Docker Desktop Edge release also supports Windows 10, version 1903 or higher.
 2. Enable WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 3. Download and install the [Linux kernel update package](https://docs.microsoft.com/windows/wsl/wsl2-kernel).
 


### PR DESCRIPTION
### Proposed changes

This PR clarifies that only the Edge release of Docker Desktop supports WSL 2 on Windows 10, version 1903 or higher.
Regression of #11374 where we just reduced the OS version number from 2004 to 1903. 

Can be reverted once we have Stable 2.4 released. 

### Unreleased project version (optional)

### Related issues (optional)

https://github.com/docker/for-win/issues/8549
