### PR TITLE
Add compatibility notes for docker multistage build

### DIFF
--- a/develop/develop-images/multistage-build.md
+++ b/develop/develop-images/multistage-build.md
@@ -199,4 +199,4 @@ RUN g++ -o /binary source.cpp
 
 ## Version compatibility
 
-Multistage build syntax was introduced in Docker Engine 17.05
+Multistage build syntax was introduced in Docker Engine 17.05.

--- a/develop/develop-images/multistage-build.md
+++ b/develop/develop-images/multistage-build.md
@@ -196,3 +196,7 @@ FROM builder as build2
 COPY source2.cpp source.cpp
 RUN g++ -o /binary source.cpp
 ```
+
+## Version compatibility
+
+Multistage build syntax was introduced in Docker Engine 17.05


### PR DESCRIPTION
add note that multistage docker builds are supported from version 17.05 and upwards.

(this is according to the release notes https://docs.docker.com/engine/release-notes/17.05/)


I ran into a build server running Docker version 1.13.1, where my multistage build failed. I found the multistage build introduction in the release notes, and decided to add it here, since I am sure others also run into the problem.

I would like you to review the format of the compatibility notes: In the future I would expect these are also relevant on other documentation pages. How do we want to show them in general? 

For a future PR, perhaps you should also consider how we would show when specific docker commands and flags are deprecated/removed.