### PR TITLE
Fix links in release notes for Docker Desktop edge 2.4.2.0 (for Mac)

### DIFF
--- a/docker-for-mac/edge-release-notes.md
+++ b/docker-for-mac/edge-release-notes.md
@@ -78,7 +78,7 @@ This release contains a Kubernetes upgrade. Note that your local Kubernetes clus
 - Always flush file system caches synchronously on container start. See [docker/for-mac#4943](https://github.com/docker/for-mac/issues/4943).
 - Allow symlinks to point outside of shared volumes. Fixes [docker/for-mac#4862](https://github.com/docker/for-mac/issues/4862).
 - Diagnostics: avoid hanging when Kubernetes is in a broken state.
-- Fixed automatic start on log in. See [docker/for-mac#4877] and [docker/for-mac#4890].
+- Fixed automatic start on log in. See [docker/for-mac#4877](https://github.com/docker/for-mac/issues/4877) and [docker/for-mac#4890](https://github.com/docker/for-mac/issues/4890).
 
 ## Docker Desktop Community 2.4.1.0
 2020-10-01


### PR DESCRIPTION
### Proposed changes

Add links to issues/PRs introduced in #11550 to the release note for Docker Desktop edge 2.4.2.0 (for Mac).
<!--Tell us what you did and why-->

### Unreleased project version (optional)

n/a

### Related issues (optional)

Following-up #11550