### PR TITLE
(temporarily) replace compose-file deep links to v3 docs

### DIFF
--- a/compose/compose-file/compose-file-v1.md
+++ b/compose/compose-file/compose-file-v1.md
@@ -436,7 +436,7 @@ Links also express dependency between services in the same way as
 
 > **Note**
 >
-> If you define both links and [networks](index.md#networks), services with
+> If you define both links and [networks](compose-file-v3.md#networks), services with
 > links between them must share at least one network in common in order to
 > communicate.
 
@@ -450,7 +450,7 @@ Links also express dependency between services in the same way as
 > Environment variables are no longer the recommended method for connecting to
 > linked services. Instead, you should use the link name (by default, the name
 > of the linked service) as the hostname to connect to. Refer to the
-> [docker-compose.yml documentation](compose-file/index.md#links) for details.
+> [docker-compose.yml documentation](compose-file/compose-file-v3.md#links) for details.
 >
 > Environment variables are only populated if you use the
 > [legacy version 1 Compose file format](compose-file/compose-versioning.md#versioning).
@@ -483,7 +483,7 @@ Fully qualified container name, such as `DB_1_NAME=/myapp_web_1/myapp_db_1`
 ### log_driver
 
 > [Version 1 file format](compose-versioning.md#version-1) only. In version 2 and up, use
-> [logging](index.md#logging).
+> [logging](compose-file-v3.md#logging).
 
 Specify a log driver. The default is `json-file`.
 
@@ -494,7 +494,7 @@ log_driver: syslog
 ### log_opt
 
 > [Version 1 file format](compose-versioning.md#version-1) only. In version 2 and up, use
-> [logging](index.md#logging).
+> [logging](compose-file-v3.md#logging).
 
 Specify logging options as key-value pairs. An example of `syslog` options:
 
@@ -506,7 +506,7 @@ log_opt:
 ### net
 
 > [Version 1 file format](compose-versioning.md#version-1) only. In version 2 and up, use
-> [network_mode](index.md#network_mode) and [networks](index.md#networks).
+> [network_mode](compose-file-v3.md#network_mode) and [networks](compose-file-v3.md#networks).
 
 Network mode. Use the same values as the docker client `--net` parameter.
 The `container:...` form can take a service name instead of a container name or

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -82,15 +82,15 @@ These differences are explained below.
 ### Version 1
 
 Compose files that do not declare a version are considered "version 1". In those
-files, all the [services](index.md#service-configuration-reference) are
+files, all the [services](compose-file-v3.md#service-configuration-reference) are
 declared at the root of the document.
 
 Version 1 is supported by **Compose up to 1.6.x**. It will be deprecated in a
 future Compose release.
 
 Version 1 files cannot declare named
-[volumes](index.md#volume-configuration-reference), [networks](index.md#network-configuration-reference) or
-[build arguments](index.md#args).
+[volumes](compose-file-v3.md#volume-configuration-reference), [networks](compose-file-v3.md#network-configuration-reference) or
+[build arguments](compose-file-v3.md#args).
 
 Compose does not take advantage of [networking](../networking.md) when you
 use version 1: every container is placed on the default `bridge` network and is
@@ -220,7 +220,7 @@ Introduces the following additional parameters:
   service definitions
 - `labels` for [volumes](compose-file-v2.md#volume-configuration-reference),
   [networks](compose-file-v2.md#network-configuration-reference), and
-  [build](index.md#build)
+  [build](compose-file-v3.md#build)
 - `name` for [volumes](compose-file-v2.md#volume-configuration-reference)
 - [`userns_mode`](compose-file-v2.md#userns_mode)
 - [`healthcheck`](compose-file-v2.md#healthcheck)
@@ -281,7 +281,7 @@ several more.
 the [upgrading](#upgrading) guide for how to migrate away from these.
 (For more information on `extends`, see [Extending services](../extends.md#extending-services).)
 
-- Added: [deploy](index.md#deploy)
+- Added: [deploy](compose-file-v3.md#deploy)
 
 > **Note**: When specifying the Compose file version to use, make sure to
 > specify both the _major_ and _minor_ numbers. If no minor version is given,
@@ -305,7 +305,7 @@ available with Docker Engine version **1.13.1+**, and higher.
 
 Introduces the following additional parameters:
 
-- [`secrets`](index.md#secrets)
+- [`secrets`](compose-file-v3.md#secrets)
 
 ### Version 3.2
 
@@ -314,11 +314,11 @@ available with Docker Engine version **17.04.0+**, and higher.
 
 Introduces the following additional parameters:
 
-- [`cache_from`](index.md#cache_from) in [build configurations](index.md#build)
-- Long syntax for [ports](index.md#ports) and [volume mounts](index.md#volumes)
-- [`attachable`](index.md#attachable) network driver option
-- [deploy `endpoint_mode`](index.md#endpoint_mode)
-- [deploy placement `preference`](index.md#placement)
+- [`cache_from`](compose-file-v3.md#cache_from) in [build configurations](compose-file-v3.md#build)
+- Long syntax for [ports](compose-file-v3.md#ports) and [volume mounts](compose-file-v3.md#volumes)
+- [`attachable`](compose-file-v3.md#attachable) network driver option
+- [deploy `endpoint_mode`](compose-file-v3.md#endpoint_mode)
+- [deploy placement `preference`](compose-file-v3.md#placement)
 
 ### Version 3.3
 
@@ -327,9 +327,9 @@ available with Docker Engine version **17.06.0+**, and higher.
 
 Introduces the following additional parameters:
 
-- [build `labels`](index.md#build)
-- [`credential_spec`](index.md#credential_spec)
-- [`configs`](index.md#configs)
+- [build `labels`](compose-file-v3.md#build)
+- [`credential_spec`](compose-file-v3.md#credential_spec)
+- [`configs`](compose-file-v3.md#configs)
 
 ### Version 3.4
 
@@ -338,11 +338,11 @@ only available with Docker Engine version **17.09.0** and higher.
 
 Introduces the following additional parameters:
 
-- [`target`](index.md#target) and [`network`](index.md#network) in
-  [build configurations](index.md#build)
-- `start_period` for [`healthchecks`](index.md#healthcheck)
-- `order` for [update configurations](index.md#update_config)
-- `name` for [volumes](index.md#volume-configuration-reference)
+- [`target`](compose-file-v3.md#target) and [`network`](compose-file-v3.md#network) in
+  [build configurations](compose-file-v3.md#build)
+- `start_period` for [`healthchecks`](compose-file-v3.md#healthcheck)
+- `order` for [update configurations](compose-file-v3.md#update_config)
+- `name` for [volumes](compose-file-v3.md#volume-configuration-reference)
 
 ### Version 3.5
 
@@ -351,9 +351,9 @@ only available with Docker Engine version **17.12.0** and higher.
 
 Introduces the following additional parameters:
 
-- [`isolation`](index.md#isolation) in service definitions
+- [`isolation`](compose-file-v3.md#isolation) in service definitions
 - `name` for networks, secrets and configs
-- `shm_size` in [build configurations](index.md#build)
+- `shm_size` in [build configurations](compose-file-v3.md#build)
 
 ### Version 3.6
 
@@ -362,7 +362,7 @@ only available with Docker Engine version **18.02.0** and higher.
 
 Introduces the following additional parameters:
 
-- [`tmpfs` size](index.md#long-syntax-3) for `tmpfs`-type mounts
+- [`tmpfs` size](compose-file-v3.md#long-syntax-3) for `tmpfs`-type mounts
 
 ### Version 3.7
 
@@ -371,8 +371,8 @@ only available with Docker Engine version **18.06.0** and higher.
 
 Introduces the following additional parameters:
 
-- [`init`](index.md#init) in service definitions
-- [`rollback_config`](index.md#rollback_config) in deploy configurations
+- [`init`](compose-file-v3.md#init) in service definitions
+- [`rollback_config`](compose-file-v3.md#rollback_config) in deploy configurations
 - Support for extension fields at the root of service, network, volume, secret
   and config definitions
 
@@ -383,13 +383,13 @@ only available with Docker Engine version **19.03.0** and higher.
 
 Introduces the following additional parameters:
 
-- [`max_replicas_per_node`](index.md#max_replicas_per_node) in placement
+- [`max_replicas_per_node`](compose-file-v3.md#max_replicas_per_node) in placement
   configurations
-- `template_driver` option for [config](index.md#configs-configuration-reference)
-   and [secret](index.md#secrets-configuration-reference) configurations. This
+- `template_driver` option for [config](compose-file-v3.md#configs-configuration-reference)
+   and [secret](compose-file-v3.md#secrets-configuration-reference) configurations. This
    option is only supported when deploying swarm services using
    `docker stack deploy`.
-- `driver` and `driver_opts` option for [secret](index.md#secrets-configuration-reference)
+- `driver` and `driver_opts` option for [secret](compose-file-v3.md#secrets-configuration-reference)
    configurations. This option is only supported when deploying swarm services
    using `docker stack deploy`.
 
@@ -402,7 +402,7 @@ several options have been removed:
 
 -   `volume_driver`: Instead of setting the volume driver on the service, define
     a volume using the
-    [top-level `volumes` option](index.md#volume-configuration-reference)
+    [top-level `volumes` option](compose-file-v3.md#volume-configuration-reference)
     and specify the driver there.
 
         version: "{{ site.compose_file_v3 }}"
@@ -416,12 +416,12 @@ several options have been removed:
             driver: mydriver
 
 -   `volumes_from`: To share a volume between services, define it using the
-    [top-level `volumes` option](index.md#volume-configuration-reference)
+    [top-level `volumes` option](compose-file-v3.md#volume-configuration-reference)
     and reference it from each service that shares it using the
-    [service-level `volumes` option](index.md#driver).
+    [service-level `volumes` option](compose-file-v3.md#driver).
 
 -   `cpu_shares`, `cpu_quota`, `cpuset`, `mem_limit`, `memswap_limit`: These
-    have been replaced by the [resources](index.md#resources) key under
+    have been replaced by the [resources](compose-file-v3.md#resources) key under
     `deploy`. `deploy` configuration only takes effect when using
     `docker stack deploy`, and is ignored by `docker-compose`.
 
@@ -476,7 +476,7 @@ It's more complicated if you're using particular configuration features:
     your service's containers to an
     [external network](../networking.md#use-a-pre-existing-network).
 
--   `net`: This is now replaced by [network_mode](index.md#network_mode):
+-   `net`: This is now replaced by [network_mode](compose-file-v3.md#network_mode):
 
         net: host    ->  network_mode: host
         net: bridge  ->  network_mode: bridge
@@ -523,9 +523,9 @@ help developers transition to version 3 more easily. When enabled,
 attempts to translate it into the equivalent version 2 parameter. Currently,
 the following deploy keys are translated:
 
-- [resources](index.md#resources) limits and memory reservations
-- [replicas](index.md#replicas)
-- [restart_policy](index.md#restart_policy) `condition` and `max_attempts`
+- [resources](compose-file-v3.md#resources) limits and memory reservations
+- [replicas](compose-file-v3.md#replicas)
+- [restart_policy](compose-file-v3.md#restart_policy) `condition` and `max_attempts`
 
 All other keys are ignored and produce a warning if present. You can review
 the configuration that will be used to deploy by using the `--compatibility`

--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -21,7 +21,7 @@ These syntax rules apply to the `.env` file:
 ## Compose file and CLI variables
 
 The environment variables you define here are used for
-[variable substitution](compose-file/index.md#variable-substitution)
+[variable substitution](compose-file/compose-file-v3.md#variable-substitution)
 in your Compose file, and can also be used to define the following
 [CLI variables](reference/envvars.md):
 

--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -33,14 +33,14 @@ docker-compose --env-file ./config/.env.dev up
 ```
 
 For more information, see the
-[Variable substitution](compose-file/index.md#variable-substitution) section in the
+[Variable substitution](compose-file/compose-file-v3.md#variable-substitution) section in the
 Compose file reference.
 
 
 ## Set environment variables in containers
 
 You can set environment variables in a service's containers with the
-['environment' key](compose-file/index.md#environment), just like with
+['environment' key](compose-file/compose-file-v3.md#environment), just like with
 `docker run -e VARIABLE=VALUE ...`:
 
 ```yaml
@@ -52,7 +52,7 @@ web:
 ## Pass environment variables to containers
 
 You can pass environment variables from your shell straight through to a
-service's containers with the ['environment' key](compose-file/index.md#environment)
+service's containers with the ['environment' key](compose-file/compose-file-v3.md#environment)
 by not giving them a value, just like with `docker run -e VARIABLE ...`:
 
 ```yaml
@@ -67,7 +67,7 @@ the same variable in the shell in which Compose is run.
 ## The “env_file” configuration option
 
 You can pass multiple environment variables from an external file through to
-a service's containers with the ['env_file' option](compose-file/index.md#env_file),
+a service's containers with the ['env_file' option](compose-file/compose-file-v3.md#env_file),
 just like with `docker run --env-file=FILE ...`:
 
 ```yaml
@@ -194,7 +194,7 @@ documented in [CLI Environment Variables](reference/envvars.md).
 
 ## Environment variables created by links
 
-When using the ['links' option](compose-file/index.md#links) in a
+When using the ['links' option](compose-file/compose-file-v3.md#links) in a
 [v1 Compose file](compose-file/compose-file-v1.md#link-environment-variables),
 environment variables are created for each link. These variables are deprecated.
 Use the link alias as a hostname instead.

--- a/compose/index.md
+++ b/compose/index.md
@@ -119,7 +119,7 @@ environment very quickly.
 
 Compose supports variables in the Compose file. You can use these variables
 to customize your composition for different environments, or different users.
-See [Variable substitution](compose-file/index.md#variable-substitution) for more
+See [Variable substitution](compose-file/compose-file-v3.md#variable-substitution) for more
 details.
 
 You can extend a Compose file using the `extends` field or by creating multiple

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -135,7 +135,7 @@ Here's an example Compose file defining two custom networks. The `proxy` service
 
 Networks can be configured with static IP addresses by setting the [ipv4_address and/or ipv6_address](compose-file/compose-file-v2.md#ipv4_address-ipv6_address) for each attached network.
 
-Networks can also be given a [custom name](compose-file/index.md#network-configuration-reference) (since version 3.5):
+Networks can also be given a [custom name](compose-file/compose-file-v3.md#network-configuration-reference) (since version 3.5):
 
     version: "3.5"
     networks:

--- a/compose/reference/build.md
+++ b/compose/reference/build.md
@@ -26,9 +26,9 @@ Options:
 
 Services are built once and then tagged, by default as `project_service`. For
 example, `composetest_db`. If the Compose file specifies an
-[image](../compose-file/index.md#image) name, the image is
+[image](../compose-file/compose-file-v3.md#image) name, the image is
 tagged with that name, substituting any variables beforehand. See
-[variable substitution](../compose-file/index.md#variable-substitution).
+[variable substitution](../compose-file/compose-file-v3.md#variable-substitution).
 
 If you change a service's Dockerfile or the contents of its
 build directory, run `docker-compose build` to rebuild it.

--- a/compose/reference/scale.md
+++ b/compose/reference/scale.md
@@ -26,7 +26,7 @@ Numbers are specified as arguments in the form `service=num`. For example:
     docker-compose scale web=2 worker=3
 
 >**Tip**: Alternatively, in
-[Compose file version 3.x](../compose-file/index.md), you can specify
-[replicas](../compose-file/index.md#replicas)
-under the [deploy](../compose-file/index.md#deploy) key as part of a
+[Compose file version 3.x](../compose-file/compose-file-v3.md), you can specify
+[replicas](../compose-file/compose-file-v3.md#replicas)
+under the [deploy](../compose-file/compose-file-v3.md#deploy) key as part of a
 service configuration for [Swarm mode](/engine/swarm/). The `deploy` key and its sub-options (including `replicas`) only works with the `docker stack deploy` command, not `docker-compose up` or `docker-compose run`.

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -816,7 +816,7 @@ naming scheme accordingly before upgrading.
 
 - Added support for `extra_hosts` in build configuration
 
-- Added support for the [long syntax](compose-file/index.md#long-syntax-3) for volume entries, as previously introduced in the 3.2 format.
+- Added support for the [long syntax](compose-file/compose-file-v3.md#long-syntax-3) for volume entries, as previously introduced in the 3.2 format.
   Using this syntax will create [mounts](../storage/bind-mounts.md) instead of volumes.
 
 #### Compose file version 2.1 and up

--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -6,7 +6,7 @@ notoc: true
 ---
 
 You can control the order of service startup and shutdown with the
-[depends_on](compose-file/index.md#depends_on) option. Compose always starts and stops
+[depends_on](compose-file/compose-file-v3.md#depends_on) option. Compose always starts and stops
 containers in dependency order, where dependencies are determined by
 `depends_on`, `links`, `volumes_from`, and `network_mode: "service:..."`.
 

--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -129,7 +129,7 @@ Docker configs.
 
 The `docker stack` command supports defining configs in a Compose file.
 However, the `configs` key is not supported for `docker compose`. See
-[the Compose file reference](../../compose/compose-file/index.md#configs) for details.
+[the Compose file reference](../../compose/compose-file/compose-file-v3.md#configs) for details.
 
 ### Simple example: Get started with configs
 

--- a/engine/swarm/secrets.md
+++ b/engine/swarm/secrets.md
@@ -137,7 +137,7 @@ a similar way, see
 
 Both the `docker-compose` and `docker stack` commands support defining secrets
 in a compose file. See
-[the Compose file reference](../../compose/compose-file/index.md#secrets) for details.
+[the Compose file reference](../../compose/compose-file/compose-file-v3.md#secrets) for details.
 
 ### Simple example: Get started with secrets
 
@@ -1028,5 +1028,5 @@ Each service uses environment variables to specify where the service should look
 for that secret data.
 
 More information on short and long syntax for secrets can be found at
-[Compose file version 3 reference](../../compose/compose-file/index.md#secrets).
+[Compose file version 3 reference](../../compose/compose-file/compose-file-v3.md#secrets).
 

--- a/engine/swarm/stack-deploy.md
+++ b/engine/swarm/stack-deploy.md
@@ -6,7 +6,7 @@ title: Deploy a stack to a swarm
 
 When running Docker Engine in swarm mode, you can use `docker stack deploy` to
 deploy a complete application stack to the swarm. The `deploy` command accepts
-a stack description in the form of a [Compose file](../../compose/compose-file/index.md).
+a stack description in the form of a [Compose file](../../compose/compose-file/compose-file-v3.md).
 
 The `docker stack deploy` command supports any Compose file of version "3.0" or
 above. If you have an older version, see the [upgrade guide](../../compose/compose-file/compose-versioning.md#upgrading).

--- a/storage/volumes.md
+++ b/storage/volumes.md
@@ -247,7 +247,7 @@ volumes:
 ```
 
 For more information about using volumes with compose see
-[the compose reference](../compose/compose-file/index.md#volume-configuration-reference).
+[the compose reference](../compose/compose-file/compose-file-v3.md#volume-configuration-reference).
 
 ### Start a service with volumes
 

--- a/test.md
+++ b/test.md
@@ -447,7 +447,7 @@ and CSS only.)
 >For each drop-down, the value for `data-target` and
 `collapse` `id` must match, and id's must be unique per page. In this example,
 we name these `collapseSample1` and `collapseSample2`. Check out the
-[Compose file structure example](compose/compose-file/index.md#compose-file-structure-and-examples)
+[Compose file structure example](compose/compose-file/compose-file-v3.md#compose-file-structure-and-examples)
 to see another example.
 {: .important-vanilla}
 


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/9996

The documentation curently doesn't contain reference docs for the unified (version-less) compose-file syntax, so for now replacing all links to point to the v3 compose-file reference, which is still present.

