### PR TITLE
Explain Compose file relative path resolution

### DIFF
--- a/compose/reference/overview.md
+++ b/compose/reference/overview.md
@@ -114,6 +114,10 @@ webapp:
     - DEBUG=1
 ```
 
+When you use multiple Compose files, all paths in the files are relative to the
+first configuration file specified with `-f`. You can use the
+`--project-directory` option to override this base path.
+
 Use a `-f` with `-` (dash) as the filename to read the configuration from
 `stdin`. When `stdin` is used all paths in the configuration are
 relative to the current working directory.


### PR DESCRIPTION
### Proposed changes

Add explanation of relative path handling when multiple Compose files are specified. This is covered in the [Extends section](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files) of the Compose Product Manual, but not the docker-compose CLI reference.

### Related issues
#8268 (added the comment about `--project-directory` to avoid making another instance of this issue)
https://github.com/docker/compose/issues/3874 (note the reference to the product manual in [this comment](https://github.com/docker/compose/issues/3874#issuecomment-487037338))
https://github.com/docker/compose/issues/3568 (note the reference to the product manual in [this comment](https://github.com/docker/compose/issues/3568#issuecomment-279509578))
