### PR TITLE
Add /go/formatting/ redirect

### DIFF
--- a/go/formatting.md
+++ b/go/formatting.md
@@ -1,0 +1,4 @@
+---
+description: Instructions on using Go templates to format CLI output with --format
+redirect_to: /config/formatting/
+---


### PR DESCRIPTION
This URL will be referred to from the CLI to point to documentation on using Go templates to format CLI output.


relates to https://github.com/docker/cli/pull/2936


@silvin-lubecki 
