### PR TITLE
Rename Product Manuals to Manuals

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -6,7 +6,7 @@ horizontalnav:
 - title: Guides
   path: /get-started/overview/
   node: guides
-- title: Product manuals
+- title: Manuals
   path: /desktop/
   node: manuals
 - title: Reference

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -5,8 +5,7 @@ This include constructs breadcrumbs for the page; breadcrumbs are based on the
 page's location in the TOC (_data/toc.yaml). To get the "parent" TOC entries
 for the current page, we:
 
-    - iterate through each of the main sections / categories in the TOC (home, guides,
-      product manuals, reference, samples)
+    - iterate through each of the main sections / categories in the TOC (home, guides, manuals, reference, samples)
     - in each section, we iterate throught pages and sections. "sections" do not
       have URLs ("path") of their own, but can contain pages and sub-sections.
       Liquid doesn't allow us to "recursively" iterate through these, so we added

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -5,7 +5,8 @@ This include constructs breadcrumbs for the page; breadcrumbs are based on the
 page's location in the TOC (_data/toc.yaml). To get the "parent" TOC entries
 for the current page, we:
 
-    - iterate through each of the main sections / categories in the TOC (home, guides, manuals, reference, samples)
+    - iterate through each of the main sections / categories in the TOC (home, guides,
+      manuals, reference, samples)
     - in each section, we iterate throught pages and sections. "sections" do not
       have URLs ("path") of their own, but can contain pages and sub-sections.
       Liquid doesn't allow us to "recursively" iterate through these, so we added

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -94,7 +94,7 @@
       </div>
       <div class="col-xs-12 col-sm-6 col-lg-4 card-holder">
         <a class="card manuals" href="/desktop/">
-          <h5 class="title">Product manuals</h5>
+          <h5 class="title">Manuals</h5>
           <p>
             Browse through the manuals and learn how to use Docker products.
           </p>

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -118,7 +118,7 @@ It gives you quick access to container logs, lets you get a shell inside the con
 easily manage container lifecycle (stop, remove, etc.).
 
 To access the dashboard, follow the instructions in the
-[Docker Desktop product manual](../desktop/dashboard.md). If you open the dashboard
+[Docker Desktop manual](../desktop/dashboard.md). If you open the dashboard
 now, you will see this tutorial running! The container name (`jolly_bouman` below) is a
 randomly created name. So, you'll most likely have a different name.
 

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -6,7 +6,7 @@ title: Docker release notes
 
 Find out what's new in Docker! Release notes contain information about new
 features, improvements, known issues, and bug fixes in each release. You can
-find release notes for each component in the product manuals section. We suggest
+find release notes for each component in the Manuals section. We suggest
 that you regularly visit the release notes to learn about updates.
 
 - [Docker Engine](../engine/release-notes/index.md)


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Rename the section Product Manuals to Manuals in the light of the recent subscription updates
