### PR TITLE
Set correct Compose version in Linux installation guide

### DIFF
--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -79,7 +79,7 @@ from the [project release page](https://github.com/docker/compose/releases){:tar
 
     ```console
     $ mkdir -p ~/.docker/cli-plugins/
-    $ curl -SL https://github.com/docker/compose/releases/download/v2.0.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+    $ curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
     ```
 
     This command installs Compose V2 for the active user under `$HOME` directory. To install Docker Compose for all users on your system, replace `~/.docker/cli-plugins` with `/usr/local/lib/docker/cli-plugins`.
@@ -94,7 +94,7 @@ from the [project release page](https://github.com/docker/compose/releases){:tar
 
     ```console
     $ docker compose version
-    Docker Compose version 2.0.0
+    Docker Compose version 2.0.1
     ```
 
 ### Compose Switch


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

This sets the correct Docker Compose version for installation in Linux environments.

#13654 Made a PR for this but didn't set the correct version.

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

Resolves #13674 #13668
Closes #13654
