### PR TITLE
Update compose v2 reference docs, and fix relative_url filter to ignore non-.md links

### DIFF
--- a/_data/compose-cli/docker_compose.yaml
+++ b/_data/compose-cli/docker_compose.yaml
@@ -1,186 +1,242 @@
 command: docker compose
 short: Docker Compose
-long: "You can use compose subcommand, `docker compose [-f <arg>...] [options] [COMMAND]
-    [ARGS...]`, to build and manage\nmultiple services in Docker containers.\n\n###
-    Use `-f` to specify name and path of one or more Compose files\nUse the `-f` flag
-    to specify the location of a Compose configuration file.\n\n#### Specifying multiple
-    Compose files\nYou can supply multiple `-f` configuration files. When you supply
-    multiple files, Compose combines them into a single \nconfiguration. Compose builds
-    the configuration in the order you supply the files. Subsequent files override
-    and add \nto their predecessors.\n\nFor example, consider this command line:\n\n```\n$
-    docker-compose -f docker-compose.yml -f docker-compose.admin.yml run backup_db\n```\nThe
-    `docker-compose.yml` file might specify a `webapp` service.\n\n```yaml\nservices:\n
-    \ webapp:\n    image: examples/web\n    ports:\n      - \"8000:8000\"\n    volumes:\n
-    \     - \"/data\"\n```\nIf the `docker-compose.admin.yml` also specifies this
-    same service, any matching fields override the previous file. \nNew values, add
-    to the `webapp` service configuration.\n\n```yaml\nservices:\n  webapp:\n    build:
-    .\n    environment:\n      - DEBUG=1\n```\n\nWhen you use multiple Compose files,
-    all paths in the files are relative to the first configuration file specified
-    \nwith `-f`. You can use the `--project-directory` option to override this base
-    path.\n\nUse a `-f` with `-` (dash) as the filename to read the configuration
-    from stdin. When stdin is used all paths in the \nconfiguration are relative to
-    the current working directory.\n\nThe `-f` flag is optional. If you don’t provide
-    this flag on the command line, Compose traverses the working directory \nand its
-    parent directories looking for a `compose.yaml` or `docker-compose.yaml` file.\n\n####
-    Specifying a path to a single Compose file\nYou can use the `-f` flag to specify
-    a path to a Compose file that is not located in the current directory, either
-    \nfrom the command line or by setting up a `COMPOSE_FILE` environment variable
-    in your shell or in an environment file.\n\nFor an example of using the `-f` option
-    at the command line, suppose you are running the Compose Rails sample, and \nhave
-    a `compose.yaml` file in a directory called `sandbox/rails`. You can use a command
-    like `docker compose pull` to \nget the postgres image for the db service from
-    anywhere by using the `-f` flag as follows: \n```\ndocker compose -f ~/sandbox/rails/compose.yaml
-    pull db\n```\n\n### Use `-p` to specify a project name\n\nEach configuration has
-    a project name. If you supply a `-p` flag, you can specify a project name. If
-    you don’t \nspecify the flag, Compose uses the current directory name. \nProject
-    name can also be set by `COMPOSE_PROJECT_NAME` environment variable.\n\nMost compose
-    subcommand can be ran without a compose file, just passing \nproject name to retrieve
-    the relevant resources.\n\n```\n$ docker compose -p my_project ps -a\nNAME                 SERVICE
-    \   STATUS     PORTS\nmy_project_demo_1    demo       running             \n\n$
-    docker compose -p my_project logs\ndemo_1  | PING localhost (127.0.0.1): 56 data
-    bytes\ndemo_1  | 64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.095 ms\n```\n\n###
-    Use profiles to enable optional services\n\nUse `--profile` to specify one or
-    more active profiles\nCalling `docker compose --profile frontend up` will start
-    the services with the profile `frontend` and services \nwithout any specified
-    profiles. \nYou can also enable multiple profiles, e.g. with `docker compose --profile
-    frontend --profile debug up` the profiles `frontend` and `debug` will be enabled.\n\nProfiles
-    can also be set by `COMPOSE_PROFILES` environment variable.\n\n### Set up environment
-    variables\n\nYou can set environment variables for various docker-compose options,
-    including the `-f`, `-p` and `--profiles` flags.\n\nSetting the `COMPOSE_FILE`
-    environment variable is equivalent to passing the `-f` flag,\n`COMPOSE_PROJECT_NAME`
-    environment variable does the same for to the `-p` flag,\nand so does `COMPOSE_PROFILES`
-    environment variable for to the `--profiles` flag.\n\nIf flags are explicitly
-    set on command line, associated environment variable is ignored"
+long: |-
+  You can use compose subcommand, `docker compose [-f <arg>...] [options] [COMMAND] [ARGS...]`, to build and manage
+  multiple services in Docker containers.
+
+  ### Use `-f` to specify name and path of one or more Compose files
+  Use the `-f` flag to specify the location of a Compose configuration file.
+
+  #### Specifying multiple Compose files
+  You can supply multiple `-f` configuration files. When you supply multiple files, Compose combines them into a single
+  configuration. Compose builds the configuration in the order you supply the files. Subsequent files override and add
+  to their predecessors.
+
+  For example, consider this command line:
+
+  ```console
+  $ docker compose -f docker-compose.yml -f docker-compose.admin.yml run backup_db
+  ```
+
+  The `docker-compose.yml` file might specify a `webapp` service.
+
+  ```yaml
+  services:
+    webapp:
+      image: examples/web
+      ports:
+        - "8000:8000"
+      volumes:
+        - "/data"
+  ```
+  If the `docker-compose.admin.yml` also specifies this same service, any matching fields override the previous file.
+  New values, add to the `webapp` service configuration.
+
+  ```yaml
+  services:
+    webapp:
+      build: .
+      environment:
+        - DEBUG=1
+  ```
+
+  When you use multiple Compose files, all paths in the files are relative to the first configuration file specified
+  with `-f`. You can use the `--project-directory` option to override this base path.
+
+  Use a `-f` with `-` (dash) as the filename to read the configuration from stdin. When stdin is used all paths in the
+  configuration are relative to the current working directory.
+
+  The `-f` flag is optional. If you don’t provide this flag on the command line, Compose traverses the working directory
+  and its parent directories looking for a `compose.yaml` or `docker-compose.yaml` file.
+
+  #### Specifying a path to a single Compose file
+  You can use the `-f` flag to specify a path to a Compose file that is not located in the current directory, either
+  from the command line or by setting up a `COMPOSE_FILE` environment variable in your shell or in an environment file.
+
+  For an example of using the `-f` option at the command line, suppose you are running the Compose Rails sample, and
+  have a `compose.yaml` file in a directory called `sandbox/rails`. You can use a command like `docker compose pull` to
+  get the postgres image for the db service from anywhere by using the `-f` flag as follows:
+
+  ```console
+  $ docker compose -f ~/sandbox/rails/compose.yaml pull db
+  ```
+
+  ### Use `-p` to specify a project name
+
+  Each configuration has a project name. If you supply a `-p` flag, you can specify a project name. If you don’t
+  specify the flag, Compose uses the current directory name.
+  Project name can also be set by `COMPOSE_PROJECT_NAME` environment variable.
+
+  Most compose subcommand can be ran without a compose file, just passing
+  project name to retrieve the relevant resources.
+
+  ```console
+  $ docker compose -p my_project ps -a
+  NAME                 SERVICE    STATUS     PORTS
+  my_project_demo_1    demo       running
+
+  $ docker compose -p my_project logs
+  demo_1  | PING localhost (127.0.0.1): 56 data bytes
+  demo_1  | 64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.095 ms
+  ```
+
+  ### Use profiles to enable optional services
+
+  Use `--profile` to specify one or more active profiles
+  Calling `docker compose --profile frontend up` will start the services with the profile `frontend` and services
+  without any specified profiles.
+  You can also enable multiple profiles, e.g. with `docker compose --profile frontend --profile debug up` the profiles `frontend` and `debug` will be enabled.
+
+  Profiles can also be set by `COMPOSE_PROFILES` environment variable.
+
+  ### Set up environment variables
+
+  You can set environment variables for various docker compose options, including the `-f`, `-p` and `--profiles` flags.
+
+  Setting the `COMPOSE_FILE` environment variable is equivalent to passing the `-f` flag,
+  `COMPOSE_PROJECT_NAME` environment variable does the same for to the `-p` flag,
+  and so does `COMPOSE_PROFILES` environment variable for to the `--profiles` flag.
+
+  If flags are explicitly set on command line, associated environment variable is ignored
 usage: docker compose
 pname: docker
 plink: docker.yaml
 cname:
