### PR TITLE
ECS Cloud Documentation: Include port for SSL

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -489,6 +489,7 @@ x-aws-cloudformation:
         Certificates:
           - CertificateArn: "arn:aws:acm:certificate/123abc"
         Protocol: HTTPS
+        Port: 443
 ```
 
 ## Using existing AWS network resources


### PR DESCRIPTION
Without including the port, the ELB is configured to HTTPS on port 80. 

### Proposed changes

Updated documentation for ECS Cloud with SSL Termination
