### PR TITLE
Rootless updates

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -576,15 +576,35 @@ Installing slirp4netns may improve the network throughput.
 See [RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/tree/v0.13.0#network-drivers) for the benchmark result.
 
 Also, changing MTU value may improve the throughput.
-The MTU value can be specified by adding `Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=<INTEGER>"`
-to `~/.config/systemd/user/docker.service` and then running `systemctl --user daemon-reload`.
+The MTU value can be specified by creating `~/.config/systemd/user/docker.service.d/override.conf` with the following content:
+
+```systemd
+[Service]
+Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=<INTEGER>"
+```
+
+And then restart the daemon:
+```console
+$ systemctl --user daemon-reload
+$ systemctl --user restart docker
+```
 
 **`docker run -p` does not propagate source IP addresses**
 
 This is because Docker with rootless mode uses RootlessKit's builtin port driver by default.
 
-The source IP addresses can be propagated by adding `Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=slirp4netns"`
-to `~/.config/systemd/user/docker.service` and then running `systemctl --user daemon-reload`.
+The source IP addresses can be propagated by creating `~/.config/systemd/user/docker.service.d/override.conf` with the following content:
+
+```systemd
+[Service]
+Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=slirp4netns"
+```
+
+And then restart the daemon:
+```console
+$ systemctl --user daemon-reload
+$ systemctl --user restart docker
+```
 
 Note that this configuration decreases throughput.
 See [RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/tree/v0.13.0#port-drivers) for the benchmark result.


### PR DESCRIPTION
### Commit 1:  rootless: update for Debian 11
- sysctl `kernel.unprivileged_userns_clone=1` is no longer needed
- Recommend fuse-overlayfs. Debian kernel has modprobe option `permit_mounts_in_userns=1` but still unstable (moby/moby#42302)
- Now apt repo has relatively recent version of slirp4netns (1.0.1)

### Commit 2: rootless: recommend installing `dbus-user-session`
    
rootless+cgroup2+systemd fails with a cryptic error when dbus-user-session dpkg is not installed.
    
 ```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:385: applying cgroup configuration for process caused: error while starting unit "docker-931c15729b5a968ce803784d04c7421f791d87e5ca1891f34387bb9f694c488e.scope" with properties [{Name:Description Value:"libcontainer container 931c15729b5a968ce803784d04c7421f791d87e5ca1891f34387bb9f694c488e"} {Name:Slice Value:"user.slice"} {Name:PIDs Value:@au [4529]} {Name:Delegate Value:true} {Name:MemoryAccounting Value:true} {Name:CPUAccounting Value:true} {Name:IOAccounting Value:true} {Name:TasksAccounting Value:true} {Name:DefaultDependencies Value:false}]: read unix @->/run/systemd/private: read: connection reset by peer: unknown.
```
 
moby/moby#42793

### Commit 3: rootless: remove outdated SELinux workaround for `/run/xtables.lock`
The SELinux workaround for `/run/xtables.lock` is no longer needed since Docker 20.10.8 (moby/moby#42462)

### Commit 4: rootless: suggest creating `docker.service.d/override.conf`, without modifying `docker.service` itself

Suggest creating `~/.config/systemd/docker.service.d/override.conf`, without modifying `~/.config/systemd/docker.service` itself