### PR TITLE
Add tooltips and links to reference docs to Dockerfile codeblocks

### DIFF
--- a/js/docs.js
+++ b/js/docs.js
@@ -215,4 +215,14 @@ ready(() => {
         const group = $(this).attr("data-group");
         $(`.nav-tabs > li > a[data-group='${ group }']`).tab("show");
     });
+
+    $('.language-dockerfile span.k').tooltip({
+        title: function() {
+            let c = this.textContent;
+            this.style.cursor = 'help';
+            $(this).on('click', () => { window.location.href = "/engine/reference/builder/#"+c.toLowerCase()});
+            return 'Learn more about the "'+ c + '" Dockerfile command.'
+        },
+        placement: "auto"
+    });
 });


### PR DESCRIPTION
This is an initial "experiment" on making codeblocks more useful; it's
just a quick implementation, and can use a lot of improvements, but we
can see if it's useful in its current form already (as a starting point).

More context below:

With example blocks being parsed/highlighted by rouge, we should be able
to pick keywords from them; for example, in the highlighted Dockerfile
examples, we can show tool-tips (even a hover-card) with more details
about the command.

Shell examples may be a bit more involved, but we could still detect;

- adjacent keywords (`docker` + `run` => `docker run`)
- with the yaml-docs we have (we could generate JSON and upload them
  as a "database"),   we could even do an AJAX call to dynamically
  fetch  flag  descriptions, etc.

This very quick and dirty test adds tooltips to Dockerfile commands
in examples. When hovering, it shoulds a tooltip ("click for  more
information about this command"), and when clicking, navigates to the
Dockerfile reference.

Ideally, we wouldn't navigate away from the current page for initial
details (instead, we should present a rich hoverbox / pane), to provide
the user with more details without interrupting the article they were
reading.

Some screenshots:

A Dockerfile example in our docs:

<img width="507" alt="Screenshot 2021-08-17 at 21 46 22" src="https://user-images.githubusercontent.com/1804568/129790956-649d8446-d80a-4d2c-9fe5-895c5dc0e03e.png">

When hovering over a keyword:

<img width="416" alt="Screenshot 2021-08-17 at 21 46 42" src="https://user-images.githubusercontent.com/1804568/129790964-fd0a6588-6862-45c9-81ff-7f0054078fc8.png">

And when clicking on the keyword, the user is navigated to the reference docs:

<img width="1176" alt="Screenshot 2021-08-17 at 21 47 16" src="https://user-images.githubusercontent.com/1804568/129790968-fba98e75-71ac-442e-952b-568f5b6795c7.png">

