### PR TITLE
_scss: tweak white-space / margins

### DIFF
--- a/_scss/_typography.scss
+++ b/_scss/_typography.scss
@@ -43,6 +43,8 @@ h1,h2,h3,h4,h5,h6 {
     font-family: $headings;
     clear: both;
     line-height: 26px;
+    margin-top:  30px;
+    margin-bottom: 0;
 }
 
 h1 {
@@ -74,4 +76,8 @@ h6 {
 
 dd, dt {
     line-height: 25px;
+}
+
+ol, ul {
+  padding-left: 25px;
 }


### PR DESCRIPTION
- Reduce white-space after headings, so that the section content groups better with the heading
- Increase white-space before headings, so that sections are more separated from the previous sections.
- Reduce indentation of bullet-lists and numbered-lists. These lists are still indented slightly (5px), but reducing the indentation to make the   layout a bit less "busy", and to give list-items slightly more width  before content is wrapped.

Bullet-list before/after:

<img width="560" alt="Screenshot 2021-09-01 at 12 44 47" src="https://user-images.githubusercontent.com/1804568/131660014-f7f11d18-a475-480f-ad0f-84945c658212.png">
<img width="587" alt="Screenshot 2021-09-01 at 12 44 39" src="https://user-images.githubusercontent.com/1804568/131660020-1c6ca97f-1a07-43ad-9683-2c6372988545.png">

Numbered list before/after:

<img width="690" alt="Screenshot 2021-09-01 at 12 45 30" src="https://user-images.githubusercontent.com/1804568/131660192-13c3ebc7-ee57-468d-8388-b13646f60709.png">

<img width="691" alt="Screenshot 2021-09-01 at 12 46 41" src="https://user-images.githubusercontent.com/1804568/131660125-13ee0dcc-f9e4-4a63-be8b-55e2d5684327.png">

Headings before/after:

<img width="998" alt="Screenshot 2021-09-01 at 12 52 29" src="https://user-images.githubusercontent.com/1804568/131660270-af831a26-f494-4e04-8415-1c3c4653a1bf.png">
<img width="1008" alt="Screenshot 2021-09-01 at 12 52 02" src="https://user-images.githubusercontent.com/1804568/131660274-b5751b0d-32ea-4df8-aaba-a4e9807fc5c2.png">

