### PR TITLE
Fix header link to Guides

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -4,7 +4,7 @@ horizontalnav:
   path: /
   node: home
 - title: Guides
-  path: /get-started/
+  path: /get-started/overview/
   node: guides
 - title: Product manuals
   path: /engine/


### PR DESCRIPTION
This link was changed for the landing page in 49a964493882d0e01c4eaf5debdaa0e09aabee19 (https://github.com/docker/docker.github.io/pull/11485) but other pages still used the old link.

