### PR TITLE
get-started: fix markdown formatting

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -109,13 +109,14 @@ simply another process on your machine that has been isolated from all other pro
 on the host machine. That isolation leverages [kernel namespaces and cgroups](https://medium.com/@saschagrunert/demystifying-containers-part-i-kernel-space-2c53d6979504), features that have been 
 in Linux for a long time. Docker has worked to make these capabilities approachable and easy to use.
 
-!!! info "Creating Containers from Scratch"
-    If you'd like to see how containers are built from scratch, Liz Rice from Aqua Security
-    has a fantastic talk in which she creates a container from scratch in Go. While she makes
-    a simple container, this talk doesn't go into networking, using images for the filesystem, 
-    and more. But, it gives a _fantastic_ deep dive into how things are working.
-
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/8fi7uSYlOdc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+> **Creating containers from scratch**
+>
+> If you'd like to see how containers are built from scratch, Liz Rice from Aqua Security
+> has a fantastic talk in which she creates a container from scratch in Go. While she makes
+> a simple container, this talk doesn't go into networking, using images for the filesystem, 
+> and more. But, it gives a _fantastic_ deep dive into how things are working.
+> 
+> <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/8fi7uSYlOdc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## What is a container image?
 
@@ -127,10 +128,11 @@ a default command to run, and other metadata.
 
 We'll dive deeper into images later on, covering topics such as layering, best practices, and more.
 
-!!! info
-    If you're familiar with `chroot`, think of a container as an extended version of `chroot`. The
-    filesystem is simply coming from the image. But, a container adds additional isolation not
-    available when simply using chroot.
+> **Info**
+> 
+> If you're familiar with `chroot`, think of a container as an extended version of `chroot`. The
+> filesystem is simply coming from the image. But, a container adds additional isolation not
+> available when simply using chroot.
 
 ## CLI references
 


### PR DESCRIPTION
The markdown seemed to be intended as "info" admonition; updating
the markdown syntax to fix that.

fixes https://github.com/docker/docker.github.io/issues/11978
