### PR TITLE
Add --service-ports note to ports section

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -1641,7 +1641,7 @@ Expose ports.
 
 > **Note**
 >
-> `ports` is ignored by `docker-compose run` unless you include `--service-ports`
+> `docker-compose run` ignores `ports` unless you include `--service-ports`.
 
 #### Short syntax
 

--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -1639,6 +1639,10 @@ Expose ports.
 >
 > Port mapping is incompatible with `network_mode: host`
 
+> **Note**
+>
+> `ports` is ignored by `docker-compose run` unless you include `--service-ports`
+
 #### Short syntax
 
 There are three options: 


### PR DESCRIPTION
## Description

Add note in `ports` section of file reference docs pointing to the `run` command's `--service-ports` flag

## Motivation

Spent quite a few hours spinning my wheels before I came across `run`'s `--service-ports` flag.

I'm struggling to find the issue where I found this, but the comment pointing to `--service-ports` had a lot of reacts, so this might be a relatively common mistake

## Things I'd still like to do

- [ ] link to the [`--service-ports` docs](https://github.com/docker/docker.github.io/blob/master/compose/reference/run.md) -- not sure how to do this
- [ ] clean up location of this note -- not sure if I've put the note in a good place -- we can shunt it to the bottom
- [ ] Duplicate for older versions

Thanks

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

