### PR TITLE
Fixed duplicate image in the minecraft tutorial

### DIFF
--- a/kitematic/minecraft-server.md
+++ b/kitematic/minecraft-server.md
@@ -36,7 +36,7 @@ Open your Minecraft client, log in with your Minecraft account and click on the
 Click the "Add Server" button to add the Minecraft server you want to connect
 to.
 
-![Add server](images/minecraft-login.png)
+![Add server](images/minecraft-add-server.png)
 
 Fill in the "Server Address" text box with the marked IP and port from Kitematic
 you saw earlier.


### PR DESCRIPTION
The image of the minecraft start window from the first point is duplicated in the second point after "Click the “Add Server” button"

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
Replaced the duplicate image with the desired one in the minecraft tutorial. 

