### PR TITLE
Remove duplicate sentences from Published ports section

### DIFF
--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -24,10 +24,7 @@ it does not publish any of its ports to the outside world. To make a port availa
 to services outside of Docker, or to Docker containers which are not connected to
 the container's network, use the `--publish` or `-p` flag. This creates a firewall
 rule which maps a container port to a port on the Docker host to the outside world.
-Here are some examples. To make a port available to services outside of Docker, or
-to Docker containers which are not connected to the container's network, use the
-`--publish` or `-p` flag. This creates a firewall rule which maps a container
-port to a port on the Docker host. Here are some examples.
+Here are some examples.
 
 | Flag value                      | Description                                                                                                                                     |
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Remove duplicate sentences from Published ports section

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
This PR aims to remove a couple of duplicated sentences in the Published ports section

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
