### PR TITLE
Describe failed to find a Stack API version errors

### DIFF
--- a/_includes/kubernetes-mac-win.md
+++ b/_includes/kubernetes-mac-win.md
@@ -63,8 +63,13 @@ Kubernetes.
 
 ## Use Docker commands
 
-You can deploy a stack on Kubernetes with `docker stack deploy`, the
-`docker-compose.yml` file, and the name of the stack.
+To ensure that the docker stack commands are available on your installation, try
+`docker stack ls`.  If you see the message `failed to find a Stack API version`
+then the commands described on this page are not available.  This can be confirmed
+with `docker version` which should contain the line `StackAPI: Unknown`.
+
+If docker stack commands are working then you can deploy a stack on Kubernetes with
+`docker stack deploy`, the `docker-compose.yml` file, and the name of the stack.
 
 ```bash
 docker stack deploy --compose-file /path/to/docker-compose.yml mystack


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
Document the `failed to find a Stack API version` errors that prevent `docker stack` commands from working on Linux, macOS, and Windows.  This should reduce frustration if users attempt to use this missing functionality.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
Related to #11773, docker/cli#2844, and docker/for-mac#4966.

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
