### PR TITLE
Offering an alternative to the deprecated apt-key tool

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -84,13 +84,13 @@ from the repository.
         apt-transport-https \
         ca-certificates \
         curl \
-        gnupg-agent
+        gnupg
     ```
 
 2.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base }}/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/docker-ce-archive-keyring.gpg > /dev/null
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
     ```
 
@@ -115,7 +115,7 @@ from the repository.
 
     ```bash
     $ echo \
-      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
@@ -124,7 +124,7 @@ from the repository.
 
     ```bash
     $ echo \
-      "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=armhf signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
@@ -133,7 +133,7 @@ from the repository.
 
     ```bash
     $ echo \
-      "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -116,7 +116,7 @@ from the repository.
     ```bash
     $ echo \
       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
     </div>
@@ -125,7 +125,7 @@ from the repository.
     ```bash
     $ echo \
       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
     </div>
@@ -134,7 +134,7 @@ from the repository.
     ```bash
     $ echo \
       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
     </div>

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -115,30 +115,27 @@ from the repository.
     <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
-       $(lsb_release -cs) \
-       stable"
+    $ echo \
+      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
     </div>
     <div id="armhf_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
-       $(lsb_release -cs) \
-       stable"
+    $ echo \
+      "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
     </div>
     <div id="arm64_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
-       $(lsb_release -cs) \
-       stable"
+    $ echo \
+      "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
     </div>

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -91,20 +91,8 @@ from the repository.
 2.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
-    ```
+    $ curl -fsSL {{ download-url-base }}/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/docker-ce-archive-keyring.gpg > /dev/null
 
-    Verify that you now have the key with the fingerprint
-    `9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88`, by searching for the
-    last 8 characters of the fingerprint.
-
-    ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
-
-    pub   4096R/0EBFCD88 2017-02-22
-          Key fingerprint = 9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88
-    uid                  Docker Release (CE deb) <docker@docker.com>
-    sub   4096R/F273FCD8 2017-02-22
     ```
 
 3.  Use the following command to set up the **stable** repository. To add the
@@ -128,7 +116,7 @@ from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-       "deb [arch=amd64] {{ download-url-base }} \
+       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```
@@ -138,7 +126,7 @@ from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-       "deb [arch=armhf] {{ download-url-base }} \
+       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```
@@ -148,7 +136,7 @@ from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-       "deb [arch=arm64] {{ download-url-base }} \
+       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -84,8 +84,7 @@ from the repository.
         apt-transport-https \
         ca-certificates \
         curl \
-        gnupg-agent \
-        software-properties-common
+        gnupg-agent
     ```
 
 2.  Add Docker's official GPG key:

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -123,7 +123,7 @@ from the repository.
     ```bash
     $ echo \
       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
     </div>
@@ -132,7 +132,7 @@ from the repository.
     ```bash
     $ echo \
       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
     </div>
@@ -141,7 +141,7 @@ from the repository.
     ```bash
     $ echo \
       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
     </div>

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -92,13 +92,13 @@ from the repository.
         apt-transport-https \
         ca-certificates \
         curl \
-        gnupg-agent
+        gnupg
     ```
 
 2.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base }}/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/docker-ce-archive-keyring.gpg > /dev/null
+    $ curl -fsSL {{ download-url-base }}/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
     ```
 
 3.  Use the following command to set up the **stable** repository. To add the
@@ -122,7 +122,7 @@ from the repository.
 
     ```bash
     $ echo \
-      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
@@ -131,7 +131,7 @@ from the repository.
 
     ```bash
     $ echo \
-      "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=armhf signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
@@ -140,7 +140,7 @@ from the repository.
 
     ```bash
     $ echo \
-      "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -92,8 +92,7 @@ from the repository.
         apt-transport-https \
         ca-certificates \
         curl \
-        gnupg-agent \
-        software-properties-common
+        gnupg-agent
     ```
 
 2.  Add Docker's official GPG key:

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -99,20 +99,7 @@ from the repository.
 2.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
-    ```
-
-    Verify that you now have the key with the fingerprint
-    <span><code>9DC8 5822 9FC7 DD38 854A&nbsp;&nbsp;E2D8 8D81 803C 0EBF CD88</code></span>, by searching for the
-    last 8 characters of the fingerprint.
-
-    ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
-
-    pub   rsa4096 2017-02-22 [SCEA]
-          9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88
-    uid           [ unknown] Docker Release (CE deb) <docker@docker.com>
-    sub   rsa4096 2017-02-22 [S]
+    $ curl -fsSL {{ download-url-base }}/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/docker-ce-archive-keyring.gpg > /dev/null
     ```
 
 3.  Use the following command to set up the **stable** repository. To add the
@@ -136,7 +123,7 @@ from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-       "deb [arch=amd64] {{ download-url-base }} \
+       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```
@@ -146,7 +133,7 @@ from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-       "deb [arch=armhf] {{ download-url-base }} \
+       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```
@@ -156,7 +143,7 @@ from the repository.
 
     ```bash
     $ sudo add-apt-repository \
-       "deb [arch=arm64] {{ download-url-base }} \
+       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
     ```

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -122,30 +122,27 @@ from the repository.
     <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
-       $(lsb_release -cs) \
-       stable"
+    $ echo \
+      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
     </div>
     <div id="armhf_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
-       $(lsb_release -cs) \
-       stable"
+    $ echo \
+      "deb [arch=armhf signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
     </div>
     <div id="arm64_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
-       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
-       $(lsb_release -cs) \
-       stable"
+    $ echo \
+      "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-ce-archive-keyring.gpg] {{ download-url-base }} \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker-ce.list > /dev/null
     ```
 
     </div>


### PR DESCRIPTION
### Proposed changes

As of Debian 10 / Ubuntu 20.10, apt-key is deprecated and will not be available after Debian 11 / Ubuntu 22.04

Although adding keys directly to `/etc/apt/trusted.gpg.d`/ is suggested by apt-key deprecation message, as per [Debian Wiki](https://wiki.debian.org/DebianRepository/UseThirdParty) GPG keys for third party repositories should be added to `/usr/share/keyrings` and referenced with the `signed-by` option in the source.list.d entry.

With the proposed changes, verifying the key by fingerprint is unneeded and was removed.

### Applicable versions

The proposed changes are targeted at Debian 9 (Stretch) / Ubuntu 16.04 (Xenial) and onward, which is corresponding to Docker's own requirements described in the respective *OS requirements* sections ([Debian.md](https://github.com/denis-roy/docker.github.io/blob/patch-1/engine/install/debian.md#os-requirements) & [Ubuntu.md](https://github.com/denis-roy/docker.github.io/blob/patch-1/engine/install/ubuntu.md#os-requirements))

### Side note

Providing a binary .gpg key instead of the current ASCII Armored one might help shorten the lengthy command by removing the need for the ` | gpg --dearmor ` bit.

### Related issues & PRs

Closes #11625, closes #11851, closes #11915, closes #10778, closes #10545, closes #10505, closes #10010, closes #9373, closes #11974, closes #10347, closes #8298, closes #8725, closes #8341, closes #11776, closes #12313
