### PR TITLE
improve documentation

### DIFF
--- a/develop/develop-images/baseimages.md
+++ b/develop/develop-images/baseimages.md
@@ -11,13 +11,13 @@ Most Dockerfiles start from a parent image. If you need to completely control
 the contents of your image, you might need to create a base image instead.
 Here's the difference:
 
-- A [parent image](../../glossary.md#parent_image) is the image that your
+- A [parent image](../../glossary.md#parent-image) is the image that your
   image is based on. It refers to the contents of the `FROM` directive in the
   Dockerfile. Each subsequent declaration in the Dockerfile modifies this parent
   image. Most Dockerfiles start from a parent image, rather than a base image.
   However, the terms are sometimes used interchangeably.
 
-- A [base image](../../glossary.md#base_image) has `FROM scratch` in its Dockerfile.
+- A [base image](../../glossary.md#base-image) has `FROM scratch` in its Dockerfile.
 
 This topic shows you several ways to create a base image. The specific process
 will depend heavily on the Linux distribution you want to package. We have some

--- a/develop/develop-images/baseimages.md
+++ b/develop/develop-images/baseimages.md
@@ -34,17 +34,17 @@ use to build Ubuntu images.
 
 It can be as simple as this to create an Ubuntu parent image:
 
-    $ sudo debootstrap xenial xenial > /dev/null
-    $ sudo tar -C xenial -c . | docker import - xenial
+    $ sudo debootstrap focal focal > /dev/null
+    $ sudo tar -C focal -c . | docker import - focal
 
-    a29c15f1bf7a
+    sha256:81ec9a55a92a5618161f68ae691d092bf14d700129093158297b3d01593f4ee3
 
-    $ docker run xenial cat /etc/lsb-release
+    $ docker run focal cat /etc/lsb-release
 
     DISTRIB_ID=Ubuntu
-    DISTRIB_RELEASE=16.04
-    DISTRIB_CODENAME=xenial
-    DISTRIB_DESCRIPTION="Ubuntu 16.04 LTS"
+    DISTRIB_RELEASE=20.04
+    DISTRIB_CODENAME=focal
+    DISTRIB_DESCRIPTION="Ubuntu 20.04 LTS"
 
 There are more example scripts for creating parent images in [the Docker
 GitHub repository](https://github.com/docker/docker/blob/master/contrib).
@@ -86,7 +86,7 @@ current directory.
 > You can use a Docker container to build it:
 >
 > ```bash
-> $ docker run --rm -it -v $PWD:/build ubuntu:16.04
+> $ docker run --rm -it -v $PWD:/build ubuntu:20.04
 >
 > container# apt-get update && apt-get install build-essential
 > container# cd /build

--- a/develop/develop-images/baseimages.md
+++ b/develop/develop-images/baseimages.md
@@ -90,7 +90,7 @@ current directory.
 >
 > container# apt-get update && apt-get install build-essential
 > container# cd /build
-> container# gcc -o hello -static -nostartfiles hello.c
+> container# gcc -o hello -static hello.c
 > ```
 
 To run your new image, use the `docker run` command:


### PR DESCRIPTION
### Proposed changes

The examples are updated to the current Ubuntu LTS release and two minor issues are also fixed.

When testing the examples in xenial and focal a segmentation fault occurred:

root@b3cfbc38305b:/build# gcc -o hello -static -nostartfiles hello.c 
/usr/bin/ld: warning: cannot find entry symbol _start; defaulting to 0000000000401000
root@b3cfbc38305b:/build# ./hello > /dev/null    
Segmentation fault (core dumped)
root@b3cfbc38305b:/build# echo $?
139
root@b3cfbc38305b:/build# gcc -o hello -static hello.c 
root@b3cfbc38305b:/build# ./hello > /dev/null 
root@b3cfbc38305b:/build# echo $?
0
