### PR TITLE
compose cli reference documentation

### DIFF
--- a/_data/compose-cli/docker_compose.yaml
+++ b/_data/compose-cli/docker_compose.yaml
@@ -1,0 +1,121 @@
+command: docker compose
+short: Docker Compose
+long: Docker Compose
+pname: docker
+plink: docker.yaml
+cname:
+  - docker compose build
+  - docker compose convert
+  - docker compose create
+  - docker compose down
+  - docker compose events
+  - docker compose exec
+  - docker compose kill
+  - docker compose logs
+  - docker compose ls
+  - docker compose pause
+  - docker compose ps
+  - docker compose pull
+  - docker compose push
+  - docker compose rm
+  - docker compose run
+  - docker compose start
+  - docker compose stop
+  - docker compose top
+  - docker compose unpause
+  - docker compose up
+clink:
+  - docker_compose_build.yaml
+  - docker_compose_convert.yaml
+  - docker_compose_create.yaml
+  - docker_compose_down.yaml
+  - docker_compose_events.yaml
+  - docker_compose_exec.yaml
+  - docker_compose_kill.yaml
+  - docker_compose_logs.yaml
+  - docker_compose_ls.yaml
+  - docker_compose_pause.yaml
+  - docker_compose_ps.yaml
+  - docker_compose_pull.yaml
+  - docker_compose_push.yaml
+  - docker_compose_rm.yaml
+  - docker_compose_run.yaml
+  - docker_compose_start.yaml
+  - docker_compose_stop.yaml
+  - docker_compose_top.yaml
+  - docker_compose_unpause.yaml
+  - docker_compose_up.yaml
+options:
+  - option: ansi
+    value_type: string
+    default_value: auto
+    description: |
+        Control when to print ANSI control characters ("never"|"always"|"auto")
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: env-file
+    value_type: string
+    description: Specify an alternate environment file.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: file
+    shorthand: f
+    value_type: stringArray
+    default_value: '[]'
+    description: Compose configuration files
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: profile
+    value_type: stringArray
+    default_value: '[]'
+    description: Specify a profile to enable
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: project-directory
+    value_type: string
+    description: |-
+        Specify an alternate working directory
+        (default: the path of the Compose file)
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: project-name
+    shorthand: p
+    value_type: string
+    description: Project name
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: workdir
+    value_type: string
+    description: |-
+        DEPRECATED! USE --project-directory INSTEAD.
+        Specify an alternate working directory
+        (default: the path of the Compose file)
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_build.yaml
+++ b/_data/compose-cli/docker_compose_build.yaml
@@ -1,0 +1,50 @@
+command: docker compose build
+short: Build or rebuild services
+long: Build or rebuild services
+usage: docker compose build [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: build-arg
+    value_type: stringArray
+    default_value: '[]'
+    description: Set build-time variables for services.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: progress
+    value_type: string
+    default_value: auto
+    description: Set type of progress output ("auto", "plain", "tty")
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: pull
+    value_type: bool
+    default_value: "false"
+    description: Always attempt to pull a newer version of the image.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: quiet
+    shorthand: q
+    value_type: bool
+    default_value: "false"
+    description: Don't print anything to STDOUT
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_convert.yaml
+++ b/_data/compose-cli/docker_compose_convert.yaml
@@ -1,0 +1,42 @@
+command: docker compose convert
+aliases: config
+short: Converts the compose file to platform's canonical format
+long: Converts the compose file to platform's canonical format
+usage: docker compose convert SERVICES
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: format
+    value_type: string
+    default_value: yaml
+    description: 'Format the output. Values: [yaml | json]'
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: quiet
+    shorthand: q
+    value_type: bool
+    default_value: "false"
+    description: Only validate the configuration, don't print anything.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: resolve-image-digests
+    value_type: bool
+    default_value: "false"
+    description: Pin image tags to digests.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_create.yaml
+++ b/_data/compose-cli/docker_compose_create.yaml
@@ -1,0 +1,51 @@
+command: docker compose create
+short: Creates containers for a service.
+long: Creates containers for a service.
+usage: docker compose create [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: build
+    value_type: bool
+    default_value: "false"
+    description: Build images before starting containers.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: force-recreate
+    value_type: bool
+    default_value: "false"
+    description: |
+        Recreate containers even if their configuration and image haven't changed.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-build
+    value_type: bool
+    default_value: "false"
+    description: Don't build an image, even if it's missing.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-recreate
+    value_type: bool
+    default_value: "false"
+    description: |
+        If containers already exist, don't recreate them. Incompatible with --force-recreate.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_down.yaml
+++ b/_data/compose-cli/docker_compose_down.yaml
@@ -1,0 +1,53 @@
+command: docker compose down
+short: Stop and remove containers, networks
+long: Stop and remove containers, networks
+usage: docker compose down
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: remove-orphans
+    value_type: bool
+    default_value: "false"
+    description: |
+        Remove containers for services not defined in the Compose file.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: rmi
+    value_type: string
+    description: |
+        Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: timeout
+    shorthand: t
+    value_type: int
+    default_value: "10"
+    description: Specify a shutdown timeout in seconds
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: volumes
+    shorthand: v
+    value_type: bool
+    default_value: "false"
+    description: |4
+         Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_events.yaml
+++ b/_data/compose-cli/docker_compose_events.yaml
@@ -1,0 +1,22 @@
+command: docker compose events
+short: Receive real time events from containers.
+long: Receive real time events from containers.
+usage: docker compose events [options] [--] [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: json
+    value_type: bool
+    default_value: "false"
+    description: Output events as a stream of json objects
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_exec.yaml
+++ b/_data/compose-cli/docker_compose_exec.yaml
@@ -1,0 +1,81 @@
+command: docker compose exec
+short: Execute a command in a running container.
+long: Execute a command in a running container.
+usage: docker compose exec [options] [-e KEY=VAL...] [--] SERVICE COMMAND [ARGS...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: ""
+    shorthand: T
+    value_type: bool
+    default_value: "false"
+    description: |
+        Disable pseudo-tty allocation. By default `docker compose exec` allocates a TTY.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: detach
+    shorthand: d
+    value_type: bool
+    default_value: "false"
+    description: 'Detached mode: Run command in the background.'
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: env
+    shorthand: e
+    value_type: stringArray
+    default_value: '[]'
+    description: Set environment variables
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: index
+    value_type: int
+    default_value: "1"
+    description: |
+        index of the container if there are multiple instances of a service [default: 1].
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: privileged
+    value_type: bool
+    default_value: "false"
+    description: Give extended privileges to the process.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: user
+    shorthand: u
+    value_type: string
+    description: Run the command as this user.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: workdir
+    shorthand: w
+    value_type: string
+    description: Path to workdir directory for this command.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_kill.yaml
+++ b/_data/compose-cli/docker_compose_kill.yaml
@@ -1,0 +1,23 @@
+command: docker compose kill
+short: Force stop service containers.
+long: Force stop service containers.
+usage: docker compose kill [options] [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: signal
+    shorthand: s
+    value_type: string
+    default_value: SIGKILL
+    description: SIGNAL to send to the container.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_logs.yaml
+++ b/_data/compose-cli/docker_compose_logs.yaml
@@ -1,0 +1,51 @@
+command: docker compose logs
+short: View output from containers
+long: View output from containers
+usage: docker compose logs [service...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: follow
+    shorthand: f
+    value_type: bool
+    default_value: "false"
+    description: Follow log output.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-color
+    value_type: bool
+    default_value: "false"
+    description: Produce monochrome output.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-log-prefix
+    value_type: bool
+    default_value: "false"
+    description: Don't print prefix in logs.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: timestamps
+    shorthand: t
+    value_type: bool
+    default_value: "false"
+    description: Show timestamps.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_ls.yaml
+++ b/_data/compose-cli/docker_compose_ls.yaml
@@ -1,0 +1,40 @@
+command: docker compose ls
+short: List running compose projects
+long: List running compose projects
+usage: docker compose ls
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: filter
+    value_type: filter
+    description: Filter output based on conditions provided.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: format
+    value_type: string
+    default_value: pretty
+    description: 'Format the output. Values: [pretty | json].'
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: quiet
+    shorthand: q
+    value_type: bool
+    default_value: "false"
+    description: Only display IDs.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_pause.yaml
+++ b/_data/compose-cli/docker_compose_pause.yaml
@@ -1,0 +1,12 @@
+command: docker compose pause
+short: pause services
+long: pause services
+usage: docker compose pause [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_ps.yaml
+++ b/_data/compose-cli/docker_compose_ps.yaml
@@ -1,0 +1,52 @@
+command: docker compose ps
+short: List containers
+long: List containers
+usage: docker compose ps
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: all
+    shorthand: a
+    value_type: bool
+    default_value: "false"
+    description: |
+        Show all stopped containers (including those created by the run command)
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: format
+    value_type: string
+    default_value: pretty
+    description: 'Format the output. Values: [pretty | json].'
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: quiet
+    shorthand: q
+    value_type: bool
+    default_value: "false"
+    description: Only display IDs
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: services
+    value_type: bool
+    default_value: "false"
+    description: Display services
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_pull.yaml
+++ b/_data/compose-cli/docker_compose_pull.yaml
@@ -1,0 +1,32 @@
+command: docker compose pull
+short: Pull service images
+long: Pull service images
+usage: docker compose pull [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: include-deps
+    value_type: bool
+    default_value: "false"
+    description: Also pull services declared as dependencies
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: quiet
+    shorthand: q
+    value_type: bool
+    default_value: "false"
+    description: Pull without printing progress information
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_push.yaml
+++ b/_data/compose-cli/docker_compose_push.yaml
@@ -1,0 +1,22 @@
+command: docker compose push
+short: Push service images
+long: Push service images
+usage: docker compose push [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: ignore-push-failures
+    value_type: bool
+    default_value: "false"
+    description: Push what it can and ignores images with push failures
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_rm.yaml
+++ b/_data/compose-cli/docker_compose_rm.yaml
@@ -1,0 +1,43 @@
+command: docker compose rm
+short: Removes stopped service containers
+long: Removes stopped service containers
+usage: docker compose rm [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: force
+    shorthand: f
+    value_type: bool
+    default_value: "false"
+    description: Don't ask to confirm removal
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: stop
+    shorthand: s
+    value_type: bool
+    default_value: "false"
+    description: Stop the containers, if required, before removing
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: volumes
+    shorthand: v
+    value_type: bool
+    default_value: "false"
+    description: Remove any anonymous volumes attached to containers
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_run.yaml
+++ b/_data/compose-cli/docker_compose_run.yaml
@@ -1,0 +1,147 @@
+command: docker compose run
+short: Run a one-off command on a service.
+long: Run a one-off command on a service.
+usage: docker compose run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l
+    KEY=VALUE...] SERVICE [COMMAND] [ARGS...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: detach
+    shorthand: d
+    value_type: bool
+    default_value: "false"
+    description: Run container in background and print container ID
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: entrypoint
+    value_type: string
+    description: Override the entrypoint of the image
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: env
+    shorthand: e
+    value_type: stringArray
+    default_value: '[]'
+    description: Set environment variables
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: labels
+    shorthand: l
+    value_type: stringArray
+    default_value: '[]'
+    description: Add or override a label
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: name
+    value_type: string
+    description: ' Assign a name to the container'
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-TTY
+    shorthand: T
+    value_type: bool
+    default_value: "false"
+    description: |
+        Disable pseudo-tty allocation. By default docker compose run allocates a TTY
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-deps
+    value_type: bool
+    default_value: "false"
+    description: Don't start linked services.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: publish
+    shorthand: p
+    value_type: stringArray
+    default_value: '[]'
+    description: Publish a container's port(s) to the host.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: rm
+    value_type: bool
+    default_value: "false"
+    description: Automatically remove the container when it exits
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: service-ports
+    value_type: bool
+    default_value: "false"
+    description: |
+        Run command with the service's ports enabled and mapped to the host.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: use-aliases
+    value_type: bool
+    default_value: "false"
+    description: |
+        Use the service's network useAliases in the network(s) the container connects to.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: user
+    shorthand: u
+    value_type: string
+    description: Run as specified username or uid
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: volumes
+    shorthand: v
+    value_type: stringArray
+    default_value: '[]'
+    description: Bind mount a volume.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: workdir
+    shorthand: w
+    value_type: string
+    description: Working directory inside the container
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_start.yaml
+++ b/_data/compose-cli/docker_compose_start.yaml
@@ -1,0 +1,12 @@
+command: docker compose start
+short: Start services
+long: Start services
+usage: docker compose start [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_stop.yaml
+++ b/_data/compose-cli/docker_compose_stop.yaml
@@ -1,0 +1,23 @@
+command: docker compose stop
+short: Stop services
+long: Stop services
+usage: docker compose stop [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: timeout
+    shorthand: t
+    value_type: int
+    default_value: "10"
+    description: Specify a shutdown timeout in seconds
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_top.yaml
+++ b/_data/compose-cli/docker_compose_top.yaml
@@ -1,0 +1,12 @@
+command: docker compose top
+short: Display the running processes
+long: Display the running processes
+usage: docker compose top
+pname: docker compose
+plink: docker_compose.yaml
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_unpause.yaml
+++ b/_data/compose-cli/docker_compose_unpause.yaml
@@ -1,0 +1,12 @@
+command: docker compose unpause
+short: unpause services
+long: unpause services
+usage: docker compose unpause [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/compose-cli/docker_compose_up.yaml
+++ b/_data/compose-cli/docker_compose_up.yaml
@@ -1,0 +1,187 @@
+command: docker compose up
+short: Create and start containers
+long: Create and start containers
+usage: docker compose up [SERVICE...]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: abort-on-container-exit
+    value_type: bool
+    default_value: "false"
+    description: |
+        Stops all containers if any container was stopped. Incompatible with -d
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: always-recreate-deps
+    value_type: bool
+    default_value: "false"
+    description: |
+        Recreate dependent containers. Incompatible with --no-recreate.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: attach-dependencies
+    value_type: bool
+    default_value: "false"
+    description: Attach to dependent containers.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: build
+    value_type: bool
+    default_value: "false"
+    description: Build images before starting containers.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: detach
+    shorthand: d
+    value_type: bool
+    default_value: "false"
+    description: 'Detached mode: Run containers in the background'
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: environment
+    shorthand: e
+    value_type: stringArray
+    default_value: '[]'
+    description: Environment variables
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: exit-code-from
+    value_type: string
+    description: |
+        Return the exit code of the selected service container. Implies --abort-on-container-exit
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: force-recreate
+    value_type: bool
+    default_value: "false"
+    description: |
+        Recreate containers even if their configuration and image haven't changed.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-build
+    value_type: bool
+    default_value: "false"
+    description: Don't build an image, even if it's missing.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-color
+    value_type: bool
+    default_value: "false"
+    description: Produce monochrome output.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-deps
+    value_type: bool
+    default_value: "false"
+    description: Don't start linked services.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-log-prefix
+    value_type: bool
+    default_value: "false"
+    description: Don't print prefix in logs.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-recreate
+    value_type: bool
+    default_value: "false"
+    description: |
+        If containers already exist, don't recreate them. Incompatible with --force-recreate.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: no-start
+    value_type: bool
+    default_value: "false"
+    description: Don't start the services after creating them.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: remove-orphans
+    value_type: bool
+    default_value: "false"
+    description: |
+        Remove containers for services not defined in the Compose file.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: renew-anon-volumes
+    shorthand: V
+    value_type: bool
+    default_value: "false"
+    description: |
+        Recreate anonymous volumes instead of retrieving data from the previous containers.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: scale
+    value_type: stringArray
+    default_value: '[]'
+    description: |
+        Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: timeout
+    shorthand: t
+    value_type: int
+    default_value: "10"
+    description: |
+        Use this timeout in seconds for container shutdown when attached or when containers are already running.
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -506,6 +506,50 @@ reference:
           title: docker cluster version
     - path: /engine/reference/commandline/commit/
       title: docker commit
+    - sectiontitle: docker compose
+      section:
+        - path: /engine/reference/commandline/compose/
+          title: docker compose
+        - path: /engine/reference/commandline/compose_build/
+          title: docker compose build
+        - path: /engine/reference/commandline/compose_convert/
+          title: docker compose convert
+        - path: /engine/reference/commandline/compose_create/
+          title: docker compose create
+        - path: /engine/reference/commandline/compose_down/
+          title: docker compose down
+        - path: /engine/reference/commandline/compose_events/
+          title: docker compose events
+        - path: /engine/reference/commandline/compose_exec/
+          title: docker compose exec
+        - path: /engine/reference/commandline/compose_kill/
+          title: docker compose kill
+        - path: /engine/reference/commandline/compose_logs/
+          title: docker compose logs
+        - path: /engine/reference/commandline/compose_ls/
+          title: docker compose ls
+        - path: /engine/reference/commandline/compose_pause/
+          title: docker compose pause
+        - path: /engine/reference/commandline/compose_ps/
+          title: docker compose ps
+        - path: /engine/reference/commandline/compose_pull/
+          title: docker compose pull
+        - path: /engine/reference/commandline/compose_push/
+          title: docker compose push
+        - path: /engine/reference/commandline/compose_rm/
+          title: docker compose rm
+        - path: /engine/reference/commandline/compose_run/
+          title: docker compose run
+        - path: /engine/reference/commandline/compose_start/
+          title: docker compose start
+        - path: /engine/reference/commandline/compose_stop/
+          title: docker compose stop
+        - path: /engine/reference/commandline/compose_top/
+          title: docker compose top
+        - path: /engine/reference/commandline/compose_unpause/
+          title: docker compose unpause
+        - path: /engine/reference/commandline/compose_up/
+          title: docker compose up
     - sectiontitle: docker config
       section:
       - path: /engine/reference/commandline/config/

--- a/engine/reference/commandline/compose.md
+++ b/engine/reference/commandline/compose.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose
+title: docker compose
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_build.md
+++ b/engine/reference/commandline/compose_build.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_build
+title: docker compose build
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_convert.md
+++ b/engine/reference/commandline/compose_convert.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_convert
+title: docker compose convert
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_create.md
+++ b/engine/reference/commandline/compose_create.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_create
+title: docker compose create
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_down.md
+++ b/engine/reference/commandline/compose_down.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_down
+title: docker compose down
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_events.md
+++ b/engine/reference/commandline/compose_events.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_events
+title: docker compose events
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_exec.md
+++ b/engine/reference/commandline/compose_exec.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_exec
+title: docker compose exec
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_kill.md
+++ b/engine/reference/commandline/compose_kill.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_kill
+title: docker compose kill
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_logs.md
+++ b/engine/reference/commandline/compose_logs.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_logs
+title: docker compose logs
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_ls.md
+++ b/engine/reference/commandline/compose_ls.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_ls
+title: docker compose ls
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_pause.md
+++ b/engine/reference/commandline/compose_pause.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_pause
+title: docker compose pause
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_ps.md
+++ b/engine/reference/commandline/compose_ps.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_ps
+title: docker compose ps
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_pull.md
+++ b/engine/reference/commandline/compose_pull.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_pull
+title: docker compose pull
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_push.md
+++ b/engine/reference/commandline/compose_push.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_push
+title: docker compose push
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_rm.md
+++ b/engine/reference/commandline/compose_rm.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_rm
+title: docker compose rm
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_run.md
+++ b/engine/reference/commandline/compose_run.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_run
+title: docker compose run
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_start.md
+++ b/engine/reference/commandline/compose_start.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_start
+title: docker compose start
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_stop.md
+++ b/engine/reference/commandline/compose_stop.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_stop
+title: docker compose stop
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_top.md
+++ b/engine/reference/commandline/compose_top.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_top
+title: docker compose top
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_unpause.md
+++ b/engine/reference/commandline/compose_unpause.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_unpause
+title: docker compose unpause
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_up.md
+++ b/engine/reference/commandline/compose_up.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_up
+title: docker compose up
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
### Proposed changes

include reference documentation for the `docker compose` subcommand introduced by docker/compose-cli
yamldocs files are generated using https://github.com/docker/compose-cli/pull/1407

close https://github.com/docker/compose-cli/issues/1404