### PR TITLE
Fix python3 dependency

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -45,7 +45,7 @@ see a few flaws in the Dockerfile below. But, don't worry. We'll go over them.
    ```dockerfile
    # syntax=docker/dockerfile:1
    FROM node:12-alpine
-   RUN apk add --no-cache python g++ make
+   RUN apk add --no-cache python3 g++ make
    WORKDIR /app
    COPY . .
    RUN yarn install --production


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Fixes a problem in the getting started guide, alpine has made it more clear which version of Python you want to install. So we have to use `python3` instead of `python`.

Related fix in the docker/getting-started repo is https://github.com/docker/getting-started/pull/218

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
