### PR TITLE
engine: remove outdated instructions for derivatives

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -99,13 +99,6 @@ from the repository.
     **nightly** or **test** repository, add the word `nightly` or `test` (or both)
     after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](index.md).
 
-    > **Note**: The `lsb_release -cs` sub-command below returns the name of your
-    > Debian distribution, such as `helium`. Sometimes, in a distribution
-    > like BunsenLabs Linux, you might need to change `$(lsb_release -cs)`
-    > to your parent Debian distribution. For example, if you are using
-    >  `BunsenLabs Linux Helium`, you could use `stretch`. Docker does not offer any guarantees on untested
-    > and unsupported Debian distributions.
-
     ```console
     $ echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -122,13 +122,6 @@ from the repository.
     **nightly** or **test** repository, add the word `nightly` or `test` (or both)
     after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](index.md).
 
-    > **Note**: The `lsb_release -cs` sub-command below returns the name of your
-    > Ubuntu distribution, such as `xenial`. Sometimes, in a distribution
-    > like Linux Mint, you might need to change `$(lsb_release -cs)`
-    > to your parent Ubuntu distribution. For example, if you are using
-    >  `Linux Mint Tessa`, you could use `bionic`. Docker does not offer any guarantees on untested
-    > and unsupported Ubuntu distributions.
-
     ```console
     $ echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \


### PR DESCRIPTION
closes https://github.com/docker/docker.github.io/issues/13547

The information about which distro version to use to match upstream
Debian / Ubuntu versions was outdated. Given that Docker does not
officially support, nor tests, installing these packages on Ubuntu
and Debian derivatives, it's better to remove it, and leave it to
the user to find the correct codename; also see
https://docs.docker.com/engine/install/#other-linux-distributions

