### PR TITLE
Reduce duplication by referencing existing rootless Docker docs

### DIFF
--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -43,32 +43,13 @@ $ sudo sh get-docker.sh
 <...>
 ```
 
-If you would like to use Docker as a non-root user, you should now consider
-adding your user to the "docker" group with something like:
-
-```console
-$ sudo usermod -aG docker <your-user>
-```
-
-Remember to log out and back in for this to take effect!
-
-> **Warning**:
->
-> Adding a user to the "docker" group grants them the ability to run containers
-> which can be used to obtain root privileges on the Docker host. Refer to
-> [Docker Daemon Attack Surface](/engine/security/#docker-daemon-attack-surface)
-> for more information.
-{:.warning}
+If you would like to use Docker as a non-root user please see the
+[post-installation steps for Linux](linux-postinstall.md#manage-docker-as-a-non-root-user).
 
 Docker Engine - Community is installed. It starts automatically on `DEB`-based distributions. On
 `RPM`-based distributions, you need to start it manually using the appropriate
 `systemctl` or `service` command. As the message indicates, non-root users can't
 run Docker commands by default.
-
-> **Note**:
->
-> To install Docker without root privileges, see
-> [Run the Docker daemon as a non-root user (Rootless mode)](/engine/security/rootless/).
 
 #### Upgrade Docker after using the convenience script
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

There are instructions about rootless install on https://docs.docker.com/engine/install/ubuntu/ that are duplicated between that page and https://docs.docker.com/engine/install/linux-postinstall/. This change reduces duplication and creates one canonical location for info about rootless installs.

As a user trying to install Docker in a rootless fashion just for regular use (i.e. not for contributing to Docker itself) I was very confused as to whether this was possible or how to do it. I was on https://docs.docker.com/engine/install/ubuntu/ and did a Ctrl+F for "root" and the only info was under the convenience script section, which wasn't really relevant to me as a user installing from the repository. It turns out this info lived on the "Post-installation steps for Linux" page. If that page had been linked to under the convenience script section I would have discovered the info more more easily and realized it was applicable to all Linux users and not just convenience script users. Another possible solution might be to move it out from the convenience script section and put it someplace relevance to any installation method. However, that seemed like an additional possibly slightly larger change, so I did it this way to keep the change a bit smaller.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
