### PR TITLE
Added note about swarm ignoring the pid option

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -1632,6 +1632,12 @@ container and the host operating system the PID address space.  Containers
 launched with this flag can access and manipulate other
 containers in the bare-metal machine's namespace and vice versa.
 
+> Note when using docker stack deploy
+>
+> The `pid` option is ignored when
+> [deploying a stack in swarm mode](../../engine/reference/commandline/stack_deploy.md).
+{: .important }
+
 ### ports
 
 Expose ports.


### PR DESCRIPTION
### Proposed changes
Added a note to the `pid` block stating that it is ignored in swarm mode.

### Related issues (optional)
Fixes #12993