### PR TITLE
Use 20.10 release branch for upstream engine resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@
 ARG JEKYLL_ENV=development
 
 # Engine
-# TODO change to 20.10 branch, once created
-ARG ENGINE_BRANCH="master"
+ARG ENGINE_BRANCH="20.10"
 
 # Distribution
 ARG DISTRIBUTION_BRANCH="release/2.7"

--- a/_scripts/fetch-upstream-resources.sh
+++ b/_scripts/fetch-upstream-resources.sh
@@ -25,7 +25,7 @@ fi
 # Directories to get via SVN. We use this because you can't use git to clone just a portion of a repository
 svn co "https://github.com/docker/cli/${engine_svn_branch}/docs/extend"              ./engine/extend || (echo "Failed engine/extend download" && exit 1)
 svn co "https://github.com/docker/docker/${engine_svn_branch}/docs/api"              ./engine/api    || (echo "Failed engine/api download" && exit 1)
-svn co "https://github.com/docker/compose-cli/${compose_cli_svn_branch}/docs"              ./cloud    || (echo "Failed compose-cli/docs download" && exit 1)
+svn co "https://github.com/docker/compose-cli/${compose_cli_svn_branch}/docs"        ./cloud         || (echo "Failed compose-cli/docs download" && exit 1)
 svn co "https://github.com/docker/distribution/${distribution_svn_branch}/docs/spec" ./registry/spec || (echo "Failed registry/spec download" && exit 1)
 svn co "https://github.com/mirantis/compliance/trunk/docs/compliance"                ./compliance    || (echo "Failed docker/compliance download" && exit 1)
 


### PR DESCRIPTION
follow-up to https://github.com/docker/docker.github.io/pull/11862, which temporarily used the `master` branch because no release branch was created yet.

The 20.10 release branch now exists, and "master" will be used for Docker Engine 21.xx development.
