### PR TITLE
Fix redirect for /engine/tutorials/dockerrepos/

### DIFF
--- a/docker-hub/repos.md
+++ b/docker-hub/repos.md
@@ -2,6 +2,8 @@
 description: Using repositories on Docker Hub
 keywords: Docker, docker, trusted, registry, accounts, plans, Dockerfile, Docker Hub, webhooks, docs, documentation
 title: Repositories
+redirect_from:
+- /engine/tutorials/dockerrepos/
 ---
 
 Docker Hub repositories allow you share container images with your team,

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -20,7 +20,6 @@ redirect_from:
 - /engine/getstarted/step_two/
 - /engine/tutorials/dockerimages/
 - /engine/tutorials/dockerizing/
-- /engine/tutorials/dockerrepos/
 - /engine/tutorials/usingdocker/
 - /engine/userguide/containers/dockerimages/
 - /engine/userguide/dockerimages/


### PR DESCRIPTION
relates to https://github.com/docker/cli/pull/2833

The page in the Docker Hub section is a better match for the old content:
https://github.com/docker/docker.github.io/blob/v1.12-release/engine/tutorials/dockerrepos.md)

And fits better with the description around the link in the CLI reference;

> The image can be  any valid image – it is especially easy to start by pulling
> an image from the Public Repositories.

