### PR TITLE
Remove trailing dot from filename

### DIFF
--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -32,7 +32,7 @@ You can set default values for any environment variables referenced in the
 Compose file, or used to configure Compose, in an [environment file](env-file.md)
 named `.env`. The `.env` file path is as follows:
 
-  - Starting with `+v1.28`, `.env.` file is placed at the base of the project directory 
+  - Starting with `+v1.28`, `.env` file is placed at the base of the project directory 
   - For previous versions, it is placed in the current working directory where the
   Docker Compose command is executed unless a `--project-directory` is defined which
   overrides the path for the `.env` file. This inconsistency is addressed


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

There was a trailing dot, resulting in `.env.` instead of `.env`. This removes that dot.
<!--Tell us what you did and why-->