### PR TITLE
Update style inconsistencies for code prompts in get-started

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -52,7 +52,7 @@ So, let's do it!
     If you are using PowerShell then use this command:
 
     ```powershell
-    docker run -dp 3000:3000 `
+    PS> docker run -dp 3000:3000 `
         -w /app -v "$(pwd):/app" `
         node:12-alpine `
         sh -c "yarn install && yarn run dev"

--- a/get-started/08_using_compose.md
+++ b/get-started/08_using_compose.md
@@ -68,7 +68,7 @@ $ docker run -dp 3000:3000 \
 If you are using PowerShell then use this command.
 
 ```powershell
-docker run -dp 3000:3000 `
+PS> docker run -dp 3000:3000 `
   -w /app -v "$(pwd):/app" `
   --network todo-app `
   -e MYSQL_HOST=mysql `
@@ -174,7 +174,7 @@ $ docker run -d \
 If you are using PowerShell then use this command.
 
 ```powershell
-docker run -d `
+PS> docker run -d `
   --network todo-app --network-alias mysql `
   -v todo-mysql-data:/var/lib/mysql `
   -e MYSQL_ROOT_PASSWORD=secret `

--- a/get-started/08_using_compose.md
+++ b/get-started/08_using_compose.md
@@ -65,7 +65,7 @@ $ docker run -dp 3000:3000 \
   sh -c "yarn install && yarn run dev"
 ```
 
-If you are using PowerShell then use this command.
+If you are using PowerShell then use this command:
 
 ```powershell
 PS> docker run -dp 3000:3000 `
@@ -171,7 +171,7 @@ $ docker run -d \
   mysql:5.7
 ```
 
-If you are using PowerShell then use this command.
+If you are using PowerShell then use this command:
 
 ```powershell
 PS> docker run -d `


### PR DESCRIPTION
### Proposed changes

- Minor grammatical style updates for consistency
- Added PowerShell prompt `PS >`  for PowerShell code blocks like in [part 7](https://docs.docker.com/get-started/07_multi_container/) of the guide