### PR TITLE
Fix broken link for setting up local registry with auth

### DIFF
--- a/registry/deploying.md
+++ b/registry/deploying.md
@@ -398,7 +398,7 @@ secrets.
 > **Warning**:
 > You **cannot** use authentication with authentication schemes that send
 > credentials as clear text. You must
-> [configure TLS first](deploying.md#running-a-domain-registry) for
+> [configure TLS first](deploying.md#run-an-externally-accessible-registry) for
 > authentication to work.
 {:.warning}
 


### PR DESCRIPTION
### Proposed changes

The link for configuring TLS under the auth section for local registries is broken. This updates the link to new location.

### Unreleased project version (optional)

N/A

### Related issues (optional)

N/A
