### PR TITLE
Update the Guides tab navigation

### DIFF
--- a/_includes/body-landing.html
+++ b/_includes/body-landing.html
@@ -28,7 +28,7 @@
             <a href="/">Home</a>
           </li>
           <li>
-            <a href="/get-started/">Guides</a>
+            <a href="/get-started/overview/">Guides</a>
           </li>
           <li>
             <a href="/engine/">Product manuals</a>
@@ -101,7 +101,7 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card guides" href="/get-started/">
+        <a class="card guides" href="/get-started/overview/">
           <h5 class="title">Guides</h5>
           <p>
             Learn how to set up your Docker environment and start containerizing


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Updated the Guides tab to point to Docker Overview, instead of Get started.