### PR TITLE
VPC configuration required for service discovery

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -251,7 +251,9 @@ Services are registered automatically by the Docker Compose CLI on [AWS Cloud Ma
 
 Services can retrieve their dependencies using Compose service names (as they do when deploying locally with docker-compose), or optionally use the fully qualified names.
 
-**Note:** Service names, nor the fully qualified service names, will resolve unless you enable public dns names in your VPC.
+> **Note**
+> 
+> Short service names, nor the fully qualified service names, will resolve unless you enable public dns names in your VPC.
 
 ### Dependent service startup time and DNS resolution
 

--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -251,6 +251,8 @@ Services are registered automatically by the Docker Compose CLI on [AWS Cloud Ma
 
 Services can retrieve their dependencies using Compose service names (as they do when deploying locally with docker-compose), or optionally use the fully qualified names.
 
+**Note:** Service names, nor the fully qualified service names, will resolve unless you enable public dns names in your VPC.
+
 ### Dependent service startup time and DNS resolution
 
 Services get concurrently scheduled on ECS when a Compose file is deployed. AWS Cloud Map introduces an initial delay for DNS service to be able to resolve your services domain names. Your code needs to support this delay by waiting for dependent services to be ready, or by adding a wait-script as the entrypoint to your Docker image, as documented in [Control startup order](../compose/startup-order.md).


### PR DESCRIPTION
Make a note that VPC must be configured correctly with public dns names enabled in order for service name resolution to function.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
