### PR TITLE
Unset environment variables when uninstall rootless docker

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -218,6 +218,8 @@ Removed /home/testuser/.config/systemd/user/default.target.wants/docker.service.
 [INFO] To remove data, run: `/usr/bin/rootlesskit rm -rf /home/testuser/.local/share/docker`
 ```
 
+Unset environment variables PATH and DOCKER_HOST if you have added them to `~/.bashrc`.
+
 To remove the data directory, run `rootlesskit rm -rf ~/.local/share/docker`.
 
 To remove the binaries, remove `docker-ce-rootless-extras` package if you installed Docker with package managers.


### PR DESCRIPTION
### Proposed changes

When users install rootless docker, the tool ask them to set environment variables PATH and DOCKER_HOST.

Consequently, when users uninstall rootless docker, they need to unset these environment variables if they have added them to `~/.bashrc` per the previous instruction.

If a user didn't unset these variables in bashrc, docker will refuse to start.