### PR TITLE
Incorrect minimum required version.

### DIFF
--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -43,7 +43,7 @@ To verify your machine meets these requirements, do the following:
   operating system.
 
     If you have a newer system, specifically 64bit Windows 10 Pro, with
-    Enterprise and Education (1607 Anniversary update, Build 14393 or later),
+    Enterprise and Education (1607 Anniversary update, Build 15063 or later),
     consider using [Docker Desktop for Windows](/docker-for-windows) instead. It runs
     natively on the Windows, so there is no need for a pre-configured Docker
     QuickStart shell. It also uses Hyper-V for virtualization, so the

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -42,8 +42,7 @@ To verify your machine meets these requirements, do the following:
     If you aren't using a supported version, you could consider upgrading your
   operating system.
 
-    If you have a newer system, specifically 64bit Windows 10 Pro, with
-    Enterprise and Education (1607 Anniversary update, Build 15063 or later),
+    If you have a recent version of Windows,
     consider using [Docker Desktop for Windows](/docker-for-windows) instead. It runs
     natively on the Windows, so there is no need for a pre-configured Docker
     QuickStart shell. It also uses Hyper-V for virtualization, so the


### PR DESCRIPTION
Tried installing Docker Desktop on Windows Server 2016 build 14393 and got the error: Docker Desktop requires Windows 10 Pro/Enterprise (15063+) or Windows 10 home (19018+)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
