### PR TITLE
Service accounts removed abbreviations

### DIFF
--- a/docker-hub/service-accounts.md
+++ b/docker-hub/service-accounts.md
@@ -16,11 +16,11 @@ Refer to the following table for details on the Enhanced Service Account add-on 
 
 | Tier | Pull Rates Per Day* | Annual Fee |
 | ------ | ------ | ------ |
-| 1 | 5-10k | $9,950/yr |
-| 2 | 10-25k | $17,950/yr |
-| 3 | 25k-50k | $32,950/yr |
-| 4 | 50-100k | $58,950/yr |
-| 5 | 100k+ | [Contact Sales](https://www.docker.com/pricing/questions){:target="_blank" rel="noopener" class="_"} |
+| 1 | 5,000-10,000 | $9,950/yr |
+| 2 | 10,000-25,000 | $17,950/yr |
+| 3 | 25,000-50,000 | $32,950/yr |
+| 4 | 50,000-100,000 | $58,950/yr |
+| 5 | 100,000+ | [Contact Sales](https://www.docker.com/pricing/questions){:target="_blank" rel="noopener" class="_"} |
 
 <sub>*Once the initial Tier is established, that is the minimum fee for the year.  Annual commitment required.  The service account may exceed Pulls by up to 25% for up to 20 days during the year without incurring additional fees.  Reports on consumption will be provided upon request.  At the end of the initial 1-year term, the appropriate Tier will be established for the following year.<sub>
 


### PR DESCRIPTION
Removed abbreviations for numerical values (example: 5k > 5,000).