### PR TITLE
Add "/go/rootless/" redirect to running engine in rootless mode

### DIFF
--- a/go/rootless.md
+++ b/go/rootless.md
@@ -1,0 +1,5 @@
+---
+# Instructions on running docker in rootless mode. This redirect is currently
+# used in the installation script at "get.docker.com"
+redirect_to: /engine/security/rootless/
+---


### PR DESCRIPTION
Relates to https://github.com/docker/docker-install/pull/215