### PR TITLE
Alpine Linux is no longer under 5 MB

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -406,7 +406,7 @@ maintainable `Dockerfile`.
 
 Whenever possible, use current official images as the basis for your
 images. We recommend the [Alpine image](https://hub.docker.com/_/alpine/) as it
-is tightly controlled and small in size (currently under 5 MB), while still
+is tightly controlled and small in size (currently under 6 MB), while still
 being a full Linux distribution.
 
 ### LABEL


### PR DESCRIPTION
### Proposed changes

The docs say Alpine is under 5 MB, but `alpine:latest` is currently 5.61 MB. I changed the docs to say Alpine is under 6 MB.