### PR TITLE
highlighting: make comments, prompt and command-output non-selectable

### DIFF
--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -37,18 +37,17 @@ Always examine scripts downloaded from the internet before
 > running them locally.
 {:.warning}
 
-```bash
+```console
 $ curl -fsSL https://get.docker.com -o get-docker.sh
 $ sudo sh get-docker.sh
-
-<output truncated>
+<...>
 ```
 
 If you would like to use Docker as a non-root user, you should now consider
 adding your user to the "docker" group with something like:
 
-```bash
-  sudo usermod -aG docker <your-user>
+```console
+$ sudo usermod -aG docker <your-user>
 ```
 
 Remember to log out and back in for this to take effect!

--- a/_scss/_perldoc.scss
+++ b/_scss/_perldoc.scss
@@ -17,6 +17,20 @@
 .highlight .gi { color: #00aa00 } /* Generic.Inserted */
 .highlight .go { color: #888888 } /* Generic.Output */
 .highlight .gp { color: #555555 } /* Generic.Prompt */
+
+// Prevent selecting comments, command-output and command-prompt in shell
+// examples that use the "console" lexer/highlighter to allow easier copying.
+// See https://github.com/rouge-ruby/rouge/issues/1023
+.highlight .c,
+.highlight .go,
+.highlight .gp
+{
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none
+}
+
 .highlight .gs {} /* Generic.Strong */
 .highlight .gu { color: #800080 } /* Generic.Subheading */
 .highlight .gt { color: #aa0000 } /* Generic.Traceback */

--- a/_scss/_perldoc.scss
+++ b/_scss/_perldoc.scss
@@ -31,6 +31,13 @@
           user-select: none
 }
 
+// Show a "text" cursor for the prompt. Even though the prompt itself is not
+// selectable, make it appear as if it is, so that users don't get confused
+// when they try to select an example for copying.
+.highlight .gp {
+  cursor: text;
+}
+
 .highlight .gs {} /* Generic.Strong */
 .highlight .gu { color: #800080 } /* Generic.Subheading */
 .highlight .gt { color: #aa0000 } /* Generic.Traceback */

--- a/engine/install/binaries.md
+++ b/engine/install/binaries.md
@@ -86,7 +86,7 @@ instructions for enabling and configuring AppArmor or SELinux.
 2.  Extract the archive using the `tar` utility. The `dockerd` and `docker`
     binaries are extracted.
 
-    ```bash
+    ```console
     $ tar xzvf /path/to/<FILE>.tar.gz
     ```
 
@@ -94,13 +94,13 @@ instructions for enabling and configuring AppArmor or SELinux.
     as `/usr/bin/`. If you skip this step, you must provide the path to the
     executable when you invoke `docker` or `dockerd` commands.
 
-    ```bash
+    ```console
     $ sudo cp docker/* /usr/bin/
     ```
 
 4.  Start the Docker daemon:
 
-    ```bash
+    ```console
     $ sudo dockerd &
     ```
 
@@ -111,7 +111,7 @@ instructions for enabling and configuring AppArmor or SELinux.
 5.  Verify that Docker is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -132,7 +132,7 @@ The macOS binary includes the Docker client only. It does not include the
 2.  Extract the archive using the `tar` utility. The `docker` binary is
     extracted.
 
-    ```bash
+    ```console
     $ tar xzvf /path/to/<FILE>.tar.gz
     ```
 
@@ -140,7 +140,7 @@ The macOS binary includes the Docker client only. It does not include the
     as `/usr/local/bin/`. If you skip this step, you must provide the path to the
     executable when you invoke `docker` or `dockerd` commands.
 
-    ```bash
+    ```console
     $ sudo cp docker/docker /usr/local/bin/
     ```
 
@@ -148,7 +148,7 @@ The macOS binary includes the Docker client only. It does not include the
     image. The value of `<hostname>` is a hostname or IP address running the
     Docker daemon and accessible to the client.
 
-    ```bash
+    ```console
     $ sudo docker -H <hostname> run hello-world
     ```
 

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -33,7 +33,7 @@ The `overlay2` storage driver is recommended.
 Older versions of Docker were called `docker` or `docker-engine`. If these are
 installed, uninstall them, along with associated dependencies.
 
-```bash
+```console
 $ sudo yum remove docker \
                   docker-client \
                   docker-client-latest \
@@ -79,7 +79,7 @@ from the repository.
 Install the `yum-utils` package (which provides the `yum-config-manager`
 utility) and set up the **stable** repository.
 
-```bash
+```console
 $ sudo yum install -y yum-utils
 
 $ sudo yum-config-manager \
@@ -93,13 +93,13 @@ $ sudo yum-config-manager \
 > by default. You can enable them alongside the stable repository.  The following
 > command enables the **nightly** repository.
 >
-> ```bash
+> ```console
 > $ sudo yum-config-manager --enable docker-ce-nightly
 > ```
 >
 > To enable the **test** channel, run the following command:
 >
-> ```bash
+> ```console
 > $ sudo yum-config-manager --enable docker-ce-test
 > ```
 >
@@ -107,7 +107,7 @@ $ sudo yum-config-manager \
 > `yum-config-manager` command with the `--disable` flag. To re-enable it, use
 > the `--enable` flag. The following command disables the **nightly** repository.
 >
-> ```bash
+> ```console
 > $ sudo yum-config-manager --disable docker-ce-nightly
 > ```
 >
@@ -117,7 +117,7 @@ $ sudo yum-config-manager \
 
 1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
 
-    ```bash
+    ```console
     $ sudo yum install docker-ce docker-ce-cli containerd.io
     ```
 
@@ -139,7 +139,7 @@ $ sudo yum-config-manager \
     a. List and sort the versions available in your repo. This example sorts
        results by version number, highest to lowest, and is truncated:
 
-    ```bash
+    ```console
     $ yum list docker-ce --showduplicates | sort -r
 
     docker-ce.x86_64  3:18.09.1-3.el7                     docker-ce-stable
@@ -156,7 +156,7 @@ $ sudo yum-config-manager \
        starting at the first colon (`:`), up to the first hyphen, separated by
        a hyphen (`-`). For example, `docker-ce-18.09.1`.
 
-    ```bash
+    ```console
     $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
     ```
 
@@ -164,14 +164,14 @@ $ sudo yum-config-manager \
 
 3.  Start Docker.
 
-    ```bash
+    ```console
     $ sudo systemctl start docker
     ```
 
 4.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -205,7 +205,7 @@ a new file each time you want to upgrade Docker Engine.
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
-    ```bash
+    ```console
     $ sudo yum install /path/to/package.rpm
     ```
 
@@ -214,14 +214,14 @@ a new file each time you want to upgrade Docker Engine.
 
 3.  Start Docker.
 
-    ```bash
+    ```console
     $ sudo systemctl start docker
     ```
 
 4.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -245,7 +245,7 @@ instead of `yum -y install`, and pointing to the new file.
 
 1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
-    ```bash
+    ```console
     $ sudo yum remove docker-ce docker-ce-cli containerd.io
     ```
 
@@ -253,7 +253,7 @@ instead of `yum -y install`, and pointing to the new file.
     are not automatically removed. To delete all images, containers, and
     volumes:
 
-    ```bash
+    ```console
     $ sudo rm -rf /var/lib/docker
     ```
 

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -255,6 +255,7 @@ instead of `yum -y install`, and pointing to the new file.
 
     ```console
     $ sudo rm -rf /var/lib/docker
+    $ sudo rm -rf /var/lib/containerd
     ```
 
 You must delete any edited configuration files manually.

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -170,7 +170,6 @@ This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and Ras
       docker-ce | 5:18.09.0~3-0~debian-stretch | {{ download-url-base }} stretch/stable amd64 Packages
       docker-ce | 18.06.1~ce~3-0~debian        | {{ download-url-base }} stretch/stable amd64 Packages
       docker-ce | 18.06.0~ce~3-0~debian        | {{ download-url-base }} stretch/stable amd64 Packages
-      ...
     ```
 
     b. Install a specific version using the version string from the second column,

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -32,7 +32,7 @@ Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` archit
 Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
-```bash
+```console
 $ sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
@@ -77,7 +77,7 @@ from the repository.
 1.  Update the `apt` package index and install packages to allow `apt` to use a
     repository over HTTPS:
 
-    ```bash
+    ```console
     $ sudo apt-get update
 
     $ sudo apt-get install \
@@ -89,9 +89,8 @@ from the repository.
 
 2.  Add Docker's official GPG key:
 
-    ```bash
+    ```console
     $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-
     ```
 
 3.  Use the following command to set up the **stable** repository. To add the
@@ -113,7 +112,7 @@ from the repository.
     <div class="tab-content">
     <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
 
-    ```bash
+    ```console
     $ echo \
       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -122,7 +121,7 @@ from the repository.
     </div>
     <div id="armhf_repo" class="tab-pane fade" markdown="1">
 
-    ```bash
+    ```console
     $ echo \
       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -131,7 +130,7 @@ from the repository.
     </div>
     <div id="arm64_repo" class="tab-pane fade" markdown="1">
 
-    ```bash
+    ```console
     $ echo \
       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -142,13 +141,12 @@ from the repository.
 
 #### Install Docker Engine
 
-> **Note**: This procedure works for Debian on `x86_64` / `amd64`, Debian ARM,
-> or Raspbian.
+This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and Raspbian.
 
 1. Update the `apt` package index, and install the _latest version_ of Docker
    Engine and containerd, or go to the next step to install a specific version:
 
-    ```bash
+    ```console
     $ sudo apt-get update
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io
     ```
@@ -165,7 +163,7 @@ from the repository.
 
     a. List the versions available in your repo:
 
-    ```bash
+    ```console
     $ apt-cache madison docker-ce
 
       docker-ce | 5:18.09.1~3-0~debian-stretch | {{ download-url-base }} stretch/stable amd64 Packages
@@ -178,14 +176,14 @@ from the repository.
     b. Install a specific version using the version string from the second column,
        for example, `5:18.09.1~3-0~debian-stretch `.
 
-    ```bash
+    ```console
     $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
     ```
 
 3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -211,8 +209,8 @@ a new file each time you want to upgrade Docker.
 
 1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" },
     choose your Debian version, then browse to `pool/stable/`, choose `amd64`,
-    `armhf`, or `arm64` and download the `.deb` file for the Docker version
-    you want to install.
+    `armhf`, or `arm64`, and download the `.deb` file for the Docker Engine
+    version you want to install.
 
     > **Note**: To install a **nightly** or **test** (pre-release) package,
     > change the word `stable` in the above URL to `nightly` or `test`.
@@ -221,7 +219,7 @@ a new file each time you want to upgrade Docker.
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
-    ```bash
+    ```console
     $ sudo dpkg -i /path/to/package.deb
     ```
 
@@ -230,7 +228,7 @@ a new file each time you want to upgrade Docker.
 3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -254,7 +252,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
 
 1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
-    ```bash
+    ```console
     $ sudo apt-get purge docker-ce docker-ce-cli containerd.io
     ```
 
@@ -262,7 +260,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
     are not automatically removed. To delete all images, containers, and
     volumes:
 
-    ```bash
+    ```console
     $ sudo rm -rf /var/lib/docker
     $ sudo rm -rf /var/lib/containerd
     ```

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -253,6 +253,7 @@ instead of `dnf -y install`, and pointing to the new file.
 
     ```console
     $ sudo rm -rf /var/lib/docker
+    $ sudo rm -rf /var/lib/containerd
     ```
 
 You must delete any edited configuration files manually.

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -28,7 +28,7 @@ To install Docker Engine, you need the 64-bit version of one of these Fedora ver
 Older versions of Docker were called `docker` or `docker-engine`. If these are
 installed, uninstall them, along with associated dependencies.
 
-```bash
+```console
 $ sudo dnf remove docker \
                   docker-client \
                   docker-client-latest \
@@ -76,7 +76,7 @@ from the repository.
 Install the `dnf-plugins-core` package (which provides the commands to manage
 your DNF repositories) and set up the **stable** repository.
 
-```bash
+```console
 $ sudo dnf -y install dnf-plugins-core
 
 $ sudo dnf config-manager \
@@ -90,13 +90,13 @@ $ sudo dnf config-manager \
 > by default. You can enable them alongside the stable repository.  The following
 > command enables the **nightly** repository.
 >
-> ```bash
+> ```console
 > $ sudo dnf config-manager --set-enabled docker-ce-nightly
 > ```
 >
 > To enable the **test** channel, run the following command:
 >
-> ```bash
+> ```console
 > $ sudo dnf config-manager --set-enabled docker-ce-test
 > ```
 >
@@ -105,7 +105,7 @@ $ sudo dnf config-manager \
 > use the `--set-enabled` flag. The following command disables the **nightly**
 > repository.
 >
-> ```bash
+> ```console
 > $ sudo dnf config-manager --set-disabled docker-ce-nightly
 > ```
 >
@@ -115,7 +115,7 @@ $ sudo dnf config-manager \
 
 1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
 
-    ```bash
+    ```console
     $ sudo dnf install docker-ce docker-ce-cli containerd.io
     ```
 
@@ -137,7 +137,7 @@ $ sudo dnf config-manager \
     a. List and sort the versions available in your repo. This example sorts
        results by version number, highest to lowest, and is truncated:
 
-    ```bash
+    ```console
     $ dnf list docker-ce  --showduplicates | sort -r
 
     docker-ce.x86_64  3:18.09.1-3.fc28                 docker-ce-stable
@@ -154,7 +154,7 @@ $ sudo dnf config-manager \
        the first hyphen, separated by a hyphen (`-`), for example,
        `docker-ce-3:18.09.1`.
 
-    ```bash
+    ```console
     $ sudo dnf -y install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
     ```
 
@@ -162,14 +162,14 @@ $ sudo dnf config-manager \
 
 3.  Start Docker.
 
-    ```bash
+    ```console
     $ sudo systemctl start docker
     ```
 
 4.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -203,7 +203,7 @@ a new file each time you want to upgrade Docker Engine.
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
-    ```bash
+    ```console
     $ sudo dnf -y install /path/to/package.rpm
     ```
 
@@ -212,14 +212,14 @@ a new file each time you want to upgrade Docker Engine.
 
 3.  Start Docker.
 
-    ```bash
+    ```console
     $ sudo systemctl start docker
     ```
 
 4.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -243,7 +243,7 @@ instead of `dnf -y install`, and pointing to the new file.
 
 1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
-    ```bash
+    ```console
     $ sudo dnf remove docker-ce docker-ce-cli containerd.io
     ```
 
@@ -251,7 +251,7 @@ instead of `dnf -y install`, and pointing to the new file.
     are not automatically removed. To delete all images, containers, and
     volumes:
 
-    ```bash
+    ```console
     $ sudo rm -rf /var/lib/docker
     ```
 

--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -168,7 +168,7 @@ recommended for Linux distributions that do not use systemd.
 
 2.  Add or modify the following lines, substituting your own values.
 
-    ```none
+    ```systemd
     [Service]
     ExecStart=
     ExecStart=/usr/bin/dockerd -H fd:// -H tcp://127.0.0.1:2375
@@ -284,13 +284,12 @@ file in `/usr/lib/systemd/network/` on your Docker host
 (ex: `/usr/lib/systemd/network/80-container-host0.network`) and add the
 following block within the `[Network]` section.
 
-```
+```systemd
 [Network]
 ...
 IPForward=kernel
 # OR
 IPForward=true
-...
 ```
 
 This configuration allows IP forwarding from the container as expected.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -267,6 +267,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
 
     ```console
     $ sudo rm -rf /var/lib/docker
+    $ sudo rm -rf /var/lib/containerd
     ```
 
 You must delete any edited configuration files manually.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -36,7 +36,7 @@ Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` archit
 Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
-```bash
+```console
 $ sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
@@ -85,7 +85,7 @@ from the repository.
 1.  Update the `apt` package index and install packages to allow `apt` to use a
     repository over HTTPS:
 
-    ```bash
+    ```console
     $ sudo apt-get update
 
     $ sudo apt-get install \
@@ -97,7 +97,7 @@ from the repository.
 
 2.  Add Docker's official GPG key:
 
-    ```bash
+    ```console
     $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
     ```
 
@@ -120,7 +120,7 @@ from the repository.
     <div class="tab-content">
     <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
 
-    ```bash
+    ```console
     $ echo \
       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -129,7 +129,7 @@ from the repository.
     </div>
     <div id="armhf_repo" class="tab-pane fade" markdown="1">
 
-    ```bash
+    ```console
     $ echo \
       "deb [arch=armhf signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -138,7 +138,7 @@ from the repository.
     </div>
     <div id="arm64_repo" class="tab-pane fade" markdown="1">
 
-    ```bash
+    ```console
     $ echo \
       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -152,7 +152,7 @@ from the repository.
 1. Update the `apt` package index, and install the _latest version_ of Docker
    Engine and containerd, or go to the next step to install a specific version:
 
-    ```bash
+    ```console
     $ sudo apt-get update
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io
     ```
@@ -169,7 +169,7 @@ from the repository.
 
     a. List the versions available in your repo:
 
-    ```bash
+    ```console
     $ apt-cache madison docker-ce
 
       docker-ce | 5:18.09.1~3-0~ubuntu-xenial | {{ download-url-base }}  xenial/stable amd64 Packages
@@ -182,14 +182,14 @@ from the repository.
     b. Install a specific version using the version string from the second column,
        for example, `5:18.09.1~3-0~ubuntu-xenial`.
 
-    ```bash
+    ```console
     $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
     ```
 
 3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -215,8 +215,8 @@ a new file each time you want to upgrade Docker.
 
 1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" },
     choose your Ubuntu version, then browse to `pool/stable/`, choose `amd64`,
-    `armhf`, or `arm64`, and download the `.deb` file for the
-    Docker Engine version you want to install.
+    `armhf`, or `arm64`, and download the `.deb` file for the Docker Engine
+    version you want to install.
 
     > **Note**: To install a **nightly** or **test** (pre-release) package,
     > change the word `stable` in the above URL to `nightly` or `test`.
@@ -225,7 +225,7 @@ a new file each time you want to upgrade Docker.
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
-    ```bash
+    ```console
     $ sudo dpkg -i /path/to/package.deb
     ```
 
@@ -234,7 +234,7 @@ a new file each time you want to upgrade Docker.
 3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
-    ```bash
+    ```console
     $ sudo docker run hello-world
     ```
 
@@ -258,7 +258,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
 
 1.  Uninstall the Docker Engine, CLI, and Containerd packages:
 
-    ```bash
+    ```console
     $ sudo apt-get purge docker-ce docker-ce-cli containerd.io
     ```
 
@@ -266,7 +266,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
     are not automatically removed. To delete all images, containers, and
     volumes:
 
-    ```bash
+    ```console
     $ sudo rm -rf /var/lib/docker
     ```
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -176,7 +176,6 @@ from the repository.
       docker-ce | 5:18.09.0~3-0~ubuntu-xenial | {{ download-url-base }}  xenial/stable amd64 Packages
       docker-ce | 18.06.1~ce~3-0~ubuntu       | {{ download-url-base }}  xenial/stable amd64 Packages
       docker-ce | 18.06.0~ce~3-0~ubuntu       | {{ download-url-base }}  xenial/stable amd64 Packages
-      ...
     ```
 
     b. Install a specific version using the version string from the second column,

--- a/storage/storagedriver/btrfs-driver.md
+++ b/storage/storagedriver/btrfs-driver.md
@@ -124,7 +124,7 @@ This procedure is essentially identical on SLES and Ubuntu.
     Storage Driver: btrfs
      Build Version: Btrfs v4.4
      Library Version: 101
-    <output truncated>
+    <...>
     ```
 
 8.  When you are ready, remove the `/var/lib/docker.bk` directory.

--- a/storage/storagedriver/device-mapper-driver.md
+++ b/storage/storagedriver/device-mapper-driver.md
@@ -114,7 +114,7 @@ For production systems, see
       Data loop file: /var/lib/docker/devicemapper/data
       Metadata loop file: /var/lib/docker/devicemapper/metadata
       Library Version: 1.02.135-RHEL7 (2016-11-16)
-    <output truncated>
+    <...>
     ```
 
   This host is running in `loop-lvm` mode, which is **not** supported on
@@ -398,7 +398,7 @@ assumes that the Docker daemon is in the `stopped` state.
      Deferred Deletion Enabled: true
      Deferred Deleted Device Count: 0
      Library Version: 1.02.135-RHEL7 (2016-11-16)
-    <output truncated>
+    <...>
     ```
 
     If Docker is configured correctly, the `Data file` and `Metadata file` is
@@ -627,7 +627,7 @@ block device and other parameters to suit your situation.
      Metadata Space Used: 286.7 kB
      Metadata Space Total: 1.07 GB
      Metadata Space Available: 1.069 GB
-    <output truncated>
+    <...>
     ```
 
 ### Activate the `devicemapper` after reboot

--- a/storage/storagedriver/overlayfs-driver.md
+++ b/storage/storagedriver/overlayfs-driver.md
@@ -114,7 +114,7 @@ need to use the legacy `overlay` driver, specify it instead.
      Backing Filesystem: xfs
      Supports d_type: true
      Native Overlay Diff: true
-    <output truncated>
+    <...>
     ```
 
 Docker is now using the `overlay2` storage driver and has automatically

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -228,7 +228,7 @@ Containers: 0
 Images: 0
 Storage Driver: overlay2
  Backing Filesystem: xfs
-<output truncated>
+<...>
 ```
 
 To change the storage driver, see the specific instructions for the new storage

--- a/storage/storagedriver/zfs-driver.md
+++ b/storage/storagedriver/zfs-driver.md
@@ -112,7 +112,7 @@ use unless you have substantial experience with ZFS on Linux.
        Space Available: 103498395648
        Parent Quota: no
        Compression: off
-    <output truncated>
+    <...>
     ```
 
 ## Manage `zfs`


### PR DESCRIPTION
relates to https://github.com/docker/docker.github.io/issues/5380 and https://github.com/docker/docker.github.io/issues/5282 (and others)

Prevent selecting comments, command-output and command-prompt in shell
examples that use the "console" lexer/highlighter to allow easier copying.
See rouge-ruby/rouge#1023

The "comment"  and "command-output" non-selectable may be ones we need to keep an eye on, to check if it properly detects commands from "output" and "comments"

Before this:

<img width="978" alt="Screenshot 2021-03-02 at 13 50 06" src="https://user-images.githubusercontent.com/1804568/109660091-c103d080-7b68-11eb-921e-6d467518607d.png">

After this:

<img width="948" alt="Screenshot 2021-03-02 at 15 06 16" src="https://user-images.githubusercontent.com/1804568/109660212-e1338f80-7b68-11eb-8cea-f86b01cb2839.png">
