### PR TITLE
chore: silent completion and avoid manual version update

### DIFF
--- a/compose/completion.md
+++ b/compose/completion.md
@@ -21,8 +21,8 @@ available.
 2. Place the completion script in `/etc/bash_completion.d/`.
 
    ```console
-   $ sudo curl \
-       -L https://raw.githubusercontent.com/docker/compose/{{site.compose_version}}/contrib/completion/bash/docker-compose \
+   $ sudo curl -s \
+       -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/bash/docker-compose \
        -o /etc/bash_completion.d/docker-compose
    ```
 

--- a/compose/completion.md
+++ b/compose/completion.md
@@ -38,8 +38,8 @@ available.
    For example, place the completion script in `/usr/local/etc/bash_completion.d/`.
 
    ```console
-   $ sudo curl \
-       -L https://raw.githubusercontent.com/docker/compose/{{site.compose_version}}/contrib/completion/bash/docker-compose \
+   $ sudo curl -s \
+       -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/bash/docker-compose \
        -o /usr/local/etc/bash_completion.d/docker-compose
    ```
 
@@ -90,8 +90,8 @@ plugins=(... docker docker-compose)
 
    ```console
    $ mkdir -p ~/.zsh/completion
-   $ curl \
-       -L https://raw.githubusercontent.com/docker/compose/{{site.compose_version}}/contrib/completion/zsh/_docker-compose \
+   $ curl -s \
+       -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/zsh/_docker-compose \
        -o ~/.zsh/completion/_docker-compose
    ```
 


### PR DESCRIPTION
### Proposed changes

Avoid showing the curl download info on every shell start.

As well, avoid having to manually update the docker compose version and use the current installed version

Signed-off-by: Francisco Robles Martín <f.robles.martin@pm.me>
