### PR TITLE
Doc bug fixing - wrong link in ecs-integration.md

### DIFF
--- a/engine/context/ecs-integration.md
+++ b/engine/context/ecs-integration.md
@@ -86,7 +86,7 @@ using the `docker compose logs` command.
 
 ## Private Docker images
 
-The Docker ECS integration automatically configures authorization so you can pull private images from the Amazon ECR registry on the same AWS account. To pull private images from another registry, including Docker Hub, you’ll have to create a Username + Password (or a Username + Token) secret on the [Amazon SSM service](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html){: target="_blank" class="_"}.
+The Docker ECS integration automatically configures authorization so you can pull private images from the Amazon ECR registry on the same AWS account. To pull private images from another registry, including Docker Hub, you’ll have to create a Username + Password (or a Username + Token) secret on the [AWS Secrets Manager service](https://docs.aws.amazon.com/secretsmanager/){: target="_blank" class="_"}.
 
 For your convenience, Docker ECS integration offers the `docker secret` command, so you can manage secrets created on AWS SMS without having to install the AWS CLI.
 


### PR DESCRIPTION
### Proposed changes

`docker secret` creates secrets in AWS Secrets Manager Service - not in AWS Systems Manager Parameter Store Service. Note the `arn:aws:secretsmanager:...` reference in the existing example.
