### PR TITLE
Docs: Fix auth challenge in rate limit preview

### DIFF
--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -52,7 +52,7 @@ If you have a proxy or other layer in place that logs your requests, you can ins
 To get a token anonymously (if you are pulling anonymously):
 
 ```
-$ TOKEN=$(curl "https://auth.docker.io/token?service=registry-1.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+$ TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
 ```
 
 To get a token with a user account (if you are authenticating your pulls) - don't forget to insert your username and password in the following command:


### PR DESCRIPTION
### Proposed changes

The docs seem to have a mismatch between the given service and the actually necessary service in the auth challenge for previewing ones rate limits, for an anonymous user.

We rename the service in the token request to correspond to the service presented in the authentication challenge.

### Related issues (optional)

Fixes #11660
