### PR TITLE
Various link fixes

### DIFF
--- a/_includes/body-landing.html
+++ b/_includes/body-landing.html
@@ -135,7 +135,7 @@
               <a href="/network/">Manage container networking</a>
             </div>
             <div class="col-xs-12 col-md-6">
-              <a href="/compose/compose-file">Write a Docker Compose file</a>
+              <a href="/compose/compose-file/">Write a Docker Compose file</a>
             </div>
             <div class="col-xs-12 col-md-6">
               <a href="/storage/">Work with volumes and bind mounts</a>

--- a/_includes/content/compose-extfields-sub.md
+++ b/_includes/content/compose-extfields-sub.md
@@ -20,7 +20,7 @@ x-custom:
 ```
 
 The contents of those fields are ignored by Compose, but they can be
-inserted in your resource definitions using [YAML anchors](http://www.yaml.org/spec/1.2/spec.html#id2765878).
+inserted in your resource definitions using [YAML anchors](https://yaml.org/spec/1.2/spec.html#id2765878).
 For example, if you want several of your services to use the same logging
 configuration:
 
@@ -53,7 +53,7 @@ services:
 ```
 
 It is also possible to partially override values in extension fields using
-the [YAML merge type](http://yaml.org/type/merge.html). For example:
+the [YAML merge type](https://yaml.org/type/merge.html). For example:
 
 ```yaml
 version: '3.4'

--- a/_includes/content/ssh/ssh-overview.md
+++ b/_includes/content/ssh/ssh-overview.md
@@ -10,5 +10,5 @@ topics below are derived from that GitHub documentation.
 
 Commands for working with SSH keys are described for Mac, Windows, and Linux.
 The Windows steps suggest using [Git Bash](https://git-for-windows.github.io/) but you could also use a tool like
-[PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) or
+[PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) or
 [Bitvise](https://www.bitvise.com/index).

--- a/_samples/library/jruby.md
+++ b/_samples/library/jruby.md
@@ -8,10 +8,10 @@ hide_from_sitemap: true
 redirect_from:
 - /samples/jruby/
 description: |
-  JRuby (http://www.jruby.org) is an implementation of Ruby (http://www.ruby-lang.org) on the JVM.
+  JRuby (https://www.jruby.org) is an implementation of Ruby (https://www.ruby-lang.org/en/) on the JVM.
 ---
 
-JRuby (http://www.jruby.org) is an implementation of Ruby (http://www.ruby-lang.org) on the JVM.
+JRuby (https://www.jruby.org) is an implementation of Ruby (https://www.ruby-lang.org/en/) on the JVM.
 
 
 {% include library-samples.md %}

--- a/components.md
+++ b/components.md
@@ -4,12 +4,12 @@ title: Components
 hide_from_sitemap: true
 ---
 
-For components and controls we are using [Bootstrap](http://getbootstrap.com/)
+For components and controls we are using [Bootstrap](https://getbootstrap.com)
 
 
 <!-- ### Dropdowns
 <div class="dropdown">
-  <a id="dLabel" data-target="#" href="http://example.com" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+  <a id="dLabel" data-target="#" href="https://example.com" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
     Dropdown trigger
     <span class="caret"></span>
   </a>
@@ -52,7 +52,7 @@ For components and controls we are using [Bootstrap](http://getbootstrap.com/)
 
 
 ### Accordion
-[Bootstrap docs](http://getbootstrap.com/javascript/#collapse)
+[Bootstrap docs](https://getbootstrap.com/docs/3.4/javascript/)
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="headingOne">

--- a/compose/completion.md
+++ b/compose/completion.md
@@ -4,7 +4,7 @@ keywords: fig, composition, compose, docker, orchestration, cli, reference
 title: Command-line completion
 ---
 
-Compose comes with [command completion](http://en.wikipedia.org/wiki/Command-line_completion)
+Compose comes with [command completion](https://en.wikipedia.org/wiki/Command-line_completion)
 for the bash and zsh shell.
 
 ## Install command completion

--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -22,7 +22,7 @@ how to upgrade, see **[About versions and upgrading](compose-versioning.md)**.
 
 ## Service configuration reference
 
-The Version 1 Compose file is a [YAML](http://yaml.org/) file that defines [services](#service-configuration-reference).
+The Version 1 Compose file is a [YAML](https://yaml.org) file that defines [services](#service-configuration-reference).
 
 The default path for a Compose file is `./docker-compose.yml`.
 

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -20,7 +20,7 @@ how to upgrade, see **[About versions and upgrading](compose-versioning.md)**.
 
 ## Service configuration reference
 
-The Compose file is a [YAML](http://yaml.org/) file defining
+The Compose file is a [YAML](https://yaml.org) file defining
 [services](#service-configuration-reference),
 [networks](#network-configuration-reference) and
 [volumes](#volume-configuration-reference).

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -4,7 +4,7 @@ keywords: fig, composition, compose, versions, upgrading, docker
 title: Compose file versions and upgrading
 ---
 
-The Compose file is a [YAML](http://yaml.org/) file defining services,
+The Compose file is a [YAML](https://yaml.org) file defining services,
 networks, and volumes for a Docker application.
 
 The Compose file formats are now described in these references, specific to each version.

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -143,7 +143,7 @@ Compose file.
 
 ## Service configuration reference
 
-The Compose file is a [YAML](http://yaml.org/) file defining
+The Compose file is a [YAML](https://yaml.org) file defining
 [services](#service-configuration-reference),
 [networks](#network-configuration-reference) and
 [volumes](#volume-configuration-reference).

--- a/compose/faq.md
+++ b/compose/faq.md
@@ -45,7 +45,7 @@ add an explicit signal handler for `SIGTERM`.
         stop_signal: SIGINT
 
 * If you can't modify the application, wrap the application in a lightweight init
-system (like [s6](http://skarnet.org/software/s6/)) or a signal proxy (like
+system (like [s6](https://skarnet.org/software/s6/)) or a signal proxy (like
 [dumb-init](https://github.com/Yelp/dumb-init) or
 [tini](https://github.com/krallin/tini)).  Either of these wrappers takes care of
 handling `SIGTERM` properly.
@@ -79,7 +79,7 @@ containers.
 
 ## Can I use json instead of yaml for my Compose file?
 
-Yes. [Yaml is a superset of json](http://stackoverflow.com/a/1729545/444646) so
+Yes. [Yaml is a superset of json](https://stackoverflow.com/a/1729545/444646) so
 any JSON file should be valid Yaml.  To use a JSON file with Compose,
 specify the filename to use, for example:
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -184,7 +184,7 @@ using `pip`, we recommend that you use a
 [virtualenv](https://virtualenv.pypa.io/en/latest/) because many operating
 systems have python system packages that conflict with docker-compose
 dependencies. See the [virtualenv
-tutorial](http://docs.python-guide.org/en/latest/dev/virtualenvs/) to get
+tutorial](https://docs.python-guide.org/dev/virtualenvs/) to get
 started.
 
 ```bash

--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -11,7 +11,7 @@ The `awslogs` logging driver sends container logs to
 [Amazon CloudWatch Logs](https://aws.amazon.com/cloudwatch/details/#log-monitoring).
 Log entries can be retrieved through the [AWS Management
 Console](https://console.aws.amazon.com/cloudwatch/home#logs:) or the [AWS SDKs
-and Command Line Tools](http://docs.aws.amazon.com/cli/latest/reference/logs/index.html).
+and Command Line Tools](https://docs.aws.amazon.com/cli/latest/reference/logs/index.html).
 
 ## Usage
 
@@ -85,7 +85,7 @@ with the provided endpoint.
 ### awslogs-group
 
 You must specify a
-[log group](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchLogs.html)
+[log group](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
 for the `awslogs` logging driver. You can specify the log group with the
 `awslogs-group` log option:
 
@@ -96,7 +96,7 @@ $ docker run --log-driver=awslogs --log-opt awslogs-region=us-east-1 --log-opt a
 ### awslogs-stream
 
 To configure which
-[log stream](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchLogs.html)
+[log stream](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
 should be used, you can specify the `awslogs-stream` log option. If not
 specified, the container ID is used as the log stream.
 
@@ -129,7 +129,7 @@ $ docker run \
 ### awslogs-datetime-format
 
 The `awslogs-datetime-format` option defines a multiline start pattern in [Python
-`strftime` format](http://strftime.org). A log message consists of a line that
+`strftime` format](https://strftime.org). A log message consists of a line that
 matches the pattern and any following lines that don't match the pattern. Thus
 the matched line is the delimiter between log messages.
 

--- a/config/containers/logging/fluentd.md
+++ b/config/containers/logging/fluentd.md
@@ -9,9 +9,9 @@ title: Fluentd logging driver
 ---
 
 The `fluentd` logging driver sends container logs to the
-[Fluentd](http://www.fluentd.org/) collector as structured log data. Then, users
+[Fluentd](https://www.fluentd.org) collector as structured log data. Then, users
 can use any of the [various output plugins of
-Fluentd](http://www.fluentd.org/plugins) to write these logs to various
+Fluentd](https://www.fluentd.org/plugins) to write these logs to various
 destinations.
 
 In addition to the log message itself, the `fluentd` log
@@ -133,8 +133,8 @@ Generates event logs in nanosecond resolution. Defaults to `false`.
 
 ## Fluentd daemon management with Docker
 
-About `Fluentd` itself, see [the project webpage](http://www.fluentd.org)
-and [its documents](http://docs.fluentd.org/).
+About `Fluentd` itself, see [the project webpage](https://www.fluentd.org)
+and [its documents](https://docs.fluentd.org).
 
 To use this logging driver, start the `fluentd` daemon on a host. We recommend
 that you use [the Fluentd docker

--- a/config/containers/logging/gelf.md
+++ b/config/containers/logging/gelf.md
@@ -9,7 +9,7 @@ title: Graylog Extended Format logging driver
 
 The `gelf` logging driver is a convenient format that is understood by a number of tools such as
 [Graylog](https://www.graylog.org/), [Logstash](https://www.elastic.co/products/logstash), and
-[Fluentd](http://www.fluentd.org/). Many tools use this format.
+[Fluentd](https://www.fluentd.org). Many tools use this format.
 
 In GELF, every log message is a dict with the following fields:
 

--- a/config/containers/logging/index.md
+++ b/config/containers/logging/index.md
@@ -20,7 +20,7 @@ may include input from the keyboard or input from another command. `STDOUT` is
 usually a command's normal output, and `STDERR` is typically used to output
 error messages. By default, `docker logs` shows the command's `STDOUT` and
 `STDERR`. To read more about I/O and Linux, see the
-[Linux Documentation Project article on I/O redirection](http://www.tldp.org/LDP/abs/html/io-redirection.html).
+[Linux Documentation Project article on I/O redirection](https://tldp.org/LDP/abs/html/io-redirection.html).
 
 In some cases, `docker logs` may not show useful information unless you take
 additional steps.

--- a/config/containers/logging/journald.md
+++ b/config/containers/logging/journald.md
@@ -8,7 +8,7 @@ title: Journald logging driver
 ---
 
 The `journald` logging driver sends container logs to the
-[`systemd` journal](http://www.freedesktop.org/software/systemd/man/systemd-journald.service.html).
+[`systemd` journal](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html).
 Log entries can be retrieved using the `journalctl` command, through use of the
 `journal` API, or using the `docker logs` command.
 

--- a/config/containers/logging/splunk.md
+++ b/config/containers/logging/splunk.md
@@ -8,7 +8,7 @@ title: Splunk logging driver
 ---
 
 The `splunk` logging driver sends container logs to
-[HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE6M)
+[HTTP Event Collector](https://dev.splunk.com/enterprise/docs/devtools/httpeventcollector/)
 in Splunk Enterprise and Splunk Cloud.
 
 ## Usage

--- a/config/containers/runmetrics.md
+++ b/config/containers/runmetrics.md
@@ -177,7 +177,7 @@ Those times are expressed in ticks of 1/100th of a second, also called "user
 jiffies". There are `USER_HZ` *"jiffies"* per second, and on x86 systems,
 `USER_HZ` is 100. Historically, this mapped exactly to the number of scheduler
 "ticks" per second, but higher frequency scheduling and
-[tickless kernels]( http://lwn.net/Articles/549580/) have made the number of
+[tickless kernels](https://lwn.net/Articles/549580/) have made the number of
 ticks irrelevant.
 
 #### Block I/O metrics

--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -73,7 +73,7 @@ Keep the following in mind when using restart policies:
 If restart policies don't suit your needs, such as when processes outside
 Docker depend on Docker containers, you can use a process manager such as
 [upstart](http://upstart.ubuntu.com/),
-[systemd](http://freedesktop.org/wiki/Software/systemd/), or
+[systemd](https://freedesktop.org/wiki/Software/systemd/), or
 [supervisor](http://supervisord.org/) instead.
 
 > **Warning**

--- a/desktop/enterprise/admin/install/windows.md
+++ b/desktop/enterprise/admin/install/windows.md
@@ -29,7 +29,7 @@ This page contains information about the system requirements and specific instru
 - The following hardware prerequisites are required to successfully run Client
 Hyper-V on Windows 10:
 
-  - 64 bit processor with [Second Level Address Translation (SLAT)](http://en.wikipedia.org/wiki/Second_Level_Address_Translation)
+  - 64 bit processor with [Second Level Address Translation (SLAT)](https://en.wikipedia.org/wiki/Second_Level_Address_Translation)
 
   - 4GB system RAM
 

--- a/desktop/enterprise/user/mac-user.md
+++ b/desktop/enterprise/user/mac-user.md
@@ -403,7 +403,7 @@ installed both in Bash and Zsh.
 
 Bash has [built-in support for completion](https://www.debian-administration.org/article/316/An_introduction_to_bash_completion_part_1). To activate completion for Docker commands, these files need to be
 copied or symlinked to your `bash_completion.d/` directory. For example, if you have
-installed bash through [Homebrew](http://brew.sh/).
+installed bash through [Homebrew](https://brew.sh).
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc
@@ -416,7 +416,7 @@ ln -s $etc/docker-compose.bash-completion $(brew --prefix)/etc/bash_completion.d
 In Zsh, the [completion
 system](http://zsh.sourceforge.net/Doc/Release/Completion-System.html) takes care of things. To activate completion for Docker commands,
 these files need to be copied or symlinked to your Zsh `site-functions/`
-directory. For example, if you installed Zsh through [Homebrew](http://brew.sh/):
+directory. For example, if you installed Zsh through [Homebrew](https://brew.sh):
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc

--- a/desktop/enterprise/user/windows-user.md
+++ b/desktop/enterprise/user/windows-user.md
@@ -228,7 +228,7 @@ do not need to open port 445 on any other network.
 
 By default, allow connections to `10.0.75.1` on port 445 (the Windows host) from
 `10.0.75.2` (the virtual machine). If your firewall rules seem correct, you may
-need to toggle or [reinstall the File and Print sharing service on the Hyper-V virtual network card](http://stackoverflow.com/questions/42203488/settings-to-windows-firewall-to-allow-docker-for-windows-to-share-drive/43904051#43904051).
+need to toggle or [reinstall the File and Print sharing service on the Hyper-V virtual network card](https://stackoverflow.com/questions/42203488/settings-to-windows-firewall-to-allow-docker-for-windows-to-share-drive/43904051#43904051).
 
 ##### Shared drives on demand
 

--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -107,7 +107,7 @@ can be useful to perform one-off builds without writing a Dockerfile to disk,
 or in situations where the `Dockerfile` is generated, and should not persist
 afterwards.
 
-> The examples in this section use [here documents](http://tldp.org/LDP/abs/html/here-docs.html)
+> The examples in this section use [here documents](https://tldp.org/LDP/abs/html/here-docs.html)
 > for convenience, but any method to provide the `Dockerfile` on `stdin` can be
 > used.
 > 
@@ -192,7 +192,7 @@ docker build [OPTIONS] -f- PATH
 
 The example below uses the current directory (`.`) as the build context, and builds
 an image using a `Dockerfile` that is passed through `stdin` using a [here
-document](http://tldp.org/LDP/abs/html/here-docs.html).
+document](https://tldp.org/LDP/abs/html/here-docs.html).
 
 ```bash
 # create a directory to work in
@@ -315,7 +315,7 @@ Limiting each container to one process is a good rule of thumb, but it is not a
 hard and fast rule. For example, not only can containers be
 [spawned with an init process](../../engine/reference/run.md#specify-an-init-process),
 some programs might spawn additional processes of their own accord. For
-instance, [Celery](http://www.celeryproject.org/) can spawn multiple worker
+instance, [Celery](https://docs.celeryproject.org/) can spawn multiple worker
 processes, and [Apache](https://httpd.apache.org/) can create one process per
 request.
 
@@ -646,7 +646,7 @@ version bumps are easier to maintain, as seen in the following example:
 ```dockerfile
 ENV PG_MAJOR=9.3
 ENV PG_VERSION=9.3.4
-RUN curl -SL http://example.com/postgres-$PG_VERSION.tar.xz | tar -xJC /usr/src/postgress && …
+RUN curl -SL https://example.com/postgres-$PG_VERSION.tar.xz | tar -xJC /usr/src/postgress && …
 ENV PATH=/usr/local/postgres-$PG_MAJOR/bin:$PATH
 ```
 
@@ -729,7 +729,7 @@ have to add another layer in your image. For example, you should avoid doing
 things like:
 
 ```dockerfile
-ADD http://example.com/big.tar.xz /usr/src/things/
+ADD https://example.com/big.tar.xz /usr/src/things/
 RUN tar -xJf /usr/src/things/big.tar.xz -C /usr/src/things
 RUN make -C /usr/src/things all
 ```
@@ -738,7 +738,7 @@ And instead, do something like:
 
 ```dockerfile
 RUN mkdir -p /usr/src/things \
-    && curl -SL http://example.com/big.tar.xz \
+    && curl -SL https://example.com/big.tar.xz \
     | tar -xJC /usr/src/things \
     && make -C /usr/src/things all
 ```
@@ -802,7 +802,7 @@ exec "$@"
 
 > Configure app as PID 1
 >
-> This script uses [the `exec` Bash command](http://wiki.bash-hackers.org/commands/builtin/exec)
+> This script uses [the `exec` Bash command](https://wiki.bash-hackers.org/commands/builtin/exec)
 > so that the final running application becomes the container's PID 1. This
 > allows the application to receive any Unix signals sent to the container.
 > For more, see the [`ENTRYPOINT` reference](../../engine/reference/builder.md#entrypoint).

--- a/develop/develop-images/multistage-build.md
+++ b/develop/develop-images/multistage-build.md
@@ -13,7 +13,7 @@ optimize Dockerfiles while keeping them easy to read and maintain.
 > **Acknowledgment**:
 > Special thanks to [Alex Ellis](https://twitter.com/alexellisuk) for granting
 > permission to use his blog post
-> [Builder pattern vs. Multi-stage builds in Docker](http://blog.alexellis.io/mutli-stage-docker-builds/)
+> [Builder pattern vs. Multi-stage builds in Docker](https://blog.alexellis.io/mutli-stage-docker-builds/)
 > as the basis of the examples below.
 
 ## Before multi-stage builds

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -284,8 +284,7 @@ certificates](#directory-structures-for-certificates).
 
 For a complete explanation of how to do this, see the blog post [Adding
 Self-signed Registry Certs to Docker & Docker Desktop for
-Mac](http://container-solutions.com/adding-self-signed-registry-certs-docker-mac/){:target="_blank"
-class="_"}.
+Mac](https://blog.container-solutions.com/adding-self-signed-registry-certs-docker-mac){:target="_blank" rel="noopener" class="_"}.
 
 ### Add client certificates
 
@@ -359,7 +358,7 @@ Bash has [built-in support for
 completion](https://www.debian-administration.org/article/316/An_introduction_to_bash_completion_part_1){:target="_blank"
 class="_"} To activate completion for Docker commands, these files need to be
 copied or symlinked to your `bash_completion.d/` directory. For example, if you
-installed bash via [Homebrew](http://brew.sh/):
+installed bash via [Homebrew](https://brew.sh):
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc
@@ -384,10 +383,10 @@ fi
 ### Zsh
 
 In Zsh, the [completion
-system](http://zsh.sourceforge.net/Doc/Release/Completion-System.html){:target="_blank"
-class="_"} takes care of things. To activate completion for Docker commands,
+system](http://zsh.sourceforge.net/Doc/Release/Completion-System.html){:target="_blank" rel="nooopener" class="_"}
+takes care of things. To activate completion for Docker commands,
 these files need to be copied or symlinked to your Zsh `site-functions/`
-directory. For example, if you installed Zsh via [Homebrew](http://brew.sh/):
+directory. For example, if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="nooopener" class="_"}:
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc

--- a/docker-for-mac/multi-arch.md
+++ b/docker-for-mac/multi-arch.md
@@ -23,7 +23,7 @@ which means you can run containers for different Linux architectures
 such as `arm`, `mips`, `ppc64le`, and even `s390x`.
 
 This does not require any special configuration in the container itself as it uses
-<a href="http://wiki.qemu.org/" target="_blank" rel="noopener">qemu-static</a> from the **Docker for
+<a href="https://wiki.qemu.org/Main_Page" target="_blank" rel="noopener">qemu-static</a> from the **Docker for
 Mac VM**. Because of this, you can run an ARM container, like the `arm32v7` or `ppc64le`
 variants of the busybox image.
 

--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -97,7 +97,7 @@ the `--privileged` flag. See [docker/for-win#8326](https://github.com/docker/for
 
 ### Bug fixes and minor changes
 
-- Fixed a privilege escalation vulnerability in `com.docker.vmnetd`. See [CVE-2020-15360](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15360)
+- Fixed a privilege escalation vulnerability in `com.docker.vmnetd`. See [CVE-2020-15360](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15360)
 - Fixed an issue with startup when the Kubernetes certificates have expired. See [docker/for-mac#4594](https://github.com/docker/for-mac/issues/4594)
 - Fix an incompatibility between `hyperkit` and [osquery](https://osquery.io) which resulted in excessive `hyperkit` CPU usage. See [docker/for-mac#3499](https://github.com/docker/for-mac/issues/3499#issuecomment-619544836)
 - Dashboard: Fixed containers logs which were sometimes truncated. Fixes [docker/for-win#5954](https://github.com/docker/for-win/issues/5954)

--- a/docker-for-windows/index.md
+++ b/docker-for-windows/index.md
@@ -150,7 +150,7 @@ If you wish to set the proxy settings for your containers, you need to define
 environment variables for them, just like you would do on Linux, for example:
 
 ```ps
-> docker run -e HTTP_PROXY=http://proxy.example.com:3128 alpine env
+> docker run -e HTTP_PROXY=https://proxy.example.com:3128 alpine env
 
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOSTNAME=b7edf988b2b5

--- a/docker-for-windows/install-windows-home.md
+++ b/docker-for-windows/install-windows-home.md
@@ -39,7 +39,7 @@ Windows 10 Home machines must meet the following requirements to install Docker 
   - The following hardware prerequisites are required to successfully run
 WSL 2 on Windows 10 Home:
 
-     - 64 bit processor with [Second Level Address Translation (SLAT)](http://en.wikipedia.org/wiki/Second_Level_Address_Translation)
+     - 64 bit processor with [Second Level Address Translation (SLAT)](https://en.wikipedia.org/wiki/Second_Level_Address_Translation)
      - 4GB system RAM
     - BIOS-level hardware virtualization support must be enabled in the
     BIOS settings.  For more information, see

--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -26,7 +26,7 @@ By downloading Docker Desktop, you agree to the terms of the [Docker Software En
   - The following hardware prerequisites are required to successfully run Client
 Hyper-V on Windows 10:
 
-     - 64 bit processor with [Second Level Address Translation (SLAT)](http://en.wikipedia.org/wiki/Second_Level_Address_Translation)
+     - 64 bit processor with [Second Level Address Translation (SLAT)](https://en.wikipedia.org/wiki/Second_Level_Address_Translation)
      - 4GB system RAM
     - BIOS-level hardware virtualization support must be enabled in the
     BIOS settings.  For more information, see

--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -95,5 +95,5 @@ The following parameters are recognized in callback data:
       "state": "success",
       "description": "387 tests PASSED",
       "context": "Continuous integration by Acme CI",
-      "target_url": "http://ci.acme.com/results/afd339c1c3d27"
+      "target_url": "https://ci.acme.com/results/afd339c1c3d27"
     }

--- a/engine/examples/postgresql_service.md
+++ b/engine/examples/postgresql_service.md
@@ -7,7 +7,7 @@ title: Dockerize PostgreSQL
 ## Install PostgreSQL on Docker
 
 Assuming there is no Docker image that suits your needs on the [Docker
-Hub](http://hub.docker.com), you can create one yourself.
+Hub](https://hub.docker.com), you can create one yourself.
 
 Start by creating a new `Dockerfile`:
 

--- a/engine/examples/running_riak_service.md
+++ b/engine/examples/running_riak_service.md
@@ -96,6 +96,6 @@ Now you can build a Docker image for Riak:
 
 Riak is a distributed database. Many production deployments consist of
 [at least five nodes](
-http://basho.com/why-your-riak-cluster-should-have-at-least-five-nodes/).
+https://riak.com/why-your-riak-cluster-should-have-at-least-five-nodes/).
 See the [docker-riak](https://github.com/hectcastro/docker-riak) project
 details on how to deploy a Riak cluster using Docker and Pipework.

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -83,7 +83,7 @@ private containers, for internal server deployments for example.
 ### What is different between a Docker container and a VM?
 
 There's a great StackOverflow answer [showing the differences](
-http://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-normal-virtual-machine){: target="_blank" rel="noopener" class="_"}.
+https://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-normal-virtual-machine){: target="_blank" rel="noopener" class="_"}.
 
 ### Do I lose my data when the container exits?
 
@@ -119,7 +119,7 @@ You can learn about the project's security policy
 ### Why do I need to sign my commits to Docker with the DCO?
 
 Read [our blog post](
-http://blog.docker.com/2014/01/docker-code-contributions-require-developer-certificate-of-origin/){: target="_blank" rel="noopener" class="_"} on the introduction of the DCO.
+https://www.docker.com/blog/docker-code-contributions-require-developer-certificate-of-origin/){: target="_blank" rel="noopener" class="_"} on the introduction of the DCO.
 
 ### When building an image, should I prefer system libraries or bundled ones?
 
@@ -141,9 +141,9 @@ The key point about system libraries is not about saving disk or memory space.
 It is about security. All major distributions handle security seriously, by
 having dedicated security teams, following up closely with published
 vulnerabilities, and disclosing advisories themselves. (Look at the [Debian
-Security Information](https://www.debian.org/security/){: target="_blank"
-class="_"} for an example of those procedures.) Upstream developers, however, do
-not always implement similar practices.
+Security Information](https://www.debian.org/security/){: target="_blank" rel="noopener" class="_"}
+for an example of those procedures.) Upstream developers, however, do not always
+implement similar practices.
 
 Before setting up a Docker image to compile a program from source, if you want
 to use bundled libraries, you should check if the upstream authors provide a
@@ -155,8 +155,7 @@ Likewise, before using packages built by others, you should check if the
 channels providing those packages implement similar security best practices.
 Downloading and installing an "all-in-one" .deb or .rpm sounds great at first,
 except if you have no way to figure out that it contains a copy of the OpenSSL
-library vulnerable to the [Heartbleed](http://heartbleed.com/){: target="_blank"
-class="_"} bug.
+library vulnerable to the [Heartbleed](https://heartbleed.com){: target="_blank" rel="noopener" class="_"} bug.
 
 ### Why is `DEBIAN_FRONTEND=noninteractive` discouraged in Dockerfiles?
 
@@ -223,8 +222,8 @@ You need to tell Docker to talk to that machine. You can do this with the
 
 You can find more answers on:
 
-- [Docker community Slack channel](http://dockr.ly/slack)
-- [Docker Support Forums](https://forums.docker.com)
+- [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
+- [Docker Support Forums](https://forums.docker.com){: target="_blank" rel="noopener" class="_"}
 - [GitHub](https://github.com/moby/moby){: target="_blank" rel="noopener" class="_"}
-- [Ask questions on Stackoverflow](http://stackoverflow.com/search?q=docker){: target="_blank" rel="noopener" class="_"}
-- [Join the conversation on Twitter](http://twitter.com/docker){: target="_blank" rel="noopener" class="_"}
+- [Ask questions on Stackoverflow](https://stackoverflow.com/search?q=docker){: target="_blank" rel="noopener" class="_"}
+- [Join the conversation on Twitter](https://twitter.com/docker){: target="_blank" rel="noopener" class="_"}

--- a/engine/install/binaries.md
+++ b/engine/install/binaries.md
@@ -40,7 +40,7 @@ meets the prerequisites:
 - `iptables` version 1.4 or higher
 - `git` version 1.7 or higher
 - A `ps` executable, usually provided by `procps` or a similar package.
-- [XZ Utils](http://tukaani.org/xz/) 4.9 or higher
+- [XZ Utils](https://tukaani.org/xz/) 4.9 or higher
 - A [properly mounted](
   https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount)
   `cgroupfs` hierarchy; a single, all-encompassing `cgroup` mount

--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -436,7 +436,7 @@ otherwise.
 
 Two common firewall daemons are
 [UFW (Uncomplicated Firewall)](https://help.ubuntu.com/community/UFW) (often
-used for Ubuntu systems) and [firewalld](http://www.firewalld.org/) (often used
+used for Ubuntu systems) and [firewalld](https://firewalld.org) (often used
 for RPM-based systems). Consult the documentation for your OS and firewall, but
 the following information might help you get started. These options are fairly
 permissive and you may want to use a different configuration that locks your

--- a/engine/release-notes/17.09.md
+++ b/engine/release-notes/17.09.md
@@ -29,7 +29,7 @@ skip_read_time: true
 
 - Protect `health monitor` Go channel [moby/moby#35482](https://github.com/moby/moby/pull/35482)
 - Fix leaking container/exec state [moby/moby#35484](https://github.com/moby/moby/pull/35484)
-- Add /proc/scsi to masked paths (patch to work around [CVE-2017-16539](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16539)) [moby/moby/#35399](https://github.com/moby/moby/pull/35399)
+- Add /proc/scsi to masked paths (patch to work around [CVE-2017-16539](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16539) [moby/moby/#35399](https://github.com/moby/moby/pull/35399)
 - Vendor tar-split: fix to prevent memory exhaustion issue that could crash Docker daemon [moby/moby/#35424](https://github.com/moby/moby/pull/35424) Fixes [CVE-2017-14992](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14992)
 - Fix P/Z HubPullSuite tests  [moby/moby#34837](https://github.com/moby/moby/pull/34837)
 + Windows: Add support for version filtering on pull [moby/moby#35090](https://github.com/moby/moby/pull/35090)

--- a/engine/release-notes/index.md
+++ b/engine/release-notes/index.md
@@ -362,7 +362,7 @@ See [kubernetes/kubernetes#91507](https://github.com/kubernetes/kubernetes/issue
 
 ### Logging
 
-* Fix for reading journald logs. [moby/moby#37819](https://github.com/moby/moby/pull/37819) [moby/moby#38859](http://github.com/moby/moby/pull/38859)
+* Fix for reading journald logs. [moby/moby#37819](https://github.com/moby/moby/pull/37819) [moby/moby#38859](https://github.com/moby/moby/pull/38859)
 
 ### Networking
 

--- a/engine/security/index.md
+++ b/engine/security/index.md
@@ -48,13 +48,13 @@ common Ethernet switch; no more, no less.
 How mature is the code providing kernel namespaces and private
 networking? Kernel namespaces were introduced [between kernel version
 2.6.15 and
-2.6.26](http://man7.org/linux/man-pages/man7/namespaces.7.html).
+2.6.26](https://man7.org/linux/man-pages/man7/namespaces.7.html).
 This means that since July 2008 (date of the 2.6.26 release
 ), namespace code has been exercised and scrutinized on a large
 number of production systems. And there is more: the design and
 inspiration for the namespaces code are even older. Namespaces are
 actually an effort to reimplement the features of [OpenVZ](
-http://en.wikipedia.org/wiki/OpenVZ) in such a way that they could be
+https://en.wikipedia.org/wiki/OpenVZ) in such a way that they could be
 merged within the mainstream kernel. And OpenVZ was initially released
 in 2005, so both the design and the implementation are pretty mature.
 
@@ -196,7 +196,7 @@ drops all capabilities except [those
 needed](https://github.com/moby/moby/blob/master/oci/caps/defaults.go#L6-L19),
 an allowlist instead of a denylist approach. You can see a full list of
 available capabilities in [Linux
-manpages](http://man7.org/linux/man-pages/man7/capabilities.7.html).
+manpages](https://man7.org/linux/man-pages/man7/capabilities.7.html).
 
 One primary risk with running Docker containers is that the default set
 of capabilities and mounts given to a container may provide incomplete

--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -535,9 +535,9 @@ generate the site key and certificate, name the files `site.key` and
     working. Further configuration is required.</p>
 
     <p>For online documentation and support, refer to
-    <a href="http://nginx.org/">nginx.org</a>.<br/>
+    <a href="https://nginx.org">nginx.org</a>.<br/>
     Commercial support is available at
-    <a href="http://nginx.com/">nginx.com</a>.</p>
+    <a href="https://www.nginx.com">www.nginx.com</a>.</p>
 
     <p><em>Thank you for using nginx.</em></p>
     </body>

--- a/engine/swarm/ingress.md
+++ b/engine/swarm/ingress.md
@@ -195,7 +195,7 @@ combination with the routing mesh or without using the routing mesh at all.
 ### Using the routing mesh
 
 You can configure an external load balancer to route requests to a swarm
-service. For example, you could configure [HAProxy](http://www.haproxy.org) to
+service. For example, you could configure [HAProxy](https://www.haproxy.org) to
 balance requests to an nginx service published to port 8080.
 
 ![ingress with external load balancer image](images/ingress-lb.png)

--- a/engine/swarm/networking.md
+++ b/engine/swarm/networking.md
@@ -261,7 +261,7 @@ service's external clients to an individual swarm node, without the client
 needing to know how many nodes are participating in the service or their
 IP addresses or ports. You don't need to publish ports which are used between
 services on the same network. For instance, if you have a
-[WordPress service that stores its data in a MySQL service](http://training.play-with-docker.com/swarm-service-discovery/),
+[WordPress service that stores its data in a MySQL service](https://training.play-with-docker.com/swarm-service-discovery/),
 and they are connected to the same overlay network, you do not need to publish
 the MySQL port to the client, only the WordPress HTTP port.
 

--- a/engine/swarm/raft.md
+++ b/engine/swarm/raft.md
@@ -31,7 +31,7 @@ cope with failures if the manager set is not healthy.
 The implementation of the consensus algorithm in swarm mode means it features
 the properties inherent to distributed systems:
 
-- *agreement on values* in a fault tolerant system. (Refer to [FLP impossibility theorem](http://the-paper-trail.org/blog/a-brief-tour-of-flp-impossibility/)
+- *agreement on values* in a fault tolerant system. (Refer to [FLP impossibility theorem](https://www.the-paper-trail.org/post/2008-08-13-a-brief-tour-of-flp-impossibility/)
  and the [Raft Consensus Algorithm paper](https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf))
 - *mutual exclusion* through the leader election process
 - *cluster membership* management

--- a/engine/swarm/secrets.md
+++ b/engine/swarm/secrets.md
@@ -561,9 +561,9 @@ generate the site key and certificate, name the files `site.key` and
     working. Further configuration is required.</p>
 
     <p>For online documentation and support. refer to
-    <a href="http://nginx.org/">nginx.org</a>.<br/>
+    <a href="https://nginx.org">nginx.org</a>.<br/>
     Commercial support is available at
-    <a href="http://nginx.com/">nginx.com</a>.</p>
+    <a href="https://www.nginx.com">nginx.com</a>.</p>
 
     <p><em>Thank you for using nginx.</em></p>
     </body>

--- a/get-started/nav.html
+++ b/get-started/nav.html
@@ -1,5 +1,5 @@
 <ul class="pagination">
-  <li {% if include.selected=="1"%}class="active"{% endif %}><a href="/get-started/part1">Orientation and setup</a></li>
-  <li {% if include.selected=="2"%}class="active"{% endif %}><a href="/get-started/part2">Build and run your image</a></li>
-  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="/get-started/part3">Share images on Docker Hub</a></li>
+  <li {% if include.selected=="1"%}class="active"{% endif %}><a href="/get-started/part1/">Orientation and setup</a></li>
+  <li {% if include.selected=="2"%}class="active"{% endif %}><a href="/get-started/part2/">Build and run your image</a></li>
+  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="/get-started/part3/">Share images on Docker Hub</a></li>
 </ul>

--- a/get-started/nodejs/nav.html
+++ b/get-started/nodejs/nav.html
@@ -1,5 +1,5 @@
 <ul class="pagination">
-  <li {% if include.selected=="1"%}class="active"{% endif %}><a href="/get-started/nodejs/build-images">Build images</a></li>
-  <li {% if include.selected=="2"%}class="active"{% endif %}><a href="/get-started/nodejs/run-containers">Run your image as a container</a></li>
-  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="/get-started/nodejs/develop">Use containers for development</a></li>
+  <li {% if include.selected=="1"%}class="active"{% endif %}><a href="/get-started/nodejs/build-images/">Build images</a></li>
+  <li {% if include.selected=="2"%}class="active"{% endif %}><a href="/get-started/nodejs/run-containers/">Run your image as a container</a></li>
+  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="/get-started/nodejs/develop/">Use containers for development</a></li>
 </ul>

--- a/get-started/overview.md
+++ b/get-started/overview.md
@@ -218,8 +218,8 @@ the consumer, the Docker service appears to be a single application. Docker
 Engine supports swarm mode in Docker 1.12 and higher.
 
 ## The underlying technology
-Docker is written in [Go](https://golang.org/) and takes advantage of several
-features of the Linux kernel to deliver its functionality.
+Docker is written in the [Go programming language](https://golang.org/) and takes
+advantage of several features of the Linux kernel to deliver its functionality.
 
 ### Namespaces
 Docker uses a technology called `namespaces` to provide the isolated workspace

--- a/kitematic/rethinkdb-dev-database.md
+++ b/kitematic/rethinkdb-dev-database.md
@@ -40,7 +40,7 @@ Now, create the RethinkDB example chat application running on your local
 macOS system to test drive your new containerized database.
 
 First, if you don't have it yet, [download and install
-Node.js](http://nodejs.org/).
+Node.js](https://nodejs.org/en/).
 
 > **Note**: This example needs Xcode installed.
 

--- a/machine/completion.md
+++ b/machine/completion.md
@@ -4,7 +4,7 @@ keywords: machine, docker, orchestration, cli, reference
 title: Command-line completion
 ---
 
-Docker Machine comes with [command completion](http://en.wikipedia.org/wiki/Command-line_completion)
+Docker Machine comes with [command completion](https://en.wikipedia.org/wiki/Command-line_completion)
 for the bash and zsh shell.
 
 ## Installing Command Completion

--- a/machine/drivers/aws.md
+++ b/machine/drivers/aws.md
@@ -5,9 +5,9 @@ title: Amazon Web Services
 hide_from_sitemap: true
 ---
 
-Create machines on [Amazon Web Services](http://aws.amazon.com).
+Create machines on [Amazon Web Services](https://aws.amazon.com).
 
-To create machines on [Amazon Web Services](http://aws.amazon.com), you must supply two parameters: the AWS Access Key ID and the AWS Secret Access Key.
+To create machines on [Amazon Web Services](https://aws.amazon.com), you must supply two parameters: the AWS Access Key ID and the AWS Secret Access Key.
 
 ## Configuring credentials
 
@@ -21,7 +21,7 @@ One way to configure credentials is to use the standard credential file for Amaz
     aws_access_key_id = AKID1234567890
     aws_secret_access_key = MY-SECRET-KEY
 
-On Mac OS or various flavors of Linux you can install the [AWS Command Line Interface](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-quick-configuration) (`aws cli`) in the terminal and use the `aws configure` command which guides you through the creation of the credentials file.
+On Mac OS or various flavors of Linux you can install the [AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#cli-quick-configuration) (`aws cli`) in the terminal and use the `aws configure` command which guides you through the creation of the credentials file.
 
 This is the simplest method, you can then create a new machine with:
 

--- a/machine/drivers/azure.md
+++ b/machine/drivers/azure.md
@@ -13,7 +13,7 @@ You need an Azure Subscription to use this Docker Machine driver.
 > Azure driver. If you want to continue managing your existing Azure machines, please
 > download and use machine versions prior to v0.7.0.
 
-[azure]: http://azure.microsoft.com/
+[azure]: https://azure.microsoft.com/
 [trial]: https://azure.microsoft.com/free/
 
 ## Authentication

--- a/machine/drivers/hyper-v.md
+++ b/machine/drivers/hyper-v.md
@@ -20,9 +20,9 @@ Hyper-V](https://msdn.microsoft.com/en-us/virtualization/hyperv_on_windows/quick
 >
 >* You need an existing virtual switch to use the
 > driver. Hyper-V can share an external network interface (also known as
-> bridging). See [this blog](http://blogs.technet.com/b/canitpro/archive/2014/03/11/step-by-step-enabling-hyper-v-for-use-on-windows-8-1.aspx) to learn more.
+> bridging). See [this blog](https://docs.microsoft.com/en-us/archive/blogs/canitpro/step-by-step-enabling-hyper-v-for-use-on-windows-8-1) to learn more.
 > If you would like to use NAT, create an internal network, and use
-> [Internet Connection Sharing](http://www.packet6.com/allowing-windows-8-1-hyper-v-vm-to-work-with-wifi/).
+> [Internet Connection Sharing](https://packet6.com/allowing-windows-8-1-hyper-v-vm-to-work-with-wifi/).
 >
 > * This reference page includes an [example](hyper-v.md#example) showing you how to use an elevated (Administrator-level) PowerShell and create and use an external network switch.
 

--- a/machine/drivers/openstack.md
+++ b/machine/drivers/openstack.md
@@ -5,7 +5,7 @@ title: OpenStack
 hide_from_sitemap: true
 ---
 
-Create machines on [OpenStack](http://www.openstack.org/software/)
+Create machines on [OpenStack](https://www.openstack.org/software/)
 
 Mandatory:
 

--- a/machine/drivers/rackspace.md
+++ b/machine/drivers/rackspace.md
@@ -5,7 +5,7 @@ title: Rackspace
 hide_from_sitemap: true
 ---
 
-Create machines on [Rackspace cloud](http://www.rackspace.com/cloud)
+Create machines on [Rackspace cloud](https://www.rackspace.com/cloud)
 
 ## Usage
 

--- a/machine/drivers/vm-cloud.md
+++ b/machine/drivers/vm-cloud.md
@@ -5,7 +5,7 @@ title: VMware vCloud Air
 hide_from_sitemap: true
 ---
 
-Creates machines on [vCloud Air](http://vcloud.vmware.com) subscription service.
+Creates machines on [vCloud Air](https://cloudsolutions.vmware.com) subscription service.
 You need an account within an existing subscription of vCloud Air VPC or
 Dedicated Cloud.
 

--- a/machine/drivers/vm-fusion.md
+++ b/machine/drivers/vm-fusion.md
@@ -5,7 +5,7 @@ title: VMware Fusion
 hide_from_sitemap: true
 ---
 
-Creates machines locally on [VMware Fusion](http://www.vmware.com/products/fusion). Requires VMware Fusion to be installed.
+Creates machines locally on [VMware Fusion](https://www.vmware.com/products/fusion.html). Requires VMware Fusion to be installed.
 
 ## Usage
 

--- a/machine/drivers/vsphere.md
+++ b/machine/drivers/vsphere.md
@@ -5,7 +5,7 @@ title: VMware vSphere
 hide_from_sitemap: true
 ---
 
-Creates machines on a [VMware vSphere](http://www.vmware.com/products/vsphere)
+Creates machines on a [VMware vSphere](https://www.vmware.com/products/vsphere.html)
 Virtual Infrastructure. The machine must have a working vSphere ESXi
 installation. You can use a paid license or free 60 day trial license. Your
 installation may also include an optional VCenter server.

--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -232,9 +232,9 @@ Run a container with `docker run` to verify your set up.
             working. Further configuration is required.</p>
 
             <p>For online documentation and support, refer to
-            <a href="http://nginx.org/">nginx.org</a>.<br/>
+            <a href="https://nginx.org">nginx.org</a>.<br/>
             Commercial support is available at
-            <a href="http://nginx.com/">nginx.com</a>.</p>
+            <a href="https://www.nginx.com">www.nginx.com</a>.</p>
 
             <p><em>Thank you for using nginx.</em></p>
             </body>

--- a/notary/service_architecture.md
+++ b/notary/service_architecture.md
@@ -97,7 +97,7 @@ server, and signer:
 ![Notary Service Sequence Diagram](https://cdn.rawgit.com/docker/notary/27469f01fe244bdf70f34219616657b336724bc3/docs/images/metadata-sequence.svg)
 
 1.  Notary server optionally supports authentication from clients using
-    [JWT](http://jwt.io/){:target="_blank" rel="noopener" class="_"} tokens. This requires an
+    [JWT](https://jwt.io){:target="_blank" rel="noopener" class="_"} tokens. This requires an
     authorization server that manages access controls, and a cert bundle from this
     authorization server containing the public key it uses to sign tokens.
 

--- a/opensource/ways.md
+++ b/opensource/ways.md
@@ -102,7 +102,7 @@ contribute mentoring if you have good knowledge of:
 * using Docker in some particular domain (for example, testing or deployment)
 * using Git, Go, GitHub, IRC, or other common tools
 
-Also, choose mentoring if you like to be happy. Studies show that [helping others](http://www.huffingtonpost.com/2013/09/03/five-minute-favor-adam-rifkin_n_3805090.html){: target="_blank" rel="noopener" class="_"} is a great way to
+Also, choose mentoring if you like to be happy. Studies show that [helping others](https://www.huffpost.com/entry/five-minute-favor-adam-rifkin_n_3805090){: target="_blank" rel="noopener" class="_"} is a great way to
 boost your own well being.
 
 
@@ -110,9 +110,9 @@ boost your own well being.
 
 Docker users are people using Docker in their daily work. To help Docker users, visit:
 
+* the [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
 * the [Docker Community Forum](https://forums.docker.com/){: target="_blank" rel="noopener" class="_"}
-* the `#docker` channel on Freenode IRC
-* [StackOverflow](http://stackoverflow.com/search?tab=newest&q=docker){: target="_blank" rel="noopener" class="_"}
+* [StackOverflow](https://stackoverflow.com/questions/tagged/docker){: target="_blank" rel="noopener" class="_"}
 
 You can also check the lists of [open issues on the Docker docs](https://github.com/docker/docker.github.io/issues){: target="_blank" rel="noopener" class="_"} and [open issues on the Moby project](https://github.com/moby/moby/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fquestion+-label%3Astatus%2Fclaimed+-label%3Astatus%2Fassigned+no%3Aassignee){: target="_blank" rel="noopener" class="_"}.
 
@@ -122,11 +122,7 @@ You can also check the lists of [open issues on the Docker docs](https://github.
 Docker contributors are people like you, interested in the open source projects
 and product documentation. Contributors may need help with IRC, Go programming,
 Markdown, or with other aspects of contributing. To help Docker contributors,
-visit:
-
-* the [Docker Gitter IM](https://gitter.im/docker/docker){: target="_blank" rel="noopener" class="_"} room
-* the [Google group](https://groups.google.com/forum/#!forum/docker-dev){: target="_blank" rel="noopener" class="_"}
-* the `#docker-dev` channel on Freenode IRC
+join the [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}.
 
 ## Contribute to the Moby open source project
 

--- a/registry/help.md
+++ b/registry/help.md
@@ -9,7 +9,7 @@ title: Get help
 If you need help, or just want to chat, you can reach us:
 
 - on the [Docker forums](https://forums.docker.com/c/open-source-projects/opensrcreg).
-- on the [Docker community Slack](https://blog.docker.com/2016/11/introducing-docker-community-directory-docker-community-slack/).
+- on the [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
 - on the [mailing list](https://groups.google.com/a/dockerproject.org/forum/#!forum/distribution) (mail at <distribution@dockerproject.org>).
 
 If you want to report a bug:

--- a/registry/index.md
+++ b/registry/index.md
@@ -12,7 +12,7 @@ title: Docker Registry
 
 The Registry is a stateless, highly scalable server side application that stores
 and lets you distribute Docker images. The Registry is open-source, under the
-permissive [Apache license](http://en.wikipedia.org/wiki/Apache_License).
+permissive [Apache license](https://en.wikipedia.org/wiki/Apache_License).
 
 ## Why use it
 

--- a/registry/notifications.md
+++ b/registry/notifications.md
@@ -172,7 +172,7 @@ Content-Type: application/vnd.docker.distribution.events.v1+json
             "length": 1,
             "digest": "sha256:fea8895f450959fa676bcc1df0611ea93823a735a01205fd8622846041d0c7cf",
             "repository": "library/test",
-            "url": "http://example.com/v2/library/test/manifests/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
+            "url": "https://example.com/v2/library/test/manifests/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
          },
          "request": {
             "id": "asdfasdf",
@@ -197,7 +197,7 @@ Content-Type: application/vnd.docker.distribution.events.v1+json
             "length": 2,
             "digest": "sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5",
             "repository": "library/test",
-            "url": "http://example.com/v2/library/test/blobs/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
+            "url": "https://example.com/v2/library/test/blobs/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
          },
          "request": {
             "id": "asdfasdf",
@@ -222,7 +222,7 @@ Content-Type: application/vnd.docker.distribution.events.v1+json
             "length": 3,
             "digest": "sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5",
             "repository": "library/test",
-            "url": "http://example.com/v2/library/test/blobs/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
+            "url": "https://example.com/v2/library/test/blobs/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
          },
          "request": {
             "id": "asdfasdf",

--- a/registry/storage-drivers/azure.md
+++ b/registry/storage-drivers/azure.md
@@ -6,7 +6,7 @@ title: Microsoft Azure storage driver
 
 {% include registry.md %}
 
-An implementation of the `storagedriver.StorageDriver` interface which uses [Microsoft Azure Blob Storage](http://azure.microsoft.com/en-us/services/storage/) for object storage.
+An implementation of the `storagedriver.StorageDriver` interface which uses [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/) for object storage.
 
 ## Parameters
 
@@ -21,6 +21,6 @@ An implementation of the `storagedriver.StorageDriver` interface which uses [Mic
 ## Related information
 
 * To get information about
-[azure-blob-storage](http://azure.microsoft.com/en-us/services/storage/), visit
+[azure-blob-storage](https://azure.microsoft.com/en-us/services/storage/), visit
 the Microsoft website.
-* You can use Microsoft's [Blob Service REST API](https://msdn.microsoft.com/en-us/library/azure/dd135733.aspx) to [create a storage container](https://msdn.microsoft.com/en-us/library/azure/dd179468.aspx).
+* You can use Microsoft's [Blob Service REST API](https://docs.microsoft.com/en-us/rest/api/storageservices/Blob-Service-REST-API) to [create a storage container](https://docs.microsoft.com/en-us/rest/api/storageservices/Create-Container).

--- a/registry/storage-drivers/filesystem.md
+++ b/registry/storage-drivers/filesystem.md
@@ -13,7 +13,7 @@ An implementation of the `storagedriver.StorageDriver` interface which uses the 
 * `rootdirectory`: (optional) The absolute path to a root directory tree in which
 to store all registry files. The registry stores all its data here so make sure
 there is adequate space available. Defaults to `/var/lib/registry`. If the directory
-does not exist, it will be created honoring [`umask`](http://man7.org/linux/man-pages/man2/umask.2.html)
+does not exist, it will be created honoring [`umask`](https://man7.org/linux/man-pages/man2/umask.2.html)
 bits. If `umask` bits are not set, the resulting permission will be `0777`.
 * `maxthreads`: (optional) The maximum number of simultaneous blocking filesystem
 operations permitted within the registry. Each operation spawns a new thread and

--- a/registry/storage-drivers/index.md
+++ b/registry/storage-drivers/index.md
@@ -17,8 +17,8 @@ This storage driver package comes bundled with several drivers:
 - [inmemory](inmemory.md): A temporary storage driver using a local inmemory map. This exists solely for reference and testing.
 - [filesystem](filesystem.md): A local storage driver configured to use a directory tree in the local filesystem.
 - [s3](s3.md): A driver storing objects in an Amazon Simple Storage Service (S3) bucket.
-- [azure](azure.md): A driver storing objects in [Microsoft Azure Blob Storage](http://azure.microsoft.com/en-us/services/storage/).
-- [swift](swift.md): A driver storing objects in [Openstack Swift](http://docs.openstack.org/developer/swift/).
+- [azure](azure.md): A driver storing objects in [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/).
+- [swift](swift.md): A driver storing objects in [Openstack Swift](https://docs.openstack.org/swift/latest/).
 - [oss](oss.md): A driver storing objects in [Aliyun OSS](http://www.aliyun.com/product/oss).
 - [gcs](gcs.md): A driver storing objects in a [Google Cloud Storage](https://cloud.google.com/storage/) bucket.
 

--- a/test.md
+++ b/test.md
@@ -327,7 +327,7 @@ This image was originally created on a white background and converted to a trans
 ## Bootstrap and CSS tricks
 
 Here are cool components you can include on Docs pages using
-[Bootstrap](http://getbootstrap.com/) and [CSS](https://www.w3schools.com/css/).
+[Bootstrap](https://getbootstrap.com) and [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS).
 
 ### Tabs
 
@@ -736,7 +736,7 @@ end
 
 Warning: Syntax highlighting breaks easily for JSON if the code you present is
 not a valid JSON document. Try running your snippet through [this
-linter](http://jsonlint.com/) to make sure it's valid, and remember: there is no
+linter](https://jsonlint.com) to make sure it's valid, and remember: there is no
 syntax for comments in JSON!
 
 ```json

--- a/toolbox/toolbox_install_windows.md
+++ b/toolbox/toolbox_install_windows.md
@@ -71,7 +71,7 @@ To verify your machine meets these requirements, do the following:
     <br>
     **For Windows 7**
 
-    Run a tool like the [Microsoft® Hardware-Assisted Virtualization Detection Tool](http://www.microsoft.com/en-us/download/details.aspx?id=592){: target="_blank" rel="noopener" class="_"} or [Speccy](https://www.piriform.com/speccy){: target="_blank" rel="noopener" class="_"}, and follow the on-screen instructions.
+    Run a tool like the [Microsoft® Hardware-Assisted Virtualization Detection Tool](https://www.microsoft.com/en-us/download/details.aspx?id=592){: target="_blank" rel="noopener" class="_"} or [Speccy](https://www.piriform.com/speccy){: target="_blank" rel="noopener" class="_"}, and follow the on-screen instructions.
     <br><br>
 3. Verify your Windows OS is 64-bit (x64)
 


### PR DESCRIPTION
- get started: update link title for accessibility (lighthouse was complaining)
- Fix links not having a trailing /. This avoids resulting in a redirect to the URL with /
  (Found these using `href="[^#][^#"]+[^/]"`)
- Use https:// for links and examples
  (Found these using `http://[^lp10\*`<][^o]` (to exclude "localhost" and IP-addresses))
