### PR TITLE
Update debian.md

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -93,7 +93,16 @@ from the repository.
     ```bash
     $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
     ```
-
+    Newer versions of Debian have deprecated using `apt-key` like this. If you 
+    are receiving the following error:
+    ```
+    Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
+    ```
+    then you can avoid it by using the following instead:
+    ```
+    curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key --keyring /etc/apt/trusted.gpg.d/docker-apt-key.gpg add -
+    ```
+    
     Verify that you now have the key with the fingerprint
     `9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88`, by searching for the
     last 8 characters of the fingerprint.


### PR DESCRIPTION
### Proposed changes

Added workaround for `apt-key` deprecation errors.

The installation instructions for Debian use a plain `sudo apt-key add -` to 
add the gpg fingerprint, resulting in errors when trying to install on newer 
Debian builds, as detailed in #11625 . The workaround is copied from [this](https://github.com/docker/docker.github.io/issues/11625#issuecomment-735273469) comment.

### Related issues (optional)

#11625 
