### PR TITLE
add /go/experimental/ redirect

### DIFF
--- a/go/experimental.md
+++ b/go/experimental.md
@@ -1,0 +1,4 @@
+---
+description: Redirect refer users on how to enable experimental CLI features (now enabled by default)
+redirect_to: /engine/reference/commandline/cli/#experimental-features
+---


### PR DESCRIPTION
We already have a redirect for this that's defined in the docker/cli repository,
but unifying these redirects to live in the docs repository.

relates to https://github.com/docker/cli/pull/2773

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
