### PR TITLE
fix(yaml): Avoid bool type error

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -1538,16 +1538,16 @@ volumes_from:
 `no` is the default restart policy, and it doesn't restart a container under any circumstance. When `always` is specified, the container always restarts. The `on-failure` policy restarts a container if the exit code indicates an on-failure error.
 
 ```yaml
-restart: no
+restart: "no"
 ```
 ```yaml
-restart: always
+restart: "always"
 ```
 ```yaml
-restart: on-failure
+restart: "on-failure"
 ```
 ```yaml
-restart: unless-stopped
+restart: "unless-stopped"
 ```
 
 {: id="cpu-and-other-resources"}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Docs contained an invalid example:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:                                                                                                                   
services.*.restart contains an invalid type, it should be a string 
```

Use quotes to avoid YAML's implicit type conversion.  Someone may also want to do an audit of [other type conversions that might cause problems](https://www.rpatterson.net/blog/docker-gotchas/#yaml-needs-some-zen) and/or quote all string values to avoid surprising behavior.

### Unreleased project version (optional)

https://docs.docker.com/compose/compose-file/compose-file-v3/
