### PR TITLE
Add `lsb-release` to required debian packages.

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -84,7 +84,8 @@ from the repository.
         apt-transport-https \
         ca-certificates \
         curl \
-        gnupg
+        gnupg \
+        lsb-release
     ```
 
 2.  Add Docker's official GPG key:

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -92,7 +92,8 @@ from the repository.
         apt-transport-https \
         ca-certificates \
         curl \
-        gnupg
+        gnupg \
+        lsb-release
     ```
 
 2.  Add Docker's official GPG key:


### PR DESCRIPTION
### Proposed changes

Add `lsb-release` to list of required debian packages.

Certain installations may not have this.  Without this, the step where `/etc/apt/sources.list.d/docker.list` is created will fail and write garbled data to the file, potentially breaking apt.

### Unreleased project version (optional)

NA

### Related issues (optional)

NA
