### PR TITLE
Fix broken link to BuildKit page, and remove mention of 18.09

### DIFF
--- a/_includes/enable-buildkit.md
+++ b/_includes/enable-buildkit.md
@@ -2,13 +2,17 @@
 
 ### Enable BuildKit
 
-Before we start building images, ensure you have enabled BuildKit on your machine. BuildKit allows you to build Docker images efficiently. For more information, see [Building images with BuildKit](../develop/develop-images/build_enhancements.md).
+Before we start building images, ensure you have enabled BuildKit on your machine.
+BuildKit allows you to build Docker images efficiently. For more information,
+see [Building images with BuildKit](/develop/develop-images/build_enhancements/).
 
-BuildKit is enabled by default for all users on Docker Desktop. If you have installed Docker Desktop, you don't have to manually enable BuildKit. If you are running Docker on Linux, you can enable BuildKit either by using an environment variable or by making BuildKit the default setting.
+BuildKit is enabled by default for all users on Docker Desktop. If you have
+installed Docker Desktop, you don't have to manually enable BuildKit. If you are
+running Docker on Linux, you can enable BuildKit either by using an environment
+variable or by making BuildKit the default setting.
 
-> You must be running Docker 18.09 or higher to use BuildKit.
-
-To set the BuildKit environment variable when running the `docker build` command, run:
+To set the BuildKit environment variable when running the `docker build` command,
+run:
 
 ```
 $ DOCKER_BUILDKIT=1 docker build .


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/13254

Markdown links don't work well in include files, so use a plain "HTML" link
instead.

Also removing the mention of Docker 18.09. Docker 18.09 has been released
3 years ago, so users not yet on that release (or up) did not update their
docker install for 3 years, which should be "rare" (hopefully)

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
