### PR TITLE
DNS lookup resolver advice change for MacOS

### DIFF
--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -295,7 +295,7 @@ in the Apple documentation, and Docker Desktop [Mac system requirements](install
 * `docker-compose` 1.7.1 performs DNS unnecessary lookups for
   `localunixsocket.local` which can take 5s to timeout on some networks. If
   `docker-compose` commands seem very slow but seem to speed up when the network
-  is disabled, try appending `127.0.0.1 localunixsocket localunixsocket.local localunixsocket.home` to the file
+  is disabled, try appending `127.0.0.1 localunixsocket localunixsocket.local` to the file
   `/etc/hosts`.  Alternatively you could create a plain-text TCP proxy on
   localhost:1234 using:
 

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -295,7 +295,7 @@ in the Apple documentation, and Docker Desktop [Mac system requirements](install
 * `docker-compose` 1.7.1 performs DNS unnecessary lookups for
   `localunixsocket.local` which can take 5s to timeout on some networks. If
   `docker-compose` commands seem very slow but seem to speed up when the network
-  is disabled, try appending `127.0.0.1 localunixsocket.local` to the file
+  is disabled, try appending `127.0.0.1 localunixsocket localunixsocket.local localunixsocket.home` to the file
   `/etc/hosts`.  Alternatively you could create a plain-text TCP proxy on
   localhost:1234 using:
 


### PR DESCRIPTION
**Proposed changes**
Suggestion to MacOS user to troubleshooting DNS issue appending `127.0.0.1 localunixsocket localunixsocket.local` into `/etc/hosts`

**Reason**
docker-compose performance is a known problem on Mac OS.  It has been suggested to appending `127.0.0.1 localunixsocket.local` to resolve DNS issue but the original suggestion didn't work and help until I include `localunixsocket` into `/etc/hosts`

I've iMac running High Sierra and Mac Book Pro running Catalina both was having relatively slow performance even with the small projects. 

However, when I included `localunixsocket` in addition to the recommended solution both of my environment started to work blazing fast. 


**Related issues**
Appending `localunixsocket` suggested in the below treats and approved by end users

- https://github.com/docker/for-mac/issues/286#issuecomment-241477285
- https://github.com/docker/for-mac/issues/2260#issuecomment-348965354
- https://github.com/docker/for-mac/issues/286#issuecomment-271112664
- https://github.com/docker/for-mac/issues/1395#issuecomment-284471230
- https://github.com/docker/for-mac/issues/2167#issuecomment-338621094


