### PR TITLE
Bump docker-compose to 1.28.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ exclude: ["_samples", "_scripts", "404.html", "datacenter", "ee", "index.html", 
 # You can't have - characters in these for non-YAML reasons
 latest_engine_api_version: "1.41"
 docker_ce_version: "20.10"
-compose_version: "1.27.4"
+compose_version: "1.28.0"
 compose_file_v3: "3.9"
 compose_file_v2: "2.4"
 machine_version: "0.16.0"

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -12,15 +12,17 @@ redirect_from:
 
 ### Features
 
-- Added support for Nvidia GPUs via device requests.
+- Added support for NVIDIA GPUs through device requests.
 
 - Added support for service profiles.
 
-- Changed the SSH connection approach to the Docker CLI's via shellout to the local SSH client (old behaviour enabled by setting `COMPOSE_PARAMIKO_SSH` environment variable).
+- Changed the SSH connection approach to the Docker CLI by shelling out to the local SSH client. Set the `COMPOSE_PARAMIKO_SSH=1` environment variable to enable the old behavior.
 
-- Added flag to disable log prefix.
+- Added a flag to disable log prefix.
 
-- Added flag for ansi output control.
+- Added a flag for ANSI output control.
+
+- Docker Compose now uses the native Docker CLI's `build` command when building images. Set the `COMPOSE_DOCKER_CLI_BUILD=0` environment variable to disable this feature.
 
 ### Bugs
 
@@ -30,11 +32,9 @@ redirect_from:
 
 - Took `--file` into account when defining `project_dir`.
 
-- Fixed service attach bug on `compose up`.
+- Fixed a service attach bug on `compose up`.
 
 ### Miscellaneous
-
-- Made COMPOSE_DOCKER_CLI_BUILD=1 the default.
 
 - Added usage metrics.
 
@@ -42,31 +42,31 @@ redirect_from:
 
 - Improved failure report for missing mandatory environment variables.
 
-- Bumped attrs to 20.3.0.
+- Bumped `attrs` to 20.3.0.
 
-- Bumped more_itertools to 8.6.0.
+- Bumped `more_itertools` to 8.6.0.
 
-- Bumped cryptograhy to 3.2.1.
+- Bumped `cryptograhy` to 3.2.1.
 
-- Bumped cffi to 1.14.4.
+- Bumped `cffi` to 1.14.4.
 
-- Bumped virtualenv to 20.2.2.
+- Bumped `virtualenv` to 20.2.2.
 
-- Bumped bcrypt to 3.2.0.
+- Bumped `bcrypt` to 3.2.0.
 
-- Bumped gitpython to 3.1.11.
+- Bumped GitPython to 3.1.11.
 
-- Bumped docker-py to 4.4.1.
+- Bumped `docker-py` to 4.4.1.
 
 - Bumped Python to 3.9.
 
 - Linux: bumped Debian base image from stretch to buster (required for Python 3.9).
 
-- macOS: OpenSSL 1.1.1g to 1.1.1h, Python 3.7.7 to 3.9.0.
+- macOS: Bumped OpenSSL 1.1.1g to 1.1.1h, and Python 3.7.7 to 3.9.0.
 
-- Bumped pyinstaller 4.1.
+- Bumped PyInstaller to 4.1.
 
-- Loosed restriction on base images to latest minor.
+- Relaxed the restriction on base images to latest minor.
 
 - Updated READMEs.
 

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -7,6 +7,69 @@ redirect_from:
   - /release-notes/docker-compose/
 ---
 
+## 1.28.0 
+(2021-01-20)
+
+### Features
+
+- Added support for Nvidia GPUs via device requests.
+
+- Added support for service profiles.
+
+- Changed the SSH connection approach to the Docker CLI's via shellout to the local SSH client (old behaviour enabled by setting `COMPOSE_PARAMIKO_SSH` environment variable).
+
+- Added flag to disable log prefix.
+
+- Added flag for ansi output control.
+
+### Bugs
+
+- Made `parallel_pull=True` by default.
+
+- Restored the warning for configs in non-swarm mode.
+
+- Took `--file` into account when defining `project_dir`.
+
+- Fixed service attach bug on `compose up`.
+
+### Miscellaneous
+
+- Made COMPOSE_DOCKER_CLI_BUILD=1 the default.
+
+- Added usage metrics.
+
+- Synced schema with COMPOSE specification.
+
+- Improved failure report for missing mandatory environment variables.
+
+- Bumped attrs to 20.3.0.
+
+- Bumped more_itertools to 8.6.0.
+
+- Bumped cryptograhy to 3.2.1.
+
+- Bumped cffi to 1.14.4.
+
+- Bumped virtualenv to 20.2.2.
+
+- Bumped bcrypt to 3.2.0.
+
+- Bumped gitpython to 3.1.11.
+
+- Bumped docker-py to 4.4.1.
+
+- Bumped Python to 3.9.
+
+- Linux: bumped Debian base image from stretch to buster (required for Python 3.9).
+
+- macOS: OpenSSL 1.1.1g to 1.1.1h, Python 3.7.7 to 3.9.0.
+
+- Bumped pyinstaller 4.1.
+
+- Loosed restriction on base images to latest minor.
+
+- Updated READMEs.
+
 ## 1.27.4 
 (2020-09-24)
 


### PR DESCRIPTION
Post-release docker-compose 1.28.0