### PR TITLE
Update engine reference for 20.10 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@
 ARG JEKYLL_ENV=development
 
 # Engine
-ARG ENGINE_BRANCH="19.03"
+# TODO change to 20.10 branch, once created
+ARG ENGINE_BRANCH="master"
 
 # Distribution
 ARG DISTRIBUTION_BRANCH="release/2.7"

--- a/_config.yml
+++ b/_config.yml
@@ -20,10 +20,10 @@ exclude: ["_samples", "_scripts", "404.html", "datacenter", "ee", "index.html", 
 
 # Component versions -- address like site.docker_ce_version
 # You can't have - characters in these for non-YAML reasons
-latest_engine_api_version: "1.40"
-docker_ce_version: "19.03"
+latest_engine_api_version: "1.41"
+docker_ce_version: "20.10"
 compose_version: "1.27.4"
-compose_file_v3: "3.8"
+compose_file_v3: "3.9"
 compose_file_v2: "2.4"
 machine_version: "0.16.0"
 distribution_version: "2.7"

--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -403,8 +403,7 @@ options:
   default_value: "false"
   description: Stream attaches to server to negotiate build context
   deprecated: false
-  min_api_version: "1.31"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -952,10 +951,9 @@ examples: |-
 
   #### Enable Docker experimental
 
-  Experimental features are now included in the standard Docker binaries as of
-  version 1.13.0. For enabling experimental features, you need to start the
-  Docker daemon with `--experimental` flag. You can also enable the daemon flag
-  via `/etc/docker/daemon.json`. e.g.
+  To enable experimental features, you need to start the Docker daemon with
+  `--experimental` flag. You can also enable the daemon flag via
+  `/etc/docker/daemon.json`, for example:
 
   ```json
   {

--- a/_data/engine-cli/docker_builder_build.yaml
+++ b/_data/engine-cli/docker_builder_build.yaml
@@ -295,8 +295,7 @@ options:
   default_value: "false"
   description: Stream attaches to server to negotiate build context
   deprecated: false
-  min_api_version: "1.31"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_container_create.yaml
+++ b/_data/engine-cli/docker_container_create.yaml
@@ -65,6 +65,20 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: cgroupns
+  value_type: string
+  description: |-
+    Cgroup namespace to use (host|private)
+    'host':    Run the container in the Docker host's cgroup namespace
+    'private': Run the container in its own private cgroup namespace
+    '':        Use the cgroup namespace as configured by the
+               default-cgroupns-mode option on the daemon (default)
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
@@ -657,7 +671,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -684,6 +698,15 @@ options:
   value_type: bool
   default_value: "false"
   description: Publish all exposed ports to random ports
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: string
+  default_value: missing
+  description: Pull image before creating ("always"|"missing"|"never")
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_container_exec.yaml
+++ b/_data/engine-cli/docker_container_exec.yaml
@@ -33,6 +33,15 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: env-file
+  value_type: list
+  description: Read in a file of environment variables
+  deprecated: false
+  min_api_version: "1.25"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool

--- a/_data/engine-cli/docker_container_logs.yaml
+++ b/_data/engine-cli/docker_container_logs.yaml
@@ -27,13 +27,14 @@ options:
 - option: since
   value_type: string
   description: |
-    Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
+    Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: tail
+  shorthand: "n"
   value_type: string
   default_value: all
   description: Number of lines to show from the end of the logs
@@ -55,7 +56,7 @@ options:
 - option: until
   value_type: string
   description: |
-    Show logs before a timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
+    Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   min_api_version: "1.35"
   experimental: false

--- a/_data/engine-cli/docker_container_ls.yaml
+++ b/_data/engine-cli/docker_container_ls.yaml
@@ -66,7 +66,7 @@ options:
   shorthand: q
   value_type: bool
   default_value: "false"
-  description: Only display numeric IDs
+  description: Only display container IDs
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_container_run.yaml
+++ b/_data/engine-cli/docker_container_run.yaml
@@ -65,6 +65,20 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: cgroupns
+  value_type: string
+  description: |-
+    Cgroup namespace to use (host|private)
+    'host':    Run the container in the Docker host's cgroup namespace
+    'private': Run the container in its own private cgroup namespace
+    '':        Use the cgroup namespace as configured by the
+               default-cgroupns-mode option on the daemon (default)
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
@@ -675,7 +689,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -702,6 +716,15 @@ options:
   value_type: bool
   default_value: "false"
   description: Publish all exposed ports to random ports
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: string
+  default_value: missing
+  description: Pull image before running ("always"|"missing"|"never")
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_create.yaml
+++ b/_data/engine-cli/docker_create.yaml
@@ -76,6 +76,20 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: cgroupns
+  value_type: string
+  description: |-
+    Cgroup namespace to use (host|private)
+    'host':    Run the container in the Docker host's cgroup namespace
+    'private': Run the container in its own private cgroup namespace
+    '':        Use the cgroup namespace as configured by the
+               default-cgroupns-mode option on the daemon (default)
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
@@ -668,7 +682,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -695,6 +709,15 @@ options:
   value_type: bool
   default_value: "false"
   description: Publish all exposed ports to random ports
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: string
+  default_value: missing
+  description: Pull image before creating ("always"|"missing"|"never")
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_exec.yaml
+++ b/_data/engine-cli/docker_exec.yaml
@@ -46,6 +46,15 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: env-file
+  value_type: list
+  description: Read in a file of environment variables
+  deprecated: false
+  min_api_version: "1.25"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: interactive
   shorthand: i
   value_type: bool

--- a/_data/engine-cli/docker_export.yaml
+++ b/_data/engine-cli/docker_export.yaml
@@ -6,7 +6,7 @@ long: |-
   the container, `docker export` will export the contents of the *underlying*
   directory, not the contents of the volume.
 
-  Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/v17.03/engine/tutorials/dockervolumes/#backup-restore-or-migrate-data-volumes)
+  Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes)
   in the user guide for examples on exporting data in a volume.
 usage: docker export [OPTIONS] CONTAINER
 pname: docker

--- a/_data/engine-cli/docker_history.yaml
+++ b/_data/engine-cli/docker_history.yaml
@@ -36,7 +36,7 @@ options:
   shorthand: q
   value_type: bool
   default_value: "false"
-  description: Only show numeric IDs
+  description: Only show image IDs
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_image_build.yaml
+++ b/_data/engine-cli/docker_image_build.yaml
@@ -295,8 +295,7 @@ options:
   default_value: "false"
   description: Stream attaches to server to negotiate build context
   deprecated: false
-  min_api_version: "1.31"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_image_history.yaml
+++ b/_data/engine-cli/docker_image_history.yaml
@@ -36,7 +36,7 @@ options:
   shorthand: q
   value_type: bool
   default_value: "false"
-  description: Only show numeric IDs
+  description: Only show image IDs
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_image_import.yaml
+++ b/_data/engine-cli/docker_image_import.yaml
@@ -28,7 +28,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_image_ls.yaml
+++ b/_data/engine-cli/docker_image_ls.yaml
@@ -1,5 +1,5 @@
 command: docker image ls
-aliases: images, list
+aliases: list
 short: List images
 long: List images
 usage: docker image ls [OPTIONS] [REPOSITORY[:TAG]]
@@ -55,7 +55,7 @@ options:
   shorthand: q
   value_type: bool
   default_value: "false"
-  description: Only show numeric IDs
+  description: Only show image IDs
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_image_pull.yaml
+++ b/_data/engine-cli/docker_image_pull.yaml
@@ -29,7 +29,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_image_push.yaml
+++ b/_data/engine-cli/docker_image_push.yaml
@@ -5,10 +5,30 @@ usage: docker image push [OPTIONS] NAME[:TAG]
 pname: docker image
 plink: docker_image.yaml
 options:
+- option: all-tags
+  shorthand: a
+  value_type: bool
+  default_value: "false"
+  description: Push all tagged images in the repository
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
   description: Skip image signing
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Suppress verbose output
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_images.yaml
+++ b/_data/engine-cli/docker_images.yaml
@@ -69,7 +69,7 @@ options:
   shorthand: q
   value_type: bool
   default_value: "false"
-  description: Only show numeric IDs
+  description: Only show image IDs
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_import.yaml
+++ b/_data/engine-cli/docker_import.yaml
@@ -40,7 +40,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_info.yaml
+++ b/_data/engine-cli/docker_info.yaml
@@ -41,6 +41,7 @@ examples: |-
   ```bash
   $ docker info
   Client:
+   Context:    default
    Debug Mode: false
 
   Server:
@@ -100,6 +101,7 @@ examples: |-
   ```bash
   $ docker -D info
   Client:
+   Context:    default
    Debug Mode: true
 
   Server:
@@ -199,6 +201,7 @@ examples: |-
   ```console
   E:\docker>docker info
   Client:
+   Context:    default
    Debug Mode: false
 
   Server:

--- a/_data/engine-cli/docker_logs.yaml
+++ b/_data/engine-cli/docker_logs.yaml
@@ -64,13 +64,14 @@ options:
 - option: since
   value_type: string
   description: |
-    Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
+    Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: tail
+  shorthand: "n"
   value_type: string
   default_value: all
   description: Number of lines to show from the end of the logs
@@ -92,7 +93,7 @@ options:
 - option: until
   value_type: string
   description: |
-    Show logs before a timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
+    Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   min_api_version: "1.35"
   experimental: false

--- a/_data/engine-cli/docker_manifest.yaml
+++ b/_data/engine-cli/docker_manifest.yaml
@@ -56,6 +56,7 @@ long: |-
         --arch string               Set architecture
         --help                      Print usage
         --os string                 Set operating system
+        --os-version string         Set operating system version
         --os-features stringSlice   Set operating system feature
         --variant string            Set architecture variant
 
@@ -94,11 +95,13 @@ cname:
 - docker manifest create
 - docker manifest inspect
 - docker manifest push
+- docker manifest rm
 clink:
 - docker_manifest_annotate.yaml
 - docker_manifest_create.yaml
 - docker_manifest_inspect.yaml
 - docker_manifest_push.yaml
+- docker_manifest_rm.yaml
 examples: |-
   ### Inspect an image's manifest object
 

--- a/_data/engine-cli/docker_manifest_annotate.yaml
+++ b/_data/engine-cli/docker_manifest_annotate.yaml
@@ -30,6 +30,14 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: os-version
+  value_type: string
+  description: Set operating system version
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: variant
   value_type: string
   description: Set architecture variant

--- a/_data/engine-cli/docker_manifest_rm.yaml
+++ b/_data/engine-cli/docker_manifest_rm.yaml
@@ -1,0 +1,12 @@
+command: docker manifest rm
+short: Delete one or more manifest lists from local storage
+long: Delete one or more manifest lists from local storage
+usage: docker manifest rm MANIFEST_LIST [MANIFEST_LIST...]
+pname: docker manifest
+plink: docker_manifest.yaml
+deprecated: false
+experimental: false
+experimentalcli: true
+kubernetes: false
+swarm: false
+

--- a/_data/engine-cli/docker_network_create.yaml
+++ b/_data/engine-cli/docker_network_create.yaml
@@ -85,7 +85,7 @@ options:
   swarm: false
 - option: config-from
   value_type: string
-  description: The network from which copying the configuration
+  description: The network from which to copy the configuration
   deprecated: false
   min_api_version: "1.30"
   experimental: false

--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -65,7 +65,7 @@ options:
   shorthand: q
   value_type: bool
   default_value: "false"
-  description: Only display numeric IDs
+  description: Only display container IDs
   deprecated: false
   experimental: false
   experimentalcli: false
@@ -448,7 +448,8 @@ examples: |-
   | `.CreatedAt`  | Time when the container was created.                                                            |
   | `.RunningFor` | Elapsed time since the container was started.                                                   |
   | `.Ports`      | Exposed ports.                                                                                  |
-  | `.Status`     | Container status.                                                                               |
+  | `.State`      | Container status (for example; "created", "running", "exited").                                 |
+  | `.Status`     | Container status with details about duration and health-status.                                 |
   | `.Size`       | Container disk size.                                                                            |
   | `.Names`      | Container names.                                                                                |
   | `.Labels`     | All labels assigned to the container.                                                           |

--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -53,7 +53,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false

--- a/_data/engine-cli/docker_push.yaml
+++ b/_data/engine-cli/docker_push.yaml
@@ -1,13 +1,13 @@
 command: docker push
 short: Push an image or a repository to a registry
 long: |-
-  Use `docker push` to share your images to the [Docker Hub](https://hub.docker.com)
+  Use `docker image push` to share your images to the [Docker Hub](https://hub.docker.com)
   registry or to a self-hosted one.
 
-  Refer to the [`docker tag`](tag.md) reference for more information about valid
+  Refer to the [`docker image tag`](tag.md) reference for more information about valid
   image and tag names.
 
-  Killing the `docker push` process, for example by pressing `CTRL-c` while it is
+  Killing the `docker image push` process, for example by pressing `CTRL-c` while it is
   running in a terminal, terminates the push operation.
 
   Progress bars are shown during docker push, which show the uncompressed size.
@@ -26,6 +26,16 @@ usage: docker push [OPTIONS] NAME[:TAG]
 pname: docker
 plink: docker.yaml
 options:
+- option: all-tags
+  shorthand: a
+  value_type: bool
+  default_value: "false"
+  description: Push all tagged images in the repository
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: disable-content-trust
   value_type: bool
   default_value: "true"
@@ -35,15 +45,25 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Suppress verbose output
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 examples: |-
   ### Push a new image to a registry
 
-  First save the new image by finding the container ID (using [`docker ps`](ps.md))
+  First save the new image by finding the container ID (using [`docker container ls`](ps.md))
   and then committing it to a new image name.  Note that only `a-z0-9-_.` are
   allowed when naming images:
 
   ```bash
-  $ docker commit c16378f943fe rhel-httpd
+  $ docker container commit c16378f943fe rhel-httpd:latest
   ```
 
   Now, push the image to the registry using the image ID. In this example the
@@ -52,19 +72,65 @@ examples: |-
   registry:
 
   ```bash
-  $ docker tag rhel-httpd registry-host:5000/myadmin/rhel-httpd
+  $ docker image tag rhel-httpd:latest registry-host:5000/myadmin/rhel-httpd:latest
 
-  $ docker push registry-host:5000/myadmin/rhel-httpd
+  $ docker image push registry-host:5000/myadmin/rhel-httpd:latest
   ```
 
   Check that this worked by running:
 
   ```bash
-  $ docker images
+  $ docker image ls
   ```
 
   You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
   listed.
+
+  ### Push all tags of an image
+
+  Use the `-a` (or `--all-tags`) option to push To push all tags of a local image.
+
+  The following example creates multiple tags for an image, and pushes all those
+  tags to Docker Hub.
+
+
+  ```bash
+  $ docker image tag myimage registry-host:5000/myname/myimage:latest
+  $ docker image tag myimage registry-host:5000/myname/myimage:v1.0.1
+  $ docker image tag myimage registry-host:5000/myname/myimage:v1.0
+  $ docker image tag myimage registry-host:5000/myname/myimage:v1
+  ```
+
+  The image is now tagged under multiple names:
+
+  ```bash
+  $ docker image ls
+
+  REPOSITORY                          TAG        IMAGE ID       CREATED      SIZE
+  myimage                             latest     6d5fcfe5ff17   2 hours ago  1.22MB
+  registry-host:5000/myname/myimage   latest     6d5fcfe5ff17   2 hours ago  1.22MB
+  registry-host:5000/myname/myimage   v1         6d5fcfe5ff17   2 hours ago  1.22MB
+  registry-host:5000/myname/myimage   v1.0       6d5fcfe5ff17   2 hours ago  1.22MB
+  registry-host:5000/myname/myimage   v1.0.1     6d5fcfe5ff17   2 hours ago  1.22MB
+  ```
+
+  When pushing with the `--all-tags` option, all tags of the `registry-host:5000/myname/myimage`
+  image are pushed:
+
+
+  ```bash
+  $ docker image push --all-tags registry-host:5000/myname/myimage
+
+  The push refers to repository [registry-host:5000/myname/myimage]
+  195be5f8be1d: Pushed
+  latest: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+  195be5f8be1d: Layer already exists
+  v1: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+  195be5f8be1d: Layer already exists
+  v1.0: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+  195be5f8be1d: Layer already exists
+  v1.0.1: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -76,6 +76,20 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: cgroupns
+  value_type: string
+  description: |-
+    Cgroup namespace to use (host|private)
+    'host':    Run the container in the Docker host's cgroup namespace
+    'private': Run the container in its own private cgroup namespace
+    '':        Use the cgroup namespace as configured by the
+               default-cgroupns-mode option on the daemon (default)
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
@@ -686,7 +700,7 @@ options:
   description: Set platform if server is multi-platform capable
   deprecated: false
   min_api_version: "1.32"
-  experimental: true
+  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -713,6 +727,15 @@ options:
   value_type: bool
   default_value: "false"
   description: Publish all exposed ports to random ports
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: string
+  default_value: missing
+  description: Pull image before running ("always"|"missing"|"never")
   deprecated: false
   experimental: false
   experimentalcli: false
@@ -1304,7 +1327,8 @@ examples: |-
 
   By default, the container will be able to `read`, `write` and `mknod` these devices.
   This can be overridden using a third `:rwm` set of options to each `--device`
-  flag:
+  flag. If the container is running in privileged mode, then the permissions specified
+  will be ignored.
 
   ```bash
   $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc

--- a/_data/engine-cli/docker_search.yaml
+++ b/_data/engine-cli/docker_search.yaml
@@ -5,15 +5,6 @@ usage: docker search [OPTIONS] TERM
 pname: docker
 plink: docker.yaml
 options:
-- option: automated
-  value_type: bool
-  default_value: "false"
-  description: Only show automated builds
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
 - option: filter
   shorthand: f
   value_type: filter
@@ -45,16 +36,6 @@ options:
   default_value: "false"
   description: Don't truncate output
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: stars
-  shorthand: s
-  value_type: uint
-  default_value: "0"
-  description: Only displays with at least x stars
-  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -13,6 +13,24 @@ usage: docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker service
 plink: docker_service.yaml
 options:
+- option: cap-add
+  value_type: list
+  description: Add Linux capabilities
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: cap-drop
+  value_type: list
+  description: Drop Linux capabilities
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: config
   value_type: config
   description: Specify configurations to expose to the service
@@ -248,6 +266,16 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: limit-pids
+  value_type: int64
+  default_value: "0"
+  description: Limit maximum number of processes (default 0 = unlimited)
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: log-driver
   value_type: string
   description: Logging driver for service
@@ -264,10 +292,21 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: max-concurrent
+  value_type: uint
+  description: |
+    Number of job tasks to run concurrently (default equal to --replicas)
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: mode
   value_type: string
   default_value: replicated
-  description: Service mode (replicated or global)
+  description: |
+    Service mode (replicated, global, replicated-job, or global-job)
   deprecated: false
   experimental: false
   experimentalcli: false
@@ -529,6 +568,16 @@ options:
   description: Allocate a pseudo-TTY
   deprecated: false
   min_api_version: "1.25"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: ulimit
+  value_type: ulimit
+  default_value: '[]'
+  description: Ulimit options
+  deprecated: false
+  min_api_version: "1.41"
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -1640,6 +1689,66 @@ examples: |-
       --generic-resource "SSD=1" \
       nvidia/cuda
   ```
+
+  ### Running as a job
+
+  Jobs are a special kind of service designed to run an operation to completion
+  and then stop, as opposed to running long-running daemons. When a Task
+  belonging to a job exits successfully (return value 0), the Task is marked as
+  "Completed", and is not run again.
+
+  Jobs are started by using one of two modes, `replicated-job` or `global-job`
+
+  ```bash
+  $ docker service create --name myjob \
+                          --mode replicated-job \
+                          bash "true"
+  ```
+
+  This command will run one Task, which will, using the `bash` image, execute the
+  command `true`, which will return 0 and then exit.
+
+  Though Jobs are ultimately a different kind of service, they a couple of
+  caveats compared to other services:
+
+  - None of the update or rollback configuration options are valid.  Jobs can be
+    updated, but cannot be rolled out or rolled back, making these configuration
+    options moot.
+  - Jobs are never restarted on reaching the `Complete` state. This means that
+    for jobs, setting `--restart-condition` to `any` is the same as setting it to
+    `on-failure`.
+
+  Jobs are available in both replicated and global modes.
+
+  #### Replicated Jobs
+
+  A replicated job is like a replicated service. Setting the `--replicas` flag
+  will specify total number of iterations of a job to execute.
+
+  By default, all replicas of a replicated job will launch at once. To control
+  the total number of replicas that are executing simultaneously at any one time,
+  the `--max-concurrent` flag can be used:
+
+  ```bash
+  $ docker service create --name mythrottledjob \
+                          --mode replicated-job \
+                          --replicas 10 \
+                          --max-concurrent 2 \
+                          bash "true"
+  ```
+
+  The above command will execute 10 Tasks in total, but only 2 of them will be
+  run at any given time.
+
+  #### Global Jobs
+
+  Global jobs are like global services, in that a Task is executed once on each node
+  matching placement constraints. Global jobs are represented by the mode `global-job`.
+
+  Note that after a Global job is created, any new Nodes added to the cluster
+  will have a Task from that job started on them. The Global Job does not as a
+  whole have a "done" state, except insofar as every Node meeting the job's
+  constraints has a Completed task.
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_service_logs.yaml
+++ b/_data/engine-cli/docker_service_logs.yaml
@@ -114,13 +114,14 @@ options:
 - option: since
   value_type: string
   description: |
-    Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
+    Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: tail
+  shorthand: "n"
   value_type: string
   default_value: all
   description: Number of lines to show from the end of the logs

--- a/_data/engine-cli/docker_service_ls.yaml
+++ b/_data/engine-cli/docker_service_ls.yaml
@@ -41,122 +41,51 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: |-
-  On a manager node:
-
-  ```bash
-  $ docker service ls
-
-  ID            NAME      MODE        REPLICAS    IMAGE
-  c8wgl7q4ndfd  frontend  replicated  5/5         nginx:alpine
-  dmu1ept4cxcf  redis     replicated  3/3         redis:3.0.6
-  iwe3278osahj  mongo     global      7/7         mongo:3.3
-  ```
-
-  The `REPLICAS` column shows both the *actual* and *desired* number of tasks for
-  the service.
-
-  ### Filtering
-
-  The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
-  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
-
-  The currently supported filters are:
-
-  * [id](service_ls.md#id)
-  * [label](service_ls.md#label)
-  * [mode](service_ls.md#mode)
-  * [name](service_ls.md#name)
-
-  #### id
-
-  The `id` filter matches all or part of a service's id.
-
-  ```bash
-  $ docker service ls -f "id=0bcjw"
-  ID            NAME   MODE        REPLICAS  IMAGE
-  0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
-  ```
-
-  #### label
-
-  The `label` filter matches services based on the presence of a `label` alone or
-  a `label` and a value.
-
-  The following filter matches all services with a `project` label regardless of
-  its value:
-
-  ```bash
-  $ docker service ls --filter label=project
-  ID            NAME       MODE        REPLICAS  IMAGE
-  01sl1rp6nj5u  frontend2  replicated  1/1       nginx:alpine
-  36xvvwwauej0  frontend   replicated  5/5       nginx:alpine
-  74nzcxxjv6fq  backend    replicated  3/3       redis:3.0.6
-  ```
-
-  The following filter matches only services with the `project` label with the
-  `project-a` value.
-
-  ```bash
-  $ docker service ls --filter label=project=project-a
-  ID            NAME      MODE        REPLICAS  IMAGE
-  36xvvwwauej0  frontend  replicated  5/5       nginx:alpine
-  74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
-  ```
-
-  #### mode
-
-  The `mode` filter matches on the mode (either `replicated` or `global`) of a service.
-
-  The following filter matches only `global` services.
-
-  ```bash
-  $ docker service ls --filter mode=global
-  ID                  NAME                MODE                REPLICAS            IMAGE
-  w7y0v2yrn620        top                 global              1/1                 busybox
-  ```
-
-  #### name
-
-  The `name` filter matches on all or part of a service's name.
-
-  The following filter matches services with a name containing `redis`.
-
-  ```bash
-  $ docker service ls --filter name=redis
-  ID            NAME   MODE        REPLICAS  IMAGE
-  0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
-  ```
-
-  ### Formatting
-
-  The formatting options (`--format`) pretty-prints services output
-  using a Go template.
-
-  Valid placeholders for the Go template are listed below:
-
-  Placeholder | Description
-  ------------|------------------------------------------------------------------------------------------
-  `.ID`       | Service ID
-  `.Name`     | Service name
-  `.Mode`     | Service mode (replicated, global)
-  `.Replicas` | Service replicas
-  `.Image`    | Service image
-  `.Ports`    | Service ports published in ingress mode
-
-  When using the `--format` option, the `service ls` command will either
-  output the data exactly as the template declares or, when using the
-  `table` directive, includes column headers as well.
-
-  The following example uses a template without headers and outputs the
-  `ID`, `Mode`, and `Replicas` entries separated by a colon (`:`) for all services:
-
-  ```bash
-  $ docker service ls --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
-
-  0zmvwuiu3vue: replicated 10/10
-  fm6uf97exkul: global 5/5
-  ```
+examples: "On a manager node:\n\n```bash\n$ docker service ls\n\nID            NAME
+  \     MODE            REPLICAS             IMAGE\nc8wgl7q4ndfd  frontend  replicated
+  \     5/5                  nginx:alpine\ndmu1ept4cxcf  redis     replicated      3/3
+  \                 redis:3.0.6\niwe3278osahj  mongo     global          7/7                  mongo:3.3\nhh08h9uu8uwr
+  \ job       replicated-job  1/1 (3/5 completed)  nginx:latest        \n```\n\nThe
+  `REPLICAS` column shows both the *actual* and *desired* number of tasks for\nthe
+  service. If the service is in `replicated-job` or `global-job`, it will\nadditionally
+  show the completion status of the job as completed tasks over\ntotal tasks the job
+  will execute.\n\n### Filtering\n\nThe filtering flag (`-f` or `--filter`) format
+  is of \"key=value\". If there is more\nthan one filter, then pass multiple flags
+  (e.g., `--filter \"foo=bar\" --filter \"bif=baz\"`)\n\nThe currently supported filters
+  are:\n\n* [id](service_ls.md#id)\n* [label](service_ls.md#label)\n* [mode](service_ls.md#mode)\n*
+  [name](service_ls.md#name)\n\n#### id\n\nThe `id` filter matches all or part of
+  a service's id.\n\n```bash\n$ docker service ls -f \"id=0bcjw\"\nID            NAME
+  \  MODE        REPLICAS  IMAGE\n0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6\n```\n\n####
+  label\n\nThe `label` filter matches services based on the presence of a `label`
+  alone or\na `label` and a value.\n\nThe following filter matches all services with
+  a `project` label regardless of\nits value:\n\n```bash\n$ docker service ls --filter
+  label=project\nID            NAME       MODE        REPLICAS  IMAGE\n01sl1rp6nj5u
+  \ frontend2  replicated  1/1       nginx:alpine\n36xvvwwauej0  frontend   replicated
+  \ 5/5       nginx:alpine\n74nzcxxjv6fq  backend    replicated  3/3       redis:3.0.6\n```\n\nThe
+  following filter matches only services with the `project` label with the\n`project-a`
+  value.\n\n```bash\n$ docker service ls --filter label=project=project-a\nID            NAME
+  \     MODE        REPLICAS  IMAGE\n36xvvwwauej0  frontend  replicated  5/5       nginx:alpine\n74nzcxxjv6fq
+  \ backend   replicated  3/3       redis:3.0.6\n```\n\n#### mode\n\nThe `mode` filter
+  matches on the mode (either `replicated` or `global`) of a service.\n\nThe following
+  filter matches only `global` services.\n\n```bash\n$ docker service ls --filter
+  mode=global\nID                  NAME                MODE                REPLICAS
+  \           IMAGE\nw7y0v2yrn620        top                 global              1/1
+  \                busybox\n```\n\n#### name\n\nThe `name` filter matches on all or
+  part of a service's name.\n\nThe following filter matches services with a name containing
+  `redis`.\n\n```bash\n$ docker service ls --filter name=redis\nID            NAME
+  \  MODE        REPLICAS  IMAGE\n0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6\n```\n\n###
+  Formatting\n\nThe formatting options (`--format`) pretty-prints services output\nusing
+  a Go template.\n\nValid placeholders for the Go template are listed below:\n\nPlaceholder
+  | Description\n------------|------------------------------------------------------------------------------------------\n`.ID`
+  \      | Service ID\n`.Name`     | Service name\n`.Mode`     | Service mode (replicated,
+  global)\n`.Replicas` | Service replicas\n`.Image`    | Service image\n`.Ports`    |
+  Service ports published in ingress mode\n\nWhen using the `--format` option, the
+  `service ls` command will either\noutput the data exactly as the template declares
+  or, when using the\n`table` directive, includes column headers as well.\n\nThe following
+  example uses a template without headers and outputs the\n`ID`, `Mode`, and `Replicas`
+  entries separated by a colon (`:`) for all services:\n\n```bash\n$ docker service
+  ls --format \"{{.ID}}: {{.Mode}} {{.Replicas}}\"\n\n0zmvwuiu3vue: replicated 10/10\nfm6uf97exkul:
+  global 5/5\n```"
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_service_scale.yaml
+++ b/_data/engine-cli/docker_service_scale.yaml
@@ -49,7 +49,7 @@ examples: |-
 
   $ docker service scale backend=10
 
-  backend: scale can only be used with replicated mode
+  backend: scale can only be used with replicated or replicated-job mode
   ```
 
   Directly afterwards, run `docker service ls`, to see the actual number of

--- a/_data/engine-cli/docker_service_update.yaml
+++ b/_data/engine-cli/docker_service_update.yaml
@@ -29,6 +29,24 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: cap-add
+  value_type: list
+  description: Add Linux capabilities
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: cap-drop
+  value_type: list
+  description: Drop Linux capabilities
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: config-add
   value_type: config
   description: Add or update a config file on a service
@@ -366,6 +384,16 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: limit-pids
+  value_type: int64
+  default_value: "0"
+  description: Limit maximum number of processes (default 0 = unlimited)
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: true
 - option: log-driver
   value_type: string
   description: Logging driver for service
@@ -378,6 +406,16 @@ options:
   value_type: list
   description: Logging driver options
   deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: max-concurrent
+  value_type: uint
+  description: |
+    Number of job tasks to run concurrently (default equal to --replicas)
+  deprecated: false
+  min_api_version: "1.41"
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -693,6 +731,25 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: ulimit-add
+  value_type: ulimit
+  default_value: '[]'
+  description: Add or update a ulimit option
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: ulimit-rm
+  value_type: list
+  description: Remove a ulimit option
+  deprecated: false
+  min_api_version: "1.41"
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: update-delay
   value_type: duration
   default_value: 0s
@@ -953,6 +1010,23 @@ examples: |-
 
   `service update` supports the same `--isolation` flag as `service create`
   See [`service create`](service_create.md) for the reference.
+
+  ### Updating Jobs
+
+  When a service is created as a job, by setting its mode to `replicated-job` or
+  to `global-job` when doing `service create`, options for updating it are
+  limited.
+
+  Updating a Job immediately stops any Tasks that are in progress. The operation
+  creates a new set of Tasks for the job and effectively resets its completion
+  status. If any Tasks were running before the update, they are stopped, and new
+  Tasks are created.
+
+  Jobs cannot be rolled out or rolled back. None of the flags for configuring
+  update or rollback settings are valid with job modes.
+
+  To run a job again with the same parameters that it was run previously, it can
+  be force updated with the `--force` flag.
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_stack_deploy.yaml
+++ b/_data/engine-cli/docker_stack_deploy.yaml
@@ -14,14 +14,6 @@ usage: docker stack deploy [OPTIONS] STACK
 pname: docker stack
 plink: docker_stack.yaml
 options:
-- option: bundle-file
-  value_type: string
-  description: Path to a Distributed Application Bundle file
-  deprecated: false
-  experimental: true
-  experimentalcli: false
-  kubernetes: false
-  swarm: true
 - option: compose-file
   shorthand: c
   value_type: stringSlice
@@ -142,34 +134,6 @@ examples: |-
   Creating service vossibility_kibana
   Creating service vossibility_ghollector
   Creating service vossibility_lookupd
-  ```
-
-  You can verify that the services were correctly created:
-
-  ```bash
-  $ docker service ls
-
-  ID            NAME                               MODE        REPLICAS  IMAGE
-  29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
-  4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
-  4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
-  7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
-  9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
-  axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
-  ```
-
-  ### DAB file
-
-  ```bash
-  $ docker stack deploy --bundle-file vossibility-stack.dab vossibility
-
-  Loading bundle from vossibility-stack.dab
-  Creating service vossibility_elasticsearch
-  Creating service vossibility_kibana
-  Creating service vossibility_logstash
-  Creating service vossibility_lookupd
-  Creating service vossibility_nsqd
-  Creating service vossibility_vossibility-collector
   ```
 
   You can verify that the services were correctly created:

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -11,10 +11,15 @@ long: |-
 
   > **Note**
   >
-  > On Linux, the Docker CLI reports memory usage by subtracting page cache usage
-  > from the total memory usage. The API does not perform such a calculation but
-  > rather provides the total memory usage and the amount from the page cache so
-  > that clients can use the data as needed.
+  > On Linux, the Docker CLI reports memory usage by subtracting cache usage from
+  > the total memory usage. The API does not perform such a calculation but rather
+  > provides the total memory usage and the amount from the cache so that clients
+  > can use the data as needed. The cache usage is defined as the value of
+  > `total_inactive_file` field in the `memory.stat` file on cgroup v1 hosts.
+  >
+  > On Docker 19.03 and older, the cache usage was defined as the value of `cache`
+  > field. On cgroup v2 hosts, the cache usage is defined as the value of
+  > `inactive_file` field.
 
   > **Note**
   >

--- a/_data/engine-cli/docker_system_prune.yaml
+++ b/_data/engine-cli/docker_system_prune.yaml
@@ -117,15 +117,6 @@ examples: |-
   Total reclaimed space: 13.5 MB
   ```
 
-  > **Note**
-  >
-  > The `--volumes` option was added in Docker 17.06.1. Older versions of Docker
-  > prune volumes by default, along with other Docker objects. On older versions,
-  > run `docker container prune`, `docker network prune`, and `docker image prune`
-  > separately to remove unused containers, networks, and images, without removing
-  > volumes.
-
-
   ### Filtering
 
   The filtering flag (`--filter`) format is of "key=value". If there is more

--- a/_data/engine-cli/docker_update.yaml
+++ b/_data/engine-cli/docker_update.yaml
@@ -189,6 +189,10 @@ examples: |-
   If the container was started *without* `--kernel-memory` you need to stop
   the container before updating kernel memory.
 
+  > **Note**
+  >
+  > The `--kernel-memory` option has been deprecated since Docker 20.10.
+
   For example, if you started a container with this command:
 
   ```bash

--- a/_data/engine-cli/docker_version.yaml
+++ b/_data/engine-cli/docker_version.yaml
@@ -40,6 +40,7 @@ examples: |-
    Git commit:        afacb8b
    Built:             Wed Mar 11 01:21:11 2020
    OS/Arch:           darwin/amd64
+   Context:           default
    Experimental:      true
 
   Server:
@@ -77,6 +78,50 @@ examples: |-
 
   {"Client":{"Platform":{"Name":"Docker Engine - Community"},"Version":"19.03.8","ApiVersion":"1.40","DefaultAPIVersion":"1.40","GitCommit":"afacb8b","GoVersion":"go1.12.17","Os":"darwin","Arch":"amd64","BuildTime":"Wed Mar 11 01:21:11 2020","Experimental":true},"Server":{"Platform":{"Name":"Docker Engine - Community"},"Components":[{"Name":"Engine","Version":"19.03.8","Details":{"ApiVersion":"1.40","Arch":"amd64","BuildTime":"Wed Mar 11 01:29:16 2020","Experimental":"true","GitCommit":"afacb8b","GoVersion":"go1.12.17","KernelVersion":"4.19.76-linuxkit","MinAPIVersion":"1.12","Os":"linux"}},{"Name":"containerd","Version":"v1.2.13","Details":{"GitCommit":"7ad184331fa3e55e52b890ea95e65ba581ae3429"}},{"Name":"runc","Version":"1.0.0-rc10","Details":{"GitCommit":"dc9208a3303feef5b3839f4323d9beb36df0a9dd"}},{"Name":"docker-init","Version":"0.18.0","Details":{"GitCommit":"fec3683"}}],"Version":"19.03.8","ApiVersion":"1.40","MinAPIVersion":"1.12","GitCommit":"afacb8b","GoVersion":"go1.12.17","Os":"linux","Arch":"amd64","KernelVersion":"4.19.76-linuxkit","Experimental":true,"BuildTime":"2020-03-11T01:29:16.000000000+00:00"}}
   ```
+
+  ### Print the current context
+
+  The following example prints the currently used [`docker context`](context.md):
+
+  ```bash
+  $ docker version --format='{{.Client.Context}}'
+  default
+  ```
+
+  As an example, this output can be used to dynamically change your shell prompt
+  to indicate your active context. The example below illustrates how this output
+  could be used when using Bash as your shell.
+
+  Declare a function to obtain the current context in your `~/.bashrc`, and set
+  this command as your `PROMPT_COMMAND`
+
+  ```bash
+  function docker_context_prompt() {
+          PS1="context: $(docker version --format='{{.Client.Context}}')> "
+  }
+
+  PROMPT_COMMAND=docker_context_prompt
+  ```
+
+  After reloading the `~/.bashrc`, the prompt now shows the currently selected
+  `docker context`:
+
+  ```bash
+  $ source ~/.bashrc
+  context: default> docker context create --docker host=unix:///var/run/docker.sock my-context
+  my-context
+  Successfully created context "my-context"
+  context: default> docker context use my-context
+  my-context
+  Current context is now "my-context"
+  context: my-context> docker context use default
+  default
+  Current context is now "default"
+  context: default>
+  ```
+
+  Refer to the [`docker context` section](context.md) in the command line reference
+  for more information about `docker context`.
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -610,6 +610,8 @@ reference:
         title: docker manifest inspect
       - path: /engine/reference/commandline/manifest_push/
         title: docker manifest push
+      - path: /engine/reference/commandline/manifest_rm/
+        title: docker manifest rm
     - sectiontitle: docker network
       section:
       - path: /engine/reference/commandline/network/
@@ -912,6 +914,8 @@ reference:
       section:
       - path: /engine/api/version-history/
         title: Version history overview
+      - path: /engine/api/v1.41/
+        title: v1.41 reference
       - path: /engine/api/v1.40/
         title: v1.40 reference
       - path: /engine/api/v1.39/

--- a/_includes/api-version-matrix.md
+++ b/_includes/api-version-matrix.md
@@ -1,6 +1,7 @@
 
 | Docker version | Maximum API version        | Change log                                               |
 |:---------------|:---------------------------|:---------------------------------------------------------|
+| 20.10          | [1.41](/engine/api/v1.41/) | [changes](/engine/api/version-history/#v141-api-changes) |
 | 19.03          | [1.40](/engine/api/v1.40/) | [changes](/engine/api/version-history/#v140-api-changes) |
 | 18.09          | [1.39](/engine/api/v1.39/) | [changes](/engine/api/version-history/#v139-api-changes) |
 | 18.06          | [1.38](/engine/api/v1.38/) | [changes](/engine/api/version-history/#v138-api-changes) |

--- a/_scripts/fetch-upstream-resources.sh
+++ b/_scripts/fetch-upstream-resources.sh
@@ -34,6 +34,10 @@ wget --quiet --directory-prefix=./engine/reference/commandline/ "https://raw.git
 wget --quiet --directory-prefix=./engine/reference/commandline/ "https://raw.githubusercontent.com/docker/cli/${ENGINE_BRANCH}/docs/reference/commandline/dockerd.md" || (echo "Failed engine/reference/commandline/dockerd.md download" && exit 1)
 wget --quiet --directory-prefix=./registry/                     "https://raw.githubusercontent.com/docker/distribution/${DISTRIBUTION_BRANCH}/docs/configuration.md"  || (echo "Failed registry/configuration.md download" && exit 1)
 
+# temporarily fetching API v1.41 by copying from the v20.10.0-rc2 tag
+wget --quiet --directory-prefix=./engine/api/                   "https://raw.githubusercontent.com/moby/moby/v20.10.0-rc2/api/swagger.yaml"  || (echo "Failed engine/deprecated.md download" && exit 1)
+mv ./engine/api/swagger.yaml ./engine/api/v1.41.yaml
+
 # Remove things we don't want in the build
 rm -f ./engine/extend/cli_plugins.md # the cli plugins api is not a stable API, and not included in the TOC for that reason.
 rm -f ./registry/spec/api.md.tmpl

--- a/engine/api/index.md
+++ b/engine/api/index.md
@@ -55,22 +55,22 @@ To see the highest version of the API your Docker daemon and client support, use
 ```bash
 $ docker version
 
-Client:
-  Version:           19.03.5
-  API version:       1.40
-  Go version:        go1.12.12
-  Git commit:        633a0ea
-  Built:             Wed Nov 13 07:22:37 2019
-  OS/Arch:           windows/amd64
-  Experimental:      true
-
-
-Server:
-  Version:          19.03.5
-  API version:      1.40 (minimum version 1.12)
-  Go version:       go1.12.12
-  Git commit:       633a0ea
-  Built:            Wed Nov 13 07:29:19 2019
+Client: Docker Engine - Community
+ Version:           20.10.0
+ API version:       1.41
+ Go version:        go1.13.15
+ Git commit:        7287ab3
+ Built:             Tue Dec  8 19:00:39 2020
+ OS/Arch:           linux/amd64
+ Context:           default
+ Experimental:      true
+Server: Docker Engine - Community
+ Engine:
+  Version:          20.10.0
+  API version:      1.41 (minimum version 1.12)
+  Go version:       go1.13.15
+  Git commit:       eeddea2
+  Built:            Tue Dec  8 18:58:12 2020
   OS/Arch:          linux/amd64
   ...
 ```
@@ -82,7 +82,7 @@ You can specify the API version to use, in one of the following ways:
 
 - When using `curl` directly, specify the version as the first part of the URL.
   For instance, if the endpoint is `/containers/`, you can use
-  `/v1.40/containers/`.
+  `/v1.41/containers/`.
 
 - To force the Docker CLI or the Docker Engine SDKs to use an old version
   version of the API than the version reported by `docker version`, set the
@@ -90,7 +90,7 @@ You can specify the API version to use, in one of the following ways:
   on Linux, Windows, or macOS clients.
 
   ```bash
-  DOCKER_API_VERSION='1.40'
+  DOCKER_API_VERSION='1.41'
   ```
 
   While the environment variable is set, that version of the API is used, even

--- a/engine/api/v1.41.md
+++ b/engine/api/v1.41.md
@@ -1,0 +1,3 @@
+---
+layout: engine-api
+---

--- a/engine/reference/commandline/manifest_rm.md
+++ b/engine/reference/commandline/manifest_rm.md
@@ -1,0 +1,14 @@
+---
+datafolder: engine-cli
+datafile: docker_manifest_rm
+title: docker manifest rm
+---
+<!--
+This page is automatically generated from Docker's source code. If you want to
+suggest a change to the text that appears here, open a ticket or pull request
+in the source repository on GitHub:
+
+https://github.com/docker/cli
+-->
+
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
Some temporary changes until upstream API version is in sync, and until a 20.10 release branch is created