### PR TITLE
Update compose docs for `logs|up --no-log-prefix` (#7435)

### DIFF
--- a/compose/reference/logs.md
+++ b/compose/reference/logs.md
@@ -6,14 +6,15 @@ notoc: true
 ---
 
 ```none
-Usage: logs [options] [SERVICE...]
+Usage: logs [options] [--] [SERVICE...]
 
 Options:
-    --no-color          Produce monochrome output.
-    -f, --follow        Follow log output.
-    -t, --timestamps    Show timestamps.
-    --tail="all"        Number of lines to show from the end of the logs
-                        for each container.
+    --no-color              Produce monochrome output.
+    -f, --follow            Follow log output.
+    -t, --timestamps        Show timestamps.
+    --tail="all"            Number of lines to show from the end of the logs
+                            for each container.
+    --no-log-prefix         Don't print prefix in logs.
 ```
 
 Displays log output from services.

--- a/compose/reference/up.md
+++ b/compose/reference/up.md
@@ -6,7 +6,7 @@ notoc: true
 ---
 
 ```none
-Usage: up [options] [--scale SERVICE=NUM...] [SERVICE...]
+Usage: up [options] [--scale SERVICE=NUM...] [--] [SERVICE...]
 
 Options:
     -d, --detach               Detached mode: Run containers in the background,
@@ -20,13 +20,12 @@ Options:
     --always-recreate-deps     Recreate dependent containers.
                                Incompatible with --no-recreate.
     --no-recreate              If containers already exist, don't recreate
-                               them. Incompatible with --force-recreate and 
-                               --renew-anon-volumes.
+                               them. Incompatible with --force-recreate and -V.
     --no-build                 Don't build an image, even if it's missing.
     --no-start                 Don't start the services after creating them.
     --build                    Build images before starting containers.
     --abort-on-container-exit  Stops all containers if any container was
-                               stopped. Incompatible with --detach.
+                               stopped. Incompatible with -d.
     --attach-dependencies      Attach to dependent containers.
     -t, --timeout TIMEOUT      Use this timeout in seconds for container
                                shutdown when attached or when containers are
@@ -39,6 +38,7 @@ Options:
                                container. Implies --abort-on-container-exit.
     --scale SERVICE=NUM        Scale SERVICE to NUM instances. Overrides the
                                `scale` setting in the Compose file if present.
+    --no-log-prefix            Don't print prefix in logs.
 ```
 
 Builds, (re)creates, starts, and attaches to containers for a service.


### PR DESCRIPTION
https://github.com/docker/compose/pull/7435 introduced a new option `--no-log-prefix`.

This PR updates the help message to that of docker-compose 1.28.0.
This pulls in minor additional changes that were not yet updated here.