### PR TITLE
logging: remove incorrect line about docker inspect

### DIFF
--- a/config/containers/logging/configure.md
+++ b/config/containers/logging/configure.md
@@ -56,9 +56,7 @@ example sets two configurable options on the `json-file` logging driver:
 > be provided as strings. Boolean and numeric values (such as the value for
 > `max-file` in the example above) must therefore be enclosed in quotes (`"`).
 
-If you do not specify a logging driver, the default is `json-file`. Thus,
-the default output for commands such as `docker inspect <CONTAINER>` is JSON.
-
+If you do not specify a logging driver, the default is `json-file`.
 To find the current default logging driver for the Docker daemon, run
 `docker info` and search for `Logging Driver`. You can use the following
 command on Linux, macOS, or PowerShell on Windows:


### PR DESCRIPTION
The logging driver bears not relation to the output of commands such as `docker inspect`, so this line was incorrect.

Looks like this was added as part of a bigger rewrite/refactor in d536881651da2c17f011815f82cc4b073d244579 (https://github.com/docker/docker.github.io/pull/997), so likely missed
