### PR TITLE
Release notes: fix incorrect header level for 20.10.8 Swarm

### DIFF
--- a/engine/release-notes/index.md
+++ b/engine/release-notes/index.md
@@ -66,7 +66,7 @@ for Docker Engine.
 - Windows: Fix a situation where containers were not stopped if `HcsShutdownComputeSystem`
   returned an `ERROR_PROC_NOT_FOUND` error moby/moby#42613](https://github.com/moby/moby/pull/42613) 
 
-## Swarm
+### Swarm
 
 - Fix a possibility where overlapping IP addresses could exist as a result of the
   node failing to clean up its old loadbalancer IPs [moby/moby#42538](https://github.com/moby/moby/pull/42538)


### PR DESCRIPTION
This should fix the misleading ToC, which includes "Swarm" as a past released version:

https://docs.docker.com/engine/release-notes/#swarm

<img width="136" alt="Screenshot 2021-08-08 at 18 03 33" src="https://user-images.githubusercontent.com/369699/128638201-8537132e-2fee-4c2d-9e18-4153f2d12beb.png">
