### PR TITLE
Add DockerCon wrap-up banner to the homepage

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,7 +22,7 @@
                     <ul class="footer_links">
                         <li><b><a href="https://www.docker.com/why-docker">Why Docker?</a></b></li>
                         <li><a href="https://www.docker.com/what-container">What is a Container?</a></li>
-                        <li><a href="https://www.docker.com/dockercon-live/2021/?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-registration-dockercon">Register for DockerCon21</a></li>
+                        <li><a href="https://docker.events.cube365.net/dockercon/">DockerCon</a></li>
                         <li><b><a href="https://www.docker.com/products/overview">Products</a></b></li>
                         <li><a href="https://www.docker.com/products/docker-desktop">Docker Desktop</a></li>
                         <li><a href="https://www.docker.com/products/docker-hub">Docker Hub</a></li>

--- a/_includes/landing-page/dockercon-wrapup-banner.html
+++ b/_includes/landing-page/dockercon-wrapup-banner.html
@@ -2,16 +2,19 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-offset-1 col-lg-7">
-        <img src="/images/docker-con-2020.svg" alt="docker con" />
+        <img src="/images/dockercon21.png" alt="dockercon" />
         <h2>
-          Thank you for attending DockerCon 2020!
+          Thank you for attending DockerCon21!
         </h2>
         <h5>
           You can now watch the sessions you missed and share your favourites with your friends and colleagues.
         </h5>
+      </br>
+        <p><b>Save 20% on Docker Pro and Team Subscriptions</b></p>
+      <p>New and returning customers can use the <b>DOCKERCON21</b> promo code to receive a 20% discount on an annual subscription, or for the first 3 months on a monthly subscription. This offer is valid until 11:59 PM PT on June 11, 2021.<a href="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade" target="_blank"> Check out the pricing plans</a>.</p>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-4 text-center">
-        <a class="btn" href="https://docker.events.cube365.net/docker/dockercon/" target="_blank" class="card">
+        <a class="btn" href="https://docker.events.cube365.net/dockercon-live/2021" target="_blank" class="card">
           Watch the recordings
         </a>
       </div>

--- a/_includes/landing-page/dockercon-wrapup-banner.html
+++ b/_includes/landing-page/dockercon-wrapup-banner.html
@@ -7,11 +7,11 @@
           Thank you for attending DockerCon21!
         </h2>
         <h5>
-          You can now watch the sessions you missed and share your favourites with your friends and colleagues.
+          You can now watch the sessions you missed and share your favorites with your friends and colleagues.
         </h5>
       </br>
         <p><b>Save 20% on Docker Pro and Team Subscriptions</b></p>
-      <p>New and returning customers can use the <b>DOCKERCON21</b> promo code to receive a 20% discount on an annual subscription, or for the first 3 months on a monthly subscription. This offer is valid until 11:59 PM PT on June 11, 2021.<a href="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade" target="_blank"> Check out the pricing plans</a>.</p>
+      <p>New and returning customers can use the <b>DOCKERCON21</b> promo code to receive a 20% discount on an annual subscription, or for the first three months on a monthly subscription. This offer is valid until 11:59 PM PT on June 11, 2021.<a href="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade" target="_blank"> Check out the pricing plans</a>.</p>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-4 text-center">
         <a class="btn" href="https://docker.events.cube365.net/dockercon-live/2021" target="_blank" class="card">

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -143,7 +143,7 @@
     </div>
   </section>
 
-  {% include landing-page/dockercon-banner.html %}
+  {% include landing-page/dockercon-wrapup-banner.html %}
 
   <section class="container help-by-product">
     <div class="row">


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Replaced existing banner on the homepage with DockerCon wrapup banner and updated the link to the recordings