### PR TITLE
Explain the use of the `COPY` command in the NodeJS example

### DIFF
--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -130,10 +130,14 @@ WORKDIR /app
 
 Usually the very first thing you do once you’ve downloaded a project written in Node.js is to install npm packages. This ensures that your application has all its dependencies installed into the `node_modules` directory where the Node runtime will be able to find them.
 
-Before we can run `npm install`, we need to get our `package.json` and `package-lock.json` files into our images. We use the `COPY` command to do this. The `COPY` command takes two parameters: `src` and `dest`. The first parameter `src` tells Docker what file(s) you would like to copy into the image. The second parameter `dest` tells Docker where you want that file(s) to be copied to.
-For example: `COPY ["<src>", "<dest>"]`.
-Multiple `src` resources may be specified but seperated by a comma: `COPY ["<src1>", "<src2>",..., "<dest>"]`.
-We’ll copy the `package.json` and `package-lock.json` file into our working directory `/app`.
+Before we can run `npm install`, we need to get our `package.json` and `package-lock.json` files into our images. We use the `COPY` command to do this. The `COPY` command takes two parameters: `src` and `dest`. The first parameter `src` tells Docker what file(s) you would like to copy into the image. The second parameter `dest` tells Docker where you want that file(s) to be copied to. For example:
+
+ ```dockerfile
+ COPY ["<src>", "<dest>"]
+ ```
+
+You can specify multiple `src` resources seperated by a comma. For example, `COPY ["<src1>", "<src2>",..., "<dest>"]`.
+We’ll copy the `package.json` and the `package-lock.json` file into our working directory `/app`.
 
 ```dockerfile
 COPY ["package.json", "package-lock.json*", "./"]

--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -130,7 +130,10 @@ WORKDIR /app
 
 Usually the very first thing you do once you’ve downloaded a project written in Node.js is to install npm packages. This ensures that your application has all its dependencies installed into the `node_modules` directory where the Node runtime will be able to find them.
 
-Before we can run `npm install`, we need to get our `package.json` and `package-lock.json` files into our images. We use the `COPY` command to do this. The `COPY` command takes two parameters. The first parameter tells Docker what file(s) you would like to copy into the image. The second parameter tells Docker where you want that file(s) to be copied to. We’ll copy the `package.json` and `package-lock.json` file into our working directory `/app`.
+Before we can run `npm install`, we need to get our `package.json` and `package-lock.json` files into our images. We use the `COPY` command to do this. The `COPY` command takes two parameters: `src` and `dest`. The first parameter `src` tells Docker what file(s) you would like to copy into the image. The second parameter `dest` tells Docker where you want that file(s) to be copied to.
+For example: `COPY ["<src>", "<dest>"]`.
+Multiple `src` resources may be specified but seperated by a comma: `COPY ["<src1>", "<src2>",..., "<dest>"]`.
+We’ll copy the `package.json` and `package-lock.json` file into our working directory `/app`.
 
 ```dockerfile
 COPY ["package.json", "package-lock.json*", "./"]


### PR DESCRIPTION
### Proposed changes

The explanation of the `COPY` command given in the NodeJS language guide does not correspond with the example.
The explanation says the `COPY` command takes in two parameters but goes on to use three parameters in the example without explaining that it can take in multiple `src` parameters. This is a confusing explanation/example:

![docker_docs_website_issue_close_1](https://user-images.githubusercontent.com/58262528/137603846-734115b5-f569-4fbc-bb8a-08db733c5491.png)

This PR explicitly shows that the `COPY` command takes in two parameters `src` and `dest` and there can be multiple `src` parameters but they should be separated by a comma for example: `COPY ["<src1>", "<src2>", ..., "<dest>"]`
It also explicitly shows readers that the last parameter is always the destination path avoiding confusions like #13669


### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Closes #13669

cc @usha-mandya 
