### PR TITLE
Add link to HVS docs from docker scan CLI page

### DIFF
--- a/engine/scan/index.md
+++ b/engine/scan/index.md
@@ -10,10 +10,13 @@ toc_max: 2
 
 Vulnerability scanning for Docker local images runs on Snyk engine, providing users with visibility into the security posture of their local Dockerfiles and local images. Users trigger vulnerability scans through the CLI, and use the CLI to view the scan results.  The scanning function creates the list of Common Vulnerabilities and Exposures (CVEs), and provides recommendations for CVE remediations.
 
+This page contains information about the `docker scan` CLI command. For information about automatically scanning Docker images through Docker Hub, see [Hub Vulnerability Scanning](/docker-hub/vulnerability-scanning/).
+
 >**Note**
 >
 > Docker vulnerability scanning for local images  is currently a beta release. The commands and flags are subject to change in subsequent releases.
 {:.important}
+
 
 ## Prerequisites
 


### PR DESCRIPTION
Added a link to reference Hub Vulnerability Scan docs from the `docker scan` CLI page.