### PR TITLE
Publish updates from master

### DIFF
--- a/compose/reference/overview.md
+++ b/compose/reference/overview.md
@@ -114,6 +114,10 @@ webapp:
     - DEBUG=1
 ```
 
+When you use multiple Compose files, all paths in the files are relative to the
+first configuration file specified with `-f`. You can use the
+`--project-directory` option to override this base path.
+
 Use a `-f` with `-` (dash) as the filename to read the configuration from
 `stdin`. When `stdin` is used all paths in the configuration are
 relative to the current working directory.

--- a/engine/swarm/swarm-tutorial/create-swarm.md
+++ b/engine/swarm/swarm-tutorial/create-swarm.md
@@ -27,7 +27,7 @@ machines.
     > single-node swarm, simply run `docker swarm init` with no arguments. There is no
     > need to specify `--advertise-addr` in this case. To learn more, see the topic
     > on how to
-    > [Use Docker Desktop or Mac or Docker Desktop for Windows](index.md#use-docker-desktop-for-mac-or-docker-desktop-for-windows)
+    > [Use Docker Desktop for Mac or Docker Desktop for Windows](index.md#use-docker-desktop-for-mac-or-docker-desktop-for-windows)
     > with Swarm.
 
     In the tutorial, the following command creates a swarm on the `manager1`


### PR DESCRIPTION
Looks like for some reason, the last publish omitted the "registry" spec. I tried reproducing the problem locally, but was not able to, so it may have been a temporary glitch or issue with GitHub's svn service

Let's try another publish to see if it resolves the problem

fixes / relates to https://github.com/docker/docker.github.io/issues/11816
fixes / relates to https://github.com/docker/docker.github.io/issues/11822
fixes / relates to https://github.com/docker/docker.github.io/issues/11823
fixes / relates to https://github.com/docker/docker.github.io/issues/11824
fixes / relates to https://github.com/docker/docker.github.io/issues/11828
fixes / relates to https://github.com/docker/docker.github.io/issues/11829
fixes / relates to https://github.com/docker/docker.github.io/issues/11830
fixes / relates to https://github.com/docker/docker.github.io/issues/11831
fixes / relates to https://github.com/docker/docker.github.io/issues/11832
fixes / relates to https://github.com/docker/docker.github.io/issues/11833
fixes / relates to https://github.com/docker/docker.github.io/issues/11834
fixes / relates to https://github.com/docker/docker.github.io/issues/11835
