### PR TITLE
Typo Fixed In the File: language/python/run-containers.md

### DIFF
--- a/language/python/run-containers.md
+++ b/language/python/run-containers.md
@@ -31,7 +31,7 @@ $ curl localhost:5000
 curl: (7) Failed to connect to localhost port 5000: Connection refused
 ```
 
-As you can see, our `curl` command failed because the connection to our server was refused. This means, we were not able to connect to the localhost on port 5000. This is expected because our container is run in isolation which includes networking. Let’s stop the container and restart with port 5000 published on our local network.
+As you can see, our `curl` command failed because the connection to our server was refused. This means, we were not able to connect to the localhost on port 5000. This is expected because our container is running in isolation which includes networking. Let’s stop the container and restart with port 5000 published on our local network.
 
 To stop the container, press ctrl-c. This will return you to the terminal prompt.
 


### PR DESCRIPTION
### Proposed changes

For the first time, I was dockerizing my python app and found a typo in the file: `language/python/run-containers.md`. 
I feel that the line: `This is expected because our container is run in isolation which includes networking.` is grammatically incorrect. In the sense that, its intention is to express that the container running at port 5000 is the cause for the curl cmd to fail but for that, it is making use of an incorrect form of the verb run. So, I feel it should be using the gerund or present participle form, which is running.
Hence, I feel that the correct line should be: `This is expected because our container is running in isolation which includes networking.`

Please review it. 😊 

### Unreleased project version (optional)


### Related issues (optional)

