### PR TITLE
Clarify note on launching iTerm2 terminal

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -38,7 +38,7 @@ This page contains information about the new features, improvements, known issue
 
 - The Docker Dashboard opens automatically when you start Docker Desktop.
 - The Docker Dashboard displays a tip once a week.
-- Docker Desktop uses iTerm2 to launch the container's terminal if it is installed. Otherwise, it launches the default Terminal.App. [docker/roadmap#98](https://github.com/docker/roadmap/issues/98)
+- Docker Desktop uses iTerm2 to launch the terminal on the container if it is installed. Otherwise, it launches the default Terminal.App. [docker/roadmap#98](https://github.com/docker/roadmap/issues/98)
 - Add experimental support to use the new Apple Virtualization framework (requires macOS Big Sur 11.1 or later)
 
 ### Upgrades


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Update the note to clarify that Docker Desktop opens the iTerm2 terminal to run commands on the container.
