### PR TITLE
Adding --delete-untagged to registry garbage collection docs

### DIFF
--- a/registry/garbage-collection.md
+++ b/registry/garbage-collection.md
@@ -92,10 +92,10 @@ This type of garbage collection is known as stop-the-world garbage collection.
 
 Garbage collection can be run as follows
 
-`bin/registry garbage-collect [--dry-run] /path/to/config.yml`
+`bin/registry garbage-collect [--dry-run] [--delete-untagged] /path/to/config.yml`
 
 The garbage-collect command accepts a `--dry-run` parameter, which prints the progress
-of the mark and sweep phases without removing any data. Running with a log level of `info`
+of the mark and sweep phases without removing any data. If you need to clean up untagged manifests as well, you can run the command with `--delete-untagged` parameter. Running with a log level of `info`
 gives a clear indication of items eligible for deletion.
 
 The config.yml file should be in the following format:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Based on the pull request distribution/distribution#2302 there is a parameter for cleaning up untagged manifests available. In the original pull request it is called "-m" / "--delete-manifests", but in the current version of registry and it's garbage-collector, it's called "--delete-untagged" ([source](https://github.com/zetaab/distribution/blob/master/registry/root.go#L21)). Anyway, it was missing from the documentation so I thought it would be useful to add there.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
- Issue: https://github.com/distribution/distribution/issues/2301
- PR: https://github.com/distribution/distribution/pull/2302
