### PR TITLE
engine: add missing release notes for 19.03.14

### DIFF
--- a/engine/release-notes/19.03.md
+++ b/engine/release-notes/19.03.md
@@ -5,6 +5,37 @@ toc_max: 2
 skip_read_time: true
 ---
 
+## 19.03.14
+2020-12-01
+
+### Security
+
+- [CVE-2020-15257](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15257):
+  Update bundled static binaries of containerd to v1.3.9 [moby/moby#41731](https://github.com/moby/moby/pull/41731).
+  Package managers should update the containerd.io package.
+
+### Builder
+
+- Beta versions of apparmor are now parsed correctly preventing build failures [moby/moby#41542](https://github.com/moby/moby/pull/41542)
+
+### Networking
+
+- Fix panic when swarmkit service keeps failing to start [moby/moby#41635](https://github.com/moby/moby/pull/41635)
+
+### Runtime
+
+- Return correct errors instead of spurrious -EINVAL [moby/moby#41293](https://github.com/moby/moby/pull/41293)
+
+### Rootless
+
+- Lock state dir for preventing automatic clean-up by systemd-tmpfiles [moby/moby#41635](https://github.com/moby/moby/pull/41635)
+- dockerd-rootless.sh: support new containerd shim socket path convention [moby/moby#41557](https://github.com/moby/moby/pull/41557)
+
+### Logging
+
+- gcplogs: Fix memory/connection leak [moby/moby#41522](https://github.com/moby/moby/pull/41522)
+- awslogs: Support for AWS imdsv2 [moby/moby#41494](https://github.com/moby/moby/pull/41494)
+
 ## 19.03.13
 2020-09-16
 


### PR DESCRIPTION
copied from https://github.com/moby/moby/releases/tag/v19.03.14

@usha-mandya @chris-crone ptal