### PR TITLE
Add missing docker compose cli commands

### DIFF
--- a/_data/compose-cli/docker_compose.yaml
+++ b/_data/compose-cli/docker_compose.yaml
@@ -14,9 +14,11 @@ cname:
   - docker compose logs
   - docker compose ls
   - docker compose pause
+  - docker compose port
   - docker compose ps
   - docker compose pull
   - docker compose push
+  - docker compose restart
   - docker compose rm
   - docker compose run
   - docker compose start
@@ -35,9 +37,11 @@ clink:
   - docker_compose_logs.yaml
   - docker_compose_ls.yaml
   - docker_compose_pause.yaml
+  - docker_compose_port.yaml
   - docker_compose_ps.yaml
   - docker_compose_pull.yaml
   - docker_compose_push.yaml
+  - docker_compose_restart.yaml
   - docker_compose_rm.yaml
   - docker_compose_run.yaml
   - docker_compose_start.yaml
@@ -118,4 +122,3 @@ experimental: false
 experimentalcli: false
 kubernetes: false
 swarm: false
-

--- a/_data/compose-cli/docker_compose_port.yaml
+++ b/_data/compose-cli/docker_compose_port.yaml
@@ -1,0 +1,30 @@
+command: docker compose port
+short: Print the public port for a port binding.
+long: Print the public port for a port binding.
+usage: docker compose port [options] [--] SERVICE PRIVATE_PORT
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: index
+    value_type: int
+    default_value: "1"
+    description: index of the container if service has multiple replicas
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+  - option: protocol
+    value_type: string
+    default_value: tcp
+    description: tcp or udp
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false

--- a/_data/compose-cli/docker_compose_restart.yaml
+++ b/_data/compose-cli/docker_compose_restart.yaml
@@ -1,0 +1,22 @@
+command: docker compose restart
+short: Restart containers
+long: Restart containers
+usage: docker compose restart
+pname: docker compose
+plink: docker_compose.yaml
+options:
+  - option: timeout
+    shorthand: t
+    value_type: int
+    default_value: "10"
+    description: Specify a shutdown timeout in seconds
+    deprecated: false
+    experimental: false
+    experimentalcli: false
+    kubernetes: false
+    swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -546,12 +546,16 @@ reference:
           title: docker compose ls
         - path: /engine/reference/commandline/compose_pause/
           title: docker compose pause
+        - path: /engine/reference/commandline/compose_port/
+          title: docker compose port
         - path: /engine/reference/commandline/compose_ps/
           title: docker compose ps
         - path: /engine/reference/commandline/compose_pull/
           title: docker compose pull
         - path: /engine/reference/commandline/compose_push/
           title: docker compose push
+        - path: /engine/reference/commandline/compose_restart/
+          title: docker compose restart
         - path: /engine/reference/commandline/compose_rm/
           title: docker compose rm
         - path: /engine/reference/commandline/compose_run/

--- a/engine/reference/commandline/compose_port.md
+++ b/engine/reference/commandline/compose_port.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_port
+title: docker compose port
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_restart.md
+++ b/engine/reference/commandline/compose_restart.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_restart
+title: docker compose restart
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose-cli
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
This PR adds the missing commands "docker compose port" and "docker compose restart".