### PR TITLE
fixup: Add documentation for Compose service profiles

### DIFF
--- a/compose/profiles.md
+++ b/compose/profiles.md
@@ -15,8 +15,8 @@ development tasks.
 ## Assigning profiles to services
 
 Services are associated with profiles through the
-[`profiles` attribute](compose-file/index.md#profiles) which takes an array of
-profile names:
+[`profiles` attribute](compose-file/compose-file-v3.md#profiles) which takes an
+array of profile names:
 
 ```yaml
 version: "{{ site.compose_file_v3 }}"

--- a/compose/profiles.md
+++ b/compose/profiles.md
@@ -6,7 +6,9 @@ keywords: cli, compose, profile, profiles reference
 
 Profiles allow adjusting the Compose application model for various usages and
 environments by selectively enabling services.
-This is achieved by assigning each service to zero or more profiles. If unassigned, the service is _always_ started but if assigned, it is only started if the profile is activated.
+This is achieved by assigning each service to zero or more profiles. If
+unassigned, the service is _always_ started but if assigned, it is only started
+if the profile is activated.
 
 This allows one to define additional services in a single `docker-compose.yml` file
 that should only be started in specific scenarios, e.g. for debugging or


### PR DESCRIPTION
### Proposed changes

These are two small fixups for #11844:
* rebasing from 202aee8d2f657864854bc8dc5b4228ab9ecd1b73 to fab7cf6c9d1ec8502131ef37f0a9f3a0fbefbd42 broke a link due to d0f70fdbb98791037123fc2fabccf64f19add75a
* a long line was not wrapped correctly

### Related issues (optional)

#11844 
