### PR TITLE
remove some ee "stubs", and move redirects

### DIFF
--- a/docker-for-windows/install.md
+++ b/docker-for-windows/install.md
@@ -3,7 +3,12 @@ description: How to install Docker Desktop for Windows
 keywords: windows, install, download, run, docker, local
 title: Install Docker Desktop on Windows
 redirect_from:
+- /docker-ee-for-windows/install/
 - /docker-for-windows/install-windows-home/
+- /ee/docker-ee/windows/docker-ee/
+- /engine/installation/windows/docker-ee/
+- /install/windows/docker-ee/
+- /install/windows/ee-preview/
 ---
 
 Welcome to Docker Desktop for Windows. This page contains information about Docker Desktop for Windows system requirements, download URL, installation instructions, and automatic updates.

--- a/ee/docker-ee/centos.md
+++ b/ee/docker-ee/centos.md
@@ -1,6 +1,0 @@
----
-redirect_from:
-- /engine/installation/centos/
-- /engine/installation/linux/docker-ee/centos/
-- /install/linux/docker-ee/centos/
----

--- a/ee/docker-ee/oracle.md
+++ b/ee/docker-ee/oracle.md
@@ -1,7 +1,0 @@
----
-redirect_from:
-- /engine/installation/oracle/
-- /engine/installation/linux/oracle/
-- /engine/installation/linux/docker-ee/oracle/
-- /install/linux/docker-ee/oracle/
----

--- a/ee/docker-ee/release-notes.md
+++ b/ee/docker-ee/release-notes.md
@@ -1,8 +1,0 @@
----
-redirect_from:
-  - /cs-engine/1.12/release-notes/
-  - /cs-engine/1.12/release-notes/release-notes/
-  - /cs-engine/1.12/release-notes/prior-release-notes/
-  - /cs-engine/1.13/release-notes/
-  - /ee/engine/release-notes/
----

--- a/ee/docker-ee/rhel.md
+++ b/ee/docker-ee/rhel.md
@@ -1,8 +1,0 @@
----
-redirect_from:
-- /engine/installation/rhel/
-- /installation/rhel/
-- /engine/installation/linux/rhel/
-- /engine/installation/linux/docker-ee/rhel/
-- /install/linux/docker-ee/rhel/
----

--- a/ee/docker-ee/suse.md
+++ b/ee/docker-ee/suse.md
@@ -1,8 +1,0 @@
----
-redirect_from:
-- /engine/installation/SUSE/
-- /engine/installation/linux/SUSE/
-- /engine/installation/linux/suse/
-- /engine/installation/linux/docker-ee/suse/
-- /install/linux/docker-ee/suse/
----

--- a/ee/docker-ee/ubuntu.md
+++ b/ee/docker-ee/ubuntu.md
@@ -1,8 +1,0 @@
----
-redirect_from:
-- /engine/installation/ubuntulinux/
-- /installation/ubuntulinux/
-- /engine/installation/linux/ubuntulinux/
-- /engine/installation/linux/docker-ee/ubuntu/
-- /install/linux/docker-ee/ubuntu/
----

--- a/ee/docker-ee/windows/docker-ee.md
+++ b/ee/docker-ee/windows/docker-ee.md
@@ -1,7 +1,0 @@
----
-redirect_from:
-- /docker-ee-for-windows/install/
-- /engine/installation/windows/docker-ee/
-- /install/windows/ee-preview/
-- /install/windows/docker-ee/
----

--- a/ee/supported-platforms.md
+++ b/ee/supported-platforms.md
@@ -1,9 +1,0 @@
----
-redirect_from:
-  - /enterprise/supported-platforms/
-  - /cs-engine/
-  - /cs-engine/1.12/
-  - /cs-engine/1.12/upgrade/
-  - /cs-engine/1.13/
-  - /cs-engine/1.13/upgrade/
----

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -2,11 +2,21 @@
 description: Instructions for installing Docker Engine on CentOS
 keywords: requirements, apt, installation, centos, rpm, install, uninstall, upgrade, update
 redirect_from:
+- /ee/docker-ee/centos/
+- /ee/docker-ee/rhel/
 - /engine/installation/centos/
