### PR TITLE
Clarify which image architecture is run by default

### DIFF
--- a/desktop/multi-arch.md
+++ b/desktop/multi-arch.md
@@ -17,7 +17,7 @@ selects the image variant that matches your OS and architecture.
 Most of the Docker Official Images on Docker Hub provide a [variety of architectures](https://github.com/docker-library/official-images#architectures-other-than-amd64){: target="_blank" rel="noopener" class="_" }.
 For example, the `busybox` image supports `amd64`, `arm32v5`, `arm32v6`,
 `arm32v7`, `arm64v8`, `i386`, `ppc64le`, and `s390x`. When running this image
-on an `x86_64` / `amd64` machine, the `x86_64` variant is pulled and run.
+on an `x86_64` / `amd64` machine, the `amd64` variant is pulled and run.
 
 ## Multi-arch support on Docker Desktop
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Given the list of architectures supported by the busybox image, it's confusing to reference "the `x86_64` variant is pulled and run" when there's no platform architecture that matches that name. Instead, changing the documentation to reference `amd64` makes more sense as there is no `linux/x86_64` architecture that's supported by Docker (AFAIK), but there _is_ `linux/amd64`.

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
