### PR TITLE
Added label for menu toggle to improve site accessibility on screen readers

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -29,6 +29,6 @@
         </ul>
     </div>
     <div class="ctrl-right">
-        <a href="javascript:void(0)" id="menu-toggle"><i class="fa fa-indent" aria-hidden="true"></i></a>
+        <a href="javascript:void(0)" id="menu-toggle" aria-label="Current page's menu toggle"><i class="fa fa-indent" aria-hidden="true"></i></a>
     </div>
 </div>


### PR DESCRIPTION
The toggle button on the top right of the individual pages was flagged by [Google's lighthouse](https://developers.google.com/web/tools/lighthouse) as a sub-optimal component for users on screen readers. The exact flag was:

> Links do not have a discernible name
Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. Learn more.
Failing Elements
a#menu-toggle

To address this issue, I have added an [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) with the value "Current page's menu toggle", feel free to change it to a more suitable string as you see fit. 

**Here is a screenshot of the menu component I am speaking about:**

![The Toggle Menu](https://i.imgur.com/KvCeLxG.png)


This is the last of major the accessibility issues that were spotted on docker's documentation website. Thank you!