### PR TITLE
Minor typo correction in Python getting started guide

### DIFF
--- a/language/python/build-images.md
+++ b/language/python/build-images.md
@@ -131,7 +131,7 @@ CMD [ "python3", "-m" , "flask", "run", "--host=0.0.0.0"]
 
 ### Directory structure
 
-Just to recap, we created a directory in our local machine called `docker-python` and created a simple Python application using the Flask framework. We also used the `requirements.txt` file to gather our requirements, and created a Dockerfile containing the commands to build an image. The Python application directory structure would now look like:
+Just to recap, we created a directory in our local machine called `python-docker` and created a simple Python application using the Flask framework. We also used the `requirements.txt` file to gather our requirements, and created a Dockerfile containing the commands to build an image. The Python application directory structure would now look like:
 
 ```shell
 python-docker


### PR DESCRIPTION
### Proposed changes

Replaced `docker-python` directory reference with `python-docker` to reduce confusion when following the tutorial. The tutorial establishes creating a `python-docker` directory, so proposing this change to maintain consistency with instructions.