### PR TITLE
add explicit instruction to stop local server

### DIFF
--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -72,12 +72,22 @@ $ curl http://localhost:8000/test
 
 Switch back to the terminal where our server is running. You should now see the following requests in the server logs.
 
-```
+```console
 2020-XX-31T16:35:08:4260  INFO: POST /test
 2020-XX-31T16:35:21:3560  INFO: GET /test
 ```
 
-At this stage, you're done with testing this server script locally, so stop it running by going back to the first terminal session where you started it up, and press ctrl-c.
+Great! We verified the application works. At this stage, you're done with testing the server script locally.
+
+Press `CTRL-c` from within the terminal session where the server is running to stop it.
+
+```console
+2021-08-06T12:11:33:8930  INFO: POST /test
+2021-08-06T12:11:41:5860  INFO: GET /test
+^Cshutting down...
+```
+
+We will now continue to build and run the application in Docker.
 
 ## Create a Dockerfile for Node.js
 

--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -77,7 +77,7 @@ Switch back to the terminal where our server is running. You should now see the 
 2020-XX-31T16:35:21:3560  INFO: GET /test
 ```
 
-Great! We verified the application works. At this stage, you're done with testing the server script locally.
+Great! We verified that the application works. At this stage, you've completed testing the server script locally.
 
 Press `CTRL-c` from within the terminal session where the server is running to stop it.
 

--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -77,6 +77,8 @@ Switch back to the terminal where our server is running. You should now see the 
 2020-XX-31T16:35:21:3560  INFO: GET /test
 ```
 
+At this stage, you're done with testing this server script locally, so stop it running by going back to the first terminal session where you started it up, and press ctrl-c.
+
 ## Create a Dockerfile for Node.js
 
 A Dockerfile is a text document that contains all the commands a user could call on the command line to assemble an image. When we tell Docker to build our image by executing the `docker build` command, Docker reads these instructions and executes them one by one and creates a Docker image as a result.


### PR DESCRIPTION
### Proposed changes

This relates to the [Test the application section of the Build images tutorial](https://docs.docker.com/language/nodejs/build-images/#test-the-application). In this section, `node server.js` is used to start the server locally. The reader is not instructed to stop the server. 

In the [Run containers](https://docs.docker.com/language/nodejs/run-containers/) tutorial that follows this one, the reader is instructed to start up the container, and try to access `http://localhost:8000/test` which is now being served from the Node.js process inside the container. The idea is that this should not work (without port forwarding) and they should see an error. However, if the local Node.js process from the `node server.js` invocation earlier, they won't see the error and may be confused.

So this modification adds an explicit instruction to the "Build containers" tutorial to stop the `node server.js` process. I used the same phrasing as in the "Run containers" tutorial, i.e. "press ctrl-c". 

Great tutorials, btw!
