### PR TITLE
document compose.v2 new repository and RC3 release

### DIFF
--- a/compose/cli-command-compatibility.md
+++ b/compose/cli-command-compatibility.md
@@ -4,11 +4,9 @@ keywords: documentation, docs, docker, compose, containers
 title: Compose command compatibility with docker-compose
 ---
 
-The `compose` command in the Docker CLI supports most of the `docker-compose` commands and flags. It is expected to be a drop-in replacement for `docker-compose`. There are a few remaining flags that have yet to be implemented, and we are prioritizing these implementations based on usage metrics and user feedback.
+The `compose` command in the Docker CLI supports most of the `docker-compose` commands and flags. It is expected to be a drop-in replacement for `docker-compose`. 
 
-You can follow progress on the implementation of the remaining commands and flags in the  [Compose-CLI](https://github.com/docker/compose-cli/issues/1283){:target="_blank" rel="noopener" class="_"} GitHub repository.
-
-If you see any Compose functionality that is not available in the `compose` command, create an issue in the [Compose-CLI](https://github.com/docker/compose-cli/issues){:target="_blank" rel="noopener" class="_"} GitHub repository so we can prioritize it.
+If you see any Compose functionality that is not available in the `compose` command, create an issue in the [Compose](https://github.com/docker/compose/issues){:target="_blank" rel="noopener" class="_"} GitHub repository so we can prioritize it.
 
 ## Commands or flags not yet implemented
 

--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -19,7 +19,7 @@ Starting with Docker Desktop 3.4.0, you can run Compose V2 commands without modi
 
 We will gradually turn this option on automatically for Docker Desktop users, so that users can seamlessly move to Docker Compose V2 without the need to upgrade any of their scripts. If you run into any problems with Compose V2, you can easily switch back to Compose v1 by either by making changes in Docker Desktop **Experimental** Settings, or by running the command `docker-compose disable-v2`.
 
-Your feedback is important to us. Let us know your feedback on the new 'compose' command by creating an issue in the [Compose-CLI](https://github.com/docker/compose-cli/issues){:target="_blank" rel="noopener" class="_"} GitHub repository.
+Your feedback is important to us. Let us know your feedback on the new 'compose' command by creating an issue in the [Compose](https://github.com/docker/compose/issues){:target="_blank" rel="noopener" class="_"} GitHub repository.
 {: .important}
 
 ## Context of Docker Compose evolution
@@ -63,10 +63,10 @@ $ docker-compose disable-v2
 ### Install on Linux
 
 You can install Compose V2 by downloading the adequate binary for your system 
-from the [project release page](https://github.com/docker/compose-cli/releases){:target="_blank" rel="noopener" class="_"} and copying it into `$HOME/.docker/cli-plugins` as `docker-compose`.
+from the [project release page](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"} and copying it into `$HOME/.docker/cli-plugins` as `docker-compose`.
 
 ```console
 $ mkdir -p ~/.docker/cli-plugins/
-$ curl -SL https://github.com/docker/compose-cli/releases/download/v2.0.0-rc.1/docker-compose-linux-amd64 -o ~/.docker/cli-plugins/docker-compose
+$ curl -SL https://github.com/docker/compose/releases/download/v2.0.0-rc.3/docker-compose-linux-amd64 -o ~/.docker/cli-plugins/docker-compose
 $ chmod +x ~/.docker/cli-plugins/docker-compose
 ```

--- a/engine/reference/commandline/compose.md
+++ b/engine/reference/commandline/compose.md
@@ -7,6 +7,6 @@ title: docker compose
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_build.md
+++ b/engine/reference/commandline/compose_build.md
@@ -7,6 +7,6 @@ title: docker compose build
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_convert.md
+++ b/engine/reference/commandline/compose_convert.md
@@ -7,6 +7,6 @@ title: docker compose convert
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_cp.md
+++ b/engine/reference/commandline/compose_cp.md
@@ -7,6 +7,6 @@ title: docker compose cp
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_create.md
+++ b/engine/reference/commandline/compose_create.md
@@ -7,6 +7,6 @@ title: docker compose create
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_down.md
+++ b/engine/reference/commandline/compose_down.md
@@ -7,6 +7,6 @@ title: docker compose down
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_events.md
+++ b/engine/reference/commandline/compose_events.md
@@ -7,6 +7,6 @@ title: docker compose events
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_exec.md
+++ b/engine/reference/commandline/compose_exec.md
@@ -7,6 +7,6 @@ title: docker compose exec
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_images.md
+++ b/engine/reference/commandline/compose_images.md
@@ -7,6 +7,6 @@ title: docker compose images
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_kill.md
+++ b/engine/reference/commandline/compose_kill.md
@@ -7,6 +7,6 @@ title: docker compose kill
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_logs.md
+++ b/engine/reference/commandline/compose_logs.md
@@ -7,6 +7,6 @@ title: docker compose logs
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_ls.md
+++ b/engine/reference/commandline/compose_ls.md
@@ -7,6 +7,6 @@ title: docker compose ls
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_pause.md
+++ b/engine/reference/commandline/compose_pause.md
@@ -7,6 +7,6 @@ title: docker compose pause
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_port.md
+++ b/engine/reference/commandline/compose_port.md
@@ -7,6 +7,6 @@ title: docker compose port
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_ps.md
+++ b/engine/reference/commandline/compose_ps.md
@@ -7,6 +7,6 @@ title: docker compose ps
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_pull.md
+++ b/engine/reference/commandline/compose_pull.md
@@ -7,6 +7,6 @@ title: docker compose pull
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_push.md
+++ b/engine/reference/commandline/compose_push.md
@@ -7,6 +7,6 @@ title: docker compose push
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_restart.md
+++ b/engine/reference/commandline/compose_restart.md
@@ -7,6 +7,6 @@ title: docker compose restart
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_rm.md
+++ b/engine/reference/commandline/compose_rm.md
@@ -7,6 +7,6 @@ title: docker compose rm
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_run.md
+++ b/engine/reference/commandline/compose_run.md
@@ -7,6 +7,6 @@ title: docker compose run
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_start.md
+++ b/engine/reference/commandline/compose_start.md
@@ -7,6 +7,6 @@ title: docker compose start
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_stop.md
+++ b/engine/reference/commandline/compose_stop.md
@@ -7,6 +7,6 @@ title: docker compose stop
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_top.md
+++ b/engine/reference/commandline/compose_top.md
@@ -7,6 +7,6 @@ title: docker compose top
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_unpause.md
+++ b/engine/reference/commandline/compose_unpause.md
@@ -7,6 +7,6 @@ title: docker compose unpause
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/compose_up.md
+++ b/engine/reference/commandline/compose_up.md
@@ -7,6 +7,6 @@ title: docker compose up
 Sorry, but the contents of this page are automatically generated from
 Docker's source code. If you want to suggest a change to the text that appears
 here, you'll need to find the string by searching this repo:
-https://github.com/docker/compose-cli
+https://github.com/docker/compose
 -->
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
### Proposed changes

Compose v2 codebase has been migrated to github.com/docker/compose under "v2" branch
This PR updates docs accordinlgy, replacing references to compose-cli but for "Cloud Integrations"
