### PR TITLE
Remove 'utility' capability

### DIFF
--- a/compose/gpu-support.md
+++ b/compose/gpu-support.md
@@ -54,7 +54,7 @@ services:
           devices:
             - driver: nvidia
               count: 1
-              capabilities: [gpu, utility]
+              capabilities: [gpu]
 ```
 
 Run with Docker Compose:


### PR DESCRIPTION
'utility' capability is not available for compose, only 'gpu' and 'tpu' are recognized :
Source: https://github.com/compose-spec/compose-spec/blob/master/deploy.md#capabilities

It brokes CUDA integration (clGetPlatformIDs(): CL_PLATFORM_NOT_FOUND_KHR) if specified.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
