### PR TITLE
Add link to licensing from the Desktop overview page

### DIFF
--- a/desktop/index.md
+++ b/desktop/index.md
@@ -6,6 +6,8 @@ toc_min: 1
 toc_max: 2
 redirect_from:
 - /desktop/opensource/
+- /docker-for-mac/opensource/
+- /docker-for-windows/opensource/
 ---
 
 Docker Desktop is an easy-to-install application for your Mac or Windows environment that enables you to build and share containerized applications and microservices. Docker Desktop includes [Docker Engine](../engine/), Docker CLI client, [Docker Compose](../compose/), [Docker Content Trust](../engine/security/trust.md), [Kubernetes](https://github.com/kubernetes/kubernetes/), and [Credential Helper](https://github.com/docker/docker-credential-helpers/).
@@ -30,6 +32,8 @@ Docker Desktop is available for Mac and Windows. For download information, syste
 
 * [Install Docker Desktop on Mac](mac/install.md)
 * [Install Docker Desktop on Windows](windows/install.md)
+
+For information about Docker Desktop licensing, see [Docker Desktop License Agreement](../subscription/index.md#docker-desktop-license-agreement).
 
 ## Configure Docker Desktop
 

--- a/subscription/index.md
+++ b/subscription/index.md
@@ -8,7 +8,7 @@ redirect_from:
 - /subscription/faq/
 ---
 
-On August 31, 2021, we [announced](https://www.docker.com/blog/updating-product-subscriptions/){: target="_blank" rel="noopener" class="_" id="dkr_docs_subscription_btl"} updates and extensions to our product subscriptions to increase productivity, collaboration, and added security for our developers and businesses. Docker subscription tiers now include Personal, Pro, Team, and Business. 
+On August 31, 2021, we [announced](https://www.docker.com/blog/updating-product-subscriptions/){: target="_blank" rel="noopener" class="_" id="dkr_docs_subscription_btl"} updates and extensions to our product subscriptions to increase productivity, collaboration, and added security for our developers and businesses. Docker subscription tiers now include Personal, Pro, Team, and Business.
 
 ### Here's a summary of the changes
 
@@ -16,10 +16,10 @@ On August 31, 2021, we [announced](https://www.docker.com/blog/updating-product-
 
 - Our [Docker Subscription Service Agreement](https://www.docker.com/legal/docker-subscription-service-agreement){: target="_blank" rel="noopener" class="_" id="dkr_docs_subscription_btl"} includes a change to the terms for **Docker Desktop**.
     - Docker Desktop **remains free** for small businesses (fewer than 250 employees AND less than $10 million in annual revenue), personal use, education, and non-commercial open-source projects.
-    - It requires a paid subscription (**Pro, Team, or Business**), for as little as $5 a month, for professional use in larger enterprises. 
+    - It requires a paid subscription (**Pro, Team, or Business**), for as little as $5 a month, for professional use in larger enterprises.
     - The effective date of these terms is August 31, 2021. There is a grace period until January 31, 2022 for those that will require a paid subscription to use Docker Desktop.
 - The Docker Pro and Docker Team subscriptions now **include commercial use** of Docker Desktop.
-- The existing Docker Free subscription has been renamed **Docker Personal**. 
+- The existing Docker Free subscription has been renamed **Docker Personal**.
 - **No changes** to Docker Engine or any other upstream **open-source** Docker or Moby project.
 
 To understand how these changes affect you, read the [Docker subscription FAQs](https://www.docker.com/pricing/faq){: target="_blank" rel="noopener" class="_" id="dkr_docs_subscription_btl"}.
@@ -36,7 +36,7 @@ For a list of features available in each tier, see [Docker Pricing](https://www.
 
 ## Docker Pro
 
-**Docker Pro** enables individual developers to get more control of their development environment and provides an integrated and reliable developer experience. It reduces the amount of time developers spend on mundane and repetitive tasks and empowers developers to spend more time creating value for their customers. 
+**Docker Pro** enables individual developers to get more control of their development environment and provides an integrated and reliable developer experience. It reduces the amount of time developers spend on mundane and repetitive tasks and empowers developers to spend more time creating value for their customers.
 
 Docker Pro includes all the features available in Personal, additionally, it includes unlimited private repositories, unlimited public repositories, unlimited [collaborators](../docker-hub/repos.md#collaborators-and-their-role) for public repositories, [Auto Builds](../docker-hub/builds/index.md) with 5 concurrent builds, 300 [Hub Vulnerability Scans](../docker-hub/vulnerability-scanning.md), 5 [Scoped Access Tokens](../docker-hub/access-tokens.md), and more.
 
@@ -44,7 +44,7 @@ For a list of features available in each tier, see [Docker Pricing](https://www.
 
 ## Docker Team
 
-**Docker Team** offers capabilities for collaboration, productivity, and security across organizations. It enables groups of developers to unlock the full power of collaboration and sharing combined with essential security features and team management capabilities. 
+**Docker Team** offers capabilities for collaboration, productivity, and security across organizations. It enables groups of developers to unlock the full power of collaboration and sharing combined with essential security features and team management capabilities.
 
 Docker Team includes everything included in Docker Pro, plus unlimited private repositories, [Auto Builds](../docker-hub/builds/index.md) with 15 concurrent builds, unlimited [Scoped Access Tokens](../docker-hub/access-tokens.md), advanced collaboration and management tools, including organization and team management with Role Based Access Control (RBAC) for the whole team, [Audit Logs](../docker-hub/audit-log.md), and more.
 
@@ -69,14 +69,17 @@ Docker Desktop is licensed under the Docker Subscription Service Agreement. When
 **Here’s a summary of the key changes:**
 
 - Our Docker Subscription Service Agreement include a change to the terms of use for Docker Desktop
-    - It **remains free** for small businesses (fewer than 250 employees AND less than $10 million in revenue), personal use, education, and non-commercial open source projects.  
+    - It **remains free** for small businesses (fewer than 250 employees AND less than $10 million in revenue), personal use, education, and non-commercial open source projects.
     - It requires a paid subscription for professional use in larger enterprises.
-- The effective date of these terms is August 31, 2021. There is a **grace period** until January 31, 2022 for those that will require a paid subscription to use Docker Desktop. 
+- The effective date of these terms is August 31, 2021. There is a **grace period** until January 31, 2022 for those that will require a paid subscription to use Docker Desktop.
 - The existing Docker Free subscription has been renamed **Docker Personal** and we have introduced a Docker Business subscription .
 - The Docker Pro, Team, and Business subscriptions include commercial use of Docker Desktop.
-
-Docker Desktop is built using open-source software. For information about the licensing of open-source components in Docker Desktop, Select ![whale menu](../desktop/mac/images/whale-x.png){: .inline} > **About Docker Desktop** > **Acknowledgements**.
 
 > **Note**
 >
 > The licensing and distribution terms for Docker and Moby **open-source** projects, such as Docker Engine, are not changing.
+
+Docker Desktop is built using open-source software. For information about the licensing of open-source components in Docker Desktop, Select ![whale menu](../desktop/mac/images/whale-x.png){: .inline} > **About Docker Desktop** > **Acknowledgements**.
+
+Docker Desktop distributes some components that are licensed under the
+GNU General Public License. Click [here](https://download.docker.com/opensource/License.tar.gz) to download the source for these components.


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

- Add missing redirects
- Add link to licensing info from the Desktop overview page