### PR TITLE
Theme: refactor colors and some fixes/updates

### DIFF
--- a/_includes/landing-page/community-banner.html
+++ b/_includes/landing-page/community-banner.html
@@ -1,19 +1,18 @@
-<section class="join-community slack">
+<section class="cta-banner slack">
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-offset-1 col-lg-7">
-        <h5 class="title">
+        <h2>Join the Docker Community Slack channel</h2>
+        <h5>
           Connect with Docker Captains and Docker enthusiasts through our
-          Community Slack channel.
+          Community Slack channel. It’s a great place to learn and ask questions
+          along your journey.
         </h5>
-        <p>
-          It’s a great place to learn and ask questions along your journey.
-        </p>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-4 text-center">
-        <a href="http://dockr.ly/slack" class="slack-button">
-          <img src="/images/slack-icon.svg" alt="slack" />
-          <span>Join the community</span>
+        <a href="http://dockr.ly/slack" class="btn slack-button">
+          <img src="/images/slack-icon.svg" width="56" height="56" alt="slack" />
+          Join the community
         </a>
       </div>
     </div>

--- a/_includes/landing-page/community-banner.html
+++ b/_includes/landing-page/community-banner.html
@@ -10,7 +10,7 @@
         </h5>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-4 text-center">
-        <a href="http://dockr.ly/slack" class="btn slack-button">
+        <a href="https://dockr.ly/slack" class="btn slack-button">
           <img src="/images/slack-icon.svg" width="56" height="56" alt="slack" />
           Join the community
         </a>

--- a/_includes/landing-page/docker-aci.html
+++ b/_includes/landing-page/docker-aci.html
@@ -1,4 +1,4 @@
-<section class="join-community dockercon">
+<section class="cta-banner dockercon">
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-offset-1 col-lg-7">

--- a/_includes/landing-page/docker-hub-signup.html
+++ b/_includes/landing-page/docker-hub-signup.html
@@ -1,4 +1,4 @@
-<section class="join-community dockercon">
+<section class="cta-banner dockercon">
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-offset-1 col-lg-7">

--- a/_includes/landing-page/docker-pricing.html
+++ b/_includes/landing-page/docker-pricing.html
@@ -1,4 +1,4 @@
-<section class="join-community dockercon">
+<section class="cta-banner dockercon">
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-offset-1 col-lg-7">

--- a/_includes/landing-page/dockercon-banner.html
+++ b/_includes/landing-page/dockercon-banner.html
@@ -1,4 +1,4 @@
-<section class="join-community dockercon">
+<section class="cta-banner dockercon">
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-offset-1 col-lg-7">

--- a/_includes/landing-page/dockercon-wrapup-banner.html
+++ b/_includes/landing-page/dockercon-wrapup-banner.html
@@ -1,4 +1,4 @@
-<section class="join-community dockercon">
+<section class="cta-banner dockercon">
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-offset-1 col-lg-7">

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -368,16 +368,12 @@ body.landing {
     }
   }
 
-  footer.footer {
-    background-color: $dark-blue;
+  footer {
+    background-color: $bg-footer-landing;
     margin-top: 130px;
 
     a, p {
       color: white;
     }
   }
-}
-
-body.landing:not(.night) {
-  background-color: $bg-sidebar;
 }

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -243,65 +243,46 @@ body.landing {
     }
   }
 
