### PR TITLE
Add remark about non-glibc based distros in WSL docs

### DIFF
--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -77,6 +77,8 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     Optionally, select any additional distributions you would like to enable WSL 2 on.
 
+    Please note that the WSL Integrations bits running in your distro depend on glibc. This make it difficult to run it on musl-based distros such as Alpine Linux.
+
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 
 8. Click **Apply & Restart**.

--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -77,7 +77,7 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     Optionally, select any additional distributions you would like to enable WSL 2 on.
 
-    Please note that the WSL Integrations bits running in your distro depend on glibc. This make it difficult to run it on musl-based distros such as Alpine Linux.
+    Please note that the WSL Integrations bits running in your distro depend on glibc. This make it difficult to run it on musl-based distros such as Alpine Linux. Alpine users can use [this package](https://github.com/sgerrand/alpine-pkg-glibc) to deploy a glibc side by side with musl to run the integration.
 
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 

--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -77,7 +77,9 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     Optionally, select any additional distributions you would like to enable WSL 2 on.
 
-    Please note that the WSL Integrations bits running in your distro depend on glibc. This make it difficult to run it on musl-based distros such as Alpine Linux. Alpine users can use [this package](https://github.com/sgerrand/alpine-pkg-glibc) to deploy a glibc side by side with musl to run the integration.
+    > **Note**
+    >
+    > WSL Integration components running in your distro depend on glibc. This can cause issues when running WSL 2 on musl-based distros such as Alpine Linux. Alpine users can use the [alpine-pkg-glibc(https://github.com/sgerrand/alpine-pkg-glibc){:target="_blank" rel="noopener" class="_"} package to deploy a glibc with musl to run the integration.
 
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 

--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -79,7 +79,7 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     > **Note**
     >
-    > WSL Integration components running in your distro depend on glibc. This can cause issues when running WSL 2 on musl-based distros such as Alpine Linux. Alpine users can use the [alpine-pkg-glibc(https://github.com/sgerrand/alpine-pkg-glibc){:target="_blank" rel="noopener" class="_"} package to deploy a glibc with musl to run the integration.
+    > WSL Integration components running in your distro depend on glibc. This can cause issues when running WSL 2 on musl-based distros such as Alpine Linux. Alpine users can use the [alpine-pkg-glibc(https://github.com/sgerrand/alpine-pkg-glibc){:target="_blank" rel="noopener" class="_"} package to deploy a glibc side by side with musl to run the integration.
 
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 

--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -79,7 +79,7 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     > **Note**
     >
-    > WSL Integration components running in your distro depend on glibc. This can cause issues when running WSL 2 on musl-based distros such as Alpine Linux. Alpine users can use the [alpine-pkg-glibc(https://github.com/sgerrand/alpine-pkg-glibc){:target="_blank" rel="noopener" class="_"} package to deploy a glibc side by side with musl to run the integration.
+    > WSL Integration components running in your distro depend on glibc. This can cause issues when running WSL 2 on musl-based distros such as Alpine Linux. Alpine users can use the [alpine-pkg-glibc(https://github.com/sgerrand/alpine-pkg-glibc){:target="_blank" rel="noopener" class="_"} package to deploy glibc alongside musl to run the integration.
 
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 


### PR DESCRIPTION
Signed-off-by: Simon Ferquel <simon.ferquel@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
This adds a remark about the glibc dependency in Docker Desktop WSL backend.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
