### PR TITLE
Fixed error 'docker run' to 'docker build'

### DIFF
--- a/get-started/nodejs/build-images.md
+++ b/get-started/nodejs/build-images.md
@@ -79,7 +79,7 @@ Switch back to the terminal where our server is running. You should now see the 
 
 ## Create a Dockerfile for Node.js
 
-A Dockerfile is a text document that contains all the commands a user could call on the command line to assemble an image. When we tell Docker to build our image by executing the `docker run` command, Docker reads these instructions and executes them one by one and creates a Docker image as a result.
+A Dockerfile is a text document that contains all the commands a user could call on the command line to assemble an image. When we tell Docker to build our image by executing the `docker build` command, Docker reads these instructions and executes them one by one and creates a Docker image as a result.
 
 Let’s walk through the process of creating a Dockerfile for our application. In the root of your working directory, create a file named `Dockerfile` and open this file in your text editor.
 


### PR DESCRIPTION
### Proposed changes

Fixed an error in the documentation: https://github.com/docker/docker.github.io/blob/master/get-started/nodejs/build-images.md
Fixed the command from 'docker run' to 'docker build' under the section "Create a Dockerfile for Node.js"


### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
