### PR TITLE
Add "rel=noopener" and fix canonical links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=upstream-resources /usr/src/app/md_source/. ./
 # API docs, based on the latest_engine_api_version parameter in _config.yml
 RUN ./_scripts/update-api-toc.sh
 RUN jekyll build -d ${TARGET} \
- && find ${TARGET} -type f -name '*.html' | while read i; do sed -i 's#href="https://docs.docker.com/#href="/#g' "$i"; done \
+ && find ${TARGET} -type f -name '*.html' | while read i; do sed -i 's#\(<a[^>]* href="\)https://docs.docker.com/#\1/#g' "$i"; done \
  && sed -i 's#<loc>/#<loc>https://docs.docker.com/#' "${TARGET}/sitemap.xml"
 
 

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -8,9 +8,9 @@
 
 {% if controller_data.min_api_version %}
 
-<a href="/engine/api/v{{ controller_data.min_api_version }}/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the {{ controller_data.min_api_version }} API reference (in a new window)">API {{ controller_data.min_api_version }}+</span></a>&nbsp;
+<a href="/engine/api/v{{ controller_data.min_api_version }}/" target="_blank" rel="noopener" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the {{ controller_data.min_api_version }} API reference (in a new window)">API {{ controller_data.min_api_version }}+</span></a>&nbsp;
 The client and daemon API must both be at least
-<a href="/engine/api/v{{ controller_data.min_api_version }}/" target="_blank" class="_">{{ controller_data.min_api_version }}</a>
+<a href="/engine/api/v{{ controller_data.min_api_version }}/" target="_blank" rel="noopener" class="_">{{ controller_data.min_api_version }}</a>
 to use this command. Use the `docker version` command on the client to check
 your client and daemon API versions.
 
@@ -18,7 +18,7 @@ your client and daemon API versions.
 
 {% if controller_data.deprecated %}
 
-> This command is [deprecated](/engine/deprecated/){: target="_blank" class="_"}.
+> This command is [deprecated](/engine/deprecated/){: target="_blank" rel="noopener" class="_"}.
 >
 > It may be removed in a future Docker version.
 {: .warning }
@@ -29,7 +29,7 @@ your client and daemon API versions.
 
 > This command is only available on Docker Enterprise Edition.
 >
-> Learn more about [Docker Enterprise products](/ee/supported-platforms/){: target="_blank" class="_"}.
+> Learn more about [Docker Enterprise products](/ee/supported-platforms/){: target="_blank" rel="noopener" class="_"}.
 {: .important }
 
 {% endif %}
