### PR TITLE
Update getting started for Docker Dashboard

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -110,6 +110,7 @@ you a quick view of the containers running on your machine. It gives you quick
 access to container logs, lets you get a shell inside the container, and lets you
 easily manage container lifecycle (stop, remove, etc.).
 
+Docker Dashboard is available for Mac and Windows, for more information see [Docker Desktop](../../desktop/).
 To access the dashboard, follow the instructions for either 
 [Mac](../../docker-for-mac/dashboard/) or 
 [Windows](../../docker-for-windows/dashboard/). If you open the dashboard

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -106,11 +106,10 @@ You'll notice a few flags being used. Here's some more info on them:
 ## The Docker Dashboard
 
 Before going too far, we want to highlight the Docker Dashboard, which gives
-you a quick view of the containers running on your machine. It gives you quick
-access to container logs, lets you get a shell inside the container, and lets you
+you a quick view of the containers running on your machine. The Docker Dashboard is available for Mac and Windows. 
+It gives you quick access to container logs, lets you get a shell inside the container, and lets you
 easily manage container lifecycle (stop, remove, etc.).
 
-Docker Dashboard is available for Mac and Windows, for more information see [Docker Desktop](../../desktop/).
 To access the dashboard, follow the instructions for either 
 [Mac](../../docker-for-mac/dashboard/) or 
 [Windows](../../docker-for-windows/dashboard/). If you open the dashboard


### PR DESCRIPTION
Update getting started for Docker Dashboard to explicitly specify that it's available for Mac and Windows.

### Proposed changes

Explicitly specified that Docker Dashboard is available for Mac and Windows.

### Related issues (optional)

Resolves: #12363  