### PR TITLE
add postgresql-dev, python3-dev to Dockerfile

### DIFF
--- a/samples/django.md
+++ b/samples/django.md
@@ -32,6 +32,8 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
    FROM python:3
    ENV PYTHONUNBUFFERED=1
    WORKDIR /code
+   RUN apk update \
+    && apk add postgresql-dev gcc python3-dev musl-dev
    COPY requirements.txt /code/
    RUN pip install -r requirements.txt
    COPY . /code/


### PR DESCRIPTION
add postgresql-dev, python3-dev to Dockerfile, because could not install psycopg2-binary package from requirements.txt

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
