### PR TITLE
Fix references to docker-compose command

### DIFF
--- a/_data/compose-cli/docker_compose.yaml
+++ b/_data/compose-cli/docker_compose.yaml
@@ -8,7 +8,7 @@ long: "You can use compose subcommand, `docker compose [-f <arg>...] [options] [
     multiple files, Compose combines them into a single \nconfiguration. Compose builds
     the configuration in the order you supply the files. Subsequent files override
     and add \nto their predecessors.\n\nFor example, consider this command line:\n\n```\n$
-    docker-compose -f docker-compose.yml -f docker-compose.admin.yml run backup_db\n```\nThe
+    docker compose -f docker-compose.yml -f docker-compose.admin.yml run backup_db\n```\nThe
     `docker-compose.yml` file might specify a `webapp` service.\n\n```yaml\nservices:\n
     \ webapp:\n    image: examples/web\n    ports:\n      - \"8000:8000\"\n    volumes:\n
     \     - \"/data\"\n```\nIf the `docker-compose.admin.yml` also specifies this
@@ -45,7 +45,7 @@ long: "You can use compose subcommand, `docker compose [-f <arg>...] [options] [
     profiles. \nYou can also enable multiple profiles, e.g. with `docker compose --profile
     frontend --profile debug up` the profiles `frontend` and `debug` will be enabled.\n\nProfiles
     can also be set by `COMPOSE_PROFILES` environment variable.\n\n### Set up environment
-    variables\n\nYou can set environment variables for various docker-compose options,
+    variables\n\nYou can set environment variables for various docker compose options,
     including the `-f`, `-p` and `--profiles` flags.\n\nSetting the `COMPOSE_FILE`
     environment variable is equivalent to passing the `-f` flag,\n`COMPOSE_PROJECT_NAME`
     environment variable does the same for to the `-p` flag,\nand so does `COMPOSE_PROFILES`


### PR DESCRIPTION
Apologies if this is not the correct way to fix this. I just noticed on https://docs.docker.com/engine/reference/commandline/compose/ that the first example is using `docker-compose` instead of `docker compose`. It was very confusing trying to open a PR to fix it, as the "Edit this page" link leads into an (I think?) outdated repository, and the other option "Request docs changes" seems overly complicated for a simple copy&paste fix like this.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
