### PR TITLE
engine: add missing sudo in ubuntu instructions

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -98,7 +98,7 @@ from the repository.
 2.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base }}/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
     ```
 
 3.  Use the following command to set up the **stable** repository. To add the


### PR DESCRIPTION
Looks like the Debian version was updated during review, but the Ubuntu variant was forgotten in 760bb64ea3cc619e653b6eb0f8d186d6c0a9faa7 (https://github.com/docker/docker.github.io/pull/11990)
