### PR TITLE
u with lsb_release gives upstream release codename

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -134,7 +134,7 @@ from the repository.
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=amd64] {{ download-url-base }} \
-       $(lsb_release -cs) \
+       $(lsb_release -cus) \
        stable"
     ```
 
@@ -144,7 +144,7 @@ from the repository.
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=armhf] {{ download-url-base }} \
-       $(lsb_release -cs) \
+       $(lsb_release -cus) \
        stable"
     ```
 
@@ -154,7 +154,7 @@ from the repository.
     ```bash
     $ sudo add-apt-repository \
        "deb [arch=arm64] {{ download-url-base }} \
-       $(lsb_release -cs) \
+       $(lsb_release -cus) \
        stable"
     ```
 


### PR DESCRIPTION
### Proposed changes

When adding repo using `add-apt-repository` on a flavour of Ubuntu, `lsb_release` will give you the flavour's codename instead of Ubuntu's. Adding `-u` flag gives you the upstream codename instead which is more helpful.
E.g. On Elementary OS Hera `lsb_release -cs` returns `hera` but `lsb_release -cus` returns `bionic`.
