### PR TITLE
Removed phrase repetition typo

### DIFF
--- a/desktop/dashboard.md
+++ b/desktop/dashboard.md
@@ -92,7 +92,7 @@ From the Docker Dashboard, select the example voting application we started earl
 
 The **Containers/Apps** view lists all the containers running on the application and contains a detailed logs view. It also allows you to start, stop, or delete the application. Use the **Search** option at the bottom of the logs view to search application logs for specific events, or select the **Copy** icon to copy the logs to your clipboard.
 
-Click **Open in Visual Studio Code** to open the application to open the application in VS Code. Hover over the list of containers to see some of the core actions you can perform.
+Click **Open in Visual Studio Code** to open the application in VS Code. Hover over the list of containers to see some of the core actions you can perform.
 
 ![Application view](images/mac-application-view.png){:width="700px"}
 


### PR DESCRIPTION
Removed duplicate "to open the application" from VSCode section

### Proposed changes

Underneath the 'Interact with containers and applications' section, there is unnecessary repetition in the sentence "Click Open in Visual Studio Code to open the application to open the application in VS Code."
