### PR TITLE
Docker Desktop on Mac Apple silicon: Remove release date and first official version number

### DIFF
--- a/docker-for-mac/apple-silicon.md
+++ b/docker-for-mac/apple-silicon.md
@@ -12,13 +12,11 @@ Docker Desktop for Mac on Apple silicon is now available as a GA release. This e
 
 Docker Desktop for Apple silicon also supports multi-platform images, which allows you to build and run images for both x86 and ARM architectures without having to set up a complex cross-compilation development environment. Additionally, you can use [docker buildx](../engine/reference/commandline/buildx.md){:target="_blank" rel="noopener" class="_"} to seamlessly integrate multi-platform builds into your build pipeline, and use [Docker Hub](https://hub.docker.com/){:target="_blank" rel="noopener" class="_"} to identify and share repositories that provide multi-platform images.
 
-## Docker Desktop 3.3.1
-
-2021-04-15
-
-Click the following link to download Docker Desktop.
+Download Docker Desktop for Mac on Apple silicon:
 
 [Download](https://desktop.docker.com/mac/stable/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn}
+
+{% include eula.md %}
 
 <br>
 
@@ -26,7 +24,7 @@ Click the following link to download Docker Desktop.
 
 You must install **Rosetta 2** as some binaries are still Darwin/AMD64. To install Rosetta 2 manually from the command line, run the following command:
 
-```
+```shell
 softwareupdate --install-rosetta
 ```
 


### PR DESCRIPTION
Now that Docker Desktop for Mac on Apple silicon is GA and also has some newer patch releases, this page looks a bit confusing. We showed the first official release date and the first version number. Now we are at 3.3.3 and the next minor version bump is just around the corner.

I think it's time to clean the page a little bit.
