### PR TITLE
fix vertical size of "get docker" blocks

### DIFF
--- a/_scss/_content.scss
+++ b/_scss/_content.scss
@@ -59,17 +59,28 @@ code {
  */
 
 .component-container {
-    padding: 0;
-    margin: 0 0 50px;
-    width: 100%;
-}
+  padding:  0;
+  margin:   0 0 50px;
+  width:    100%;
 
-.component {
-    padding: 15px 25px 5px 15px;
+  .block {
+    padding: 0 15px 10px 15px;
+  }
+
+  .row {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .row > [class*='col-'] {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .component {
+    padding: 15px 25px 15px 15px;
     text-align: center;
-    margin: 0 8px 15px;
     float: left;
-    height: 250px;
+    height: 100%;
     width: 100%;
     background: $bg-component;
     img {
@@ -80,11 +91,12 @@ code {
       justify-content: center;
     }
     h2 {
-      font-size: 22px;
+      font-size: 18px;
     }
     h2, h3, p {
       margin: 0;
     }
+  }
 }
 
 a.anchorLink {

--- a/_scss/_content.scss
+++ b/_scss/_content.scss
@@ -63,23 +63,21 @@ code {
   margin:   0 0 50px;
   width:    100%;
 
-  .block {
-    padding: 0 15px 10px 15px;
-  }
-
   .row {
     display: flex;
     flex-wrap: wrap;
   }
-  .row > [class*='col-'] {
+
+  // "get-docker" tiles
+  .row > .block {
     display: flex;
     flex-direction: column;
+    padding: 10px;
   }
 
   .component {
     padding: 15px 25px 15px 15px;
     text-align: center;
-    float: left;
     height: 100%;
     width: 100%;
     background: $bg-component;

--- a/_scss/_utilities.scss
+++ b/_scss/_utilities.scss
@@ -67,11 +67,6 @@ i.fa.fa-outdent {
     opacity: 0.5;
 }
 
-.block {
-    padding: 0 15px 10px 15px;
-}
-
-
 /* Inline graphics and icons (like the whale menu icon in d4mac, d4win) */
 img.inline {
     display: inline;

--- a/get-docker.md
+++ b/get-docker.md
@@ -22,7 +22,7 @@ section and choose the best installation path for you.
 <div class="component-container">
     <!--start row-->
     <div class="row">
-        <div class="col-sm-12 col-md-12 col-lg-4 block">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
                     <a href="/desktop/mac/install/"><img src="/images/apple_48.svg" alt="Docker Desktop for Mac" width="70" height="70"></a>
@@ -31,7 +31,7 @@ section and choose the best installation path for you.
                 <p>A native application using the macOS sandbox security model which delivers all Docker tools to your Mac.</p>
             </div>
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-4 block">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
                     <a href="/desktop/windows/install/"><img src="/images/windows_48.svg" alt="Docker Desktop for Windows" width="70" height="70"></a>
@@ -40,7 +40,7 @@ section and choose the best installation path for you.
                 <p>A native Windows application which delivers all Docker tools to your Windows computer.</p>
             </div>
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-4 block">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
                     <a href="/engine/install/"><img src="/images/linux_48.svg" alt="Docker for Linux" width="70" height="70"></a>

--- a/language/index.md
+++ b/language/index.md
@@ -23,28 +23,18 @@ Learn how to set up your Docker environment and start containerizing your applic
 
 <div class="component-container">
     <!--start row-->
-    <div class="row" style="display: flex; align-items: center">
-        <div class="col-sm-12 col-md-12 col-lg-4 block" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
-                <div class="component-icon">
-                    <a href="/language/nodejs/"><img src="/language/images/nodejs.png" alt="Develop with Node"></a>
-                </div>
+    <div class="row" style="display: flex; align-items: center; flex-wrap: nowrap;">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
+            <a href="/language/nodejs/"><img src="/language/images/nodejs.png" alt="Develop with Node"></a>
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-4 block" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
-        <a href="/language/python/">
-                <div class="component-icon">
-                    <img src="/language/images/python.png" alt="Develop with Python">
-                </div>
-            </a>
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
+            <a href="/language/python/"><img src="/language/images/python.png" alt="Develop with Python"></a>
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-4 block" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
-                <div class="component-icon">
-                    <a href="/language/java/"><img src="/language/images/java.png" alt="Develop with Java"></a>
-                </div>
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
+            <a href="/language/java/"><img src="/language/images/java.png" alt="Develop with Java"></a>
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-4 block" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
-                <div class="component-icon">
-                    <a href="/language/golang/"><img src="/language/images/golang.png" alt="Develop with Go"></a>
-                </div>
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4" style="margin: 0 10px;box-shadow: 0 3px 6px #0b214a17, 0 -2px 2px #0b214a08; height: 140px; display: flex; align-items: center">
+            <a href="/language/golang/"><img src="/language/images/golang.png" alt="Develop with Go"></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
closes https://github.com/docker/docker.github.io/pull/13433
fixes https://github.com/docker/docker.github.io/issues/13432

This attempts to fix the problem where (on smaller windows), the text
flows out of the blocks.

This uses one of the solutions mentioned in https://stackoverflow.com/a/19695851/1811501,
with some additonal style changes.

Unfortunately, it introduces another issue, where (just before a break-point; after
the right-hand navigation is hidden, but before we switch to "mobile" / "small",
the blocks are wrapped, but no longer have equal _widths_.

See https://github.com/docker/docker.github.io/pull/13433#issuecomment-910843789

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
