### PR TITLE
Fix samples redirect, and remove old sshd from TOC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1158,8 +1158,6 @@ samples:
     title: Rails and PostgreSQL
   - path: /samples/running_riak_service/
     title: Riak
-  - path: /samples/running_ssh_service/
-    title: SSHd
 - path: /samples/#library-references
   title: Library references
 

--- a/_samples/library/wordpress.md
+++ b/_samples/library/wordpress.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/wordpress/
-redirect_from:
-- /samples/wordpress/
 ---

--- a/samples/index.md
+++ b/samples/index.md
@@ -42,7 +42,6 @@ Run popular software using Docker.
 | [PostgreSQL](postgresql_service.md)                           | Run a Dockerized PostgreSQL instance.                     |
 | [Rails + PostgreSQL](rails.md)                                | Run a Dockerized Rails + PostgreSQL environment.          |
 | [Riak](running_riak_service.md)                               | Run a Dockerized Riak instance.                           |
-| [SSHd](running_ssh_service.md)                                | Run a Dockerized SSHd instance.                           |
 | [WordPress](wordpress.md)                                     | Quickstart: Compose and WordPress.                        |
 
 ## Samples and documentation for official Docker images {#library-references}


### PR DESCRIPTION
- The /samples/wordpress/ location collided with an old redirect to the official images, so removed the redirect
- Removed the sshd example from the table and TOC, as the example   was removed, and now pointing to an alternative examples. The   page is kept for people that may have bookmarked it, but no  need to include it in the navigation.
