### PR TITLE
Fix Dockerfile COPY/ADD examples without a trailing slash

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -170,13 +170,13 @@ context, refer to [exclude with .dockerignore](#exclude-with-dockerignore).
 > 
 > docker build -t myimage:latest -<<EOF
 > FROM busybox
-> COPY somefile.txt .
+> COPY somefile.txt ./
 > RUN cat /somefile.txt
 > EOF
 > 
 > # observe that the build fails
 > ...
-> Step 2/3 : COPY somefile.txt .
+> Step 2/3 : COPY somefile.txt ./
 > COPY failed: stat /var/lib/docker/tmp/docker-builder249218248/somefile.txt: no such file or directory
 > ```
 
@@ -206,7 +206,7 @@ touch somefile.txt
 # build an image using the current directory as context, and a Dockerfile passed through stdin
 docker build -t myimage:latest -f- . <<EOF
 FROM busybox
-COPY somefile.txt .
+COPY somefile.txt ./
 RUN cat /somefile.txt
 EOF
 ```
@@ -232,7 +232,7 @@ the `hello.c` file from the ["hello-world" Git repository on GitHub](https://git
 ```bash
 docker build -t myimage:latest -f- https://github.com/docker-library/hello-world.git <<EOF
 FROM busybox
-COPY hello.c .
+COPY hello.c ./
 EOF
 ```
 

--- a/develop/develop-images/multistage-build.md
+++ b/develop/develop-images/multistage-build.md
@@ -40,7 +40,7 @@ builder pattern above:
 # syntax=docker/dockerfile:1
 FROM golang:1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
-COPY app.go .
+COPY app.go ./
 RUN go get -d -v golang.org/x/net/html \
   && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 ```
@@ -57,7 +57,7 @@ and forget to continue the line using the `\` character, for example.
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY app .
+COPY app ./
 CMD ["./app"]  
 ```
 
@@ -103,13 +103,13 @@ multi-stage builds.
 FROM golang:1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
+COPY --from=0 /go/src/github.com/alexellis/href-counter/app ./
 CMD ["./app"]  
 ```
 
@@ -143,13 +143,13 @@ Dockerfile are re-ordered later, the `COPY` doesn't break.
 FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go    .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=builder /go/src/github.com/alexellis/href-counter/app .
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
 CMD ["./app"]  
 ```
 

--- a/language/golang/build-images.md
+++ b/language/golang/build-images.md
@@ -152,8 +152,8 @@ In its simplest form, the `COPY` command takes two parameters. The first paramet
 We’ll copy the `go.mod` and `go.sum` file into our working directory `/app` which, owing to our use of `WORKDIR`, is the current directory (`.`) inside the image.
 
 ```dockerfile
-COPY go.mod .
-COPY go.sum .
+COPY go.mod ./
+COPY go.sum ./
 ```
 
 Now that we have the module files inside the Docker image that we are building, we can use the `RUN` command to execute the command `go mod download` there as well. This works exactly the same as if we were running `go` locally on our machine, but this time these Go modules will be installed into the a directory inside our image.
@@ -167,7 +167,7 @@ At this point, we have an image that is based on Go environment version 1.16 (or
 The next thing we need to do is to copy our source code into the image. We’ll use the `COPY` command just like we did with our module files before.
 
 ```dockerfile
-COPY *.go .
+COPY *.go ./
 ```
 
 This `COPY` command uses a wildcard to copy all files with `.go` extension located in the current directory on the host (the directory where the `Dockerfile` is located) into the current directory inside the image. 
@@ -195,11 +195,11 @@ FROM golang:1.16-alpine
 
 WORKDIR /app
 
-COPY go.mod .
-COPY go.sum .
+COPY go.mod ./
+COPY go.sum ./
 RUN go mod download
 
-COPY *.go .
+COPY *.go ./
 
 RUN go build -o /docker-gs-ping
 
@@ -218,8 +218,8 @@ FROM golang:1.16-alpine
 WORKDIR /app
 
 # Download necessary Go modules
-COPY go.mod .
-COPY go.sum .
+COPY go.mod ./
+COPY go.sum ./
 RUN go mod download
 
 # ... the rest of the Dockerfile is ...
@@ -351,11 +351,11 @@ FROM golang:1.16-buster AS build
 
 WORKDIR /app
 
-COPY go.mod .
-COPY go.sum .
+COPY go.mod ./
+COPY go.sum ./
 RUN go mod download
 
-COPY *.go .
+COPY *.go ./
 
 RUN go build -o /docker-gs-ping
 


### PR DESCRIPTION
Fixes https://github.com/docker/docker.github.io/issues/13207

When copying files to a destination directory, the classic builder requires
the destination to have a trailing slash (to indicate the target is a _directory_.
not a filename). BuildKit is a bit more flexible in this, and will assume the
target is a directory, but users following the example with buildkit disabled
might see an error message, e.g.:

    Sending build context to Docker daemon  3.072kB
    Step 1/2 : FROM busybox
     ---> 69593048aa3a
    Step 2/2 : COPY *.go .
    When using COPY with more than one source file, the destination must be a directory and end with a /

It doesn't hurt to be explicit, so this patch updates some examples to prevent
this.

