### PR TITLE
engine/install: remove mention of Fedora 33

### DIFF
--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -20,7 +20,6 @@ To get started with Docker Engine on Fedora, make sure you
 
 To install Docker Engine, you need the 64-bit version of one of these Fedora versions:
 
-- Fedora 33
 - Fedora 34
 - Fedora 35
 


### PR DESCRIPTION
Fedora 33 reaches EOL Tomorrow, so let's remove it from the list to not encourage using it.
