### PR TITLE
Add anonymous volumes autoremove info

### DIFF
--- a/storage/volumes.md
+++ b/storage/volumes.md
@@ -578,6 +578,11 @@ the Docker Engine removes the `/foo` volume but not the `awesome` volume.
 $ docker run --rm -v /foo -v awesome:/bar busybox top
 ```
 
+> **Important**: If another container binds the volumes with
+> `--volumes-from`, the volume definitions are _copied_ and the 
+> anonymous volume also stays after the first container is removed.
+{: .important }
+  
 ### Remove all volumes
 
 To remove all unused volumes and free up space:


### PR DESCRIPTION
Anonymous volumes aren't removed if another container adopts them with `--volumes-from`, see: https://github.com/docker/docker.github.io/issues/13435

### Proposed changes

Updated documentation to match what happens.