### PR TITLE
Update pull limits for service accounts

### DIFF
--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -76,9 +76,9 @@ Multiple registry caches can be deployed over the same back-end. A single
 registry cache ensures that concurrent requests do not pull duplicate data,
 but this property does not hold true for a registry cache cluster.
 
-**Note**
+> **Note**
 >
-> Service accounts included in the Team plan are limited to 15,000 pulls per day. See [Service Accounts](/docker-hub/service-accounts/) for more details.
+> Service accounts included in the Team plan are limited to 5,000 pulls per day. See [Service Accounts](/docker-hub/service-accounts/) for more details.
 
 ### Configure the cache
 


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Updated text to indicate Service accounts included in the Team plan are limited to 5,000 pulls per day.