### PR TITLE
Fix authorization header doc in hub api

### DIFF
--- a/docker-hub/api/latest.yaml
+++ b/docker-hub/api/latest.yaml
@@ -58,7 +58,7 @@ definitions:
       token:
         description: |
           Created authentication token.
-          This token can be used in the HTTP Authentication header as a JWT to authenticate with the Docker Hub APIs.
+          This token can be used in the HTTP Authorization header as a JWT to authenticate with the Docker Hub APIs.
         type: string
         x-nullable: false
         example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
@@ -484,7 +484,7 @@ paths:
       description: |
         Creates an authentication token that can be used to authenticate with the Docker Hub APIs.
 
-        The returned token is used in the HTTP Authentication header like `Authentication: JWT {TOKEN}`.
+        The returned token is used in the HTTP Authorization header like `Authorization: JWT {TOKEN}`.
 
         Most Docker Hub APIs require this token either to consume or to get detailed information. For example, to list images in a private repository.
       parameters:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Quick fix to the Hub API spec that incorrectly says `Authentication` HTTP header when it should say `Authorization`

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
