### PR TITLE
Add go/buildkit redirect

### DIFF
--- a/go/buildkit.md
+++ b/go/buildkit.md
@@ -1,0 +1,6 @@
+---
+title: How to enable BuildKit
+description: Instructions on enabling BuildKit
+keywords: BuildKit, docker build, configuration
+redirect_to: /develop/develop-images/build_enhancements/#to-enable-buildkit-builds
+---


### PR DESCRIPTION
This URL will be used in the docker cli to direct users to instructions on enabling buildkit.

With this PR, https://docs.docker.com/go/buildkit/ will redirect to https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds


relates to https://github.com/docker/cli/pull/2809