### PR TITLE
Update Hub release note - Stale image info

### DIFF
--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -9,6 +9,12 @@ toc_max: 2
 Here you can learn about the latest changes, new features, bug fixes, and
 known issues for each Docker Hub release.
 
+# 2020-11-12
+
+### New features
+
+* The repository views now show which images are stale (without recent push/pull activity). For more information, see [repository tags](repos.md/#viewing-repository-tags)
+
 # 2020-10-07
 
 ### New features

--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -13,7 +13,7 @@ known issues for each Docker Hub release.
 
 ### New features
 
-* The **Repositories** view now shows which images are stale (without recent push/pull activity). For more information, see [repository tags](repos.md/#viewing-repository-tags).
+* The **Repositories** view now shows which images have gone stale because they haven't been pulled or pushed recently. . For more information, see [repository tags](repos.md/#viewing-repository-tags).
 
 # 2020-10-07
 

--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -13,7 +13,8 @@ known issues for each Docker Hub release.
 
 ### New features
 
-* The **Repositories** view now shows which images have gone stale because they haven't been pulled or pushed recently. . For more information, see [repository tags](repos.md/#viewing-repository-tags).
+* The **Repositories** view now shows which images have gone stale because they haven't been 
+pulled or pushed recently. For more information, see [repository tags](repos.md/#viewing-repository-tags).
 
 # 2020-10-07
 

--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -9,7 +9,7 @@ toc_max: 2
 Here you can learn about the latest changes, new features, bug fixes, and
 known issues for each Docker Hub release.
 
-# 2020-11-12
+# 2020-11-10
 
 ### New features
 

--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -13,7 +13,7 @@ known issues for each Docker Hub release.
 
 ### New features
 
-* The repository views now show which images are stale (without recent push/pull activity). For more information, see [repository tags](repos.md/#viewing-repository-tags).
+* The **Repositories** view now shows which images are stale (without recent push/pull activity). For more information, see [repository tags](repos.md/#viewing-repository-tags).
 
 # 2020-10-07
 

--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -13,7 +13,7 @@ known issues for each Docker Hub release.
 
 ### New features
 
-* The repository views now show which images are stale (without recent push/pull activity). For more information, see [repository tags](repos.md/#viewing-repository-tags)
+* The repository views now show which images are stale (without recent push/pull activity). For more information, see [repository tags](repos.md/#viewing-repository-tags).
 
 # 2020-10-07
 


### PR DESCRIPTION
### Proposed changes

Mentioned the new feature "Stale image info" released on 2020/11/10

### Related issues (optional)
This is the only feature released.
This should go along with the doc update in repo.md with updated screenshot and more detailed description of the new feature #11679 