### PR TITLE
Remove glossary left-overs

### DIFF
--- a/_includes/body.html
+++ b/_includes/body.html
@@ -140,7 +140,6 @@
     <script src="/js/bootstrap.min.js"></script>
     <script src="/js/stickyfill.min.js"></script>
     <script defer src="/js/metadata.js"></script>
-    <script src="/js/glossary.js"></script>
     <script defer src="/js/docs.js"></script>
     <script defer src="/js/toc.js"></script>
     <script defer src="/js/search.js"></script>

--- a/js/docs.js
+++ b/js/docs.js
@@ -328,9 +328,6 @@ $(function () {
     $('[data-toggle="tooltip"]').tooltip()
 });
 
-// Enable glossary link popovers
-$(".glossLink").popover();
-
 // sync tabs with the same data-group
 window.onload = function () {
     $(".nav-tabs > li > a").click(function (e) {

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -1,6 +1,0 @@
-var glossary = [
-{%- for entry in site.data.glossary -%}
-    {"term": {{ entry[0] | jsonify }}, "def": {{ entry[1] | markdownify | jsonify }}}
-    {%- unless forloop.last -%},{%- endunless -%}
-{%- endfor -%}
-]

--- a/search.md
+++ b/search.md
@@ -24,8 +24,6 @@ skip_read_time: true
 .gsc-adBlock { display: none; }
 </style>
 
-<div id="glossaryMatch"></div>
-
 <div id="my-cse1">
 <script>
   (function() {


### PR DESCRIPTION
Looks like removing the front-matter in f17ebae568a15033c914d2024f5e939dee89a4a8
caused the output to break, resulting in a JavaScript error.

Looking at where this file was used, it turned out that it was loaded, but
never used anywhere.

This commit removes the remaining parts of the glossary search functionality,
which was not used.

