### PR TITLE
Fixes for language-specific (Python) tutorial

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -35,26 +35,25 @@ Now we’ll create a network that our application and database will use to talk 
 $ docker network create mysqlnet
 ```
 
-Now we can run MySQL in a container and attach to the volumes and network we created above. Docker pulls the image from Hub and run it for you locally.
+Now we can run MySQL in a container and attach to the volumes and network we created above. Docker pulls the image from Hub and runs it for you locally.
 
 ```shell
 $ docker run -it --rm -d -v mysql:/var/lib/mysql \
   -v mysql_config:/etc/mysql -p 3306:3306 \
   --network mysqlnet \
   --name mysqldb \
-  -e MYSQL_ALLOW_EMPTY_PASSWORD=true \
-  mysql
+  -e MYSQL_ROOT_PASSWORD=p@ssw0rd1 \
+  mysql:5.7
 ```
 
-Now, let’s make sure that our MySQL database is running and that we can connect to it. Connect to the running MySQL database inside the container using the following command:
+Now, let’s make sure that our MySQL database is running and that we can connect to it. Connect to the running MySQL database inside the container using the following command and enter "p@ssw0rd1" when prompted for the password:
 
 ```shell
-$ docker run -it --network mysqlnet --rm mysql mysql -hmysqldb
-Enter password: ********
-
+$ docker exec -ti mysqldb mysql -u root -p
+Enter password:
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 8
-Server version: 8.0.23 MySQL Community Server - GPL
+Server version: 5.7.33 MySQL Community Server (GPL)
 
 Copyright (c) 2000, 2021, Oracle and/or its affiliates.
 
@@ -69,11 +68,11 @@ mysql>
 
 ### Connect the application to the database
 
-In the above command, we used the same MySQL image to connect to the database but this time, we passed the ‘mysql’ command to the container with the `-h` flag containing the name of our MySQL container name. Press CTRL-D to exit the MySQL  interactive terminal.
+In the above command, we logged in to the MySQL database by passing the ‘mysql’ command to the `mysqldb` container. Press CTRL-D to exit the MySQL interactive terminal.
 
 Next, we'll update the sample application we created in the [Build images](build-images.md#sample-application) module. To see the directory structure of the Python app, see [Python application directory structure](build-images.md#directory-structure).
 
-Okay, now that we have a running MySQL, let’s update the`app.py` to use MySQL as a datastore. Let’s also add some routes to our server. One for fetching records and one for inserting records.
+Okay, now that we have a running MySQL, let’s update the `app.py` to use MySQL as a datastore. Let’s also add some routes to our server. One for fetching records and one for inserting records.
 
 ```shell
 import mysql.connector
@@ -110,7 +109,7 @@ def get_widgets() :
 
   return json.dumps(json_data)
 
-@app.route('/db')
+@app.route('/initdb')
 def db_init():
   mydb = mysql.connector.connect(
     host="mysqldb",
@@ -203,7 +202,7 @@ services:
   - ./:/app
 
  mysqldb:
-  image: mysql
+  image: mysql:5.7
   ports:
   - 3306:3306
   environment:


### PR DESCRIPTION
Proposed changes
Quick grammar fix: run -> runs

Set the mysql server to use the root password as used in the Flask application

Switched from latest mysql image to mysql:5.7 image, which accepts remote root logins (the current 8.0 version did not accept root logins from anywhere but localhost for me). The same image is used in the "Get Started"-tutorial.

Changed checking whether the MySQL server is running properly from using docker run to docker exec since you want to log in to the existing mysql container. Added the password as set by the previous docker run command.

Changed @app.route in App.py to initdb, the path used in later parts of the tutorial.

Changed mysql image in docker-compose from mysql to mysql:5.7 for reason listed earlier.