### PR TITLE
Add upgrade CTA widget

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{scss,html,md}]
+indent_style = space
+indent_size = 2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+# It's pretty common for devs to have prettier configured to format on save,
+# so let's include some config to prevent it messing up files in this repo
+
+# Prettier struggles with the kramdown extensions
+*.md
+
+# Our stylesheets use a particular in-house(?) style
+*.scss

--- a/_includes/upgrade-cta.html
+++ b/_includes/upgrade-cta.html
@@ -1,0 +1,9 @@
+<div class="docker-upgrade-cta" role="alert">
+  <div class="docker-upgrade-cta__heading">This feature requires a Pro or Team plan.</div>
+
+  {{ include.body | markdownify }}
+
+  <a class="btn btn-primary" role="button" href="{{include.target-url}}">
+    Upgrade my plan
+  </a>
+</div>

--- a/_scss/_color-palette.scss
+++ b/_scss/_color-palette.scss
@@ -1,0 +1,97 @@
+$red-10: #f8a09a;
+$red-20: #f3847e;
+$red-30: #ee635f;
+$red-40: #e9524f;
+$red-50: #e44141;
+$red-60: #da3333;
+$red-70: #c82828;
+$red-80: #b21c1c;
+$red-90: #9e1011;
+$red-100: #8c0607;
+
+$magenta-10: #fbd5fa;
+$magenta-20: #f5b8f3;
+$magenta-30: #ef94eb;
+$magenta-40: #e96fe4;
+$magenta-50: #e34adc;
+$magenta-60: #dd26d5;
+$magenta-70: #cc18c4;
+$magenta-80: #a611a0;
+$magenta-90: #7b0a76;
+$magenta-100: #530450;
+
+$purple-10: #d4c1f8;
+$purple-20: #bca5ea;
+$purple-30: #aa92dc;
+$purple-40: #987ece;
+$purple-50: #866abf;
+$purple-60: #7457b1;
+$purple-70: #6243a3;
+$purple-80: #4e2d8f;
+$purple-90: #3c1980;
+$purple-100: #270769;
+
+$marine-10: #9fd1f9;
+$marine-20: #6fb6f6;
+$marine-30: #4ba0f3;
+$marine-40: #268aef;
+$marine-50: #007bff;
+$marine-60: #0162cc;
+$marine-70: #0151ad;
+$marine-80: #003f8c;
+$marine-90: #002c66;
+$marine-100: #0b214a;
+
+$grey-10: #d7dade;
+$grey-20: #b9c2c9;
+$grey-30: #a5b1ba;
+$grey-40: #90a0ac;
+$grey-50: #768491;
+$grey-60: #5a6774;
+$grey-70: #404d59;
+$grey-80: #26323f;
+$grey-90: #17222f;
+$grey-100: #161f2a;
+
+$blue-10: #c4f0ff;
+$blue-20: #98e0ff;
+$blue-30: #71cfff;
+$blue-40: #51bcfd;
+$blue-50: #37aaf7;
+$blue-60: #2496ed;
+$blue-70: #1282d7;
+$blue-80: #076cad;
+$blue-90: #025391;
+$blue-100: #004375;
+
+$green-10: #c7efe6;
+$green-20: #aae8d8;
+$green-30: #8de0ca;
+$green-40: #70d8bd;
+$green-50: #54d1b0;
+$green-60: #43b899;
+$green-70: #33977e;
+$green-80: #237663;
+$green-90: #135446;
+$green-100: #094539;
+
+$orange-10: #fef5c3;
+$orange-20: #f9e3ae;
+$orange-30: #f5d19a;
+$orange-40: #f0bf85;
+$orange-50: #ecad71;
+$orange-60: #e79a5c;
+$orange-70: #e28847;
+$orange-80: #db7432;
+$orange-90: #d4611d;
+$orange-100: #cc4e09;
+
+$white-0: #ffffff;
+$white-5: #fafafb;
+$white-10: #f7f7f8;
+$white-15: #f2f3f5;
+$white-25: #e9ebee;
+
+$black-0: #0f161e;
+$black-5: #121a24;
+$black-15: #151c26;

--- a/_scss/_upgrade-cta.scss
+++ b/_scss/_upgrade-cta.scss
@@ -1,0 +1,18 @@
+.docker-upgrade-cta {
+  background-color: $orange-10;
+
+  padding: 16px 25px;
+  margin: 0 0 20px;
+
+  border-radius: 4px;
+  border: 1px solid $orange-20;
+
+  .docker-upgrade-cta__heading {
+    font-weight: bold;
+    font-size: 16px;
+
+    font-family: $headings;
+
+    margin-top: 0;
+  }
+}

--- a/css/style.scss
+++ b/css/style.scss
@@ -3,6 +3,7 @@
 ---
 
 @import "breakpoint";
+@import "color-palette";
 @import "variables";
 @import "night-mode";
 @import "base";

--- a/css/style.scss
+++ b/css/style.scss
@@ -18,3 +18,4 @@
 @import "overrides";
 @import "mobile";
 @import "notes";
+@import "upgrade-cta";

--- a/test.md
+++ b/test.md
@@ -659,6 +659,17 @@ It will render like this  with a colored sidebar and icon:
 
 ![warning admonition example](/images/warning-admonition-example.png)
 
+## Upgrade CTA
+
+Use the `upgrade-cta.html` include to render a CTA asking the user to upgrade their plan. There are two parameters:
+
+- `target-url`: This will typically be something like https://www.docker.com/pricing, possibly with a utm code.
+- `body`: This forms the body of the CTA. It accepts Markdown. To use multi-line bodies, use named captures as explained in [the Jekyll docs](https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes).
+
+```
+{% include upgrade-cta.html body="Upgrade to gain access to this feature" target-url="https://www.example.com/" %}
+```
+
 ## Code blocks
 
 Rouge provides lots of different code block "hints". If you leave off the hint,


### PR DESCRIPTION
### Proposed changes

- Add .editorconfig, .prettierignore, color palette. Same as PR #13158 
- Add new include for rendering an upgrade CTA
- Add docs for new include

![image](https://user-images.githubusercontent.com/70579116/125258763-2cfffd80-e2ee-11eb-972f-584362f36cf6.png)
