### PR TITLE
be explicit about having a breakpoint-able line

### DIFF
--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -198,7 +198,7 @@ Click the **Open dedicated DevTools for Node** link. This opens the DevTools tha
 
 Let’s change the source code and then set a breakpoint.
 
-Add the following code above the existing `server.use()` statement, and save the file.
+Add the following code above the existing `server.use()` statement, and save the file. Make sure that the `return` statement is on a line of its own, as shown here, so you can set the breakpoint appropriately.
 
 ```js
  server.use( '/foo', (req, res) => {


### PR DESCRIPTION
This is a great tutorial, thanks. 

In it, however, I tripped myself up and was unable to successfully see the process stop at the breakpoint, and it turns out that it was because I typed in the additional `server.use` call for `/foo` as an entirely single line, like this:

```
server.use( '/foo', (req, res) => { return res.json({ "foo": "bar" }) })
```

When it came to setting the breakpoint, I only had that single line, and of course, I was effectively adding a breakpoint to the wrong place - the call to `server.use`, which had already been executed. And so my breakpoint was never hit, and I was sad that I couldn't complete the tutorial.

Then I realised what was going on :-)

This small addition of text might help others avoid this (self-inflicted!) confusion in future.