### PR TITLE
Use go 1.15

### DIFF
--- a/.github/actions/update-website-config/Dockerfile
+++ b/.github/actions/update-website-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.15
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/.github/actions/update-website-config/go.mod
+++ b/.github/actions/update-website-config/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/docker.github.io/upload-website-config
 
-go 1.14
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.29.24


### PR DESCRIPTION
We see ongoing errors in GitHub Actions https://github.com/docker/docker.github.io/runs/2021344197
```
  Step 1/7 : FROM golang:1.14
  1.14: Pulling from library/golang
  0ecb575e629c: Already exists
  7467d1831b69: Already exists
  feab2c490a3c: Already exists
  f15a0f46f8c3: Already exists
  1517911a35d7: Pulling fs layer
  48bbd1746d63: Pulling fs layer
  944903612fdd: Pulling fs layer
  944903612fdd: Verifying Checksum
  944903612fdd: Download complete
  error pulling image configuration: read tcp 10.1.0.4:41624->104.18.121.25:443: read: connection reset by peer
Error: Docker build failed with exit code 1
```

Let's try and update to Go 1.15