### PR TITLE
Update examples.md (Add parameter platform value is nil)

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -186,7 +186,7 @@ func main() {
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: imageName,
-	}, nil, nil, "")
+	}, nil, nil, nil, "")
 	if err != nil {
 		panic(err)
 	}
@@ -732,7 +732,7 @@ func main() {
 	createResp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: "alpine",
 		Cmd:   []string{"touch", "/helloworld"},
-	}, nil, nil, "")
+	}, nil, nil, nil, "")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Proposed changes
Add parameter platform value is ``nil`` in function ``cli.ContainerCreate`` 

Before example -> ``Run a container in the background``
```go
resp, err := cli.ContainerCreate(ctx, &container.Config{
    Image: imageName,
}, nil, nil, "")
```

After example -> ``Run a container in the background``

```go
resp, err := cli.ContainerCreate(ctx, &container.Config{
    Image: imageName,
}, nil, nil, nil, "")
```

Before example -> ``Commit a container``

```go
createResp, err := cli.ContainerCreate(ctx, &container.Config{
    Image: "alpine",
    Cmd:   []string{"touch", "/helloworld"},
}, nil, nil, "")
```

After example -> ``Commit a container``

```go
createResp, err := cli.ContainerCreate(ctx, &container.Config{
    Image: "alpine",
    Cmd:   []string{"touch", "/helloworld"},
}, nil, nil, nil, "")
```
