### PR TITLE
Fix YAML indentation for CI/CD guides

### DIFF
--- a/language/java/configure-ci-cd.md
+++ b/language/java/configure-ci-cd.md
@@ -210,7 +210,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
-        registry: ghcr.io
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 ```

--- a/language/nodejs/configure-ci-cd.md
+++ b/language/nodejs/configure-ci-cd.md
@@ -209,7 +209,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
-        registry: ghcr.io
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 ```

--- a/language/python/configure-ci-cd.md
+++ b/language/python/configure-ci-cd.md
@@ -209,7 +209,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
-        registry: ghcr.io
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 ```


### PR DESCRIPTION
### Proposed changes

This fixes bad YAML indentation in the Python, NodeJs, and Java CI-CD guides, which caused a syntax error when the GitHub Action is run.
