### PR TITLE
update engine reference docs

### DIFF
--- a/_data/engine-cli/docker_context_create.yaml
+++ b/_data/engine-cli/docker_context_create.yaml
@@ -11,7 +11,7 @@ options:
   value_type: string
   description: |
     Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,10 +45,10 @@ options:
   value_type: stringToString
   default_value: '[]'
   description: set the kubernetes endpoint
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
-  kubernetes: false
+  kubernetes: true
   swarm: false
 examples: |-
   ### Create a context with a docker and kubernetes endpoint

--- a/_data/engine-cli/docker_context_export.yaml
+++ b/_data/engine-cli/docker_context_export.yaml
@@ -13,10 +13,10 @@ options:
   value_type: bool
   default_value: "false"
   description: Export as a kubeconfig file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
-  kubernetes: false
+  kubernetes: true
   swarm: false
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_context_update.yaml
+++ b/_data/engine-cli/docker_context_update.yaml
@@ -11,7 +11,7 @@ options:
   value_type: string
   description: |
     Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,10 +37,10 @@ options:
   value_type: stringToString
   default_value: '[]'
   description: set the kubernetes endpoint
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
-  kubernetes: false
+  kubernetes: true
   swarm: false
 examples: |-
   ### Update an existing context

--- a/_data/engine-cli/docker_network_create.yaml
+++ b/_data/engine-cli/docker_network_create.yaml
@@ -291,7 +291,7 @@ examples: |-
   | `com.docker.network.bridge.enable_icc`           | `--icc`     | Enable or Disable Inter Container Connectivity        |
   | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
   | `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
-  | `com.docker.network.container_interface_prefix`  | -           | Set a custom prefix for container interfaces          |
+  | `com.docker.network.container_iface_prefix`      | -           | Set a custom prefix for container interfaces          |
 
   The following arguments can be passed to `docker network create` for any
   network driver, again with their approximate equivalents to `docker daemon`.

--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -181,7 +181,7 @@ examples: |-
 
   ```dockerfile
   FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-  LABEL maintainer="some maintainer <maintainer@example.com>"
+  LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
   ```
 
   > **Note**

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -1236,7 +1236,7 @@ examples: |-
   If you want to add a running container to a network use the `docker network connect` subcommand.
 
   You can connect multiple containers to the same network. Once connected, the
-  containers can communicate easily need only another container's IP address
+  containers can communicate easily using only another container's IP address
   or name. For `overlay` networks or custom plugins that support multi-host
   connectivity, containers connected to the same multi-host network but launched
   from different Engines can also communicate in this way.

--- a/_data/engine-cli/docker_stack.yaml
+++ b/_data/engine-cli/docker_stack.yaml
@@ -20,7 +20,7 @@ options:
 - option: kubeconfig
   value_type: string
   description: Kubernetes config file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -28,7 +28,7 @@ options:
 - option: orchestrator
   value_type: string
   description: Orchestrator to use (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_stack_deploy.yaml
+++ b/_data/engine-cli/docker_stack_deploy.yaml
@@ -28,7 +28,7 @@ options:
 - option: namespace
   value_type: string
   description: Kubernetes namespace to use
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -67,7 +67,7 @@ inherited_options:
 - option: kubeconfig
   value_type: string
   description: Kubernetes config file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -75,7 +75,7 @@ inherited_options:
 - option: orchestrator
   value_type: string
   description: Orchestrator to use (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_stack_ls.yaml
+++ b/_data/engine-cli/docker_stack_ls.yaml
@@ -18,7 +18,7 @@ options:
   value_type: bool
   default_value: "false"
   description: List stacks from all Kubernetes namespaces
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -35,7 +35,7 @@ options:
   value_type: stringSlice
   default_value: '[]'
   description: Kubernetes namespaces to use
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -44,7 +44,7 @@ inherited_options:
 - option: kubeconfig
   value_type: string
   description: Kubernetes config file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -52,7 +52,7 @@ inherited_options:
 - option: orchestrator
   value_type: string
   description: Orchestrator to use (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_stack_ps.yaml
+++ b/_data/engine-cli/docker_stack_ps.yaml
@@ -33,7 +33,7 @@ options:
 - option: namespace
   value_type: string
   description: Kubernetes namespace to use
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -70,7 +70,7 @@ inherited_options:
 - option: kubeconfig
   value_type: string
   description: Kubernetes config file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -78,7 +78,7 @@ inherited_options:
 - option: orchestrator
   value_type: string
   description: Orchestrator to use (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_stack_rm.yaml
+++ b/_data/engine-cli/docker_stack_rm.yaml
@@ -17,7 +17,7 @@ options:
 - option: namespace
   value_type: string
   description: Kubernetes namespace to use
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -26,7 +26,7 @@ inherited_options:
 - option: kubeconfig
   value_type: string
   description: Kubernetes config file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -34,7 +34,7 @@ inherited_options:
 - option: orchestrator
   value_type: string
   description: Orchestrator to use (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_stack_services.yaml
+++ b/_data/engine-cli/docker_stack_services.yaml
@@ -33,7 +33,7 @@ options:
 - option: namespace
   value_type: string
   description: Kubernetes namespace to use
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -52,7 +52,7 @@ inherited_options:
 - option: kubeconfig
   value_type: string
   description: Kubernetes config file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true
@@ -60,7 +60,7 @@ inherited_options:
 - option: orchestrator
   value_type: string
   description: Orchestrator to use (swarm|kubernetes|all)
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_version.yaml
+++ b/_data/engine-cli/docker_version.yaml
@@ -22,7 +22,7 @@ options:
 - option: kubeconfig
   value_type: string
   description: Kubernetes config file
-  deprecated: false
+  deprecated: true
   experimental: false
   experimentalcli: false
   kubernetes: true


### PR DESCRIPTION
updating to the latest changes from the 20.10 branch


also includes the changes from https://github.com/docker/cli/pull/3174 and https://github.com/docker/cli/pull/3175 (soon to be merged)

