### PR TITLE
Improve font handling for best practices

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,10 +43,21 @@
   <meta name="theme-color" content="#2496ed" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  {%- comment -%}
+  preload fonts: https://www.freecodecamp.org/news/web-fonts-in-2018-f191a48367e8/
+  we only preload the "woff2" variants, as older formats (woff, eot) are only used
+  by older browsers, and we don't optimize for those. For fontawesome we "prefetch"
+  to allow the browser to pre-heat the cache, but not load it if the page does not
+  use it.
+  {%- endcomment -%}
+  <link rel="prefetch" as="font" href="/fonts/fontawesome-webfont.woff2?v=4.7.0"     type="font/woff2" crossorigin="anonymous">
+  <link rel="preload"  as="font" href="/fonts/glyphicons-halflings-regular.woff2"    type="font/woff2" crossorigin="anonymous">
+  <link rel="preload"  as="font" href="/fonts/geomanist/hinted-Geomanist-Book.woff2" type="font/woff2" crossorigin="anonymous">
+
   <link rel="stylesheet" href="/css/font-awesome.min.css">
   <link rel="stylesheet" href="/css/bootstrap.min.css">
   <link rel="stylesheet" href="/css/style.css" id="pagestyle">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans">
 
   <!-- SEO stuff -->
   <meta name="twitter:title" itemprop="title name" content="{{ page.title | default: page_title }}"/>

--- a/_scss/_typography.scss
+++ b/_scss/_typography.scss
@@ -8,6 +8,7 @@
     src: url("../fonts/geomanist/hinted-Geomanist-Book.eot?#iefix") format("embedded-opentype"), url("../fonts/geomanist/hinted-Geomanist-Book.woff2") format("woff2"), url("../fonts/geomanist/hinted-Geomanist-Book.woff") format("woff"), url("../fonts/geomanist/hinted-Geomanist-Book.ttf") format("truetype"), url("../fonts/geomanist/hinted-Geomanist-Book.svg#Geomanist-Book") format("svg");
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -16,6 +17,26 @@
     src: url("../fonts/geomanist/hinted-Geomanist-Regular.eot?#iefix") format("embedded-opentype"), url("../fonts/geomanist/hinted-Geomanist-Regular.woff2") format("woff2"), url("../fonts/geomanist/hinted-Geomanist-Regular.woff") format("woff"), url("../fonts/geomanist/hinted-Geomanist-Regular.ttf") format("truetype"), url("../fonts/geomanist/hinted-Geomanist-Book.svg#Geomanist-Regular") format("svg");
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+}
+
+/*
+ * inlining the style from https://fonts.googleapis.com/css?family=Open+Sans&display=swap
+ *
+ * We're only including the "latin" glyphs. While including @font-faces for more
+ * glyphs would not cause the fonts to be loaded, it would make the stylesheet
+ * itself larger, and we don't need those glyhps for our purpose as the website
+ * is written in US-English; https://stackoverflow.com/a/14897846/1811501
+ */
+
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v18/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 h1,

--- a/fonts/comfortaa/stylesheet.css
+++ b/fonts/comfortaa/stylesheet.css
@@ -10,6 +10,7 @@
 		url('hinted-Comfortaa.svg#Comfortaa') format('svg');
 	font-weight: normal;
 	font-style: normal;
+	font-display: swap;
 }
 
 @font-face {
@@ -22,6 +23,7 @@
 		url('hinted-Comfortaa-Light.svg#Comfortaa-Light') format('svg');
 	font-weight: 300;
 	font-style: normal;
+	font-display: swap;
 }
 
 @font-face {
@@ -34,4 +36,5 @@
 		url('hinted-Comfortaa-Bold.svg#Comfortaa-Bold') format('svg');
 	font-weight: bold;
 	font-style: normal;
+	font-display: swap;
 }


### PR DESCRIPTION
preload fonts and add font-display: swap to prevent flickering;
see: https://www.freecodecamp.org/news/web-fonts-in-2018-f191a48367e8/
we only preload the "woff2" variants, as older formats (woff, eot) are only used
by older browsers, and we don't optimize for those. For fontawesome we "prefetch"
to allow the browser to pre-heat the cache, but not load it if the page does not
use it.