### PR TITLE
Prepend /etc to /app in the container volume mount

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -44,7 +44,7 @@ So, let's do it!
 
     ```bash
     docker run -dp 3000:3000 \
-        -w /app -v "$(pwd):/app" \
+        -w /app -v "$(pwd):/etc/app" \
         node:12-alpine \
         sh -c "yarn install && yarn run dev"
     ```
@@ -53,7 +53,7 @@ So, let's do it!
 
     ```powershell
     docker run -dp 3000:3000 `
-        -w /app -v "$(pwd):/app" `
+        -w /app -v "$(pwd):/etc/app" `
         node:12-alpine `
         sh -c "yarn install && yarn run dev"
     ```


### PR DESCRIPTION
The existing/app in the container bind mount does not work. Prepending /etc works normally.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
