### PR TITLE
_includes/head.html: fix escaping in generated descriptions and titles

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
     {%- assign a = content | split: '<h1' | last -%}
     {%- assign b = a | split: '</h1' | first -%}
     {%- assign c = b | split: '>' | last -%}
-    {%- assign page_title = c | strip_html | strip | truncatewords: 10 -%}
+    {%- assign page_title = c | strip_html | strip | truncatewords: 10 | escape_once -%}
 {%- endif -%}
 {%- if page.description == nil and page.datafile != nil and page.datafile != '' -%}
     {%- assign yaml_data = site.data[page.datafolder][page.datafile] -%}
@@ -31,8 +31,8 @@
   <meta name="robots" content="noindex"/>
   {%- endif %}
   <title>{{ page.title | default: page_title }} | Docker Documentation</title>
-  <meta name="description" content="{{ page.description | default: page_description }}" />
-  <meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization{% endif %}">
+  <meta name="description" content="{{ page.description | default: page_description | escape}}" />
+  <meta name="keywords" content="{{ page.keywords | default: 'docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization' }}">
   <link rel="canonical" href="{{ page.url }}" />
 
   <!-- favicon -->
@@ -51,7 +51,7 @@
 
   <!-- SEO stuff -->
   <meta name="twitter:title" itemprop="title name" content="{{ page.title | default: page_title }}"/>
-  <meta name="twitter:description" property="og:description" itemprop="description" content="{{ page_description }}" />
+  <meta name="twitter:description" property="og:description" itemprop="description" content="{{ page_description | escape_once }}" />
   <meta name="twitter:card" content="summary"/>
   <meta name="twitter:domain" content="docs.docker.com"/>
   <meta name="twitter:site" content="@docker_docs"/>
@@ -59,7 +59,7 @@
   <meta name="twitter:image:src" content="/images/docs@2x.png"/>
   <meta name="twitter:image:alt" content="Docker Documentation"/>
   <meta property="og:title" content="{{ page.title | default: page_title }}" />
-  <meta property="og:description" content="{{ page.description | default: page_description }}" />
+  <meta property="og:description" content="{{ page.description | default: page_description | escape_once }}" />
   <meta property="og:type" content="website"/>
   <meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
   <meta property="og:image" itemprop="image primaryImageOfPage" content="/images/docs@2x.png"/>
@@ -67,6 +67,6 @@
   <meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
   <meta property="og:site_name" content="Docker Documentation" />
   <meta property="article:published_time" itemprop="datePublished" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
-  <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"{{ page.title | default: page_title }}","description":"{{ page.description | default: page_description }}","url":"https://docs.docker.com{{ page.url }}"}</script>
+  <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":{{ page.title | default: page_title | jsonify }},"description":{{ page.description | default: page_description | jsonify }},"url":"https://docs.docker.com{{ page.url }}"}</script>
   <!-- END SEO STUFF -->
 </head>


### PR DESCRIPTION
Commits 7e5352f1ae2dbe7e9d02f8193096d4513de3a2ba (https://github.com/docker/docker.github.io/pull/11488) and e72030d2c6fb4ffa31af7a6f9e5905d70db38de9 (https://github.com/docker/docker.github.io/pull/11489) added automatic generation of page titles and descriptions from the page's content if no front-matter metadata was present.

Some pages may include characters that should be escaped before using as a HTML attribute or JSON field.

This patch adds escaping to those texts to prevent the HTML or JSON from being invalid.

Before this:

HTML meta:

```html
<meta name="description" content="docker build: The `docker build` command builds Docker images from a Dockerfile and a " context".="" a="" build's="" context="" is="" the="" set="" of="" files="" located="" in="" specified="" `path`="" or="" `url`...."="" />
```

JSON meta:

```html
<script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"docker build","description":"docker build: The `docker build` command builds Docker images from a Dockerfile and a "context". A build's context is the set of files located in the specified `PATH` or `URL`....","url":"https://docs.docker.com/engine/reference/commandline/build/"}</script>
```

After this:

HTML meta:

```html
<meta name="description" content="docker build: The `docker build` command builds Docker images from a Dockerfile and a &quot;context&quot;. A build&#39;s context is the set of files located in the specified `PATH` or `URL`...." />
```

JSON meta:

```html
<script type="application/ld+json">{"@context":"http://schema.org","@type":"WebPage","headline":"docker build","description":"docker build: The `docker build` command builds Docker images from a Dockerfile and a \"context\". A build's context is the set of files located in the specified `PATH` or `URL`....","url":"https://docs.docker.com/engine/reference/commandline/build/"}</script>
```

