### PR TITLE
take "+ tab" out of the monospaced codeword

### DIFF
--- a/compose/completion.md
+++ b/compose/completion.md
@@ -78,7 +78,7 @@ Make sure you have [installed `oh-my-zsh`](https://ohmyz.sh/) on your computer.
 Add `docker` and `docker-compose` to the plugins list in `~/.zshrc` to run
 autocompletion within the oh-my-zsh shell. In the following example, `...`
 represent other Zsh plugins you may have installed. After that, type `source ~/.zshrc` to bring the changes. 
-To test whether it is successful, type `docker ps + tab`.
+To test whether it is successful, type `docker ps` + tab.
 
 ```shell
 plugins=(... docker docker-compose)

--- a/compose/completion.md
+++ b/compose/completion.md
@@ -78,7 +78,7 @@ Make sure you have [installed `oh-my-zsh`](https://ohmyz.sh/) on your computer.
 Add `docker` and `docker-compose` to the plugins list in `~/.zshrc` to run
 autocompletion within the oh-my-zsh shell. In the following example, `...`
 represent other Zsh plugins you may have installed. After that, type `source ~/.zshrc` to bring the changes. 
-To test whether it is successful, type `docker ps` + tab.
+To test whether it is successful, type `docker ps` and then press the **Tab** key.
 
 ```shell
 plugins=(... docker docker-compose)


### PR DESCRIPTION
### Proposed changes

Correct what seems to be a typo in the completion.md readme where "+ tab" was included in the monospaced codeword instruction. 