### PR TITLE
Generate page title from H1 if needed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,9 +16,10 @@
           display: block;
       }
   </style>
-  {% if site.google_analytics != '' %}{% include analytics/google_analytics.html GOOGLE_ID=site.google_analytics %}{% endif %}
-  {% if site.GH_ENV == "gh_pages" %}
-  <meta name="robots" content="noindex">{% endif %}
+  {%- if site.google_analytics != '' -%}{%- include analytics/google_analytics.html GOOGLE_ID=site.google_analytics -%}{%- endif -%}
+  {%- if page.hide_from_sitemap or site.GH_ENV == "gh_pages" %}
+  <meta name="robots" content="noindex"/>
+  {%- endif %}
   <!-- favicon -->
   <link rel="icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">
   <meta name="msapplication-TileImage" content="/favicons/docs@2x.ico">
@@ -58,5 +59,4 @@
   <meta property="og:site_name" content="Docker Documentation" />
   <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
   <!-- END SEO STUFF -->
-  {% if page.hide_from_sitemap %}<meta name="robots" content="noindex" />{% endif %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,3 +1,19 @@
+{%- if page.title == nil -%}
+    {%- comment -%}
+    # This is a very hacky way to extract the page title from pages that do not have
+    # front-matter yaml, but have a H1 header. We need to take (id-) attributes into
+    # account, so some hacking is needed. Taking the following example:
+    # <h1 id="docker-run-reference">Docker run reference</h1>
+    #
+    # a. split on '<h1', which gives us ['content before', '<h1 id="docker-run-reference">Docker run reference</h1>']
+    # b. split the last element on '</h1', which gives us ['<h1 id="docker-run-reference">Docker run reference', '</h1', '>']
+    # c. split the first element on '>', which gives us ['<h1 id="docker-run-reference"', '>', 'Docker run reference']
+    {%- endcomment -%}
+    {%- assign a = content | split: '<h1' | last -%}
+    {%- assign b = a | split: '</h1' | first -%}
+    {%- assign c = b | split: '>' | last -%}
+    {%- assign page_title = c | strip_html | strip | truncatewords: 10 -%}
+{%- endif -%}
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <style type="text/css">
@@ -20,7 +36,7 @@
   {%- if page.hide_from_sitemap or site.GH_ENV == "gh_pages" %}
   <meta name="robots" content="noindex"/>
   {%- endif %}
-  <title>{{ page.title }} | Docker Documentation</title>
+  <title>{{ page.title | default: page_title }} | Docker Documentation</title>
   <meta name="description" content="{{ page.description }}" />
   <meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization{% endif %}">
   <link rel="canonical" href="{{ page.url }}" />
@@ -40,7 +56,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans">
 
   <!-- SEO stuff -->
-  <meta name="twitter:title" itemprop="title name" content="{{ page.title }}"/>
+  <meta name="twitter:title" itemprop="title name" content="{{ page.title | default: page_title }}"/>
   <meta name="twitter:description" property="og:description" itemprop="description" content="{{ content | strip_html | truncatewords: 30}}" />
   <meta name="twitter:card" content="summary"/>
   <meta name="twitter:domain" content="docs.docker.com"/>
@@ -48,7 +64,7 @@
   <meta name="twitter:url" content="https://twitter.com/docker_docs"/>
   <meta name="twitter:image:src" content="/images/docs@2x.png"/>
   <meta name="twitter:image:alt" content="Docker Documentation"/>
-  <meta property="og:title" content="{{ page.title }}" />
+  <meta property="og:title" content="{{ page.title | default: page_title }}" />
   <meta property="og:description" content="{{ page.description }}" />
   <meta property="og:type" content="website"/>
   <meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
@@ -57,6 +73,6 @@
   <meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
   <meta property="og:site_name" content="Docker Documentation" />
   <meta property="article:published_time" itemprop="datePublished" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
-  <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
+  <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title | default: page_title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
   <!-- END SEO STUFF -->
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,43 +20,43 @@
   {%- if page.hide_from_sitemap or site.GH_ENV == "gh_pages" %}
   <meta name="robots" content="noindex"/>
   {%- endif %}
+  <title>{{ page.title }} | Docker Documentation</title>
+  <meta name="description" content="{{ page.description }}" />
+  <meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization{% endif %}">
+  <link rel="canonical" href="{{ page.url }}" />
+
   <!-- favicon -->
   <link rel="icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">
-  <meta name="msapplication-TileImage" content="/favicons/docs@2x.ico">
   <link rel="apple-touch-icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">
+  <meta name="msapplication-TileImage" content="/favicons/docs@2x.ico">
   <meta property="og:image" content="/favicons/docs@2x.ico"/>
   <!-- metadata -->
-  <meta property="og:type" content="website"/>
-  <meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
-  <meta property="og:image" itemprop="image primaryImageOfPage" content="/images/docs@2x.png"/>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/font-awesome.min.css">
+  <link rel="stylesheet" href="/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/css/pygments/perldoc.css" id="pygments">
+  <link rel="stylesheet" href="/css/style.css" id="pagestyle">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans">
+
+  <!-- SEO stuff -->
+  <meta name="twitter:title" itemprop="title name" content="{{ page.title }}"/>
+  <meta name="twitter:description" property="og:description" itemprop="description" content="{{ content | strip_html | truncatewords: 30}}" />
   <meta name="twitter:card" content="summary"/>
   <meta name="twitter:domain" content="docs.docker.com"/>
   <meta name="twitter:site" content="@docker_docs"/>
   <meta name="twitter:url" content="https://twitter.com/docker_docs"/>
-  <meta name="twitter:title" itemprop="title name" content="{{ page.title }}"/>
-  <meta name="twitter:description" property="og:description" itemprop="description" content="{{ content | strip_html | truncatewords: 30}}" />
   <meta name="twitter:image:src" content="/images/docs@2x.png"/>
   <meta name="twitter:image:alt" content="Docker Documentation"/>
-  <meta property="article:published_time" itemprop="datePublished" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
-
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization{% endif %}">
-  <link rel="stylesheet" href="/css/font-awesome.min.css">
-  <link rel="stylesheet" href="/css/bootstrap.min.css">
-  <link id="pygments" rel="stylesheet" href="/css/pygments/perldoc.css">
-  <link id="pagestyle" rel="stylesheet" href="/css/style.css">
-
-  <!-- Go get "Open Sans" font from Google -->
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-  <!-- SEO stuff -->
-  <title>{{ page.title }} | Docker Documentation</title>
   <meta property="og:title" content="{{ page.title }}" />
-  <meta property="og:locale" content="en_US" />
-  <meta name="description" content="{{ page.description }}" />
   <meta property="og:description" content="{{ page.description }}" />
-  <link rel="canonical" href="{{ page.url }}" />
+  <meta property="og:type" content="website"/>
+  <meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
+  <meta property="og:image" itemprop="image primaryImageOfPage" content="/images/docs@2x.png"/>
+  <meta property="og:locale" content="en_US" />
   <meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
   <meta property="og:site_name" content="Docker Documentation" />
+  <meta property="article:published_time" itemprop="datePublished" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
   <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
   <!-- END SEO STUFF -->
 </head>


### PR DESCRIPTION
This is a very hacky way to extract the page title from pages that do not have
front-matter yaml, but have a H1 header. We need to take (id-) attributes into
account, so some hacking is needed.

Note that there's also a Jekyll plugin that features similar functionality, but
it requires additional dependencies, and we only have a few pages that need
this, so for now using this hack.

First two commits are some basic cleaning up