### PR TITLE
fix: update name of config option `network_mode`

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1004,19 +1004,19 @@ Network mode. Use the same values as the docker client `--network` parameter, pl
 the special form `service:[service name]`.
 
 ```yaml
-net: "bridge"
+network_mode: "bridge"
 ```
 ```yaml
-net: "host"
+network_mode: "host"
 ```
 ```yaml
-net: "none"
+network_mode: "none"
 ```
 ```yaml
-net: "service:[service name]"
+network_mode: "service:[service name]"
 ```
 ```yaml
-net: "container:[container name/id]"
+network_mode: "container:[container name/id]"
 ```
 
 ### networks


### PR DESCRIPTION
### Proposed changes

The documentation of configuration option `network_mode` uses `net`. Seems to be a relict from v1 format.
