### PR TITLE
Add awslogs logging driver options awslogs-force-flush-interval-seconds and awslogs-max-buffered-events

### DIFF
--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -288,6 +288,21 @@ If not specified, the container ID is used as the log stream.
 > {% endraw %}
 > the output is something like: `alpine_latest-bf0072049c76`
 
+### awslogs-force-flush-interval-seconds
+
+The `awslogs` driver periodically flushs logs to CloudWatch.
+
+The `awslogs-force-flush-interval-seconds` option changes log flush interval seconds.
+
+Default is 5 seconds.
+
+### awslogs-max-buffered-events
+
+The `awslogs` driver buffers logs.
+
+The `awslogs-max-buffered-events` option changes log buffer size.
+
+Default is 4K.
 
 ## Credentials
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The `awslogs` logging driver add awslogs-force-flush-interval-seconds and awslogs-max-buffered-events options in the [PR](https://github.com/moby/moby/pull/38407).

So, this PR adds the two options.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
https://github.com/moby/moby/pull/38407

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
