### PR TITLE
Fix link to Credential Helper

### DIFF
--- a/desktop/index.md
+++ b/desktop/index.md
@@ -15,7 +15,7 @@ that enables you to build and share containerized applications and microservices
 Docker Desktop includes [Docker Engine](../engine/index.md), Docker CLI client,
 [Docker Compose](../compose/index.md), [Docker Content Trust](../engine/security/trust/index.md),
 [Kubernetes](https://github.com/kubernetes/kubernetes/), and 
-Credential Helper](https://github.com/docker/docker-credential-helpers/).
+[Credential Helper](https://github.com/docker/docker-credential-helpers/).
 
 Docker Desktop works with your choice of development tools and languages and
 gives you access to a vast library of certified images and templates in


### PR DESCRIPTION
### Proposed changes

Fixed the link to Credential Helper in the Docker Desktop documentation.