### PR TITLE
config/containers/runmetrics.md: cgroup v2 graduated from experimental

### DIFF
--- a/config/containers/runmetrics.md
+++ b/config/containers/runmetrics.md
@@ -101,7 +101,7 @@ and run `sudo update-grub`.
 
 ### Running Docker on cgroup v2
 
-Docker supports cgroup v2 experimentally since Docker 20.10.
+Docker supports cgroup v2 since Docker 20.10.
 Running Docker on cgroup v2 also requires the following conditions to be satisfied:
 * containerd: v1.4 or later
 * runc: v1.0.0-rc91 or later


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

```diff
- Docker supports cgroup v2 experimentally since Docker 20.10.
+ Docker supports cgroup v2 since Docker 20.10.
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
Docker support for cgroup v2 graduated from experimental in v20.10.6.
https://github.com/moby/moby/pull/42263

