### PR TITLE
Indent webhook notifications Authorization header

### DIFF
--- a/registry/notifications.md
+++ b/registry/notifications.md
@@ -35,7 +35,7 @@ notifications:
     - name: alistener
       url: https://mylistener.example.com/event
       headers:
-      Authorization: [Bearer <your token, if needed>]
+        Authorization: [Bearer <your token, if needed>]
       timeout: 500ms
       threshold: 5
       backoff: 1s


### PR DESCRIPTION
### Proposed changes

Since `Authorization` is intended to be a header applied to HTTP requests it should be indented to place it in the YAML map named `headers` instead of being a sibling of it.
