### PR TITLE
_includes/cli.md: fix flag descriptions with < and >

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -126,7 +126,7 @@ For example uses of this command, refer to the [examples section](#examples) bel
   <tr>
     <td markdown="span">`--{{ option.option }}{% if option.shorthand %} , -{{ option.shorthand }}{% endif %}`</td>
     <td markdown="span">{{ option-default }}</td>
-    <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip }}</td>
+    <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip | escape }}</td>
   </tr>
 {% endfor %} <!-- end for option -->
 </tbody>


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/11331
replaces / closes https://github.com/docker/docker.github.io/pull/12064

Some flag descriptions contain point-brackets to indicate required options, e.g.:

    --ssh stringArray   SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])

When rendering those options as HTML, those options were not visible as
they were rendered as a HTML element.

Given that flag-descriptions are not expected to have MarkDown or HTML
formatting, we can HTML-escape them to prevent this.

This patch escapes the flag-descriptions using liquid's `esacape` command.

Before this patch:

<img width="983" alt="Screenshot 2021-01-12 at 16 20 38" src="https://user-images.githubusercontent.com/1804568/104335534-be371880-54f3-11eb-91c8-859c3425c4fe.png">

After this patch:

<img width="990" alt="Screenshot 2021-01-12 at 16 20 16" src="https://user-images.githubusercontent.com/1804568/104335539-bf684580-54f3-11eb-87b9-46c8f202219a.png">


