### PR TITLE
Fix volume mismatch in Node.js guide

### DIFF
--- a/get-started/nodejs/develop.md
+++ b/get-started/nodejs/develop.md
@@ -123,7 +123,7 @@ services:
    - SERVER_PORT=8080
    - CONNECTIONSTRING=mongodb://mongo:27017/notes
   volumes:
-   - ./:/code
+   - ./:/app
   command: npm run debug
 
  mongo:

--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -125,7 +125,7 @@ services:
    - SERVER_PORT=8000
    - CONNECTIONSTRING=mongodb://mongo:27017/notes
   volumes:
-   - ./:/code
+   - ./:/app
   command: npm run debug
 
  mongo:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Node.js guide  uses `/app` path in the [Build Images](https://github.com/docker/docker.github.io/blob/master/language/nodejs/build-images.md) step. Whereas develop your app step used `/code`. This PR fixes the mismatch and uses `/app` on both pages. (Note: Python uses `/app` on both pages, that's why I chose to keep `/app`.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Related https://github.com/docker/docker.github.io/issues/12329
