### PR TITLE
engine: update list of distros that we build on

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -22,8 +22,10 @@ To get started with Docker Engine on Debian, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Debian or
 Raspbian versions:
 
+- Debian Bullseye 11 (testing)
 - Debian Buster 10 (stable)
-- Debian Stretch 9 / Raspbian Stretch
+- Raspbian Bullseye 11 (testing)
+- Raspbian Buster 10 (stable)
 
 Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -22,6 +22,7 @@ To install Docker Engine, you need the 64-bit version of one of these Fedora ver
 
 - Fedora 32
 - Fedora 33
+- Fedora 34
 
 ### Uninstall old versions
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -24,6 +24,7 @@ To get started with Docker Engine on Ubuntu, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
+- Ubuntu Hirsute 21.04
 - Ubuntu Groovy 20.10
 - Ubuntu Focal 20.04 (LTS)
 - Ubuntu Bionic 18.04 (LTS)


### PR DESCRIPTION
relates to https://github.com/docker/docker.github.io/pull/12604

Adds new distros:

- Ubuntu 21.04 "hirsute hippo"
- Debian 11 "bullseye"
- Fedora 34

Removes Debian 9 "stretch", which reached EOL in upstream Debian
