### PR TITLE
print() is a function in Python 3

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -102,7 +102,7 @@ func main() {
 ```python
 import docker
 client = docker.from_env()
-print client.containers.run("alpine", ["echo", "hello", "world"])
+print(client.containers.run("alpine", ["echo", "hello", "world"]))
 ```
 
 </div>
@@ -207,7 +207,7 @@ func main() {
 import docker
 client = docker.from_env()
 container = client.containers.run("bfirsh/reticulate-splines", detach=True)
-print container.id
+print(container.id)
 ```
 
 </div>
@@ -278,7 +278,7 @@ func main() {
 import docker
 client = docker.from_env()
 for container in client.containers.list():
-  print container.id
+  print(container.id)
 ```
 
 </div>
@@ -435,7 +435,7 @@ func main() {
 import docker
 client = docker.from_env()
 container = client.containers.get('f1064a8a4c82')
-print container.logs()
+print(container.logs())
 ```
 
 </div>
@@ -504,7 +504,7 @@ func main() {
 import docker
 client = docker.from_env()
 for image in client.images.list():
-  print image.id
+  print(image.id)
 ```
 
 </div>
@@ -575,7 +575,7 @@ func main() {
 import docker
 client = docker.from_env()
 image = client.images.pull("alpine")
-print image.id
+print(image.id)
 ```
 
 </div>
@@ -668,7 +668,7 @@ uses these credentials automatically.
 import docker
 client = docker.from_env()
 image = client.images.pull("alpine")
-print image.id
+print(image.id)
 ```
 
 </div>
@@ -769,7 +769,7 @@ client = docker.from_env()
 container = client.containers.run("alpine", ["touch", "/helloworld"], detach=True)
 container.wait()
 image = container.commit("helloworld")
-print image.id
+print(image.id)
 ```
 
 </div>


### PR DESCRIPTION
Python 2 died on 1/1/2020 and legacy print statements are syntax errors in all currently supported versions of CPython.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