-  section.join-community {
+  section.cta-banner {
     background-color: $dark-blue;
-    padding: 75px 0;
+    padding:          75px 0;
 
     h2, h5, p {
       color: white;
     }
 
-    &.dockercon {
-      text-align: center;
+    text-align: center;
 
-      @include md-width {
-        text-align: left;
-      }
-
-      img {
-        margin-bottom: 20px;
-        max-height: 100px;
-      }
-
-      h2 {
-        color: white;
-        font-size: 32px;
-        line-height: 37px;;
-      }
-
-      a.btn {
-        background-color: #FF3F73;
-        color: white;
-        font-family: 'Open Sans', sans-serif;
-        font-size: 17px;
-        font-weight: bold;
-        padding: 20px 60px;
-        margin-top: 50px;
-      }
+    @include md-width {
+      text-align: left;
     }
 
-    &.slack {
-      a.slack-button {
-        background: #FFFFFF;
-        border: 2px solid #FFFFFF;
-        box-sizing: border-box;
-        border-radius: 3px;
-        align-items: center;
-        display: inline-flex;
-        padding: 0 26px 0 2px;
-        text-transform: none;
-        margin-top: 2rem;
+    img {
+      margin-bottom: 20px;
+      max-height:    100px;
+    }
 
-        img {
-          height: 56px;
-          width: 56px;
-        }
-        span {
-          font-weight: bold;
-          font-size: 17px;
-          line-height: 24px;
-          color: $dark-blue;
-        }
+    h2 {
+      font-size:   32px;
+      line-height: 37px;;
+    }
+
+    a.btn {
+      background:  #FF3F73;
+      color:       white;
+      font-size:   17px;
+      font-weight: bold;
+      margin-top:  50px;
+      padding:     20px 60px;
+
+      img {
+        margin: 0;
+      }
+
+      &.slack-button {
+        background:  white;
+        color:       $dark-blue;
+        padding:     2px 25px 2px 10px;
       }
     }
   }

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -11,6 +11,9 @@ body.night {
             color: inherit;
             background-color: $bg-card-night;
         }
+        footer {
+            background-color: $bg-footer-landing-night;
+        }
     }
 
     .rating-nero-value,

--- a/_scss/_variables.scss
+++ b/_scss/_variables.scss
@@ -3,14 +3,12 @@
  * global
  */
 $headings:              "Geomanist Book", sans-serif;
-$headings-landing:      'Geomanist Regular', sans-serif;
+$headings-landing:      "Geomanist Regular", sans-serif;
 $buttons:               "Geomanist Book", sans-serif;
 $font:                  "Open Sans", sans-serif;
 $body-text-size:        14px;
-$global-header-height:  440px;
-$bg-secondary-tabs:     rgba(0, 0, 0, 0.05);
-$white: #fff;
-$black: #000;
+$white:                 #fff;
+$black:                 #000;
 
 /*
  * standard mode

--- a/_scss/_variables.scss
+++ b/_scss/_variables.scss
@@ -16,49 +16,49 @@ $black:                 #000;
 $body-text:               hsl(199,  20%,  25%);
 $primary-links:           hsl(206,  85%,  54%);
 
-$bg-body:                 hsl(  0,   0%, 100%);
-$bg-body-landing:         hsl(240,  14%,  99%);
+$bg-body:                 hsl(206,   0%, 100%);
+$bg-body-landing:         hsl(206,  14%,  99%);
 $bg-header:               hsl(206,  85%,  54%);
 $bg-secondary:            hsl(206,  85%,  54%);
-$bg-sidebar:              hsl(240,  14%,  99%);
-$bg-footer:               hsl(  0,   0%, 100%);
+$bg-sidebar:              hsl(206,  14%,  99%);
+$bg-footer:               hsl(206,   0%, 100%);
 
 $bg-component:            hsl(240,  14%,  99%);
 $bg-card:                 hsl(  0,   0%, 100%);
 
 // notes, warnings
-$note-color:              hsl(201,  82%,  43%);
-$note-bg-color:           hsl(204,  83%,  98%);
+$note-color:              hsl(206,  82%,  43%);
+$note-bg-color:           hsl(206,  83%,  98%);
 $important-color:         hsl( 35,  91%,  35%);
 $warning-color:           hsl(  2,  58%,  54%);
 
-$slider-bg:               hsl(202,  76%,  87%);
+$slider-bg:               hsl(206,  76%,  87%);
 $slider-btn:              hsl(206,  85%,  54%);
 
-$table-head:              hsl(204,   5%,  82%);
+$table-head:              hsl(206,   5%,  82%);
 
 /*
  * night mode
  */
 $body-text-night:         hsl(180,   1%,  83%);
-$primary-links-night:     hsl(201,  85%,  79%);
+$primary-links-night:     hsl(203,  85%,  79%);
 
-$bg-body-night:           hsl(203,  77%,  10%);
-$bg-body-landing-night:   hsl(203,  77%,  10%);
-$bg-header-night:         hsl(211,  44%,  11%);
-$bg-secondary-night:      hsl(211,  44%,  11%);
-$bg-sidebar-night:        hsl(202,  41%,  11%);
-$bg-footer-night:         hsl(  0,   0%,   0%);
+$bg-body-night:           hsl(203,  90%,  10%);
+$bg-body-landing-night:   hsl(203,  90%,  10%);
+$bg-header-night:         hsl(203,  40%,  10%);
+$bg-secondary-night:      hsl(203,  40%,  10%);
+$bg-sidebar-night:        hsl(203,  40%,  10%);
+$bg-footer-night:         hsl(203,   0%,   0%);
 
-$bg-component-night:      hsl(211,  44%,  11%);
-$bg-card-night:           hsl(212,  33%,   9%);
+$bg-component-night:      hsl(203,  44%,  10%);
+$bg-card-night:           hsl(203,  33%,   8%);
 
 // notes, warnings
 $note-color-night:        hsl(180,   1%,  83%);
-$note-bg-color-night:     hsl(205,  35%,  19%);
+$note-bg-color-night:     hsl(203,  35%,  19%);
 $important-color-night:   hsl( 35,  90%,  62%);
 $warning-color-night:     hsl(  2, 100%,  74%);
 
-$active-sidebar-night:    hsl(201,  85%,   79%);
+$active-sidebar-night:    hsl(203,  85%,   79%);
 
 $bg-search-results-night: hsla(0,    0%,    4%, 0.95);

--- a/_scss/_variables.scss
+++ b/_scss/_variables.scss
@@ -22,6 +22,7 @@ $bg-header:               hsl(206,  85%,  54%);
 $bg-secondary:            hsl(206,  85%,  54%);
 $bg-sidebar:              hsl(206,  14%,  99%);
 $bg-footer:               hsl(206,   0%, 100%);
+$bg-footer-landing:       hsl(214, 100%,  20%);
 
 $bg-component:            hsl(240,  14%,  99%);
 $bg-card:                 hsl(  0,   0%, 100%);
@@ -49,6 +50,7 @@ $bg-header-night:         hsl(203,  40%,  10%);
 $bg-secondary-night:      hsl(203,  40%,  10%);
 $bg-sidebar-night:        hsl(203,  40%,  10%);
 $bg-footer-night:         hsl(203,   0%,   0%);
+$bg-footer-landing-night: hsl(214, 100%,  20%);
 
 $bg-component-night:      hsl(203,  44%,  10%);
 $bg-card-night:           hsl(203,  33%,   8%);

--- a/_scss/_variables.scss
+++ b/_scss/_variables.scss
@@ -13,52 +13,52 @@ $black:                 #000;
 /*
  * standard mode
  */
-$body-text:             #33444c;
-$primary-links:         #2496ed;
+$body-text:               hsl(199,  20%,  25%);
+$primary-links:           hsl(206,  85%,  54%);
 
-$bg-body:               #ffffff;
-$bg-body-landing:       #fbfbfc;
-$bg-header:             #2496ed;
-$bg-secondary:          #2496ed;
-$bg-sidebar:            #fbfbfc;
-$bg-footer:             #ffffff;
+$bg-body:                 hsl(  0,   0%, 100%);
+$bg-body-landing:         hsl(240,  14%,  99%);
+$bg-header:               hsl(206,  85%,  54%);
+$bg-secondary:            hsl(206,  85%,  54%);
+$bg-sidebar:              hsl(240,  14%,  99%);
+$bg-footer:               hsl(  0,   0%, 100%);
 
-$bg-component:          #fbfbfc;
-$bg-card:               #ffffff;
+$bg-component:            hsl(240,  14%,  99%);
+$bg-card:                 hsl(  0,   0%, 100%);
 
 // notes, warnings
-$note-color:            #1488C6;
-$note-bg-color:         #f4fafe;
-$important-color:       #aa6708;
-$warning-color:         #ce4844;
+$note-color:              hsl(201,  82%,  43%);
+$note-bg-color:           hsl(204,  83%,  98%);
+$important-color:         hsl( 35,  91%,  35%);
+$warning-color:           hsl(  2,  58%,  54%);
 
-$slider-bg:             #c3e4f7;
-$slider-btn:            #2496ed;
+$slider-bg:               hsl(202,  76%,  87%);
+$slider-btn:              hsl(206,  85%,  54%);
 
-$table-head:            #cfd2d4;
+$table-head:              hsl(204,   5%,  82%);
 
 /*
  * night mode
  */
-$body-text-night:       #d3d4d4;
-$primary-links-night:   #9cd7f7;
+$body-text-night:         hsl(180,   1%,  83%);
+$primary-links-night:     hsl(201,  85%,  79%);
 
-$bg-body-night:         #061f2f;
-$bg-body-landing-night: #061f2f;
-$bg-header-night:       #101c29;
-$bg-secondary-night:    #101c29;
-$bg-sidebar-night:      #101e26;
-$bg-footer-night:       #000000;
+$bg-body-night:           hsl(203,  77%,  10%);
+$bg-body-landing-night:   hsl(203,  77%,  10%);
+$bg-header-night:         hsl(211,  44%,  11%);
+$bg-secondary-night:      hsl(211,  44%,  11%);
+$bg-sidebar-night:        hsl(202,  41%,  11%);
+$bg-footer-night:         hsl(  0,   0%,   0%);
 
-$bg-component-night:    #101c29;
-$bg-card-night:         #0f161e;
+$bg-component-night:      hsl(211,  44%,  11%);
+$bg-card-night:           hsl(212,  33%,   9%);
 
 // notes, warnings
-$note-color-night:      #d3d4d4;
-$note-bg-color-night:   #1f3341;
-$important-color-night: #f5ac45;
-$warning-color-night:   #ff7e7a;
+$note-color-night:        hsl(180,   1%,  83%);
+$note-bg-color-night:     hsl(205,  35%,  19%);
+$important-color-night:   hsl( 35,  90%,  62%);
+$warning-color-night:     hsl(  2, 100%,  74%);
 
-$active-sidebar-night:  #9cd7f7;
+$active-sidebar-night:    hsl(201,  85%,   79%);
 
-$bg-search-results-night: rgba(10, 10, 10, 0.95);
+$bg-search-results-night: hsla(0,    0%,    4%, 0.95);

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -222,7 +222,7 @@ You need to tell Docker to talk to that machine. You can do this with the
 
 You can find more answers on:
 
-- [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
+- [Docker community Slack channel](https://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
 - [Docker Support Forums](https://forums.docker.com){: target="_blank" rel="noopener" class="_"}
 - [GitHub](https://github.com/moby/moby){: target="_blank" rel="noopener" class="_"}
 - [Ask questions on Stackoverflow](https://stackoverflow.com/search?q=docker){: target="_blank" rel="noopener" class="_"}

--- a/opensource/ways.md
+++ b/opensource/ways.md
@@ -110,7 +110,7 @@ boost your own well being.
 
 Docker users are people using Docker in their daily work. To help Docker users, visit:
 
-* the [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
+* the [Docker community Slack channel](https://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
 * the [Docker Community Forum](https://forums.docker.com/){: target="_blank" rel="noopener" class="_"}
 * [StackOverflow](https://stackoverflow.com/questions/tagged/docker){: target="_blank" rel="noopener" class="_"}
 
@@ -122,7 +122,7 @@ You can also check the lists of [open issues on the Docker docs](https://github.
 Docker contributors are people like you, interested in the open source projects
 and product documentation. Contributors may need help with IRC, Go programming,
 Markdown, or with other aspects of contributing. To help Docker contributors,
-join the [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}.
+join the [Docker community Slack channel](https://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}.
 
 ## Contribute to the Moby open source project
 

--- a/registry/help.md
+++ b/registry/help.md
@@ -9,7 +9,7 @@ title: Get help
 If you need help, or just want to chat, you can reach us:
 
 - on the [Docker forums](https://forums.docker.com/c/open-source-projects/opensrcreg).
-- on the [Docker community Slack channel](http://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
+- on the [Docker community Slack channel](https://dockr.ly/slack){: target="_blank" rel="noopener" class="_"}
 - on the [mailing list](https://groups.google.com/a/dockerproject.org/forum/#!forum/distribution) (mail at <distribution@dockerproject.org>).
 
 If you want to report a bug:


### PR DESCRIPTION
Continuing to "upstream" changes I have in my working branches 😅 

- _scss: remove some unused variables
- _scss: change colors to HSL
  While more verbose, HSL colors (Hue, Saturation, Lightness) allow for easier selecting color variations that only differ in lightness, but have the same hue. This conversion also reveals some slight differences in hue between existing color-variations that I'll address in a follow-up commit.
- _scss: tweak inconsistencies in hue
  Changes should be mostly invisible, except for a very slight increase in contrast in the "night" theme between the body- background and left/right navigation blocks.
- _scss: define variable for landing footer color
- _scss: some refactoring of landing-page cta-banners
- update http://dockr.ly links to use TLS

