### PR TITLE
Minor grammar fix ("an unified" -> "a unified")

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -12,7 +12,7 @@ toc_min: 1
 ## Reference and guidelines
 
 These topics describe the Docker Compose implementation of the Compose format.
-Docker Compose **1.27.0+** implements the format defined by the [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md). Previous Docker Compose versions have support for several Compose file formats – 2, 2.x, and 3.x. The Compose specification is an unified 2.x and 3.x file format, aggregating properties across these formats.
+Docker Compose **1.27.0+** implements the format defined by the [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md). Previous Docker Compose versions have support for several Compose file formats – 2, 2.x, and 3.x. The Compose specification is a unified 2.x and 3.x file format, aggregating properties across these formats.
 
 ## Compose and Docker compatibility matrix
 


### PR DESCRIPTION
### Proposed changes

In the `Reference / Compose file reference / Compose Specification` section of the documentation, change the sentence "_The Compose specification is **an** unified 2.x and 3.x file format, aggregating properties across these formats._" to "_The Compose specification is **a** unified 2.x and 3.x file format, aggregating properties across these formats._"
