### PR TITLE
Fix missing descriptions

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,16 @@
     {%- assign c = b | split: '>' | last -%}
     {%- assign page_title = c | strip_html | strip | truncatewords: 10 -%}
 {%- endif -%}
+{%- if page.description == nil and page.datafile != nil and page.datafile != '' -%}
+    {%- assign yaml_data = site.data[page.datafolder][page.datafile] -%}
+    {%- if yaml_data.long and yaml_data.long != '' -%}
+        {%- assign page_description = page.title | append: ': ' | append: yaml_data.long | strip_html | strip | truncatewords: 30 -%}
+    {%- elsif yaml_data.short and yaml_data.short != '' -%}
+        {%- assign page_description = page.title | append: ': ' | append: yaml_data.short | strip_html | strip | truncatewords: 30 -%}
+    {%- else -%}
+        {%- assign page_description = content | strip_html | strip | truncatewords: 30 -%}
+    {%- endif -%}
+{%- endif -%}
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <style type="text/css">
@@ -37,7 +47,7 @@
   <meta name="robots" content="noindex"/>
   {%- endif %}
   <title>{{ page.title | default: page_title }} | Docker Documentation</title>
-  <meta name="description" content="{{ page.description }}" />
+  <meta name="description" content="{{ page.description | default: page_description }}" />
   <meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization{% endif %}">
   <link rel="canonical" href="{{ page.url }}" />
 
@@ -57,7 +67,7 @@
 
   <!-- SEO stuff -->
   <meta name="twitter:title" itemprop="title name" content="{{ page.title | default: page_title }}"/>
-  <meta name="twitter:description" property="og:description" itemprop="description" content="{{ content | strip_html | truncatewords: 30}}" />
+  <meta name="twitter:description" property="og:description" itemprop="description" content="{{ page_description }}" />
   <meta name="twitter:card" content="summary"/>
   <meta name="twitter:domain" content="docs.docker.com"/>
   <meta name="twitter:site" content="@docker_docs"/>
@@ -65,7 +75,7 @@
   <meta name="twitter:image:src" content="/images/docs@2x.png"/>
   <meta name="twitter:image:alt" content="Docker Documentation"/>
   <meta property="og:title" content="{{ page.title | default: page_title }}" />
-  <meta property="og:description" content="{{ page.description }}" />
+  <meta property="og:description" content="{{ page.description | default: page_description }}" />
   <meta property="og:type" content="website"/>
   <meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
   <meta property="og:image" itemprop="image primaryImageOfPage" content="/images/docs@2x.png"/>
@@ -73,6 +83,6 @@
   <meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
   <meta property="og:site_name" content="Docker Documentation" />
   <meta property="article:published_time" itemprop="datePublished" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
-  <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title | default: page_title }}","description":"{{ page.description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
+  <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title | default: page_title }}","description":"{{ page.description | default: page_description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
   <!-- END SEO STUFF -->
 </head>

--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -1,5 +1,6 @@
 ---
 title: Examples using the Docker Engine SDKs and Docker API
+description: Examples on how to perform a given Docker operation using the Go and Python SDKs and the HTTP API using curl.
 keywords: developing, api, sdk, developers, rest, curl, python, go
 redirect_from:
 - /engine/api/getting-started/

--- a/reference/index.md
+++ b/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference documentation
+description: This section includes the reference documentation for the Docker platform’s various APIs, CLIs, and file formats.
 notoc: true
 ---
 

--- a/samples/index.md
+++ b/samples/index.md
@@ -1,5 +1,6 @@
 ---
 title: Samples
+description: Learn how to develop and ship containerized applications, by walking through samples that exhibits canonical practices.
 ---
 
 {% assign labsbase = "https://github.com/docker/labs/tree/master" %}


### PR DESCRIPTION
follow-up to https://github.com/docker/docker.github.io/pull/11488

- Add missing descriptions, and move reference index page
- _includes/head.html: generate description for reference pages
  This generates a description for pages that don't have one;
    - for reference docs, try the "long" description
    - fallback to "short" description
    - finally, fallback to taking the first 30 words from the page content