### PR TITLE
Fix iframe mobile view

### DIFF
--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -77,6 +77,9 @@
         overflow: visible;
         height: auto;
     }
+    iframe {
+        width: 100%;
+    }
 }
 
 /* Portrait */


### PR DESCRIPTION
### Proposed changes

Change the `iframe` tag styling for mobile view as the embedded Youtube videos on docker docs were overflowing the parent HTML and the whole page were rendering weirdly due to this.

**Results:**
1. **For medium mobile view**

|Original![original-1](https://user-images.githubusercontent.com/54525741/108070889-0f09d600-708b-11eb-870d-fe56f7d23d25.png)|Fixed![Fixed-1](https://user-images.githubusercontent.com/54525741/108070978-29dc4a80-708b-11eb-909a-9e70e351a564.png)|
|---|---|

2. **For small mobile view**

|Original![Original-2](https://user-images.githubusercontent.com/54525741/108071065-44aebf00-708b-11eb-9cd9-03b4e0bc8759.png)|Fixed![Fixed-2](https://user-images.githubusercontent.com/54525741/108071128-5d1ed980-708b-11eb-8e37-684a69f526ae.png)|
|---|---|

3. **Real Mobile view**

|Original![mobile-original](https://user-images.githubusercontent.com/54525741/108071555-de766c00-708b-11eb-8092-0f7762671835.jpg)|Fixed![mobile-fixed](https://user-images.githubusercontent.com/54525741/108071579-e7ffd400-708b-11eb-9801-4b4ebd0f39e6.jpg)|
|---|---|


### Unreleased project version (optional)

No

### Related issues (optional)

No
