### PR TITLE
Fix incorrect link to compose-file-v3

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -982,7 +982,7 @@ reference:
   path: /engine/reference/builder/
 - sectiontitle: Compose file reference
   section:
-    - path: /compose/compose-file/
+    - path: /compose/compose-file/compose-file-v3/
       title: Version 3
     - path: /compose/compose-file/compose-file-v2/
       title: Version 2


### PR DESCRIPTION
The navigation item for "Version 3" of the docker compose file referenced a nearly useless page, while the exceedingly thorough and useful v3 docs were only discoverable via Google.

### Proposed changes

Fixed link
