### PR TITLE
Add missing opening tag in Get-started > Multi-Container

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -185,6 +185,7 @@ With all of that explained, let's start our dev-ready container!
 
 1. We'll specify each of the environment variables above, as well as connect the container to our app network.
 
+    ```bash
     docker run -dp 3000:3000 \
       -w /app -v "$(pwd):/app" \
       --network todo-app \


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add a missing opening tag for a code snippet : https://docs.docker.com/get-started/07_multi_container/#running-our-app-with-mysql
