### PR TITLE
Add .gitattributes file for default line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto-detect text files, ensure they use LF.
+* text=auto eol=lf


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Add .gitattributes file to set default line endings to LF.