### PR TITLE
Fixes docker/for-mac#5117

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -59,7 +59,7 @@ This page contains information about the new features, improvements, known issue
 ## Docker Desktop Community 2.5.0.1
 2020-11-10
 
-> [Download](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
+> [Download](https://desktop.docker.com/mac/stable/49550/Docker.dmg)
 
 ### Upgrades
 


### PR DESCRIPTION
### Proposed changes

Adds correct download link for Docker for Mac 2.5.0.1


### Related issues (optional)

https://github.com/docker/for-mac/issues/5117
