### PR TITLE
Fixing broken get-started links

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -1,7 +1,9 @@
 ---
 title: "Our Application"
 keywords: get started, setup, orientation, quickstart, intro, concepts, containers, docker desktop
-description: overview of our simple applicaiton for learning docker
+redirect_from:
+- /get-started/part2/
+description: overview of our simple application for learning docker
 ---
 
 

--- a/get-started/04_sharing_app.md
+++ b/get-started/04_sharing_app.md
@@ -1,6 +1,8 @@
 ---
 title: "Sharing Our Application"
 keywords: get started, setup, orientation, quickstart, intro, concepts, containers, docker desktop, docker hub, sharing 
+redirect_from:
+- /get-started/part3/
 description: Sharing our image we built for our example application so we can run it else where and other developers can use it
 ---
 

--- a/get-started/kube-deploy.md
+++ b/get-started/kube-deploy.md
@@ -7,7 +7,7 @@ description: Learn how to describe and deploy a simple application on Kubernetes
 ## Prerequisites
 
 - Download and install Docker Desktop as described in [Orientation and setup](index.md).
-- Work through containerizing an application in [Part 2](part2.md).
+- Work through containerizing an application in [Part 2](02_our_app.md).
 - Make sure that Kubernetes is enabled on your Docker Desktop:
   - **Mac**: Click the Docker icon in your menu bar, navigate to **Preferences** and make sure there's a green light beside 'Kubernetes'.
   - **Windows**: Click the Docker icon in the system tray and navigate to **Settings** and make sure there's a green light beside 'Kubernetes'.
@@ -111,7 +111,7 @@ All containers in Kubernetes are scheduled as _pods_, which are groups of co-loc
 
     In addition to the default `kubernetes` service, we see our `bb-entrypoint` service, accepting traffic on port 30001/TCP.
 
-3.  Open a browser and visit your bulletin board at `localhost:30001`; you should see your bulletin board, the same as when we ran it as a stand-alone container in [Part 2](part2.md) of the Quickstart tutorial.
+3.  Open a browser and visit your bulletin board at `localhost:30001`; you should see your bulletin board, the same as when we ran it as a stand-alone container in [Part 2](02_our_app.md) of the Quickstart tutorial.
 
 4.  Once satisfied, tear down your application:
 

--- a/get-started/nav.html
+++ b/get-started/nav.html
@@ -1,5 +1,5 @@
 <ul class="pagination">
   <li {% if include.selected=="1"%}class="active"{% endif %}><a href="/get-started/">Orientation and setup</a></li>
   <li {% if include.selected=="2"%}class="active"{% endif %}><a href="/get-started/02_our_app/">Our Application</a></li>
-  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="/get-started/part3/">Share images on Docker Hub</a></li>
+  <li {% if include.selected=="3"%}class="active"{% endif %}><a href="/get-started/04_sharing_app/">Share images on Docker Hub</a></li>
 </ul>

--- a/get-started/swarm-deploy.md
+++ b/get-started/swarm-deploy.md
@@ -9,7 +9,7 @@ redirect_from:
 ## Prerequisites
 
 - Download and install Docker Desktop as described in [Orientation and setup](index.md).
-- Work through containerizing an application in [Part 2](part2.md).
+- Work through containerizing an application in [Part 2](02_our_app.md).
 - Make sure that Swarm is enabled on your Docker Desktop by typing `docker system info`, and looking for a message `Swarm: active` (you might have to scroll up a little).
 
   If Swarm isn't running, simply type `docker swarm init` in a shell prompt to set it up.
@@ -36,7 +36,7 @@ services:
       - "8000:8080"
 ```
 
-In this Swarm YAML file, we have just one object: a `service`, describing a scalable group of identical containers. In this case, you'll get just one container (the default), and that container will be based on your `bulletinboard:1.0` image created in [Part 2](part2.md) of the Quickstart tutorial. In addition, We've asked Swarm to forward all traffic arriving at port 8000 on our development machine to port 8080 inside our bulletin board container.
+In this Swarm YAML file, we have just one object: a `service`, describing a scalable group of identical containers. In this case, you'll get just one container (the default), and that container will be based on your `bulletinboard:1.0` image created in [Part 2](02_our_app.md) of the Quickstart tutorial. In addition, We've asked Swarm to forward all traffic arriving at port 8000 on our development machine to port 8080 inside our bulletin board container.
 
 > **Kubernetes Services and Swarm Services are very different!** Despite the similar name, the two orchestrators mean very different things by the term 'service'. In Swarm, a service provides both scheduling _and_ networking facilities, creating containers and providing tools for routing traffic to them. In Kubernetes, scheduling and networking are handled separately: _deployments_ (or other controllers) handle the scheduling of containers as pods, while _services_ are responsible only for adding networking features to those pods.
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add redirects for /get-started/part2/ and /get-started/part3/ to fix broken links from emails.

### Related issues (optional)

fixes https://github.com/docker/docker.github.io/issues/12043
closes https://github.com/docker/docker.github.io/pull/12003

This updates PR #11838 

fixes #11932 
fixes #11938 
fixes #11939 
fixes #11948 
fixes #11950 
fixes #11953 
fixes #11955 
fixes #11957
fixes #11968
fixes #11969
fixes #11970
fixes #11981
fixes #11987
fixes #11997
fixes #11998
fixes #12001
fixes #12017
fixes #12043

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
