### PR TITLE
Remove Desktop install references

### DIFF
--- a/machine/get-started.md
+++ b/machine/get-started.md
@@ -7,6 +7,11 @@ title: Get started with Docker Machine and a local VM
 Let's take a look at using `docker-machine` to create, use, and manage a
 Docker host inside of a local virtual machine.
 
+> **Note**
+>
+> Docker Machine is no longer included in the Docker Desktop installer. You can download it separately from the [docker/machine](https://github.com/docker/machine/releases/){: target="_blank" rel="noopener" class="_" } release
+page on GitHub.
+
 ## Prerequisite information
 
 With the advent of [Docker Desktop for Mac](../docker-for-mac/index.md) and
@@ -16,9 +21,7 @@ on your local system without using Docker Machine at all.
 
 For now, however, if you want to create _multiple_ local machines, you still
 need Docker Machine to create and manage machines for multi-node
-experimentation. Both Docker Desktop for Mac and Docker Desktop for Windows include the newest
-version of Docker Machine, so when you install either of these, you get
-`docker-machine`.
+experimentation.
 
 The new solutions come with their own native virtualization solutions rather
 than Oracle VirtualBox, so keep the following considerations in mind when using

--- a/machine/index.md
+++ b/machine/index.md
@@ -33,8 +33,7 @@ v1.12. Starting with the beta program and Docker v1.12,
 [Docker Desktop for Mac](../docker-for-mac/index.md) and
 [Docker Desktop for Windows](../docker-for-windows/index.md) are available as native apps and the
 better choice for this use case on newer desktops and laptops. We encourage you
-to try out these new apps. The installers for Docker Desktop for Mac and Docker Desktop for
-Windows include Docker Machine, along with Docker Compose.
+to try out these new apps.
 
 If you aren't sure where to begin, see [Get Started with Docker](../get-started/index.md),
 which guides you through a brief end-to-end tutorial on Docker.


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Removed statements that mention that Docker Desktop includes Docker Machine.
Added a note to state that Docker Machine is no longer included in the Docker Desktop installer and included a link to Machine releases page on GitHub

Fixes https://github.com/docker/docker.github.io/issues/12243