### PR TITLE
Self-signed certificate with Kubernetes fix

### DIFF
--- a/registry/insecure.md
+++ b/registry/insecure.md
@@ -68,6 +68,7 @@ This is more secure than the insecure registry solution.
 
     $ openssl req \
       -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
+      -addext "subjectAltName = DNS:myregistry.domain.com" \
       -x509 -days 365 -out certs/domain.crt
     ```
 


### PR DESCRIPTION
In Go 1.15 there is deprecation for using Common name:
https://golang.google.cn/doc/go1.15#commonname

This causes the self-signed cert to be rejected by some Kubernetes platforms:
https://stackoverflow.com/questions/64814173/how-do-i-use-sans-with-openssl-instead-of-common-name

Fix is to add this field to the cert.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
