### PR TITLE
Fix missing htpasswd script

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -407,9 +407,7 @@ secrets.
 
     ```bash
     $ mkdir auth
-    $ docker run \
-      --entrypoint htpasswd \
-      registry:2 -Bbn testuser testpassword > auth/htpasswd
+    $ docker run --rm xmartlabs/htpasswd testuser testpassword > auth/htpasswd
     ```
 
 2.  Stop the registry.


### PR DESCRIPTION
I ran into a missing executable when following the documentation for deploying the registry with a htpasswd file, see https://docs.docker.com/registry/deploying/.
The image `registry:2` does not contain a `htpasswd` binary anymore:
```
starting container process caused "exec: \"htpasswd\": executable file not found in $PATH": unknown.
```
Searching it via `find / --name htpasswd` inside the image gave no results.
Assuming that it is intended to have a small and clean `registry` image I propose to fix the documentation by using  `xmartlabs/htpasswd` instead. It provides the `-Bbn` option by default.
