### PR TITLE
Adding additional documentation for running hello-world image in setting up Docker tutorial

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -170,6 +170,7 @@ from the repository.
     image.
 
     ```console
+    $ sudo docker pull hello-world
     $ sudo docker run hello-world
     ```
 


### PR DESCRIPTION
While following this documentation, I got an error after trying to run 'sudo docker run hello-world' stating the repo didn't exist. After running 'sudo docker pull hello-world' , I was able to run the image. I wanted to add this additional documentation for those that follow this in the future.
