### PR TITLE
docs: update supported Fedora versions

### DIFF
--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -22,6 +22,8 @@ To install Docker Engine, you need the 64-bit version of one of these Fedora ver
 
 - Fedora 30
 - Fedora 31
+- Fedora 32
+- Fedora 33
 
 ### Uninstall old versions
 


### PR DESCRIPTION
### Proposed changes

Update supported Fedora versions. Since Fedora 33 was released on 27.10.2020 I think it is a good idea to keep the documentation up-to-date. Ideally, this merge could go after https://github.com/docker/for-linux/issues/1114 is merged.