### PR TITLE
Fixed rootlesskit binary path, mention daemon restart

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -348,7 +348,7 @@ Add `net.ipv4.ping_group_range = 0   2147483647` to `/etc/sysctl.conf` (or
 To expose privileged ports (< 1024), set `CAP_NET_BIND_SERVICE` on `rootlesskit` binary and restart the daemon.
 
 ```console
-$ sudo setcap cap_net_bind_service=ep /usr/bin/rootlesskit
+$ sudo setcap cap_net_bind_service=ep $(which rootlesskit)
 $ systemctl --user restart docker
 ```
 

--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -345,10 +345,11 @@ Add `net.ipv4.ping_group_range = 0   2147483647` to `/etc/sysctl.conf` (or
 
 ### Exposing privileged ports
 
-To expose privileged ports (< 1024), set `CAP_NET_BIND_SERVICE` on `rootlesskit` binary.
+To expose privileged ports (< 1024), set `CAP_NET_BIND_SERVICE` on `rootlesskit` binary and restart the daemon.
 
 ```console
-$ sudo setcap cap_net_bind_service=ep $HOME/bin/rootlesskit
+$ sudo setcap cap_net_bind_service=ep /usr/bin/rootlesskit
+$ systemctl --user restart docker
 ```
 
 Or add `net.ipv4.ip_unprivileged_port_start=0` to `/etc/sysctl.conf` (or


### PR DESCRIPTION
Hi!

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The only rootlesskit binary file I could find on my system (Ubuntu 20.04) was at `/usr/bin/rootlesskit`. I suspect `$HOME/bin/rootlesskit` was correct in some older version of the `dockerd-rootless-setuptool.sh` script?

Also I mentioned that after setting the `CAP_NET_BIND_SERVICE` capability the docker daemon has to be restarted (at least this was the case in my tests).

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
None