### PR TITLE
Increase Windows 10 version requirement to 17134

### DIFF
--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -19,7 +19,7 @@ By downloading Docker Desktop, you agree to the terms of the [Docker Software En
 
 ### System Requirements
 
-  - Windows 10 64-bit: Pro, Enterprise, or Education (Build 16299 or later).
+  - Windows 10 64-bit: Pro, Enterprise, or Education (Build 17134 or later).
   
     For Windows 10 Home, see [Install Docker Desktop on Windows Home](install-windows-home.md).
   - Hyper-V and Containers Windows features must be enabled.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Increase Windows 10 version requirement to 17134.
16299 has been end of life since October 2020.
