### PR TITLE
daemon.json does not exist in a fresh docker install - Update json-file.md

### DIFF
--- a/config/containers/logging/json-file.md
+++ b/config/containers/logging/json-file.md
@@ -29,7 +29,7 @@ only one container.
 To use the `json-file` driver as the default logging driver, set the `log-driver`
 and `log-opts` keys to appropriate values in the `daemon.json` file, which is
 located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\` on Windows Server. For more information about
+`C:\ProgramData\docker\config\` on Windows Server. If the file does not exist, create it first. For more information about
 configuring Docker using `daemon.json`, see
 [daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
 


### PR DESCRIPTION
The file daemon.json does not exist in a fresh docker install in Ubuntu. This needs to be explained in the docs.
