### PR TITLE
Add a stable url for Personal Access Tokens

### DIFF
--- a/go/access-tokens.md
+++ b/go/access-tokens.md
@@ -1,0 +1,6 @@
+---
+title: Managing access tokens
+description: Learn how to create and manage your personal Docker Hub access tokens to securely push and pull images programmatically
+keywords: docker hub, hub, security, PAT, personal access token
+redirect_to: /docker-hub/access-tokens/
+---


### PR DESCRIPTION
Signed-off-by: Amine Chouki <amine.chouki@docker.com>

### Proposed changes

Add a go/redirect file for Personal Access Tokens (PAT) https://docs.docker.com/docker-hub/access-tokens/. This new URL will be included in compose-cli to promote PAT usage.
