### PR TITLE
Fix a typo in Docker Hub Quickstart

### DIFF
--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -162,7 +162,7 @@ Congratulations! You've successfully:
 - Signed up for a Docker account
 - Created your first repository
 - Built a Docker container image on your computer
-- Pushed it succesfully to Docker Hub
+- Pushed it successfully to Docker Hub
 
 ### Next steps
 


### PR DESCRIPTION
### Proposed changes

Fix a typo in [Docker Hub Quickstart](https://docs.docker.com/docker-hub/).