### PR TITLE
Doc currently_tagged filter for image list API

### DIFF
--- a/docker-hub/api/latest.yaml
+++ b/docker-hub/api/latest.yaml
@@ -530,6 +530,14 @@ paths:
           description: Filters to only show images of this status.
           type: string
           enum: [active, inactive]
+        - name: currently_tagged
+          in: query
+          required: false
+          type: boolean
+          description: | 
+            Filters to only show images with:
+            * `true`: at least 1 current tag.
+            * `false`: no current tags.
         - name: ordering
           in: query
           required: false


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Adds the `currently_tagged` query parameter to the Advance Image Management - List Images API documentation. This filter has been added to the Docker Hub API already and allows consumers to list only images that have 0 or at least 1 current tags. Not including the query parameter will return images regardless of whether they have current tags or not.
This filter combines with the `status` filter
