### PR TITLE
golang: Fix username mismatch issue in tutorial GitHub workflow

### DIFF
--- a/language/golang/configure-ci-cd.md
+++ b/language/golang/configure-ci-cd.md
@@ -175,7 +175,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -195,7 +195,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ github.repository }}:latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:latest
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Correctly handles a mismatch between GitHub and Docker Hub usernames in the golang CI/CD tutorial.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Fixes an issue in the golang tutorial.  Specifically, the tutorial's GitHub workflow for building and pushing an image to Docker Hub fails if the user's GitHub and Docker Hub usernames are not the same.

This PR provides a generic fix combining the Docker Hub username already provided in the workflow (as a secret) with the GitHub repository name to create a new image tag, which can then be successfully pushed to Docker Hub.

### Related issues (optional)

The proposed change mirrors a related [PR](https://github.com/olliefr/docker-gs-ping/pull/4) to the example code repository, which is tied to an [issue](https://github.com/olliefr/docker-gs-ping/issues/3) in the example code repository.
