### PR TITLE
Fix broken link in storage/volumes.md

### DIFF
--- a/storage/volumes.md
+++ b/storage/volumes.md
@@ -247,7 +247,7 @@ volumes:
 ```
 
 For more information about using volumes with compose see
-[the compose reference](../compose/compose-file-v2.md#volume-configuration-reference).
+[the compose reference](../compose/compose-file/index.md#volume-configuration-reference).
 
 ### Start a service with volumes
 


### PR DESCRIPTION
### Proposed changes

Fix broken link in https://docs.docker.com/storage/volumes/#use-a-volume-with-docker-compose.