### PR TITLE
Reorganize toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -7,7 +7,7 @@ horizontalnav:
   path: /get-started/overview/
   node: guides
 - title: Product manuals
-  path: /engine/
+  path: /desktop/
   node: manuals
 - title: Reference
   path: /reference/
@@ -398,6 +398,8 @@ guides:
 - path: /docsarchive/
   title: Documentation archive
 reference:
+- path: /reference/
+  title: Reference documentation
 - sectiontitle: Command-line reference
   section:
   - sectiontitle: Docker CLI (docker)
@@ -1142,12 +1144,12 @@ reference:
 
 
 samples:
+- path: /samples/
+  title: Samples overview
 - path: /samples/#tutorial-labs
   title: Tutorial labs
 - sectiontitle: Sample applications
   section:
-  - path: /samples/
-    title: Samples home
   - path: /samples/apt-cacher-ng/
     title: apt-cacher-ng
   - path: /samples/dotnetcore/
@@ -1170,6 +1172,53 @@ samples:
   title: Library references
 
 manuals:
+- sectiontitle: Docker Desktop
+  section:
+    - path: /desktop/
+      title: Overview
+    - sectiontitle: Mac
+      section:
+        - path: /docker-for-mac/install/
+          title: Install Docker Desktop for Mac
+        - path: /docker-for-mac/
+          title: User manual
+        - path: /docker-for-mac/networking/
+          title: Networking
+        - path: /docker-for-mac/space/
+          title: Disk utilization
+        - path: /docker-for-mac/troubleshoot/
+          title: Logs and troubleshooting
+        - path: /docker-for-mac/release-notes/
+          title: Release notes
+        - path: /docker-for-mac/apple-silicon/
+          title: Apple silicon
+    - sectiontitle: Windows
+      section:
+        - path: /docker-for-windows/install/
+          title: Install Docker Desktop for Windows
+        - path: /docker-for-windows/
+          title: User manual
+        - path: /docker-for-windows/networking/
+          title: Networking
+        - path: /docker-for-windows/troubleshoot/
+          title: Logs and troubleshooting
+        - path: /docker-for-windows/release-notes/
+          title: Release notes
+        - path: /docker-for-windows/wsl/
+          title: Docker Desktop WSL 2 backend
+    - path: /desktop/dashboard/
+      title: Dashboard
+    - path: /desktop/multi-arch/
+      title: Multi-arch support
+    - path: /desktop/kubernetes/
+      title: Deploy on Kubernetes
+    - path: /desktop/faqs/
+      title: FAQs
+    - path: /desktop/backup-and-restore/
+      title: Back up and restore data
+    - path: /desktop/opensource/
+      title: Open source licensing
+
 - sectiontitle: Docker Engine
   section:
   - path: /engine/
@@ -1276,52 +1325,7 @@ manuals:
     title: Sample apps with Compose
   - path: /compose/release-notes/
     title: Release notes
-- sectiontitle: Docker Desktop
-  section:
-  - path: /desktop/
-    title: Overview
-  - sectiontitle: Mac
-    section:
-    - path: /docker-for-mac/install/
-      title: Install Docker Desktop for Mac
-    - path: /docker-for-mac/
-      title: User manual
-    - path: /docker-for-mac/networking/
-      title: Networking
-    - path: /docker-for-mac/space/
-      title: Disk utilization
-    - path: /docker-for-mac/troubleshoot/
-      title: Logs and troubleshooting
-    - path: /docker-for-mac/release-notes/
-      title: Release notes
-    - path: /docker-for-mac/apple-silicon/
-      title: Apple silicon
-  - sectiontitle: Windows
-    section:
-    - path: /docker-for-windows/install/
-      title: Install Docker Desktop for Windows
-    - path: /docker-for-windows/
-      title: User manual
-    - path: /docker-for-windows/networking/
-      title: Networking
-    - path: /docker-for-windows/troubleshoot/
-      title: Logs and troubleshooting
-    - path: /docker-for-windows/release-notes/
-      title: Release notes
-    - path: /docker-for-windows/wsl/
-      title: Docker Desktop WSL 2 backend
-  - path: /desktop/dashboard/
-    title: Dashboard
-  - path: /desktop/multi-arch/
-    title: Multi-arch support
-  - path: /desktop/kubernetes/
-    title: Deploy on Kubernetes
-  - path: /desktop/faqs/
-    title: FAQs
-  - path: /desktop/backup-and-restore/
-    title: Back up and restore data
-  - path: /desktop/opensource/
-    title: Open source licensing
+
 - sectiontitle: Docker Hub
   section:
   - path: /docker-hub/

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -93,7 +93,7 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
-        <a class="card manuals" href="/engine/">
+        <a class="card manuals" href="/desktop/">
           <h5 class="title">Product manuals</h5>
           <p>
             Browse through the manuals and learn how to use Docker products.


### PR DESCRIPTION
- move "docker desktop" to the top of the "product manuals" section,
  and make it the default page
- Add a "Reference documentation" menu item to the TOC, which will be
  the "active" menu item when opening the reference section.
- move the "Samples home" menu item outside of the "samples" sub-menu,
  and add it at the top level as "samples overview", so that the "index"
  highlights that menu-item without opening the "samples" sub-menu. The
  "samples" submenu contains various samples which are a bit outdated,
  so probably shouldn't be _that_ prominent when opening the page.
  Moving the menu item also makes the "breadcrumb" navigation more
  natural (moving from a sample to "samples overview" navigates back
  to the "top" of the samples section.

With this change:

<img width="1300" alt="Screenshot 2021-05-20 at 19 24 21" src="https://user-images.githubusercontent.com/1804568/119022564-1948b280-b9a1-11eb-8a44-cb03752e916a.png">
<img width="1339" alt="Screenshot 2021-05-20 at 19 24 32" src="https://user-images.githubusercontent.com/1804568/119022577-1c43a300-b9a1-11eb-9191-70efa4e5604b.png">
<img width="1321" alt="Screenshot 2021-05-20 at 19 24 53" src="https://user-images.githubusercontent.com/1804568/119022580-1cdc3980-b9a1-11eb-82d1-b35f44268e36.png">

