### PR TITLE
fix windows networking redirect

### DIFF
--- a/docker-for-windows/networking.md
+++ b/docker-for-windows/networking.md
@@ -3,7 +3,7 @@ description: Networking
 keywords: windows, networking
 title: Networking features in Docker Desktop for Windows
 redirect_from:
-- /docker-for-windows/networking/
+- /docker-for-win/networking/
 ---
 {% assign Arch = 'Windows' %}
 


### PR DESCRIPTION
I accidentally used the "correct" URL as redirect-from, resulting in an infinite redirect loop

Introduced in https://github.com/docker/docker.github.io/commit/9be0eea761844e768fadf442f653f9bd671e960e (https://github.com/docker/docker.github.io/pull/12046)

fixes https://github.com/docker/docker.github.io/issues/12089