### PR TITLE
_scss: cleanup navigation styles, and various small fixes

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -20,8 +20,8 @@
     </button>
 </div>
 <div class="nav-container hidden-sm hidden-xs">
-    <div id="tabs">
-        <ul class="tabs jsTOCHorizontal">
+    <div>
+        <ul class="nav navbar-nav">
         {%- for entry in site.data.toc.horizontalnav -%}
           <li><a href="{{ entry.path }}" id="{{ entry.node }}">{{ entry.title }}</a></li>
         {%- endfor -%}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -50,7 +50,7 @@
                     <nav class="col-nav">
                         <div id="sidebar-nav" class="sidebar hidden-sm hidden-xs">
                             <div id="navbar" class="nav-sidebar">
-                                <ul class="nav jsTOCHorizontal hidden-md hidden-lg"></ul>
+                                <ul class="nav hidden-md hidden-lg"></ul>
                                 <ul class="nav" id="jsTOCLeftNav"></ul>
                             </div>
                         </div>

--- a/_scss/_landing.scss
+++ b/_scss/_landing.scss
@@ -56,24 +56,6 @@ body.landing {
       }
     }
 
-    @include md-width {
-      .navbar-nav > li > a {
-        font-weight: bold;
-        line-height: 25px;
-        padding-top: 17px;
-        padding-bottom: 9px;
-        border-bottom-style: solid;
-        border-bottom-width: 4px;
-        border-bottom-color: rgba(255, 255, 255, 0);
-      }
-    }
-
-    @include md-width {
-      .navbar-nav > li.active > a {
-        border-bottom-color: rgba(255, 255, 255, 0.5);
-      }
-    }
-
     .toggle-mode {
       margin-top: 15px;
 

--- a/_scss/_mobile.scss
+++ b/_scss/_mobile.scss
@@ -54,6 +54,7 @@
     and (max-width : 900px) {
     .sidebar {
         position: fixed;
+        top:   55px; // top-navigation bar (without breadcrumbs)
         width: 100%;
         z-index: 100;
         background-color: $bg-sidebar;
@@ -197,7 +198,7 @@
     }
     .sidebar {
         background-color: $bg-sidebar;
-        top: 51px;
+        top: 55px; // top-navigation bar (without breadcrumbs)
         left: 0;
         display: block;
         padding: 0;
@@ -253,9 +254,6 @@
   and (min-device-width: 768px)
   and (max-device-width: 1024px)
   and (orientation: landscape) {
-    .search-form {
-        float: left;
-    }
     .ctrl-right {
         display: block;
     }

--- a/_scss/_navigation.scss
+++ b/_scss/_navigation.scss
@@ -58,15 +58,11 @@
 
 .nav-sidebar ul {
     list-style: none;
-    padding: 0 15px;
+    padding: 0;
     text-align: left;
 
     li {
         display: block;
-    }
-
-    @include lg-width {
-        padding: 0 0 0 7px; // left-padding to align with logo
     }
 }
 
@@ -83,10 +79,18 @@
 .nav-sidebar ul li a:focus,
 .nav-sidebar ul li a:hover {
     border-bottom: none;
+    border-left:   4px solid rgba($primary-links, 0);
+}
+
+.nav-sidebar .nav > li > a {
+  padding-left: 22px; // left-padding to align with logo
+  @include before-md-width {
+    padding-right: 32px; // right-align with hamburger menu
+  }
 }
 
 .nav-sidebar ul li a.active,
-.nav-sidebar.nav>li>a:focus {
+.nav-sidebar.nav > li > a:focus {
     background:  $bg-sidebar-active;
     border-left: 4px solid $primary-links;
     font-weight: 600;
@@ -234,37 +238,36 @@ input:checked+.slider:before {
 /*
  * Tabs ************************************************************************
  */
-#tabs {
-    float: left;
-    margin: 0;
-    padding-left: 8px;
-    ul {
-        padding: 0;
-    }
+
+.navbar-nav > li > a {
+  border-left:   4px solid rgba($white, 0.0);
+}
+.navbar-nav > li.active > a {
+  border-left:   4px solid rgba($white, 0.75);
 }
 
-.tabs {
-    li {
-        float: left;
-        list-style: none;
-        a {
-            color: $white;
-            padding: 17px 19px 14px 15px;
-            float: left;
-            font-weight: 600;
-            &:hover {
-                background: rgba(0, 0, 0, 0.17) !important;
-                border-bottom: 4px solid #fff;
-            }
-        }
-    }
-}
+@include md-width {
+  .landing .navbar-nav > li > a {
+    padding-top:    17px;
+    padding-bottom:  9px;
+  }
+  .navbar-nav > li > a {
+    color:          $white;
+    line-height:    25px;
+    padding-top:    14px;
+    padding-bottom: 12px;
+    font-weight:    600;
 
-.tabs li.active a {
-    background: transparent !important;
-    color: #fff;
-    cursor: default;
-    border-bottom: 4px solid #fff;
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.17);
+      border-bottom:    4px solid rgba($white, 0.75);
+    }
+  }
+  .navbar-nav > li.active > a {
+    cursor:        default;
+    border-left:   none;
+    border-bottom: 4px solid rgba($white, 0.5);
+  }
 }
 
 /*

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -61,8 +61,8 @@ body.night {
         background:  $bg-sidebar-night-active;
         border-left: 4px solid $primary-links;
     }
-    .tabs li.active a {
-        border-bottom: 4px solid $primary-links;
+    .navbar-nav > li.active > a {
+      border-color: $primary-links;
     }
     .slider {
         background-color: #344658;

--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -82,7 +82,7 @@ img.inline {
  */
 .search-form {
     float: left;
-    margin: 5px 0 0;
+    margin: 5px 8px 0 0;
     & input[type=text] {
         background: rgba(0, 0, 0, 0.17) url("/images/search.png") no-repeat 10px 9px;
         border: 0;


### PR DESCRIPTION
This fixes various inconsistencies between the landing page and the other pages by sharing more styles between both:

- fix homepage using a different color for the active tab
- fix homepage not having "hover" styles for the top navigation

I addition, this:

- fixes unwanted whitespace in the hamburger-menu on mobile
- fixes "active" menu item not being highlighted on mobile

Active menu item in night-mode before:

<img width="875" alt="Screenshot 2021-08-17 at 12 13 46" src="https://user-images.githubusercontent.com/1804568/129709692-43902a6a-553e-447e-983b-614278c04398.png">


And after:

<img width="901" alt="Screenshot 2021-08-17 at 12 13 40" src="https://user-images.githubusercontent.com/1804568/129709697-cd6497b8-d7fa-47ad-a4a7-154426ea7de5.png">


Hamburger menu (homepage) before and after (was missing a highlight for active menu item):

<img width="574" alt="Screenshot 2021-08-17 at 13 49 55" src="https://user-images.githubusercontent.com/1804568/129720771-38553bb2-541a-47bd-a8a2-a43e114c52e5.png">
<img width="574" alt="Screenshot 2021-08-17 at 13 49 59" src="https://user-images.githubusercontent.com/1804568/129720758-12ab596b-4137-46bc-a07c-1ec5c5d54387.png">


Hamburger menu on other pages before and after (fixed excessive whitespace):

<img width="574" alt="Screenshot 2021-08-17 at 12 06 46" src="https://user-images.githubusercontent.com/1804568/129709998-2e162691-48f9-4635-b74d-6907452f7038.png">
<img width="574" alt="Screenshot 2021-08-17 at 12 06 35" src="https://user-images.githubusercontent.com/1804568/129710001-6992ab67-186c-4c38-bc8f-b99658c98792.png">

And fixes some white-space on the "desktop" menu (left-aligning);

<img width="382" alt="Screenshot 2021-08-17 at 13 52 05" src="https://user-images.githubusercontent.com/1804568/129721055-cc1c1152-cd99-4b12-b2af-7889d91bf6cb.png">
<img width="387" alt="Screenshot 2021-08-17 at 13 52 22" src="https://user-images.githubusercontent.com/1804568/129721050-dd4f9b18-005e-4d56-8d3e-81c2081753e4.png">