-  - docker compose build
-  - docker compose convert
-  - docker compose cp
-  - docker compose create
-  - docker compose down
-  - docker compose events
-  - docker compose exec
-  - docker compose images
-  - docker compose kill
-  - docker compose logs
-  - docker compose ls
-  - docker compose pause
-  - docker compose port
-  - docker compose ps
-  - docker compose pull
-  - docker compose push
-  - docker compose restart
-  - docker compose rm
-  - docker compose run
-  - docker compose start
-  - docker compose stop
-  - docker compose top
-  - docker compose unpause
-  - docker compose up
+- docker compose build
+- docker compose convert
+- docker compose cp
+- docker compose create
+- docker compose down
+- docker compose events
+- docker compose exec
+- docker compose images
+- docker compose kill
+- docker compose logs
+- docker compose ls
+- docker compose pause
+- docker compose port
+- docker compose ps
+- docker compose pull
+- docker compose push
+- docker compose restart
+- docker compose rm
+- docker compose run
+- docker compose start
+- docker compose stop
+- docker compose top
+- docker compose unpause
+- docker compose up
 clink:
-  - docker_compose_build.yaml
-  - docker_compose_convert.yaml
-  - docker_compose_cp.yaml
-  - docker_compose_create.yaml
-  - docker_compose_down.yaml
-  - docker_compose_events.yaml
-  - docker_compose_exec.yaml
-  - docker_compose_images.yaml
-  - docker_compose_kill.yaml
-  - docker_compose_logs.yaml
-  - docker_compose_ls.yaml
-  - docker_compose_pause.yaml
-  - docker_compose_port.yaml
-  - docker_compose_ps.yaml
-  - docker_compose_pull.yaml
-  - docker_compose_push.yaml
-  - docker_compose_restart.yaml
-  - docker_compose_rm.yaml
-  - docker_compose_run.yaml
-  - docker_compose_start.yaml
-  - docker_compose_stop.yaml
-  - docker_compose_top.yaml
-  - docker_compose_unpause.yaml
-  - docker_compose_up.yaml
+- docker_compose_build.yaml
+- docker_compose_convert.yaml
+- docker_compose_cp.yaml
+- docker_compose_create.yaml
+- docker_compose_down.yaml
+- docker_compose_events.yaml
+- docker_compose_exec.yaml
+- docker_compose_images.yaml
+- docker_compose_kill.yaml
+- docker_compose_logs.yaml
+- docker_compose_ls.yaml
+- docker_compose_pause.yaml
+- docker_compose_port.yaml
+- docker_compose_ps.yaml
+- docker_compose_pull.yaml
+- docker_compose_push.yaml
+- docker_compose_restart.yaml
+- docker_compose_rm.yaml
+- docker_compose_run.yaml
+- docker_compose_start.yaml
+- docker_compose_stop.yaml
+- docker_compose_top.yaml
+- docker_compose_unpause.yaml
+- docker_compose_up.yaml
 options:
-  - option: ansi
-    value_type: string
-    default_value: auto
-    description: |
-        Control when to print ANSI control characters ("never"|"always"|"auto")
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: env-file
-    value_type: string
-    description: Specify an alternate environment file.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: file
-    shorthand: f
-    value_type: stringArray
-    default_value: '[]'
-    description: Compose configuration files
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-ansi
-    value_type: bool
-    default_value: "false"
-    description: Do not print ANSI control characters (DEPRECATED)
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: profile
-    value_type: stringArray
-    default_value: '[]'
-    description: Specify a profile to enable
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: project-directory
-    value_type: string
-    description: |-
-        Specify an alternate working directory
-        (default: the path of the Compose file)
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: project-name
-    shorthand: p
-    value_type: string
-    description: Project name
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: workdir
-    value_type: string
-    description: |-
-        DEPRECATED! USE --project-directory INSTEAD.
-        Specify an alternate working directory
-        (default: the path of the Compose file)
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: ansi
+  value_type: string
+  default_value: auto
+  description: |
+    Control when to print ANSI control characters ("never"|"always"|"auto")
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: env-file
+  value_type: string
+  description: Specify an alternate environment file.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: file
+  shorthand: f
+  value_type: stringArray
+  default_value: '[]'
+  description: Compose configuration files
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-ansi
+  value_type: bool
+  default_value: "false"
+  description: Do not print ANSI control characters (DEPRECATED)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: profile
+  value_type: stringArray
+  default_value: '[]'
+  description: Specify a profile to enable
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: project-directory
+  value_type: string
+  description: |-
+    Specify an alternate working directory
+    (default: the path of the Compose file)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: project-name
+  shorthand: p
+  value_type: string
+  description: Project name
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: verbose
+  value_type: bool
+  default_value: "false"
+  description: Show more output
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: workdir
+  value_type: string
+  description: |-
+    DEPRECATED! USE --project-directory INSTEAD.
+    Specify an alternate working directory
+    (default: the path of the Compose file)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_build.yaml
+++ b/_data/compose-cli/docker_compose_build.yaml
@@ -1,108 +1,112 @@
 command: docker compose build
 short: Build or rebuild services
