### PR TITLE
small addition to document expected behavior of parallel autobuilds

### DIFF
--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -33,8 +33,8 @@ image. Automated tests do not push images to the registry on their own. [Learn m
 
 Depending on your plan, you may get parallel builds, which means that `N`
 autobuilds can be run at the same time. `N` is configured by the plan that you
-subscribe to. Once `N+1` builds are running, any additional builds will
-be queued up to be run later.
+subscribe to. Once `N+1` builds are running, any additional builds are
+queued to be run later.
 
 
 ![An automated build dashboard](images/index-dashboard.png)

--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -31,6 +31,11 @@ pushing to the registry. You can use these tests to create a continuous
 integration workflow where a build that fails its tests does not push the built
 image. Automated tests do not push images to the registry on their own. [Learn more about automated image testing here.](automated-testing.md)
 
+Depending on your plan, you may get parallel builds, which means that `N`
+autobuilds can be run at the same time. `N` is configured by the plan that you
+subscribe to. Once `N+1` builds are running, any builds additional builds will
+be queued up to be run later.
+
 
 ![An automated build dashboard](images/index-dashboard.png)
 

--- a/docker-hub/builds/index.md
+++ b/docker-hub/builds/index.md
@@ -33,7 +33,7 @@ image. Automated tests do not push images to the registry on their own. [Learn m
 
 Depending on your plan, you may get parallel builds, which means that `N`
 autobuilds can be run at the same time. `N` is configured by the plan that you
-subscribe to. Once `N+1` builds are running, any builds additional builds will
+subscribe to. Once `N+1` builds are running, any additional builds will
 be queued up to be run later.
 
 


### PR DESCRIPTION
### Proposed changes

There was no documentation on the expected behavior of parallel builds, which is a line item on our pricing page.

### Unreleased project version (optional)


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
