### PR TITLE
Workaround for outdated slirp4netns on debian

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -79,15 +79,12 @@ testuser:231072:65536
   
 - Rootless docker requires version of `slirp4netns` greater than `v0.4.0`.
   Check you have this with 
-  ```
+  
+  ```console
   $ slirp4netns --version
   ```
-  If you do not have this run 
-  ```
-  $ echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" | sudo tee -a /etc/apt/sources.list
-  $ sudo apt update
-  $ sudo apt upgrade slirp4netns
-  ```
+  If you do not have this download and install the latest [release](https://github.com/rootless-containers/slirp4netns/releases).
+
 </div>
 <div id="hint-arch" class="tab-pane fade in" markdown="1">
 - Installing `fuse-overlayfs` is recommended. Run `sudo pacman -S fuse-overlayfs`.

--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -76,6 +76,18 @@ testuser:231072:65536
   `sudo modprobe overlay permit_mounts_in_userns=1`
    ([Debian-specific kernel patch, introduced in Debian 10](https://salsa.debian.org/kernel-team/linux/blob/283390e7feb21b47779b48e0c8eb0cc409d2c815/debian/patches/debian/overlayfs-permit-mounts-in-userns.patch)).
    Add the configuration to `/etc/modprobe.d` for persistence.
+  
+- Rootless docker requires version of `slirp4netns` greater than `v0.4.0`.
+  Check you have this with 
+  ```
+  $ slirp4netns --version
+  ```
+  If you do not have this run 
+  ```
+  $ echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" | sudo tee -a /etc/apt/sources.list
+  $ sudo apt update
+  $ sudo apt upgrade slirp4netns
+  ```
 </div>
 <div id="hint-arch" class="tab-pane fade in" markdown="1">
 - Installing `fuse-overlayfs` is recommended. Run `sudo pacman -S fuse-overlayfs`.

--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -77,7 +77,7 @@ testuser:231072:65536
    ([Debian-specific kernel patch, introduced in Debian 10](https://salsa.debian.org/kernel-team/linux/blob/283390e7feb21b47779b48e0c8eb0cc409d2c815/debian/patches/debian/overlayfs-permit-mounts-in-userns.patch)).
    Add the configuration to `/etc/modprobe.d` for persistence.
   
-- Rootless docker requires version of `slirp4netns` greater than `v0.4.0`.
+- Rootless docker requires version of `slirp4netns` greater than `v0.4.0` (when `vpnkit` is not installed).
   Check you have this with 
   
   ```console


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add in hint to check the version of `slirp4netns` , add the Debian testing repo and upgrade `slirp4netns`.

<!--Tell us what you did and why-->
I did this because I had issue on debian 11 where the package for `slirp4netns` on the 
main apt repositories was too old, causing the `dockerd-rootless.sh` command to fail.
### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
