### PR TITLE
Update resource_constraints.md

### DIFF
--- a/config/containers/resource_constraints.md
+++ b/config/containers/resource_constraints.md
@@ -323,7 +323,7 @@ $ docker run -it --rm --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a ubu
 Exposes that specific GPU.
 
 ```bash
-$ docker run -it --rm --gpus device=0,2 ubuntu nvidia-smi
+$ docker run -it --rm --gpus '"device=0,2"' ubuntu nvidia-smi
 ```
 
 Exposes the first and third GPUs.


### PR DESCRIPTION
The docker engine seems to get confused if you don't  quote device=1,2 as shown  I.E. '"device=1,2"'

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
