### PR TITLE
Typos Fixed in the run-container.md files of language folder

### DIFF
--- a/language/golang/run-containers.md
+++ b/language/golang/run-containers.md
@@ -45,7 +45,7 @@ $ curl http://localhost:8080/
 curl: (7) Failed to connect to localhost port 8080: Connection refused
 ```
 
-Our curl command failed because the connection to our server was refused. Meaning that we were not able to connect to localhost on port 8080. This is expected because our container is run in isolation which includes networking. Let’s stop the container and restart with port 8080 published on our local network.
+Our curl command failed because the connection to our server was refused. Meaning that we were not able to connect to localhost on port 8080. This is expected because our container is running in isolation which includes networking. Let’s stop the container and restart with port 8080 published on our local network.
 
 To stop the container, press ctrl-c. This will return you to the terminal prompt.
 

--- a/language/java/run-containers.md
+++ b/language/java/run-containers.md
@@ -33,7 +33,7 @@ $ curl --request GET \
 curl: (7) Failed to connect to localhost port 8080: Connection refused
 ```
 
-As you can see, our `curl` command failed because the connection to our server was refused. This means, we were not able to connect to the localhost on port 8080. This is expected because our container is run in isolation which includes networking. Let’s stop the container and restart with port 8080 published on our local network.
+As you can see, our `curl` command failed because the connection to our server was refused. This means, we were not able to connect to the localhost on port 8080. This is expected because our container is running in isolation which includes networking. Let’s stop the container and restart with port 8080 published on our local network.
 
 To stop the container, press `ctrl-c`. This will return you to the terminal prompt.
 

--- a/language/nodejs/run-containers.md
+++ b/language/nodejs/run-containers.md
@@ -38,7 +38,7 @@ $ curl --request POST \
 curl: (7) Failed to connect to localhost port 8000: Connection refused
 ```
 
-Our curl command failed because the connection to our server was refused. Meaning that we were not able to connect to localhost on port 8000. This is expected because our container is run in isolation which includes networking. Let’s stop the container and restart with port 8000 published on our local network.
+Our curl command failed because the connection to our server was refused. Meaning that we were not able to connect to localhost on port 8000. This is expected because our container is running in isolation which includes networking. Let’s stop the container and restart with port 8000 published on our local network.
 
 To stop the container, press ctrl-c. This will return you to the terminal prompt.
 


### PR DESCRIPTION

### Proposed changes

<!--Tell us what you did and why-->

While I was exploring other parts of the documentation, I realized that some more typos exist in the run-container.md files: `language/golang/run-containers.md`, `language/java/run-containers.md`, `language/nodejs/run-containers.md`. 
In all these files, I feel that the problem lies in the line: `This is expected because our container is run in isolation which includes networking`. 
In the sense that, its intention is to express that the container running at the respective port (8080 for golang and java, and 8000 for nodejs) is the cause for the curl cmd to fail but for that, it is making use of an incorrect form of the verb run. So, I feel it should be using the gerund or present participle form, which is running.
Hence, I feel that the correct line should be: `This is expected because our container is running in isolation which includes networking.`

Please review it. 😊👨‍💻👩‍💻

### Unreleased project version (optional)


### Related issues (optional)

This PR is similar to #13161. In that PR, I resolved this same issue with the file: `language/python/run-containers.md`. Then after exploring more, I found that the typo lies in other run-container.md files as well. So, I thought of resolving it. 

