### PR TITLE
Update systemd.md

### DIFF
--- a/config/daemon/systemd.md
+++ b/config/daemon/systemd.md
@@ -119,6 +119,13 @@ you need to add this configuration in the Docker systemd service file.
     Environment="HTTP_PROXY=http://proxy.example.com:80"
     Environment="HTTPS_PROXY=https://proxy.example.com:443"
     ```
+        
+    If you have to use special characters in the proxy value they must be both URL encoded and escape the % signs with double %%.
+    
+    ```
+    [Service]
+    Environment="HTTP_PROXY=http://domain%%5Cuser:complex%%23pass@proxy.example.com:8080/"
+    ```
      
 3.  If you have internal Docker registries that you need to contact without
     proxying you can specify them via the `NO_PROXY` environment variable.
@@ -194,6 +201,13 @@ you need to add this configuration in the Docker systemd service file.
     [Service]
     Environment="HTTP_PROXY=http://proxy.example.com:80"
     Environment="HTTPS_PROXY=https://proxy.example.com:443"
+    ```
+    
+    If you have to use special characters in the proxy value they must be both URL encoded and escape the % signs with double %%.
+    
+    ```
+    [Service]
+    Environment="HTTP_PROXY=http://domain%%5Cuser:complex%%23pass@proxy.example.com:8080/"
     ```
      
 3.  If you have internal Docker registries that you need to contact without


### PR DESCRIPTION
Systemctl requires different escape characters than a URL does so a proxy var with special URL characters needs to have them escaped with the hex equivalent and the systemctl escapes.

A backslash in domain\user becomes domain%5Cuser but this breaks systemctl because of the % sign.

If you need to use systemctl with a url and special chars is domain%%5Cuser (Notice the DOUBLE %).

[Service]
Environment="HTTP_PROXY=http://domain%%5Cuser:complex%%23pass@proxy.example.com:8080/"

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
