### PR TITLE
Improves how requirements.txt is managed in Python tutorial #13506

### DIFF
--- a/language/python/build-images.md
+++ b/language/python/build-images.md
@@ -29,7 +29,7 @@ Let’s create a simple Python application using the Flask framework that we’l
 ```console
 $ cd /path/to/python-docker
 $ pip3 install Flask
-$ pip3 freeze > requirements.txt
+$ pip3 freeze | grep Flask >> requirements.txt
 $ touch app.py
 ```
 

--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -147,7 +147,7 @@ First, let’s add the `mysql-connector-python` module to our application using 
 
 ```console
 $ pip3 install mysql-connector-python
-$ pip3 freeze > requirements.txt
+$ pip3 freeze | grep mysql-connector-python >> requirements.txt
 ```
 
 Now we can build our image.


### PR DESCRIPTION
### Proposed changes
Changing how the `requirements.txt` file is populated in the Python tutorial to simplify and reduce the amount of packages are inside of it. The original command was grabbing all packages from the global Python scope. This was causing unwanted/unpredictable errors during the docker build stage where `pip` failed to find certain packages. Most likely due to certain pre-requisite system packages missing in the base docker image needing to be installed. This PR remedies that by being more precise about what goes in to the `requirements.txt` file. The mentioned issue below provides full details on the issue.

### Related issues
Fixes: #13506