### PR TITLE
Updated Wordpress Sample Markdown page

### DIFF
--- a/samples/wordpress.md
+++ b/samples/wordpress.md
@@ -36,6 +36,8 @@ Compose to set up and run WordPress. Before starting, make sure you have
 3.  Create a `docker-compose.yml` file that starts your
     `WordPress` blog and a separate `MySQL` instance with volume
     mounts for data persistence:
+    
+    >**Tip**: If you are using an M1 Mac. You will need to add ```platform: linux/amd64``` underneath the image of mysql:5.7
 
     ```yaml
     version: "{{ site.compose_file_v3 }}"


### PR DESCRIPTION
### Proposed changes

Added a tip for users that are on an M1 mac to add ```platform: linux/amd64``` underneath image of mysql:5.7
This is a quality of life change. 
