### PR TITLE
fix code-highlighting in "get started"

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -42,38 +42,38 @@ see a few flaws in the Dockerfile below. But, don't worry. We'll go over them.
 
 1. Create a file named `Dockerfile` in the same folder as the file `package.json` with the following contents.
 
-    ```dockerfile
-    # syntax=docker/dockerfile:1
-    FROM node:12-alpine
-    RUN apk add --no-cache python g++ make
-    WORKDIR /app
-    COPY . .
-    RUN yarn install --production
-    CMD ["node", "src/index.js"]
-    ```
-    
-    Please check that the file `Dockerfile` has no file extension like `.txt`. Some editors may append this file extension automatically and this would result in an error in the next step.
+   ```dockerfile
+   # syntax=docker/dockerfile:1
+   FROM node:12-alpine
+   RUN apk add --no-cache python g++ make
+   WORKDIR /app
+   COPY . .
+   RUN yarn install --production
+   CMD ["node", "src/index.js"]
+   ```
+
+   Please check that the file `Dockerfile` has no file extension like `.txt`. Some editors may append this file extension automatically and this would result in an error in the next step.
 
 2. If you haven't already done so, open a terminal and go to the `app` directory with the `Dockerfile`. Now build the container image using the `docker build` command.
 
-    ```console
-    $ docker build -t getting-started .
-    ```
+   ```console
+   $ docker build -t getting-started .
+   ```
 
-    This command used the Dockerfile to build a new container image. You might
-    have noticed that a lot of "layers" were downloaded. This is because we instructed
-    the builder that we wanted to start from the `node:12-alpine` image. But, since we
-    didn't have that on our machine, that image needed to be downloaded.
+   This command used the Dockerfile to build a new container image. You might
+   have noticed that a lot of "layers" were downloaded. This is because we instructed
+   the builder that we wanted to start from the `node:12-alpine` image. But, since we
+   didn't have that on our machine, that image needed to be downloaded.
 
-    After the image was downloaded, we copied in our application and used `yarn` to 
-    install our application's dependencies. The `CMD` directive specifies the default 
-    command to run when starting a container from this image.
+   After the image was downloaded, we copied in our application and used `yarn` to 
+   install our application's dependencies. The `CMD` directive specifies the default 
+   command to run when starting a container from this image.
 
-    Finally, the `-t` flag tags our image. Think of this simply as a human-readable name
-    for the final image. Since we named the image `getting-started`, we can refer to that
-    image when we run a container.
+   Finally, the `-t` flag tags our image. Think of this simply as a human-readable name
+   for the final image. Since we named the image `getting-started`, we can refer to that
+   image when we run a container.
 
-    The `.` at the end of the `docker build` command tells that Docker should look for the `Dockerfile` in the current directory.
+   The `.` at the end of the `docker build` command tells that Docker should look for the `Dockerfile` in the current directory.
 
 ## Start an app container
 
@@ -81,21 +81,21 @@ Now that we have an image, let's run the application. To do so, we will use the 
 command (remember that from earlier?).
 
 1. Start your container using the `docker run` command and specify the name of the image we 
-    just created:
+   just created:
 
-    ```console
-    $ docker run -dp 3000:3000 getting-started
-    ```
+   ```console
+   $ docker run -dp 3000:3000 getting-started
+   ```
 
-    Remember the `-d` and `-p` flags? We're running the new container in "detached" mode (in the 
-    background) and creating a mapping between the host's port 3000 to the container's port 3000.
-    Without the port mapping, we wouldn't be able to access the application.
+   Remember the `-d` and `-p` flags? We're running the new container in "detached" mode (in the 
+   background) and creating a mapping between the host's port 3000 to the container's port 3000.
+   Without the port mapping, we wouldn't be able to access the application.
 
 2. After a few seconds, open your web browser to [http://localhost:3000](http://localhost:3000).
-    You should see our app.
+   You should see our app.
 
-    ![Empty Todo List](images/todo-list-empty.png){: style="width:450px;margin-top:20px;"}
-    {: .text-center }
+   ![Empty Todo List](images/todo-list-empty.png){: style="width:450px;margin-top:20px;"}
+   {: .text-center }
 
 3. Go ahead and add an item or two and see that it works as you expect. You can mark items as
    complete and remove items. Your frontend is successfully storing items in the backend.

--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -56,8 +56,8 @@ For now, we will create the network first and attach the MySQL container at star
 
     If you are using PowerShell then use this command.
 
-    ```powershell
-    docker run -d `
+    ```console
+    PS> docker run -d `
         --network todo-app --network-alias mysql `
         -v todo-mysql-data:/var/lib/mysql `
         -e MYSQL_ROOT_PASSWORD=secret `
@@ -80,7 +80,7 @@ For now, we will create the network first and attach the MySQL container at star
     When the password prompt comes up, type in **secret**. In the MySQL shell, list the databases and verify
     you see the `todos` database.
 
-    ```cli
+    ```console
     mysql> SHOW DATABASES;
     ```
 
@@ -194,8 +194,8 @@ With all of that explained, let's start our dev-ready container!
 
     If you are using PowerShell then use this command.
 
-    ```powershell
-    docker run -dp 3000:3000 `
+    ```console
+    PS> docker run -dp 3000:3000 `
       -w /app -v "$(pwd):/app" `
       --network todo-app `
       -e MYSQL_HOST=mysql `
@@ -209,8 +209,7 @@ With all of that explained, let's start our dev-ready container!
 2. If we look at the logs for the container (`docker logs <container-id>`), we should see a message indicating it's
    using the mysql database.
 
-    ```
-    # Previous log messages omitted
+    ```console
     $ nodemon src/index.js
     [nodemon] 1.19.2
     [nodemon] to restart at any time, enter `rs`
@@ -231,7 +230,7 @@ With all of that explained, let's start our dev-ready container!
 
     And in the mysql shell, run the following:
 
-    ```plaintext
+    ```console
     mysql> select * from todo_items;
     +--------------------------------------+--------------------+-----------+
     | id                                   | name               | completed |

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -93,8 +93,8 @@ For Docker Desktop installation instructions, see [Install Docker Desktop on Mac
 
 If you've already run the command to get started with the tutorial, congratulations! If not, open a command prompt or bash window, and run the command:
 
-```cli
-docker run -d -p 80:80 docker/getting-started
+```console
+$ docker run -d -p 80:80 docker/getting-started
 ```
 
 You'll notice a few flags being used. Here's some more info on them:


### PR DESCRIPTION
Indentation in some bullet-lists had one space too little, causing
code-highlighting to not work.

Also fixed some other minor issues.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
