### PR TITLE
Make first apt example follow all best practices

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -352,7 +352,8 @@ RUN apt-get update && apt-get install -y \
   cvs \
   git \
   mercurial \
-  subversion
+  subversion \
+  && rm -rf /var/lib/apt/lists/*
 ```
 
 ### Leverage build cache
@@ -482,7 +483,8 @@ statement. For example:
 RUN apt-get update && apt-get install -y \
     package-bar \
     package-baz \
-    package-foo
+    package-foo  \
+    && rm -rf /var/lib/apt/lists/*
 ```
 
 Using `apt-get update` alone in a `RUN` statement causes caching issues and


### PR DESCRIPTION
### Proposed changes

This is a bit of a draft, but I came across this issue in the documentation. When I searched for `docker apt-get` I found this page and copy-pasted the first example, but then I remembered it's best practice to install all packages at once and after that clear the `lists` to minimize the image size. Putting the example with all best practices first might help newer docker users to produce smaller images.

I'm not sure about the approach, perhaps I should just simply move the best example header to the top and leave the smaller examples alone.
