### PR TITLE
Update debian.md

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -22,10 +22,10 @@ To get started with Docker Engine on Debian, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Debian or
 Raspbian versions:
 
-- Debian Bullseye 11 (testing)
-- Debian Buster 10 (stable)
-- Raspbian Bullseye 11 (testing)
-- Raspbian Buster 10 (stable)
+- Debian Bullseye 11 (stable)
+- Debian Buster 10 (oldstable)
+- Raspbian Bullseye 11 (stable)
+- Raspbian Buster 10 (oldstable)
 
 Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
 


### PR DESCRIPTION
Bullseye has been Debian's stable and Raspbian's stable and Buster has been Debian's oldstable and Raspbian's oldstable.
ref. [Debian 11 "bullseye" has been released!](https://bits.debian.org/2021/08/bullseye-released.html)
