### PR TITLE
Remove deprecated instruction, for issue #9766

### DIFF
--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -181,7 +181,7 @@ examples: |-
 
   ```dockerfile
   FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-  MAINTAINER some maintainer <maintainer@example.com>
+  LABEL maintainer="some maintainer <maintainer@example.com>"
   ```
 
   > **Note**


### PR DESCRIPTION
# Proposed changes

Change instruction from MAINTAINER to LABEL maintainer
as indicated in the docs https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
Fixes #9766