### PR TITLE
Add page for Apple Silicon

### DIFF
--- a/go/apple-silicon.md
+++ b/go/apple-silicon.md
@@ -1,0 +1,6 @@
+---
+title: How to run Docker Desktop on new Mac with Apple Silicon processors
+description: Instructions on enabling BuildKit
+keywords: mac, troubleshooting, apple, silicon, issues
+redirect_to: /docker-for-mac/troubleshoot/#support-for-apple-silicon-processors
+---


### PR DESCRIPTION
Add a short `/go/` page for Docker Desktop when a user tries to install and run Docker Desktop on one of the new Mac's with Apple Silicon processors.
