### PR TITLE
Update up.md

### DIFF
--- a/compose/reference/up.md
+++ b/compose/reference/up.md
@@ -20,12 +20,13 @@ Options:
     --always-recreate-deps     Recreate dependent containers.
                                Incompatible with --no-recreate.
     --no-recreate              If containers already exist, don't recreate
-                               them. Incompatible with --force-recreate and -V.
+                               them. Incompatible with --force-recreate and 
+                               --renew-anon-volumes.
     --no-build                 Don't build an image, even if it's missing.
     --no-start                 Don't start the services after creating them.
     --build                    Build images before starting containers.
     --abort-on-container-exit  Stops all containers if any container was
-                               stopped. Incompatible with -d.
+                               stopped. Incompatible with --detach.
     --attach-dependencies      Attach to dependent containers.
     -t, --timeout TIMEOUT      Use this timeout in seconds for container
                                shutdown when attached or when containers are
@@ -44,8 +45,8 @@ Builds, (re)creates, starts, and attaches to containers for a service.
 
 Unless they are already running, this command also starts any linked services.
 
-The `docker-compose up` command aggregates the output of each container (essentially running `docker-compose logs -f`). When
-the command exits, all containers are stopped. Running `docker-compose up -d`
+The `docker-compose up` command aggregates the output of each container (essentially running `docker-compose logs --follow`). When
+the command exits, all containers are stopped. Running `docker-compose up --detach`
 starts the containers in the background and leaves them running.
 
 If there are existing containers for a service, and the service's configuration


### PR DESCRIPTION
An option's short form should not be used to identify them in descriptions since these are intentionally terse and as such don't provide the otherwise nice narrative and intuition of the long form.

I have replaced the short form with their long forms in this documentation. That includes the `docker-compose logs --f` out of band referent.