### PR TITLE
Less overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ following keys are supported. The title, description, and keywords are required.
 | notoc                  | no        | Either `true` or `false`. If `true`, no in-page TOC is generated for the HTML output of this page. Defaults to `false`. Appropriate for some landing pages that have no in-page headings.|
 | toc_min                | no        | Ignored if `notoc` is set to `true`. The minimum heading level included in the in-page TOC. Defaults to `2`, to show `<h2>` headings as the minimum. |
 | toc_max                | no        | Ignored if `notoc` is set to `false`. The maximum heading level included in the in-page TOC. Defaults to `3`, to show `<h3>` headings. Set to the same as `toc_min` to only show `toc_min` level of headings. |
-| tree                   | no        | Either `true` or `false`. Set to `false` to disable the left-hand site-wide navigation for this page. Appropriate for some pages like the search page or the 404 page. |
 | no_ratings             | no        | Either `true` or `false`. Set to `true` to disable the page-ratings applet for this page. Defaults to `false`. |
 | skip_read_time         | no        | Set to `true` to disable the 'Estimated reading time' banner for this page. |
 | sitemap                | no        | Exclude the page from indexing by search engines. When set to `false`, the page is excluded from `sitemap.xml`, and a `<meta name="robots" content="noindex"/>` header is added to the page. |

--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,6 @@ defaults:
       layout: docs
       toc_min: 2
       toc_max: 3
-      tree: true
 
   # Set the correct edit-URL for upstream resources. We usually don't create a direct
   # edit link for these, and instead point to the directory that contains the file.

--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,7 @@ defaults:
       path: engine/reference/commandline
     values:
       edit_url: "https://github.com/docker/cli/tree/master/docs/reference/commandline"
+      skip_read_time: true
   - scope:
       path: glossary
     values:

--- a/_includes/body.html
+++ b/_includes/body.html
@@ -19,7 +19,7 @@
                             {%- if page.advisory -%}
                             <blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>
                             {%- endif -%}
-                            {%- unless page.tree == false or page.skip_read_time == true -%}{% include read_time.html %}{%- endunless -%}
+                            {%- unless page.skip_read_time == true -%}{% include read_time.html %}{%- endunless -%}
                             {{ content }}
                             {%- unless page.notags == true -%}
                             {%- assign keywords = page.keywords | split:"," -%}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -74,6 +74,7 @@
   we only preload the "woff2" variants, as older formats (woff, eot) are only used
   by older browsers, and we don't optimize for those.
   {%- endcomment -%}
+  <link rel="preload" as="font" href="https://fonts.gstatic.com/s/opensans/v18/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" as="font" href="/fonts/geomanist/hinted-Geomanist-Book.woff2"    type="font/woff2" crossorigin="anonymous">
   <link rel="preload" as="font" href="/fonts/geomanist/hinted-Geomanist-Regular.woff2" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" as="font" href="/fonts/glyphicons-halflings-regular.woff2"       type="font/woff2" crossorigin="anonymous">

--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,6 +1,4 @@
 {%- assign words = content | number_of_words -%}
-{%- if words < 360 -%}
-<p><em class="reading-time">Estimated reading time: 1 minute</em></p>
-{%- else -%}
+{%- if words >= 360 -%}
 <p><em class="reading-time">Estimated reading time: {{ words | divided_by:180 }} minutes</em></p>
 {%- endif -%}

--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,9 +1,6 @@
-<span class="reading-time" title="Estimated reading time">
-  <span class="reading-time-label">Estimated reading time: </span>
-  {% assign words = content | number_of_words %}
-  {% if words < 360 %}
-    1 minute
-  {% else %}
-    {{ words | divided_by:180 }} minutes
-  {% endif %}
-</span>
+{%- assign words = content | number_of_words -%}
+{%- if words < 360 -%}
+<p><em class="reading-time">Estimated reading time: 1 minute</em></p>
+{%- else -%}
+<p><em class="reading-time">Estimated reading time: {{ words | divided_by:180 }} minutes</em></p>
+{%- endif -%}

