### PR TITLE
`condition` is supported for `depends_on`

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -654,7 +654,6 @@ services:
 >   starting `web` - only until they have been started. If you need to wait
 >   for a service to be ready, see [Controlling startup order](../startup-order.md)
 >   for more on this problem and strategies for solving it.
-> - Version 3 no longer supports the `condition` form of `depends_on`.
 > - The `depends_on` option is ignored when
 >   [deploying a stack in swarm mode](../../engine/reference/commandline/stack_deploy.md)
 >   with a version 3 Compose file.


### PR DESCRIPTION
Removed a statement about `condition` not being supported for `depends_on` in Version 3, as it is supported.

### Proposed changes

Remove the statement regarding Version 3 of the Docker Compose file not supporting `condition`. As seen in https://github.com/porterdarby/docker-compose-condition-test, the `condition` field works when used with the `depends_on` field for Docker Compose file with Version 3.