### PR TITLE
Update hello-world ref to clarify it is source only

### DIFF
--- a/develop/develop-images/baseimages.md
+++ b/develop/develop-images/baseimages.md
@@ -68,9 +68,8 @@ ADD hello /
 CMD ["/hello"]
 ```
 
-Assuming you built the "hello" executable example by following the instructions
-at
-[https://github.com/docker-library/hello-world/](https://github.com/docker-library/hello-world/),
+Assuming you built the "hello" executable example by using the source code at
+[https://github.com/docker-library/hello-world](https://github.com/docker-library/hello-world),
 and you compiled it with the `-static` flag, you can build this Docker
 image using this `docker build` command:
 


### PR DESCRIPTION
The "hello-world" repository (somewhat intentionally) does not contain any instructions for building it, but the instructions to do so already followed this line, so this adjusts the wording to be more clear that the source code lives in the hello-world repository without implying that there are instructions for building there as well.

(Closes https://github.com/docker-library/hello-world/issues/90)