### PR TITLE
Use custom Dockerfile for Dev Environments image

### DIFF
--- a/.docker/Dockerfile.devenv
+++ b/.docker/Dockerfile.devenv
@@ -1,0 +1,3 @@
+FROM docker/dev-environments-ruby:stable-1
+RUN gem install bundler jekyll
+CMD ["bundle", "install"]

--- a/.docker/config.json
+++ b/.docker/config.json
@@ -1,3 +1,3 @@
 {
-    "image": "jekyll/jekyll"
+    "dockerfile": "Dockerfile.devenv"
 }


### PR DESCRIPTION
### Proposed changes
Use a dedicated Dockerfile to start a Dev Environments of the `docker.github.io` repo. 

First step is to `bundle install` and then you can run Jekyll with `bundle exec jekyll serve`

https://user-images.githubusercontent.com/705411/123113482-e2056f80-d43e-11eb-8e33-7f9834b4e419.mp4

