### PR TITLE
Add not about NFS mounts for rootless data-root

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -138,6 +138,7 @@ testuser:231072:65536
 - `IPAddress` shown in `docker inspect` and is namespaced inside RootlessKit's network namespace.
   This means the IP address is not reachable from the host without `nsenter`-ing into the network namespace.
 - Host network (`docker run --net=host`) is also namespaced inside RootlessKit.
+- NFS mounts as the docker "data-root" is not supported
 
 ## Install
 > **Note**


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
NFS mounts are not currently supported for rootless data-root so there should probably be a note about it so no one gets confused when it doesn't work.

Errors for running rootless containers when your data-root is an NFS mount look like:

```
docker: failed to register layer: ApplyLayer exit status 1 stdout:  stderr: open /root/.bash_logout: permission denied.
```

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
