### PR TITLE
remove unnecessary commands

### DIFF
--- a/compose/django.md
+++ b/compose/django.md
@@ -28,7 +28,6 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
    ```dockerfile
    FROM python:3
    ENV PYTHONUNBUFFERED=1
-   RUN mkdir /code
    WORKDIR /code
    COPY requirements.txt /code/
    RUN pip install -r requirements.txt

--- a/compose/rails.md
+++ b/compose/rails.md
@@ -15,7 +15,6 @@ Dockerfile consists of:
 
     FROM ruby:2.5
     RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
-    RUN mkdir /myapp
     WORKDIR /myapp
     COPY Gemfile /myapp/Gemfile
     COPY Gemfile.lock /myapp/Gemfile.lock


### PR DESCRIPTION
these lines aren't needed anymore, and add extra layers to the final image.

### Proposed changes

This commit removes unnecessary `RUN mkdir` commands in the examples for django and rails.

These are needed anymore, and add extra layers to the final image.
