### PR TITLE
Make the latest API reference page the canonical URL

### DIFF
--- a/_layouts/engine-api.html
+++ b/_layouts/engine-api.html
@@ -12,6 +12,8 @@
     <link rel="apple-touch-icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128" />
     <link rel="icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128" />
     <link rel="stylesheet" type="text/css" href="/css/api-reference.css" />
+    <!-- make the latest API version the canonical page as that's what we want users to be using mostly -->
+    <link rel="canonical" href="/engine/api/v{{ site.latest_engine_api_version }}/" />
 </head>
 <body>
 <redoc spec-url="/engine/api/{{ page.name | replace: '.md'}}.yaml" hide-hostname="true" suppress-warnings="true" lazy-rendering></redoc>


### PR DESCRIPTION
We host multiple versions of the API reference. While older versions of the
API are still supported by the latest engine release, users should generally
refer to the latest version of the API.

This patch adds a "canonical" meta-tag to the API reference pages, and points
it to the latest version of the API.

Note that there's also a /engine/api/latest/ page, but I didn't pick that
URL, because it's a redirect to `/engine/api/v<current>/`, which Google
probably doesn't like.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
