### PR TITLE
_includes/head.html: remove unused ng-cloak styles

### DIFF
--- a/_includes/body-landing.html
+++ b/_includes/body-landing.html
@@ -1,4 +1,4 @@
-<body ng-app="Docker" ng-controller="DockerController" id="landing" class="landing">
+<body id="landing" class="landing">
   <nav class="navbar header">
     <div class="container">
       <div class="navbar-header">

--- a/_includes/body.html
+++ b/_includes/body.html
@@ -3,7 +3,7 @@
 {%- else -%}
     {%- assign edit_url = "https://github.com/docker/docker.github.io/edit/master/" | append: page.path -%}
 {%- endif -%}
-<body ng-app="Docker" ng-controller="DockerController" class="colums">
+<body class="colums">
     <header>
         {% include header.html %}
     </header>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,22 +26,6 @@
 {%- endif -%}
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <style type="text/css">
-      @charset "UTF-8";
-      [ng\:cloak],
-      [ng-cloak],
-      [data-ng-cloak],
-      [x-ng-cloak],
-      .ng-cloak,
-      .x-ng-cloak,
-      .ng-hide:not(.ng-hide-animate) {
-          display: none !important;
-      }
-
-      ng\:form {
-          display: block;
-      }
-  </style>
   {%- if site.google_analytics != '' -%}{%- include analytics/google_analytics.html GOOGLE_ID=site.google_analytics -%}{%- endif -%}
   {%- if page.hide_from_sitemap or site.GH_ENV == "gh_pages" %}
   <meta name="robots" content="noindex"/>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -4,7 +4,7 @@
     </a>
 </div>
 <div class="search-form" id="search-div">
-    <form class="search-form form-inline ng-pristine ng-valid" id="searchForm" action="/search/">
+    <form class="search-form form-inline" id="searchForm" action="/search/">
         <input class="search-field form-control ds-input" id="st-search-input" value="" name="q" placeholder="Search the docs" type="search" autocomplete="off" spellcheck="false" dir="auto" style="position: relative; vertical-align: top;">
         <div id="autocompleteContainer">
             <div id="autocompleteResults"></div>


### PR DESCRIPTION
These styles seem to be used when using AngularJS;
https://docs.angularjs.org/api/ng/directive/ngCloak

> The ngCloak directive is used to prevent the AngularJS html template from
> being briefly displayed by the browser in its raw (uncompiled) form while
> your application is loading. Use this directive to avoid the undesirable
> flicker effect caused by the html template display.

And I don't think that's used anywhere currently, so let's remove

