### PR TITLE
Add note about anonymous volumes to docker-compose down

### DIFF
--- a/compose/reference/down.md
+++ b/compose/reference/down.md
@@ -32,3 +32,5 @@ By default, the only things removed are:
 - The default network, if one is used
 
 Networks and volumes defined as `external` are never removed.
+
+Anonymous volumes are not removed by default but because they don't have a stable name, they will not be automatically mounted by a subsequent `up`. For data that needs to persist between updates, use host or named volumes.

--- a/compose/reference/down.md
+++ b/compose/reference/down.md
@@ -33,4 +33,7 @@ By default, the only things removed are:
 
 Networks and volumes defined as `external` are never removed.
 
-Anonymous volumes are not removed by default but because they don't have a stable name, they will not be automatically mounted by a subsequent `up`. For data that needs to persist between updates, use host or named volumes.
+Anonymous volumes are not removed by default. However, as they don't 
+have a stable name, they will not be automatically mounted by a subsequent
+`up`. For data that needs to persist between updates, use host or
+named volumes.


### PR DESCRIPTION
### Proposed changes

I propose adding an explicit note about anonymous volumes in the docs for `docker-compose down`. I had the bad experience of using a `docker-compose.yml` file with an anonymous volume not realizing that `docker-compose down` would result in what presents as data loss. Issues below suggest I'm not alone.

https://deploy-preview-11601--docsdocker.netlify.app/compose/reference/down/

### Related issues (optional)

See https://github.com/docker/compose/issues/7444, https://github.com/moby/moby/issues/30647#issuecomment-276882545 and the ensuing thread for general confusion.