### PR TITLE
Check if site_id is empty and skip delete command

### DIFF
--- a/.github/actions/netlify-clean/entrypoint.sh
+++ b/.github/actions/netlify-clean/entrypoint.sh
@@ -28,6 +28,10 @@ echo "searching site ${site_name}"
 clean_site_name=$(slug $site_name)
 site_id=$(get_site_id $clean_site_name)
 
-echo "deleting site"
+if [ -z "$site_id" ]; then
+  echo "site already deleted"
+else
+  echo "deleting site"
 
-netlify sites:delete --force "${site_id}"
+  netlify sites:delete --force "${site_id}"
+fi


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Fix a case when the netlify site is already deleted. Fixes this situation: https://github.com/docker/docker.github.io/runs/4119974208?check_suite_focus=true
If no `site_id` could be retrieved, skip the sites:delete command.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
