### PR TITLE
Add more "/go/" redirects for use in the install scripts, and move "post install" in TOC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1128,8 +1128,8 @@ manuals:
       title: Install on Ubuntu
     - path: /engine/install/binaries/
       title: Install binaries
-    - path: /engine/install/linux-postinstall/
-      title: Optional post-installation steps
+  - path: /engine/install/linux-postinstall/
+    title: Optional post-installation steps
   - path: /engine/release-notes/
     title: Release notes
   - sectiontitle: Previous versions

--- a/go/attack-surface.md
+++ b/go/attack-surface.md
@@ -1,0 +1,6 @@
+---
+# Details about the "Docker Daemon attack surface". This redirect is currently
+# used in warnings printed by the Docker Engine, and in the installation script
+# at "get.docker.com"
+redirect_to: /engine/security/#docker-daemon-attack-surface
+---

--- a/go/daemon-access.md
+++ b/go/daemon-access.md
@@ -1,0 +1,5 @@
+---
+# Details about how to give "non-root" users access to a privileged Docker Daemon
+# This redirect is currently in the installation script at "get.docker.com"
+redirect_to: /engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
+---


### PR DESCRIPTION
follow-up to https://github.com/docker/docker.github.io/pull/12382, and also relates to https://github.com/docker/docker-install/pull/215.

Adding more "/go/" redirects to use in the installation scripts (and some other places). Also moving the "post install" step out of the "installation per-distro" submenu, because these instructions are more "in general".