### PR TITLE
Remove DockerCon21 promo code

### DIFF
--- a/_includes/landing-page/dockercon-wrapup-banner.html
+++ b/_includes/landing-page/dockercon-wrapup-banner.html
@@ -10,8 +10,6 @@
           You can now watch the sessions you missed and share your favorites with your friends and colleagues.
         </h5>
       </br>
-        <p><b>Save 20% on Docker Pro and Team Subscriptions</b></p>
-      <p>New and returning customers can use the <b>DOCKERCON21</b> promo code to receive a 20% discount on an annual subscription, or for the first three months on a monthly subscription. This offer is valid until 11:59 PM PT on June 18, 2021.<a href="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade" target="_blank"> Check out the pricing plans</a>.</p>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-4 text-center">
         <a class="btn" href="https://docker.events.cube365.net/dockercon-live/2021" target="_blank" class="card">


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Removed info on Promo codes as these expired on 18 June 2021