### PR TITLE
Update get started docs to use BuildKit for building images

### DIFF
--- a/_includes/enable-buildkit.md
+++ b/_includes/enable-buildkit.md
@@ -1,0 +1,26 @@
+<!-- This text will be included in Build images topic in the Get started guides -->
+
+### Enable BuildKit
+
+Before we start building images, ensure you have enabled BuildKit on your machine. BuildKit allows you to build Docker images efficiently. For more information, see [Building images with BuildKit](../develop/develop-images/build_enhancements.md).
+
+BuildKit is enabled by default for all users on Docker Desktop. If you have installed Docker Desktop, you don't have to manually enable BuildKit. If you are running Docker on Linux, you can enable BuildKit either by using an environment variable or by making BuildKit the default setting.
+
+> You must be running Docker 18.09 or higher to use BuildKit.
+
+To set the BuildKit environment variable when running the `docker build` command, run:
+
+```
+$ DOCKER_BUILDKIT=1 docker build .
+```
+
+To enable docker BuildKit by default, set daemon configuration in `/etc/docker/daemon.json` feature to `true` and restart the daemon.
+If the `daemon.json` file doesn't exist, create new file called `daemon.json` and then add the following to the file.
+
+```json
+{
+  "features":{"buildkit" : true}
+}
+```
+
+Restart the Docker daemon.

--- a/language/java/build-images.md
+++ b/language/java/build-images.md
@@ -10,6 +10,8 @@ description: Learn how to build your first Docker image by writing a Dockerfile
 
 Work through the orientation and setup in Get started [Part 1](../../get-started/index.md){:target="_blank" rel="noopener" class="_"} to understand Docker concepts. Refer to the following section for Java prerequisites.
 
+{% include enable-buildkit.md %}
+
 ## Overview
 
 Now that we have a good overview of containers and the Docker platform, let’s take a look at building our first image. An image includes everything needed to run an application - the code or binary, runtime, dependencies, and any other file system objects required.

--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -12,6 +12,8 @@ redirect_from:
 
 Work through the orientation and setup in Get started [Part 1](../../get-started/index.md) to understand Docker concepts.
 
+{% include enable-buildkit.md %}
+
 ## Overview
 
 Now that we have a good overview of containers and the Docker platform, let’s take a look at building our first image. An image includes everything you need to run an application - the code or binary, runtime, dependencies, and any other file system objects required.
@@ -201,13 +203,15 @@ $ docker build --tag node-docker .
 ```
 
 ```shell
-Sending build context to Docker daemon  82.94kB
-Step 1/7 : FROM node:12.18.1
----> f5be1883c8e0
-Step 2/7 : WORKDIR /code
-...
-Successfully built e03018e56163
-Successfully tagged node-docker:latest
+[+] Building 93.8s (11/11) FINISHED
+ => [internal] load build definition from dockerfile                                          0.1s
+ => => transferring dockerfile: 617B                                                          0.0s
+ => [internal] load .dockerignore                                                             0.0s
+ ...
+ => [2/5] WORKDIR /app                                                                        0.4s
+ => [3/5] COPY [package.json, package-lock.json*, ./]                                         0.2s
+ => [4/5] RUN npm install --production                                                        9.8s
+ => [5/5] COPY . .
 ```
 
 ## View local images
@@ -220,10 +224,9 @@ To list images, simply run the `images` command.
 $ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
 node-docker         latest              3809733582bc        About a minute ago   945MB
-node                12.18.1             f5be1883c8e0        2 months ago         918MB
 ```
 
-You should see at least two images listed. One for the base image `node:12.18.1` and the other for our image we just build `node-docker:latest`.
+Your exact output may vary, but you should see the image we just built `node-docker:latest` with the `latest` tag.
 
 ## Tag images
 
@@ -246,7 +249,6 @@ $ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 node-docker         latest              3809733582bc        24 minutes ago      945MB
 node-docker         v1.0.0              3809733582bc        24 minutes ago      945MB
