### PR TITLE
engine/security: add more description about ssh://

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -205,7 +205,7 @@ guides:
         title: Docker security
       - path: /engine/security/non-events/
         title: Docker security non-events
-      - path: /engine/security/https/
+      - path: /engine/security/protect-access/
         title: Protect the Docker daemon socket
       - path: /engine/security/certificates/
         title: Using certificates for repository client verification

--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -151,7 +151,7 @@ the [Docker CLI Reference](/engine/reference/commandline/dockerd/) article.
 > understand the security implications of opening docker to the network. If steps are not taken to secure the connection, 
 > it is possible for remote non-root users to gain root access on the host. For more information on how to use TLS 
 > certificates to secure this connection, check this article on 
-> [how to protect the Docker daemon socket](../security/https.md).
+> [how to protect the Docker daemon socket](../security/protect-access.md).
 {: .warning}
 
 Configuring Docker to accept remote connections can be done with the `docker.service`

--- a/engine/security/certificates.md
+++ b/engine/security/certificates.md
@@ -6,7 +6,7 @@ redirect_from:
 title: Verify repository client with certificates
 ---
 
-In [Running Docker with HTTPS](https.md), you learned that, by default,
+In [Running Docker with HTTPS](protect-access.md), you learned that, by default,
 Docker runs via a non-networked Unix socket and TLS must be enabled in order
 to have the Docker client and the daemon communicate securely over HTTPS.  TLS ensures authenticity of the registry endpoint and that traffic to/from registry is encrypted.
 
@@ -92,4 +92,4 @@ If the Docker registry is accessed without a port number, do not add the port to
 ## Related information
 
 * [Use trusted images](trust/index.md)
-* [Protect the Docker daemon socket](https.md)
+* [Protect the Docker daemon socket](protect-access.md)

--- a/engine/security/https/README.md
+++ b/engine/security/https/README.md
@@ -2,7 +2,7 @@
 published: false
 ---
 
-This is an initial attempt to make it easier to test the examples in the https.md
+This is an initial attempt to make it easier to test the TLS (HTTPS) examples in the protect-access.md
 doc.
 
 At this point, it is a manual thing, and I've been running it in boot2docker.

--- a/engine/security/https/parsedocs.sh
+++ b/engine/security/https/parsedocs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "#!/bin/sh"
-cat ../https.md | awk '{if (sub(/\\$/,"")) printf "%s", $0; else print $0}' \
+cat ../protect-access.md | awk '{if (sub(/\\$/,"")) printf "%s", $0; else print $0}' \
         | grep '   $ ' \
         | sed 's/    $ //g' \
         | sed 's/2375/7777/g' \

--- a/engine/security/index.md
+++ b/engine/security/index.md
@@ -116,7 +116,7 @@ Note that even if you have a firewall to limit accesses to the REST API
 endpoint from other hosts in the network, the endpoint can be still accessible
 from containers, and it can easily result in the privilege escalation.
 Therefore it is *mandatory* to secure API endpoints with 
-[HTTPS and certificates](https.md).
+[HTTPS and certificates](protect-access.md).
 It is also recommended to ensure that it is reachable only from a trusted
 network or VPN.
 


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Previously, the `ssh://` helper was only mentioned in `engine/security/index.md`.

The `ssh://` helper is now documented in "Protect the Docker daemon socket" (`engine/security/protect-access.md`, nee `engine/security/https.md`).

