### PR TITLE
Remove license modal from Apple silicon docs

### DIFF
--- a/desktop/mac/apple-silicon.md
+++ b/desktop/mac/apple-silicon.md
@@ -17,9 +17,8 @@ Download Docker Desktop for Mac on Apple silicon:
 
 > Download Docker Desktop
 >
-> {%- include eula.md -%}
 >
-> [Mac with Apple chip](https://desktop.docker.com/mac/stable/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn .accept-eula }
+> [Mac with Apple chip](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn }
 
 <br>
 


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Removed the license modal from the Apple silicon docs as the download URL points to the latest version which prompts user to accept the license agreement in the UI.