### PR TITLE
Self-diagnose tool is no longer experimental

### DIFF
--- a/desktop/mac/troubleshoot.md
+++ b/desktop/mac/troubleshoot.md
@@ -116,27 +116,23 @@ To view the contents of the diagnostic file, run:
 $ open /tmp/BE9AFAAF-F68B-41D0-9D12-84760E6B8740/20190905152051.zip
 ```
 
-### Experimental self-diagnose tool
+### Self-diagnose tool
 
-Docker Desktop 3.6.0 contains an experimental "self-diagnose" tool which helps identify some common
-problems. To run it: first locate `com.docker.diagnose`. If you have installed Docker Desktop
-in the Applications directory, then it is located at
+Docker Desktop contains a self-diagnose tool which helps you to identify some common problems. Before you run the self-diagnose tool, locate `com.docker.diagnose`. If you have installed Docker Desktop
+in the Applications directory, then the self-diagnose tool will be located at
 `/Applications/Docker.app/Contents/MacOS/com.docker.diagnose`.
 
-To run the self-diagnose tool:
+To run the self-diagnose tool, run:
 
 ```console
 $ /Applications/Docker.app/Contents/MacOS/com.docker.diagnose check
 ```
 
-The tool runs a suite of checks and displays **PASS** or **FAIL** next to each one. If there are any failures, it highlights the most relevant at the end.
-it will try to highlight the most relevant at the end.
+The tool runs a suite of checks and displays **PASS** or **FAIL** next to each check. If there are any failures, it highlights the most relevant at the end of the report.
 
-> **Note**
+> **Feedback**
 >
-> The Self-diagnose tool is still experimental. Let us know your feedback by creating an issue in the [for-mac](https://github.com/docker/for-mac/issues) GitHub repository.
-
-The Self-diagnose tool is still experimental. Let us know your feedback by creating an issue in the [for-mac](https://github.com/docker/for-mac/issues) GitHub repository.
+> Let us know your feedback on the self-diagnose tool by creating an issue in the [for-mac](https://github.com/docker/for-mac/issues) GitHub repository.
 
 <a name="logs"></a>
 

--- a/desktop/windows/troubleshoot.md
+++ b/desktop/windows/troubleshoot.md
@@ -83,10 +83,10 @@ Diagnostics Bundle: C:\Users\User\AppData\Local\Temp\CD6CF862-9CBD-4007-9C2F-5FB
 Diagnostics ID:     CD6CF862-9CBD-4007-9C2F-5FBE0572BBC2/20180720152545 (uploaded)
 ```
 
-### Experimental self-diagnose tool
+### Self-diagnose tool
 
-Docker Desktop 3.6.0 contains an experimental "self-diagnose" tool which helps identify some common
-problems. To run it: first locate `com.docker.diagnose.exe`, usually installed in `C:\Program
+Docker Desktop contains a self-diagnose tool which helps you to identify some common
+problems. Before you run the self-diagnose tool, locate `com.docker.diagnose.exe`. This is usually installed in `C:\Program
 Files\Docker\Docker\resources\com.docker.diagnose.exe`.
 
 To run the self-diagnose tool in Powershell:
@@ -95,14 +95,11 @@ To run the self-diagnose tool in Powershell:
 PS C:\> & "C:\Program Files\Docker\Docker\resources\com.docker.diagnose.exe" check
 ```
 
-The tool runs a suite of checks and displays **PASS** or **FAIL** next to each one. If there are any failures, it highlights the most relevant at the end.
-it will try to highlight the most relevant at the end.
+The tool runs a suite of checks and displays **PASS** or **FAIL** next to each check. If there are any failures, it highlights the most relevant at the end.
 
-> **Note**
+> **Feedback**
 >
-> The Self-diagnose tool is still experimental. Let us know your feedback by creating an issue in the [for-win](https://github.com/docker/for-win/issues) GitHub repository.
-
-The Self-diagnose tool is still experimental. Let us know your feedback by creating an issue in the [for-win](https://github.com/docker/for-win/issues) GitHub repository.
+> Let us know your feedback on the self-diagnose tool by creating an issue in the [for-win](https://github.com/docker/for-win/issues) GitHub repository.
 
 ## Troubleshooting topics
 


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Update docs to reflect that the Self-diagnose tool is no longer experimental