### PR TITLE
Update rate limit header and plans info

### DIFF
--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -8,11 +8,11 @@ title: Download rate limit
 
 Docker Hub limits the number of Docker image downloads ("pulls")
 based on the account type of the user pulling the image. 
-See the [pricing page](https://www.docker.com/pricing) for current options.
+See the [pricing page](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"} for current options.
 
-Some images are unlimited via our [Open Source](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/) and [Publisher](https://www.docker.com/partners/programs) programs.
+Some images are unlimited through our [Open Source](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/){: target="_blank" rel="noopener" class="_"} and [Publisher](https://www.docker.com/partners/programs){: target="_blank" rel="noopener" class="_"} programs.
 
-Unlimited pulls by IP is also available via our [Large Organization](https://www.docker.com/pricing) plan.
+Unlimited pulls by IP is also available through our [Large Organization](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"} plan.
 
 ## Definition of limits
 
@@ -85,13 +85,13 @@ This means my limit is 100 per 21600 seconds (6 hours), and I have 76 pulls rema
 
 ### I don't see any RateLimit headers
 
-If you do not see these headers, that means pulling that image would not count towards pull limits. This could be because you are authenticated with a user associated with a Pro/Team Docker Hub account, or because the image or your IP is unlimited in partnership with a publisher, provider, or open source organization.
+If you do not see these headers, that means pulling that image would not count towards pull limits. This could be because you are authenticated with a user associated with a Pro/Team Docker Hub account, or because the image or your IP is unlimited in partnership with a publisher, provider, or an open-source organization.
 
 ## I'm being limited even though I have a Pro/Team account
 
-In order to take advantage of the higher limits included in these plans, you must [authenticate pulls](#how-do-i-authenticate-pull-requests) with your user account. 
+To take advantage of the higher limits included in these plans, you must [authenticate pulls](#how-do-i-authenticate-pull-requests) with your user account. 
 
-A Pro/Team plan does not increase limits on your images for other users - please see our [Open Source](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/), [Publisher](https://www.docker.com/partners/programs), or [Large Organization](https://www.docker.com/pricing) offerings.
+A Pro/Team plan does not increase limits on your images for other users. See our [Open Source](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/){: target="_blank" rel="noopener" class="_"}, [Publisher](https://www.docker.com/partners/programs){: target="_blank" rel="noopener" class="_"}, or [Large Organization](https://www.docker.com/pricing){: target="_blank" rel="noopener" class="_"} offerings.
 
 ## How do I authenticate pull requests
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -4,13 +4,21 @@ keywords: Docker, pull requests, download, limit,
 title: Download rate limit
 ---
 
-Docker has enabled download rate limits for pull requests on 
-Docker Hub. Limits are determined based on the account type. 
-For more information, see [Resource Consumption FAQs](https://www.docker.com/pricing/resource-consumption-updates){: target="_blank" rel="noopener" class="_"} and [Docker Hub Pricing](https://hub.docker.com/pricing){: target="_blank" rel="noopener" class="_"}.
+## What is the download rate limit on Docker Hub
 
-A user's limit will be equal to the highest entitlement of their
+Docker Hub limits the number of Docker image downloads ("pulls")
+based on the account type of the user pulling the image. 
+See the [pricing page](https://www.docker.com/pricing) for current options.
+
+Some images are unlimited via our [Open Source](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/) and [Publisher](https://www.docker.com/partners/programs) programs.
+
+Unlimited pulls by IP is also available via our [Large Organization](https://www.docker.com/pricing) plan.
+
+## Definition of limits
+
+A user's limit is equal to the highest entitlement of their
 personal account or any organization they belong to. To take 
-advantage of this, you must log into 
+advantage of this, you must log in to 
 [Docker Hub](https://hub.docker.com/){: target="_blank" rel="noopener" class="_"} 
 as an authenticated user. For more information, see
 [How do I authenticate pull requests](#how-do-i-authenticate-pull-requests). 
@@ -23,10 +31,7 @@ single manifest request.
 - A pull request for a multi-arch image makes two 
 manifest requests. 
 - `HEAD` requests are not counted. 
-- Limits are applied based on the user doing the pull, and 
-not based on the image being pulled or its owner.
 
-Docker will gradually introduce these rate limits starting November 2nd, 2020.
 
 ## How do I know my pull requests are being limited
 
@@ -43,8 +48,8 @@ You will see this error message in the Docker CLI or in the Docker Engine logs.
 Valid manifest API requests to Hub will usually include the following rate limit headers in the response:
 
 ```
-RateLimit-Limit    
-RateLimit-Remaining
+ratelimit-limit    
+ratelimit-remaining
 ```
 
 These headers will be returned on both GET and HEAD requests. Note that using GET emulates a real pull and will count towards the limit; using HEAD will not, so we will use it in this example. To check your limits, you will need `curl`, `grep`, and `jq` installed.
@@ -70,8 +75,8 @@ $ curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/
 Which should return headers including these:
 
 ```http
-RateLimit-Limit: 100;w=21600
-RateLimit-Remaining: 76;w=21600
+ratelimit-limit: 100;w=21600
+ratelimit-remaining: 76;w=21600
 ```
 
 This means my limit is 100 per 21600 seconds (6 hours), and I have 76 pulls remaining.
@@ -80,7 +85,13 @@ This means my limit is 100 per 21600 seconds (6 hours), and I have 76 pulls rema
 
 ### I don't see any RateLimit headers
 
-If you do not see these headers, that means pulling that image would not count towards pull limits. This could be because you are authenticated with a user associated with a Legacy/Pro/Team Docker Hub account, or because the image or your IP is unlimited in partnership with a publisher, provider, or open source organization.
+If you do not see these headers, that means pulling that image would not count towards pull limits. This could be because you are authenticated with a user associated with a Pro/Team Docker Hub account, or because the image or your IP is unlimited in partnership with a publisher, provider, or open source organization.
+
+## I'm being limited even though I have a Pro/Team account
+
+In order to take advantage of the higher limits included in these plans, you must [authenticate pulls](#how-do-i-authenticate-pull-requests) with your user account. 
+
+A Pro/Team plan does not increase limits on your images for other users - please see our [Open Source](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/), [Publisher](https://www.docker.com/partners/programs), or [Large Organization](https://www.docker.com/pricing) offerings.
 
 ## How do I authenticate pull requests
 


### PR DESCRIPTION
### Proposed changes

* Update ratelimit header formatting (http/2 requires lowercase headers)
* Specifically call out instances where limiting is applied based on the user (anonymous/free/pro/team) versus based on the image (open source and partner programs, large org plans).

