### PR TITLE
Disable hardware acceleration option

### DIFF
--- a/desktop/faqs.md
+++ b/desktop/faqs.md
@@ -83,8 +83,7 @@ For more information, see [Running Docker Desktop in nested virtualization scena
 
 ### Docker Desktop's UI appears green, distorted, or has visual artifacts. How do I fix this?
 
-Docker Desktop is built on Electron which enables hardware-accelerated graphics by default. 
-However, some graphics cards may not support hardware acceleration. In such cases, 
+Docker Desktop uses hardware-accelerated graphics by default, which may cause problems for some GPUs. In such cases, 
 Docker Desktop will launch successfully, but some screens may appear green, distorted, 
 or have some visual artifacts.
 

--- a/desktop/faqs.md
+++ b/desktop/faqs.md
@@ -87,12 +87,12 @@ Docker Desktop uses hardware-accelerated graphics by default, which may cause pr
 Docker Desktop will launch successfully, but some screens may appear green, distorted, 
 or have some visual artifacts.
 
-To work around this issue, disable hardware acceleration by turning on `disableHardwareAcceleration` option in `settings.json` for Docker Desktop. This file can be found in
+To work around this issue, disable hardware acceleration by creating a `"disableHardwareAcceleration": true` entry in Docker Desktop's settings file. This file can be found at:
 
-- `~/Library/Group Containers/group.com.docker/settings.json` for Mac
-- `C:\Users\{username}\AppData\Roaming\Docker\settings.json` for Windows
+- **Mac**: `~/Library/Group Containers/group.com.docker/settings.json`
+- **Windows**: `C:\Users\[USERNAME]\AppData\Roaming\Docker\settings.json`
  
-and then reopen Docker Desktop's UI.
+Completely close and restart Docker Desktop to apply the changes.
 
 ## Releases
 

--- a/desktop/faqs.md
+++ b/desktop/faqs.md
@@ -87,10 +87,12 @@ Docker Desktop uses hardware-accelerated graphics by default, which may cause pr
 Docker Desktop will launch successfully, but some screens may appear green, distorted, 
 or have some visual artifacts.
 
-To work around this issue, disable hardware acceleration by 
-setting the `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION` environment 
-variable to any value. For example, set `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION=1` 
-and then restart Docker Desktop.
+To work around this issue, disable hardware acceleration by turning on `disableHardwareAcceleration` option in `settings.json` for Docker Desktop. This file can be found in
+
+- `~/Library/Group Containers/group.com.docker/settings.json` for Mac
+- `C:\Users\{username}\AppData\Roaming\Docker\settings.json` for Windows
+ 
+and then reopen Docker Desktop's UI.
 
 ## Releases
 

--- a/desktop/faqs.md
+++ b/desktop/faqs.md
@@ -81,6 +81,12 @@ nested virtualization scenarios**. It might work in some cases, and not in other
 
 For more information, see [Running Docker Desktop in nested virtualization scenarios](../docker-for-windows/troubleshoot.md#running-docker-desktop-in-nested-virtualization-scenarios).
 
+### I have the problem with displaying some views in Docker Desktop, what should I do?
+
+Docker Desktop is built on top of Electron which enables hardware accelerated graphics by default, but some graphics cards have issues with hardware acceleration which means Docker Desktop will launch successfully but it will have broken dashboard view.
+
+If you want to work around this default option, you will need set the `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION` environment variable to any value (example `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION=1`) and relaunch Docker Desktop again it will disable hardware acceleration on launch.
+
 ## Releases
 
 ### When will Docker Desktop move to a cumulative release stream?

--- a/desktop/faqs.md
+++ b/desktop/faqs.md
@@ -87,12 +87,12 @@ Docker Desktop uses hardware-accelerated graphics by default, which may cause pr
 Docker Desktop will launch successfully, but some screens may appear green, distorted, 
 or have some visual artifacts.
 
-To work around this issue, disable hardware acceleration by creating a `"disableHardwareAcceleration": true` entry in Docker Desktop's settings file. This file can be found at:
+To work around this issue, disable hardware acceleration by creating a `"disableHardwareAcceleration": true` entry in Docker Desktop's `settings.json` file. You can find this file at:
 
 - **Mac**: `~/Library/Group Containers/group.com.docker/settings.json`
 - **Windows**: `C:\Users\[USERNAME]\AppData\Roaming\Docker\settings.json`
  
-Completely close and restart Docker Desktop to apply the changes.
+After updating the `settings.json` file, close and restart Docker Desktop to apply the changes.
 
 ## Releases
 

--- a/desktop/faqs.md
+++ b/desktop/faqs.md
@@ -81,11 +81,17 @@ nested virtualization scenarios**. It might work in some cases, and not in other
 
 For more information, see [Running Docker Desktop in nested virtualization scenarios](../docker-for-windows/troubleshoot.md#running-docker-desktop-in-nested-virtualization-scenarios).
 
-### I have the problem with displaying some views in Docker Desktop, what should I do?
+### Docker Desktop's UI appears green, distorted, or has visual artifacts. How do I fix this?
 
-Docker Desktop is built on top of Electron which enables hardware accelerated graphics by default, but some graphics cards have issues with hardware acceleration which means Docker Desktop will launch successfully but it will have broken dashboard view.
+Docker Desktop is built on Electron which enables hardware-accelerated graphics by default. 
+However, some graphics cards may not support hardware acceleration. In such cases, 
+Docker Desktop will launch successfully, but some screens may appear green, distorted, 
+or have some visual artifacts.
 
-If you want to work around this default option, you will need set the `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION` environment variable to any value (example `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION=1`) and relaunch Docker Desktop again it will disable hardware acceleration on launch.
+To work around this issue, disable hardware acceleration by 
+setting the `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION` environment 
+variable to any value. For example, set `DOCKER_DESKTOP_DISABLE_HARDWARE_ACCELERATION=1` 
+and then restart Docker Desktop.
 
 ## Releases
 


### PR DESCRIPTION
Signed-off-by: Trung Nguyen <trung.nguyen@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I suggest this setting option `disableHardwareAcceleration` to make Docker Desktop 
 displayed without hardware acceleration turned on by default by Electron. This file can be found in

- `~/Library/Group Containers/group.com.docker/settings.json` for Mac
- `C:\Users\{username}\AppData\Roaming\Docker\settings.json` for Windows

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

https://github.com/docker/for-mac/issues/5121

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
