### PR TITLE
[fix]: Fix links to Compose File v3 reference [Docs: docker-compose restart]

### DIFF
--- a/compose/reference/restart.md
+++ b/compose/reference/restart.md
@@ -23,4 +23,4 @@ If you are looking to configure a service's restart policy, please refer to
 [restart](../compose-file/compose-file-v3.md#restart) in Compose file v3 and
 [restart](../compose-file/compose-file-v2.md#restart) in Compose v2. Note that if
 you are [deploying a stack in swarm mode](../../engine/reference/commandline/stack_deploy.md),
-you should use [restart_policy](../compose-file/compose-file-v3/#restart_policy), instead.
+you should use [restart_policy](../compose-file/compose-file-v3.md#restart_policy), instead.

--- a/compose/reference/restart.md
+++ b/compose/reference/restart.md
@@ -20,7 +20,7 @@ If you make changes to your `docker-compose.yml` configuration these changes are
 For example, changes to environment variables (which are added after a container is built, but before the container's command is executed) are not updated after restarting.
 
 If you are looking to configure a service's restart policy, please refer to
-[restart](../compose-file/index.md#restart) in Compose file v3 and
+[restart](../compose-file/compose-file-v3.md#restart) in Compose file v3 and
 [restart](../compose-file/compose-file-v2.md#restart) in Compose v2. Note that if
 you are [deploying a stack in swarm mode](../../engine/reference/commandline/stack_deploy.md),
-you should use [restart_policy](../compose-file/index.md#restart), instead.
+you should use [restart_policy](../compose-file/compose-file-v3/#restart_policy), instead.


### PR DESCRIPTION
Replaces some links for this page from `compose-file/index.md` to `compose-file/compose-file-v3.md`.

### Proposed changes

Related to the problem causing multiple issues being raised by users and initial fix available in https://github.com/docker/docker.github.io/pull/11959

I've only updated the links for the docs page I was visiting, I assume the issue will exist on many other md docs. Maybe a find/replace search on `compose-file/index.md` would be sufficient?

### Related issues (optional)

Related PR: https://github.com/docker/docker.github.io/pull/11959
