### PR TITLE
Add indication to use docker create/run on port mapping #11420

### DIFF
--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -19,7 +19,11 @@ point of view of the container.
 
 ## Published ports
 
-By default, when you create/run a container using `docker create` or `docker run`, it does not publish any of its ports
+By default, when you create or run a container using `docker create` or `docker run`,
+it does not publish any of its ports to the outside world. To make a port available
+to services outside of Docker, or to Docker containers which are not connected to
+the container's network, use the `--publish` or `-p` flag. This creates a firewall
+rule which maps a container port to a port on the Docker host. Here are some examples.
 to the outside world. To make a port available to services outside of Docker, or
 to Docker containers which are not connected to the container's network, use the
 `--publish` or `-p` flag. This creates a firewall rule which maps a container

--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -19,7 +19,7 @@ point of view of the container.
 
 ## Published ports
 
-By default, when you create a container, it does not publish any of its ports
+By default, when you create/run a container using `docker create` or `docker run`, it does not publish any of its ports
 to the outside world. To make a port available to services outside of Docker, or
 to Docker containers which are not connected to the container's network, use the
 `--publish` or `-p` flag. This creates a firewall rule which maps a container


### PR DESCRIPTION
Signed-off-by: Maximillian Fan Xavier <maximillianfx@gmail.com>

Proposed changes
Add some extra info to documentation to indicate the use of docker run/create when executing port mapping.

Related issues (optional)
Fixes #11420 