### PR TITLE
engine/install: remove apt-transport-https from instructions

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -83,7 +83,6 @@ from the repository.
     $ sudo apt-get update
 
     $ sudo apt-get install \
-        apt-transport-https \
         ca-certificates \
         curl \
         gnupg \

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -105,7 +105,6 @@ from the repository.
     $ sudo apt-get update
 
     $ sudo apt-get install \
-        apt-transport-https \
         ca-certificates \
         curl \
         gnupg \


### PR DESCRIPTION
This package is no longer needed on all current distro versions we support. From
the package description (https://packages.debian.org/buster/apt-transport-https);

> This is a dummy transitional package - https support has been moved into the
> apt package in 1.5. It can be safely removed.

Verifying the version of apt that's available in Ubuntu and Debian:

Ubuntu:

    docker run --rm ubuntu:xenial apt --version
    apt 1.2.35 (amd64)

    docker run --rm ubuntu:17.04 apt --version
    apt 1.4.6 (amd64)

    docker run --rm ubuntu:17.10 apt --version
    apt 1.5.2 (amd64)

    docker run --rm ubuntu:18.04 apt --version
    apt 1.6.14 (amd64)

    docker run --rm ubuntu:20.04 apt --version
    apt 2.0.6 (amd64)

Debian:

    docker run --rm debian:stretch apt --version
    apt 1.4.11 (amd64)

    docker run --rm debian:buster apt --version
    apt 1.8.2.3 (amd64)

    docker run --rm debian:bullseye apt --version
    apt 2.2.4 (amd64)

From the above; all currently supported versions of Ubuntu (18.04 and up), and
Debian (old-stable and stable) have apt > 1.5, so we can remove this dependency
from the installation instructions.

