### PR TITLE
Document manually installing rootlesskit

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -173,6 +173,8 @@ extract `docker-rootless-extras-<version>.tgz`. The archive can be extracted
 under an arbitrary directory listed in the `$PATH`. For example, `/usr/local/bin`,
 or `$HOME/bin`.
 
+You will need to [install](https://github.com/rootless-containers/rootlesskit#setup) rootlesskit.
+
 ### Nightly channel
 
 To install a nightly version of the Rootless Docker, run the installation script


### PR DESCRIPTION
I'm assuming this is done in the install script, but if you're manually
installing the binaries you also need to manually install rootlesskit.
