### PR TITLE
Remove a link from the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -63,7 +63,6 @@
                 <nav class="footer_sub_nav">
                     <ul class="menu">
                         <li><a href="http://status.docker.com/">Status</a></li>
-                        <li><a href="https://www.docker.com/docker-security">Security</a></li>
                         <li><a href="https://www.docker.com/legal">Legal</a></li>
                         <li><a href="https://www.docker.com/company/contact">Contact</a></li>
                     </ul>


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Removed a link to Docker Security which was pointing to an outdated page. Need to restore this when we have an update page.