### PR TITLE
aws elbv2 correction & x-aws-pull_policy mentioned

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -201,13 +201,19 @@ docker secret create dockerhubAccessToken --username <dockerhubuser>  --password
 arn:aws:secretsmanager:eu-west-3:12345:secret:DockerHubAccessToken
 ```
 
-Once created, you can use this ARN in you Compose file using using `x-aws-pull_credentials` custom extension with the Docker image URI for your service.
+Once created, you can use this ARN in you Compose file using using `x-aws-pull_credentials` custom extension with the Docker image URI for your service. For AWS ECR Registry private repository, use `x-aws-pull_policy` to authenticate.
 
 ```yaml
 services:
   worker:
     image: mycompany/privateimage
     x-aws-pull_credentials: "arn:aws:secretsmanager:eu-west-3:12345:secret:DockerHubAccessToken"
+```
+```yaml
+services:
+  worker:
+    image: mycompany/privateimage
+    x-aws-pull_policy: "arn:aws:secretsmanager:eu-west-3:12345:secret:DockerHubAccessToken"
 ```
 
 > **Note**
@@ -458,7 +464,7 @@ $ aws ec2 describe-subnets --filters Name=vpc-id,Values=vpc-123456 --query 'Subn
 1. Use the AWS CLI to create your load balancer. The AWS Web Console can also be used but will require adding at least one listener, which we don't need here.
 
 ```console
-$ aws elbv2 create-load-balancer --name myloadbalancer --type application --subnets "subnet-1234abcd" "subnet-6789ef00"
+$ aws elbv2 create-load-balancer --name myloadbalancer --type application --subnets subnet-1234abcd subnet-6789ef00
 
 {
     "LoadBalancers": [


### PR DESCRIPTION
-  Subnet ids should be passed withou quotation mark (""). 
- x-aws-pull_policy mentioned in documentation with a tested example.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
