### PR TITLE
Add "-dev"-suffix to new image

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -153,7 +153,7 @@ $ pip3 freeze > requirements.txt
 Now we can build our image.
 
 ```shell
-$ docker build --tag python-docker .
+$ docker build --tag python-docker-dev .
 ```
 
 Now, let’s add the container to the database network and then run our container. This allows us to access the database by its container name.
@@ -164,7 +164,7 @@ $ docker run \
   --network mysqlnet \
   --name rest-server \
   -p 5000:5000 \
-  python-docker
+  python-docker-dev
 ```
 
 Let’s test that our application is connected to the database and is able to add a note.
@@ -182,9 +182,9 @@ You should receive the following JSON back from our service.
 
 ## Use Compose to develop locally
 
-In this section, we’ll create a [Compose file](../../compose/index.md) to start our python-docker and the MySQL database using a single command. We’ll also set up the Compose file to start the `python-docker` application in debug mode so that we can connect a debugger to the running process.
+In this section, we’ll create a [Compose file](../../compose/index.md) to start our python-docker and the MySQL database using a single command. We’ll also set up the Compose file to start the `python-docker-dev` application in debug mode so that we can connect a debugger to the running process.
 
-Open the `python-docker` code in your IDE or a text editor and create a new file named `docker-compose.dev.yml`. Copy and paste the following commands into the file.
+Open the `python-docker` directory in your IDE or a text editor and create a new file named `docker-compose.dev.yml`. Copy and paste the following commands into the file.
 
 ```yaml
 version: '3.8'


### PR DESCRIPTION
### Proposed changes

I've added a "-dev"-suffix in the lines where we are working with the new python-docker image.
In this way we do not overwrite the previous one which we build in the [image part of the guide](https://docs.docker.com/language/python/build-images/).
In this way the can differentiate between the two different images and make more clear what happens.
Otherwise (with the current version of the docs) the previous image name would turn to "<none>".

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
