### PR TITLE
Show command how to install Rosetta 2

### DIFF
--- a/docker-for-mac/apple-m1.md
+++ b/docker-for-mac/apple-m1.md
@@ -23,7 +23,10 @@ Click the following link to download the Apple M1 tech preview build:
 The tech preview of Docker Desktop for Apple M1 currently has the following limitations:
 
 - The tech preview build does not update automatically. You must manually install any future versions of Docker Desktop.
-- You must install Rosetta 2 as some binaries are still Darwin/AMD64.
+- You must install Rosetta 2 as some binaries are still Darwin/AMD64. To install Rosetta 2 manually from the command line use this command:
+    ```
+    softwareupdate --install-rosetta
+    ```
 - The DNS name `host.docker.internal` only works if you add `--add-host=host.docker.internal:host-gateway` to the `docker run` command
 - The DNS name `vm.docker.internal` does not work.
 - Kubernetes does not initialize because of a missing DNS name.

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -156,6 +156,12 @@ ways, and create reports.
 
 At the moment, Docker Desktop is compatible with Intel processors only. You can follow the status of Apple Silicon support in our [roadmap](https://github.com/docker/roadmap/issues/142){:target="_blank" rel="noopener" class="_"}.
 
+The technical preview builds of Docker Desktop for Apple silicon require Rosetta 2 to run correctly. To install Rosetta 2 manually from the command line use this command:
+
+```
+softwareupdate --install-rosetta
+```
+
 ### Make sure certificates are set up correctly
 
 Docker Desktop ignores certificates listed under insecure registries, and does

--- a/docker-for-mac/troubleshoot.md
+++ b/docker-for-mac/troubleshoot.md
@@ -154,13 +154,7 @@ ways, and create reports.
 
 ### Support for Apple silicon processors
 
-At the moment, Docker Desktop is compatible with Intel processors only. You can follow the status of Apple Silicon support in our [roadmap](https://github.com/docker/roadmap/issues/142){:target="_blank" rel="noopener" class="_"}.
-
-The technical preview builds of Docker Desktop for Apple silicon require Rosetta 2 to run correctly. To install Rosetta 2 manually from the command line use this command:
-
-```
-softwareupdate --install-rosetta
-```
+At the moment, Docker Desktop is compatible with Intel processors only. You can learn more about the technical preview for Apple silicon in our [docs](apple-m1.md).
 
 ### Make sure certificates are set up correctly
 

--- a/go/apple-silicon.md
+++ b/go/apple-silicon.md
@@ -2,5 +2,5 @@
 title: How to run Docker Desktop on new Mac with Apple Silicon processors
 description: Instructions on enabling BuildKit
 keywords: mac, troubleshooting, apple, silicon, issues
-redirect_to: /docker-for-mac/troubleshoot/#support-for-apple-silicon-processors
+redirect_to: /docker-for-mac/apple-m1/
 ---


### PR DESCRIPTION
The preview builds of Docker Desktop for Apple silicon cannot show the Apple dialog to install Rosetta 2. This nice little helper dialog only pops up for Intel apps as described here in the Apple support pages: [If you need to install Rosetta on your Mac](https://support.apple.com/en-us/HT211861)

So instead Docker Desktop shows this dialog on an Apple silicon machine that hasn't Rosetta 2 installed:

<img width="624" alt="docker-desktop-arm64-requires-rosetta-error" src="https://user-images.githubusercontent.com/207759/107270039-b9aa4500-6a4a-11eb-9e07-aadc56de8f07.png">

The link opens our troubleshoot page and we  should at least show the command to install Rosetta from a terminal.

In the long term we want to ship all binaries as native arm64 mac binaries to avoid this dependency,  but for the preview builds we still need this trick.

### Related issues (optional)

internal JIRA DESKTOP-3583
