### PR TITLE
Fixed networking.md malformed whitespace

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -111,19 +111,19 @@ Here's an example Compose file defining two custom networks. The `proxy` service
 version: "{{ site.compose_file_v3 }}"
 
 services:
-   proxy:
+  proxy:
     build: ./proxy
-      networks:
-        - frontend
-   app:
-     build: ./app
-      networks:
-        - frontend
-        - backend
-   db:
-     image: postgres
-      networks:
-        - backend
+    networks:
+      - frontend
+  app:
+    build: ./app
+    networks:
+      - frontend
+      - backend
+  db:
+    image: postgres
+    networks:
+      - backend
 
 networks:
   frontend:


### PR DESCRIPTION
Adjusted what appeared to be malformed yaml whitespace in the 'Specify custom networks' section. 

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
