### PR TITLE
Mention the necessity of `--network host`

### DIFF
--- a/network/proxy.md
+++ b/network/proxy.md
@@ -47,6 +47,9 @@ configure it in different ways:
 
  2. When you create or start new containers, the environment variables are
     set automatically within the container.
+ 
+ 3. If the intention was to use host's 127.0.0.1:3001 - don't forget to
+    specify `--network host` when creating container.
 
 
 ## Use environment variables


### PR DESCRIPTION
This example is, honestly, idiotic, because it doesn't even explain what task it solves.
No one needs to "just pass *_PROXY envs to created containers", as it is useless by itself.
People want to make containers have internet access via proxy, but the proxy is usually on the host machine's host or networks, not on docker containers networks!
The example described in the docs just tells how to configure containers query THEIR 127.0.0.1:3001, not host machine's 127.0.0.1:3001. This is useless!

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
I improved docs by adding an important mention of an extra step that is necessary to solve a common task (that the article should've explained how to solve, but instead failed to).

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
