### PR TITLE
Change "WSL 2 integration" to "Docker-WSL integration"

### DIFF
--- a/docker-for-windows/wsl.md
+++ b/docker-for-windows/wsl.md
@@ -71,15 +71,15 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
 7. When Docker Desktop restarts, go to **Settings** > **Resources** > **WSL Integration**.
 
-    WSL Integration will be enabled on your default WSL distribution. To change your default WSL distro, run `wsl --set-default <distro name>`.
+    The Docker-WSL integration will be enabled on your default WSL distribution. To change your default WSL distro, run `wsl --set-default <distro name>`.
 
     For example, to set Ubuntu as your default WSL distro, run `wsl --set-default ubuntu`.
 
-    Optionally, select any additional distributions you would like to enable WSL 2 on.
+    Optionally, select any additional distributions you would like to enable the Docker-WSL integration on.
 
     > **Note**
     >
-    > WSL Integration components running in your distro depend on glibc. This can cause issues when running WSL 2 on musl-based distros such as Alpine Linux. Alpine users can use the [alpine-pkg-glibc(https://github.com/sgerrand/alpine-pkg-glibc){:target="_blank" rel="noopener" class="_"} package to deploy glibc alongside musl to run the integration.
+    > The Docker-WSL integration components running in your distro depend on glibc. This can cause issues when running musl-based distros such as Alpine Linux. Alpine users can use the [alpine-pkg-glibc](https://github.com/sgerrand/alpine-pkg-glibc){:target="_blank" rel="noopener" class="_"} package to deploy glibc alongside musl to run the integration.
 
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 


### PR DESCRIPTION
As discussed privately, change "WSL 2 integration" to "Docker-WSL integration" because the former is confusing when in the context of doing something to a WSL distro.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
