### PR TITLE
Typo Fix for docker-compose up.

### DIFF
--- a/compose/index.md
+++ b/compose/index.md
@@ -28,7 +28,7 @@ anywhere.
 2. Define the services that make up your app in `docker-compose.yml`
 so they can be run together in an isolated environment.
 
-3. Run `docker compose up` and the [Docker compose command](cli-command.md) starts and runs your entire app. You can alternatively run `docker-compose up` using the docker-compose binary.
+3. Run `docker-compose up` and the [Docker compose command](cli-command.md) starts and runs your entire app. You can alternatively run `docker-compose up` using the docker-compose binary.
 
 A `docker-compose.yml` looks like this:
 


### PR DESCRIPTION
### Proposed changes

Changes "docker compose up" to "docker-compse up" which is the correct command in documentation.
