### PR TITLE
Added instructions on how to deal with MacOS security measures

### DIFF
--- a/engine/install/binaries.md
+++ b/engine/install/binaries.md
@@ -136,7 +136,7 @@ The macOS binary includes the Docker client only. It does not include the
     $ tar xzvf /path/to/<FILE>.tar.gz
     ```
 
-3.  Clear the extended attributes to allow it to be run.
+3.  Clear the extended attributes to allow it run.
     
     In case executing `docker/docker` you get the error message: *'docker' is*
     *damaged and cannot be opened. You should move it to the bin.*
@@ -145,13 +145,14 @@ The macOS binary includes the Docker client only. It does not include the
     mechanism preventing us running the executable.
     
     ```console
-    # Recursively clear all entended attributes
-    sudo xattr -rc docker
+    $ sudo xattr -rc docker
     ```
     
-    Test again: `docker/docker`
+    Now, when you run the following command, you can see the Docker CLI usage instructions:
     
-    Now you should get the well know help text.
+    ```console
+    $ docker/docker
+    ```
 
 4.  **Optional**: Move the binary to a directory on your executable path, such
     as `/usr/local/bin/`. If you skip this step, you must provide the path to the

--- a/engine/install/binaries.md
+++ b/engine/install/binaries.md
@@ -136,7 +136,24 @@ The macOS binary includes the Docker client only. It does not include the
     $ tar xzvf /path/to/<FILE>.tar.gz
     ```
 
-3.  **Optional**: Move the binary to a directory on your executable path, such
+3.  Clear the extended attributes to allow it to be run.
+    
+    In case executing `docker/docker` you get the error message: *'docker' is*
+    *damaged and cannot be opened. You should move it to the bin.*
+    
+    Apple takes care about our security. Hence, we need to remove the security 
+    mechanism preventing us running the executable.
+    
+    ```console
+    # Recursively clear all entended attributes
+    sudo xattr -rc docker
+    ```
+    
+    Test again: `docker/docker`
+    
+    Now you should get the well know help text.
+
+4.  **Optional**: Move the binary to a directory on your executable path, such
     as `/usr/local/bin/`. If you skip this step, you must provide the path to the
     executable when you invoke `docker` or `dockerd` commands.
 
@@ -144,7 +161,7 @@ The macOS binary includes the Docker client only. It does not include the
     $ sudo cp docker/docker /usr/local/bin/
     ```
 
-4.  Verify that Docker is installed correctly by running the `hello-world`
+5.  Verify that Docker is installed correctly by running the `hello-world`
     image. The value of `<hostname>` is a hostname or IP address running the
     Docker daemon and accessible to the client.
 


### PR DESCRIPTION
Mac OS prevents downloaded files to be executed.

Added the description how to allow it again.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
