### PR TITLE
desktop (for mac) remove "button" styling for older release downloads

### DIFF
--- a/docker-for-mac/release-notes.md
+++ b/docker-for-mac/release-notes.md
@@ -64,8 +64,8 @@ This page contains information about the new features, improvements, known issue
 ## Docker Desktop 3.3.3
 2021-05-06
 
-[Mac with Intel chip](https://desktop.docker.com/mac/stable/amd64/64133/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64)
-[Mac with Apple chip](https://desktop.docker.com/mac/stable/arm64/64133/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64)
+[Download for Mac with Intel chip](https://desktop.docker.com/mac/stable/amd64/64133/Docker.dmg)
+[Download for Mac with Apple chip](https://desktop.docker.com/mac/stable/arm64/64133/Docker.dmg)
 
 ### Upgrades
 
@@ -79,8 +79,8 @@ This page contains information about the new features, improvements, known issue
 ### Docker Desktop 3.3.2
 2021-05-03
 
-[Mac with Intel chip](https://desktop.docker.com/mac/stable/amd64/63878/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64)
-[Mac with Apple chip](https://desktop.docker.com/mac/stable/arm64/63878/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64)
+[Download for Mac with Intel chip](https://desktop.docker.com/mac/stable/amd64/63878/Docker.dmg)
+[Download for Mac with Apple chip](https://desktop.docker.com/mac/stable/arm64/63878/Docker.dmg)
 
 ### Upgrades
 
@@ -104,8 +104,8 @@ This page contains information about the new features, improvements, known issue
 ## Docker Desktop 3.3.1
 2021-04-15
 
-[Mac with Intel chip](https://desktop.docker.com/mac/stable/amd64/63152/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64)
-[Mac with Apple chip](https://desktop.docker.com/mac/stable/arm64/63152/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64)
+[Download for Mac with Intel chip](https://desktop.docker.com/mac/stable/amd64/63152/Docker.dmg)
+[Download for Mac with Apple chip](https://desktop.docker.com/mac/stable/arm64/63152/Docker.dmg)
 
 ### New
 

--- a/docker-for-windows/release-notes.md
+++ b/docker-for-windows/release-notes.md
@@ -68,7 +68,7 @@ This page contains information about the new features, improvements, known issue
 ## Docker Desktop 3.3.2
 2021-05-03
 
-> [Download](https://desktop.docker.com/win/stable/amd64/63878/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64)
+> [Download](https://desktop.docker.com/win/stable/amd64/63878/Docker%20Desktop%20Installer.exe)
 
 ### Upgrades
 
@@ -88,7 +88,7 @@ This page contains information about the new features, improvements, known issue
 ## Docker Desktop 3.3.1
 2021-04-15
 
-> [Download](https://desktop.docker.com/win/stable/amd64/63152/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64)
+> [Download](https://desktop.docker.com/win/stable/amd64/63152/Docker%20Desktop%20Installer.exe)
 
 ### Bug fixes and minor changes
 


### PR DESCRIPTION
Only show the latest release download links as a CTA button, and older
releases as regular links.

