### PR TITLE
[FIX] update documentation

### DIFF
--- a/samples/django.md
+++ b/samples/django.md
@@ -75,12 +75,6 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
        image: postgres
        volumes:
          - ./data/db:/var/lib/postgresql/data
-       environment:
-         - POSTGRES_NAME=postgres
-         - POSTGRES_USER=postgres
-         - POSTGRES_PASSWORD=postgres
-         - POSTGRES_HOST=db
-         - POSTGRES_PORT=5432
      web:
        build: .
        command: python manage.py runserver 0.0.0.0:8000
@@ -88,6 +82,10 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
          - .:/code
        ports:
          - "8000:8000"
+       environment:
+         - POSTGRES_NAME=postgres
+         - POSTGRES_USER=postgres
+         - POSTGRES_PASSWORD=postgres
        depends_on:
          - db
    ```
@@ -182,8 +180,8 @@ In this section, you set up the database connection for Django.
            'NAME': os.environ.get('POSTGRES_NAME'),
            'USER': os.environ.get('POSTGRES_USER'),
            'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-           'HOST': os.environ.get('POSTGRES_HOST'),
-           'PORT': os.environ.get('POSTGRES_PORT'),
+           'HOST': 'db',
+           'PORT': 5432,
        }
    }
    ```

--- a/samples/django.md
+++ b/samples/django.md
@@ -30,6 +30,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
    ```dockerfile
    # syntax=docker/dockerfile:1
    FROM python:3
+   ENV PYTHONDONTWRITEBYTECODE=1
    ENV PYTHONUNBUFFERED=1
    WORKDIR /code
    COPY requirements.txt /code/
@@ -50,7 +51,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
 6. Add the required software in the file.
 
        Django>=3.0,<4.0
-       psycopg2-binary>=2.8
+       psycopg2>=2.8
 
 7. Save and close the `requirements.txt` file.
 
@@ -75,9 +76,11 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
        volumes:
          - ./data/db:/var/lib/postgresql/data
        environment:
-         - POSTGRES_DB=postgres
+         - POSTGRES_NAME=postgres
          - POSTGRES_USER=postgres
          - POSTGRES_PASSWORD=postgres
+         - POSTGRES_HOST=db
+         - POSTGRES_PORT=5432
      web:
        build: .
        command: python manage.py runserver 0.0.0.0:8000
@@ -169,14 +172,18 @@ In this section, you set up the database connection for Django.
    ```python
    # settings.py
    
+   import os
+   
+   [...]
+   
    DATABASES = {
        'default': {
            'ENGINE': 'django.db.backends.postgresql',
-           'NAME': 'postgres',
-           'USER': 'postgres',
-           'PASSWORD': 'postgres',
-           'HOST': 'db',
-           'PORT': 5432,
+           'NAME': os.environ.get('POSTGRES_NAME'),
+           'USER': os.environ.get('POSTGRES_USER'),
+           'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
+           'HOST': os.environ.get('POSTGRES_HOST'),
+           'PORT': os.environ.get('POSTGRES_PORT'),
        }
    }
    ```


### PR DESCRIPTION
### Proposed changes

- add `PYTHONDONTWRITEBYTECODE` environment variable
> Python will no longer write these files to disk, and your development environment will remain nice and clean.

- rename pip package `psycopg2-binary` to `psycopg2`:
> `psycopg2-binary` and `psycopg2` both give us the same code that we interact with. The difference between the two is in how that code is installed in our computer.
If we use `psycopg2-binary` we have the following issue when `docker-compose up`: 
```
$> django.db.utils.OperationalError: SCRAM authentication requires libpq version 10 or above`
```

- add environment variable to `db` in docker-compose for a better usage
- use `os.environment` in `setting.py` to get those previous variables
