### PR TITLE
Fix missing opening for code block

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -184,7 +184,7 @@ The todo app supports the setting of a few environment variables to specify MySQ
 With all of that explained, let's start our dev-ready container!
 
 1. We'll specify each of the environment variables above, as well as connect the container to our app network.
-
+    ```bash
     docker run -dp 3000:3000 \
       -w /app -v "$(pwd):/app" \
       --network todo-app \


### PR DESCRIPTION
While going through the tutorial I noticed one of the code blocks was missing formatting, this fixes that

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
Fix the code block that was missing the opening back-ticks ` ```bash ` this fixes it.
<!--Tell us what you did and why-->

