### PR TITLE
Fix to no password error on database run

### DIFF
--- a/samples/django.md
+++ b/samples/django.md
@@ -75,6 +75,10 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
        image: postgres
        volumes:
          - ./data/db:/var/lib/postgresql/data
+       environment:
+         - POSTGRES_NAME=postgres
+         - POSTGRES_USER=postgres
+         - POSTGRES_PASSWORD=postgres
      web:
        build: .
        command: python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
### Proposed changes

Based on the docker/django tutorial at https://docs.docker.com/samples/django/.
I updated the suggested docker-compose.yml file so that the three postgres environmental variables declared under the web service are also declared under the db service. 
This successfully fixed the error message that appears when following the tutorial: "Error: Database is uninitialized and superuser password is not specified."
