### PR TITLE
fix username for tagged image in github actions

### DIFF
--- a/language/nodejs/configure-ci-cd.md
+++ b/language/nodejs/configure-ci-cd.md
@@ -100,7 +100,7 @@ Now, we can add the steps required. The first one checks-out our repository unde
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ushamandya/simplewhale:latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/simplewhale:latest
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
@@ -153,7 +153,7 @@ Using the cache we set up earlier for it to store to and to retrieve
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags:  ushamandya/simplewhale:latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/simplewhale:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Image digest


### PR DESCRIPTION
the username is hardcoded, but should use the same secret from the first step

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I was getting an error when trying to push the image to Docker Hub. I'm guessing this was such a trivial thing that original authors assumed everyone would just know to not push to someone else's account name.

<!--Tell us what you did and why-->