### PR TITLE
Add a redirect from App template docs

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,4 +6,6 @@ title: Docker Documentation
 notoc: true
 notags: true
 skip_read_time: true
+redirect_from:
+- /app-template/working-with-template/
 ---


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Application template docs currently give a 404 as the docs have been removed from the repository. Added a redirect to point users to the docs homepage.