### PR TITLE
Take note of TLS limitation for TCP connections

### DIFF
--- a/config/containers/logging/gelf.md
+++ b/config/containers/logging/gelf.md
@@ -74,8 +74,8 @@ The `gelf` logging driver supports the following options:
 | `env-regex`                | optional  | Similar to and compatible with `env`. A regular expression to match logging-related environment variables. Used for advanced [log tag options](log_tags.md).                                                                                                                        | `--log-opt env-regex=^(os|customer)`                |
 
 > **Note**
-> The `gelf` driver does not currently support tls for tcp connections.
-> Messages sent to TLS-Protected inputs will silently fail
+> 
+> The `gelf` driver does not support TLS for TCP connections. Messages sent to TLS-protected inputs can silently fail.
 
 ### Examples
 

--- a/config/containers/logging/gelf.md
+++ b/config/containers/logging/gelf.md
@@ -73,6 +73,10 @@ The `gelf` logging driver supports the following options:
 | `env`                      | optional  | Applies when starting the Docker daemon. A comma-separated list of logging-related environment variables this daemon accepts. Adds additional key on the `extra` fields, prefixed by an underscore (`_`). Used for advanced [log tag options](log_tags.md).                         | `--log-opt env=os,customer`                         |
 | `env-regex`                | optional  | Similar to and compatible with `env`. A regular expression to match logging-related environment variables. Used for advanced [log tag options](log_tags.md).                                                                                                                        | `--log-opt env-regex=^(os|customer)`                |
 
+> **Note**
+> The `gelf` driver does not currently support tls for tcp connections.
+> Messages sent to TLS-Protected inputs will silently fail
+
 ### Examples
 
 This example configures the container to use the GELF server running at


### PR DESCRIPTION
Add a small note about the gelf driver not supporting TLS connections to the gelf options section.

c.f. Graylog2/go-gelf#39 for the currently open issue requesting that TLS support be added to go-gelf
