### PR TITLE
Fix link to default capabilities

### DIFF
--- a/engine/security/index.md
+++ b/engine/security/index.md
@@ -193,7 +193,7 @@ to the host.
 This doesn't affect regular web apps, but reduces the vectors of attack by
 malicious users considerably. By default Docker
 drops all capabilities except [those
-needed](https://github.com/moby/moby/blob/master/oci/defaults.go#L14-L30),
+needed](https://github.com/moby/moby/blob/master/oci/caps/defaults.go#L6-L19),
 an allowlist instead of a denylist approach. You can see a full list of
 available capabilities in [Linux
 manpages](http://man7.org/linux/man-pages/man7/capabilities.7.html).


### PR DESCRIPTION
## Proposed changes

Fix link to default Docker capabilities. Old link pointed to a file that probably has been changed. New link points to the file in the source code where the default capabilities are listed.
