### PR TITLE
Fix redirect for "/engine/security/https/"

### DIFF
--- a/engine/security/protect-access.md
+++ b/engine/security/protect-access.md
@@ -2,9 +2,9 @@
 description: How to setup and run Docker with SSH or HTTPS
 keywords: docker, docs, article, example, ssh, https, daemon, tls, ca,  certificate
 redirect_from:
-- /engine/articles/https/
 - /articles/https/
-- /engine/https/
+- /engine/articles/https/
+- /engine/security/https/
 title: Protect the Docker daemon socket
 ---
 


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/12308

I overlooked this during review of https://github.com/docker/docker.github.io/pull/12237
