### PR TITLE
build-images.md copy command and Dockerfile fixes

### DIFF
--- a/get-started/nodejs/build-images.md
+++ b/get-started/nodejs/build-images.md
@@ -119,7 +119,7 @@ WORKDIR /app
 
 Usually the very first thing you do once you’ve downloaded a project written in Node.js is to install npm packages. This will ensure that your application has all its dependencies installed into the `node_modules` directory where the Node runtime will be able to find them.
 
-Before we can run `npm install`, we need to get our `package.json` and `package-lock.json` files into our images. We use the `COPY` command to do this. The  `COPY` command takes two parameters. The first parameter tells Docker what file(s) you would like to copy into the image. The second parameter tells Docker where you want that file(s) to be copied to. We’ll copy the `package.json` and `package-lock.json` file into our working directory `/app`.
+Before we can run `npm install`, we need to get our `package.json` and `package-lock.json` files into our images. We use the `COPY` command to do this. The  `COPY` command takes a minimum of two parameters. The last parameter tells Docker where you want that file(s) to be copied to. The preceding parameters tells Docker what file(s) you would like to copy into the image. We’ll copy the `package.json` and `package-lock.json` file into our working directory `/app`.
 
 ```dockerfile
 COPY ["package.json", "package-lock.json*", "./"]
@@ -153,7 +153,7 @@ WORKDIR /app
 
 COPY ["package.json", "package-lock.json*", "./"]
 
-RUN npm install
+RUN npm install --production
 
 COPY . .
 


### PR DESCRIPTION
* The COPY command says it takes 2 parameters, but 3 are show in the example
* The completed Dockerfile has the environment missing from npm --install