### PR TITLE
fix: add wordpress volume to docker-compose

### DIFF
--- a/samples/wordpress.md
+++ b/samples/wordpress.md
@@ -34,8 +34,8 @@ Compose to set up and run WordPress. Before starting, make sure you have
     ```
 
 3.  Create a `docker-compose.yml` file that starts your
-    `WordPress` blog and a separate `MySQL` instance with a volume
-    mount for data persistence:
+    `WordPress` blog and a separate `MySQL` instance with volume
+    mounts for data persistence:
 
     ```yaml
     version: "{{ site.compose_file_v3 }}"
@@ -56,6 +56,8 @@ Compose to set up and run WordPress. Before starting, make sure you have
         depends_on:
           - db
         image: wordpress:latest
+        volumes:
+          - wordpress_data:/var/www/html
         ports:
           - "8000:80"
         restart: always
@@ -66,12 +68,13 @@ Compose to set up and run WordPress. Before starting, make sure you have
           WORDPRESS_DB_NAME: wordpress
     volumes:
       db_data: {}
+      wordpress_data: {}
     ```
 
    > **Notes**:
    >
-   * The docker volume `db_data` persists any updates made by WordPress
-   to the database. [Learn more about docker volumes](../storage/volumes.md)
+   * The docker volumes `db_data` and `wordpress_data` persists updates made by WordPress
+   to the database, as well as the installed themes and plugins. [Learn more about docker volumes](../storage/volumes.md)
    >
    * WordPress Multisite works only on ports `80` and `443`.
    {: .note-vanilla}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
This adds a volume to the WordPress container in the `docker-compose.yml` file, and rewords some documentation to reference it.

When using WordPress themes, plugins, and certain settings are stored in /var/www/html, the currently recommended configuration doesn't persist these.

Also see the Docker Compose example on the official WordPress image:

> ```yml
> wordpress:
>   image: wordpress
>   restart: always
>   ports:
>     - 8080:80
>   environment:
>     WORDPRESS_DB_HOST: db
>     WORDPRESS_DB_USER: exampleuser
>     WORDPRESS_DB_PASSWORD: examplepass
>     WORDPRESS_DB_NAME: exampledb
>   volumes:
>     - wordpress:/var/www/html
> ```
> \- https://hub.docker.com/_/wordpress/

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

Issues:
Closes #11715
Closes #9826
Closes #9008

Pull Requests:
Closes #11783 - Merge conflict, only modifies docker-compose.yml
Closes #10927 - Merge conflict, only modifies docker-compose.yml, and only adds wp-content. (Helpful to have /var/www/html to ensure we also persist modifications to wp-config.php for example.)

