### PR TITLE
Clarify Advanced Wordpress section

### DIFF
--- a/engine/swarm/secrets.md
+++ b/engine/swarm/secrets.md
@@ -896,7 +896,7 @@ use it, then remove the old secret.
     ```
 
 4.  Update the `wordpress` service to use the new password, keeping the target
-    path at `/run/secrets/wp_db_secret` and keeping the file permissions at
+    path at `/run/secrets/wp_db_password` and keeping the file permissions at
     `0400`.  This triggers a rolling restart of the WordPress service and
     the new secret is used.
 


### PR DESCRIPTION
I believe this is the intended meaning, otherwise it is unclear where the name wp_db_secret is coming from when referenced as "keeping the same" by wp_db_password

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
