### PR TITLE
docker docker run -rm -d -p ... fix

### DIFF
--- a/language/java/run-containers.md
+++ b/language/java/run-containers.md
@@ -161,7 +161,7 @@ Now, let’s address the random naming issue. The standard practice is to name y
 To name a container, we just need to pass the `--name` flag to the `docker run` command.
 
 ```console
-$ docker run --rm -d -p 8080:8080 --name springboot-server java-docker
+$ docker run -d -p 8080:8080 --name springboot-server java-docker
 2e907c68d1c98be37d2b2c2ac6b16f353c85b3757e549254de68746a94a8a8d3
 $ docker ps
 CONTAINER ID   IMAGE         COMMAND                  CREATED         STATUS         PORTS                    NAMES


### PR DESCRIPTION
docker run -rm .. command is incorrect. 
➜  docker docker run -rm -d -p 8080:8080 --name springboot-server java-docker
unknown shorthand flag: 'r' in -rm
See 'docker run --help'.
correct command
➜  docker docker run -d -p 8080:8080 --name springboot-server java-docker

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