-long: "Services are built once and then tagged, by default as `project_service`. \n\nIf
-    the Compose file specifies an\n[image](https://github.com/compose-spec/compose-spec/blob/master/spec.md#image)
-    name, \nthe image is tagged with that name, substituting any variables beforehand.
-    See\n[variable interpolation](https://github.com/compose-spec/compose-spec/blob/master/spec.md#interpolation).\n\nIf
-    you change a service's `Dockerfile` or the contents of its build directory, \nrun
-    `docker compose build` to rebuild it."
+long: |-
+  Services are built once and then tagged, by default as `project_service`.
+
+  If the Compose file specifies an
+  [image](https://github.com/compose-spec/compose-spec/blob/master/spec.md#image) name,
+  the image is tagged with that name, substituting any variables beforehand. See
+  [variable interpolation](https://github.com/compose-spec/compose-spec/blob/master/spec.md#interpolation).
+
+  If you change a service's `Dockerfile` or the contents of its build directory,
+  run `docker compose build` to rebuild it.
 usage: docker compose build [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: build-arg
-    value_type: stringArray
-    default_value: '[]'
-    description: Set build-time variables for services.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: compress
-    value_type: bool
-    default_value: "true"
-    description: Compress the build context using gzip. DEPRECATED
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: force-rm
-    value_type: bool
-    default_value: "true"
-    description: Always remove intermediate containers. DEPRECATED
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: memory
-    shorthand: m
-    value_type: string
-    description: |
-        Set memory limit for the build container. Not supported on buildkit yet.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-cache
-    value_type: bool
-    default_value: "false"
-    description: Do not use cache when building the image
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-rm
-    value_type: bool
-    default_value: "false"
-    description: |
-        Do not remove intermediate containers after a successful build. DEPRECATED
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: parallel
-    value_type: bool
-    default_value: "true"
-    description: Build images in parallel. DEPRECATED
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: progress
-    value_type: string
-    default_value: auto
-    description: Set type of progress output ("auto", "plain", "noTty")
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: pull
-    value_type: bool
-    default_value: "false"
-    description: Always attempt to pull a newer version of the image.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: quiet
-    shorthand: q
-    value_type: bool
-    default_value: "false"
-    description: Don't print anything to STDOUT
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: build-arg
+  value_type: stringArray
+  default_value: '[]'
+  description: Set build-time variables for services.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: compress
+  value_type: bool
+  default_value: "true"
+  description: Compress the build context using gzip. DEPRECATED
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: force-rm
+  value_type: bool
+  default_value: "true"
+  description: Always remove intermediate containers. DEPRECATED
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: memory
+  shorthand: m
+  value_type: string
+  description: |
+    Set memory limit for the build container. Not supported on buildkit yet.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-cache
+  value_type: bool
+  default_value: "false"
+  description: Do not use cache when building the image
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-rm
+  value_type: bool
+  default_value: "false"
+  description: |
+    Do not remove intermediate containers after a successful build. DEPRECATED
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: parallel
+  value_type: bool
+  default_value: "true"
+  description: Build images in parallel. DEPRECATED
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: progress
+  value_type: string
+  default_value: auto
+  description: Set type of progress output ("auto", "plain", "noTty")
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: pull
+  value_type: bool
+  default_value: "false"
+  description: Always attempt to pull a newer version of the image.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Don't print anything to STDOUT
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_convert.yaml
+++ b/_data/compose-cli/docker_compose_convert.yaml
@@ -1,87 +1,88 @@
 command: docker compose convert
 aliases: config
 short: Converts the compose file to platform's canonical format
-long: "`docker compose convert` render the actual data model to be applied on target
-    platform. When used with Docker engine,\nit merges the Compose files set by `-f`
-    flags, resolves variables in Compose file, and expands short-notation into \nfully
-    defined Compose model. \n\nTo allow smooth migration from docker-compose, this
-    subcommand declares alias `docker compose config`"
+long: |-
+  `docker compose convert` render the actual data model to be applied on target platform. When used with Docker engine,
+  it merges the Compose files set by `-f` flags, resolves variables in Compose file, and expands short-notation into
+  fully defined Compose model.
+
+  To allow smooth migration from docker-compose, this subcommand declares alias `docker compose config`
 usage: docker compose convert SERVICES
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: format
-    value_type: string
-    default_value: yaml
-    description: 'Format the output. Values: [yaml | json]'
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: hash
-    value_type: string
-    description: Print the service config hash, one per line.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-interpolate
-    value_type: bool
-    default_value: "false"
-    description: Don't interpolate environment variables.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: profiles
-    value_type: bool
-    default_value: "false"
-    description: Print the profile names, one per line.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: quiet
-    shorthand: q
-    value_type: bool
-    default_value: "false"
-    description: Only validate the configuration, don't print anything.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: resolve-image-digests
-    value_type: bool
-    default_value: "false"
-    description: Pin image tags to digests.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: services
-    value_type: bool
-    default_value: "false"
-    description: Print the service names, one per line.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: volumes
-    value_type: bool
-    default_value: "false"
-    description: Print the volume names, one per line.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: format
+  value_type: string
+  default_value: yaml
+  description: 'Format the output. Values: [yaml | json]'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: hash
+  value_type: string
+  description: Print the service config hash, one per line.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-interpolate
+  value_type: bool
+  default_value: "false"
+  description: Don't interpolate environment variables.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: profiles
+  value_type: bool
+  default_value: "false"
+  description: Print the profile names, one per line.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Only validate the configuration, don't print anything.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: resolve-image-digests
+  value_type: bool
+  default_value: "false"
+  description: Pin image tags to digests.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: services
+  value_type: bool
+  default_value: "false"
+  description: Print the service names, one per line.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: volumes
+  value_type: bool
+  default_value: "false"
+  description: Print the volume names, one per line.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_cp.yaml
+++ b/_data/compose-cli/docker_compose_cp.yaml
@@ -1,51 +1,50 @@
 command: docker compose cp
 short: Copy files/folders between a service container and the local filesystem
 long: Copy files/folders between a service container and the local filesystem
-usage: |-
-    docker compose cp [OPTIONS] SERVICE:SRC_PATH DEST_PATH|-
-    	docker compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+usage: "docker compose cp [OPTIONS] SERVICE:SRC_PATH DEST_PATH|-\n\tdocker compose
+  cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH"
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: all
-    value_type: bool
-    default_value: "false"
-    description: Copy to all the containers of the service.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: archive
-    shorthand: a
-    value_type: bool
-    default_value: "false"
-    description: Archive mode (copy all uid/gid information)
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: follow-link
-    shorthand: L
-    value_type: bool
-    default_value: "false"
-    description: Always follow symbol link in SRC_PATH
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: index
-    value_type: int
-    default_value: "1"
-    description: |
-        Index of the container if there are multiple instances of a service [default: 1].
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: all
+  value_type: bool
+  default_value: "false"
+  description: Copy to all the containers of the service.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: archive
+  shorthand: a
+  value_type: bool
+  default_value: "false"
+  description: Archive mode (copy all uid/gid information)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: follow-link
+  shorthand: L
+  value_type: bool
+  default_value: "false"
+  description: Always follow symbol link in SRC_PATH
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: index
+  value_type: int
+  default_value: "1"
+  description: |
+    Index of the container if there are multiple instances of a service [default: 1].
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_create.yaml
+++ b/_data/compose-cli/docker_compose_create.yaml
@@ -5,44 +5,44 @@ usage: docker compose create [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: build
-    value_type: bool
-    default_value: "false"
-    description: Build images before starting containers.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: force-recreate
-    value_type: bool
-    default_value: "false"
-    description: |
-        Recreate containers even if their configuration and image haven't changed.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-build
-    value_type: bool
-    default_value: "false"
-    description: Don't build an image, even if it's missing.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-recreate
-    value_type: bool
-    default_value: "false"
-    description: |
-        If containers already exist, don't recreate them. Incompatible with --force-recreate.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: build
+  value_type: bool
+  default_value: "false"
+  description: Build images before starting containers.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: force-recreate
+  value_type: bool
+  default_value: "false"
+  description: |
+    Recreate containers even if their configuration and image haven't changed.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-build
+  value_type: bool
+  default_value: "false"
+  description: Don't build an image, even if it's missing.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-recreate
+  value_type: bool
+  default_value: "false"
+  description: |
+    If containers already exist, don't recreate them. Incompatible with --force-recreate.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_down.yaml
+++ b/_data/compose-cli/docker_compose_down.yaml
@@ -1,63 +1,62 @@
 command: docker compose down
 short: Stop and remove containers, networks
 long: |-
-    Stops containers and removes containers, networks, volumes, and images created by ``up`.
+  Stops containers and removes containers, networks, volumes, and images created by `up`.
 
-    By default, the only things removed are:
+  By default, the only things removed are:
 
-    - Containers for services defined in the Compose file
-    - Networks defined in the networks section of the Compose file
-    - The default network, if one is used
+  - Containers for services defined in the Compose file
+  - Networks defined in the networks section of the Compose file
+  - The default network, if one is used
 
-    Networks and volumes defined as external are never removed.
+  Networks and volumes defined as external are never removed.
 
-    Anonymous volumes are not removed by default. However, as they don’t have a stable name, they will not be automatically
-    mounted by a subsequent `up`. For data that needs to persist between updates, use explicit paths as bind mounts or
-    named volumes.
+  Anonymous volumes are not removed by default. However, as they don’t have a stable name, they will not be automatically
+  mounted by a subsequent `up`. For data that needs to persist between updates, use explicit paths as bind mounts or
+  named volumes.
 usage: docker compose down
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: remove-orphans
-    value_type: bool
-    default_value: "false"
-    description: |
-        Remove containers for services not defined in the Compose file.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: rmi
-    value_type: string
-    description: |
-        Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: timeout
-    shorthand: t
-    value_type: int
-    default_value: "10"
-    description: Specify a shutdown timeout in seconds
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: volumes
-    shorthand: v
-    value_type: bool
-    default_value: "false"
-    description: |4
-         Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: remove-orphans
+  value_type: bool
+  default_value: "false"
+  description: Remove containers for services not defined in the Compose file.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: rmi
+  value_type: string
+  description: |
+    Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: timeout
+  shorthand: t
+  value_type: int
+  default_value: "10"
+  description: Specify a shutdown timeout in seconds
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: volumes
+  shorthand: v
+  value_type: bool
+  default_value: "false"
+  description: |
+    Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_events.yaml
+++ b/_data/compose-cli/docker_compose_events.yaml
@@ -1,38 +1,38 @@
 command: docker compose events
 short: Receive real time events from containers.
 long: |-
-    Stream container events for every container in the project.
+  Stream container events for every container in the project.
 
-    With the `--json` flag, a json object is printed one per line with the format:
+  With the `--json` flag, a json object is printed one per line with the format:
 
-    ```json
-    {
-        "time": "2015-11-20T18:01:03.615550",
-        "type": "container",
-        "action": "create",
-        "id": "213cf7...5fc39a",
-        "service": "web",
-        "attributes": {
-          "name": "application_web_1",
-          "image": "alpine:edge"
-        }
-    }
-    ```
+  ```json
+  {
+      "time": "2015-11-20T18:01:03.615550",
+      "type": "container",
+      "action": "create",
+      "id": "213cf7...5fc39a",
+      "service": "web",
+      "attributes": {
+        "name": "application_web_1",
+        "image": "alpine:edge"
+      }
+  }
+  ```
 
-    The events that can be received using this can be seen [here](https://docs.docker.com/engine/reference/commandline/events/#object-types).
+  The events that can be received using this can be seen [here](/engine/reference/commandline/events/#object-types).
 usage: docker compose events [options] [--] [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: json
-    value_type: bool
-    default_value: "false"
-    description: Output events as a stream of json objects
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: json
+  value_type: bool
+  default_value: "false"
+  description: Output events as a stream of json objects
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_exec.yaml
+++ b/_data/compose-cli/docker_compose_exec.yaml
@@ -1,81 +1,82 @@
 command: docker compose exec
 short: Execute a command in a running container.
-long: "This is the equivalent of `docker exec` targeting a Compose service. \n\nWith
-    this subcommand you can run arbitrary commands in your services. Commands are
-    by default allocating a TTY, so \nyou can use a command such as `docker compose
-    exec web sh` to get an interactive prompt."
+long: |-
+  This is the equivalent of `docker exec` targeting a Compose service.
+
+  With this subcommand you can run arbitrary commands in your services. Commands are by default allocating a TTY, so
+  you can use a command such as `docker compose exec web sh` to get an interactive prompt.
 usage: docker compose exec [options] [-e KEY=VAL...] [--] SERVICE COMMAND [ARGS...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: ""
-    shorthand: T
-    value_type: bool
-    default_value: "false"
-    description: |
-        Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: detach
-    shorthand: d
-    value_type: bool
-    default_value: "false"
-    description: 'Detached mode: Run command in the background.'
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: env
-    shorthand: e
-    value_type: stringArray
-    default_value: '[]'
-    description: Set environment variables
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: index
-    value_type: int
-    default_value: "1"
-    description: |
-        index of the container if there are multiple instances of a service [default: 1].
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: privileged
-    value_type: bool
-    default_value: "false"
-    description: Give extended privileges to the process.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: user
-    shorthand: u
-    value_type: string
-    description: Run the command as this user.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: workdir
-    shorthand: w
-    value_type: string
-    description: Path to workdir directory for this command.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: detach
+  shorthand: d
+  value_type: bool
+  default_value: "false"
+  description: 'Detached mode: Run command in the background.'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: env
+  shorthand: e
+  value_type: stringArray
+  default_value: '[]'
+  description: Set environment variables
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: index
+  value_type: int
+  default_value: "1"
+  description: |
+    index of the container if there are multiple instances of a service [default: 1].
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-TTY
+  shorthand: T
+  value_type: bool
+  default_value: "false"
+  description: |
+    Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: privileged
+  value_type: bool
+  default_value: "false"
+  description: Give extended privileges to the process.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: user
+  shorthand: u
+  value_type: string
+  description: Run the command as this user.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: workdir
+  shorthand: w
+  value_type: string
+  description: Path to workdir directory for this command.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_images.yaml
+++ b/_data/compose-cli/docker_compose_images.yaml
@@ -5,16 +5,16 @@ usage: docker compose images [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: quiet
-    shorthand: q
-    value_type: bool
-    default_value: "false"
-    description: Only display IDs
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Only display IDs
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_kill.yaml
+++ b/_data/compose-cli/docker_compose_kill.yaml
@@ -1,25 +1,25 @@
 command: docker compose kill
 short: Force stop service containers.
 long: |-
-    Forces running containers to stop by sending a `SIGKILL` signal. Optionally the signal can be passed, for example:
+  Forces running containers to stop by sending a `SIGKILL` signal. Optionally the signal can be passed, for example:
 
-    ```
-    docker-compose kill -s SIGINT
-    ```
+  ```console
+  $ docker-compose kill -s SIGINT
+  ```
 usage: docker compose kill [options] [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: signal
-    shorthand: s
-    value_type: string
-    default_value: SIGKILL
-    description: SIGNAL to send to the container.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: signal
+  shorthand: s
+  value_type: string
+  default_value: SIGKILL
+  description: SIGNAL to send to the container.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_logs.yaml
+++ b/_data/compose-cli/docker_compose_logs.yaml
@@ -1,48 +1,76 @@
 command: docker compose logs
 short: View output from containers
 long: Displays log output from services.
-usage: docker compose logs [service...]
+usage: docker compose logs [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: follow
-    shorthand: f
-    value_type: bool
-    default_value: "false"
-    description: Follow log output.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-color
-    value_type: bool
-    default_value: "false"
-    description: Produce monochrome output.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-log-prefix
-    value_type: bool
-    default_value: "false"
-    description: Don't print prefix in logs.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: timestamps
-    shorthand: t
-    value_type: bool
-    default_value: "false"
-    description: Show timestamps.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: follow
+  shorthand: f
+  value_type: bool
+  default_value: "false"
+  description: Follow log output.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-color
+  value_type: bool
+  default_value: "false"
+  description: Produce monochrome output.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-log-prefix
+  value_type: bool
+  default_value: "false"
+  description: Don't print prefix in logs.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: since
+  value_type: string
+  description: |
+    Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: tail
+  value_type: string
+  default_value: all
+  description: |
+    Number of lines to show from the end of the logs for each container.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: timestamps
+  shorthand: t
+  value_type: bool
+  default_value: "false"
+  description: Show timestamps.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: until
+  value_type: string
+  description: |
+    Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_ls.yaml
+++ b/_data/compose-cli/docker_compose_ls.yaml
@@ -5,33 +5,43 @@ usage: docker compose ls
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: filter
-    value_type: filter
-    description: Filter output based on conditions provided.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: format
-    value_type: string
-    default_value: pretty
-    description: 'Format the output. Values: [pretty | json].'
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: quiet
-    shorthand: q
-    value_type: bool
-    default_value: "false"
-    description: Only display IDs.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: all
+  shorthand: a
+  value_type: bool
+  default_value: "false"
+  description: Show all stopped Compose projects
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: filter
+  value_type: filter
+  description: Filter output based on conditions provided.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: format
+  value_type: string
+  default_value: pretty
+  description: 'Format the output. Values: [pretty | json].'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Only display IDs.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_pause.yaml
+++ b/_data/compose-cli/docker_compose_pause.yaml
@@ -1,7 +1,7 @@
 command: docker compose pause
 short: pause services
-long: Pauses running containers of a service. They can be unpaused with `docker compose
-    unpause`.
+long: |
+  Pauses running containers of a service. They can be unpaused with `docker compose unpause`.
 usage: docker compose pause [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml

--- a/_data/compose-cli/docker_compose_port.yaml
+++ b/_data/compose-cli/docker_compose_port.yaml
@@ -5,24 +5,24 @@ usage: docker compose port [options] [--] SERVICE PRIVATE_PORT
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: index
-    value_type: int
-    default_value: "1"
-    description: index of the container if service has multiple replicas
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: protocol
-    value_type: string
-    default_value: tcp
-    description: tcp or udp
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: index
+  value_type: int
+  default_value: "1"
+  description: index of the container if service has multiple replicas
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: protocol
+  value_type: string
+  default_value: tcp
+  description: tcp or udp
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_ps.yaml
+++ b/_data/compose-cli/docker_compose_ps.yaml
@@ -1,52 +1,73 @@
 command: docker compose ps
 short: List containers
-long: "Lists containers for a Compose project, with current status and exposed ports.\n\n```\n$
-    docker compose ps\nNAME                SERVICE             STATUS              PORTS\nexample_foo_1
-    \      foo                 running (healthy)   0.0.0.0:8000->80/tcp\nexample_bar_1
-    \      bar                 exited (1)          \n```"
-usage: docker compose ps
+long: |-
+  Lists containers for a Compose project, with current status and exposed ports.
+
+  ```console
+  $ docker compose ps
+  NAME                SERVICE             STATUS              PORTS
+  example_foo_1       foo                 running (healthy)   0.0.0.0:8000->80/tcp
+  example_bar_1       bar                 exited (1)
+  ```
+usage: docker compose ps [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: all
-    shorthand: a
-    value_type: bool
-    default_value: "false"
-    description: |
-        Show all stopped containers (including those created by the run command)
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: format
-    value_type: string
-    default_value: pretty
-    description: 'Format the output. Values: [pretty | json].'
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: quiet
-    shorthand: q
-    value_type: bool
-    default_value: "false"
-    description: Only display IDs
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: services
-    value_type: bool
-    default_value: "false"
-    description: Display services
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: all
+  shorthand: a
+  value_type: bool
+  default_value: "false"
+  description: |
+    Show all stopped containers (including those created by the run command)
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: filter
+  value_type: string
+  description: Filter services by a property
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: format
+  value_type: string
+  default_value: pretty
+  description: 'Format the output. Values: [pretty | json]'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Only display IDs
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: services
+  value_type: bool
+  default_value: "false"
+  description: Display services
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: status
+  value_type: string
+  description: Filter services by status
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_pull.yaml
+++ b/_data/compose-cli/docker_compose_pull.yaml
@@ -1,80 +1,58 @@
 command: docker compose pull
 short: Pull service images
-long: "Pulls an image associated with a service defined in a `compose.yaml` file,
-    but does not start containers based on \nthose images."
+long: |-
+  Pulls an image associated with a service defined in a `compose.yaml` file, but does not start containers based on
+  those images.
 usage: docker compose pull [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: ignore-pull-failures
-    value_type: bool
-    default_value: "false"
-    description: Pull what it can and ignores images with pull failures
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: include-deps
-    value_type: bool
-    default_value: "false"
-    description: Also pull services declared as dependencies
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-parallel
-    value_type: bool
-    default_value: "true"
-    description: DEPRECATED disable parallel pulling.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: parallel
-    value_type: bool
-    default_value: "true"
-    description: DEPRECATED pull multiple images in parallel.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: quiet
-    shorthand: q
-    value_type: bool
-    default_value: "false"
-    description: Pull without printing progress information
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-examples: "suppose you have this `compose.yaml` file from the Quickstart: [Compose
-    and Rails sample](compose/rails/).\n\n```yaml\nservices:\n  db:\n    image: postgres\n
-    \ web:\n    build: .\n    command: bundle exec rails s -p 3000 -b '0.0.0.0'\n
-    \   volumes:\n    - .:/myapp\n    ports:\n    - \"3000:3000\"\n    depends_on:\n
-    \   - db\n```\n\nIf you run `docker compose pull ServiceName` in the same directory
-    as the `ccompose.yaml` file that defines the service, \nDocker pulls the associated
-    image. For example, to call the postgres image configured as the db service in
-    our example, \nyou would run `docker compose pull db`.\n\n```\n$ docker compose
-    pull db\n[+] Running 1/15\n ⠸ db Pulling                                                             12.4s\n
-    \  ⠿ 45b42c59be33 Already exists                                           0.0s\n
-    \  ⠹ 40adec129f1a Downloading  3.374MB/4.178MB                             9.3s\n
-    \  ⠹ b4c431d00c78 Download complete                                        9.3s\n
-    \  ⠹ 2696974e2815 Download complete                                        9.3s\n
-    \  ⠹ 564b77596399 Downloading  5.622MB/7.965MB                             9.3s\n
-    \  ⠹ 5044045cf6f2 Downloading  216.7kB/391.1kB                             9.3s\n
-    \  ⠹ d736e67e6ac3 Waiting                                                  9.3s\n
-    \  ⠹ 390c1c9a5ae4 Waiting                                                  9.3s\n
-    \  ⠹ c0e62f172284 Waiting                                                  9.3s\n
-    \  ⠹ ebcdc659c5bf Waiting                                                  9.3s\n
-    \  ⠹ 29be22cb3acc Waiting                                                  9.3s\n
-    \  ⠹ f63c47038e66 Waiting                                                  9.3s\n
-    \  ⠹ 77a0c198cde5 Waiting                                                  9.3s\n
-    \  ⠹ c8752d5b785c Waiting                                                  9.3s\n``̀"
+- option: ignore-pull-failures
+  value_type: bool
+  default_value: "false"
+  description: Pull what it can and ignores images with pull failures
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: include-deps
+  value_type: bool
+  default_value: "false"
+  description: Also pull services declared as dependencies
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-parallel
+  value_type: bool
+  default_value: "true"
+  description: DEPRECATED disable parallel pulling.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: parallel
+  value_type: bool
+  default_value: "true"
+  description: DEPRECATED pull multiple images in parallel.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Pull without printing progress information
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_push.yaml
+++ b/_data/compose-cli/docker_compose_push.yaml
@@ -1,24 +1,37 @@
 command: docker compose push
 short: Push service images
-long: "Pushes images for services to their respective registry/repository.\n\nThe
-    following assumptions are made:\n- You are pushing an image you have built locally\n-
-    You have access to the build key\n\nExamples\n\n```yaml\nservices:\n    service1:\n
-    \       build: .\n        image: localhost:5000/yourimage  ## goes to local registry\n
-    \   \n    service2:\n        build: .\n        image: your-dockerid/yourimage
-    \ ## goes to your repository on Docker Hub\n```"
+long: |-
+  Pushes images for services to their respective registry/repository.
+
+  The following assumptions are made:
+  - You are pushing an image you have built locally
+  - You have access to the build key
+
+  Examples
+
+  ```yaml
+  services:
+    service1:
+      build: .
+      image: localhost:5000/yourimage  ## goes to local registry
+
+    service2:
+      build: .
+      image: your-dockerid/yourimage  ## goes to your repository on Docker Hub
+  ```
 usage: docker compose push [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: ignore-push-failures
-    value_type: bool
-    default_value: "false"
-    description: Push what it can and ignores images with push failures
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: ignore-push-failures
+  value_type: bool
+  default_value: "false"
+  description: Push what it can and ignores images with push failures
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_restart.yaml
+++ b/_data/compose-cli/docker_compose_restart.yaml
@@ -5,16 +5,16 @@ usage: docker compose restart
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: timeout
-    shorthand: t
-    value_type: int
-    default_value: "10"
-    description: Specify a shutdown timeout in seconds
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: timeout
+  shorthand: t
+  value_type: int
+  default_value: "10"
+  description: Specify a shutdown timeout in seconds
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_rm.yaml
+++ b/_data/compose-cli/docker_compose_rm.yaml
@@ -1,65 +1,65 @@
 command: docker compose rm
 short: Removes stopped service containers
 long: |-
-    Removes stopped service containers.
+  Removes stopped service containers.
 
-    By default, anonymous volumes attached to containers are not removed. You can override this with `-v`. To list all
-    volumes, use `docker volume ls`.
+  By default, anonymous volumes attached to containers are not removed. You can override this with `-v`. To list all
+  volumes, use `docker volume ls`.
 
-    Any data which is not in a volume is lost.
+  Any data which is not in a volume is lost.
 
-    Running the command with no options also removes one-off containers created by `docker compose run`:
+  Running the command with no options also removes one-off containers created by `docker compose run`:
 
-    ```
-    $ docker compose rm
-    Going to remove djangoquickstart_web_run_1
-    Are you sure? [yN] y
-    Removing djangoquickstart_web_run_1 ... done
-    ```
+  ```console
+  $ docker compose rm
+  Going to remove djangoquickstart_web_run_1
+  Are you sure? [yN] y
+  Removing djangoquickstart_web_run_1 ... done
+  ```
 usage: docker compose rm [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: all
-    shorthand: a
-    value_type: bool
-    default_value: "false"
-    description: Deprecated - no effect
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: force
-    shorthand: f
-    value_type: bool
-    default_value: "false"
-    description: Don't ask to confirm removal
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: stop
-    shorthand: s
-    value_type: bool
-    default_value: "false"
-    description: Stop the containers, if required, before removing
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: volumes
-    shorthand: v
-    value_type: bool
-    default_value: "false"
-    description: Remove any anonymous volumes attached to containers
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: all
+  shorthand: a
+  value_type: bool
+  default_value: "false"
+  description: Deprecated - no effect
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: force
+  shorthand: f
+  value_type: bool
+  default_value: "false"
+  description: Don't ask to confirm removal
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: stop
+  shorthand: s
+  value_type: bool
+  default_value: "false"
+  description: Stop the containers, if required, before removing
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: volumes
+  shorthand: v
+  value_type: bool
+  default_value: "false"
+  description: Remove any anonymous volumes attached to containers
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_run.yaml
+++ b/_data/compose-cli/docker_compose_run.yaml
@@ -1,169 +1,197 @@
 command: docker compose run
 short: Run a one-off command on a service.
-long: "Runs a one-time command against a service. \n\nthe following command starts
-    the `web` service and runs `bash` as its command.\n`docker compose run web bash`\n\nCommands
-    you use with run start in new containers with configuration defined by that of
-    the service,\nincluding volumes, links, and other details. However, there are
-    two important differences:\n\nFirst, the command passed by `run` overrides the
-    command defined in the service configuration. For example, if the \n`web` service
-    configuration is started with `bash`, then `docker compose run web python app.py`
-    overrides it with \n`python app.py`.\n\nThe second difference is that the `docker
-    compose run` command does not create any of the ports specified in the \nservice
-    configuration. This prevents port collisions with already-open ports. If you do
-    want the service’s ports \nto be created and mapped to the host, specify the `--service-ports`\n\n```\ndocker
-    compose run --service-ports web python manage.py shell\n```\n\nAlternatively,
-    manual port mapping can be specified with the `--publish` or `-p` options, just
-    as when using docker run:\n\n```\ndocker compose run --publish 8080:80 -p 2022:22
-    -p 127.0.0.1:2021:21 web python manage.py shell\n```\n\n\nIf you start a service
-    configured with links, the run command first checks to see if the linked service
-    is running \nand starts the service if it is stopped. Once all the linked services
-    are running, the run executes the command you \npassed it. For example, you could
-    run:\n\n```\ndocker compose run db psql -h db -U docker\n```\n\nThis opens an
-    interactive PostgreSQL shell for the linked `db` container.\n\nIf you do not want
-    the run command to start linked containers, use the `--no-deps` flag:\n\n```\ndocker
-    compose run --no-deps web python manage.py shell\n```\n\nIf you want to remove
-    the container after running while overriding the container’s restart policy, use
-    the `--rm` flag:\n\n```\ndocker compose run --rm web python manage.py db upgrade\n```\n\nThis
-    runs a database upgrade script, and removes the container when finished running,
-    even if a restart policy is \nspecified in the service configuration."
+long: |-
+  Runs a one-time command against a service.
+
+  the following command starts the `web` service and runs `bash` as its command:
+
+  ```console
+  $ docker compose run web bash
+  ```
+
+  Commands you use with run start in new containers with configuration defined by that of the service,
+  including volumes, links, and other details. However, there are two important differences:
+
+  First, the command passed by `run` overrides the command defined in the service configuration. For example, if the
+  `web` service configuration is started with `bash`, then `docker compose run web python app.py` overrides it with
+  `python app.py`.
+
+  The second difference is that the `docker compose run` command does not create any of the ports specified in the
+  service configuration. This prevents port collisions with already-open ports. If you do want the service’s ports
+  to be created and mapped to the host, specify the `--service-ports`
+
+  ```console
+  $ docker compose run --service-ports web python manage.py shell
+  ```
+
+  Alternatively, manual port mapping can be specified with the `--publish` or `-p` options, just as when using docker run:
+
+  ```console
+  $ docker compose run --publish 8080:80 -p 2022:22 -p 127.0.0.1:2021:21 web python manage.py shell
+  ```
+
+  If you start a service configured with links, the run command first checks to see if the linked service is running
+  and starts the service if it is stopped. Once all the linked services are running, the run executes the command you
+  passed it. For example, you could run:
+
+  ```console
+  $ docker compose run db psql -h db -U docker
+  ```
+
+  This opens an interactive PostgreSQL shell for the linked `db` container.
+
+  If you do not want the run command to start linked containers, use the `--no-deps` flag:
+
+  ```console
+  $ docker compose run --no-deps web python manage.py shell
+  ```
+
+  If you want to remove the container after running while overriding the container’s restart policy, use the `--rm` flag:
+
+  ```console
+  $ docker compose run --rm web python manage.py db upgrade
+  ```
+
+  This runs a database upgrade script, and removes the container when finished running, even if a restart policy is
+  specified in the service configuration.
 usage: docker compose run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l
-    KEY=VALUE...] SERVICE [COMMAND] [ARGS...]
+  KEY=VALUE...] SERVICE [COMMAND] [ARGS...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: detach
-    shorthand: d
-    value_type: bool
-    default_value: "false"
-    description: Run container in background and print container ID
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: entrypoint
-    value_type: string
-    description: Override the entrypoint of the image
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: env
-    shorthand: e
-    value_type: stringArray
-    default_value: '[]'
-    description: Set environment variables
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: labels
-    shorthand: l
-    value_type: stringArray
-    default_value: '[]'
-    description: Add or override a label
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: name
-    value_type: string
-    description: ' Assign a name to the container'
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-TTY
-    shorthand: T
-    value_type: bool
-    default_value: "false"
-    description: |
-        Disable pseudo-noTty allocation. By default docker compose run allocates a TTY
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-deps
-    value_type: bool
-    default_value: "false"
-    description: Don't start linked services.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: publish
-    shorthand: p
-    value_type: stringArray
-    default_value: '[]'
-    description: Publish a container's port(s) to the host.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: rm
-    value_type: bool
-    default_value: "false"
-    description: Automatically remove the container when it exits
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: service-ports
-    value_type: bool
-    default_value: "false"
-    description: |
-        Run command with the service's ports enabled and mapped to the host.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: use-aliases
-    value_type: bool
-    default_value: "false"
-    description: |
-        Use the service's network useAliases in the network(s) the container connects to.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: user
-    shorthand: u
-    value_type: string
-    description: Run as specified username or uid
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: volumes
-    shorthand: v
-    value_type: stringArray
-    default_value: '[]'
-    description: Bind mount a volume.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: workdir
-    shorthand: w
-    value_type: string
-    description: Working directory inside the container
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: detach
+  shorthand: d
+  value_type: bool
+  default_value: "false"
+  description: Run container in background and print container ID
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: entrypoint
+  value_type: string
+  description: Override the entrypoint of the image
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: env
+  shorthand: e
+  value_type: stringArray
+  default_value: '[]'
+  description: Set environment variables
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: labels
+  shorthand: l
+  value_type: stringArray
+  default_value: '[]'
+  description: Add or override a label
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: name
+  value_type: string
+  description: Assign a name to the container
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-TTY
+  shorthand: T
+  value_type: bool
+  default_value: "false"
+  description: |
+    Disable pseudo-noTty allocation. By default docker compose run allocates a TTY
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-deps
+  value_type: bool
+  default_value: "false"
+  description: Don't start linked services.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: publish
+  shorthand: p
+  value_type: stringArray
+  default_value: '[]'
+  description: Publish a container's port(s) to the host.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: rm
+  value_type: bool
+  default_value: "false"
+  description: Automatically remove the container when it exits
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: service-ports
+  value_type: bool
+  default_value: "false"
+  description: |
+    Run command with the service's ports enabled and mapped to the host.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: use-aliases
+  value_type: bool
+  default_value: "false"
+  description: |
+    Use the service's network useAliases in the network(s) the container connects to.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: user
+  shorthand: u
+  value_type: string
+  description: Run as specified username or uid
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: volume
+  shorthand: v
+  value_type: stringArray
+  default_value: '[]'
+  description: Bind mount a volume.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: workdir
+  shorthand: w
+  value_type: string
+  description: Working directory inside the container
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_stop.yaml
+++ b/_data/compose-cli/docker_compose_stop.yaml
@@ -1,21 +1,21 @@
 command: docker compose stop
 short: Stop services
-long: Stops running containers without removing them. They can be started again with
-    `docker compose start`.
+long: |
+  Stops running containers without removing them. They can be started again with `docker compose start`.
 usage: docker compose stop [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: timeout
-    shorthand: t
-    value_type: int
-    default_value: "10"
-    description: Specify a shutdown timeout in seconds
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: timeout
+  shorthand: t
+  value_type: int
+  default_value: "10"
+  description: Specify a shutdown timeout in seconds
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_top.yaml
+++ b/_data/compose-cli/docker_compose_top.yaml
@@ -1,12 +1,16 @@
 command: docker compose top
 short: Display the running processes
 long: Displays the running processes.
-usage: docker compose top
+usage: docker compose top [SERVICES...]
 pname: docker compose
 plink: docker_compose.yaml
-examples: "```\n$ docker compose top\nexample_foo_1\nUID    PID      PPID     C    STIME
-    \  TTY   TIME       CMD\nroot   142353   142331   2    15:33   ?     00:00:00
-    \  ping localhost -c 5 \n```"
+examples: |-
+  ```console
+  $ docker compose top
+  example_foo_1
+  UID    PID      PPID     C    STIME   TTY   TIME       CMD
+  root   142353   142331   2    15:33   ?     00:00:00   ping localhost -c 5
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_up.yaml
+++ b/_data/compose-cli/docker_compose_up.yaml
@@ -1,206 +1,216 @@
 command: docker compose up
 short: Create and start containers
-long: "Builds, (re)creates, starts, and attaches to containers for a service.\n\nUnless
-    they are already running, this command also starts any linked services.\n\nThe
-    `docker compose up` command aggregates the output of each container (liked `docker
-    compose logs --follow` does). \nWhen the command exits, all containers are stopped.
-    Running `docker compose up --detach` starts the containers in the \nbackground
-    and leaves them running.\n\nIf there are existing containers for a service, and
-    the service’s configuration or image was changed after the \ncontainer’s creation,
-    `docker compose up` picks up the changes by stopping and recreating the containers
-    \n(preserving mounted volumes). To prevent Compose from picking up changes, use
-    the `--no-recreate` flag.\n\nIf you want to force Compose to stop and recreate
-    all containers, use the `--force-recreate` flag.\n\nIf the process encounters
-    an error, the exit code for this command is `1`.\nIf the process is interrupted
-    using `SIGINT` (ctrl + C) or `SIGTERM`, the containers are stopped, and the exit
-    code is `0`."
+long: |-
+  Builds, (re)creates, starts, and attaches to containers for a service.
+
+  Unless they are already running, this command also starts any linked services.
+
+  The `docker compose up` command aggregates the output of each container (liked `docker compose logs --follow` does).
+  When the command exits, all containers are stopped. Running `docker compose up --detach` starts the containers in the
+  background and leaves them running.
+
+  If there are existing containers for a service, and the service’s configuration or image was changed after the
+  container’s creation, `docker compose up` picks up the changes by stopping and recreating the containers
+  (preserving mounted volumes). To prevent Compose from picking up changes, use the `--no-recreate` flag.
+
+  If you want to force Compose to stop and recreate all containers, use the `--force-recreate` flag.
+
+  If the process encounters an error, the exit code for this command is `1`.
+  If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the containers are stopped, and the exit code is `0`.
 usage: docker compose up [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
-  - option: abort-on-container-exit
-    value_type: bool
-    default_value: "false"
-    description: |
-        Stops all containers if any container was stopped. Incompatible with -d
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: always-recreate-deps
-    value_type: bool
-    default_value: "false"
-    description: |
-        Recreate dependent containers. Incompatible with --no-recreate.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: attach-dependencies
-    value_type: bool
-    default_value: "false"
-    description: Attach to dependent containers.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: build
-    value_type: bool
-    default_value: "false"
-    description: Build images before starting containers.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: detach
-    shorthand: d
-    value_type: bool
-    default_value: "false"
-    description: 'Detached mode: Run containers in the background'
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: environment
-    shorthand: e
-    value_type: stringArray
-    default_value: '[]'
-    description: Environment variables
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: exit-code-from
-    value_type: string
-    description: |
-        Return the exit code of the selected service container. Implies --abort-on-container-exit
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: force-recreate
-    value_type: bool
-    default_value: "false"
-    description: |
-        Recreate containers even if their configuration and image haven't changed.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-build
-    value_type: bool
-    default_value: "false"
-    description: Don't build an image, even if it's missing.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-color
-    value_type: bool
-    default_value: "false"
-    description: Produce monochrome output.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-deps
-    value_type: bool
-    default_value: "false"
-    description: Don't start linked services.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-log-prefix
-    value_type: bool
-    default_value: "false"
-    description: Don't print prefix in logs.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-recreate
-    value_type: bool
-    default_value: "false"
-    description: |
-        If containers already exist, don't recreate them. Incompatible with --force-recreate.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: no-start
-    value_type: bool
-    default_value: "false"
-    description: Don't start the services after creating them.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: quiet-pull
-    value_type: bool
-    default_value: "false"
-    description: Pull without printing progress information.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: remove-orphans
-    value_type: bool
-    default_value: "false"
-    description: |
-        Remove containers for services not defined in the Compose file.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: renew-anon-volumes
-    shorthand: V
-    value_type: bool
-    default_value: "false"
-    description: |
-        Recreate anonymous volumes instead of retrieving data from the previous containers.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: scale
-    value_type: stringArray
-    default_value: '[]'
-    description: |
-        Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
-  - option: timeout
-    shorthand: t
-    value_type: int
-    default_value: "10"
-    description: |
-        Use this timeout in seconds for container shutdown when attached or when containers are already running.
-    deprecated: false
-    experimental: false
-    experimentalcli: false
-    kubernetes: false
-    swarm: false
+- option: abort-on-container-exit
+  value_type: bool
+  default_value: "false"
+  description: |
+    Stops all containers if any container was stopped. Incompatible with -d
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: always-recreate-deps
+  value_type: bool
+  default_value: "false"
+  description: Recreate dependent containers. Incompatible with --no-recreate.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: attach
+  value_type: stringArray
+  default_value: '[]'
+  description: Attach to service output.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: attach-dependencies
+  value_type: bool
+  default_value: "false"
+  description: Attach to dependent containers.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: build
+  value_type: bool
+  default_value: "false"
+  description: Build images before starting containers.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: detach
+  shorthand: d
+  value_type: bool
+  default_value: "false"
+  description: 'Detached mode: Run containers in the background'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: environment
+  shorthand: e
+  value_type: stringArray
+  default_value: '[]'
+  description: Environment variables
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: exit-code-from
+  value_type: string
+  description: |
+    Return the exit code of the selected service container. Implies --abort-on-container-exit
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: force-recreate
+  value_type: bool
+  default_value: "false"
+  description: |
+    Recreate containers even if their configuration and image haven't changed.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-build
+  value_type: bool
+  default_value: "false"
+  description: Don't build an image, even if it's missing.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-color
+  value_type: bool
+  default_value: "false"
+  description: Produce monochrome output.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-deps
+  value_type: bool
+  default_value: "false"
+  description: Don't start linked services.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-log-prefix
+  value_type: bool
+  default_value: "false"
+  description: Don't print prefix in logs.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-recreate
+  value_type: bool
+  default_value: "false"
+  description: |
+    If containers already exist, don't recreate them. Incompatible with --force-recreate.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-start
+  value_type: bool
+  default_value: "false"
+  description: Don't start the services after creating them.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet-pull
+  value_type: bool
+  default_value: "false"
+  description: Pull without printing progress information.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: remove-orphans
+  value_type: bool
+  default_value: "false"
+  description: Remove containers for services not defined in the Compose file.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: renew-anon-volumes
+  shorthand: V
+  value_type: bool
+  default_value: "false"
+  description: |
+    Recreate anonymous volumes instead of retrieving data from the previous containers.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: scale
+  value_type: stringArray
+  default_value: '[]'
+  description: |
+    Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: timeout
+  shorthand: t
+  value_type: int
+  default_value: "10"
+  description: |
+    Use this timeout in seconds for container shutdown when attached or when containers are already running.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_version.yaml
+++ b/_data/compose-cli/docker_compose_version.yaml
@@ -1,0 +1,31 @@
+command: docker compose version
+short: Show the Docker Compose version information
+long: Show the Docker Compose version information
+usage: docker compose version
+pname: docker compose
+plink: docker_compose.yaml
+options:
+- option: format
+  shorthand: f
+  value_type: string
+  description: 'Format the output. Values: [pretty | json]. (Default: pretty)'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: short
+  value_type: bool
+  default_value: "false"
+  description: Shows only Compose's version number.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -592,6 +592,8 @@ reference:
           title: docker compose unpause
         - path: /engine/reference/commandline/compose_up/
           title: docker compose up
+        - path: /engine/reference/commandline/compose_version/
+          title: docker compose version
     - sectiontitle: docker config
       section:
       - path: /engine/reference/commandline/config/

--- a/_plugins/relative_links_filter.rb
+++ b/_plugins/relative_links_filter.rb
@@ -97,12 +97,16 @@ module Jekyll
       nil
     end
 
+    def mdtarget?(string)
+      string&.include?(".md")
+    end
+
     def fragment?(string)
       string&.start_with?("#")
     end
 
     def replaceable_link?(string)
-      !fragment?(string) && !absolute_url?(string)
+      mdtarget?(string) && !fragment?(string) && !absolute_url?(string)
     end
 
     def global_entry_filter

--- a/engine/reference/commandline/compose_version.md
+++ b/engine/reference/commandline/compose_version.md
@@ -1,0 +1,12 @@
+---
+datafolder: compose-cli
+datafile: docker_compose_version
+title: docker compose version
+---
+<!--
+Sorry, but the contents of this page are automatically generated from
+Docker's source code. If you want to suggest a change to the text that appears
+here, you'll need to find the string by searching this repo:
+https://github.com/docker/compose
+-->
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
relates to https://github.com/docker/docker.github.io/pull/13514
brings in the changes from https://github.com/docker/compose/pull/8612
