### PR TITLE
Compose common flags order

### DIFF
--- a/cloud/aci-integration.md
+++ b/cloud/aci-integration.md
@@ -147,7 +147,7 @@ Also see the [full list of compose features supported by ACI](aci-compose-featur
 
 2. Run `docker compose up` and `docker compose down` to start and then stop a full Compose application.
 
-  By default, `docker compose up` uses the `docker-compose.yaml` file in the current folder. You can specify the working directory using the  --workdir  flag or specify the Compose file directly using the `--file` flag.
+  By default, `docker compose up` uses the `docker-compose.yaml` file in the current folder. You can specify the working directory using the --workdir flag or specify the Compose file directly using `docker compose --file mycomposefile.yaml up`.
 
   You can also specify a name for the Compose application using the `--project-name` flag during deployment. If no name is specified, a name will be derived from the working directory.
 
@@ -161,7 +161,7 @@ Also see the [full list of compose features supported by ACI](aci-compose-featur
 
 ## Updating applications
 
-From a deployed Compose application, you can update the application by re-deploying it with the same project name: `docker compose up --project-name PROJECT`.
+From a deployed Compose application, you can update the application by re-deploying it with the same project name: `docker compose --project-name PROJECT up`.
 
 Updating an application means the ACI node will be reused, and the application will keep the same IP address that was previously allocated to expose ports, if any. ACI has some limitations on what can be updated in an existing application (you will not be able to change CPU/memory reservation for example), in these cases, you need to deploy a new application from scratch.
 

--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -133,8 +133,8 @@ current context using the command `docker context use myecscontext`.
 stop a full Compose application.
 
   By default, `docker compose up` uses the `compose.yaml` or `docker-compose.yaml` file in
-  the current folder. You can specify the Compose file directly using the
-  `--file` flag.
+  the current folder. You can specify the working directory using the --workdir flag or
+  specify the Compose file directly using `docker compose --file mycomposefile.yaml up`.
 
   You can also specify a name for the Compose application using the `--project-name` flag during deployment. If no name is specified, a name will be derived from the working directory.
 
@@ -186,10 +186,10 @@ By default you can see logs of your compose application the same way you check l
 docker compose logs
 
 # specify compose project name
-docker compose logs --project-name PROJECT
+docker compose --project-name PROJECT logs
 
 # specify compose file
-docker compose logs --file /path/to/docker-compose.yaml
+docker compose --file /path/to/docker-compose.yaml logs
 ```
 
 A log group is created for the application as `docker-compose/<application_name>`,


### PR DESCRIPTION
Compose common flags --file and --project-name must be used before the subcommand (like docker-compose syntax).

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Slight updates to command examples to reflect Compose common flags order

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
