### PR TITLE
Add /go/wsl2/ redirect

### DIFF
--- a/go/wsl2.md
+++ b/go/wsl2.md
@@ -1,0 +1,4 @@
+---
+description: Link used by Docker Desktop to refer users on how to activate WSL 2
+redirect_to: /desktop/windows/wsl/
+---


### PR DESCRIPTION
Docker Desktop uses an informational message that prints:

    We recommend to activate the WSL integration in Docker Desktop settings.

    See https://docs.docker.com/desktop/windows/wsl/ for details.

We see quite some users trying to copy the URL, and accidentally copying part
of the text, which results in a 404;
https://github.com/docker/docker.github.io/issues?q=in%3Atitle+%2Fdocker-for-windows%2Fwsl%2Ffor%2520details+

I'm changing the message to have the URL on a separate line for easier copying,
but having a shorter URL would make it slightly easier for users to type it in
their browser, without having to copy it.

This adds a new URL https://docs.docker.com/go/wsl2/ that we can redirect to
the most appropriate location within the docs, without having to update the
URL in Docker Desktop itself.
