### PR TITLE
Update Desktop 3.2.0 release notes: Add note about docker.for.win.localhost removal

### DIFF
--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -50,6 +50,7 @@ This page contains information about the new features, improvements, known issue
 ### Deprecation
 
 - Docker Desktop cannot be installed on Windows 1709 (build 16299) anymore.
+- Removed the deprecated DNS name `docker.for.win.localhost`. Use DNS name `host.docker.internal` in a container to access services that are running on the host. [docker/for-win#10619](https://github.com/docker/for-win/issues/10619)
 
 ### Bug fixes and minor changes
 


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add a note that we have removed the DNS name `docker.for.win.localhost` in Docker Desktop for Windows 3.2.0.

### Related issues (optional)

https://github.com/docker/for-win/issues/10619
