### PR TITLE
Stop telling people not to install security updates

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -469,13 +469,6 @@ Probably the most common use-case for `RUN` is an application of `apt-get`.
 Because it installs packages, the `RUN apt-get` command has several gotchas to
 look out for.
 
-Avoid `RUN apt-get upgrade` and `dist-upgrade`, as many of the "essential"
-packages from the parent images cannot upgrade inside an
-[unprivileged container](../../engine/reference/run.md#security-configuration). If a package
-contained in the parent image is out-of-date, contact its maintainers. If you
-know there is a particular package, `foo`, that needs to be updated, use
-`apt-get install -y foo` to update automatically.
-
 Always combine `RUN apt-get update` with `apt-get install` in the same `RUN`
 statement. For example:
 


### PR DESCRIPTION
### Proposed changes

Get rid of terrible advice to not install security updates.

See https://pythonspeed.com/articles/security-updates-in-docker/ for detailed explanation of why this is bad advice, debunking the specific points on this page.

### Related issues (optional)

I've already gotten OWASP to fix this in their Docker Security cheatsheet (https://github.com/OWASP/CheatSheetSeries/pull/614), and I have an issue open for Hadolint (https://github.com/hadolint/hadolint/issues/562).