### PR TITLE
Fix Docker Desktop for Mac 2.5.0.1 download link

### DIFF
--- a/desktop/mac/release-notes/2.x.md
+++ b/desktop/mac/release-notes/2.x.md
@@ -15,7 +15,7 @@ This page contains release notes for Docker Desktop for Mac 2.x.
 >
 > {%- include eula.md -%}
 >
-> [Mac with Intel chip](https://desktop.docker.com/mac/stable/amd64/49550/Docker.dmg){: .accept-eula }
+> [Mac with Intel chip](https://desktop.docker.com/mac/stable/49550/Docker.dmg){: .accept-eula }
 
 ### Upgrades
 


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

This PR fixes the download link for DD 2.5.0.1 on Mac, we didn't have the "amd64" folder yet.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
