### PR TITLE
Add missing external flag indicator in secrets

### DIFF
--- a/engine/context/ecs-integration.md
+++ b/engine/context/ecs-integration.md
@@ -141,6 +141,7 @@ services:
 secrets:
   foo:
     name: "arn:aws:secretsmanager:eu-west-3:1234:secret:foo-ABC123"
+    external: true
 ```
 
 Secrets will be available at runtime for your service as a plain text file `/run/secrets/foo`.


### PR DESCRIPTION
### Proposed changes

This is required otherwise it tries to read a non-existing file and should make it clear for anyone following along

### Related issues (optional)

None
