### PR TITLE
Wrong HTTP Method type in documentation

### DIFF
--- a/language/python/run-containers.md
+++ b/language/python/run-containers.md
@@ -50,7 +50,7 @@ $ curl localhost:5000
 Hello, Docker!
 ```
 
-Success! We were able to connect to the application running inside of our container on port 5000. Switch back to the terminal where your container is running and you should see the POST request logged to the console.
+Success! We were able to connect to the application running inside of our container on port 5000. Switch back to the terminal where your container is running and you should see the GET request logged to the console.
 
 ```shell
 [31/Jan/2021 23:39:31] "GET / HTTP/1.1" 200 -


### PR DESCRIPTION
`curl localhost:5000` is GET request, but in doc it says POST request

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
