### PR TITLE
#docker-library has moved from Freenode to Libera.chat

### DIFF
--- a/docker-hub/official_images.md
+++ b/docker-hub/official_images.md
@@ -70,7 +70,7 @@ All Official Images contain a **User Feedback** section in their
 documentation which covers the details for that specific repository. In most
 cases, the GitHub repository which contains the Dockerfiles for an Official
 Repository also has an active issue tracker. General feedback and support
-questions should be directed to `#docker-library` on Freenode IRC.
+questions should be directed to `#docker-library` on [Libera.Chat IRC](https://libera.chat) IRC.
 
 ## Creating an Official Image
 

--- a/docker-hub/official_images.md
+++ b/docker-hub/official_images.md
@@ -70,7 +70,7 @@ All Official Images contain a **User Feedback** section in their
 documentation which covers the details for that specific repository. In most
 cases, the GitHub repository which contains the Dockerfiles for an Official
 Repository also has an active issue tracker. General feedback and support
-questions should be directed to `#docker-library` on [Libera.Chat IRC](https://libera.chat) IRC.
+questions should be directed to `#docker-library` on [Libera.Chat IRC](https://libera.chat).
 
 ## Creating an Official Image
 


### PR DESCRIPTION
### Proposed changes

The docs were still inviting people to join the `#docker-libray` on Freenode, but the channel has been moved to Libera.chat, see:

https://github.com/docker-library/official-images/commit/2d2bf418a88552f7e1231a8bd81dfc3c95c19433

