### PR TITLE
Add note on opening default terminal

### DIFF
--- a/desktop/dashboard.md
+++ b/desktop/dashboard.md
@@ -81,7 +81,7 @@ When the application starts successfully, from the Docker menu, select **Dashboa
 Now that you can see the list of running containers and applications on the Dashboard, let us explore some of the actions you can perform:
 
 - Click **Port** to open the port exposed by the container in a browser.
-- Click **CLI** to open a terminal and run commands on the container.
+- Click **CLI** to open a terminal and run commands on the container. If you have installed iTerm2 on your Mac, the CLI option opens an iTerm2 terminal. Otherwise, it opens the Terminal app on Mac, or a Command Prompt on Windows.
 - Click **Stop**, **Start**, **Restart**, or **Delete** to perform lifecycle operations on the container.
 
 Use the **Search** option to search for a specific object. You can also sort your containers and applications using various options. Click the **Sort by** drop-down to see a list of available options.


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Docker Desktop opens iterm2 by default, if installed. Otherwise, it opens users' default terminal.