### PR TITLE
Fix heading level in compose/completion.md

### DIFF
--- a/compose/completion.md
+++ b/compose/completion.md
@@ -24,7 +24,7 @@ available.
     sudo curl -L https://raw.githubusercontent.com/docker/compose/{{site.compose_version}}/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
     ```
 
-### Mac
+#### Mac
 
 ##### Install via Homebrew
 


### PR DESCRIPTION
### Proposed changes

Right now Mac section is at the same level as the surrounding Bash and zsh headings, while logically it should be nested inside the Bash one. This PR fixes that.
