### PR TITLE
Add mention of donotstart

### DIFF
--- a/compose/profiles.md
+++ b/compose/profiles.md
@@ -50,6 +50,8 @@ case running `docker-compose up` would only start `backend` and `db`.
 
 Valid profile names follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
 
+It is possible to use profile `donotstart` that will prevent service from starting.
+
 > **Note**
 >
 > The core services of your application should not be assigned `profiles` so


### PR DESCRIPTION
This post on StackOverflow lead me to try `donotstart` profile. Confirmed, this setting on docker-compose 1.29.2 prevents container from spinning up. I do not see an error message, so I guess it is a feature.
Would be great to have this documented.

In case this is not documented for purpose, can you tell me why, so I can either reflect this in PR or close it?

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
