### PR TITLE
Revert "Docker Desktop release notes 2.5.2"

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -11,23 +11,6 @@ This page contains information about Docker Desktop Edge releases. Edge releases
 For information about Stable releases, see the [Stable release notes](release-notes.md). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
-## Docker Desktop Community 2.5.2
-2020-11-24
-
-> [Download](https://desktop.docker.com/mac/edge/50073/Docker.dmg)
-
-### New
-
-- Use of three digit version number.
-- Starting with Docker Desktop 2.5.2, updates will be much smaller as they will be applied using delta patches.
-- Support for MacOS 11.0 (Big Sur) with Intel processors.
-
-### Bug fixes and minor changes
-
-- Re-enabled the experimental SOCKS proxy. Fixes [docker/for-mac#5048](https://github.com/docker/for-mac/issues/5048).
-- Fixed an unexpected EOF error when trying to start a non-existing container with `-v /var/run/docker.sock:`. See [docker/for-mac#5025](https://github.com/docker/for-mac/issues/5025).
-- Display an error message if the application needs write access on specific directories instead of crashing. See [docker/for-mac#5068](https://github.com/docker/for-mac/issues/5068)
-
 ## Docker Desktop Community 2.5.1.0
 2020-11-18
 

--- a/docker-for-windows/edge-release-notes.md
+++ b/docker-for-windows/edge-release-notes.md
@@ -11,20 +11,6 @@ This page contains information about Docker Desktop Edge releases. Edge releases
 For information about Stable releases, see the [Stable release notes](release-notes.md). For Docker Desktop system requirements, see
 [What to know before you install](install.md#what-to-know-before-you-install).
 
-## Docker Desktop Community 2.5.2
-2020-11-24
-
-> [Download](https://desktop.docker.com/win/edge/50073/Docker%20Desktop%20Installer.exe)
-
-### New
-
-- Use of three digit version number.
-- Starting with Docker Desktop 2.5.2, updates will be much smaller as they will be applied using delta patches.
-
-### Bug fixes and minor changes
-
-- Fixed an unexpected EOF error when trying to start a non-existing container with `-v /var/run/docker.sock:`. See [docker/for-mac#5025](https://github.com/docker/for-mac/issues/5025).
-
 ## Docker Desktop Community 2.5.1.0
 2020-11-18
 


### PR DESCRIPTION
Reverts docker/docker.github.io#11791