### PR TITLE
startup-order: fix example executing unquoted cmd

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -69,7 +69,6 @@ script:
   
   host="$1"
   shift
-  cmd="$@"
   
   until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$host" -U "postgres" -c '\q'; do
     >&2 echo "Postgres is unavailable - sleeping"
@@ -77,7 +76,7 @@ script:
   done
   
   >&2 echo "Postgres is up - executing command"
-  exec $cmd
+  exec "$@"
   ```
 
   You can use this as a wrapper script as in the previous example, by setting:


### PR DESCRIPTION
### Proposed changes

Using `"$@"` in variable assignment is very confusing, because in that context it behaves like `"$*"`.

`exec $cmd` performs field splitting and pathname expansion on the cmd string, which has surprising effect if some of the original parameters contain spaces or wildcards.

The correct way to execute command from positional parameters is `exec "$@"`
