### PR TITLE
[Desktop] remove content refering to removed "osxfs" topic

### DIFF
--- a/_includes/body-landing.html
+++ b/_includes/body-landing.html
@@ -233,11 +233,6 @@
                 </a>
               </p>
               <p class="only-mac">
-                <a href="/docker-for-mac/faqs/#can-i-use-an-ssh-agent-inside-a-container">
-                  Can I use an SSH agent inside a container?
-                </a>
-              </p>
-              <p class="only-mac">
                 <a href="/docker-for-mac/faqs/">
                   View all
                 </a>
@@ -252,7 +247,6 @@
               <p class="only-win"><a href="/docker-for-windows/release-notes/">Stable Release notes</a></p>
               <p class="only-win"><a href="/docker-for-windows/troubleshoot/">Logs and troubleshooting</a></p>
               <p class="only-mac"><a href="/docker-for-mac/networking/">Networking features in Docker Desktop</a></p>
-              <p class="only-mac"><a href="/docker-for-mac/osxfs/">Mac file system sharing</a></p>
             </div>
           </div>
           <!-- HUB -->

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2042,9 +2042,6 @@ expressed in the short form.
     created
 - `tmpfs`: configure additional tmpfs options
   - `size`: the size for the tmpfs mount in bytes
-- `consistency`: the consistency requirements of the mount, one of `consistent`
-  (host and container have identical view), `cached` (read cache, host view is
-  authoritative) or `delegated` (read-write cache, container's view is authoritative)
 
 ```yaml
 version: "{{ site.compose_file_v3 }}"
@@ -2114,39 +2111,6 @@ services:
       placement:
         constraints: [node.role == manager]
 ```
-
-#### Caching options for volume mounts (Docker Desktop for Mac)
-
-You can configure container-and-host consistency requirements for bind-mounted
-directories in Compose files to allow for better performance on read/write of
-volume mounts. These options address issues specific to `osxfs` file sharing,
-and therefore are only applicable on Docker Desktop for Mac.
-
-The flags are:
-
-* `consistent`: Full consistency. The container runtime and the host maintain an
-  identical view of the mount at all times.  This is the default.
-* `cached`: The host's view of the mount is authoritative. There may be delays
-  before updates made on the host are visible within a container.
-* `delegated`: The container runtime's view of the mount is authoritative. There
-  may be delays before updates made in a container are visible on the host.
-
-Here is an example of configuring a volume as `cached`:
-
-```yaml
-version: "{{ site.compose_file_v3 }}"
-services:
-  php:
-    image: php:7.1-fpm
-    ports:
-      - "9000"
-    volumes:
-      - .:/var/www/project:cached
-```
-
-Full detail on these flags, the problems they solve, and their
-`docker run` counterparts is in the Docker Desktop for Mac topic
-[Performance tuning for volume mounts (shared filesystems)](../../docker-for-mac/osxfs-caching.md).
 
 ### domainname, hostname, ipc, mac\_address, privileged, read\_only, shm\_size, stdin\_open, tty, user, working\_dir
 

--- a/desktop/enterprise/user/mac-user.md
+++ b/desktop/enterprise/user/mac-user.md
@@ -119,8 +119,6 @@ File sharing settings include the following options:
 
 For more information, see:
 
-- [Namespaces](https://docs.docker.com/docker-for-mac/osxfs/#namespaces) in [osxfs file system sharing](https://docs.docker.com/docker-for-mac/osxfs/).
-
 - [Volume mounting requires file sharing for any project directories outside of `/Users`](https://docs.docker.com/docker-for-mac/troubleshoot/#volume-mounting-requires-file-sharing-for-any-project-directories-outside-of-users).
 
 #### Disk

--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -2089,7 +2089,7 @@ events or unexpected unmounts.
 
 **Upgrades**
 
-* FUSE 7.23 for [osxfs](osxfs.md)
+* FUSE 7.23 for osxfs
 
 **Known issues**
 
@@ -2098,13 +2098,13 @@ events or unexpected unmounts.
 **Bug fixes and minor changes**
 
 * UI improvements
-* Fixed a problem in [osxfs](osxfs.md) where`mkdir` returned EBUSY but directory was created.
+* Fixed a problem in osxfs where`mkdir` returned EBUSY but directory was created.
 
 ### Beta 11 Release (2016-05-10 1.11.1-beta11)
 
 **New**
 
-The `osxfs` file system now persists ownership changes in an extended attribute. (See the topic on [ownership](osxfs.md#ownership) in [Sharing the macOS file system with Docker containers](osxfs.md).)
+The `osxfs` file system now persists ownership changes in an extended attribute.
 
 **Upgrades**
 

--- a/docker-for-mac/faqs.md
+++ b/docker-for-mac/faqs.md
@@ -76,10 +76,6 @@ We recommend that you publish a port, or connect from another container. You can
 For more information and examples, see
 [I want to connect to a container from the Mac](networking.md#i-want-to-connect-to-a-container-from-the-mac) in the [Networking](networking.md) topic.
 
-### Can I use an SSH agent inside a container?
-
-Yes, you can use the host’s SSH agent inside a container. For more information, see [SSH agent forwarding](osxfs.md#ssh-agent-forwarding).
-
 ### How do I add custom CA certificates?
 
 Docker Desktop supports all trusted certificate authorities (CAs) (root or intermediate). For more information on adding server and client side certs, see

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -303,7 +303,7 @@ in the Apple documentation, and Docker Desktop [Mac system requirements](install
 <a name="bind-mounted-dirs"></a>
 
 * There are a number of issues with the performance of directories bind-mounted
-  with `osxfs`. In particular, writes of small blocks, and traversals of large
+  into containers. In particular, writes of small blocks, and traversals of large
   directories are currently slow. Additionally, containers that perform large
   numbers of directory operations, such as repeated scans of large directory
   trees, may suffer from poor performance. Applications that behave in this way
@@ -319,11 +319,10 @@ in the Apple documentation, and Docker Desktop [Mac system requirements](install
 
   As a work-around for this behavior, you can put vendor or third-party library
   directories in Docker volumes, perform temporary file system operations
-  outside of `osxfs` mounts, and use third-party tools like Unison or `rsync` to
+  outside of bind mounts, and use third-party tools like Unison or `rsync` to
   synchronize between container directories and bind-mounted directories. We are
-  actively working on `osxfs` performance using a number of different
-  techniques.  To learn more, see the topic on
-  [Performance issues, solutions, and roadmap](osxfs.md#performance-issues-solutions-and-roadmap).
+  actively working on performance improvements using a number of different
+  techniques.  To learn more, see the [topic on our roadmap](https://github.com/docker/roadmap/issues/7){: target="_blank" rel="noopener" class="_" }.
 
 * If your system does not have access to an NTP server, then after a hibernate
   the time seen by Docker Desktop may be considerably out of sync with the host.

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -44,7 +44,7 @@ syntax separates them. Here is a comparison of the syntax for each flag.
   - The second field is the path where the file or directory is mounted in
     the container.
   - The third field is optional, and is a comma-separated list of options, such
-    as `ro`, `consistent`, `delegated`, `cached`, `z`, and `Z`. These options
+    as `ro`, `z`, and `Z`. These options
     are discussed below.
 
 - **`--mount`**: Consists of multiple key-value pairs, separated by commas and each
@@ -64,9 +64,6 @@ syntax separates them. Here is a comparison of the syntax for each flag.
   - The `bind-propagation` option, if present, changes the
     [bind propagation](#configure-bind-propagation). May be one of `rprivate`,
     `private`, `rshared`, `shared`, `rslave`, `slave`.
-  - The [`consistency`](#configure-mount-consistency-for-macos) option, if
-    present, may be one of `consistent`, `delegated`, or `cached`. This setting
-    only applies to Docker Desktop for Mac, and is ignored on all other platforms.
   - The `--mount` flag does not support `z` or `Z` options for modifying
     selinux labels.
 
@@ -380,61 +377,6 @@ $ docker run -d \
   -v "$(pwd)"/target:/app:z \
   nginx:latest
 ```
-
-## Configure mount consistency for macOS
-
-Docker Desktop for Mac uses `osxfs` to propagate directories and files shared from macOS
-to the Linux VM. This propagation makes these directories and files available to
-Docker containers running on Docker Desktop for Mac.
-
-By default, these shares are fully-consistent, meaning that every time a write
-happens on the macOS host or through a mount in a container, the changes are
-flushed to disk so that all participants in the share have a fully-consistent
-view. Full consistency can severely impact performance in some cases. Docker
-17.05 and higher introduce options to tune the consistency setting on a
-per-mount, per-container basis. The following options are available:
-
-- `consistent` or `default`: The default setting with full consistency, as
-  described above.
-
-- `delegated`: The container runtime's view of the mount is authoritative. There
-  may be delays before updates made in a container are visible on the host.
-
-- `cached`: The macOS host's view of the mount is authoritative. There may be
-  delays before updates made on the host are visible within a container.
-
-These options are completely ignored on all host operating systems except macOS.
-
-The `--mount` and `-v` examples have the same result.
-
-<ul class="nav nav-tabs">
-  <li class="active"><a data-toggle="tab" data-group="mount" data-target="#mount-consistency"><code>--mount</code></a></li>
-  <li><a data-toggle="tab" data-group="volume" data-target="#v-consistency"><code>-v</code></a></li>
-</ul>
-<div class="tab-content">
-<div id="mount-consistency" class="tab-pane fade in active" markdown="1">
-
-```bash
-$ docker run -d \
-  -it \
-  --name devtest \
-  --mount type=bind,source="$(pwd)"/target,destination=/app,consistency=cached \
-  nginx:latest
-```
-
-</div><!--mount-->
-<div id="v-consistency" class="tab-pane fade" markdown="1">
-
-```bash
-$ docker run -d \
-  -it \
-  --name devtest \
-  -v "$(pwd)"/target:/app:cached \
-  nginx:latest
-```
-
-</div><!--volume-->
-</div><!--tab-content-->
 
 ## Next steps
 


### PR DESCRIPTION
This topic was removed in 9bebb666d93f00a0bdcc34a901cdc4b414d995d1 (https://github.com/docker/docker.github.io/pull/11535)

We may want to add back the part describing sharing sshagent somewhere, which is not really a feature related to osxfs. Also, some generic description about file sharing (permissions, syncing) should probably be added back (based on https://github.com/docker/docker.github.io/pull/10184).