@@ -115,10 +115,10 @@ For example uses of this command, refer to the [examples section](#examples) bel
 </thead>
 <tbody>
 {% for option in alloptions %}
-  {% capture deprecated-badge %}{% if option.deprecated %}<a href="/engine/deprecated/" target="_blank" class="_"><span class="badge badge-danger" data-toggle="tooltip" title="Read the deprecation reference (in a new window).">deprecated</span></a>{% endif %}{% endcapture %}
-  {% capture experimental-daemon-badge %}{% if option.experimental %}<a href="/engine/reference/commandline/dockerd/#daemon-configuration-file" target="_blank" class="_"><span class="badge badge-warning" data-toggle="tooltip" title="Read about experimental daemon options (in a new window).">experimental (daemon)</span></a>{% endif %}{% endcapture %}
-  {% capture experimental-cli-badge %}{% if option.experimentalcli %}<a href="/engine/reference/commandline/cli/#configuration-files" target="_blank" class="_"><span class="badge badge-warning"  data-toggle="tooltip" title="Read about experimental CLI options (in a new window).">experimental (CLI)</span></a>{% endif %}{% endcapture %}
-  {% capture min-api %}{% if option.min_api_version %}<a href="/engine/api/v{{ option.min_api_version }}/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" ttitle="Open the {{ controller_data.min_api_version }} API reference (in a new window)">API {{ option.min_api_version }}+</span></a>{% endif %}{%endcapture%}
+  {% capture deprecated-badge %}{% if option.deprecated %}<a href="/engine/deprecated/" target="_blank" rel="noopener" class="_"><span class="badge badge-danger" data-toggle="tooltip" title="Read the deprecation reference (in a new window).">deprecated</span></a>{% endif %}{% endcapture %}
+  {% capture experimental-daemon-badge %}{% if option.experimental %}<a href="/engine/reference/commandline/dockerd/#daemon-configuration-file" target="_blank" rel="noopener" class="_"><span class="badge badge-warning" data-toggle="tooltip" title="Read about experimental daemon options (in a new window).">experimental (daemon)</span></a>{% endif %}{% endcapture %}
+  {% capture experimental-cli-badge %}{% if option.experimentalcli %}<a href="/engine/reference/commandline/cli/#configuration-files" target="_blank" rel="noopener" class="_"><span class="badge badge-warning"  data-toggle="tooltip" title="Read about experimental CLI options (in a new window).">experimental (CLI)</span></a>{% endif %}{% endcapture %}
+  {% capture min-api %}{% if option.min_api_version %}<a href="/engine/api/v{{ option.min_api_version }}/" target="_blank" rel="noopener" class="_"><span class="badge badge-info" data-toggle="tooltip" ttitle="Open the {{ controller_data.min_api_version }} API reference (in a new window)">API {{ option.min_api_version }}+</span></a>{% endif %}{%endcapture%}
   {% capture flag-orchestrator %}{% if option.swarm %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Swarm orchestrator.">Swarm</span>{% endif %}{% if option.kubernetes %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Kubernetes orchestrator.">Kubernetes</span>{% endif %}{% endcapture %}
   {% capture all-badges %}{{ deprecated-badge }}{{ experimental-daemon-badge }}{{ experimental-cli-badge }}{{ min-api }}{{ flag-orchestrator }}{% endcapture %}
   {% assign defaults-to-skip = "[],map[],false,0,0s,default,'',\"\"" | split: ',' %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,9 +47,9 @@
                 </div>
                 <div class="col-xs-12 col-sm-3 col-md-3">
                     <ul class="footer_links">
-                        <li><b><a href="https://www.docker.com/company" target="_blank">Company</a></b></li>
+                        <li><b><a href="https://www.docker.com/company" target="_blank" rel="noopener">Company</a></b></li>
                         <li><a href="https://www.docker.com/company">About Us</a></li>
-                        <li><a href="https://www.docker.com/blog/" target="_blank">Blog</a></li>
+                        <li><a href="https://www.docker.com/blog/" target="_blank" rel="noopener">Blog</a></li>
                         <li><a href="https://www.docker.com/customers">Customers</a></li>
                         <li><a href="https://www.docker.com/partners">Partners</a></li>
                         <li><a href="https://www.docker.com/company/newsroom">Newsroom</a></li>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,7 +33,7 @@
   <title>{{ page.title | default: page_title }} | Docker Documentation</title>
   <meta name="description" content="{{ page.description | default: page_description | escape}}" />
   <meta name="keywords" content="{{ page.keywords | default: 'docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization' }}">
-  <link rel="canonical" href="{{ page.url }}" />
+  <link rel="canonical" href="https://docs.docker.com{{ page.url }}" />
 
   <!-- favicon -->
   <link rel="icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128">

--- a/_layouts/archive-redirect.html
+++ b/_layouts/archive-redirect.html
@@ -8,7 +8,7 @@ layout: docs
 <p>You are viewing an archive branch of the
   <a href="https://docs.docker.com/">Docker documentation</a>, but
   {{ prod_title }} documentation is not published in the current archive.
-  <a href="https://docs.docker.com/{{ page.prod_url }}/" target="_blank">Go to https://docs.docker.com/{{ page.prod_url }}/</a>
+  <a href="https://docs.docker.com/{{ page.prod_url }}/" target="_blank" rel="noopener">Go to https://docs.docker.com/{{ page.prod_url }}/</a>
   in a new tab.</p>
 </body>
 </html>

--- a/_layouts/engine-api.html
+++ b/_layouts/engine-api.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/x-icon" href="/favicons/docs@2x.ico" sizes="129x128" />
     <link rel="stylesheet" type="text/css" href="/css/api-reference.css" />
     <!-- make the latest API version the canonical page as that's what we want users to be using mostly -->
-    <link rel="canonical" href="/engine/api/v{{ site.latest_engine_api_version }}/" />
+    <link rel="canonical" href="https://docs.docker.com/engine/api/v{{ site.latest_engine_api_version }}/" />
 </head>
 <body>
 <redoc spec-url="/engine/api/{{ page.name | replace: '.md'}}.yaml" hide-hostname="true" suppress-warnings="true" lazy-rendering></redoc>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="{{ page.redirect.to }}">
+  <link rel="canonical" href="https://docs.docker.com{{ page.redirect.to }}">
   <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -516,7 +516,7 @@ the service's task containers.
   because they are mounted in a temporary filesystem, so if you set the writable
   bit, it is ignored. The executable bit can be set. If you aren't familiar with
   UNIX file permission modes, you may find this
-  [permissions calculator](http://permissions-calculator.org/){: target="_blank" class="_" }
+  [permissions calculator](http://permissions-calculator.org/){: target="_blank" rel="noopener" class="_" }
   useful.
 
 The following example sets the name of `my_config` to `redis_config` within the
@@ -902,7 +902,7 @@ services or containers in a swarm.
 on non swarm deployments, use
 [Compose file format version 2 CPU, memory, and other resource options](compose-file-v2.md#cpu-and-other-resources).
 If you have further questions, refer to the discussion on the GitHub
-issue [docker/compose/4513](https://github.com/docker/compose/issues/4513){: target="_blank" class="_"}.
+issue [docker/compose/4513](https://github.com/docker/compose/issues/4513){: target="_blank" rel="noopener" class="_"}.
 {: .important}
 
 ##### Out Of Memory Exceptions (OOME)
@@ -1773,7 +1773,7 @@ the service's task containers.
   in a temporary filesystem, so if you set the writable bit, it is ignored. The
   executable bit can be set. If you aren't familiar with UNIX file permission
   modes, you may find this
-  [permissions calculator](http://permissions-calculator.org/){: target="_blank" class="_" }
+  [permissions calculator](http://permissions-calculator.org/){: target="_blank" rel="noopener" class="_" }
   useful.
 
 The following example sets name of the `my_secret` to `redis_secret` within the

--- a/compose/django.md
+++ b/compose/django.md
@@ -91,7 +91,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
    >
    > This uses the build in development server to run your application
    > on port 8000. Do not use this in a production environment. For more
-   > information, see [Django documentation](https://docs.djangoproject.com/en/3.1/intro/tutorial01/#the-development-server){: target="_blank" class="_”}.
+   > information, see [Django documentation](https://docs.djangoproject.com/en/3.1/intro/tutorial01/#the-development-server){: target="_blank" rel="noopener" class="_”}.
 
 10. Save and close the `docker-compose.yml` file.
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -16,7 +16,7 @@ have Docker Engine installed either locally or remote, depending on your setup.
 included as part of those desktop installs.
 
 - On Linux systems, first install the
-[Docker Engine](../engine/install/index.md#server){: target="_blank" class="_"}
+[Docker Engine](../engine/install/index.md#server){: target="_blank" rel="noopener" class="_"}
 for your OS as described on the Get Docker page, then come back here for
 instructions on installing Compose on
 Linux systems.
@@ -35,7 +35,7 @@ Python package manager or installing Compose as a container.
 > (**v{{site.compose_version}}**) of Compose. To install a different version of
 > Compose, replace the given release number with the one that you want. Compose
 > releases are also listed and available for direct download on the
-> [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" class="_"}.
+> [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"}.
 > To install a **pre-release** of Compose, refer to the [install pre-release builds](#install-pre-release-builds)
 > section.
 
@@ -119,7 +119,7 @@ on Microsoft Windows Server and want to install Docker Compose.
 ### Install Compose on Linux systems
 
 On Linux, you can download the Docker Compose binary from the
-[Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" class="_"}.
+[Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"}.
 Follow the instructions from the link, which involve running the `curl` command
 in your terminal to download the binaries. These step-by-step instructions are
 also included below.
@@ -216,12 +216,12 @@ sudo chmod +x /usr/local/bin/docker-compose
 ## Install pre-release builds
 
 If you're interested in trying out a pre-release build, you can download release
-candidates from the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank" class="_"}.
+candidates from the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank" rel="noopener" class="_"}.
 Follow the instructions from the link, which involves running the `curl` command
 in your terminal to download the binaries.
 
 Pre-releases built from the "master" branch are also available for download at
-[https://dl.bintray.com/docker-compose/master/](https://dl.bintray.com/docker-compose/master/){: target="_blank" class="_"}.
+[https://dl.bintray.com/docker-compose/master/](https://dl.bintray.com/docker-compose/master/){: target="_blank" rel="noopener" class="_"}.
 
 > Pre-release builds allow you to try out new features before they are released,
 > but may be less stable.

--- a/config/containers/logging/gcplogs.md
+++ b/config/containers/logging/gcplogs.md
@@ -7,7 +7,7 @@ redirect_from:
 ---
 
 The Google Cloud Logging driver sends container logs to
-[Google Cloud Logging](https://cloud.google.com/logging/docs/){: target="_blank" class="_" }
+[Google Cloud Logging](https://cloud.google.com/logging/docs/){: target="_blank" rel="noopener" class="_" }
 Logging.
 
 ## Usage
@@ -43,11 +43,11 @@ This log driver does not implement a reader so it is incompatible with
 
 If Docker detects that it is running in a Google Cloud Project, it discovers
 configuration from the
-[instance metadata service](https://cloud.google.com/compute/docs/metadata){: target="_blank" class="_"}.
+[instance metadata service](https://cloud.google.com/compute/docs/metadata){: target="_blank" rel="noopener" class="_"}.
 Otherwise, the user must specify
 which project to log to using the `--gcp-project` log option and Docker
 attempts to obtain credentials from the
-[Google Application Default Credential](https://developers.google.com/identity/protocols/application-default-credentials){: target="_blank" class="_"}.
+[Google Application Default Credential](https://developers.google.com/identity/protocols/application-default-credentials){: target="_blank" rel="noopener" class="_"}.
 The `--gcp-project` flag takes precedence over information discovered from the
 metadata server so a Docker daemon running in a Google Cloud Project can be
 overridden to log to a different Google Cloud Project using `--gcp-project`.

--- a/config/containers/resource_constraints.md
+++ b/config/containers/resource_constraints.md
@@ -48,7 +48,7 @@ number on the daemon or a container, or by setting `--oom-kill-disable` on a
 container.
 
 For more information about the Linux kernel's OOM management, see
-[Out of Memory Management](https://www.kernel.org/doc/gorman/html/understand/understand016.html){: target="_blank" class="_" }.
+[Out of Memory Management](https://www.kernel.org/doc/gorman/html/understand/understand016.html){: target="_blank" rel="noopener" class="_" }.
 
 You can mitigate the risk of system instability due to OOME by:
 

--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -288,5 +288,5 @@ level.
 
 ## Next steps
 
-- Read the [Prometheus documentation](https://prometheus.io/docs/introduction/overview/){: target="_blank" class="_" }
-- Set up some [alerts](https://prometheus.io/docs/alerting/overview/){: target="_blank" class="_" }
+- Read the [Prometheus documentation](https://prometheus.io/docs/introduction/overview/){: target="_blank" rel="noopener" class="_" }
+- Set up some [alerts](https://prometheus.io/docs/alerting/overview/){: target="_blank" rel="noopener" class="_" }

--- a/desktop/enterprise/admin/install/mac.md
+++ b/desktop/enterprise/admin/install/mac.md
@@ -10,7 +10,7 @@ This page contains information about the system requirements and specific instru
 
 [Download Docker Desktop Enterprise for Mac](https://download.docker.com/mac/enterprise/Docker.pkg){: .button .outline-btn}
 
-> **Note:** By downloading DDE, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement (DPA)](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
+> **Note:** By downloading DDE, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" rel="noopener" class="_"} and the [Docker Data Processing Agreement (DPA)](https://www.docker.com/legal/data-processing-agreement){: target="_blank" rel="noopener" class="_"}.
 
 ## System requirements
 

--- a/desktop/enterprise/admin/install/windows.md
+++ b/desktop/enterprise/admin/install/windows.md
@@ -10,7 +10,7 @@ This page contains information about the system requirements and specific instru
 
 [Download Docker Desktop Enterprise for Windows](https://download.docker.com/win/enterprise/DockerDesktop.msi){: .button .outline-btn}
 
->**Note:** By downloading DDE, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement (DPA)](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
+>**Note:** By downloading DDE, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" rel="noopener" class="_"} and the [Docker Data Processing Agreement (DPA)](https://www.docker.com/legal/data-processing-agreement){: target="_blank" rel="noopener" class="_"}.
 
 ## System requirements
 

--- a/desktop/enterprise/index.md
+++ b/desktop/enterprise/index.md
@@ -8,9 +8,9 @@ redirect_from:
 
 Welcome to Docker Desktop Enterprise. This page contains information about the Docker Desktop Enterprise (DDE) release. For information about Docker Desktop Community, see:
 
-- [Docker Desktop for Mac (Community)](/docker-for-mac/){: target="_blank" class="_"}
+- [Docker Desktop for Mac (Community)](/docker-for-mac/){: target="_blank" rel="noopener" class="_"}
 
-- [Docker Desktop for Windows (Community)](/docker-for-windows/){: target="_blank" class="_"}
+- [Docker Desktop for Windows (Community)](/docker-for-windows/){: target="_blank" rel="noopener" class="_"}
 
 Docker Desktop Enterprise provides local development, testing, and building of Docker applications on Mac and Windows. With work performed locally, developers can leverage a rapid feedback loop before pushing code or Docker images to shared servers / continuous integration infrastructure.
 

--- a/develop/dev-best-practices.md
+++ b/develop/dev-best-practices.md
@@ -7,7 +7,7 @@ keywords: application, development
 The following development patterns have proven to be helpful for people
 building applications with Docker. If you have discovered something we should
 add,
-[let us know](https://github.com/docker/docker.github.io/issues/new){: target="_blank" class="_"}.
+[let us know](https://github.com/docker/docker.github.io/issues/new){: target="_blank" rel="noopener" class="_"}.
 
 ## How to keep your images small
 

--- a/develop/index.md
+++ b/develop/index.md
@@ -16,19 +16,19 @@ If you're just getting started developing a brand new app on Docker, check out
 these resources to understand some of the most common patterns for getting the
 most benefits from Docker.
 
-- Use [multi-stage builds](develop-images/multistage-build.md){: target="_blank" class="_"} to keep your images lean
-- Manage application data using [volumes](../storage/volumes.md) and [bind mounts](../storage/bind-mounts.md){: target="_blank" class="_"}
-- [Scale your app with Kubernetes](../get-started/kube-deploy.md){: target="_blank" class="_"} 
-- [Scale your app as a Swarm service](../get-started/swarm-deploy.md){: target="_blank" class="_"} 
-- [General application development best practices](dev-best-practices.md){: target="_blank" class="_"}
+- Use [multi-stage builds](develop-images/multistage-build.md){: target="_blank" rel="noopener" class="_"} to keep your images lean
+- Manage application data using [volumes](../storage/volumes.md) and [bind mounts](../storage/bind-mounts.md){: target="_blank" rel="noopener" class="_"}
+- [Scale your app with Kubernetes](../get-started/kube-deploy.md){: target="_blank" rel="noopener" class="_"} 
+- [Scale your app as a Swarm service](../get-started/swarm-deploy.md){: target="_blank" rel="noopener" class="_"} 
+- [General application development best practices](dev-best-practices.md){: target="_blank" rel="noopener" class="_"}
 
 ## Learn about language-specific app development with Docker
 
-- [Docker for Java developers lab](https://github.com/docker/labs/tree/master/developer-tools/java/){: target="_blank" class="_"} 
-- [Port a node.js app to Docker lab](https://github.com/docker/labs/tree/master/developer-tools/nodejs/porting){: target="_blank" class="_"}
-- [Ruby on Rails app on Docker lab](https://github.com/docker/labs/tree/master/developer-tools/ruby){: target="_blank" class="_"}
-- [Dockerize a .Net Core application](../engine/examples/dotnetcore.md){: target="_blank" class="_"}
-- [Dockerize an ASP.NET Core application with SQL Server on Linux](../compose/aspnet-mssql-compose.md){: target="_blank" class="_"} using Docker Compose
+- [Docker for Java developers lab](https://github.com/docker/labs/tree/master/developer-tools/java/){: target="_blank" rel="noopener" class="_"} 
+- [Port a node.js app to Docker lab](https://github.com/docker/labs/tree/master/developer-tools/nodejs/porting){: target="_blank" rel="noopener" class="_"}
+- [Ruby on Rails app on Docker lab](https://github.com/docker/labs/tree/master/developer-tools/ruby){: target="_blank" rel="noopener" class="_"}
+- [Dockerize a .Net Core application](../engine/examples/dotnetcore.md){: target="_blank" rel="noopener" class="_"}
+- [Dockerize an ASP.NET Core application with SQL Server on Linux](../compose/aspnet-mssql-compose.md){: target="_blank" rel="noopener" class="_"} using Docker Compose
 
 ## Advanced development with the SDK or API
 

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -142,8 +142,8 @@ the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for
 
 ### Upgrades
 
-- [Docker ECS integration v1.0.0-beta.4](https://github.com/docker/ecs-plugin/releases/tag/v1.0.0-beta.4){: target="_blank" class="_”}
-- [Kubernetes 1.18.6](https://github.com/kubernetes/kubernetes/releases/tag/v1.18.6){: target="_blank" class="_”}
+- [Docker ECS integration v1.0.0-beta.4](https://github.com/docker/ecs-plugin/releases/tag/v1.0.0-beta.4){: target="_blank" rel="noopener" class="_”}
+- [Kubernetes 1.18.6](https://github.com/kubernetes/kubernetes/releases/tag/v1.18.6){: target="_blank" rel="noopener" class="_”}
 
 ### Bug fixes and minor changes
 
@@ -157,8 +157,8 @@ the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for
 
 ### Upgrades
 
-- [Docker ECS integration v1.0.0-beta.2](https://github.com/docker/ecs-plugin/releases/tag/v1.0.0-beta.2){: target="_blank" class="_”}
-- [Docker ACI integration 0.1.10](https://github.com/docker/aci-integration-beta/releases/tag/v0.1.10){: target="_blank" class="_”}
+- [Docker ECS integration v1.0.0-beta.2](https://github.com/docker/ecs-plugin/releases/tag/v1.0.0-beta.2){: target="_blank" rel="noopener" class="_”}
+- [Docker ACI integration 0.1.10](https://github.com/docker/aci-integration-beta/releases/tag/v0.1.10){: target="_blank" rel="noopener" class="_”}
 
 ### Bug fixes and minor changes
 
@@ -213,9 +213,9 @@ the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for
 
 ### New
 
-Docker Desktop introduces a directory caching mechanism to greatly improve disk performance in containers. This feature uses [mutagen.io](https://mutagen.io/){: target="_blank" class="_"} to sync files between the host and the containers and benefits from native disk performance. For more information, see [Mutagen-based caching](mutagen.md).
+Docker Desktop introduces a directory caching mechanism to greatly improve disk performance in containers. This feature uses [mutagen.io](https://mutagen.io/){: target="_blank" rel="noopener" class="_"} to sync files between the host and the containers and benefits from native disk performance. For more information, see [Mutagen-based caching](mutagen.md).
 
-We appreciate you trying out an early version of the Mutagen file sync feature. Please let us know your feedback by creating an issue in the [Docker Desktop for Mac GitHub](https://github.com/docker/for-mac/issues){: target="_blank" class="_"} repository with the `Mutagen` label.
+We appreciate you trying out an early version of the Mutagen file sync feature. Please let us know your feedback by creating an issue in the [Docker Desktop for Mac GitHub](https://github.com/docker/for-mac/issues){: target="_blank" rel="noopener" class="_"} repository with the `Mutagen` label.
 
 ### Upgrades
 
@@ -2078,7 +2078,7 @@ The `osxfs` file system now persists ownership changes in an extended attribute.
 
 **Upgrades**
 
-* docker-compose 1.7.1 (see [changelog](https://github.com/docker/compose/releases/tag/1.7.1){: target="_blank" class="_" })
+* docker-compose 1.7.1 (see [changelog](https://github.com/docker/compose/releases/tag/1.7.1){: target="_blank" rel="noopener" class="_" })
 * Linux kernel 4.4.9
 
 **Bug fixes and minor changes**

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -12,7 +12,7 @@ title: Frequently asked questions (FAQ)
 
 You can download the Stable or the Edge version of Docker Desktop from [Docker Hub](https://hub.docker.com/editions/community/docker-ce-desktop-mac/).
 
-For installation instructions, see [Install Docker Desktop on Mac](install.md){: target="_blank" class="_"}.
+For installation instructions, see [Install Docker Desktop on Mac](install.md){: target="_blank" rel="noopener" class="_"}.
 
 ### What is the difference between the Stable and Edge versions of Docker Desktop?
 
@@ -50,9 +50,9 @@ On Docker Desktop, clients can connect to the Docker Engine through a Unix
 socket: `unix:///var/run/docker.sock`.
 
 See also [Docker Engine API](../engine/api/index.md) and Docker Desktop for Mac forums topic
-[Using pycharm Docker plugin..](https://forums.docker.com/t/using-pycharm-docker-plugin-with-docker-beta/8617){: target="_blank" class="_"}.
+[Using pycharm Docker plugin..](https://forums.docker.com/t/using-pycharm-docker-plugin-with-docker-beta/8617){: target="_blank" rel="noopener" class="_"}.
 
-If you are working with applications like [Apache Maven](https://maven.apache.org/){: target="_blank" class="_"}
+If you are working with applications like [Apache Maven](https://maven.apache.org/){: target="_blank" rel="noopener" class="_"}
 that expect settings for `DOCKER_HOST` and `DOCKER_CERT_PATH` environment
 variables, specify these to connect to Docker instances through Unix sockets.
 For example:
@@ -138,10 +138,10 @@ functionality you'd like to see added.
 You can find information about diagnosing and troubleshooting common issues in the [Logs and Troubleshooting](troubleshoot) topic.
 
 If you do not find a solution in Troubleshooting, browse issues on
-[Docker Desktop for Mac issues on GitHub](https://github.com/docker/for-mac/issues){: target="_blank" class="_"} or create a new one. You can also create new issues based on diagnostics. To learn more, see
+[Docker Desktop for Mac issues on GitHub](https://github.com/docker/for-mac/issues){: target="_blank" rel="noopener" class="_"} or create a new one. You can also create new issues based on diagnostics. To learn more, see
 [Diagnose problems, send feedback, and create GitHub issues](troubleshoot.md#diagnose-problems-send-feedback-and-create-github-issues).
 
-The [Docker Desktop for Mac forum](https://forums.docker.com/c/docker-for-mac){: target="_blank" class="_"}
+The [Docker Desktop for Mac forum](https://forums.docker.com/c/docker-for-mac){: target="_blank" rel="noopener" class="_"}
 provides discussion threads as well, and you can create discussion topics there,
 but we recommend using the GitHub issues over the forums for better tracking and
 response.

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -102,7 +102,7 @@ File share settings are:
 
 For more information, see:
 
-- [Namespaces](osxfs.md#namespaces){: target="_blank" class="_"} in the topic on
+- [Namespaces](osxfs.md#namespaces){: target="_blank" rel="noopener" class="_"} in the topic on
   [osxfs file system sharing](osxfs.md).
 - [Volume mounting requires file sharing for any project directories outside of `/Users`](troubleshoot.md#volume-mounting-requires-file-sharing-for-any-project-directories-outside-of-users).)
 
@@ -139,8 +139,7 @@ You can configure Docker Desktop networking to work on a virtual private network
 The Docker Engine page allows you to configure the Docker daemon to determine how your containers run.
 
 Type a JSON configuration file in the box to configure the daemon settings. For a full list of options, see the Docker Engine
-[dockerd commandline reference](/engine/reference/commandline/dockerd/){:target="_blank"
-class="_"}.
+[dockerd commandline reference](/engine/reference/commandline/dockerd/){:target="_blank" rel="noopener" class="_"}.
 
 Click **Apply & Restart** to save your settings and restart Docker Desktop.
 
@@ -234,7 +233,7 @@ experience conflicts, remove `/usr/local/bin/kubectl`.
   `/usr/local/bin/kubectl` command is removed.
 
   For more about using the Kubernetes integration with Docker Desktop, see
-  [Deploy on Kubernetes](kubernetes.md){:target="_blank" class="_"}.
+  [Deploy on Kubernetes](kubernetes.md){:target="_blank" rel="noopener" class="_"}.
 
 ### Reset
 
@@ -421,10 +420,10 @@ ln -shi /Applications/Docker.app/Contents/Resources/etc/docker-compose.fish-comp
 
 To get help from the community, review current user topics, join or start a
 discussion, log on to our [Docker Desktop for Mac
-forum](https://forums.docker.com/c/docker-for-mac){:target="_blank" class="_"}.
+forum](https://forums.docker.com/c/docker-for-mac){:target="_blank" rel="noopener" class="_"}.
 
 To report bugs or problems, log on to Docker Desktop [for Mac issues on
-GitHub](https://github.com/docker/for-mac/issues){:target="_blank" class="_"},
+GitHub](https://github.com/docker/for-mac/issues){:target="_blank" rel="noopener" class="_"},
 where you can review community reported issues, and file new ones.  See
 [Logs and Troubleshooting](troubleshoot.md) for more details.
 
@@ -432,13 +431,13 @@ For information about providing feedback on the documentation or update it yours
 
 ## Docker Hub
 
-Select **Sign in /Create Docker ID** from the Docker Desktop menu to access your [Docker Hub](https://hub.docker.com/){: target="_blank" class="_" } account. Once logged in, you can access your Docker Hub repositories and organizations directly from the Docker Desktop menu.
+Select **Sign in /Create Docker ID** from the Docker Desktop menu to access your [Docker Hub](https://hub.docker.com/){: target="_blank" rel="noopener" class="_" } account. Once logged in, you can access your Docker Hub repositories and organizations directly from the Docker Desktop menu.
 
 For more information, refer to the following [Docker Hub topics](../docker-hub/index.md){:target="_blank"
 class="_"}:
 
-* [Organizations and Teams in Docker Hub](../docker-hub/orgs.md){:target="_blank" class="_"}
-* [Builds](../docker-hub/builds/index.md){:target="_blank" class="_"}
+* [Organizations and Teams in Docker Hub](../docker-hub/orgs.md){:target="_blank" rel="noopener" class="_"}
+* [Builds](../docker-hub/builds/index.md){:target="_blank" rel="noopener" class="_"}
 
 ### Two-factor authentication
 
@@ -467,8 +466,8 @@ After you have successfully authenticated, you can access your organizations and
   walkthroughs and source code.
 
 * For a summary of Docker command line interface (CLI) commands, see
-  [Docker CLI Reference Guide](../engine/api/index.md){: target="_blank" class="_"}.
+  [Docker CLI Reference Guide](../engine/api/index.md){: target="_blank" rel="noopener" class="_"}.
 
 * Check out the blog post, [What’s New in Docker 17.06 Community Edition
   (CE)](https://blog.docker.com/2017/07/whats-new-docker-17-06-community-edition-ce/){:
-  target="_blank" class="_"}.
+  target="_blank" rel="noopener" class="_"}.

--- a/docker-for-mac/install.md
+++ b/docker-for-mac/install.md
@@ -9,7 +9,7 @@ You can download Docker Desktop for Mac from Docker Hub.
 
 [Download from Docker Hub](https://hub.docker.com/editions/community/docker-ce-desktop-mac/){: .button .outline-btn}
 
-By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
+By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" rel="noopener" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" rel="noopener" class="_"}.
 
 ## What to know before you install
 

--- a/docker-for-mac/multi-arch.md
+++ b/docker-for-mac/multi-arch.md
@@ -23,7 +23,7 @@ which means you can run containers for different Linux architectures
 such as `arm`, `mips`, `ppc64le`, and even `s390x`.
 
 This does not require any special configuration in the container itself as it uses
-<a href="http://wiki.qemu.org/" target="_blank">qemu-static</a> from the **Docker for
+<a href="http://wiki.qemu.org/" target="_blank" rel="noopener">qemu-static</a> from the **Docker for
 Mac VM**. Because of this, you can run an ARM container, like the `arm32v7` or `ppc64le`
 variants of the busybox image.
 

--- a/docker-for-windows/docker-toolbox.md
+++ b/docker-for-windows/docker-toolbox.md
@@ -41,4 +41,4 @@ be copied across manually.
 
 Whether or not you migrate your Docker Toolbox images, you may decide to
 uninstall it. For details on how to perform a clean uninstall of Toolbox,
-see [How to uninstall Toolbox](../toolbox/toolbox_install_windows.md#how-to-uninstall-toolbox){: target="_blank" class="_"}.
+see [How to uninstall Toolbox](../toolbox/toolbox_install_windows.md#how-to-uninstall-toolbox){: target="_blank" rel="noopener" class="_"}.

--- a/docker-for-windows/faqs.md
+++ b/docker-for-windows/faqs.md
@@ -10,7 +10,7 @@ title: Frequently asked questions (FAQ)
 
 You can download the Stable or the Edge version of Docker Desktop from [Docker Hub](https://hub.docker.com/editions/community/docker-ce-desktop-windows/).
 
-For installation instructions, see [Install Docker Desktop on Windows](install.md){: target="_blank" class="_"}.
+For installation instructions, see [Install Docker Desktop on Windows](install.md){: target="_blank" rel="noopener" class="_"}.
 
 ### What is the difference between the Stable and Edge versions of Docker Desktop?
 
@@ -49,7 +49,7 @@ On Docker Desktop, clients can connect to the Docker Engine through a
 This sets `DOCKER_HOST` and `DOCKER_CERT_PATH` environment variables to the
 given values (for the named pipe or TCP socket, whichever you use).
 
-See also [Docker Engine API](../engine/api/index.md) and the Docker Desktop for Windows forums topic [How to find the remote API](https://forums.docker.com/t/how-to-find-the-remote-api/20988){: target="_blank" class="_"}.
+See also [Docker Engine API](../engine/api/index.md) and the Docker Desktop for Windows forums topic [How to find the remote API](https://forums.docker.com/t/how-to-find-the-remote-api/20988){: target="_blank" rel="noopener" class="_"}.
 
 ### How do I connect from a container to a service on the host?
 
@@ -74,7 +74,7 @@ For more information and examples, see
 No, at this point, Docker Desktop does not enable you to control (`chmod`)
 the Unix-style permissions on [shared volumes](index.md#file-sharing) for
 deployed containers, but rather sets permissions to a default value of
-[0777](http://permissions-calculator.org/decode/0777/){: target="_blank" class="_"}
+[0777](http://permissions-calculator.org/decode/0777/){: target="_blank" rel="noopener" class="_"}
 (`read`, `write`, `execute` permissions for `user` and for 
 `group`) which is not configurable.
 
@@ -113,7 +113,7 @@ Docker Desktop can run inside a Windows 10 VM running on apps like Parallels or 
 
 ### Can I use VirtualBox alongside Docker Desktop?
 
-Yes, you can run VirtualBox along with Docker Desktop if you have enabled the [ Windows Hypervisor Platform](https://docs.microsoft.com/en-us/virtualization/api/){: target="_blank" class="_"} feature on your machine.
+Yes, you can run VirtualBox along with Docker Desktop if you have enabled the [ Windows Hypervisor Platform](https://docs.microsoft.com/en-us/virtualization/api/){: target="_blank" rel="noopener" class="_"} feature on your machine.
 
 ## Windows requirements
 
@@ -125,7 +125,7 @@ No, running Docker Desktop on Windows Server is not supported.
 
 You can install a native Windows binary which allows you to develop and run
 Windows containers without Docker Desktop. For more information, see the tutorial about running Windows containers on Windows Server in
-[Getting Started with Windows Containers](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md){: target="_blank" class="_"}.
+[Getting Started with Windows Containers](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md){: target="_blank" rel="noopener" class="_"}.
 
 ### Can I install Docker Desktop on Windows 10 Home?
 
@@ -157,11 +157,11 @@ functionality you'd like to see added.
 You can find information about diagnosing and troubleshooting common issues in the [Logs and Troubleshooting](troubleshoot.md) topic.
 
 If you do not find a solution in Troubleshooting, browse issues on
-[Docker Desktop for Windows issues on GitHub](https://github.com/docker/for-win/issues){: target="_blank" class="_"}
+[Docker Desktop for Windows issues on GitHub](https://github.com/docker/for-win/issues){: target="_blank" rel="noopener" class="_"}
 or create a new one. You can also create new issues based on diagnostics. To learn more, see
 [Diagnose problems, send feedback, and create GitHub issues](troubleshoot.md#diagnose-problems-send-feedback-and-create-github-issues).
 
-The [Docker Desktop for Windows forum](https://forums.docker.com/c/docker-for-windows){: target="_blank" class="_"}
+The [Docker Desktop for Windows forum](https://forums.docker.com/c/docker-for-windows){: target="_blank" rel="noopener" class="_"}
 contains discussion threads. You can also create discussion topics there,
 but we recommend using the GitHub issues over the forums for better tracking and
 response.

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -363,12 +363,12 @@ The Docker Desktop Dashboard enables you to interact with containers and applica
 
 ## Docker Hub
 
-Select **Sign in /Create Docker ID** from the Docker Desktop menu to access your [Docker Hub](https://hub.docker.com/){: target="_blank" class="_" } account. Once logged in, you can access your Docker Hub repositories directly from the Docker Desktop menu.
+Select **Sign in /Create Docker ID** from the Docker Desktop menu to access your [Docker Hub](https://hub.docker.com/){: target="_blank" rel="noopener" class="_" } account. Once logged in, you can access your Docker Hub repositories directly from the Docker Desktop menu.
 
-For more information, refer to the following [Docker Hub topics](../docker-hub/index.md){: target="_blank" class="_" }:
+For more information, refer to the following [Docker Hub topics](../docker-hub/index.md){: target="_blank" rel="noopener" class="_" }:
 
-* [Organizations and Teams in Docker Hub](../docker-hub/orgs.md){: target="_blank" class="_" }
-* [Builds and Images](../docker-hub/builds/index.md){: target="_blank" class="_" }
+* [Organizations and Teams in Docker Hub](../docker-hub/orgs.md){: target="_blank" rel="noopener" class="_" }
+* [Builds and Images](../docker-hub/builds/index.md){: target="_blank" rel="noopener" class="_" }
 
 ### Two-factor authentication
 
@@ -433,8 +433,8 @@ in the Docker Engine topics.
 
 ## Where to go next
 
-* Try out the walkthrough at [Get Started](../get-started/index.md){: target="_blank" class="_"}.
+* Try out the walkthrough at [Get Started](../get-started/index.md){: target="_blank" rel="noopener" class="_"}.
 
 * Dig in deeper with [Docker Labs](https://github.com/docker/labs/) example walkthroughs and source code.
 
-* Refer to the [Docker CLI Reference Guide](/engine/reference/commandline/cli/){: target="_blank" class="_"}.
+* Refer to the [Docker CLI Reference Guide](/engine/reference/commandline/cli/){: target="_blank" rel="noopener" class="_"}.

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -13,7 +13,7 @@ This page contains information on installing Docker Desktop on Windows 10 Pro, E
 Hub](https://hub.docker.com/editions/community/docker-ce-desktop-windows/){:
 .button .outline-btn}
 
-By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" class="_"}.
+By downloading Docker Desktop, you agree to the terms of the [Docker Software End User License Agreement](https://www.docker.com/legal/docker-software-end-user-license-agreement){: target="_blank" rel="noopener" class="_"} and the [Docker Data Processing Agreement](https://www.docker.com/legal/data-processing-agreement){: target="_blank" rel="noopener" class="_"}.
 
 ## What to know before you install
 

--- a/docker-for-windows/troubleshoot.md
+++ b/docker-for-windows/troubleshoot.md
@@ -186,7 +186,7 @@ In the subsequent screen, verify that Hyper-V is enabled:
 #### Hyper-V driver for Docker Machine
 
 The Docker Desktop installation includes the legacy tool Docker Machine which uses the old
-[`boot2docker.iso`](https://github.com/boot2docker/boot2docker){:target="_blank" class="_"},
+[`boot2docker.iso`](https://github.com/boot2docker/boot2docker){:target="_blank" rel="noopener" class="_"},
 and the [Microsoft Hyper-V driver](../machine/drivers/hyper-v.md) to create local
 virtual machines. _This is tangential to using Docker Desktop_, but if you want to use Docker Machine
 to create multiple local Virtual Machines (VMs), or to provision remote machines, see the

--- a/docker-hub/billing/add-seats.md
+++ b/docker-hub/billing/add-seats.md
@@ -14,7 +14,7 @@ You can manage your Docker Hub subscription anytime by adding seats to your plan
 
 To add seats to a monthly plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 
 2. Navigate to **Organizations** from the menu at the top of the page and then choose your organization.
 
@@ -35,7 +35,7 @@ To add seats to a monthly plan:
 
 To add monthly seats to an annual plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 
 2. Navigate to **Organizations** from the menu at the top of the page and then choose your organization.
 

--- a/docker-hub/billing/downgrade.md
+++ b/docker-hub/billing/downgrade.md
@@ -17,12 +17,12 @@ The following sections contain instructions on how to downgrade from Pro and Tea
 >**Note:**
 >
 > - It is not possible to offer prorated refunds when you downgrade an annual plan that’s already paid for and is still active. After you have downgraded, you can choose to reinstate your annual plan if it hasn't expired.
-> - Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+> - Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 {: .important }
 
 To downgrade from a Pro plan to a Free plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 
 2. Open the drop-down menu next to your username in the top-right corner and select **Billing**. The Billing page displays billing information about your existing user account.
 
@@ -45,12 +45,12 @@ To downgrade from a Pro plan to a Free plan:
 >**Note:**
 >
 > - It is not possible to offer prorated refunds when you downgrade an annual plan that’s already paid for and is still active. After you have downgraded, you can choose to reinstate your annual plan if it hasn't expired.
-> - Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+> - Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 {: .important }
 
 To downgrade to a Free Team plan from a Team plan:
 
-1. Log into an owner account for the organization in [Docker Hub](https://hub.docker.com){: target="_blank" class="_"}.
+1. Log into an owner account for the organization in [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"}.
 
 2. Navigate to **Organizations** from the menu at the top of the page, then choose your organization.
 

--- a/docker-hub/billing/faq.md
+++ b/docker-hub/billing/faq.md
@@ -20,7 +20,7 @@ Immediately available for **Individuals** and **Teams**:
 
 ### How can I compare which features are in each plan?
 
-You can see pricing and a full list of features for each product at [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+You can see pricing and a full list of features for each product at [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 ### What is the difference between a legacy plan and these new announced plans?
 
@@ -44,7 +44,7 @@ Pro includes unlimited collaborators for both private and public repositories. F
 
 ### How can I create a new Docker Hub account?
 
-You can create a new account at [Docker Hub pricing](https://hub.docker.com/pricing){: target="_blank" class="_"} where you can choose a plan for **Individuals** or a plan for **Teams**.
+You can create a new account at [Docker Hub pricing](https://hub.docker.com/pricing){: target="_blank" rel="noopener" class="_"} where you can choose a plan for **Individuals** or a plan for **Teams**.
 
 ### How do I upgrade to a Pro plan from a legacy individual plan?
 
@@ -64,13 +64,13 @@ When you downgrade your existing plan, changes are applied at the end of your bi
 
 ### How do I downgrade from a Team plan to a Free plan?
 
-Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+Before you downgrade to a Free Team plan, you must convert all private repositories to public repositories and update the organization details to reflect features available in the Free plan. For example, you may need to reduce the number of team members. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 For information on how to downgrade from a Team plan to a Free plan, see [Downgrade from Team to a Free plan](/downgrade.md#downgrade-from-team-to-a-free-plan).
 
 ### How do I downgrade from Pro to a Free plan?
 
-Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+Before you downgrade to a Free plan, ensure that your account details are updated to reflect features available in the Free plan. For example, you may need to convert any private repositories to public repositories. For information on what’s included in the Free plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 For information on how to downgrade from Pro to a Free plan, see [Downgrade from Pro to a Free plan](/downgrade.md#downgrade-from-pro-to-a-free-plan).
 
@@ -92,7 +92,7 @@ For information on how to add a member to a team, see [Add a member to a team](.
 
 Yes, both the Pro and Team plans are available through annual subscriptions and include a discount from the monthly subscription price.
 
-You can view the annual subscription pricing for each product at [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+You can view the annual subscription pricing for each product at [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 ### Are legacy plans eligible for annual pricing?
 
@@ -138,7 +138,7 @@ for the full month, and have access to the subscription content until the end of
 that billing period.
 
 We do not offer refunds. If you believe that you've been billed in error,
-contact our [Billing Support team](mailto:billing@docker.com){: target="_blank" class="_"}.
+contact our [Billing Support team](mailto:billing@docker.com){: target="_blank" rel="noopener" class="_"}.
 
 ### How do I download the licenses my organization has purchased?
 
@@ -150,4 +150,4 @@ select the organization from the **Accounts** drop-down menu.
 
 ### I have more questions regarding the new pricing, who can I reach out to?
 
-If you have any questions about how the new seat-based pricing impacts you that are not covered in the FAQ, please reach out to [pricingquestions@docker.com](mailto:pricingquestions@docker.com){: target="_blank" class="_"} and a member of the Docker team will get back to you.
+If you have any questions about how the new seat-based pricing impacts you that are not covered in the FAQ, please reach out to [pricingquestions@docker.com](mailto:pricingquestions@docker.com){: target="_blank" rel="noopener" class="_"} and a member of the Docker team will get back to you.

--- a/docker-hub/billing/index.md
+++ b/docker-hub/billing/index.md
@@ -6,7 +6,7 @@ redirect_from:
 - /docker-hub/billing/faq/
 ---
 
-On May 14, 2020, Docker announced a new, per-seat pricing model that aligns with Docker’s [product strategy](https://www.docker.com/blog/docker-strategy-helping-devs-build-and-ship-faster/){: target="_blank" class="_"} to accelerate developer workflows for cloud-native development. The previous private repository/parallel autobuild-based plans have been replaced with new **Pro** and **Team** plans that include unlimited private repositories.
+On May 14, 2020, Docker announced a new, per-seat pricing model that aligns with Docker’s [product strategy](https://www.docker.com/blog/docker-strategy-helping-devs-build-and-ship-faster/){: target="_blank" rel="noopener" class="_"} to accelerate developer workflows for cloud-native development. The previous private repository/parallel autobuild-based plans have been replaced with new **Pro** and **Team** plans that include unlimited private repositories.
 
 Existing Docker customers subscribed to a paid plan before May 14, 2020 must upgrade to the new Pro or Team plan by January 31, 2021. Starting with May 14, 2020, new customers who sign up for Docker can choose between the new Free, Pro, and Team plans.
 
@@ -30,9 +30,9 @@ The **Team** plan includes unlimited public and unlimited private repositories s
 
 The **Free Team** plan includes unlimited public repositories at no cost per month. This plan also offers advanced collaboration and management tools, including organization and team management with role-based access controls which are limited to 1 team and 3 team members.
 
-For detailed information about the features available in each plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+For detailed information about the features available in each plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
-For frequently asked questions about pricing, see [Docker pricing FAQ](https://www.docker.com/pricing/faq){: target="_blank" class="_"}.
+For frequently asked questions about pricing, see [Docker pricing FAQ](https://www.docker.com/pricing/faq){: target="_blank" rel="noopener" class="_"}.
 
 ### Purchase a Pro plan
 
@@ -40,7 +40,7 @@ The following section contains information on how to purchase a Pro plan for new
 
 To purchase a Pro plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 
 2. The Docker Hub **Pricing** page displays information about the new pricing plans.
 
@@ -62,7 +62,7 @@ The following section contains information on how to purchase a Team plan for ne
 
 To purchase a Team plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 
 2. The Docker Hub **Pricing** page displays information about the new pricing plans.
 

--- a/docker-hub/billing/remove-seats.md
+++ b/docker-hub/billing/remove-seats.md
@@ -17,7 +17,7 @@ For example, if you receive your billing on the 8th of every month for 10 seats 
 
 To remove seats from a monthly plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 
 2. Navigate to **Organizations** from the menu at the top of the page and then choose your organization.
 

--- a/docker-hub/billing/upgrade.md
+++ b/docker-hub/billing/upgrade.md
@@ -6,7 +6,7 @@ redirect_from:
 - /docker-hub/upgrade/
 ---
 
-You can upgrade to a Pro or a Team plan from a Free plan, or from your current legacy plan. When you upgrade to a Pro or a Team plan, you will be able to immediately use all the features and entitlements offered in your new plan. For detailed information on features available in each plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+You can upgrade to a Pro or a Team plan from a Free plan, or from your current legacy plan. When you upgrade to a Pro or a Team plan, you will be able to immediately use all the features and entitlements offered in your new plan. For detailed information on features available in each plan, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 >**Note:**
 >
@@ -21,7 +21,7 @@ The following sections contain instructions on how to upgrade to Pro and Team pl
 
 To upgrade to a Pro plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 
 2. Open the drop-down menu next to your username in the top-right corner and select **Billing**. The Billing page displays billing information about your existing user account.
 
@@ -41,7 +41,7 @@ To upgrade to a Pro plan:
 
 To upgrade to a Team plan:
 
-1. Log into an owner account for the organization in [Docker Hub](https://hub.docker.com){: target="_blank" class="_"}.
+1. Log into an owner account for the organization in [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"}.
 
 2. Navigate to **Organizations** from the menu at the top of the page, then choose your organization.
 
@@ -65,7 +65,7 @@ To upgrade to a Team plan:
 
 To upgrade from a monthly Team plan to an annual Team plan:
 
-1. Log into an owner account for the organization in [Docker Hub](https://hub.docker.com){: target="_blank" class="_"}.
+1. Log into an owner account for the organization in [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"}.
 2. Navigate to **Organizations** from the menu at the top of the page, choose your organization, and select the **Billing** tab.
 3. Click **switch to annual billing**.
 4. Review the information displayed on the **Change to an Annual Plan** page and click **Accept Terms and Purchase** to confirm.
@@ -76,7 +76,7 @@ To upgrade from a monthly Team plan to an annual Team plan:
 
 To upgrade from a monthly Pro plan to an annual Pro plan:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 2. Open the drop-down menu next to your username in the top-right corner and select **Billing**. The Billing page displays billing information about your existing user account.
 3. Click **switch to annual billing**.
 4. Review the information displayed on the **Change to an Annual Plan** page and click **Accept Terms and Purchase** to confirm.

--- a/docker-hub/convert-account.md
+++ b/docker-hub/convert-account.md
@@ -46,7 +46,7 @@ Before you convert a user account to an organization, ensure that you have compl
 >
 > When you convert a Pro or a legacy individual repository plan to an organization, the account
 will be migrated to a Team plan and will be charged $35 per month for 5 seats. For more information,
-see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 1. Ensure you have removed your user account from all teams and organizations and that you have a new Docker ID before you convert an account. See the [Prerequisites](#prerequisites) section for details.
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -6,12 +6,12 @@ title: Download rate limit
 
 Docker has enabled download rate limits for pull requests on 
 Docker Hub. Limits are determined based on the account type. 
-For more information, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" class="_"}.
+For more information, see [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 A user's limit will be equal to the highest entitlement of their
 personal account or any organization they belong to. To take 
 advantage of this, you must log into 
-[Docker Hub](https://hub.docker.com/){: target="_blank" class="_"} 
+[Docker Hub](https://hub.docker.com/){: target="_blank" rel="noopener" class="_"} 
 as an authenticated user. For more information, see
 [How do I authenticate pull requests](#how-do-i-authenticate-pull-requests). 
 Unauthenticated (anonymous) users will have the limits enforced via IP.
@@ -49,18 +49,18 @@ If you are running Docker Swarm, you must use the `-- with-registry-auth` flag t
 
 ### GitHub Actions
 
-If you are using GitHub Actions to build and push Docker images to Docker Hub, see [login action](https://github.com/docker/login-action#dockerhub){: target="_blank" class="_"}. If you are using another Action, you must add your username and access token in a similar way for authentication.
+If you are using GitHub Actions to build and push Docker images to Docker Hub, see [login action](https://github.com/docker/login-action#dockerhub){: target="_blank" rel="noopener" class="_"}. If you are using another Action, you must add your username and access token in a similar way for authentication.
 
 ### Kubernetes
 
-If you are running Kubernetes, follow the instructions in [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/){: target="_blank" class="_"} for information on authentication.
+If you are running Kubernetes, follow the instructions in [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/){: target="_blank" rel="noopener" class="_"} for information on authentication.
 
 ### Third-party platforms
 
 If you are using any third-party platforms, follow your provider’s instructions on using registry authentication.
 
-- [CircleCI](https://circleci.com/docs/2.0/private-images/){: target="_blank" class="_"}
-- [Drone.io](https://docs.drone.io/pipeline/docker/syntax/images/#pulling-private-images){: target="_blank" class="_"}
-- [Codefresh](https://codefresh.io/docs/docs/docker-registries/external-docker-registries/docker-hub/){: target="_blank" class="_"}
-- [AWS ECS/Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html){: target="_blank" class="_"}
-- [AWS CodeBuild](https://aws.amazon.com/blogs/devops/how-to-use-docker-images-from-a-private-registry-in-aws-codebuild-for-your-build-environment/){: target="_blank" class="_"}
+- [CircleCI](https://circleci.com/docs/2.0/private-images/){: target="_blank" rel="noopener" class="_"}
+- [Drone.io](https://docs.drone.io/pipeline/docker/syntax/images/#pulling-private-images){: target="_blank" rel="noopener" class="_"}
+- [Codefresh](https://codefresh.io/docs/docs/docker-registries/external-docker-registries/docker-hub/){: target="_blank" rel="noopener" class="_"}
+- [AWS ECS/Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html){: target="_blank" rel="noopener" class="_"}
+- [AWS CodeBuild](https://aws.amazon.com/blogs/devops/how-to-use-docker-images-from-a-private-registry-in-aws-codebuild-for-your-build-environment/){: target="_blank" rel="noopener" class="_"}

--- a/docker-hub/publish/publish.md
+++ b/docker-hub/publish/publish.md
@@ -72,11 +72,11 @@ Here are some best practices when it comes to building vulnerability-free Docker
 
 Many base images have a strong record of being secure, including:
 
-* [Debian](https://hub.docker.com/r/library/debian/tags/jessie/){: target="_blank" class="_"}
+* [Debian](https://hub.docker.com/r/library/debian/tags/jessie/){: target="_blank" rel="noopener" class="_"}
   Linux: both small and tightly-controlled, Debian-linux is a good alternative
   if you're currently using Ubuntu.
 
-* [Alpine](https://hub.docker.com/_/alpine/){: target="_blank" class="_"} Linux:
+* [Alpine](https://hub.docker.com/_/alpine/){: target="_blank" rel="noopener" class="_"} Linux:
   Alpine is a minimal linux distribution with an excellent security record.
 
 * Alpine-based application images: these include `python:alpine`, `ruby:alpine`,
@@ -206,10 +206,10 @@ and are never shared with end customers or other publishers.
 
 To interpret the results of a scanned image:
 
-1.  Log on to [Docker Hub](https://hub.docker.com){: target="_blank" class="_"}.
+1.  Log on to [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"}.
 
 2.  Navigate to the repository details page (for example,
-    [nodejs](https://hub.docker.com/_/nodejs){: target="_blank" class="_"}).
+    [nodejs](https://hub.docker.com/_/nodejs){: target="_blank" rel="noopener" class="_"}).
 
 3.  Click **Tags**.
 
@@ -300,7 +300,7 @@ additional suite of API compliance testing.
 Docker Certified Container images and plugins are meant to differentiate high
 quality content on Docker Hub. Customers can consume Certified Containers with
 confidence knowing that both Docker and the publisher stands behind the
-solution. Further details and an application can be [found here.](https://goto.docker.com/2019-Partner-Program-Technology.html){: target="_blank" class="_"}.
+solution. Further details and an application can be [found here.](https://goto.docker.com/2019-Partner-Program-Technology.html){: target="_blank" rel="noopener" class="_"}.
 
 #### What are the benefits of Docker Certified?
 
@@ -322,7 +322,7 @@ for exchange of support tickets between the publisher and Docker.
 #### How does a publisher apply to the Docker Certified program?
 
 Start by applying to be a [Docker Technology
-Partner](https://goto.docker.com/2019-Partner-Program-Technology.html){: target="_blank" class="_"}
+Partner](https://goto.docker.com/2019-Partner-Program-Technology.html){: target="_blank" rel="noopener" class="_"}
 
 #### What is the difference between Official Images and Docker Certified?
 

--- a/docker-hub/slack_integration.md
+++ b/docker-hub/slack_integration.md
@@ -44,4 +44,4 @@ Enjoy your new Slack channel integration!
 
 * From the Slack **Notifications** section you can also change the channel that the integration posts to. Click the reload icon (two arrows) next to the Slack integration to reopen the OAuth channel selector.
 
-* Alternately, go to the <a href="https://slack.com/apps/manage" target="_blank">Slack App Management page</a> and search for "Docker Hub". Click the result to see all of the Docker Hub notification channels set for the Slack team.
+* Alternately, go to the <a href="https://slack.com/apps/manage" target="_blank" rel="noopener">Slack App Management page</a> and search for "Docker Hub". Click the result to see all of the Docker Hub notification channels set for the Slack team.

--- a/docker-hub/vulnerability-scanning.md
+++ b/docker-hub/vulnerability-scanning.md
@@ -10,7 +10,7 @@ When you push an image to Docker Hub after enabling vulnerability scanning, Dock
 
 > **Note**
 >
-> Docker Hub Vulnerability Scanning is available for users subscribed to a Pro or a Teams plan. For more information about the pricing plans, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" class="_"}.
+> Docker Hub Vulnerability Scanning is available for users subscribed to a Pro or a Teams plan. For more information about the pricing plans, see [Docker Pricing](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
 
 ## Scan images
 
@@ -28,7 +28,7 @@ Repository owners and administrators can enable vulnerability scanning on a repo
 
 To enable vulnerability scanning:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 2. Click **Repositories** from the main menu and select a repository from the list.
 3. By default, scanning is disabled for all repositories. You can enable scanning separately for each repository. Go to the **Settings** tab and click **Enable Image Scanning**.
 
@@ -54,7 +54,7 @@ To scan an image for vulnerabilities, push the image to Docker Hub:
 
 To view the vulnerability report:
 
-1. Go to [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} and open the repository to view a summary of the vulnerability scanning report.
+1. Go to [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} and open the repository to view a summary of the vulnerability scanning report.
 
     > **Note**
     >
@@ -76,7 +76,7 @@ To view the vulnerability report:
 
 Repository owners and administrators can disable vulnerability scanning on a repository. To disable scanning:
 
-1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" class="_"} account.
+1. Log into your [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"} account.
 2. Click **Repositories** from the main menu and select a repository from the list.
 3. Go to the **Settings** tab and click **Disable Image Scanning**.
 
@@ -98,4 +98,4 @@ After you have followed the steps suggested above, browse the new vulnerability 
 
 ## Feedback
 
-Thank you for trying out the Hub Vulnerability Scanning feature. Your feedback is very important to us. Let us know your feedback by creating an issue in the [hub-feedback](https://github.com/docker/hub-feedback/issues){: target="_blank" class="_"} GitHub repository.
+Thank you for trying out the Hub Vulnerability Scanning feature. Your feedback is very important to us. Let us know your feedback by creating an issue in the [hub-feedback](https://github.com/docker/hub-feedback/issues){: target="_blank" rel="noopener" class="_"} GitHub repository.

--- a/engine/api/index.md
+++ b/engine/api/index.md
@@ -104,7 +104,7 @@ You can specify the API version to use, in one of the following ways:
 
 - For the SDKs, you can also specify the API version programmatically, as a
   parameter to the `client` object. See the
-  [Go constructor](https://github.com/moby/moby/blob/v19.03.6/client/client.go#L119){: target="_blank" class="_"}
+  [Go constructor](https://github.com/moby/moby/blob/v19.03.6/client/client.go#L119){: target="_blank" rel="noopener" class="_"}
   or the
   [Python SDK documentation for `client`](https://docker-py.readthedocs.io/en/stable/client.html).
 

--- a/engine/context/aci-integration.md
+++ b/engine/context/aci-integration.md
@@ -27,12 +27,12 @@ To deploy Docker containers on Azure, you must meet the following requirements:
 
 1. Download and install Docker Desktop Stable version 2.3.0.5 or later, or Edge version 2.3.2.0 or later.
 
-    - [Download for Mac](https://desktop.docker.com/mac/edge/Docker.dmg){: target="_blank" class="_"}
-    - [Download for Windows](https://desktop.docker.com/win/edge/Docker%20Desktop%20Installer.exe){: target="_blank" class="_"}
+    - [Download for Mac](https://desktop.docker.com/mac/edge/Docker.dmg){: target="_blank" rel="noopener" class="_"}
+    - [Download for Windows](https://desktop.docker.com/win/edge/Docker%20Desktop%20Installer.exe){: target="_blank" rel="noopener" class="_"}
 
     Alternatively, install the [Docker Compose CLI for Linux](#install-the-docker-compose-cli-on-linux).
 
-2. Ensure you have an Azure subscription. You can get started with an [Azure free account](https://aka.ms/AA8r2pj){: target="_blank" class="_"}.
+2. Ensure you have an Azure subscription. You can get started with an [Azure free account](https://aka.ms/AA8r2pj){: target="_blank" rel="noopener" class="_"}.
 
 ## Run Docker containers on ACI
 
@@ -274,7 +274,7 @@ curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/instal
 ### Manual install
 
 You can download the Docker ACI Integration CLI from the 
-[latest release](https://github.com/docker/compose-cli/releases/latest){: target="_blank" class="_"} page.
+[latest release](https://github.com/docker/compose-cli/releases/latest){: target="_blank" rel="noopener" class="_"} page.
 
 You will then need to make it executable:
 
@@ -357,4 +357,4 @@ sudo rm /usr/local/bin/docker /usr/local/bin/com.docker.cli
 
 ## Feedback
 
-Thank you for trying out the Docker Azure Integration beta release. Your feedback is very important to us. Let us know your feedback by creating an issue in the [compose-cli](https://github.com/docker/compose-cli){: target="_blank" class="_"} GitHub repository.
+Thank you for trying out the Docker Azure Integration beta release. Your feedback is very important to us. Let us know your feedback by creating an issue in the [compose-cli](https://github.com/docker/compose-cli){: target="_blank" rel="noopener" class="_"} GitHub repository.

--- a/engine/context/ecs-integration.md
+++ b/engine/context/ecs-integration.md
@@ -26,8 +26,8 @@ To deploy Docker containers on ECS, you must meet the following requirements:
 
 1. Download and install Docker Desktop Stable version 2.3.0.5 or later, or Edge version 2.3.2.0 or later.
 
-    - [Download for Mac](https://desktop.docker.com/mac/edge/Docker.dmg){: target="_blank" class="_"}
-    - [Download for Windows](https://desktop.docker.com/win/edge/Docker%20Desktop%20Installer.exe){: target="_blank" class="_"}
+    - [Download for Mac](https://desktop.docker.com/mac/edge/Docker.dmg){: target="_blank" rel="noopener" class="_"}
+    - [Download for Windows](https://desktop.docker.com/win/edge/Docker%20Desktop%20Installer.exe){: target="_blank" rel="noopener" class="_"}
 
     Alternatively, install the [Docker Compose CLI for Linux](#install-the-docker-compose-cli-on-linux).
 
@@ -44,7 +44,7 @@ Run the `docker context create ecs myecscontext` command to create an Amazon ECS
 context named `myecscontext`. If you have already installed and configured the AWS CLI,
 the setup command lets you select an existing AWS profile to connect to Amazon.
 Otherwise, you can create a new profile by passing an
-[AWS access key ID and a secret access key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys){: target="_blank" class="_"}.
+[AWS access key ID and a secret access key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys){: target="_blank" rel="noopener" class="_"}.
 
 After you have created an AWS context, you can list your Docker contexts by running the `docker context ls` command:
 
@@ -80,7 +80,7 @@ using the `docker compose logs` command.
 
 ## Private Docker images
 
-The Docker Compose CLI automatically configures authorization so you can pull private images from the Amazon ECR registry on the same AWS account. To pull private images from another registry, including Docker Hub, you’ll have to create a Username + Password (or a Username + Token) secret on the [AWS Secrets Manager service](https://docs.aws.amazon.com/secretsmanager/){: target="_blank" class="_"}.
+The Docker Compose CLI automatically configures authorization so you can pull private images from the Amazon ECR registry on the same AWS account. To pull private images from another registry, including Docker Hub, you’ll have to create a Username + Password (or a Username + Token) secret on the [AWS Secrets Manager service](https://docs.aws.amazon.com/secretsmanager/){: target="_blank" rel="noopener" class="_"}.
 
 For your convenience, the Docker Compose CLI offers the `docker secret` command, so you can manage secrets created on AWS SMS without having to install the AWS CLI.
 
@@ -105,11 +105,11 @@ services:
 
 ## Service discovery
 
-Service-to-service communication is implemented by the [Security Groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html){: target="_blank" class="_"} rules, allowing services sharing a common Compose file “network” to communicate together. This allows individual services to run with distinct constraints (memory, cpu) and replication rules. However, it comes with a constraint that Docker images have to handle service discovery and wait for dependent services to be available.
+Service-to-service communication is implemented by the [Security Groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html){: target="_blank" rel="noopener" class="_"} rules, allowing services sharing a common Compose file “network” to communicate together. This allows individual services to run with distinct constraints (memory, cpu) and replication rules. However, it comes with a constraint that Docker images have to handle service discovery and wait for dependent services to be available.
 
 ### Service names
 
-Services are registered by the Docker Compose CLI on [AWS Cloud Map](https://docs.aws.amazon.com/cloud-map/latest/dg/what-is-cloud-map.html){: target="_blank" class="_"} during application deployment. They are declared as fully qualified domain names of the form: `<service>.<compose_project_name>.local`. Services can retrieve their dependencies using this fully qualified name, or can just use a short service name (as they do with docker-compose) as Docker Compose CLI automatically injects the `LOCALDOMAIN` variable. This works out of the box if your Docker image fully implements domain name resolution standards, otherwise (typically, when using Alpine-based Docker images), you’ll have to include an [entrypoint script](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint) in your Docker image to force this option:
+Services are registered by the Docker Compose CLI on [AWS Cloud Map](https://docs.aws.amazon.com/cloud-map/latest/dg/what-is-cloud-map.html){: target="_blank" rel="noopener" class="_"} during application deployment. They are declared as fully qualified domain names of the form: `<service>.<compose_project_name>.local`. Services can retrieve their dependencies using this fully qualified name, or can just use a short service name (as they do with docker-compose) as Docker Compose CLI automatically injects the `LOCALDOMAIN` variable. This works out of the box if your Docker image fully implements domain name resolution standards, otherwise (typically, when using Alpine-based Docker images), you’ll have to include an [entrypoint script](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint) in your Docker image to force this option:
 
 ```console
 #! /bin/sh
@@ -183,7 +183,7 @@ Compose file `logging.driver_opts` elements.
 
 Services get concurrently scheduled on ECS when a Compose file is deployed. AWS Cloud Map introduces an initial delay for DNS service to be able to resolve your services domain names. As a result, your code needs to be adjusted to support this delay by waiting for dependent services to be ready, or by adding a wait-script as the entrypoint to your Docker image, as documented in [Control startup order](https://docs.docker.com/compose/startup-order/).
 
-Alternatively, you can use the [depends_on](https://github.com/compose-spec/compose-spec/blob/master/spec.md#depends_on){: target="_blank" class="_"} feature of the Compose file format. By doing this, dependent service will be created first, and application deployment will wait for it to be up and running before starting the creation of the dependent services.
+Alternatively, you can use the [depends_on](https://github.com/compose-spec/compose-spec/blob/master/spec.md#depends_on){: target="_blank" rel="noopener" class="_"} feature of the Compose file format. By doing this, dependent service will be created first, and application deployment will wait for it to be up and running before starting the creation of the dependent services.
 
 ### Rolling update
 
@@ -246,11 +246,11 @@ services:
 
 ## Tuning the CloudFormation template
 
-The Docker Compose CLI relies on [Amazon CloudFormation](https://docs.aws.amazon.com/cloudformation/){: target="_blank" class="_"} to manage the application deployment. To get more control on the created resources, you can use `docker compose convert` to generate a CloudFormation stack file from your Compose file. This allows you to inspect resources it defines, or customize the template for your needs, and then apply the template to AWS using the AWS CLI, or the AWS web console.
+The Docker Compose CLI relies on [Amazon CloudFormation](https://docs.aws.amazon.com/cloudformation/){: target="_blank" rel="noopener" class="_"} to manage the application deployment. To get more control on the created resources, you can use `docker compose convert` to generate a CloudFormation stack file from your Compose file. This allows you to inspect resources it defines, or customize the template for your needs, and then apply the template to AWS using the AWS CLI, or the AWS web console.
 
 ## Using existing AWS network resources
 
-By default, the Docker Compose CLI creates an ECS cluster for your Compose application, a Security Group per network in your Compose file on your AWS account’s default VPC, and a LoadBalancer to route traffic to your services. If your AWS account does not have [permissions](https://github.com/docker/ecs-plugin/blob/master/docs/requirements.md#permissions){: target="_blank" class="_"} to create such resources, or if you want to manage these yourself, you can use the following custom Compose extensions:
+By default, the Docker Compose CLI creates an ECS cluster for your Compose application, a Security Group per network in your Compose file on your AWS account’s default VPC, and a LoadBalancer to route traffic to your services. If your AWS account does not have [permissions](https://github.com/docker/ecs-plugin/blob/master/docs/requirements.md#permissions){: target="_blank" rel="noopener" class="_"} to create such resources, or if you want to manage these yourself, you can use the following custom Compose extensions:
 
 - Use `x-aws-cluster` as a top-level element in your Compose file to set the ARN
 of an ECS cluster when deploying a Compose application. Otherwise, a
@@ -324,8 +324,8 @@ curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/instal
 
 **What does the error `this tool requires the "new ARN resource ID format"` mean?**
 
-This error message means that your account requires the new ARN resource ID format for ECS. To learn more, see [Migrating your Amazon ECS deployment to the new ARN and resource ID format](https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/){: target="_blank" class="_"}.
+This error message means that your account requires the new ARN resource ID format for ECS. To learn more, see [Migrating your Amazon ECS deployment to the new ARN and resource ID format](https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/){: target="_blank" rel="noopener" class="_"}.
 
 ## Feedback
 
-Thank you for trying out the Docker Compose CLI beta release. Your feedback is very important to us. Let us know your feedback by creating an issue in the [Compose CLI](https://github.com/docker/compose-cli){: target="_blank" class="_"} GitHub repository.
+Thank you for trying out the Docker Compose CLI beta release. Your feedback is very important to us. Let us know your feedback by creating an issue in the [Compose CLI](https://github.com/docker/compose-cli){: target="_blank" rel="noopener" class="_"} GitHub repository.

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -63,7 +63,7 @@ use it as a base for 10 different applications. Your ideal PostgreSQL setup can
 be re-used for all your future projects. And so on.
 
  - *Sharing.* Docker has access to a public registry [on Docker
-Hub](https://hub.docker.com/){: target="_blank" class="_"} where thousands of
+Hub](https://hub.docker.com/){: target="_blank" rel="noopener" class="_"} where thousands of
 people have uploaded useful images: anything from Redis, CouchDB, PostgreSQL to
 IRC bouncers to Rails app servers to Hadoop to base images for various Linux
 distros. The [*registry*](../registry/index.md) also includes an official "standard
@@ -83,7 +83,7 @@ private containers, for internal server deployments for example.
 ### What is different between a Docker container and a VM?
 
 There's a great StackOverflow answer [showing the differences](
-http://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-normal-virtual-machine){: target="_blank" class="_"}.
+http://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-normal-virtual-machine){: target="_blank" rel="noopener" class="_"}.
 
 ### Do I lose my data when the container exits?
 
@@ -119,12 +119,12 @@ You can learn about the project's security policy
 ### Why do I need to sign my commits to Docker with the DCO?
 
 Read [our blog post](
-http://blog.docker.com/2014/01/docker-code-contributions-require-developer-certificate-of-origin/){: target="_blank" class="_"} on the introduction of the DCO.
+http://blog.docker.com/2014/01/docker-code-contributions-require-developer-certificate-of-origin/){: target="_blank" rel="noopener" class="_"} on the introduction of the DCO.
 
 ### When building an image, should I prefer system libraries or bundled ones?
 
 *This is a summary of a discussion on the [docker-dev mailing list](
-https://groups.google.com/forum/#!topic/docker-dev/L2RBSPDu1L0){: target="_blank" class="_"}.*
+https://groups.google.com/forum/#!topic/docker-dev/L2RBSPDu1L0){: target="_blank" rel="noopener" class="_"}.*
 
 Virtually all programs depend on third-party libraries. Most frequently, they
 use dynamic linking and some kind of package dependency, so that when
@@ -186,7 +186,7 @@ Because of this, and because setting `DEBIAN_FRONTEND` to `noninteractive` is
 mainly a 'cosmetic' change, we *discourage* changing it.
 
 If you *really* need to change its setting, make sure to change it back to its
-[default value](https://www.debian.org/releases/stable/amd64/ch05s03.en.html#installer-args){: target="_blank" class="_"}
+[default value](https://www.debian.org/releases/stable/amd64/ch05s03.en.html#installer-args){: target="_blank" rel="noopener" class="_"}
 afterwards.
 
 ### Why do I get `Connection reset by peer` when making a request to a service running in a container?
@@ -225,6 +225,6 @@ You can find more answers on:
 
 - [Docker community Slack channel](http://dockr.ly/slack)
 - [Docker Support Forums](https://forums.docker.com)
-- [GitHub](https://github.com/moby/moby){: target="_blank" class="_"}
-- [Ask questions on Stackoverflow](http://stackoverflow.com/search?q=docker){: target="_blank" class="_"}
-- [Join the conversation on Twitter](http://twitter.com/docker){: target="_blank" class="_"}
+- [GitHub](https://github.com/moby/moby){: target="_blank" rel="noopener" class="_"}
+- [Ask questions on Stackoverflow](http://stackoverflow.com/search?q=docker){: target="_blank" rel="noopener" class="_"}
+- [Join the conversation on Twitter](http://twitter.com/docker){: target="_blank" rel="noopener" class="_"}

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -24,7 +24,7 @@ versions aren't supported or tested.
 
 The `centos-extras` repository must be enabled. This repository is enabled by
 default, but if you have disabled it, you need to
-[re-enable it](https://wiki.centos.org/AdditionalResources/Repositories){: target="_blank" class="_" }.
+[re-enable it](https://wiki.centos.org/AdditionalResources/Repositories){: target="_blank" rel="noopener" class="_" }.
 
 The `overlay2` storage driver is recommended.
 
@@ -194,7 +194,7 @@ If you cannot use Docker's repository to install Docker, you can download the
 `.rpm` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" class="_" }
+1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
     and choose your version of CentOS. Then browse to `x86_64/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -225,7 +225,7 @@ If you cannot use Docker's repository to install Docker Engine, you can download
 `.deb` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker.
 
-1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" class="_" },
+1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" },
     choose your Debian version, then browse to `pool/stable/`, choose `amd64`,
     `armhf`, or `arm64` and download the `.deb` file for the Docker version
     you want to install.

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -201,7 +201,7 @@ If you cannot use Docker's repository to install Docker, you can download the
 `.rpm` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" class="_" }
+1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
     and choose your version of Fedora. Then browse to `x86_64/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
 

--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -424,7 +424,7 @@ To disable `dnsmasq` on RHEL, CentOS, or Fedora:
     ```
 
 2.  Configure the DNS servers manually using the
-    [Red Hat documentation](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/s1-networkscripts-interfaces.html){: target="_blank" class="_"}.
+    [Red Hat documentation](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/s1-networkscripts-interfaces.html){: target="_blank" rel="noopener" class="_"}.
 
 ### Allow access to the remote API through a firewall
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -229,7 +229,7 @@ If you cannot use Docker's repository to install Docker Engine, you can download
 `.deb` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker.
 
-1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" class="_" },
+1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" },
     choose your Ubuntu version, then browse to `pool/stable/`, choose `amd64`,
     `armhf`, or `arm64`, and download the `.deb` file for the
     Docker Engine version you want to install.

--- a/engine/scan/index.md
+++ b/engine/scan/index.md
@@ -24,14 +24,14 @@ To run vulnerability scanning on your Docker images, you must meet the following
 
 1. Download and install Docker Desktop Edge version 2.3.6.0 or later.
 
-    - [Download for Mac](https://desktop.docker.com/mac/edge/Docker.dmg){: target="_blank" class="_"}
-    - [Download for Windows](https://desktop.docker.com/win/edge/Docker%20Desktop%20Installer.exe){: target="_blank" class="_"}
+    - [Download for Mac](https://desktop.docker.com/mac/edge/Docker.dmg){: target="_blank" rel="noopener" class="_"}
+    - [Download for Windows](https://desktop.docker.com/win/edge/Docker%20Desktop%20Installer.exe){: target="_blank" rel="noopener" class="_"}
 
-2. Sign into [Docker Hub](https://hub.docker.com){: target="_blank" class="_"}.
+2. Sign into [Docker Hub](https://hub.docker.com){: target="_blank" rel="noopener" class="_"}.
 
 3. From the Docker Desktop menu, select **Sign in/ Create Docker ID**. Alternatively, open a terminal and run the command `docker login`.
 
-4. (Optional) You can create a [Snyk account](https://dockr.ly/3ePqVcp){: target="_blank" class="_"} for scans, or use the additional monthly free scans provided by Snyk with your Docker Hub account.
+4. (Optional) You can create a [Snyk account](https://dockr.ly/3ePqVcp){: target="_blank" rel="noopener" class="_"} for scans, or use the additional monthly free scans provided by Snyk with your Docker Hub account.
 
 Check your installation by running `docker scan --version`, it should print the current version of docker scan and the Snyk engine version. For example:
 
@@ -271,11 +271,11 @@ Tested 200 dependencies for known issues, found 157 issues.
 For more free scans that keep your images secure, sign up to Snyk at https://dockr.ly/3ePqVcp.
 ```
 
-For more information about the vulnerability data, see [Docker Vulnerability Scanning CLI Cheat Sheet](https://goto.docker.com/rs/929-FJL-178/images/cheat-sheet-docker-desktop-vulnerability-scanning-CLI.pdf){: target="_blank" class="_"}.
+For more information about the vulnerability data, see [Docker Vulnerability Scanning CLI Cheat Sheet](https://goto.docker.com/rs/929-FJL-178/images/cheat-sheet-docker-desktop-vulnerability-scanning-CLI.pdf){: target="_blank" rel="noopener" class="_"}.
 
 ## Provider authentication
 
-If you have an existing Snyk account, you can directly use your Snyk [API token](https://app.snyk.io/account){: target="_blank" class="_"}:
+If you have an existing Snyk account, you can directly use your Snyk [API token](https://app.snyk.io/account){: target="_blank" rel="noopener" class="_"}:
 
 ```shell
 $ docker scan --login --token SNYK_AUTH_TOKEN
@@ -294,4 +294,4 @@ If you use the `--login` flag without any token, you will be redirected to the S
 
 ## Feedback
 
-Thank you for trying out the beta release of vulnerability scanning for Docker local images. Your feedback is very important to us. Let us know your feedback by creating an issue in the [scan-cli-plugin](https://github.com/docker/cli-scan-feedback/issues/new){: target="_blank" class="_"} GitHub repository.
+Thank you for trying out the beta release of vulnerability scanning for Docker local images. Your feedback is very important to us. Let us know your feedback by creating an issue in the [scan-cli-plugin](https://github.com/docker/cli-scan-feedback/issues/new){: target="_blank" rel="noopener" class="_"} GitHub repository.

--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -134,7 +134,7 @@ testuser:231072:65536
 
 ## Install
 
-The installation script is available at [https://get.docker.com/rootless](https://get.docker.com/rootless){: target="_blank" class="_" }.
+The installation script is available at [https://get.docker.com/rootless](https://get.docker.com/rootless){: target="_blank" rel="noopener" class="_" }.
 
 ```console
 $ curl -fsSL https://get.docker.com/rootless | sh
@@ -166,7 +166,7 @@ export DOCKER_HOST=unix:///run/user/1001/docker.sock
 
 To install the binaries manually without using the installer, extract
 `docker-rootless-extras-<version>.tgz` along with `docker-<version>.tgz`
-from [https://download.docker.com/linux/static/stable/x86\_64/](https://download.docker.com/linux/static/stable/x86_64/){: target="_blank" class="_" }
+from [https://download.docker.com/linux/static/stable/x86\_64/](https://download.docker.com/linux/static/stable/x86_64/){: target="_blank" rel="noopener" class="_" }
 
 If you already have the Docker daemon running as the root, you only need to
 extract `docker-rootless-extras-<version>.tgz`. The archive can be extracted

--- a/engine/security/userns-remap.md
+++ b/engine/security/userns-remap.md
@@ -7,7 +7,7 @@ title: Isolate containers with a user namespace
 Linux namespaces provide isolation for running processes, limiting their access
 to system resources without the running process being aware of the limitations.
 For more information on Linux namespaces, see
-[Linux namespaces](https://www.linux.com/news/understanding-and-securing-linux-namespaces){: target="_blank" class="_" }.
+[Linux namespaces](https://www.linux.com/news/understanding-and-securing-linux-namespaces){: target="_blank" rel="noopener" class="_" }.
 
 The best way to prevent privilege-escalation attacks from within a container is
 to configure your container's applications to run as unprivileged users. For

--- a/engine/swarm/networking.md
+++ b/engine/swarm/networking.md
@@ -15,7 +15,7 @@ A Docker swarm generates two different kinds of traffic:
 
 This topic discusses how to manage the application data for your swarm services.
 For more details about swarm networking in general, see the
-[Docker networking reference architecture](https://success.docker.com/Architecture/Docker_Reference_Architecture%3A_Designing_Scalable%2C_Portable_Docker_Container_Networks){: target="_blank" class="_" }.
+[Docker networking reference architecture](https://success.docker.com/Architecture/Docker_Reference_Architecture%3A_Designing_Scalable%2C_Portable_Docker_Container_Networks){: target="_blank" rel="noopener" class="_" }.
 
 The following three network concepts are important to swarm services:
 
@@ -417,4 +417,4 @@ $ docker swarm join \
 * [Swarm administration guide](admin_guide.md)
 * [Docker CLI reference](../reference/commandline/docker.md)
 * [Swarm mode tutorial](swarm-tutorial/index.md)
-* [Docker networking reference architecture](https://success.docker.com/Architecture/Docker_Reference_Architecture%3A_Designing_Scalable%2C_Portable_Docker_Container_Networks){: target="_blank" class="_" }
+* [Docker networking reference architecture](https://success.docker.com/Architecture/Docker_Reference_Architecture%3A_Designing_Scalable%2C_Portable_Docker_Container_Networks){: target="_blank" rel="noopener" class="_" }

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -117,7 +117,7 @@ Docker Desktop is an easy-to-install application for your Mac or Windows environ
 
 Follow the instructions appropriate for your operating system to download and install Docker Desktop.
 
- [Docker Desktop for Mac](/docker-for-mac/install/){: target="_blank" class="_"}{: .button .outline-btn} [Docker Desktop for Windows](/docker-for-windows/install/){: target="_blank" class="_"}{: .button .outline-btn}
+ [Docker Desktop for Mac](/docker-for-mac/install/){: target="_blank" rel="noopener" class="_"}{: .button .outline-btn} [Docker Desktop for Windows](/docker-for-windows/install/){: target="_blank" rel="noopener" class="_"}{: .button .outline-btn}
 
 ### Test Docker version
 
@@ -130,7 +130,7 @@ Docker version 19.03.13, build 4484c46d9d
 
 ### Test Docker installation
 
-1.  Test that your installation works by running the [hello-world](https://hub.docker.com/_/hello-world/){: target="_blank" class="_"} Docker image:
+1.  Test that your installation works by running the [hello-world](https://hub.docker.com/_/hello-world/){: target="_blank" rel="noopener" class="_"} Docker image:
 
     ```shell
         $ docker run hello-world

--- a/get-started/nodejs/build-images.md
+++ b/get-started/nodejs/build-images.md
@@ -16,7 +16,7 @@ Now that we have a good overview of containers and the Docker platform, let’s 
 
 To complete this tutorial, you need the following:
 
-- Node.js version 12.18 or later. [Download Node.js](https://nodejs.org/en/){: target="_blank" class="_"}
+- Node.js version 12.18 or later. [Download Node.js](https://nodejs.org/en/){: target="_blank" rel="noopener" class="_"}
 - Docker running locally: Follow the instructions to [download and install Docker](https://docs.docker.com/desktop/).
 - An IDE or a text editor to edit files. We recommend using Visual Studio Code.
 

--- a/get-started/part3.md
+++ b/get-started/part3.md
@@ -16,13 +16,13 @@ Work through the steps to build an image and run it as a containerized applicati
 
 At this point, you've built a containerized application described in [Part 2](part2.md) on your local development machine.
 
-The final step in developing a containerized application is to share your images on a registry like [Docker Hub](https://hub.docker.com/){: target="_blank" class="_”}, so they can be easily downloaded and run on any destination machine.
+The final step in developing a containerized application is to share your images on a registry like [Docker Hub](https://hub.docker.com/){: target="_blank" rel="noopener" class="_”}, so they can be easily downloaded and run on any destination machine.
 
 ## Set up your Docker Hub account
 
 If you don't have a Docker ID, follow these steps to create one. A Docker ID allows you to share images on Docker Hub.
 
-1.  Visit the [Docker Hub sign up](https://hub.docker.com/signup){: target="_blank" class="_”} page.
+1.  Visit the [Docker Hub sign up](https://hub.docker.com/signup){: target="_blank" rel="noopener" class="_”} page.
 
 2.  Fill out the form and submit to create your Docker ID.
 
@@ -61,7 +61,7 @@ Now let's create your first repository, and push your bulletin board image to Do
     docker push <Your Docker ID>/bulletinboard:1.0
     ```
 
-    Visit your repository in [Docker Hub](https://hub.docker.com/repositories){: target="_blank" class="_”}, and you'll see your new image there. Remember, Docker Hub repositories are public by default.
+    Visit your repository in [Docker Hub](https://hub.docker.com/repositories){: target="_blank" rel="noopener" class="_”}, and you'll see your new image there. Remember, Docker Hub repositories are public by default.
 
     > **Having trouble pushing?** Remember, you must be signed into Docker Hub through Docker Desktop or the command line, and you must also name your images correctly, as per the above steps. If the push seemed to work, but you don't see it in Docker Hub, refresh your browser after a couple of minutes and check again.
 

--- a/machine/concepts.md
+++ b/machine/concepts.md
@@ -101,5 +101,5 @@ For more information and resources, visit
 
 - Create and run a Docker host on your [local system using VirtualBox](get-started.md)
 - Provision multiple Docker hosts [on your cloud provider](get-started-cloud.md)
-- [Docker Machine driver reference](drivers/index.md){: target="_blank" class="_"}
-- [Docker Machine subcommand reference](reference/help.md){: target="_blank" class="_"}
+- [Docker Machine driver reference](drivers/index.md){: target="_blank" rel="noopener" class="_"}
+- [Docker Machine subcommand reference](reference/help.md){: target="_blank" rel="noopener" class="_"}

--- a/machine/get-started-cloud.md
+++ b/machine/get-started-cloud.md
@@ -64,9 +64,9 @@ and CPUs, rather than the default behavior of creating smaller servers.
 
 For a full list of the flags/settings available and their defaults, see the
 output of `docker-machine create -h` at the command line, the
-[create](reference/create.md){: target="_blank" class="_" } command in
+[create](reference/create.md){: target="_blank" rel="noopener" class="_" } command in
 the Machine [command line reference](reference/index.md){:
-target="_blank" class="_" }, and [driver options and operating system defaults](drivers/os-base.md){: target="_blank" class="_" }
+target="_blank" rel="noopener" class="_" }, and [driver options and operating system defaults](drivers/os-base.md){: target="_blank" rel="noopener" class="_" }
 in the Machine driver reference.
 
 ## Drivers for cloud providers
@@ -75,7 +75,7 @@ When you install Docker Machine, you get a set of drivers for various cloud
 providers (like Amazon Web Services, DigitalOcean, or Microsoft Azure) and
 local providers (like Oracle VirtualBox, VMWare Fusion, or Microsoft Hyper-V).
 
-See [Docker Machine driver reference](drivers/index.md){:target="_blank" class="_"}
+See [Docker Machine driver reference](drivers/index.md){:target="_blank" rel="noopener" class="_"}
 for details on the drivers, including required flags and configuration options
 (which vary by provider).
 
@@ -85,7 +85,7 @@ Several Docker Machine driver plugins for use with other cloud platforms are
 available from 3rd party contributors. These are use-at-your-own-risk plugins,
 not maintained by or formally associated with Docker.
 
-See [Available driver plugins](https://github.com/docker/docker.github.io/blob/master/machine/AVAILABLE_DRIVER_PLUGINS.md){:target="_blank" class="_"}.
+See [Available driver plugins](https://github.com/docker/docker.github.io/blob/master/machine/AVAILABLE_DRIVER_PLUGINS.md){:target="_blank" rel="noopener" class="_"}.
 
 ## Add a host without a driver
 

--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -61,7 +61,7 @@ use the `virtualbox` driver to create local machines. (See the
 run both HyperKit and Oracle VirtualBox on the same system. To learn more, see
 [Docker Desktop for Mac vs. Docker Toolbox](../docker-for-mac/docker-toolbox.md).
 
-* Make sure you have [the latest VirtualBox](https://www.virtualbox.org/wiki/Downloads){: target="_blank" class="_"}
+* Make sure you have [the latest VirtualBox](https://www.virtualbox.org/wiki/Downloads){: target="_blank" rel="noopener" class="_"}
   correctly installed on your system (either as part of an earlier Toolbox install,
   or manual install).
 
@@ -73,7 +73,7 @@ Toolbox.
 
 * If you are using Docker Toolbox on either Mac or an older version Windows
   system (without Hyper-V), use the `virtualbox` driver to create a local machine
-  based on Oracle [VirtualBox](https://www.virtualbox.org/){:target="_blank" class="_"}.
+  based on Oracle [VirtualBox](https://www.virtualbox.org/){:target="_blank" rel="noopener" class="_"}.
   (See the [Docker Machine driver for Oracle VirtualBox](drivers/virtualbox.md).)
 
 * If you are using Docker Toolbox on a Windows system that has Hyper-V but cannot
@@ -81,10 +81,10 @@ Toolbox.
   `hyperv` driver to create local machines. (See th
    [Docker Machine driver for Microsoft Hyper-V](drivers/hyper-v.md).)
 
-* Make sure you have [the latest VirtualBox](https://www.virtualbox.org/wiki/Downloads){: target="_blank" class="_"}
+* Make sure you have [the latest VirtualBox](https://www.virtualbox.org/wiki/Downloads){: target="_blank" rel="noopener" class="_"}
   correctly installed on your system. If you used
-  [Toolbox](https://www.docker.com/products/docker-toolbox){: target="_blank" class="_"}
-  or [Docker Desktop for Windows](../docker-for-windows/index.md){: target="_blank" class="_"}
+  [Toolbox](https://www.docker.com/products/docker-toolbox){: target="_blank" rel="noopener" class="_"}
+  or [Docker Desktop for Windows](../docker-for-windows/index.md){: target="_blank" rel="noopener" class="_"}
   to install Docker Machine, VirtualBox is
   automatically installed.
 
@@ -149,7 +149,7 @@ choose another name for this new machine.
             Docker is up and running!
             To see how to connect Docker to this machine, run: docker-machine env default
 
-      This command downloads a lightweight Linux distribution ([boot2docker](https://github.com/boot2docker/boot2docker){: target="_blank" class="_"}) with the Docker daemon installed, and creates and starts a VirtualBox VM with Docker running.
+      This command downloads a lightweight Linux distribution ([boot2docker](https://github.com/boot2docker/boot2docker){: target="_blank" rel="noopener" class="_"}) with the Docker daemon installed, and creates and starts a VirtualBox VM with Docker running.
 
 4. List available machines again to see your newly minted machine.
 
@@ -175,7 +175,7 @@ choose another name for this new machine.
 
       **Note**: If you are using `fish`, or a Windows shell such as
       Powershell/`cmd.exe`, the above method does not work as described.
-      Instead, see [the `env` command's documentation](reference/env.md){: target="_blank" class="_"}
+      Instead, see [the `env` command's documentation](reference/env.md){: target="_blank" rel="noopener" class="_"}
       to learn how to set the environment variables for your shell.
 
     This sets environment variables for the current shell that the Docker
@@ -207,7 +207,7 @@ Run a container with `docker run` to verify your set up.
         $ docker-machine ip default
         192.168.99.100
 
-3. Run a [Nginx](https://www.nginx.com/){: target="_blank" class="_"} webserver in a container with the following command:
+3. Run a [Nginx](https://www.nginx.com/){: target="_blank" rel="noopener" class="_"} webserver in a container with the following command:
 
         $ docker run -d -p 8000:80 nginx
 

--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -7,12 +7,12 @@ hide_from_sitemap: true
 
 Install Docker Machine binaries by following the instructions in the following section. You can find the latest
 versions of the binaries on the [docker/machine release
-page](https://github.com/docker/machine/releases/){: target="_blank" class="_" }
+page](https://github.com/docker/machine/releases/){: target="_blank" rel="noopener" class="_" }
 on GitHub.
 
 ## Install Docker Machine
 
-1.  Install [Docker](../engine/install/index.md){: target="_blank" class="_" }.
+1.  Install [Docker](../engine/install/index.md){: target="_blank" rel="noopener" class="_" }.
 
 2.  Download the Docker Machine binary and extract it to your PATH.
 
@@ -33,7 +33,7 @@ on GitHub.
       chmod +x /usr/local/bin/docker-machine
     ```
 
-    If you are running **Windows** with [Git BASH](https://git-for-windows.github.io/){: target="_blank" class="_"}:
+    If you are running **Windows** with [Git BASH](https://git-for-windows.github.io/){: target="_blank" rel="noopener" class="_"}:
 
     ```console
     $ base=https://github.com/docker/machine/releases/download/v{{site.machine_version}} &&
@@ -43,11 +43,11 @@ on GitHub.
     ```
 
     > The above command works on Windows only if you use a
-    terminal emulator such as [Git BASH](https://git-for-windows.github.io/){: target="_blank" class="_"}, which supports Linux commands like `chmod`.
+    terminal emulator such as [Git BASH](https://git-for-windows.github.io/){: target="_blank" rel="noopener" class="_"}, which supports Linux commands like `chmod`.
     {: .important}
 
     Otherwise, download one of the releases from the [docker/machine release
-    page](https://github.com/docker/machine/releases/){: target="_blank" class="_" } directly.
+    page](https://github.com/docker/machine/releases/){: target="_blank" rel="noopener" class="_" } directly.
 
 3.  Check the installation by displaying the Machine version:
 
@@ -90,7 +90,7 @@ PS1='[\u@\h \W$(__docker_machine_ps1)]\$ '
 You can find additional documentation in the comments at the [top of
 each
 script](https://github.com/docker/machine/tree/master/contrib/completion/bash){:
-target="_blank" class="_"}.
+target="_blank" rel="noopener" class="_"}.
 
 ## How to uninstall Docker Machine
 

--- a/notary/advanced_usage.md
+++ b/notary/advanced_usage.md
@@ -117,14 +117,14 @@ without the `-r` flag.
 ### Use a Yubikey
 
 Notary can be used with
-[Yubikey 4](https://www.yubico.com/products/yubikey-hardware/yubikey4/){: target="_blank" class="_"}
+[Yubikey 4](https://www.yubico.com/products/yubikey-hardware/yubikey4/){: target="_blank" rel="noopener" class="_"}
 keys, via a PKCS11 interface when the Yubikey has CCID mode enabled.
 The Yubikey is prioritized to store root keys, and requires user
 touch-input for signing. Yubikey support is included with the Docker Engine 1.11
 client for use with Docker Content Trust.
 
 Yubikey support requires
-[Yubico PIV libraries](https://www.yubico.com/support/knowledge-base/categories/downloads/){: target="_blank" class="_"}
+[Yubico PIV libraries](https://www.yubico.com/support/knowledge-base/categories/downloads/){: target="_blank" rel="noopener" class="_"}
 (bundled with the PIV tools) to be available in standard library locations.
 
 ## Work with delegation roles

--- a/notary/service_architecture.md
+++ b/notary/service_architecture.md
@@ -9,20 +9,20 @@ On this page, you get an overview of the Notary service architecture.
 ## Brief overview of TUF keys and roles
 
 This document assumes familiarity with
-[The Update Framework](https://www.theupdateframework.com/){:target="_blank" class="_"},
+[The Update Framework](https://www.theupdateframework.com/){:target="_blank" rel="noopener" class="_"},
 but here is a brief recap of the TUF roles and corresponding key hierarchy:
 
 ![TUF Key Hierarchy](https://cdn.rawgit.com/docker/notary/09f81717080f53276e6881ece57cbbbf91b8e2a7/docs/images/key-hierarchy.svg){:width="400px"}
 
 - The root key is the root of all trust. It signs the
-  [root metadata file](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L489){:target="_blank" class="_"},
+  [root metadata file](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L489){:target="_blank" rel="noopener" class="_"},
   which lists the IDs of the root, targets, snapshot, and timestamp public keys.
   Clients use these public keys to verify the signatures on all the metadata files
   in the repository. This key is held by a collection owner, and should be kept offline
   and safe, more so than any other key.
 
 - The snapshot key signs the
-  [snapshot metadata file](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L604){:target="_blank" class="_"},
+  [snapshot metadata file](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L604){:target="_blank" rel="noopener" class="_"},
   which enumerates the filenames, sizes, and hashes of the root,
   targets, and delegation metadata files for the collection. This file is used to
   verify the integrity of the other metadata files. The snapshot key is held by
@@ -30,7 +30,7 @@ but here is a brief recap of the TUF roles and corresponding key hierarchy:
   [signing by multiple collaborators via delegation roles](advanced_usage.md#working-with-delegation-roles).
 
 - The timestamp key signs the
-  [timestamp metadata file](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L827){:target="_blank" class="_"},
+  [timestamp metadata file](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L827){:target="_blank" rel="noopener" class="_"},
   which provides freshness guarantees for the collection by having the shortest expiry time of any particular
   piece of metadata and by specifying the filename, size, and hash of the most recent
   snapshot for the collection. It is used to verify the integrity of the snapshot
@@ -39,18 +39,18 @@ but here is a brief recap of the TUF roles and corresponding key hierarchy:
   require that a collection owner come online before each timestamp expiry.
 
 - The targets key signs the
-  [targets metadata file](ttps://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L678){:target="_blank" class="_"},
+  [targets metadata file](ttps://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L678){:target="_blank" rel="noopener" class="_"},
   which lists filenames in the collection, and their sizes and respective
-  [hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function){:target="_blank" class="_"}.
+  [hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function){:target="_blank" rel="noopener" class="_"}.
   This file is used to verify the integrity of some or all of the actual contents of the repository.
   It is also used to
   [delegate trust to other collaborators via delegation roles](advanced_usage.md#working-with-delegation-roles).
   The targets key is held by the collection owner or administrator.
 
 - Delegation keys sign
-  [delegation metadata files](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L678){:target="_blank" class="_"},
+  [delegation metadata files](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L678){:target="_blank" rel="noopener" class="_"},
   which lists filenames in the collection, and their sizes and respective
-  [hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function){:target="_blank" class="_"}.
+  [hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function){:target="_blank" rel="noopener" class="_"}.
   These files are used to verify the integrity of some or all of the actual contents of the repository.
   They are also used to
   [delegate trust to other collaborators via lower level [delegation roles](advanced_usage.md#work-with-delegation-roles).
@@ -64,7 +64,7 @@ Notary clients push metadata to one or more Notary services.
 
 A Notary service consists of a Notary server, which stores and updates the
 signed
-[TUF metadata files](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L348){:target="_blank" class="_"}
+[TUF metadata files](https://github.com/theupdateframework/tuf/blob/1bed3e09a478c2c918ffbff10b9118f6e52ee129/docs/tuf-spec.txt#L348){:target="_blank" rel="noopener" class="_"}
 for multiple trusted collections in an associated database, and a Notary signer, which
 stores private keys for and signs metadata for the Notary server. The following
 diagram illustrates this architecture:
@@ -82,10 +82,10 @@ responsible for:
 The Notary signer is responsible for:
 
 - storing the private signing keys
-  [wrapped](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-31#section-4.4){:target="_blank" class="_"}
+  [wrapped](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-31#section-4.4){:target="_blank" rel="noopener" class="_"}
   and
-  [encrypted](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-31#section-4.8){:target="_blank" class="_"}
-  using [Javascript Object Signing and Encryption](https://github.com/dvsekhvalnov/jose2go){:target="_blank" class="_"}
+  [encrypted](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-31#section-4.8){:target="_blank" rel="noopener" class="_"}
+  using [Javascript Object Signing and Encryption](https://github.com/dvsekhvalnov/jose2go){:target="_blank" rel="noopener" class="_"}
   in a database separate from the Notary server database
 - performing signing operations with these keys whenever the Notary server requests
 
@@ -97,7 +97,7 @@ server, and signer:
 ![Notary Service Sequence Diagram](https://cdn.rawgit.com/docker/notary/27469f01fe244bdf70f34219616657b336724bc3/docs/images/metadata-sequence.svg)
 
 1.  Notary server optionally supports authentication from clients using
-    [JWT](http://jwt.io/){:target="_blank" class="_"} tokens. This requires an
+    [JWT](http://jwt.io/){:target="_blank" rel="noopener" class="_"} tokens. This requires an
     authorization server that manages access controls, and a cert bundle from this
     authorization server containing the public key it uses to sign tokens.
 

--- a/opensource/index.md
+++ b/opensource/index.md
@@ -96,7 +96,7 @@ formats, and gives us a way to test and demo them.
 
 ## Looking for meetups and Docker Community?
 
-Go to the [Docker Community GitHub repository](https://github.com/docker/community/blob/master/README.md){:target="_blank" class="_"}
+Go to the [Docker Community GitHub repository](https://github.com/docker/community/blob/master/README.md){:target="_blank" rel="noopener" class="_"}
 for resources and information on the community.
 
 The topics in this guide on [Other ways to contribute](/opensource/ways/)

--- a/opensource/ways.md
+++ b/opensource/ways.md
@@ -84,7 +84,7 @@ and how long it lasts. Usual meetups tend to last 2 hours, and start between
 
 ## Learn about the Docker Community
 
-Go to the **[Docker Community GitHub repository](https://github.com/docker/community/blob/master/README.md){:target="_blank" class="_"}**
+Go to the **[Docker Community GitHub repository](https://github.com/docker/community/blob/master/README.md){:target="_blank" rel="noopener" class="_"}**
 for resources and information on the community. Those pages are the most
 up-to-date for finding out about the community and making connections.
 
@@ -102,7 +102,7 @@ contribute mentoring if you have good knowledge of:
 * using Docker in some particular domain (for example, testing or deployment)
 * using Git, Go, GitHub, IRC, or other common tools
 
-Also, choose mentoring if you like to be happy. Studies show that [helping others](http://www.huffingtonpost.com/2013/09/03/five-minute-favor-adam-rifkin_n_3805090.html){: target="_blank" class="_"} is a great way to
+Also, choose mentoring if you like to be happy. Studies show that [helping others](http://www.huffingtonpost.com/2013/09/03/five-minute-favor-adam-rifkin_n_3805090.html){: target="_blank" rel="noopener" class="_"} is a great way to
 boost your own well being.
 
 
@@ -110,11 +110,11 @@ boost your own well being.
 
 Docker users are people using Docker in their daily work. To help Docker users, visit:
 
-* the [Docker Community Forum](https://forums.docker.com/){: target="_blank" class="_"}
+* the [Docker Community Forum](https://forums.docker.com/){: target="_blank" rel="noopener" class="_"}
 * the `#docker` channel on Freenode IRC
-* [StackOverflow](http://stackoverflow.com/search?tab=newest&q=docker){: target="_blank" class="_"}
+* [StackOverflow](http://stackoverflow.com/search?tab=newest&q=docker){: target="_blank" rel="noopener" class="_"}
 
-You can also check the lists of [open issues on the Docker docs](https://github.com/docker/docker.github.io/issues){: target="_blank" class="_"} and [open issues on the Moby project](https://github.com/moby/moby/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fquestion+-label%3Astatus%2Fclaimed+-label%3Astatus%2Fassigned+no%3Aassignee){: target="_blank" class="_"}.
+You can also check the lists of [open issues on the Docker docs](https://github.com/docker/docker.github.io/issues){: target="_blank" rel="noopener" class="_"} and [open issues on the Moby project](https://github.com/moby/moby/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fquestion+-label%3Astatus%2Fclaimed+-label%3Astatus%2Fassigned+no%3Aassignee){: target="_blank" rel="noopener" class="_"}.
 
 
 ### Docker contributors
@@ -124,8 +124,8 @@ and product documentation. Contributors may need help with IRC, Go programming,
 Markdown, or with other aspects of contributing. To help Docker contributors,
 visit:
 
-* the [Docker Gitter IM](https://gitter.im/docker/docker){: target="_blank" class="_"} room
-* the [Google group](https://groups.google.com/forum/#!forum/docker-dev){: target="_blank" class="_"}
+* the [Docker Gitter IM](https://gitter.im/docker/docker){: target="_blank" rel="noopener" class="_"} room
+* the [Google group](https://groups.google.com/forum/#!forum/docker-dev){: target="_blank" rel="noopener" class="_"}
 * the `#docker-dev` channel on Freenode IRC
 
 ## Contribute to the Moby open source project

--- a/registry/insecure.md
+++ b/registry/insecure.md
@@ -97,11 +97,11 @@ This is more secure than the insecure registry solution.
 
 
     - **Docker Desktop for Mac**: Follow the instructions on
-      [Adding custom CA certificates](../docker-for-mac/faqs.md#how-do-i-add-custom-ca-certificates){: target="_blank" class="_"}.
+      [Adding custom CA certificates](../docker-for-mac/faqs.md#how-do-i-add-custom-ca-certificates){: target="_blank" rel="noopener" class="_"}.
       Restart Docker.
 
     - **Docker Desktop for Windows**: Follow the instructions on
-      [Adding custom CA certificates](../docker-for-windows/faqs.md#how-do-i-add-custom-ca-certificates){: target="_blank" class="_"}.
+      [Adding custom CA certificates](../docker-for-windows/faqs.md#how-do-i-add-custom-ca-certificates){: target="_blank" rel="noopener" class="_"}.
       Restart Docker.
 
 

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -307,7 +307,7 @@ Before you can set bind propagation on a mount point, the host filesystem needs
 to already support bind propagation.
 
 For more information about bind propagation, see the
-[Linux kernel documentation for shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt){: target="_blank" class="_"}.
+[Linux kernel documentation for shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt){: target="_blank" rel="noopener" class="_"}.
 
 The following example mounts the `target/` directory into the container twice,
 and the second mount sets both the `ro` option and the `rslave` bind propagation

--- a/storage/storagedriver/aufs-driver.md
+++ b/storage/storagedriver/aufs-driver.md
@@ -10,7 +10,7 @@ AUFS is a *union filesystem*. The `aufs` storage driver was previously the defau
 storage driver used for managing images and layers on Docker for Ubuntu, and for
 Debian versions prior to Stretch. If your Linux kernel is version 4.0 or higher,
 and you use Docker Engine - Community, consider using the newer
-[overlay2](overlayfs-driver.md){: target="_blank" class="_" }, which has
+[overlay2](overlayfs-driver.md){: target="_blank" rel="noopener" class="_" }, which has
 potential performance advantages over the `aufs` storage driver.
 
 > **Note**

--- a/storage/storagedriver/device-mapper-driver.md
+++ b/storage/storagedriver/device-mapper-driver.md
@@ -432,7 +432,7 @@ If you run into repeated problems with thin pool, you can set the storage option
 `/etc/docker/daemon.json`. For instance, setting it to `10` ensures
 that operations fail with a warning when the free space is at or near 10%.
 See the
-[storage driver options in the Engine daemon reference](/engine/reference/commandline/dockerd/#storage-driver-options){: target="_blank" class="_"}.
+[storage driver options in the Engine daemon reference](/engine/reference/commandline/dockerd/#storage-driver-options){: target="_blank" rel="noopener" class="_"}.
 
 ### Increase capacity on a running device
 

--- a/storage/storagedriver/zfs-driver.md
+++ b/storage/storagedriver/zfs-driver.md
@@ -34,7 +34,7 @@ use unless you have substantial experience with ZFS on Linux.
   installed.
   - For Ubuntu 14.04, you need to enable a supplemental package repository
     `ppa:zfs-native/stable` before you can install the package. See
-    [https://launchpad.net/~zfs-native/+archive/ubuntu/stable](https://launchpad.net/~zfs-native/+archive/ubuntu/stable){: target="_blank" class="_" }
+    [https://launchpad.net/~zfs-native/+archive/ubuntu/stable](https://launchpad.net/~zfs-native/+archive/ubuntu/stable){: target="_blank" rel="noopener" class="_" }
     for instructions.
 - ZFS is not supported on Docker EE or CS-Engine, or any other Linux platforms.
 - The `/var/lib/docker/` directory must be mounted on a ZFS-formatted

--- a/test.md
+++ b/test.md
@@ -92,14 +92,14 @@ culpa qui officia deserunt mollit anim id est laborum.
 
 - [a markdown link](https://docker.com/)
 https://github.com/docker/docker.github.io/tree/master/docker-cloud/images
-- [a markdown link that opens in a new window](https://docker.com/){: target="_blank" class="_" }
+- [a markdown link that opens in a new window](https://docker.com/){: target="_blank" rel="noopener" class="_" }
   (the `class="_"` trick prevents Atom from italicizing the whole rest of the file until it encounters another underscore.)
 
 - [a markdown link to a custom target ID](#custom-target-id)
 
 - <a href="https://docker.com/">an HTML link</a>
 
-- <a href="https://docker.com/" target="_blank" class="_">an HTML link that opens in a new window</a>
+- <a href="https://docker.com/" target="_blank" rel="noopener" class="_">an HTML link that opens in a new window</a>
 
 - A link to a Github PR in `docker/docker`: {% include github-pr.md pr=28199 %}
 
@@ -162,7 +162,7 @@ might be interesting. You can use them with Markdown or HTML images.
 
 You can add a link to a YouTube video like this:
 
-[Docker 101: Introduction to Docker](https://www.youtube.com/watch?v=V9IJj4MzZBc "Docker 101: Introduction to Docker"){:target="_blank" class="_"}
+[Docker 101: Introduction to Docker](https://www.youtube.com/watch?v=V9IJj4MzZBc "Docker 101: Introduction to Docker"){:target="_blank" rel="noopener" class="_"}
 
 To make the `.png` shown above, first take a screen snap of the YouTube video
 you want to use, then use a graphics app to overlay a play button onto the
@@ -239,7 +239,7 @@ only need to do it on the first one. If you have a `<th>`, set it there.
   <tr>
   <td>This is some test text. <br><br>This is more <b>text</b> on a new line. <br><br>Lorem ipsum dolor <tt>sit amet</tt>, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </td>
-    <td>This is some more text about the right hand side. There is a <a href="https://github.com/docker/docker-ce/blob/master/components/cli/experimental/README.md" target="_blank" class="_">link here to the Docker Experimental Features README</a> on GitHub. In tables, links need to be `<a href="/"></a>`. <br><br>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</td>
+    <td>This is some more text about the right hand side. There is a <a href="https://github.com/docker/docker-ce/blob/master/components/cli/experimental/README.md" target="_blank" rel="noopener" class="_">link here to the Docker Experimental Features README</a> on GitHub. In tables, links need to be `<a href="/"></a>`. <br><br>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</td>
   </tr>
   <tr>
   <td>
@@ -423,7 +423,7 @@ then it takes up the whole row.</div>
 You can use the Bootstrap and CSS to add expand/collapse accordions. This
 implementation makes use of the `.panel-heading` classes in
 [`_utilities.scss`](https://github.com/docker/docker.github.io/blob/master/_scss/_utilities.scsss),
-along with [FontAwesome icons](http://fontawesome.io/cheatsheet/){: target="_blank" class="_" }
+along with [FontAwesome icons](http://fontawesome.io/cheatsheet/){: target="_blank" rel="noopener" class="_" }
 <i class="fa fa-caret-down" aria-hidden="true"></i> (fa-caret-down) and
 <i class="fa fa-caret-up" aria-hidden="true"></i> (fa-caret-up).
 
@@ -433,13 +433,13 @@ the padding renders as white space around the code block grey background. If we
 don't like this effect, we can remove `block` for code samples.
 
 The `style="cursor: pointer"` tag enables the expand/collapse functionality to
-work on mobile. (You can use the [Xcode iPhone simulator](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/iOS_Simulator_Guide/GettingStartedwithiOSSimulator/GettingStartedwithiOSSimulator.html#//apple_ref/doc/uid/TP40012848-CH5-SW4){: target="_blank" class="_" } to test on mobile.)
+work on mobile. (You can use the [Xcode iPhone simulator](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/iOS_Simulator_Guide/GettingStartedwithiOSSimulator/GettingStartedwithiOSSimulator.html#//apple_ref/doc/uid/TP40012848-CH5-SW4){: target="_blank" rel="noopener" class="_" } to test on mobile.)
 
 There are a lot of samples out there for Bootstrap accordions. This is the model
 we used: [PPxOJX accordion sample with HTML and
-CSS](https://codepen.io/anon/pen/PPxOJX){: target="_blank" class="_" }. (Here is
+CSS](https://codepen.io/anon/pen/PPxOJX){: target="_blank" rel="noopener" class="_" }. (Here is
 another example, but it uses Javascript, whereas the implementation shown
-[here](https://www.bootply.com/89084){: target="_blank" class="_" } is Bootstrap
+[here](https://www.bootply.com/89084){: target="_blank" rel="noopener" class="_" } is Bootstrap
 and CSS only.)
 
 > Make sure `data-target`'s and `id`'s match, and are unique
@@ -536,10 +536,10 @@ You can make a badge a link. Wrap the `<span>` with an `<a>` (not the other way
 around) so that the text on the badge is still white.
 
 ```html
-<a href="/test/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page (in a new window)">Test</span></a>
+<a href="/test/" target="_blank" rel="noopener" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page (in a new window)">Test</span></a>
 ```
 
-<a href="/test/" target="_blank" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page (in a new window)">Test</span></a>
+<a href="/test/" target="_blank" rel="noopener" class="_"><span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="Open the test page (in a new window)">Test</span></a>
 
 
 You can also put tooltips on badges (as the example above shows). Keep reading for tooltips.

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -56,7 +56,7 @@ To verify your machine meets these requirements, do the following:
     <br>
     **For Windows 10**
     
-    Run [Speccy](https://www.piriform.com/speccy){: target="_blank" class="_"}, and look at the CPU information.    
+    Run [Speccy](https://www.piriform.com/speccy){: target="_blank" rel="noopener" class="_"}, and look at the CPU information.    
     
     <br>
     **For Windows 8 or 8.1**
@@ -71,7 +71,7 @@ To verify your machine meets these requirements, do the following:
     <br>
     **For Windows 7**
 
-    Run a tool like the [Microsoft® Hardware-Assisted Virtualization Detection Tool](http://www.microsoft.com/en-us/download/details.aspx?id=592){: target="_blank" class="_"} or [Speccy](https://www.piriform.com/speccy){: target="_blank" class="_"}, and follow the on-screen instructions.
+    Run a tool like the [Microsoft® Hardware-Assisted Virtualization Detection Tool](http://www.microsoft.com/en-us/download/details.aspx?id=592){: target="_blank" rel="noopener" class="_"} or [Speccy](https://www.piriform.com/speccy){: target="_blank" rel="noopener" class="_"}, and follow the on-screen instructions.
     <br><br>
 3. Verify your Windows OS is 64-bit (x64)
 


### PR DESCRIPTION
### Add rel="noopener" to external links

(see https://web.dev/external-anchors-use-rel-noopener/) Using noopener, as that addresses the security issue. "noreferer" blocks the REFERER header, which may still be useful for some target URLs.

### Use full URLs for canonical links

Canonical links are expected to be full URLs, not relative.

<img width="735" alt="Screenshot 2020-10-12 at 12 25 09" src="https://user-images.githubusercontent.com/1804568/95740458-d4330400-0c8c-11eb-85a5-212bfbac3ccd.png">


For this to work, the Dockerfile had to be updated, because we're stripping the domain-name from links ("`<a href...`"), but the script currently also included "`<link rel='canonical' ..`" tags.

With the change, canonical links are left alone;

These hrefs will be replaced

    echo '<a class=foo href="https://docs.docker.com/foo">hello</a>' | sed -e 's#\(<a[^>]* href="\)https://docs.docker.com/#\1/#g'
    # <a class=foo href="/foo">hello</a>
    echo '<a href="https://docs.docker.com/foo">hello</a>' | sed -e 's#\(<a[^>]* href="\)https://docs.docker.com/#\1/#g'
    # <a href="/foo">hello</a>

But, for example, this one is left alone

    echo '<link rel="canonical" href="https://docs.docker.com/foo/bar" />' | sed -e 's#\(<a[^>]* href="?\)https://docs.docker.com/#\1/#g'
    # <link rel="canonical" href="https://docs.docker.com/foo/bar" />
