### PR TITLE
Close io.ReadCloser in examples

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -62,6 +62,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	defer reader.Close()
 	io.Copy(os.Stdout, reader)
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
@@ -182,6 +184,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer out.Close()
 	io.Copy(os.Stdout, out)
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{


### PR DESCRIPTION
### Proposed changes

The `ImagePull` method on the Docker Go client returns an `io.ReadCloser`.  A couple of examples didn't seem to be handling the closing of the reader, and so this has been added.
