### PR TITLE
Use absolute URLs in sitemap.xml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ COPY --from=upstream-resources /usr/src/app/md_source/. ./
 # API docs, based on the latest_engine_api_version parameter in _config.yml
 RUN ./_scripts/update-api-toc.sh
 RUN jekyll build -d ${TARGET} \
- && find ${TARGET} -type f -name '*.html' | while read i; do sed -i 's#href="https://docs.docker.com/#href="/#g' "$i"; done
+ && find ${TARGET} -type f -name '*.html' | while read i; do sed -i 's#href="https://docs.docker.com/#href="/#g' "$i"; done \
+ && sed -i 's#<loc>/#<loc>https://docs.docker.com/#' "${TARGET}/sitemap.xml"
 
 
 # This stage only contains the generated files. It can be used to host the


### PR DESCRIPTION
We generate the website with relative URLs to allow hosting the content
on preview domains.

However, the sitemap.xml should always contain absolute URLs (including
the domain name).

I couldn't find a way to configure the sitemap URL's separately, so using
the same hack we use for stripping URL's in the HTML.

Before this, the sitemap.xml would contain;

    <url>
        <loc>/engine/reference/commandline/volume_prune/</loc>
    </url>

After this, the full URL is included

    <url>
        <loc>https://docs.docker.com/engine/reference/commandline/volume_prune/</loc>
    </url>


ping @usha-mandya ptal