### PR TITLE
Fixes docker/distribution-library-image/issues/107

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -409,7 +409,13 @@ secrets.
     $ mkdir auth
     $ docker run \
       --entrypoint htpasswd \
-      registry:2 -Bbn testuser testpassword > auth/htpasswd
+      httpd:2 -Bbn testuser testpassword > auth/htpasswd
+    ```
+    
+    On Windows, make sure the output file is correctly encoded:
+
+    ```powershell
+    docker run --rm --entrypoint htpasswd httpd:2 -Bbn testuser testpassword | Set-Content -Encoding ASCII auth/htpasswd
     ```
 
 2.  Stop the registry.


### PR DESCRIPTION
The registry docker image no longer contains htpasswd.

### Proposed changes

The documentation was outdated, as the htpasswd executable was removed from the registry image.

### Related issues (optional)

Fixes docker/distribution-library-image/issues/107
