### PR TITLE
_scss: don't use "all caps" for H4

### DIFF
--- a/_scss/_typography.scss
+++ b/_scss/_typography.scss
@@ -60,8 +60,7 @@ h3 {
 }
 
 h4 {
-    font-size: 16px;
-    text-transform: uppercase;
+    font-size: 18px;
 }
 
 h5 {


### PR DESCRIPTION
Change H4's to not be presented in "all caps". To compensate, the font
size is increased from 16px to 18px (otherwise it would be the same size
as H5 headings).

Before:

<img width="999" alt="Screenshot 2021-04-28 at 14 37 37" src="https://user-images.githubusercontent.com/1804568/116405079-8ac49380-a82f-11eb-806f-0dcffe984a9e.png">

After:

<img width="1003" alt="Screenshot 2021-04-28 at 14 36 47" src="https://user-images.githubusercontent.com/1804568/116405112-93b56500-a82f-11eb-94bb-c2594a1b51c3.png">

