### PR TITLE
Fixed references to old Bulletin Board demo

### DIFF
--- a/get-started/kube-deploy.md
+++ b/get-started/kube-deploy.md
@@ -44,7 +44,7 @@ All containers in Kubernetes are scheduled as _pods_, which are groups of co-loc
         spec:
           containers:
           - name: bb-site
-            image: bulletinboard:1.0
+            image: getting-started
     ---
     apiVersion: v1
     kind: Service
@@ -56,8 +56,8 @@ All containers in Kubernetes are scheduled as _pods_, which are groups of co-loc
       selector:
         bb: web
       ports:
-      - port: 8080
-        targetPort: 8080
+      - port: 3000
+        targetPort: 3000
         nodePort: 30001
     ```
 


### PR DESCRIPTION
The current documentation references the newer todo list built in the [Getting Started demo](https://docs.docker.com/get-started/02_our_app/) built in previous steps, but the docs listed the code for the older [BulletinBoard:1.0 image](http://www.myclass5.cn/get-started/part2/). So, this patch applies the following to run Getting Started:

- changed the name of the image to `getting-started`, and rebuild the image using `docker build -t getting-started .`
- changed the port numbers under the `ports` key in the Kubernetes YAML to *3000*

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
