### PR TITLE
recovered ssh agent forwarding documentation

### DIFF
--- a/docker-for-mac/networking.md
+++ b/docker-for-mac/networking.md
@@ -43,6 +43,32 @@ syntax for `-p` is `HOST_PORT:CLIENT_PORT`.
 
 See [Proxies](index.md#proxies).
 
+### SSH agent forwarding
+
+Docker Desktop for Mac allows you to use the host’s SSH agent inside a container. To do this:
+
+1. Bind mount the SSH agent socket by adding the following parameter to your `docker run` command:
+
+    `--mount type=bind,src=/run/host-services/ssh-auth.sock,target=/run/host-services/ssh-auth.sock`
+
+1. Add the `SSH_AUTH_SOCK` environment variable in your container:
+
+    `-e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"`
+
+To enable the SSH agent in Docker Compose, add the following flags to your service:
+
+ ```yaml
+services:
+  web:
+    image: nginx:alpine
+    volumes:
+      - type: bind
+        source: /run/host-services/ssh-auth.sock
+        target: /run/host-services/ssh-auth.sock
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+ ```
+
 ## Known limitations, use cases, and workarounds
 
 Following is a summary of current limitations on the Docker Desktop for {{Arch}}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The documentation about ssh agent forwarding got lost when osxfs.md was deleted.
So I just want to add the old documentation again at some place where users might look for it.

### Related issues (optional)
Deletion of osxfs.md: https://github.com/docker/docker.github.io/pull/11581
Commit of the old documentation that I would like to recover: https://github.com/docker/docker.github.io/commit/4dc68449055a8b734a1246004384de52144fd3fe#diff-124453101199ad6385df8981138b4ede623649e8b8b62ee7782be41830034b3a