### PR TITLE
help user view the container running

### DIFF
--- a/engine/context/aci-integration.md
+++ b/engine/context/aci-integration.md
@@ -103,7 +103,7 @@ docker run -p 80:80 nginx
 
 After you've switched to the `myacicontext` context, you can use `docker ps` to list your containers running on ACI.
 
-In the case of the demonstration nginx container you started above, you will see the result of the ps command showing a value labelled "PORTS" which will show both an IP address and port on which the container is running. For example, it may show `52.154.202.35:80->80/tcp`, in which case you can view the nginx welcome page by browsing `http://52.154.202.35`.
+In the case of the demonstration nginx container started above, the result of the ps command will display in column "PORTS" the IP address and port on which the container is running. For example, it may show `52.154.202.35:80->80/tcp`, and you can view the nginx welcome page by browsing `http://52.154.202.35`.
 
 To view logs from your container, run:
 

--- a/engine/context/aci-integration.md
+++ b/engine/context/aci-integration.md
@@ -103,6 +103,8 @@ docker run -p 80:80 nginx
 
 After you've switched to the `myacicontext` context, you can use `docker ps` to list your containers running on ACI.
 
+In the case of the demonstration nginx container you started above, you will see the result of the ps command showing a value labelled "PORTS" which will show both an IP address and port on which the container is running. For example, it may show `52.154.202.35:80->80/tcp`, in which case you can view the nginx welcome page by browsing `http://52.154.202.35`.
+
 To view logs from your container, run:
 
 ```console


### PR DESCRIPTION
The current instructions lead the user through creating a context and running a sample nginx container, but it never shows the user how to go about viewing it. I have added that.

If anyone sees a need to change/improve the formatting of my proposed text, to some style used here, feel free to do that.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
