### PR TITLE
Clarify the source name of secrets and configs

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -501,7 +501,7 @@ configs:
 The long syntax provides more granularity in how the config is created within
 the service's task containers.
 
-- `source`: The name of the config as it exists in Docker.
+- `source`: The identifier of the config as it is defined in this configuration.
 - `target`: The path and name of the file to be mounted in the service's
   task containers. Defaults to `/<source>` if not specified.
 - `uid` and `gid`: The numeric UID or GID that owns the mounted config file
@@ -1778,7 +1778,7 @@ secrets:
 The long syntax provides more granularity in how the secret is created within
 the service's task containers.
 
-- `source`: The name of the secret as it exists in Docker.
+- `source`: The identifier of the secret as it is defined in this configuration.
 - `target`: The name of the file to be mounted in `/run/secrets/` in the
   service's task containers. Defaults to `source` if not specified.
 - `uid` and `gid`: The numeric UID or GID that owns the file within


### PR DESCRIPTION
### Proposed changes

The current wording of `source` field for `configs` and `secrets` ("name of the config as it exists in Docker") suggests that the name as in `docker config ls` is used, this is not correct and instead the "key" of `configs` object in the docker-compose file is used. 

```yml
version: "3.5"

services:
  app:
    image: alpine
    configs:
      # documentation currently suggests this ("name as in Docker")
      # this causes an error- undefined config "name-as-in-docker"
      - source: name-as-in-docker
        target: /config-with-name-as-in-docker.json

      # the correct source to use is the name (key/identifier) from this docker-compose file
      - source: name-as-in-file
        target: /config-with-name-as-in-file.json

configs:
  name-as-in-file:
    name: name-as-in-docker
    file: ./cfg.json
```