### PR TITLE
Fix docker-compose database volume configuration

### DIFF
--- a/compose/django.md
+++ b/compose/django.md
@@ -69,6 +69,8 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
    services:
      db:
        image: postgres
+       volumes:
+         - ./data/db:/var/lib/postgresql/data
        environment:
          - POSTGRES_DB=postgres
          - POSTGRES_USER=postgres


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I modified the docker-compose.yml configuration related to the database server's volumes. Without this change any database data is immediately discarded. This is inconsistent with the documentation for Ruby on Rails with Docker Compose where it's retained (See https://docs.docker.com/compose/rails/) when restarting the application within compose.

<!--Tell us what you did and why-->

### Unreleased project version (optional)
N/A
<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
N/A
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
