### PR TITLE
Adding sudo command

### DIFF
--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -21,6 +21,16 @@ If you don't want to preface the `docker` command with `sudo`, create a Unix
 group called `docker` and add users to it. When the Docker daemon starts, it
 creates a Unix socket accessible by members of the `docker` group.
 
+> **Note**: 
+> 
+> For Docker: 
+If you run this command: "docker pull registry.gitlab.com/fsci/resources:debian-dev" you might get a message that access is denied.
+Just add sudo in front and it will run just fine. 
+That's one way around.
+
+This is because on production servers, you would prefer to avoid running docker as root user (as that would mean that docker gets access to the entire computer and any insecurities in docker can lead to your server being compromised). And therefore in such systems you would do this:
+sudo docker pull registry.gitlab.com/fsci/resources:debian-dev 
+
 > Warning
 >
 > The `docker` group grants privileges equivalent to the `root`


### PR DESCRIPTION
When running the command to pull the development docker image that FSCI provides, you can encounter access denial as a non-root user, you can add sudo as prefix (before) the command: docker pull registry.gitlab.com/fsci/resources:debian-dev

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
