### PR TITLE
Add FS data volume for wordpress example

### DIFF
--- a/compose/wordpress.md
+++ b/compose/wordpress.md
@@ -52,6 +52,8 @@ Compose to set up and run WordPress. Before starting, make sure you have
          depends_on:
            - db
          image: wordpress:latest
+         volumes:
+           - wordpress_data: /var/www/html
          ports:
            - "8000:80"
          restart: always
@@ -62,6 +64,7 @@ Compose to set up and run WordPress. Before starting, make sure you have
            WORDPRESS_DB_NAME: wordpress
     volumes:
         db_data: {}
+        wordpress_data: {}
     ```
 
    > **Notes**:


### PR DESCRIPTION
Without mounting a volume for the wordpress filesystem data, the user would lose any installed custom themes or plugins between down/up.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
