### PR TITLE
Docker Desktop release notes: add clock_gettime64 known issue

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -36,6 +36,11 @@ For information about Stable releases, see the [Stable release notes](release-no
 - Avoid exposing `/host_mnt` paths in `docker container inspect` and `docker volume inspect`. Fixes [docker/for-mac#4859](https://github.com/docker/for-mac/issues/4859).
 - Fixed container logs lagging under heavy load. See [docker/for-win#8216](https://github.com/docker/for-win/issues/8216).
 
+### Known issues
+
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+
+
 ## Docker Desktop Community 2.3.6.1
 2020-09-08
 

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -38,7 +38,9 @@ For information about Stable releases, see the [Stable release notes](release-no
 
 ### Known issues
 
-- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS`
+in i386 images. To work around this issue, disable `seccomp` by using 
+the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
 
 
 ## Docker Desktop Community 2.3.6.1

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -28,6 +28,10 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 ### Bug fixes and minor changes
   - Fixed automatic start on log in. See [docker/for-mac#4877](https://github.com/docker/for-mac/issues/4877) and [docker/for-mac#4890](https://github.com/docker/for-mac/issues/4890)
 
+### Known issues
+
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+
 ## Docker Desktop Community 2.3.0.4
 2020-07-27
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -30,7 +30,9 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 
 ### Known issues
 
-- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` 
+in i386 images. To work around this issue, disable `seccomp` by using 
+the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
 
 ## Docker Desktop Community 2.3.0.4
 2020-07-27

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -41,6 +41,10 @@ For information about Stable releases, see the [Stable release notes](release-no
 - Avoid exposing `/host_mnt` paths in `docker container inspect` and `docker volume inspect`. Fixes [docker/for-mac#4859](https://github.com/docker/for-mac/issues/4859).
 - Fixed container logs lagging under heavy load. See [docker/for-win#8216](https://github.com/docker/for-win/issues/8216).
 
+### Known issues
+
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+
 ## Docker Desktop Community 2.3.6.2
 2020-09-09
 

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -43,7 +43,9 @@ For information about Stable releases, see the [Stable release notes](release-no
 
 ### Known issues
 
-- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` 
+in i386 images. To work around this issue, disable `seccomp` by using 
+the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
 
 ## Docker Desktop Community 2.3.6.2
 2020-09-09

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -28,6 +28,10 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 ### Bug fixes and minor changes
   - WSL2: Fixed a crash when using an incompatible glibc. See [docker/for-win#8183](https://github.com/docker/for-win/issues/8183).
 
+### Known issues
+
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+
 ## Docker Desktop Community 2.3.0.4
 2020-07-27
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -30,7 +30,9 @@ For information about Edge releases, see the [Edge release notes](edge-release-n
 
 ### Known issues
 
-- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` in i386 images. The workaround is to disable `seccomp` by using the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
+- The `clock_gettime64` system call returns `EPERM` rather than `ENOSYS` 
+in i386 images. To work around this issue, disable `seccomp` by using 
+the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for-win/issues/8326).
 
 ## Docker Desktop Community 2.3.0.4
 2020-07-27


### PR DESCRIPTION
### Proposed changes

Added a known issue to Docker Desktop Mac and Windows, Stable and Edge.

### Related issues (optional)

See https://github.com/docker/for-win/issues/8326

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
