### PR TITLE
Note the max-retries option on the Start containers automatically page.

### DIFF
--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -27,7 +27,7 @@ any of the following:
 | Flag             | Description                                                                                     |
 |:-----------------|:------------------------------------------------------------------------------------------------|
 | `no`             | Do not automatically restart the container. (the default)                                       |
-| `on-failure`[:max-retries]     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.  Optionally, limit the number of restart retries the Docker daemon attempts.   |
+| `on-failure`(optional:`max-retries`)     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.  Optionally, limit the number of retries the Docker daemon attempts.   |
 | `always`         | Always restart the container if it stops. If it is manually stopped, it is restarted only when Docker daemon restarts or the container itself is manually restarted. (See the second bullet listed in [restart policy details](#restart-policy-details)) |
 | `unless-stopped` | Similar to `always`, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts. |
 

--- a/config/containers/start-containers-automatically.md
+++ b/config/containers/start-containers-automatically.md
@@ -27,7 +27,7 @@ any of the following:
 | Flag             | Description                                                                                     |
 |:-----------------|:------------------------------------------------------------------------------------------------|
 | `no`             | Do not automatically restart the container. (the default)                                       |
-| `on-failure`     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.     |
+| `on-failure`[:max-retries]     | Restart the container if it exits due to an error, which manifests as a non-zero exit code.  Optionally, limit the number of restart retries the Docker daemon attempts.   |
 | `always`         | Always restart the container if it stops. If it is manually stopped, it is restarted only when Docker daemon restarts or the container itself is manually restarted. (See the second bullet listed in [restart policy details](#restart-policy-details)) |
 | `unless-stopped` | Similar to `always`, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts. |
 


### PR DESCRIPTION
### Proposed changes

Include a mention of "max-retries" on https://docs.docker.com/config/containers/start-containers-automatically/ so it matches https://docs.docker.com/engine/reference/run/#restart-policies---restart

### Unreleased project version (optional)

n/a

### Related issues (optional)

n/a
