### PR TITLE
Fix broken link in compose-file docs

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -27,5 +27,5 @@ how to upgrade, see **[About versions and upgrading](compose-versioning.md)**.
 - [Installing Compose](../install.md)
 - [Compose file versions and upgrading](compose-versioning.md)
 - [Sample apps with Compose](../samples-for-compose.md)
-- [Enabling GPU access with Compose](../gpu-support-in-compose.md)
+- [Enabling GPU access with Compose](../gpu-support.md)
 - [Command line reference](../reference/index.md)


### PR DESCRIPTION
fixes the broken link I spotted in https://github.com/docker/docker.github.io/pull/12320#discussion_r575440339