### PR TITLE
Follow-up to #13275 ("Add note about NFS mounts for rootless data-root")

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -138,7 +138,7 @@ testuser:231072:65536
 - `IPAddress` shown in `docker inspect` and is namespaced inside RootlessKit's network namespace.
   This means the IP address is not reachable from the host without `nsenter`-ing into the network namespace.
 - Host network (`docker run --net=host`) is also namespaced inside RootlessKit.
-- NFS mounts as the docker "data-root" is not supported
+- NFS mounts as the docker "data-root" is not supported. This limitation is not specific to rootless mode.
 
 ## Install
 > **Note**


### PR DESCRIPTION

### Proposed changes

Follow-up to #13275.

Lack of support for NFS data-root is not specific to rootless.


