### PR TITLE
Fix og:image

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -88,17 +88,17 @@
   <!-- SEO stuff -->
   <meta name="twitter:title" itemprop="title name" content="{{ page.title | default: page_title }}"/>
   <meta name="twitter:description" property="og:description" itemprop="description" content="{{ page_description | escape_once }}" />
-  <meta name="twitter:card" content="summary"/>
+  <meta name="twitter:card" content="summary_large_image"/>
   <meta name="twitter:domain" content="docs.docker.com"/>
   <meta name="twitter:site" content="@docker_docs"/>
   <meta name="twitter:url" content="https://twitter.com/docker_docs"/>
-  <meta name="twitter:image:src" content="/images/docs@2x.png"/>
+  <meta name="twitter:image:src" content="https://docs.docker.com/images/docs@2x.png"/>
   <meta name="twitter:image:alt" content="Docker Documentation"/>
   <meta property="og:title" content="{{ page.title | default: page_title }}" />
   <meta property="og:description" content="{{ page.description | default: page_description | escape_once }}" />
   <meta property="og:type" content="website"/>
   <meta property="og:updated_time" itemprop="dateUpdated" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}"/>
-  <meta property="og:image" itemprop="image primaryImageOfPage" content="/images/docs@2x.png"/>
+  <meta property="og:image" itemprop="image primaryImageOfPage" content="https://docs.docker.com/images/docs@2x.png"/>
   <meta property="og:locale" content="en_US" />
   <meta property="og:url" content="https://docs.docker.com{{ page.url }}" />
   <meta property="og:site_name" content="Docker Documentation" />


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Currently, Logo is not displayed at Twitter card.
`og:image` is url, not path.
https://ogp.me/

Since the image size is large, this changes `summary` to `summary_large_image`.

https://deploy-preview-12314--docsdocker.netlify.app/
https://cards-dev.twitter.com/validator

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
