### PR TITLE
Fix broken link to Windows path troubleshooting

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -91,7 +91,7 @@ on your development host. Use the following command to bind-mount the `target/`
 directory into your container at `/app/`. Run the command from within the
 `source` directory. The `$(pwd)` sub-command expands to the current working
 directory on Linux or macOS hosts.
-If you're on Windows, see also Path conversions on Windows in [Volumes](../desktop/windows/troubleshoot.md#volumes)
+If you're on Windows, see also [Path conversions on Windows](../desktop/windows/troubleshoot.md#path-conversion-on-windows).
 
 The `--mount` and `-v` examples below produce the same result. You
 can't run them both unless you remove the `devtest` container after running the

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -91,7 +91,7 @@ on your development host. Use the following command to bind-mount the `target/`
 directory into your container at `/app/`. Run the command from within the
 `source` directory. The `$(pwd)` sub-command expands to the current working
 directory on Linux or macOS hosts.
-If you're on Windows, see also [Path conversions on Windows](../docker-for-windows/troubleshoot.md#path-conversions-on-windows)
+If you're on Windows, see also Path conversions on Windows in [Volumes](../desktop/windows/troubleshoot.md#volumes)
 
 The `--mount` and `-v` examples below produce the same result. You
 can't run them both unless you remove the `devtest` container after running the


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Fix broken link  link to Windows Path Troubleshooting header. The link to `#path-conversions-on-windows` seems to not work since it is not a high enough header, for example: https://docs.docker.com/desktop/windows/troubleshoot/#path-conversions-on-windows

Changed to point here and called out **Path Conversions on Windows** section: https://docs.docker.com/desktop/windows/troubleshoot/#volumes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

n/a

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

n/a

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
