### PR TITLE
Change Install Docs Order Related to Importance of the OS

### DIFF
--- a/get-docker.md
+++ b/get-docker.md
@@ -34,19 +34,19 @@ section and choose the best installation path for you.
         <div class="col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
-                    <a href="/docker-for-windows/install/"><img src="/images/windows_48.svg" alt="Docker Desktop for Windows" width="70" height="70"></a>
+                    <a href="/engine/install/"><img src="/images/linux_48.svg" alt="Docker for Linux" width="70" height="70"></a>
                 </div>
-                <h2 id="docker-for-windows/install/"><a href="/docker-for-windows/install/">Docker Desktop for Windows</a></h2>
-                <p>A native Windows application which delivers all Docker tools to your Windows computer.</p>
+                <h2 id="docker-for-linux"><a href="/engine/install/">Docker for Linux</a></h2>
+                <p>Install Docker on a computer which already has a Linux distribution installed.</p>
             </div>
         </div>
         <div class="col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
-                    <a href="/engine/install/"><img src="/images/linux_48.svg" alt="Docker for Linux" width="70" height="70"></a>
+                    <a href="/docker-for-windows/install/"><img src="/images/windows_48.svg" alt="Docker Desktop for Windows" width="70" height="70"></a>
                 </div>
-                <h2 id="docker-for-linux"><a href="/engine/install/">Docker for Linux</a></h2>
-                <p>Install Docker on a computer which already has a Linux distribution installed.</p>
+                <h2 id="docker-for-windows/install/"><a href="/docker-for-windows/install/">Docker Desktop for Windows</a></h2>
+                <p>A native Windows application which delivers all Docker tools to your Windows computer.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The order of importance in the docs when its comes to installing docker should be 
MAC, Linux, Windows or Linux, Mac, Windows

Don't put Windows systems install instructions before linux. Every serious developer is working with docker either in Linux or Mac env but not Windows.
