### PR TITLE
Updated django.md

### DIFF
--- a/samples/django.md
+++ b/samples/django.md
@@ -80,7 +80,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
          - POSTGRES_PASSWORD=postgres
      web:
        build: .
-       command: python manage.py runserver 0.0.0.0:8000
+       command: python composeexample/manage.py runserver 0.0.0.0:8000
        volumes:
          - .:/code
        ports:


### PR DESCRIPTION
I tried following this but kept receiving `ModuleNotFoundError: No module named 'composeexample'` error. This seems to have been happening because `manage.py` was inside the folder `composeexample`, so prefixing the `manage.py` from `python manage.py runserver` worked.

(furthermore, I think this should be another ticket, but after solving this I received `psycopg2.OperationalError: FATAL:  the database system is starting up` and [this](https://stackoverflow.com/a/55835081/14403987) answer on stackoverflow solved it).
