### PR TITLE
Minor fixes in the run-tests.md

### DIFF
--- a/language/java/run-tests.md
+++ b/language/java/run-tests.md
@@ -140,7 +140,7 @@ $ docker build -t java-docker --target test .
  => CACHED [base 4/6] COPY mvnw pom.xml ./
  => CACHED [base 5/6] RUN ./mvnw dependency:go-offline
  => CACHED [base 6/6] COPY src ./src
- => [test 1/1] RUN ["./mvnw", "test", "-Dspring-boot.run.profiles=mysql"]
+ => [test 1/1] RUN ["./mvnw", "test"]
  => exporting to image
  => => exporting layers
 => => writing image sha256:10cb585a7f289a04539e95d583ae97bcf8725959a6bd32c2f5632d0e7c1d16a0
@@ -153,7 +153,7 @@ Open the `src/test/java/org/springframework/samples/petclinic/model/ValidatorTes
 
 ```shell
 55   ConstraintViolation<Person> violation = constraintViolations.iterator().next();
-57   assertThat(violation.getPropertyPath().toString()).isEqualTo("firstName");
+56   assertThat(violation.getPropertyPath().toString()).isEqualTo("firstName");
 57   assertThat(violation.getMessage()).isEqualTo("must be empty");
 58 }
 ```
@@ -163,7 +163,7 @@ Now, run the `docker build` command from above and observe that the build fails 
 ```shell
 $ docker build -t java-docker --target test .
  => [base 6/6] COPY src ./src
- => ERROR [test 1/1] RUN ["./mvnw", "test", "-Dspring-boot.run.profiles=mysql"]
+ => ERROR [test 1/1] RUN ["./mvnw", "test"]
 ...
 ------
 executor failed running [./mvnw test]: exit code: 1


### PR DESCRIPTION
Fixed line numbers in example, as two lines 57 were shown and it was not obvious which line needs to be changed.
Removed profile argument from example outputs, as the corresponding Dockerfile examples for the test image do not have it.