### PR TITLE
Updated yum -y install yum-utils to yum -y upgrade

### DIFF
--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -83,7 +83,7 @@ Install the `yum-utils` package (which provides the `yum-config-manager`
 utility) and set up the **stable** repository.
 
 ```console
-$ sudo yum install -y yum-utils
+$ sudo yum -y upgrade
 
 $ sudo yum-config-manager \
     --add-repo \


### PR DESCRIPTION
Docker requires more updated libraries than yum-utils. I've tested yum-utils in a new Virtual Machine without updating any libs, and couldn't get docker working. For new environments this is a better command and for any environment.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
