### PR TITLE
Remove usage of outdated `GHCR_TOKEN`

### DIFF
--- a/language/java/configure-ci-cd.md
+++ b/language/java/configure-ci-cd.md
@@ -211,7 +211,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 ```
 {% endraw %}

--- a/language/java/configure-ci-cd.md
+++ b/language/java/configure-ci-cd.md
@@ -212,7 +212,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 ```
 {% endraw %}
 

--- a/language/java/configure-ci-cd.md
+++ b/language/java/configure-ci-cd.md
@@ -216,6 +216,11 @@ Next, change your Docker Hub login to a GitHub container registry login:
 ```
 {% endraw %}
 
+To authenticate against the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry), use the [`GITHUB_TOKEN`](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) for the best security and experience.
+
+You may need to [manage write and read access of GitHub Actions](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio) for repositories in the container settings.
+
+You can also use a [personal access token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the [appropriate scopes](https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry).
 Remember to change how the image is tagged. The following example keeps ‘latest’ as the only tag. However, you can add any logic to this if you prefer:
 
 {% raw %}

--- a/language/nodejs/configure-ci-cd.md
+++ b/language/nodejs/configure-ci-cd.md
@@ -215,6 +215,11 @@ Next, change your Docker Hub login to a GitHub container registry login:
 ```
 {% endraw %}
 
+To authenticate against the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry), use the [`GITHUB_TOKEN`](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) for the best security and experience.
+
+You may need to [manage write and read access of GitHub Actions](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio) for repositories in the container settings.
+
+You can also use a [personal access token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the [appropriate scopes](https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry).
 Remember to change how the image is tagged. The following example keeps ‘latest’ as the only tag. However, you can add any logic to this if you prefer:
 
 {% raw %}

--- a/language/nodejs/configure-ci-cd.md
+++ b/language/nodejs/configure-ci-cd.md
@@ -211,7 +211,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 ```
 {% endraw %}
 

--- a/language/nodejs/configure-ci-cd.md
+++ b/language/nodejs/configure-ci-cd.md
@@ -210,7 +210,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 ```
 {% endraw %}

--- a/language/python/configure-ci-cd.md
+++ b/language/python/configure-ci-cd.md
@@ -215,6 +215,11 @@ Next, change your Docker Hub login to a GitHub container registry login:
 ```
 {% endraw %}
 
+To authenticate against the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry), use the [`GITHUB_TOKEN`](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) for the best security and experience.
+
+You may need to [manage write and read access of GitHub Actions](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio) for repositories in the container settings.
+
+You can also use a [personal access token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the [appropriate scopes](https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry).
 Remember to change how the image is tagged. The following example keeps ‘latest’ as the only tag. However, you can add any logic to this if you prefer:
 
 {% raw %}

--- a/language/python/configure-ci-cd.md
+++ b/language/python/configure-ci-cd.md
@@ -211,7 +211,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 ```
 {% endraw %}
 

--- a/language/python/configure-ci-cd.md
+++ b/language/python/configure-ci-cd.md
@@ -210,7 +210,7 @@ Next, change your Docker Hub login to a GitHub container registry login:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 ```
 {% endraw %}


### PR DESCRIPTION
### Proposed changes

This drops the usage of the outdated `GHCR_TOKEN` in favour of the now supported `GITHUB_TOKEN` in the CI/CD section of the languages pages.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Closes #13709

cc @usha-mandya 