### PR TITLE
Remove outdated sentence

### DIFF
--- a/language/python/build-images.md
+++ b/language/python/build-images.md
@@ -145,7 +145,7 @@ python-docker
 
 Now that we’ve created our Dockerfile, let’s build our image. To do this, we use the `docker build` command. The `docker build` command builds Docker images from a Dockerfile and a “context”. A build’s context is the set of files located in the specified PATH or URL. The Docker build process can access any of the files located in this context.
 
-The build command optionally takes a `--tag` flag. The tag is used to set the name of the image and an optional tag in the format `name:tag`. We’ll leave off the optional `tag` for now to help simplify things. If you do not pass a tag, Docker uses “latest” as its default tag. You can see this in the last line of the build output.
+The build command optionally takes a `--tag` flag. The tag is used to set the name of the image and an optional tag in the format `name:tag`. We’ll leave off the optional `tag` for now to help simplify things. If you do not pass a tag, Docker uses “latest” as its default tag.
 
 Let’s build our first Docker image.
 


### PR DESCRIPTION
The output following the sentence no longer contains what the sentence
claims.

### Proposed changes

Just a documentation change. Removed a sentence that is misleading, as it refers to output that seems to no longer be there (there is no mention of "latest" in the cited output.)
