### PR TITLE
fix: docker build with URL example

### DIFF
--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -482,7 +482,7 @@ examples: |-
   ### Build with URL
 
   ```bash
-  $ docker build github.com/creack/docker-firefox
+  $ docker build https://github.com/creack/docker-firefox.git
   ```
 
   This will clone the GitHub repository and use the cloned repository as context.


### PR DESCRIPTION
Hi,

### Proposed changes

The original example in order to build from an URL didn't works so I debug in my side and found a command that works

KO:

`$ docker build github.com/creack/docker-firefox
`
WORKS:

`$ docker build https://github.com/creack/docker-firefox.git
`

