### PR TITLE
Add CentOS 8 support to official docs

### DIFF
--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -19,7 +19,7 @@ To get started with Docker Engine on CentOS, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need a maintained version of CentOS 7. Archived
+To install Docker Engine, you need a maintained version of CentOS 7/8. Archived
 versions aren't supported or tested.
 
 The `centos-extras` repository must be enabled. This repository is enabled by


### PR DESCRIPTION
Hi,

Since stable packages for CentOS 8 have been uploaded on official repository(https://download.docker.com/linux/centos/8/x86_64/stable/Packages/), we should add CentOS 8 to compatible operating systems

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added CentOS 8 as a compatible operating system

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
