### PR TITLE
It’s compose instead of compose-cli

### DIFF
--- a/desktop/mac/release-notes/index.md
+++ b/desktop/mac/release-notes/index.md
@@ -37,7 +37,7 @@ This page contains information about the new features, improvements, known issue
 - [containerd v1.4.11](https://github.com/containerd/containerd/releases/tag/v1.4.11)
 - [runc v1.0.2](https://github.com/opencontainers/runc/releases/tag/v1.0.2)
 - [Go 1.17.2](https://golang.org/doc/go1.17)
-- [Compose CLI v2.1.1](https://github.com/docker/compose/releases/tag/v2.1.1)
+- [Compose v2.1.1](https://github.com/docker/compose/releases/tag/v2.1.1)
 - [docker-scan 0.9.0](https://github.com/docker/scan-cli-plugin/releases/tag/v0.9.0)
 
 ### Bug fixes and minor changes


### PR DESCRIPTION
Same as https://github.com/docker/docker.github.io/pull/13889 but for the Mac release notes.