### PR TITLE
Link to GitLab in download rate limits documentation

### DIFF
--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -115,6 +115,7 @@ If you are using any third-party platforms, follow your provider’s instruction
 - [CircleCI](https://circleci.com/docs/2.0/private-images/){: target="_blank" rel="noopener" class="_"}
 - [Codefresh](https://codefresh.io/docs/docs/docker-registries/external-docker-registries/docker-hub/){: target="_blank" rel="noopener" class="_"}
 - [Drone.io](https://docs.drone.io/pipeline/docker/syntax/images/#pulling-private-images){: target="_blank" rel="noopener" class="_"}
+- [GitLab](https://docs.gitlab.com/ee/user/packages/container_registry/#authenticate-with-the-container-registry){: target="_blank" rel="noopener" class="_"}
 - [LayerCI](https://layerci.com/docs/advanced-workflows#logging-in-to-docker){: target="_blank" rel="noopener" class="_"}
 
 ## Other limits


### PR DESCRIPTION
### Proposed changes
This MR adds GitLab to the list of 3rd party vendors on https://docs.docker.com/docker-hub/download-rate-limit/#third-party-platforms and links to their documentation for authenticating/logging in to Docker.

The goal is that any community members using the GitLab Container Registry can understand how to remediate any issues due to rate limits.

