### PR TITLE
bind-mounts.md: source (host) path must be absolute

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -9,7 +9,7 @@ redirect_from:
 Bind mounts have been around since the early days of Docker. Bind mounts have
 limited functionality compared to [volumes](volumes.md). When you use a bind
 mount, a file or directory on the _host machine_ is mounted into a container.
-The file or directory is referenced by its full or relative path on the host
+The file or directory is referenced by its absolute path on the host
 machine. By contrast, when you use a volume, a new directory is created within
 Docker's storage directory on the host machine, and Docker manages that
 directory's contents.


### PR DESCRIPTION
The source path on the host system must be absolute. Using a relative path results in an error, e.g.

```
$ docker run -it -v ./sourcedir:/targetdir alpine
docker: Error response from daemon: create ./sourcedir: "./sourcedir" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```