### PR TITLE
Fix formatting in templates of pages related with build command

### DIFF
--- a/_data/buildx/docker_buildx_build.yaml
+++ b/_data/buildx/docker_buildx_build.yaml
@@ -310,7 +310,7 @@ options:
   value_type: stringArray
   default_value: '[]'
   description: |
-    SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])
+    SSH agent socket or keys to expose to the build (format: default|\<id\>[=\<socket\>|\<key\>[,\<key\>]])
   deprecated: false
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -391,7 +391,7 @@ options:
   value_type: stringArray
   default_value: '[]'
   description: |
-    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|<id>[=<socket>|<key>[,<key>]])
+    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|\<id\>[=\<socket\>|\<key\>[,\<key\>]])
   deprecated: false
   min_api_version: "1.39"
   experimental: false

--- a/_data/engine-cli/docker_builder_build.yaml
+++ b/_data/engine-cli/docker_builder_build.yaml
@@ -283,7 +283,7 @@ options:
   value_type: stringArray
   default_value: '[]'
   description: |
-    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|<id>[=<socket>|<key>[,<key>]])
+    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|\<id\>[=\<socket\>|\<key\>[,\<key\>]])
   deprecated: false
   min_api_version: "1.39"
   experimental: false

--- a/_data/engine-cli/docker_image_build.yaml
+++ b/_data/engine-cli/docker_image_build.yaml
@@ -283,7 +283,7 @@ options:
   value_type: stringArray
   default_value: '[]'
   description: |
-    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|<id>[=<socket>|<key>[,<key>]])
+    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|\<id\>[=\<socket\>|\<key\>[,\<key\>]])
   deprecated: false
   min_api_version: "1.39"
   experimental: false


### PR DESCRIPTION
### Proposed changes
Fix formatting in templates of pages: `commandline/build`, `commandline/builder_build`, `commandline/buildx_build` and `commandline/image_build`.
The templates were not recognizing the `<` and `>` in the description of `--ssh` option, so this PR adds a `\` before each sign so the formatting can be preserved.

Before:
![image](https://user-images.githubusercontent.com/32711358/103928710-feb12380-50fa-11eb-97c1-7141838b9879.png)

Now:
![image](https://user-images.githubusercontent.com/32711358/103928856-2bfdd180-50fb-11eb-8273-f5739f33658d.png)


### Related issues
Closes #11331 
