### PR TITLE
Improve upgrade CTA for dark mode, add header property

### DIFF
--- a/_includes/upgrade-cta.html
+++ b/_includes/upgrade-cta.html
@@ -1,5 +1,5 @@
 <div class="docker-upgrade-cta" role="alert">
-  <div class="docker-upgrade-cta__heading">This feature requires a Pro or Team plan.</div>
+  <div class="docker-upgrade-cta__heading">{{include.header-text}}</div>
 
   {{ include.body | markdownify }}
 

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -271,7 +271,6 @@ body.landing {
       background:  #FF3F73;
       color:       white;
       font-size:   17px;
-      font-weight: bold;
       margin-top:  50px;
       padding:     20px 60px;
 

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -25,7 +25,7 @@ body.night {
     div#side-toc-title {
         color: $white;
     }
-    a:not(.btn) {
+    a:not(.btn):not(.button) {
         color: $primary-links-night;
     }
     .header {

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -25,7 +25,7 @@ body.night {
     div#side-toc-title {
         color: $white;
     }
-    a {
+    a:not(.btn) {
         color: $primary-links-night;
     }
     .header {

--- a/_scss/_overrides.scss
+++ b/_scss/_overrides.scss
@@ -29,6 +29,26 @@
     display: block;
 }
 
+.btn {
+  font-weight: bold;
+}
+
+.btn-primary {
+  background-color: $marine-50;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 10px 15px 6px;
+
+  &:hover {
+    opacity: 0.8;
+
+    // override default bootstrap behaviour
+    background-color: $marine-50;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  font-family: $buttons;
+}
+
 .btn-default:hover {
     color: #fff!important;
     background-color: transparent!important;

--- a/_scss/_upgrade-cta.scss
+++ b/_scss/_upgrade-cta.scss
@@ -1,5 +1,6 @@
 .docker-upgrade-cta {
   background-color: $orange-10;
+  color: $body-text; // we want this irrespective of light/dark mode
 
   padding: 16px 25px;
   margin: 0 0 20px;

--- a/_scss/_upgrade-cta.scss
+++ b/_scss/_upgrade-cta.scss
@@ -1,12 +1,20 @@
 .docker-upgrade-cta {
-  background-color: $orange-10;
-  color: $body-text; // we want this irrespective of light/dark mode
+  body.night & {
+    background-color: change-color($orange-10, $alpha: 0.3);
+    border: 1px solid $orange-10;
+    p, .docker-upgrade-cta__heading { color: $orange-10; }
+  }
+
+  body:not(.night) & {
+    background-color: $orange-10;
+    border: 1px solid $orange-20;
+    p, .docker-upgrade-cta__heading { color: inherit; }
+  }
 
   padding: 16px 25px;
   margin: 0 0 20px;
 
-  border-radius: 4px;
-  border: 1px solid $orange-20;
+  border-radius: 3px;
 
   .docker-upgrade-cta__heading {
     font-weight: bold;

--- a/_scss/_variables.scss
+++ b/_scss/_variables.scss
@@ -31,7 +31,6 @@ $bg-card:                 hsl(  0,   0%, 100%);
 
 // notes, warnings
 $note-color:              hsl(206,  82%,  43%);
-$note-bg-color:           hsl(206,  83%,  98%);
 $important-color:         hsl( 35,  91%,  35%);
 $warning-color:           hsl(  2,  58%,  54%);
 
@@ -57,12 +56,6 @@ $bg-footer-landing-night: hsl(214, 100%,  20%);
 
 $bg-component-night:      hsl(203,  44%,  10%);
 $bg-card-night:           hsl(203,  33%,   8%);
-
-// notes, warnings
-$note-color-night:        hsl(180,   1%,  83%);
-$note-bg-color-night:     hsl(203,  35%,  19%);
-$important-color-night:   hsl( 35,  90%,  62%);
-$warning-color-night:     hsl(  2, 100%,  74%);
 
 $active-sidebar-night:    hsl(203,  85%,   79%);
 

--- a/test.md
+++ b/test.md
@@ -663,12 +663,19 @@ It will render like this  with a colored sidebar and icon:
 
 Use the `upgrade-cta.html` include to render a CTA asking the user to upgrade their plan. There are two parameters:
 
-- `target-url`: This will typically be something like https://www.docker.com/pricing, possibly with a utm code.
+- `target-url`: This is what the upgrade button will link to. Will typically be something like `https://www.docker.com/pricing`, possibly with a utm code.
+- `header-text`: The text shown in the bolded header at the top of the CTA. Only accepts strings, no Markdown support.
 - `body`: This forms the body of the CTA. It accepts Markdown. To use multi-line bodies, use named captures as explained in [the Jekyll docs](https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes).
 
+{% raw %}
+```liquid
+{% include upgrade-cta.html
+  body="Upgrade to gain access to this feature"
+  header-text="This feature is restricted to X and Y plans"
+  target-url="https://www.example.com/
+%}
 ```
-{% include upgrade-cta.html body="Upgrade to gain access to this feature" target-url="https://www.example.com/" %}
-```
+{% endraw %}
 
 ## Code blocks
 

--- a/test.md
+++ b/test.md
@@ -672,7 +672,7 @@ Use the `upgrade-cta.html` include to render a CTA asking the user to upgrade th
 {% include upgrade-cta.html
   body="Upgrade to gain access to this feature"
   header-text="This feature is restricted to X and Y plans"
-  target-url="https://www.example.com/
+  target-url="https://www.example.com/"
 %}
 ```
 {% endraw %}


### PR DESCRIPTION
### Proposed changes

- Remove some unused variables
- Make upgrade-cta include's header parameterised
- Make upgrade CTA look better on dark mode (still not perfect though)
- Update docs

![image](https://user-images.githubusercontent.com/70579116/125423472-c9773d00-0b46-4751-9328-8607a32458eb.png)

![image](https://user-images.githubusercontent.com/70579116/125423529-d3936bd8-bab2-44b7-816a-985e7d3b7885.png)
