### PR TITLE
Fix url to upgrade dockerhub #11339

### DIFF
--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -168,5 +168,5 @@ Congratulations! You've successfully:
 - Create an [organization](orgs.md) to use Docker Hub with your team.
 - Automatically build container images from code through [builds](builds/index.md).
 - [Explore](https://hub.docker.com/explore) official & publisher images.
-- [Upgrade your plan](upgrade.md) to push additional private Docker images to
+- [Upgrade your plan](billing/upgrade.md) to push additional private Docker images to
 Docker Hub.


### PR DESCRIPTION
Signed-off-by: Maximillian Fan Xavier <maximillianfx@gmail.com>

Proposed changes
Update the DockerHub upgrade link to the correct page.

Related issues (optional)
Fixes #11339 
