### PR TITLE
DOCS: Added support for arch s390x for Ubuntu, RHEL and SLES

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1243,6 +1243,10 @@ manuals:
       title: Install on Fedora
     - path: /engine/install/ubuntu/
       title: Install on Ubuntu
+    - path: /engine/install/rhel/
+      title: Install on RHEL
+    - path: /engine/install/sles/
+      title: Install on SLES
     - path: /engine/install/binaries/
       title: Install binaries
   - path: /engine/install/linux-postinstall/

--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -52,8 +52,8 @@ Executing docker install script, commit: 7cae5f8b0decc17d6571f9f52eb840fbc13b273
 ```
 
 Docker is installed. The `docker` service starts automatically on Debian based
-distributions. On `RPM` based distributions, such as CentOS or Fedora, you need
-to start it manually using the appropriate `systemctl` or `service` command.
+distributions. On `RPM` based distributions, such as CentOS, Fedora, RHEL or SLES,
+you need to start it manually using the appropriate `systemctl` or `service` command.
 As the message indicates, non-root users cannot run Docker commands by default.
 
 > **Use Docker as a non-privileged user, or install in rootless mode?**

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -56,13 +56,16 @@ your preferred operating system below.
 Docker provides `.deb` and `.rpm` packages from the following Linux distributions
 and architectures:
 
-| Platform              | x86_64 / amd64         | arm64 / aarch64        | arm (32-bit)             |
-|:----------------------|:-----------------------|:-----------------------|:-------------------------|
-| [CentOS](centos.md)   | [{{ yes }}](centos.md) | [{{ yes }}](centos.md) |                          |
-| [Debian](debian.md)   | [{{ yes }}](debian.md) | [{{ yes }}](debian.md) | [{{ yes }}](debian.md)   |
-| [Fedora](fedora.md)   | [{{ yes }}](fedora.md) | [{{ yes }}](fedora.md) |                          |
-| [Raspbian](debian.md) |                        |                        | [{{ yes }}](debian.md)   |
-| [Ubuntu](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md)   |
+| Platform              | x86_64 / amd64         | arm64 / aarch64        | arm (32-bit)           | s390x                  |
+|:----------------------|:-----------------------|:-----------------------|:-----------------------|:-----------------------|
+| [CentOS](centos.md)   | [{{ yes }}](centos.md) | [{{ yes }}](centos.md) |                        |                        |
+| [Debian](debian.md)   | [{{ yes }}](debian.md) | [{{ yes }}](debian.md) | [{{ yes }}](debian.md) |                        |
+| [Fedora](fedora.md)   | [{{ yes }}](fedora.md) | [{{ yes }}](fedora.md) |                        |                        |
+| [Raspbian](debian.md) |                        |                        | [{{ yes }}](debian.md) |                        |
+| [Ubuntu](ubuntu.md)   | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) | [{{ yes }}](ubuntu.md) |
+| [SLES](sles.md)       |                        |                        |                        | [{{ yes }}](sles.md)   |
+| [RHEL](rhel.md)       |                        |                        |                        | [{{ yes }}](rhel.md)   |
+
 
 ### Other Linux distributions
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -1,0 +1,273 @@
+---
+description: Instructions for installing Docker Engine on RHEL
+keywords: requirements, apt, installation, rhel, rpm, install, uninstall, upgrade, update
+redirect_from:
+- /ee/docker-ee/centos/
+- /ee/docker-ee/rhel/
+- /engine/installation/centos/
+- /engine/installation/rhel/
+- /engine/installation/linux/centos/
+- /engine/installation/linux/docker-ce/centos/
+- /engine/installation/linux/docker-ce/rhel/
+- /engine/installation/linux/docker-ee/centos/
+- /engine/installation/linux/docker-ee/rhel/
+- /engine/installation/linux/rhel/
+- /engine/installation/rhel/
+- /install/linux/centos/
+- /install/linux/docker-ce/centos/
+- /install/linux/docker-ee/centos/
+- /install/linux/docker-ee/rhel/
+- /installation/rhel/
+title: Install Docker Engine on RHEL
+toc_max: 4
+---
+
+To get started with Docker Engine on RHEL, make sure you
+[meet the prerequisites](#prerequisites), then
+[install Docker](#installation-methods).
+
+## Prerequisites
+
+### OS requirements
+
+To install Docker Engine, you need a maintained version of RHEL 7 or 8 on s390x (IBM Z).
+Archived versions aren't supported or tested.
+
+The `overlay2` storage driver is recommended.
+
+### Uninstall old versions
+
+Older versions of Docker were called `docker` or `docker-engine`. If these are
+installed, uninstall them, along with associated dependencies. Also uninstall 
+`Podman` and the associated dependencies if installed already. 
+
+```console
+$ sudo yum remove docker \
+                  docker-client \
+                  docker-client-latest \
+                  docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
+                  docker-engine \
+                  podman \
+                  runc
+```
+
+It's OK if `yum` reports that none of these packages are installed.
+
+The contents of `/var/lib/docker/`, including images, containers, volumes, and
+networks, are preserved. The Docker Engine package is now called `docker-ce`.
+
+## Installation methods
+
+You can install Docker Engine in different ways, depending on your needs:
+
+- Most users
+  [set up Docker's repositories](#install-using-the-repository) and install
+  from them, for ease of installation and upgrade tasks. This is the
+  recommended approach.
+
+- Some users download the RPM package and
+  [install it manually](#install-from-a-package) and manage
+  upgrades completely manually. This is useful in situations such as installing
+  Docker on air-gapped systems with no access to the internet.
+
+- In testing and development environments, some users choose to use automated
+  [convenience scripts](#install-using-the-convenience-script) to install Docker.
+
+### Install using the repository
+
+Before you install Docker Engine for the first time on a new host machine, you need
+to set up the Docker repository. Afterward, you can install and update Docker
+from the repository.
+
+#### Set up the repository
+
+{% assign download-url-base = "https://download.docker.com/linux/rhel" %}
+
+Install the `yum-utils` package (which provides the `yum-config-manager`
+utility) and set up the **stable** repository.
+
+```console
+$ sudo yum install -y yum-utils
+
+$ sudo yum-config-manager \
+    --add-repo \
+    {{ download-url-base }}/docker-ce.repo
+```
+
+> **Optional**: Enable the **nightly** or **test** repositories.
+>
+> These repositories are included in the `docker.repo` file above but are disabled
+> by default. You can enable them alongside the stable repository.  The following
+> command enables the **nightly** repository.
+>
+> ```console
+> $ sudo yum-config-manager --enable docker-ce-nightly
+> ```
+>
+> To enable the **test** channel, run the following command:
+>
+> ```console
+> $ sudo yum-config-manager --enable docker-ce-test
+> ```
+>
+> You can disable the **nightly** or **test** repository by running the
+> `yum-config-manager` command with the `--disable` flag. To re-enable it, use
+> the `--enable` flag. The following command disables the **nightly** repository.
+>
+> ```console
+> $ sudo yum-config-manager --disable docker-ce-nightly
+> ```
+>
+> [Learn about **nightly** and **test** channels](index.md).
+
+#### Install Docker Engine
+
+1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
+
+    ```console
+    $ sudo yum install docker-ce docker-ce-cli containerd.io
+    ```
+
+    If prompted to accept the GPG key, verify that the fingerprint matches
+    `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
+
+    > Got multiple Docker repositories?
+    >
+    > If you have multiple Docker repositories enabled, installing
+    > or updating without specifying a version in the `yum install` or
+    > `yum update` command always installs the highest possible version,
+    > which may not be appropriate for your stability needs.
+
+    Docker is installed but not started. The `docker` group is created, but no users are added to the group.
+
+2.  To install a _specific version_ of Docker Engine, list the available versions
+    in the repo, then select and install:
+
+    a. List and sort the versions available in your repo. This example sorts
+       results by version number, highest to lowest, and is truncated:
+
+    ```console
+    $ yum list docker-ce --showduplicates | sort -r
+
+    docker-ce.s390x                3:20.10.7-3.el8                 docker-ce-stable
+    ```
+
+    The list returned depends on which repositories are enabled, and is specific
+    to your version of RHEL (indicated by the `.el8` suffix in this example).
+
+    b. Install a specific version by its fully qualified package name, which is
+       the package name (`docker-ce`) plus the version string (2nd column)
+       starting at the first colon (`:`), up to the first hyphen, separated by
+       a hyphen (`-`). For example, `docker-ce-20.10.7`.
+
+    ```console
+    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
+    ```
+
+    Docker is installed but not started. The `docker` group is created, but no users are added to the group.
+
+3.  Start Docker.
+
+    ```console
+    $ sudo systemctl start docker
+    ```
+
+4.  Verify that Docker Engine is installed correctly by running the `hello-world`
+    image.
+
+    ```console
+    $ sudo docker run hello-world
+    ```
+
+    This command downloads a test image and runs it in a container. When the
+    container runs, it prints an informational message and exits.
+
+Docker Engine is installed and running. You need to use `sudo` to run Docker
+commands. Continue to [Linux postinstall](linux-postinstall.md) to allow
+non-privileged users to run Docker commands and for other optional configuration
+steps.
+
+#### Upgrade Docker Engine
+
+To upgrade Docker Engine, follow the [installation instructions](#install-using-the-repository),
+choosing the new version you want to install.
+
+### Install from a package
+
+If you cannot use Docker's repository to install Docker, you can download the
+`.rpm` file for your release and install it manually. You need to download
+a new file each time you want to upgrade Docker Engine.
+
+1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
+    and choose your version of RHEL. Then browse to `s390x/stable/Packages/`
+    and download the `.rpm` file for the Docker version you want to install.
+
+    > **Note**: To install a **nightly** or **test** (pre-release) package,
+    > change the word `stable` in the above URL to `nightly` or `test`.
+    > [Learn about **nightly** and **test** channels](index.md).
+
+2.  Install Docker Engine, changing the path below to the path where you downloaded
+    the Docker package.
+
+    ```console
+    $ sudo yum install /path/to/package.rpm
+    ```
+
+    Docker is installed but not started. The `docker` group is created, but no
+    users are added to the group.
+
+3.  Start Docker.
+
+    ```console
+    $ sudo systemctl start docker
+    ```
+
+4.  Verify that Docker Engine is installed correctly by running the `hello-world`
+    image.
+
+    ```console
+    $ sudo docker run hello-world
+    ```
+
+    This command downloads a test image and runs it in a container. When the
+    container runs, it prints an informational message and exits.
+
+Docker Engine is installed and running. You need to use `sudo` to run Docker commands.
+Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
+non-privileged users to run Docker commands and for other optional configuration
+steps.
+
+#### Upgrade Docker Engine
+
+To upgrade Docker Engine, download the newer package file and repeat the
+[installation procedure](#install-from-a-package), using `yum -y upgrade`
+instead of `yum -y install`, and pointing to the new file.
+
+{% include install-script.md %}
+
+## Uninstall Docker Engine
+
+1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+
+    ```console
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io
+    ```
+
+2.  Images, containers, volumes, or customized configuration files on your host
+    are not automatically removed. To delete all images, containers, and
+    volumes:
+
+    ```console
+    $ sudo rm -rf /var/lib/docker
+    $ sudo rm -rf /var/lib/containerd
+    ```
+
+You must delete any edited configuration files manually.
+
+## Next steps
+
+- Continue to [Post-installation steps for Linux](linux-postinstall.md).
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -1,0 +1,269 @@
+---
+description: Instructions for installing Docker Engine on SLES
+keywords: requirements, apt, installation, centos, rpm, sles, install, uninstall, upgrade, update
+redirect_from:
+- /ee/docker-ee/sles/
+- /engine/installation/sles/
+- /engine/installation/linux/sles/
+- /engine/installation/linux/docker-ce/sles/
+- /engine/installation/linux/docker-ee/sles/
+- /engine/installation/linux/docker-ee/sles/
+- /engine/installation/linux/sles/
+- /engine/installation/sles/
+- /install/linux/sles/
+- /install/linux/docker-ce/sles/
+- /install/linux/docker-ee/sles/
+- /installation/sles/
+title: Install Docker Engine on SLES
+toc_max: 4
+---
+
+To get started with Docker Engine on SLES, make sure you
+[meet the prerequisites](#prerequisites), then
+[install Docker](#installation-methods).
+
+## Prerequisites
+
+### OS requirements
+
+To install Docker Engine, you need a maintained version of SLES 15-SP2 on s390x (IBM Z).
+Archived versions aren't supported or tested.
+
+The [`SCC SUSE`](https://scc.suse.com/packages?name=SUSE%20Linux%20Enterprise%20Server&version=15.2&arch=s390x) repositories must be enabled. 
+
+The `SELinux (SLE_15_SP2)`repository must be enabled. This repository is not added by
+default, you need to
+[add it](https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP2/security:SELinux.repo).
+```console
+$ zypper addrepo https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP2/security:SELinux.repo
+```
+The `overlay2` storage driver is recommended.
+
+### Uninstall old versions
+
+Older versions of Docker were called `docker` or `docker-engine`. If these are
+installed, uninstall them, along with associated dependencies.
+
+```console
+$ sudo zypper remove docker \
+                  docker-client \
+                  docker-client-latest \
+                  docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
+                  docker-engine \
+                  docker-ce-cli \
+                  runc
+```
+
+It's OK if `zypper` reports that none of these packages are installed.
+
+The contents of `/var/lib/docker/`, including images, containers, volumes, and
+networks, are preserved. The Docker Engine package is now called `docker-ce`.
+
+## Installation methods
+
+You can install Docker Engine in different ways, depending on your needs:
+
+- Most users
+  [set up Docker's repositories](#install-using-the-repository) and install
+  from them, for ease of installation and upgrade tasks. This is the
+  recommended approach.
+
+- Some users download the RPM package and
+  [install it manually](#install-from-a-package) and manage
+  upgrades completely manually. This is useful in situations such as installing
+  Docker on air-gapped systems with no access to the internet.
+
+- In testing and development environments, some users choose to use automated
+  [convenience scripts](#install-using-the-convenience-script) to install Docker.
+
+### Install using the repository
+
+Before you install Docker Engine for the first time on a new host machine, you need
+to set up the Docker repository. Afterward, you can install and update Docker
+from the repository.
+
+#### Set up the repository
+
+{% assign download-url-base = "https://download.docker.com/linux/sles" %}
+
+Set up the **stable** repository.
+
+```console
+$ sudo zypper \
+    addrepo \
+    {{ download-url-base }}/docker-ce.repo
+```
+
+> **Optional**: Enable the **nightly** or **test** repositories.
+>
+> These repositories are included in the `docker.repo` file above but are disabled
+> by default. You can enable them alongside the stable repository.  The following
+> command enables the **nightly** repository.
+>
+> ```console
+> $ sudo zypper mr -e docker-ce-nightly
+> ```
+>
+> To enable the **test** channel, run the following command:
+>
+> ```console
+> $ sudo zypper mr -e docker-ce-test
+> ```
+>
+> You can disable the **nightly** or **test** repository by running the
+> ```console
+> $ sudo zypper mr -d docker-ce-nightly
+> $ sudo zypper mr -d docker-ce-test
+> ```
+>
+> [Learn about **nightly** and **test** channels](index.md).
+
+#### Install Docker Engine
+
+1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
+
+    ```console
+    $ sudo zypper install docker-ce docker-ce-cli containerd.io
+    ```
+
+    If prompted to accept the GPG key, verify that the fingerprint matches
+    `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
+
+    > Got multiple Docker repositories?
+    >
+    > If you have multiple Docker repositories enabled, installing
+    > or updating without specifying a version in the `zypper install` or
+    > `zypper update` command always installs the highest possible version,
+    > which may not be appropriate for your stability needs.
+
+    Docker is installed but not started. The `docker` group is created, but no users are added to the group.
+
+2.  To install a _specific version_ of Docker Engine, list the available versions
+    in the repo, then select and install:
+
+    a. List and sort the versions available in your repo. This example sorts
+       results by version number, highest to lowest, and is truncated:
+
+    ```console
+    $ sudo zypper se docker-ce --match-exact  | sort -r
+    ```
+
+    The list returned depends on which repositories are enabled, and is specific
+    to your version of SLES.
+
+    b. Install a specific version by its fully qualified package name, which is
+       the package name (`docker-ce`) plus the version string (2nd column)
+       starting at the first colon (`:`), up to the first hyphen, separated by
+       a hyphen (`-`). For example, `docker-ce-18.09.1`.
+
+    ```console
+    $ sudo zypper install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
+    ```
+
+    Docker is installed but not started. The `docker` group is created, but no users are added to the group.
+
+3.  Start Docker.
+
+    ```console
+    $ sudo systemctl start docker
+    ```
+
+4.  Verify that Docker Engine is installed correctly by running the `hello-world`
+    image.
+
+    ```console
+    $ sudo docker run hello-world
+    ```
+
+    This command downloads a test image and runs it in a container. When the
+    container runs, it prints an informational message and exits.
+
+Docker Engine is installed and running. You need to use `sudo` to run Docker
+commands. Continue to [Linux postinstall](linux-postinstall.md) to allow
+non-privileged users to run Docker commands and for other optional configuration
+steps.
+
+#### Upgrade Docker Engine
+
+To upgrade Docker Engine, follow the [installation instructions](#install-using-the-repository),
+choosing the new version you want to install.
+
+### Install from a package
+
+If you cannot use Docker's repository to install Docker, you can download the
+`.rpm` file for your release and install it manually. You need to download
+a new file each time you want to upgrade Docker Engine.
+
+1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
+    and choose your version of SLES. Then browse to `15/s390x/stable/Packages/`
+    and download the `.rpm` file for the Docker version you want to install.
+
+    > **Note**: To install a **nightly** or **test** (pre-release) package,
+    > change the word `stable` in the above URL to `nightly` or `test`.
+    > [Learn about **nightly** and **test** channels](index.md).
+
+2.  Install Docker Engine, changing the path below to the path where you downloaded
+    the Docker package.
+
+    ```console
+    $ sudo zypper install /path/to/package.rpm
+    ```
+
+    Docker is installed but not started. The `docker` group is created, but no
+    users are added to the group.
+
+3.  Start Docker.
+
+    ```console
+    $ sudo systemctl start docker
+    ```
+
+4.  Verify that Docker Engine is installed correctly by running the `hello-world`
+    image.
+
+    ```console
+    $ sudo docker run hello-world
+    ```
+
+    This command downloads a test image and runs it in a container. When the
+    container runs, it prints an informational message and exits.
+
+Docker Engine is installed and running. You need to use `sudo` to run Docker commands.
+Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
+non-privileged users to run Docker commands and for other optional configuration
+steps.
+
+#### Upgrade Docker Engine
+
+To upgrade Docker Engine, download the newer package file and repeat the
+[installation procedure](#install-from-a-package), using `zypper -y upgrade`
+instead of `zypper -y install`, and pointing to the new file.
+
+{% include install-script.md %}
+
+## Uninstall Docker Engine
+
+1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+
+    ```console
+    $ sudo zypper remove docker-ce docker-ce-cli containerd.io
+    ```
+
+2.  Images, containers, volumes, or customized configuration files on your host
+    are not automatically removed. To delete all images, containers, and
+    volumes:
+
+    ```console
+    $ sudo rm -rf /var/lib/docker
+    $ sudo rm -rf /var/lib/containerd
+    ```
+
+You must delete any edited configuration files manually.
+
+## Next steps
+
+- Continue to [Post-installation steps for Linux](linux-postinstall.md).
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -32,7 +32,7 @@ versions:
 - Ubuntu Focal 20.04 (LTS)
 - Ubuntu Bionic 18.04 (LTS)
 
-Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
+Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, `arm64`, and `s390x` architectures.
 
 > Ubuntu 16.04 LTS "Xenial Xerus" end-of-life
 > 
@@ -129,6 +129,7 @@ from the repository.
       <li class="active"><a data-toggle="tab" data-target="#x86_64_repo">x86_64 / amd64</a></li>
       <li><a data-toggle="tab" data-target="#armhf_repo">armhf</a></li>
       <li><a data-toggle="tab" data-target="#arm64_repo">arm64</a></li>
+      <li><a data-toggle="tab" data-target="#s390x_repo">s390x</a></li>
     </ul>
     <div class="tab-content">
     <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
@@ -154,6 +155,15 @@ from the repository.
     ```console
     $ echo \
       "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    ```
+
+    </div>
+    <div id="s390x_repo" class="tab-pane fade" markdown="1">
+
+    ```console
+    $ echo \
+      "deb [arch=s390x signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
@@ -227,7 +237,7 @@ a new file each time you want to upgrade Docker.
 
 1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" },
     choose your Ubuntu version, then browse to `pool/stable/`, choose `amd64`,
-    `armhf`, or `arm64`, and download the `.deb` file for the Docker Engine
+    `armhf`, `arm64`,or `s390x`, and download the `.deb` file for the Docker Engine
     version you want to install.
 
     > **Note**: To install a **nightly** or **test** (pre-release) package,

--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -55,8 +55,8 @@ testuser:231072:65536
   <li><a data-toggle="tab" data-target="#hint-debian">Debian GNU/Linux</a></li>
   <li><a data-toggle="tab" data-target="#hint-arch">Arch Linux</a></li>
   <li><a data-toggle="tab" data-target="#hint-opensuse">openSUSE</a></li>
-  <li><a data-toggle="tab" data-target="#hint-centos8-and-fedora">CentOS 8 and Fedora</a></li>
-  <li><a data-toggle="tab" data-target="#hint-centos7">CentOS 7</a></li>
+  <li><a data-toggle="tab" data-target="#hint-centos8-rhel8-fedora">CentOS 8, RHEL 8 and Fedora</a></li>
+  <li><a data-toggle="tab" data-target="#hint-centos7-rhel7">CentOS 7 and RHEL 7</a></li>
 </ul>
 <div class="tab-content">
 
@@ -100,7 +100,7 @@ testuser:231072:65536
 
 - Known to work on openSUSE 15.
 </div>
-<div id="hint-centos8-and-fedora" class="tab-pane fade in" markdown="1">
+<div id="hint-centos8-rhel8-fedora" class="tab-pane fade in" markdown="1">
 - Installing `fuse-overlayfs` is recommended. Run `sudo dnf install -y fuse-overlayfs`.
 
 - You might need `sudo dnf install -y iptables`.
@@ -111,7 +111,7 @@ testuser:231072:65536
 
 - Known to work on CentOS 8 and Fedora 33.
 </div>
-<div id="hint-centos7" class="tab-pane fade in" markdown="1">
+<div id="hint-centos7-rhel7" class="tab-pane fade in" markdown="1">
 - Add `user.max_user_namespaces=28633` to `/etc/sysctl.conf` (or 
   `/etc/sysctl.d`) and run `sudo sysctl --system`.
 
@@ -123,7 +123,7 @@ testuser:231072:65536
 ## Known limitations
 
 - Only the following storage drivers are supported:
-  - `overlay2` (only if running with kernel 5.11 or later, or Ubuntu-flavored kernel, or Debian-flavored kernel)
+  - `overlay2` (only if running with kernel 5.11 or later, or Ubuntu-flavored kernel, or Debian-flavored kernel, doesn't work on SLES 15)
   - `fuse-overlayfs` (only if running with kernel 4.18 or later, and `fuse-overlayfs` is installed)
   - `btrfs` (only if running with kernel 4.18 or later, or `~/.local/share/docker` is mounted with `user_subvol_rm_allowed` mount option)
   - `vfs`
@@ -179,6 +179,7 @@ $ sudo apt-get install -y docker-ce-rootless-extras
 <div id="install-without-packages" class="tab-pane fade in" markdown="1">
 If you do not have permission to run package managers like `apt-get` and `dnf`,
 consider using the installation script available at [https://get.docker.com/rootless](https://get.docker.com/rootless){: target="_blank" rel="noopener" class="_" }.
+Since static packages are not available for `s390x`, hence it is not supported for `s390x`.
 
 ```console
 $ curl -fsSL https://get.docker.com/rootless | sh

--- a/storage/storagedriver/device-mapper-driver.md
+++ b/storage/storagedriver/device-mapper-driver.md
@@ -24,7 +24,7 @@ a filesystem at the operating system (OS) level.
 ## Prerequisites
 
 - `devicemapper` is supported on Docker Engine - Community running on CentOS, Fedora,
-  Ubuntu, or Debian.
+  SLES 15, Ubuntu, Debian, or RHEL.
 - `devicemapper` requires the `lvm2` and `device-mapper-persistent-data` packages
   to be installed.
 - Changing the storage driver makes any containers you have already
@@ -213,7 +213,7 @@ assumes that the Docker daemon is in the `stopped` state.
     - **RHEL / CentOS**: `device-mapper-persistent-data`, `lvm2`, and all
       dependencies
 
-    - **Ubuntu / Debian**: `thin-provisioning-tools`, `lvm2`, and all
+    - **Ubuntu / Debian / SLES 15**: `thin-provisioning-tools`, `lvm2`, and all
       dependencies
 
 4.  Create a physical volume on your block device from step 1, using the

--- a/storage/storagedriver/select-storage-driver.md
+++ b/storage/storagedriver/select-storage-driver.md
@@ -95,6 +95,8 @@ configurations work on recent versions of the Linux distribution:
 | Docker Engine - Community on Debian | `overlay2` (Debian Stretch), `aufs` or `devicemapper` (older versions) | `overlay`¹, `vfs`                                 |
 | Docker Engine - Community on CentOS | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
 | Docker Engine - Community on Fedora | `overlay2`                                                             | `overlay`¹, `devicemapper`², `zfs`, `vfs`         |
+| Docker Engine - Community on SLES 15 | `overlay2`                                                             | `overlay`¹, `devicemapper`², `vfs`                |
+| Docker Engine - Community on RHEL | `overlay2`                                                             | `overlay`¹, `devicemapper`², `vfs`                |
 
 ¹) The `overlay` storage driver is deprecated, and will be removed in a future
 release. It is recommended that users of the `overlay` storage driver migrate to `overlay2`.


### PR DESCRIPTION
Signed-off-by: Nirman Narang <narang@us.ibm.com>

### Proposed changes
Added .md files for SLES and RHEL engine installation.
Added indexing to _data/toc.yaml and engine/install/index.md.
Modified engine/install/index.md, includes/install-script.md, engine/security/rootless.md, storage/storagedriver/device-mapper-driver.md, and storage/storagedriver/select-storage-driver.md to add info for added RHEL and SLES support.
Modified engine/install/ubuntu.md to add s390x repos and other info.
Added tab target for RHEL and SLES to engine/security/rootless.md along with other info.