### PR TITLE
reference: prefix usage output with a prompt to allow copying

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -81,7 +81,7 @@ your client and daemon API versions.
 ## Usage
 
 ```console
-{{ controller_data.usage | replace: tabChar, "" | strip }}{% if controller_data.cname %} COMMAND{% endif %}
+$ {{ controller_data.usage | replace: tabChar, "" | strip }}{% if controller_data.cname %} COMMAND{% endif %}
 ```
 
 {% endif %}


### PR DESCRIPTION
Although the usage example is not directly "runnable", it doesn't hurt to allow copying them.

