### PR TITLE
Engine: remove Ubuntu 16.04 "xenial", Fedora 32 (both EOL), and some touch-ups

### DIFF
--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -20,7 +20,6 @@ To get started with Docker Engine on Fedora, make sure you
 
 To install Docker Engine, you need the 64-bit version of one of these Fedora versions:
 
-- Fedora 32
 - Fedora 33
 - Fedora 34
 

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -46,23 +46,23 @@ your preferred operating system below.
 
 {% assign yes = '![yes](/images/green-check.svg){: .inline style="height: 14px; margin: 0 auto"}' %}
 
-| Platform                                                          | x86_64 / amd64                                   |
-|:------------------------------------------------------------------|:------------------------------------------------:|
-| [Docker Desktop for Mac (macOS)](../../docker-for-mac/install.md) | [{{ yes }}](../../docker-for-mac/install.md)     |
-| [Docker Desktop for Windows](../../docker-for-windows/install.md) | [{{ yes }}](../../docker-for-windows/install.md) |
+| Platform                                                          | x86_64 / amd64                                   | arm64 (Apple Silicon)                            |
+|:------------------------------------------------------------------|:------------------------------------------------:|:------------------------------------------------:|
+| [Docker Desktop for Mac (macOS)](../../docker-for-mac/install.md) | [{{ yes }}](../../docker-for-mac/install.md)     | [{{ yes }}](../../docker-for-mac/install.md)     |
+| [Docker Desktop for Windows](../../docker-for-windows/install.md) | [{{ yes }}](../../docker-for-windows/install.md) |                                                  |
 
 ### Server
 
 Docker provides `.deb` and `.rpm` packages from the following Linux distributions
 and architectures:
 
-| Platform              | x86_64 / amd64         | ARM                      | ARM64 / AARCH64        |
-|:----------------------|:-----------------------|:-------------------------|:-----------------------|
-| [CentOS](centos.md)   | [{{ yes }}](centos.md) |                          | [{{ yes }}](centos.md) |
-| [Debian](debian.md)   | [{{ yes }}](debian.md) | [{{ yes }}](debian.md)   | [{{ yes }}](debian.md) |
-| [Fedora](fedora.md)   | [{{ yes }}](fedora.md) |                          | [{{ yes }}](fedora.md) |
-| [Raspbian](debian.md) |                        | [{{ yes }}](debian.md)   | [{{ yes }}](debian.md) |
-| [Ubuntu](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md)   | [{{ yes }}](ubuntu.md) |
+| Platform              | x86_64 / amd64         | arm64 / aarch64        | arm (32-bit)             |
+|:----------------------|:-----------------------|:-----------------------|:-------------------------|
+| [CentOS](centos.md)   | [{{ yes }}](centos.md) | [{{ yes }}](centos.md) |                          |
+| [Debian](debian.md)   | [{{ yes }}](debian.md) | [{{ yes }}](debian.md) | [{{ yes }}](debian.md)   |
+| [Fedora](fedora.md)   | [{{ yes }}](fedora.md) | [{{ yes }}](fedora.md) |                          |
+| [Raspbian](debian.md) |                        |                        | [{{ yes }}](debian.md)   |
+| [Ubuntu](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md)   |
 
 ### Other Linux distributions
 
@@ -106,10 +106,10 @@ and **nightly**:
 
 Year-month releases are made from a release branch diverged from the master
 branch. The branch is created with format `<year>.<month>`, for example
-`19.03`. The year-month name indicates the earliest possible calendar
+`20.10`. The year-month name indicates the earliest possible calendar
 month to expect the release to be generally available. All further patch
-releases are performed from that branch. For example, once `v19.03.0` is
-released, all subsequent patch releases are built from the `19.03` branch.
+releases are performed from that branch. For example, once `v20.10.0` is
+released, all subsequent patch releases are built from the `20.10` branch.
 
 ### Test
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -31,9 +31,17 @@ versions:
 - Ubuntu Groovy 20.10
 - Ubuntu Focal 20.04 (LTS)
 - Ubuntu Bionic 18.04 (LTS)
-- Ubuntu Xenial 16.04 (LTS)
 
 Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
+
+> Ubuntu 16.04 LTS "Xenial Xerus" end-of-life
+> 
+> Ubuntu Linux 16.04 LTS reached the end of its five-year LTS window on April
+> 30th 2021 and is no longer supported. Docker no longer releases packages for
+> this distribution (including patch- and security releases). Users running
+> Docker on Ubuntu 16.04 are recommended to update their system to a currently
+> supported LTS version of Ubuntu.
+{: .important }
 
 ### Uninstall old versions
 


### PR DESCRIPTION
### engine: remove ubuntu 16.04 "xenial" and add deprecation warning

Ubuntu 16.04 was an LTS release, and is known to have been widely used (even recently), so adding a warning to make it more visible that it's EOL now.

### engine: remove Fedora 32, as it's EOL

No warning added for this one, as most users know that Fedora releases reach EOL frequently (no LTS versions).

### engine/install: various touch-ups

- swap arm / arm64 columns (as arm 32-bit is only for a single distro)
- remove raspbian arm64 Raspbian is 32 bit, and we don't ship packages
  for raspbian arm64
- add (32-bit) mention to arm column
- add "Apple Silicon" to the Docker Desktop table for completeness