### PR TITLE
Add username and password in 'Build and push' of configure-ci-cd.md

### DIFF
--- a/language/python/configure-ci-cd.md
+++ b/language/python/configure-ci-cd.md
@@ -101,6 +101,8 @@ Now, we can add the steps required. The first one checks-out our repository unde
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/simplewhale:latest
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
### Proposed changes

I've added the username and password references in the 'Build and push' step of ['Set up the GitHub Actions workflow'](https://docs.docker.com/language/python/configure-ci-cd/#set-up-the-github-actions-workflow) in the Python language guide.
The 'CI to Docker Hub' action didn't  work for me without it.

The changes are inspired by ['GitHub Actions Tutorial - Basic Concepts and CI/CD Pipeline with Docker (YouTube)'](https://youtu.be/R8_veQiYBjI?t=1860)

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

Fixes parts of #13157 (description still not intuitively clear, but functionality is solved - as long as people understand what to do)