-node                12.18.1             f5be1883c8e0        2 months ago        918MB
 ```
 
 You can see that we have two images that start with `node-docker`. We know they are the same image because if you look at the IMAGE ID column, you can see that the values are the same for the two images.
@@ -264,7 +266,6 @@ Notice that the response from Docker tells us that the image has not been remove
 $ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 node-docker         latest              3809733582bc        32 minutes ago      945MB
-node                12.18.1             f5be1883c8e0        2 months ago        918MB
 ```
 
 Our image that was tagged with `:v1.0.0` has been removed but we still have the `node-docker:latest` tag available on our machine.

--- a/language/nodejs/run-tests.md
+++ b/language/nodejs/run-tests.md
@@ -135,10 +135,18 @@ Now let’s rebuild our image and run our tests. We will run the same docker bui
 
 ```shell
 $ docker build -t node-docker --target test .
-Sending build context to Docker daemon  22.35MB
-...
-Successfully built fa583b97c4dd
-Successfully tagged node-docker:latest
+[+] Building 66.5s (12/12) FINISHED
+ => [internal] load build definition from Dockerfile                                                                                                                 0.0s
+ => => transferring dockerfile: 662B                                                                                                                                 0.0s
+ => [internal] load .dockerignore
+ ...
+  => [internal] load build context                                                                                                                                    4.2s
+ => => transferring context: 9.00MB                                                                                                                                  4.1s
+ => [base 2/4] WORKDIR /code                                                                                                                                         0.2s
+ => [base 3/4] COPY package.json package.json                                                                                                                        0.0s
+ => [base 4/4] COPY package-lock.json package-lock.json                                                                                                              0.0s
+ => [test 1/2] RUN npm ci                                                                                                                                            6.5s
+ => [test 2/2] COPY . .
 ```
 
 Now that our test image is built, we can run it in a container and see if our tests pass.
@@ -190,17 +198,11 @@ Now to run our tests, we just need to run the docker build command as above.
 
 ```console
 $ docker build -t node-docker --target test .
-Sending build context to Docker daemon  22.35MB
-Step 1/8 : FROM node:14.15.4 as base
- ---> f5be1883c8e0
-...
-Step 6/8 : RUN npm ci
- ---> Using cache
- ---> bcc5cd4a6a1e
-Step 7/8 : COPY . .
- ---> 1528ebcb73fa
-Step 8/8 : RUN npm run test
- ---> Running in beadc36b293a
+[+] Building 8.9s (13/13) FINISHED
+ => [internal] load build definition from Dockerfile                                                                                                                                                 0.0s
+ => => transferring dockerfile: 650B                                                                                                                                                                 0.0s
+ => [internal] load .dockerignore                                                                                                                                                                    0.0s
+ => => transferring context: 2B
 
 > node-docker@1.0.0 test /code
 > mocha ./**/*.js

--- a/language/nodejs/run-tests.md
+++ b/language/nodejs/run-tests.md
@@ -199,9 +199,9 @@ Now to run our tests, we just need to run the docker build command as above.
 ```console
 $ docker build -t node-docker --target test .
 [+] Building 8.9s (13/13) FINISHED
- => [internal] load build definition from Dockerfile                                                                                                                                                 0.0s
- => => transferring dockerfile: 650B                                                                                                                                                                 0.0s
- => [internal] load .dockerignore                                                                                                                                                                    0.0s
+ => [internal] load build definition from Dockerfile      0.0s
+ => => transferring dockerfile: 650B                      0.0s
+ => [internal] load .dockerignore                         0.0s
  => => transferring context: 2B
 
 > node-docker@1.0.0 test /code

--- a/language/python/build-images.md
+++ b/language/python/build-images.md
@@ -10,6 +10,8 @@ description: Learn how to build your first Docker image by writing a Dockerfile
 
 Work through the orientation and setup in Get started [Part 1](../../get-started/index.md) to understand Docker concepts.
 
+{% include enable-buildkit.md %}
+
 ## Overview
 
 Now that we have a good overview of containers and the Docker platform, let’s take a look at building our first image. An image includes everything needed to run an application - the code or binary, runtime, dependencies, and any other file system objects required.


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

- Added a prereq to enable BuildKit before explaining how to build images
- Added a new includes file to reuse the 'Enable BuildKit' section
- Update build examples to display the output when building Docker images using BuildKit