### PR TITLE
update rootless docs

### DIFF
--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -70,8 +70,6 @@ run Docker commands by default.
 >
 > To install Docker without root privileges, see
 > [Run the Docker daemon as a non-root user (Rootless mode)](/engine/security/rootless/).
->
-> Rootless mode is currently available as an experimental feature.
 
 #### Upgrade Docker after using the convenience script
 

--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -32,8 +32,6 @@ creates a Unix socket accessible by members of the `docker` group.
 >
 > To run Docker without root privileges, see
 > [Run the Docker daemon as a non-root user (Rootless mode)](../security/rootless.md).
->
-> Rootless mode is currently available as an experimental feature.
 
 To create the `docker` group and add your user:
 


### PR DESCRIPTION
## _includes/install-script.md, engine/install/linux-postinstall.md
- Remove "Rootless mode is currently available as an experimental feature."
  Close #12050

## engine/security/rootless.md
###  "Prerequiresites" section
- Remove information about old distros (Debian 9, CentOS 7.5-7.6)

###  "Distribution-specific hint" section
- Tabified (`<div class="tab-content" />`)

### "Known limitations" section
- Kernel 5.11 supports rootless overlayfs, without the Ubuntu/Debian patch. https://github.com/torvalds/linux/commit/459c7c565ac36ba09ffbf24231147f408fde4203

###  "Install" section
- Promote RPM/DEB installation over TGZ installation.
  See docker/roadmap#188

### "Uninstall" section
- Add "Uninstall" section.
  Close #12053

### "Usage" section
- Added more information about systemd
- Move `nsenter` tips to "Tips for debugging" subsection under "Troubleshooting" section

### "Best practice" section
- Remove guide for `lxc-user-nic` network driver due to immaturity.
  Will be brought back in future.
  See rootless-containers/rootlesskit#138 .

### "Troubleshooting" section
- Add a guide for "can't open lock file /run/xtables.lock: Permission denied" (SELinux).
  See moby/moby#41230

- Add a guide for "failed to register layer: ApplyLayer exit status 1 ..." (NFS).
  Close docker/for-linux#1172

- Improve guides for slirp4netns.

- Remove v19.03 information (e.g., "cgroup v2 is unsupported, use cgroup v1")

# Preview
https://deploy-preview-12234--docsdocker.netlify.app/engine/security/rootless/