--- a/_scss/_base.scss
+++ b/_scss/_base.scss
@@ -1,5 +1,5 @@
 html {
-    font-family: sans-serif;
+    font-family: $font;
     -webkit-text-size-adjust: 100%;
         -ms-text-size-adjust: 100%;
     -moz-osx-font-smoothing: grayscale;
@@ -20,7 +20,7 @@ a {
     color: $primary-links;
     text-decoration: none;
     outline: none;
-    &:hover {
+    &:hover, &:focus {
         opacity: .8;
         text-decoration: none;
     }

--- a/_scss/_buttons.scss
+++ b/_scss/_buttons.scss
@@ -57,7 +57,6 @@ a.button.outline-btn.min-hgt {
 .outline-btn {
     background: #fff;
     border: 1px solid #0087C8;
-    text-decoration: none;
     margin: 0;
     &:hover {
       color: #1488C6;

--- a/_scss/_content.scss
+++ b/_scss/_content.scss
@@ -1,11 +1,12 @@
-/*
- * Images **********************************************************************
- */
 
-.content img {
-    display: block;
+.content, p {
+  line-height: 24px;
+
+  img {
+    display:   block;
+    height:    auto;
     max-width: 100%;
-    height: auto;
+  }
 }
 
 /*
@@ -95,10 +96,8 @@ h3:hover > a.anchorLink
 
 a.glossary {
     color: $body-text;
-    text-decoration: none;
     outline: none;
      &:hover {
         opacity: 1;
-        text-decoration: none;
     }
 }

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -162,6 +162,7 @@ body.landing {
   $icons: rocket, download-docker, guides, whats-new, manuals, reference;
 
   .card {
+    color: $body-text;
     background-color: $bg-card;
     box-shadow: 0 3px 6px rgba(11, 33, 74, 0.09),
       0 -2px 2px rgba(11, 33, 74, 0.03);
@@ -182,7 +183,7 @@ body.landing {
     .title {
       font-size: 16px;
       line-height: 16px;
-      margin: 8px 0;
+      margin: 10px 0;
 
       @include sm-width {
         font-size: 18px;
@@ -212,11 +213,6 @@ body.landing {
   a.card {
     display: block;
     transition: transform 150ms ease-in-out;
-
-    &:focus,
-    &:visited {
-      text-decoration: none;
-    }
 
     &:hover {
       opacity: 1;

--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -147,7 +147,6 @@ footer {
             color: #637986;
             font-size: 12px;
             line-height: 16px;
-            text-decoration: none;
         }
     }
 }
@@ -184,7 +183,6 @@ footer {
 }
 
 .footer-copyright p {
-    font-family: $font;
     font-size: 12px;
     line-height: 17px;
     color: #637986;

--- a/_scss/_navigation.scss
+++ b/_scss/_navigation.scss
@@ -70,14 +70,11 @@
 .nav-sidebar ul li a:focus,
 .nav-sidebar ul li a:hover {
     border-bottom: none;
-    text-decoration: none;
 }
 
 .nav-sidebar ul li a.active,
 .nav-sidebar.nav>li>a:focus {
-    cursor: default;
     background: #F3F4F4;
-    color: #2089C4;
     border-left: 4px solid $primary-links;
     font-weight: 600;
 }
@@ -122,7 +119,6 @@
             display: inline-block;
             font-size: 12px;
             padding: 5px 10px 5px 10px;
-            text-decoration: none;
         }
     }
 }

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -8,11 +8,11 @@ body.night {
             background-color: $bg-header-night;
         }
         .card, .cardlet {
+            color: inherit;
             background-color: $bg-card-night;
         }
     }
 
-    p,ol,ul,
     .rating-nero-value,
     .reading-time {
         color: $body-text-night !important;
@@ -51,7 +51,6 @@ body.night {
     .nav-sidebar ul li a.active,
     .nav-sidebar.nav>li>a:focus,
     .toc-nav li a.active {
-        color: $active-sidebar-night;
         background: #0a151a;
         border-left: 4px solid $primary-links;
     }

--- a/_scss/_notes.scss
+++ b/_scss/_notes.scss
@@ -2,6 +2,7 @@
 blockquote {
   background-color:  $note-bg-color;
   border-left-color: $note-color;
+  font-size:         unset; // override bootstrap font-size for blockquotes
 
   > p:first-child {
     color:       $note-color;

--- a/_scss/_overrides.scss
+++ b/_scss/_overrides.scss
@@ -116,10 +116,6 @@ a.gs-title {
     background: transparent;
 }
 
-img.with-border {
-  border: 1px solid #eaeaea;
-}
-
 input.gsc-search-button, input.gsc-search-button:hover, input.gsc-search-button:focus {
   display: none!important;
 }

--- a/_scss/_overrides.scss
+++ b/_scss/_overrides.scss
@@ -65,7 +65,6 @@
 .dropdown-menu>li>a:focus,
 .dropdown-menu>li>a:hover {
     color: #ffffff;
-    text-decoration: none;
     background-color: #0c5176;
 }
 

--- a/_scss/_typography.scss
+++ b/_scss/_typography.scss
@@ -34,14 +34,13 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: fallback;
   src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v18/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 h1,h2,h3,h4,h5,h6 {
     font-family: $headings;
-    color: $body-text;
     clear: both;
     line-height: 26px;
 }
@@ -72,20 +71,6 @@ h5 {
 h6 {
     color: #82949e;
     font-size: 14px;
-}
-
-p {
-    color: $body-text;
-    font-family: $font;
-    font-size: $body-text-size;
-    line-height: 24px;
-    margin: 10px 0 10px 0;
-}
-
-ul {
-    li {
-        font-size: 14px;
-    }
 }
 
 dd, dt {

--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -10,9 +10,7 @@
 }
 
 .reading-time {
-    font-style: italic;
     font-size: 12px;
-    display: block;
     color: rgba(13, 86, 125, 0.55);
 }
 

--- a/docker-for-mac/index.md
+++ b/docker-for-mac/index.md
@@ -234,8 +234,7 @@ experience conflicts, remove `/usr/local/bin/kubectl`.
   The status of Kubernetes shows in the Docker menu and the context points to
   `docker-desktop`.
 
-  ![Docker Menu with Kubernetes](images/kubernetes/kube-context.png){: .with-border
-  width="400px"}
+  ![Docker Menu with Kubernetes](images/kubernetes/kube-context.png){: width="400px"}
 
 - By default, Kubernetes containers are hidden from commands like `docker
   service ls`, because managing them manually is not supported. To make them

--- a/engine/reference/commandline/app.md
+++ b/engine/reference/commandline/app.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app
 title: docker app
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_bundle.md
+++ b/engine/reference/commandline/app_bundle.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_bundle
 title: docker app bundle
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_completion.md
+++ b/engine/reference/commandline/app_completion.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_completion
 title: docker app completion
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_init.md
+++ b/engine/reference/commandline/app_init.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_init
 title: docker app init
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_inspect.md
+++ b/engine/reference/commandline/app_inspect.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_inspect
 title: docker app inspect
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_install.md
+++ b/engine/reference/commandline/app_install.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_install
 title: docker app install
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_list.md
+++ b/engine/reference/commandline/app_list.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_list
 title: docker app list
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_merge.md
+++ b/engine/reference/commandline/app_merge.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_merge
 title: docker app merge
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_pull.md
+++ b/engine/reference/commandline/app_pull.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_pull
 title: docker app pull
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_push.md
+++ b/engine/reference/commandline/app_push.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_push
 title: docker app push
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_render.md
+++ b/engine/reference/commandline/app_render.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_render
 title: docker app render
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_split.md
+++ b/engine/reference/commandline/app_split.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_split
 title: docker app split
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_status.md
+++ b/engine/reference/commandline/app_status.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_status
 title: docker app status
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_uninstall.md
+++ b/engine/reference/commandline/app_uninstall.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_uninstall
 title: docker app uninstall
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_upgrade.md
+++ b/engine/reference/commandline/app_upgrade.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_upgrade
 title: docker app upgrade
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_validate.md
+++ b/engine/reference/commandline/app_validate.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_validate
 title: docker app validate
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/app_version.md
+++ b/engine/reference/commandline/app_version.md
@@ -2,7 +2,6 @@
 datafolder: docker-app
 datafile: docker_app_version
 title: docker app version
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/attach.md
+++ b/engine/reference/commandline/attach.md
@@ -4,7 +4,6 @@ datafile: docker_attach
 title: docker attach
 redirect_from:
   - /edge/engine/reference/commandline/attach/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/build.md
+++ b/engine/reference/commandline/build.md
@@ -4,7 +4,6 @@ datafile: docker_build
 title: docker build
 redirect_from:
   - /edge/engine/reference/commandline/build/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/builder.md
+++ b/engine/reference/commandline/builder.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_builder
 title: docker builder
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/builder_build.md
+++ b/engine/reference/commandline/builder_build.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_builder_build
 title: docker builder build
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/builder_prune.md
+++ b/engine/reference/commandline/builder_prune.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_builder_prune
 title: docker builder prune
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx.md
+++ b/engine/reference/commandline/buildx.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx
 title: docker buildx
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_bake.md
+++ b/engine/reference/commandline/buildx_bake.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_bake
 title: docker buildx bake
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_build.md
+++ b/engine/reference/commandline/buildx_build.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_build
 title: docker buildx build
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_create.md
+++ b/engine/reference/commandline/buildx_create.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_create
 title: docker buildx create
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_du.md
+++ b/engine/reference/commandline/buildx_du.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_du
 title: docker buildx du
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_imagetools.md
+++ b/engine/reference/commandline/buildx_imagetools.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_imagetools
 title: docker buildx imagetools
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_imagetools_create.md
+++ b/engine/reference/commandline/buildx_imagetools_create.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_imagetools_create
 title: docker buildx imagetools create
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_imagetools_inspect.md
+++ b/engine/reference/commandline/buildx_imagetools_inspect.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_imagetools_inspect
 title: docker buildx imagetools inspect
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_inspect.md
+++ b/engine/reference/commandline/buildx_inspect.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_inspect
 title: docker buildx inspect
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_ls.md
+++ b/engine/reference/commandline/buildx_ls.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_ls
 title: docker buildx ls
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_prune.md
+++ b/engine/reference/commandline/buildx_prune.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_prune
 title: docker buildx prune
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_rm.md
+++ b/engine/reference/commandline/buildx_rm.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_rm
 title: docker buildx rm
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_stop.md
+++ b/engine/reference/commandline/buildx_stop.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_stop
 title: docker buildx stop
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_use.md
+++ b/engine/reference/commandline/buildx_use.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_use
 title: docker buildx use
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/buildx_version.md
+++ b/engine/reference/commandline/buildx_version.md
@@ -2,7 +2,6 @@
 datafolder: buildx
 datafile: docker_buildx_version
 title: docker buildx version
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/checkpoint.md
+++ b/engine/reference/commandline/checkpoint.md
@@ -4,7 +4,6 @@ datafile: docker_checkpoint
 title: docker checkpoint
 redirect_from:
   - /edge/engine/reference/commandline/checkpoint/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/checkpoint_create.md
+++ b/engine/reference/commandline/checkpoint_create.md
@@ -4,7 +4,6 @@ datafile: docker_checkpoint_create
 title: docker checkpoint create
 redirect_from:
   - /edge/engine/reference/commandline/checkpoint_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/checkpoint_ls.md
+++ b/engine/reference/commandline/checkpoint_ls.md
@@ -4,7 +4,6 @@ datafile: docker_checkpoint_ls
 title: docker checkpoint ls
 redirect_from:
   - /edge/engine/reference/commandline/checkpoint_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/checkpoint_rm.md
+++ b/engine/reference/commandline/checkpoint_rm.md
@@ -4,7 +4,6 @@ datafile: docker_checkpoint_rm
 title: docker checkpoint rm
 redirect_from:
   - /edge/engine/reference/commandline/checkpoint_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster.md
+++ b/engine/reference/commandline/cluster.md
@@ -4,7 +4,6 @@ datafile: docker_cluster
 title: docker cluster
 redirect_from: /cluster/reference/
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_backup.md
+++ b/engine/reference/commandline/cluster_backup.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_backup
 title: docker cluster backup
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_create.md
+++ b/engine/reference/commandline/cluster_create.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_create
 title: docker cluster create
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_inspect.md
+++ b/engine/reference/commandline/cluster_inspect.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_inspect
 title: docker cluster inspect
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_ls.md
+++ b/engine/reference/commandline/cluster_ls.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_ls
 title: docker cluster ls
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_restore.md
+++ b/engine/reference/commandline/cluster_restore.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_restore
 title: docker cluster restore
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_rm.md
+++ b/engine/reference/commandline/cluster_rm.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_rm
 title: docker cluster rm
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_update.md
+++ b/engine/reference/commandline/cluster_update.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_update
 title: docker cluster update
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cluster_version.md
+++ b/engine/reference/commandline/cluster_version.md
@@ -3,7 +3,6 @@ datafolder: cluster
 datafile: docker_cluster_version
 title: docker cluster version
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/commit.md
+++ b/engine/reference/commandline/commit.md
@@ -4,7 +4,6 @@ datafile: docker_commit
 title: docker commit
 redirect_from:
   - /edge/engine/reference/commandline/commit/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/config.md
+++ b/engine/reference/commandline/config.md
@@ -4,7 +4,6 @@ datafile: docker_config
 title: docker config
 redirect_from:
   - /edge/engine/reference/commandline/config/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/config_create.md
+++ b/engine/reference/commandline/config_create.md
@@ -4,7 +4,6 @@ datafile: docker_config_create
 title: docker config create
 redirect_from:
   - /edge/engine/reference/commandline/config_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/config_inspect.md
+++ b/engine/reference/commandline/config_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_config_inspect
 title: docker config inspect
 redirect_from:
   - /edge/engine/reference/commandline/config_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/config_ls.md
+++ b/engine/reference/commandline/config_ls.md
@@ -4,7 +4,6 @@ datafile: docker_config_ls
 title: docker config ls
 redirect_from:
   - /edge/engine/reference/commandline/config_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/config_rm.md
+++ b/engine/reference/commandline/config_rm.md
@@ -4,7 +4,6 @@ datafile: docker_config_rm
 title: docker config rm
 redirect_from:
   - /edge/engine/reference/commandline/config_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container.md
+++ b/engine/reference/commandline/container.md
@@ -4,7 +4,6 @@ datafile: docker_container
 title: docker container
 redirect_from:
   - /edge/engine/reference/commandline/container/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_attach.md
+++ b/engine/reference/commandline/container_attach.md
@@ -4,7 +4,6 @@ datafile: docker_container_attach
 title: docker container attach
 redirect_from:
   - /edge/engine/reference/commandline/container_attach/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_commit.md
+++ b/engine/reference/commandline/container_commit.md
@@ -4,7 +4,6 @@ datafile: docker_container_commit
 title: docker container commit
 redirect_from:
   - /edge/engine/reference/commandline/container_commit/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_cp.md
+++ b/engine/reference/commandline/container_cp.md
@@ -4,7 +4,6 @@ datafile: docker_container_cp
 title: docker container cp
 redirect_from:
   - /edge/engine/reference/commandline/container_cp/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_create.md
+++ b/engine/reference/commandline/container_create.md
@@ -4,7 +4,6 @@ datafile: docker_container_create
 title: docker container create
 redirect_from:
   - /edge/engine/reference/commandline/container_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_diff.md
+++ b/engine/reference/commandline/container_diff.md
@@ -4,7 +4,6 @@ datafile: docker_container_diff
 title: docker container diff
 redirect_from:
   - /edge/engine/reference/commandline/container_diff/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_exec.md
+++ b/engine/reference/commandline/container_exec.md
@@ -4,7 +4,6 @@ datafile: docker_container_exec
 title: docker container exec
 redirect_from:
   - /edge/engine/reference/commandline/container_exec/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_export.md
+++ b/engine/reference/commandline/container_export.md
@@ -4,7 +4,6 @@ datafile: docker_container_export
 title: docker container export
 redirect_from:
   - /edge/engine/reference/commandline/container_export/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_inspect.md
+++ b/engine/reference/commandline/container_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_container_inspect
 title: docker container inspect
 redirect_from:
   - /edge/engine/reference/commandline/container_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_kill.md
+++ b/engine/reference/commandline/container_kill.md
@@ -4,7 +4,6 @@ datafile: docker_container_kill
 title: docker container kill
 redirect_from:
   - /edge/engine/reference/commandline/container_kill/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_logs.md
+++ b/engine/reference/commandline/container_logs.md
@@ -4,7 +4,6 @@ datafile: docker_container_logs
 title: docker container logs
 redirect_from:
   - /edge/engine/reference/commandline/container_logs/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_ls.md
+++ b/engine/reference/commandline/container_ls.md
@@ -4,7 +4,6 @@ datafile: docker_container_ls
 title: docker container ls
 redirect_from:
   - /edge/engine/reference/commandline/container_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_pause.md
+++ b/engine/reference/commandline/container_pause.md
@@ -4,7 +4,6 @@ datafile: docker_container_pause
 title: docker container pause
 redirect_from:
   - /edge/engine/reference/commandline/container_pause/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_port.md
+++ b/engine/reference/commandline/container_port.md
@@ -4,7 +4,6 @@ datafile: docker_container_port
 title: docker container port
 redirect_from:
   - /edge/engine/reference/commandline/container_port/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_prune.md
+++ b/engine/reference/commandline/container_prune.md
@@ -4,7 +4,6 @@ datafile: docker_container_prune
 title: docker container prune
 redirect_from:
   - /edge/engine/reference/commandline/container_prune/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_rename.md
+++ b/engine/reference/commandline/container_rename.md
@@ -4,7 +4,6 @@ datafile: docker_container_rename
 title: docker container rename
 redirect_from:
   - /edge/engine/reference/commandline/container_rename/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_restart.md
+++ b/engine/reference/commandline/container_restart.md
@@ -4,7 +4,6 @@ datafile: docker_container_restart
 title: docker container restart
 redirect_from:
   - /edge/engine/reference/commandline/container_restart/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_rm.md
+++ b/engine/reference/commandline/container_rm.md
@@ -4,7 +4,6 @@ datafile: docker_container_rm
 title: docker container rm
 redirect_from:
   - /edge/engine/reference/commandline/container_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_run.md
+++ b/engine/reference/commandline/container_run.md
@@ -4,7 +4,6 @@ datafile: docker_container_run
 title: docker container run
 redirect_from:
   - /edge/engine/reference/commandline/container_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_start.md
+++ b/engine/reference/commandline/container_start.md
@@ -4,7 +4,6 @@ datafile: docker_container_start
 title: docker container start
 redirect_from:
   - /edge/engine/reference/commandline/container_start/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_stats.md
+++ b/engine/reference/commandline/container_stats.md
@@ -4,7 +4,6 @@ datafile: docker_container_stats
 title: docker container stats
 redirect_from:
   - /edge/engine/reference/commandline/container_stats/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_stop.md
+++ b/engine/reference/commandline/container_stop.md
@@ -4,7 +4,6 @@ datafile: docker_container_stop
 title: docker container stop
 redirect_from:
   - /edge/engine/reference/commandline/container_stop/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_top.md
+++ b/engine/reference/commandline/container_top.md
@@ -4,7 +4,6 @@ datafile: docker_container_top
 title: docker container top
 redirect_from:
   - /edge/engine/reference/commandline/container_top/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_unpause.md
+++ b/engine/reference/commandline/container_unpause.md
@@ -4,7 +4,6 @@ datafile: docker_container_unpause
 title: docker container unpause
 redirect_from:
   - /edge/engine/reference/commandline/container_unpause/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_update.md
+++ b/engine/reference/commandline/container_update.md
@@ -4,7 +4,6 @@ datafile: docker_container_update
 title: docker container update
 redirect_from:
   - /edge/engine/reference/commandline/container_update/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/container_wait.md
+++ b/engine/reference/commandline/container_wait.md
@@ -4,7 +4,6 @@ datafile: docker_container_wait
 title: docker container wait
 redirect_from:
   - /edge/engine/reference/commandline/container_wait/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context.md
+++ b/engine/reference/commandline/context.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context
 title: docker context
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_create.md
+++ b/engine/reference/commandline/context_create.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_create
 title: docker context create
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_export.md
+++ b/engine/reference/commandline/context_export.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_export
 title: docker context export
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_import.md
+++ b/engine/reference/commandline/context_import.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_import
 title: docker context import
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_inspect.md
+++ b/engine/reference/commandline/context_inspect.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_inspect
 title: docker context inspect
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_ls.md
+++ b/engine/reference/commandline/context_ls.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_ls
 title: docker context ls
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_rm.md
+++ b/engine/reference/commandline/context_rm.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_rm
 title: docker context rm
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_update.md
+++ b/engine/reference/commandline/context_update.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_update
 title: docker context update
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/context_use.md
+++ b/engine/reference/commandline/context_use.md
@@ -2,7 +2,6 @@
 datafolder: engine-cli
 datafile: docker_context_use
 title: docker context use
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/cp.md
+++ b/engine/reference/commandline/cp.md
@@ -4,7 +4,6 @@ datafile: docker_cp
 title: docker cp
 redirect_from:
   - /edge/engine/reference/commandline/cp/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/create.md
+++ b/engine/reference/commandline/create.md
@@ -4,7 +4,6 @@ datafile: docker_create
 title: docker create
 redirect_from:
   - /edge/engine/reference/commandline/create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/diff.md
+++ b/engine/reference/commandline/diff.md
@@ -4,7 +4,6 @@ datafile: docker_diff
 title: docker diff
 redirect_from:
   - /edge/engine/reference/commandline/diff/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/docker.md
+++ b/engine/reference/commandline/docker.md
@@ -5,7 +5,6 @@ title: docker
 redirect_from:
   - /engine/reference/commandline/
   - /edge/engine/reference/commandline/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/events.md
+++ b/engine/reference/commandline/events.md
@@ -4,7 +4,6 @@ datafile: docker_events
 title: docker events
 redirect_from:
   - /edge/engine/reference/commandline/events/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/exec.md
+++ b/engine/reference/commandline/exec.md
@@ -4,7 +4,6 @@ datafile: docker_exec
 title: docker exec
 redirect_from:
   - /edge/engine/reference/commandline/exec/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/export.md
+++ b/engine/reference/commandline/export.md
@@ -4,7 +4,6 @@ datafile: docker_export
 title: docker export
 redirect_from:
   - /edge/engine/reference/commandline/export/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/history.md
+++ b/engine/reference/commandline/history.md
@@ -4,7 +4,6 @@ datafile: docker_history
 title: docker history
 redirect_from:
   - /edge/engine/reference/commandline/history/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image.md
+++ b/engine/reference/commandline/image.md
@@ -4,7 +4,6 @@ datafile: docker_image
 title: docker image
 redirect_from:
   - /edge/engine/reference/commandline/image/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_build.md
+++ b/engine/reference/commandline/image_build.md
@@ -4,7 +4,6 @@ datafile: docker_image_build
 title: docker image build
 redirect_from:
   - /edge/engine/reference/commandline/image_build/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_history.md
+++ b/engine/reference/commandline/image_history.md
@@ -4,7 +4,6 @@ datafile: docker_image_history
 title: docker image history
 redirect_from:
   - /edge/engine/reference/commandline/image_history/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_import.md
+++ b/engine/reference/commandline/image_import.md
@@ -4,7 +4,6 @@ datafile: docker_image_import
 title: docker image import
 redirect_from:
   - /edge/engine/reference/commandline/image_import/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_inspect.md
+++ b/engine/reference/commandline/image_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_image_inspect
 title: docker image inspect
 redirect_from:
   - /edge/engine/reference/commandline/image_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_load.md
+++ b/engine/reference/commandline/image_load.md
@@ -4,7 +4,6 @@ datafile: docker_image_load
 title: docker image load
 redirect_from:
   - /edge/engine/reference/commandline/image_load/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_ls.md
+++ b/engine/reference/commandline/image_ls.md
@@ -4,7 +4,6 @@ datafile: docker_image_ls
 title: docker image ls
 redirect_from:
   - /edge/engine/reference/commandline/image_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_prune.md
+++ b/engine/reference/commandline/image_prune.md
@@ -4,7 +4,6 @@ datafile: docker_image_prune
 title: docker image prune
 redirect_from:
   - /edge/engine/reference/commandline/image_prune/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_pull.md
+++ b/engine/reference/commandline/image_pull.md
@@ -4,7 +4,6 @@ datafile: docker_image_pull
 title: docker image pull
 redirect_from:
   - /edge/engine/reference/commandline/image_pull/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_push.md
+++ b/engine/reference/commandline/image_push.md
@@ -4,7 +4,6 @@ datafile: docker_image_push
 title: docker image push
 redirect_from:
   - /edge/engine/reference/commandline/image_push/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_rm.md
+++ b/engine/reference/commandline/image_rm.md
@@ -4,7 +4,6 @@ datafile: docker_image_rm
 title: docker image rm
 redirect_from:
   - /edge/engine/reference/commandline/image_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_save.md
+++ b/engine/reference/commandline/image_save.md
@@ -4,7 +4,6 @@ datafile: docker_image_save
 title: docker image save
 redirect_from:
   - /edge/engine/reference/commandline/image_save/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/image_tag.md
+++ b/engine/reference/commandline/image_tag.md
@@ -4,7 +4,6 @@ datafile: docker_image_tag
 title: docker image tag
 redirect_from:
   - /edge/engine/reference/commandline/image_tag/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/images.md
+++ b/engine/reference/commandline/images.md
@@ -4,7 +4,6 @@ datafile: docker_images
 title: docker images
 redirect_from:
   - /edge/engine/reference/commandline/images/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/import.md
+++ b/engine/reference/commandline/import.md
@@ -4,7 +4,6 @@ datafile: docker_import
 title: docker import
 redirect_from:
   - /edge/engine/reference/commandline/import/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/info.md
+++ b/engine/reference/commandline/info.md
@@ -4,7 +4,6 @@ datafile: docker_info
 title: docker info
 redirect_from:
   - /edge/engine/reference/commandline/info/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/inspect.md
+++ b/engine/reference/commandline/inspect.md
@@ -4,7 +4,6 @@ datafile: docker_inspect
 title: docker inspect
 redirect_from:
   - /edge/engine/reference/commandline/inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/kill.md
+++ b/engine/reference/commandline/kill.md
@@ -4,7 +4,6 @@ datafile: docker_kill
 title: docker kill
 redirect_from:
   - /edge/engine/reference/commandline/kill/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/load.md
+++ b/engine/reference/commandline/load.md
@@ -4,7 +4,6 @@ datafile: docker_load
 title: docker load
 redirect_from:
   - /edge/engine/reference/commandline/load/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/login.md
+++ b/engine/reference/commandline/login.md
@@ -4,7 +4,6 @@ datafile: docker_login
 title: docker login
 redirect_from:
   - /edge/engine/reference/commandline/login/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/logout.md
+++ b/engine/reference/commandline/logout.md
@@ -4,7 +4,6 @@ datafile: docker_logout
 title: docker logout
 redirect_from:
   - /edge/engine/reference/commandline/logout/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/logs.md
+++ b/engine/reference/commandline/logs.md
@@ -4,7 +4,6 @@ datafile: docker_logs
 title: docker logs
 redirect_from:
   - /edge/engine/reference/commandline/logs/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/manifest.md
+++ b/engine/reference/commandline/manifest.md
@@ -4,7 +4,6 @@ datafile: docker_manifest
 title: docker manifest
 redirect_from:
   - /edge/engine/reference/commandline/manifest/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/manifest_annotate.md
+++ b/engine/reference/commandline/manifest_annotate.md
@@ -4,7 +4,6 @@ datafile: docker_manifest_annotate
 title: docker manifest annotate
 redirect_from:
   - /edge/engine/reference/commandline/manifest_annotate/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/manifest_create.md
+++ b/engine/reference/commandline/manifest_create.md
@@ -4,7 +4,6 @@ datafile: docker_manifest_create
 title: docker manifest create
 redirect_from:
   - /edge/engine/reference/commandline/manifest_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/manifest_inspect.md
+++ b/engine/reference/commandline/manifest_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_manifest_inspect
 title: docker manifest inspect
 redirect_from:
   - /edge/engine/reference/commandline/manifest_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/manifest_push.md
+++ b/engine/reference/commandline/manifest_push.md
@@ -4,7 +4,6 @@ datafile: docker_manifest_push
 title: docker manifest push
 redirect_from:
   - /edge/engine/reference/commandline/manifest_push/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network.md
+++ b/engine/reference/commandline/network.md
@@ -4,7 +4,6 @@ datafile: docker_network
 title: docker network
 redirect_from:
   - /edge/engine/reference/commandline/network/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network_connect.md
+++ b/engine/reference/commandline/network_connect.md
@@ -4,7 +4,6 @@ datafile: docker_network_connect
 title: docker network connect
 redirect_from:
   - /edge/engine/reference/commandline/network_connect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network_create.md
+++ b/engine/reference/commandline/network_create.md
@@ -4,7 +4,6 @@ datafile: docker_network_create
 title: docker network create
 redirect_from:
   - /edge/engine/reference/commandline/network_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network_disconnect.md
+++ b/engine/reference/commandline/network_disconnect.md
@@ -4,7 +4,6 @@ datafile: docker_network_disconnect
 title: docker network disconnect
 redirect_from:
   - /edge/engine/reference/commandline/network_disconnect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network_inspect.md
+++ b/engine/reference/commandline/network_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_network_inspect
 title: docker network inspect
 redirect_from:
   - /edge/engine/reference/commandline/network_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network_ls.md
+++ b/engine/reference/commandline/network_ls.md
@@ -4,7 +4,6 @@ datafile: docker_network_ls
 title: docker network ls
 redirect_from:
   - /edge/engine/reference/commandline/network_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network_prune.md
+++ b/engine/reference/commandline/network_prune.md
@@ -4,7 +4,6 @@ datafile: docker_network_prune
 title: docker network prune
 redirect_from:
   - /edge/engine/reference/commandline/network_prune/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/network_rm.md
+++ b/engine/reference/commandline/network_rm.md
@@ -4,7 +4,6 @@ datafile: docker_network_rm
 title: docker network rm
 redirect_from:
   - /edge/engine/reference/commandline/network_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node.md
+++ b/engine/reference/commandline/node.md
@@ -4,7 +4,6 @@ datafile: docker_node
 title: docker node
 redirect_from:
   - /edge/engine/reference/commandline/node/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node_demote.md
+++ b/engine/reference/commandline/node_demote.md
@@ -4,7 +4,6 @@ datafile: docker_node_demote
 title: docker node demote
 redirect_from:
   - /edge/engine/reference/commandline/node_demote/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node_inspect.md
+++ b/engine/reference/commandline/node_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_node_inspect
 title: docker node inspect
 redirect_from:
   - /edge/engine/reference/commandline/node_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node_ls.md
+++ b/engine/reference/commandline/node_ls.md
@@ -4,7 +4,6 @@ datafile: docker_node_ls
 title: docker node ls
 redirect_from:
   - /edge/engine/reference/commandline/node_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node_promote.md
+++ b/engine/reference/commandline/node_promote.md
@@ -4,7 +4,6 @@ datafile: docker_node_promote
 title: docker node promote
 redirect_from:
   - /edge/engine/reference/commandline/node_promote/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node_ps.md
+++ b/engine/reference/commandline/node_ps.md
@@ -4,7 +4,6 @@ datafile: docker_node_ps
 title: docker node ps
 redirect_from:
   - /edge/engine/reference/commandline/node_ps/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node_rm.md
+++ b/engine/reference/commandline/node_rm.md
@@ -4,7 +4,6 @@ datafile: docker_node_rm
 title: docker node rm
 redirect_from:
   - /edge/engine/reference/commandline/node_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/node_update.md
+++ b/engine/reference/commandline/node_update.md
@@ -4,7 +4,6 @@ datafile: docker_node_update
 title: docker node update
 redirect_from:
   - /edge/engine/reference/commandline/node_update/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/pause.md
+++ b/engine/reference/commandline/pause.md
@@ -4,7 +4,6 @@ datafile: docker_pause
 title: docker pause
 redirect_from:
   - /edge/engine/reference/commandline/pause/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin.md
+++ b/engine/reference/commandline/plugin.md
@@ -4,7 +4,6 @@ datafile: docker_plugin
 title: docker plugin
 redirect_from:
   - /edge/engine/reference/commandline/plugin/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_create.md
+++ b/engine/reference/commandline/plugin_create.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_create
 title: docker plugin create
 redirect_from:
   - /edge/engine/reference/commandline/plugin_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_disable.md
+++ b/engine/reference/commandline/plugin_disable.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_disable
 title: docker plugin disable
 redirect_from:
   - /edge/engine/reference/commandline/plugin_disable/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_enable.md
+++ b/engine/reference/commandline/plugin_enable.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_enable
 title: docker plugin enable
 redirect_from:
   - /edge/engine/reference/commandline/plugin_enable/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_inspect.md
+++ b/engine/reference/commandline/plugin_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_inspect
 title: docker plugin inspect
 redirect_from:
   - /edge/engine/reference/commandline/plugin_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_install.md
+++ b/engine/reference/commandline/plugin_install.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_install
 title: docker plugin install
 redirect_from:
   - /edge/engine/reference/commandline/plugin_install/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_ls.md
+++ b/engine/reference/commandline/plugin_ls.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_ls
 title: docker plugin ls
 redirect_from:
   - /edge/engine/reference/commandline/plugin_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_push.md
+++ b/engine/reference/commandline/plugin_push.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_push
 title: docker plugin push
 redirect_from:
   - /edge/engine/reference/commandline/plugin_push/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_rm.md
+++ b/engine/reference/commandline/plugin_rm.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_rm
 title: docker plugin rm
 redirect_from:
   - /edge/engine/reference/commandline/plugin_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_set.md
+++ b/engine/reference/commandline/plugin_set.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_set
 title: docker plugin set
 redirect_from:
   - /edge/engine/reference/commandline/plugin_set/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/plugin_upgrade.md
+++ b/engine/reference/commandline/plugin_upgrade.md
@@ -4,7 +4,6 @@ datafile: docker_plugin_upgrade
 title: docker plugin upgrade
 redirect_from:
   - /edge/engine/reference/commandline/plugin_upgrade/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/port.md
+++ b/engine/reference/commandline/port.md
@@ -4,7 +4,6 @@ datafile: docker_port
 title: docker port
 redirect_from:
   - /edge/engine/reference/commandline/port/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/ps.md
+++ b/engine/reference/commandline/ps.md
@@ -4,7 +4,6 @@ datafile: docker_ps
 title: docker ps
 redirect_from:
   - /edge/engine/reference/commandline/ps/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/pull.md
+++ b/engine/reference/commandline/pull.md
@@ -4,7 +4,6 @@ datafile: docker_pull
 title: docker pull
 redirect_from:
   - /edge/engine/reference/commandline/pull/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/push.md
+++ b/engine/reference/commandline/push.md
@@ -4,7 +4,6 @@ datafile: docker_push
 title: docker push
 redirect_from:
   - /edge/engine/reference/commandline/push/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry.md
+++ b/engine/reference/commandline/registry.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry
 title: docker registry
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_events.md
+++ b/engine/reference/commandline/registry_events.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_events
 title: docker registry events
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_history.md
+++ b/engine/reference/commandline/registry_history.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_history
 title: docker registry history
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_info.md
+++ b/engine/reference/commandline/registry_info.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_info
 title: docker registry info
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_inspect.md
+++ b/engine/reference/commandline/registry_inspect.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_inspect
 title: docker registry inspect
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_joblogs.md
+++ b/engine/reference/commandline/registry_joblogs.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_joblogs
 title: docker registry joblogs
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_jobs.md
+++ b/engine/reference/commandline/registry_jobs.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_jobs
 title: docker registry jobs
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_ls.md
+++ b/engine/reference/commandline/registry_ls.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_ls
 title: docker registry ls
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/registry_rmi.md
+++ b/engine/reference/commandline/registry_rmi.md
@@ -3,7 +3,6 @@ datafolder: registry-cli
 datafile: docker_registry_rmi
 title: docker registry rmi
 enterprise_only: true
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/rename.md
+++ b/engine/reference/commandline/rename.md
@@ -4,7 +4,6 @@ datafile: docker_rename
 title: docker rename
 redirect_from:
   - /edge/engine/reference/commandline/rename/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/restart.md
+++ b/engine/reference/commandline/restart.md
@@ -4,7 +4,6 @@ datafile: docker_restart
 title: docker restart
 redirect_from:
   - /edge/engine/reference/commandline/restart/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/rm.md
+++ b/engine/reference/commandline/rm.md
@@ -4,7 +4,6 @@ datafile: docker_rm
 title: docker rm
 redirect_from:
   - /edge/engine/reference/commandline/rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/rmi.md
+++ b/engine/reference/commandline/rmi.md
@@ -4,7 +4,6 @@ datafile: docker_rmi
 title: docker rmi
 redirect_from:
   - /edge/engine/reference/commandline/rmi/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/run.md
+++ b/engine/reference/commandline/run.md
@@ -5,7 +5,6 @@ title: docker run
 redirect_from:
   - /reference/run
   - /edge/engine/reference/commandline/run/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/save.md
+++ b/engine/reference/commandline/save.md
@@ -4,7 +4,6 @@ datafile: docker_save
 title: docker save
 redirect_from:
   - /edge/engine/reference/commandline/save/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/search.md
+++ b/engine/reference/commandline/search.md
@@ -4,7 +4,6 @@ datafile: docker_search
 title: docker search
 redirect_from:
   - /edge/engine/reference/commandline/search/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/secret.md
+++ b/engine/reference/commandline/secret.md
@@ -4,7 +4,6 @@ datafile: docker_secret
 title: docker secret
 redirect_from:
   - /edge/engine/reference/commandline/secret/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/secret_create.md
+++ b/engine/reference/commandline/secret_create.md
@@ -4,7 +4,6 @@ datafile: docker_secret_create
 title: docker secret create
 redirect_from:
   - /edge/engine/reference/commandline/secret_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/secret_inspect.md
+++ b/engine/reference/commandline/secret_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_secret_inspect
 title: docker secret inspect
 redirect_from:
   - /edge/engine/reference/commandline/secret_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/secret_ls.md
+++ b/engine/reference/commandline/secret_ls.md
@@ -4,7 +4,6 @@ datafile: docker_secret_ls
 title: docker secret ls
 redirect_from:
   - /edge/engine/reference/commandline/secret_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/secret_rm.md
+++ b/engine/reference/commandline/secret_rm.md
@@ -4,7 +4,6 @@ datafile: docker_secret_rm
 title: docker secret rm
 redirect_from:
   - /edge/engine/reference/commandline/secret_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service.md
+++ b/engine/reference/commandline/service.md
@@ -4,7 +4,6 @@ datafile: docker_service
 title: docker service
 redirect_from:
   - /edge/engine/reference/commandline/service/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_create.md
+++ b/engine/reference/commandline/service_create.md
@@ -4,7 +4,6 @@ datafile: docker_service_create
 title: docker service create
 redirect_from:
   - /edge/engine/reference/commandline/service_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_inspect.md
+++ b/engine/reference/commandline/service_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_service_inspect
 title: docker service inspect
 redirect_from:
   - /edge/engine/reference/commandline/service_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_logs.md
+++ b/engine/reference/commandline/service_logs.md
@@ -4,7 +4,6 @@ datafile: docker_service_logs
 title: docker service logs
 redirect_from:
   - /edge/engine/reference/commandline/service_logs/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_ls.md
+++ b/engine/reference/commandline/service_ls.md
@@ -4,7 +4,6 @@ datafile: docker_service_ls
 title: docker service ls
 redirect_from:
   - /edge/engine/reference/commandline/service_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_ps.md
+++ b/engine/reference/commandline/service_ps.md
@@ -4,7 +4,6 @@ datafile: docker_service_ps
 title: docker service ps
 redirect_from:
   - /edge/engine/reference/commandline/service_ps/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_rm.md
+++ b/engine/reference/commandline/service_rm.md
@@ -4,7 +4,6 @@ datafile: docker_service_rm
 title: docker service rm
 redirect_from:
   - /edge/engine/reference/commandline/service_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_rollback.md
+++ b/engine/reference/commandline/service_rollback.md
@@ -4,7 +4,6 @@ datafile: docker_service_rollback
 title: docker service rollback
 redirect_from:
   - /edge/engine/reference/commandline/service_rollback/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_scale.md
+++ b/engine/reference/commandline/service_scale.md
@@ -4,7 +4,6 @@ datafile: docker_service_scale
 title: docker service scale
 redirect_from:
   - /edge/engine/reference/commandline/service_scale/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/service_update.md
+++ b/engine/reference/commandline/service_update.md
@@ -4,7 +4,6 @@ datafile: docker_service_update
 title: docker service update
 redirect_from:
   - /edge/engine/reference/commandline/service_update/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stack.md
+++ b/engine/reference/commandline/stack.md
@@ -4,7 +4,6 @@ datafile: docker_stack
 title: docker stack
 redirect_from:
   - /edge/engine/reference/commandline/stack/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stack_deploy.md
+++ b/engine/reference/commandline/stack_deploy.md
@@ -7,7 +7,6 @@ redirect_from:
   - /engine/reference/commandline/deploy/
   - /edge/engine/reference/commandline/deploy/
   - /edge/engine/reference/commandline/stack_deploy/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stack_ls.md
+++ b/engine/reference/commandline/stack_ls.md
@@ -4,7 +4,6 @@ datafile: docker_stack_ls
 title: docker stack ls
 redirect_from:
   - /edge/engine/reference/commandline/stack_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stack_ps.md
+++ b/engine/reference/commandline/stack_ps.md
@@ -6,7 +6,6 @@ redirect_from:
   - /engine/reference/commandline/stack_tasks/
   - /edge/engine/reference/commandline/stack_ps/
   - /edge/engine/reference/commandline/stack_tasks/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stack_rm.md
+++ b/engine/reference/commandline/stack_rm.md
@@ -4,7 +4,6 @@ datafile: docker_stack_rm
 title: docker stack rm
 redirect_from:
   - /edge/engine/reference/commandline/stack_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stack_services.md
+++ b/engine/reference/commandline/stack_services.md
@@ -4,7 +4,6 @@ datafile: docker_stack_services
 title: docker stack services
 redirect_from:
   - /edge/engine/reference/commandline/stack_services/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/start.md
+++ b/engine/reference/commandline/start.md
@@ -4,7 +4,6 @@ datafile: docker_start
 title: docker start
 redirect_from:
   - /edge/engine/reference/commandline/start/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stats.md
+++ b/engine/reference/commandline/stats.md
@@ -4,7 +4,6 @@ datafile: docker_stats
 title: docker stats
 redirect_from:
   - /edge/engine/reference/commandline/stats/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/stop.md
+++ b/engine/reference/commandline/stop.md
@@ -4,7 +4,6 @@ datafile: docker_stop
 title: docker stop
 redirect_from:
   - /edge/engine/reference/commandline/stop/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm.md
+++ b/engine/reference/commandline/swarm.md
@@ -4,7 +4,6 @@ datafile: docker_swarm
 title: docker swarm
 redirect_from:
   - /edge/engine/reference/commandline/swarm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_ca.md
+++ b/engine/reference/commandline/swarm_ca.md
@@ -4,7 +4,6 @@ datafile: docker_swarm_ca
 title: docker swarm ca
 redirect_from:
   - /edge/engine/reference/commandline/swarm_ca/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_init.md
+++ b/engine/reference/commandline/swarm_init.md
@@ -4,7 +4,6 @@ datafile: docker_swarm_init
 title: docker swarm init
 redirect_from:
   - /edge/engine/reference/commandline/swarm_init/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_join-token.md
+++ b/engine/reference/commandline/swarm_join-token.md
@@ -6,7 +6,6 @@ redirect_from:
   - /engine/reference/commandline/swarm_join_token/
   - /edge/engine/reference/commandline/swarm_join_token/
   - /edge/engine/reference/commandline/swarm_join-token/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_join.md
+++ b/engine/reference/commandline/swarm_join.md
@@ -4,7 +4,6 @@ datafile: docker_swarm_join
 title: docker swarm join
 redirect_from:
   - /edge/engine/reference/commandline/swarm_join/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_leave.md
+++ b/engine/reference/commandline/swarm_leave.md
@@ -4,7 +4,6 @@ datafile: docker_swarm_leave
 title: docker swarm leave
 redirect_from:
   - /edge/engine/reference/commandline/swarm_leave/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_unlock-key.md
+++ b/engine/reference/commandline/swarm_unlock-key.md
@@ -4,7 +4,6 @@ datafile: docker_swarm_unlock-key
 title: docker swarm unlock-key
 redirect_from:
   - /edge/engine/reference/commandline/swarm_unlock-key/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_unlock.md
+++ b/engine/reference/commandline/swarm_unlock.md
@@ -4,7 +4,6 @@ datafile: docker_swarm_unlock
 title: docker swarm unlock
 redirect_from:
   - /edge/engine/reference/commandline/swarm_unlock/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/swarm_update.md
+++ b/engine/reference/commandline/swarm_update.md
@@ -4,7 +4,6 @@ datafile: docker_swarm_update
 title: docker swarm update
 redirect_from:
   - /edge/engine/reference/commandline/swarm_update/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/system.md
+++ b/engine/reference/commandline/system.md
@@ -4,7 +4,6 @@ datafile: docker_system
 title: docker system
 redirect_from:
   - /edge/engine/reference/commandline/system/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/system_df.md
+++ b/engine/reference/commandline/system_df.md
@@ -4,7 +4,6 @@ datafile: docker_system_df
 title: docker system df
 redirect_from:
   - /edge/engine/reference/commandline/system_df/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/system_events.md
+++ b/engine/reference/commandline/system_events.md
@@ -4,7 +4,6 @@ datafile: docker_system_events
 title: docker system events
 redirect_from:
   - /edge/engine/reference/commandline/system_events/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/system_info.md
+++ b/engine/reference/commandline/system_info.md
@@ -4,7 +4,6 @@ datafile: docker_system_info
 title: docker system info
 redirect_from:
   - /edge/engine/reference/commandline/system_info/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/system_prune.md
+++ b/engine/reference/commandline/system_prune.md
@@ -4,7 +4,6 @@ datafile: docker_system_prune
 title: docker system prune
 redirect_from:
   - /edge/engine/reference/commandline/system_prune/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/tag.md
+++ b/engine/reference/commandline/tag.md
@@ -4,7 +4,6 @@ datafile: docker_tag
 title: docker tag
 redirect_from:
   - /edge/engine/reference/commandline/tag/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/top.md
+++ b/engine/reference/commandline/top.md
@@ -4,7 +4,6 @@ datafile: docker_top
 title: docker top
 redirect_from:
   - /edge/engine/reference/commandline/top/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust.md
+++ b/engine/reference/commandline/trust.md
@@ -4,7 +4,6 @@ datafile: docker_trust
 title: docker trust
 redirect_from:
   - /edge/engine/reference/commandline/trust/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_inspect.md
+++ b/engine/reference/commandline/trust_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_trust_inspect
 title: docker trust inspect
 redirect_from:
   - /edge/engine/reference/commandline/trust_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_key.md
+++ b/engine/reference/commandline/trust_key.md
@@ -4,7 +4,6 @@ datafile: docker_trust_key
 title: docker trust key
 redirect_from:
   - /edge/engine/reference/commandline/trust_key/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_key_generate.md
+++ b/engine/reference/commandline/trust_key_generate.md
@@ -4,7 +4,6 @@ datafile: docker_trust_key_generate
 title: docker trust key generate
 redirect_from:
   - /edge/engine/reference/commandline/trust_key_generate/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_key_load.md
+++ b/engine/reference/commandline/trust_key_load.md
@@ -4,7 +4,6 @@ datafile: docker_trust_key_load
 title: docker trust key load
 redirect_from:
   - /edge/engine/reference/commandline/trust_key_load/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_revoke.md
+++ b/engine/reference/commandline/trust_revoke.md
@@ -4,7 +4,6 @@ datafile: docker_trust_revoke
 title: docker trust revoke
 redirect_from:
   - /edge/engine/reference/commandline/trust_revoke/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_sign.md
+++ b/engine/reference/commandline/trust_sign.md
@@ -4,7 +4,6 @@ datafile: docker_trust_sign
 title: docker trust sign
 redirect_from:
   - /edge/engine/reference/commandline/trust_sign/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_signer.md
+++ b/engine/reference/commandline/trust_signer.md
@@ -4,7 +4,6 @@ datafile: docker_trust_signer
 title: docker trust signer
 redirect_from:
   - /edge/engine/reference/commandline/trust_signer/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_signer_add.md
+++ b/engine/reference/commandline/trust_signer_add.md
@@ -4,7 +4,6 @@ datafile: docker_trust_signer_add
 title: docker trust signer add
 redirect_from:
   - /edge/engine/reference/commandline/trust_signer_add/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/trust_signer_remove.md
+++ b/engine/reference/commandline/trust_signer_remove.md
@@ -4,7 +4,6 @@ datafile: docker_trust_signer_remove
 title: docker trust signer remove
 redirect_from:
   - /edge/engine/reference/commandline/trust_signer_remove/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/unpause.md
+++ b/engine/reference/commandline/unpause.md
@@ -4,7 +4,6 @@ datafile: docker_unpause
 title: docker unpause
 redirect_from:
   - /edge/engine/reference/commandline/unpause/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/update.md
+++ b/engine/reference/commandline/update.md
@@ -4,7 +4,6 @@ datafile: docker_update
 title: docker update
 redirect_from:
   - /edge/engine/reference/commandline/update/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/version.md
+++ b/engine/reference/commandline/version.md
@@ -4,7 +4,6 @@ datafile: docker_version
 title: docker version
 redirect_from:
   - /edge/engine/reference/commandline/version/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/volume.md
+++ b/engine/reference/commandline/volume.md
@@ -4,7 +4,6 @@ datafile: docker_volume
 title: docker volume
 redirect_from:
   - /edge/engine/reference/commandline/volume/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/volume_create.md
+++ b/engine/reference/commandline/volume_create.md
@@ -4,7 +4,6 @@ datafile: docker_volume_create
 title: docker volume create
 redirect_from:
   - /edge/engine/reference/commandline/volume_create/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/volume_inspect.md
+++ b/engine/reference/commandline/volume_inspect.md
@@ -4,7 +4,6 @@ datafile: docker_volume_inspect
 title: docker volume inspect
 redirect_from:
   - /edge/engine/reference/commandline/volume_inspect/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/volume_ls.md
+++ b/engine/reference/commandline/volume_ls.md
@@ -4,7 +4,6 @@ datafile: docker_volume_ls
 title: docker volume ls
 redirect_from:
   - /edge/engine/reference/commandline/volume_ls/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/volume_prune.md
+++ b/engine/reference/commandline/volume_prune.md
@@ -4,7 +4,6 @@ datafile: docker_volume_prune
 title: docker volume prune
 redirect_from:
   - /edge/engine/reference/commandline/volume_prune/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/volume_rm.md
+++ b/engine/reference/commandline/volume_rm.md
@@ -4,7 +4,6 @@ datafile: docker_volume_rm
 title: docker volume rm
 redirect_from:
   - /edge/engine/reference/commandline/volume_rm/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to

--- a/engine/reference/commandline/wait.md
+++ b/engine/reference/commandline/wait.md
@@ -4,7 +4,6 @@ datafile: docker_wait
 title: docker wait
 redirect_from:
   - /edge/engine/reference/commandline/wait/
-skip_read_time: true
 ---
 <!--
 This page is automatically generated from Docker's source code. If you want to


### PR DESCRIPTION
- remove unused "tree" metadata
- preload OpenSans font to prevent redraws
- update reading-time widget;
    - cleanup html and styles
    - skip reading time if it's a minute or less; the reading-time indication was not adding much value on short pages. The reader is likely able to make a better estimation how long it would take to read.
    - disable reading-time from command-line reference through configuration, instead of setting it on each page/stub
- removed some unneeded css rules that complicated the styles, and caused inconsistencies in font color, size and line-spacing
- removed "image with border" style, which was used for a single image only, and was barely visible