+- /engine/installation/centos/
+- /engine/installation/linux/centos/
 - /engine/installation/linux/docker-ce/centos/
+- /engine/installation/linux/docker-ee/centos/
+- /engine/installation/linux/docker-ee/rhel/
+- /engine/installation/linux/rhel/
+- /engine/installation/rhel/
 - /install/linux/centos/
 - /install/linux/docker-ce/centos/
-- /engine/installation/linux/centos/
+- /install/linux/docker-ee/centos/
+- /install/linux/docker-ee/rhel/
+- /installation/rhel/
 title: Install Docker Engine on CentOS
 toc_max: 4
 ---

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -3,17 +3,35 @@ title: Install Docker Engine
 description: Lists the installation methods
 keywords: docker, installation, install, Docker Engine, Docker Engine, docker editions, stable, edge
 redirect_from:
-- /engine/installation/linux/
-- /engine/installation/linux/frugalware/
+- /cs-engine/
+- /cs-engine/1.12/
+- /cs-engine/1.12/upgrade/
+- /cs-engine/1.13/
+- /cs-engine/1.13/upgrade/
+- /ee/docker-ee/oracle/
+- /ee/docker-ee/suse/
+- /ee/supported-platforms/
+- /en/latest/installation/
+- /engine/installation/
 - /engine/installation/frugalware/
-- /engine/installation/linux/other/
+- /engine/installation/linux/
 - /engine/installation/linux/archlinux/
 - /engine/installation/linux/cruxlinux/
-- /engine/installation/linux/gentoolinux/
 - /engine/installation/linux/docker-ce/
 - /engine/installation/linux/docker-ee/
-- /engine/installation/
-- /en/latest/installation/
+- /engine/installation/linux/docker-ee/oracle/
+- /engine/installation/linux/docker-ee/suse/
+- /engine/installation/linux/frugalware/
+- /engine/installation/linux/gentoolinux/
+- /engine/installation/linux/oracle/
+- /engine/installation/linux/other/
+- /engine/installation/linux/SUSE/
+- /engine/installation/linux/suse/
+- /engine/installation/oracle/
+- /engine/installation/SUSE/
+- /enterprise/supported-platforms/
+- /install/linux/docker-ee/oracle/
+- /install/linux/docker-ee/suse/
 ---
 
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -2,13 +2,16 @@
 description: Instructions for installing Docker Engine on Ubuntu
 keywords: requirements, apt, installation, ubuntu, install, uninstall, upgrade, update
 redirect_from:
-- /engine/installation/ubuntulinux/
-- /installation/ubuntulinux/
+- /ee/docker-ee/ubuntu/
+- /engine/installation/linux/docker-ce/ubuntu/
+- /engine/installation/linux/docker-ee/ubuntu/
 - /engine/installation/linux/ubuntu/
 - /engine/installation/linux/ubuntulinux/
-- /engine/installation/linux/docker-ce/ubuntu/
-- /install/linux/ubuntu/
+- /engine/installation/ubuntulinux/
 - /install/linux/docker-ce/ubuntu/
+- /install/linux/docker-ee/ubuntu/
+- /install/linux/ubuntu/
+- /installation/ubuntulinux/
 title: Install Docker Engine on Ubuntu
 toc_max: 4
 ---

--- a/engine/release-notes/prior-releases.md
+++ b/engine/release-notes/prior-releases.md
@@ -3,6 +3,13 @@ title: Docker Engine release notes
 description: Release notes for Docker CE
 keywords: release notes, community
 toc_max: 2
+redirect_from:
+  - /cs-engine/1.12/release-notes/
+  - /cs-engine/1.12/release-notes/release-notes/
+  - /cs-engine/1.12/release-notes/prior-release-notes/
+  - /cs-engine/1.13/release-notes/
+  - /ee/engine/release-notes/
+  - /ee/docker-ee/release-notes/
 ---
 
 ## 1.13.1 (2017-02-08)


### PR DESCRIPTION
This moves some of the stubs that were still in place for docker enterprise,
and moves the redirects they contained to more sensible locations where possible,
also making these redirect slightly more "visible" for when we're editing.
