### PR TITLE
Corrected Indentation in docker-compose.dev.yml

### DIFF
--- a/get-started/nodejs/develop.md
+++ b/get-started/nodejs/develop.md
@@ -27,28 +27,28 @@ version: '3.8'
 
 services:
  notes:
-   build:
-     context: .
-   ports:
-     - 8080:8080
-     - 9229:9229
-   environment:
-     - SERVER_PORT=8080
-     - DATABASE_CONNECTIONSTRING=mongodb://mongo:27017/notes
-   volumes:
-     - ./:/code
-   command: npm run debug
+  build:
+   context: .
+  ports:
+   - 8080:8080
+   - 9229:9229
+  environment:
+   - SERVER_PORT=8080
+   - DATABASE_CONNECTIONSTRING=mongodb://mongo:27017/notes
+  volumes:
+   - ./:/code
+  command: npm run debug
 
  mongo:
-   image: mongo:4.2.8
-   ports:
-     - 27017:27017
-   volumes:
-     - mongodb:/data/db
-     - mongodb_config:/data/configdb
- volumes:
-   mongodb:
-   mongodb_config:
+  image: mongo:4.2.8
+  ports:
+   - 27017:27017
+  volumes:
+   - mongodb:/data/db
+   - mongodb_config:/data/configdb
+volumes:
+ mongodb:
+ mongodb_config:
 ```
 
 This Compose file is super convenient as we do not have to type all the parameters to pass to the `docker run` command. We can declaratively do that in the Compose file.


### PR DESCRIPTION
It didn't use the volumes as parameter, instead it defined a service called volumes and services don't have a parameter called mongodb. Corrected indentation in yml file

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
