### PR TITLE
Debugging the codeblock in the Linux install for Compose CLI

### DIFF
--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -37,6 +37,6 @@ For Docker Desktop installation instructions, see:
 
 You can install the new Compose CLI, including this Tech Preview, using the following install script:
 
-```console
+```bash
 curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
 ```

--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -37,6 +37,6 @@ For Docker Desktop installation instructions, see:
 
 You can install the new Compose CLI, including this Tech Preview, using the following install script:
 
-```bash
-curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
+```console
+$ curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
 ```


### PR DESCRIPTION
### Proposed changes

The text codeblock in [the Linux install block for Compose CLI](https://github.com/docker/docker.github.io/blob/master/compose/cli-command.md) ([web](https://docs.docker.com/compose/cli-command/)) is unselectionnable for some reason, it appears that the span that contains the code reports as a `go` class (see code)

```html
<code>
<span class="go">curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh</span>
</code>
```

In [_perldoc.scss](https://github.com/docker/docker.github.io/blob/master/_scss/_perldoc.scss) it says that *(l.21)*

> // Prevent selecting comments, command-output and command-prompt in shell
// examples that use the "console" lexer/highlighter to allow easier copying.

but I don't know why, this isn't working here (although it **is** working just as intended in other pages like [Completion page](https://github.com/docker/docker.github.io/blob/master/compose/completion.md) ([web](https://docs.docker.com/compose/completion/)) , no copy can be done, the browser has no idea of what the cursor is hovering over so for installing the Compose CLI this is really kinda hard

I replaced the `console` lang with a `bash` lang and it is woking fine