### PR TITLE
Improve the Docker ID Accounts page

### DIFF
--- a/docker-id/index.md
+++ b/docker-id/index.md
@@ -1,6 +1,6 @@
 ---
 description: Sign up for a Docker ID and log in
-keywords: accounts, docker ID, billing, paid plans, support, Hub, Store, Forums, knowledge base, beta access
+keywords: accounts, docker ID, billing, paid plans, support, Hub, Store, Forums, knowledge base, beta access, email, activation, verification
 title: Docker ID accounts
 redirect_from:
 - /docker-cloud/dockerid/
@@ -11,11 +11,11 @@ Your free Docker ID grants you access to Docker Hub repositories and some beta p
 
 ## Register for a Docker ID
 
-Your Docker ID becomes your user namespace for hosted Docker services, and becomes your username on the Docker Forums. To create a new Docker ID:
+Your Docker ID becomes your user namespace for hosted Docker services, and becomes your username on the [Docker forums](https://forums.docker.com/). To create a new Docker ID:
 
 1. Go to the [Docker Hub signup page](https://hub.docker.com/signup/).
 
-2. Enter a username that is also your Docker ID.
+2. Enter a username that will become your Docker ID.
 
     Your Docker ID must be between 4 and 30 characters long, and can only contain numbers and lowercase letters.
 
@@ -29,12 +29,11 @@ Your Docker ID becomes your user namespace for hosted Docker services, and becom
 
 6. Verify your email address to complete the registration process.
 
-> **Note**: You cannot log in with your Docker ID until you verify your email address.
+> **Note**: You have limited actions available to you until until you verify your email address.
 
 ## Log in
 
-Once you register and verify your Docker ID email address, you can log in
-to [Docker Hub](https://hub.docker.com).
+Once you register and verify your Docker ID email address, you can log in to [Docker Hub](https://hub.docker.com).
 
 You can also log in through the CLI using the `docker login` command. For more information, see [`docker login`](../engine/reference/commandline/login.md).
 
@@ -42,5 +41,15 @@ You can also log in through the CLI using the `docker login` command. For more i
 > When you use the `docker login` command, your credentials are
 stored in your home directory in `.docker/config.json`. The password is base64-encoded in this file.
 >
-> For extra security, you can use a [personal access token](../docker-hub/access-tokens.md) to log in instead, which is still encoded in this file but doesn't allow admin actions (such as changing the password). If you require secure storage for this password or personal access token, use the [Docker credential helpers](https://github.com/docker/docker-credential-helpers).
+> We recommend using one of the [Docker credential helpers](https://github.com/docker/docker-credential-helpers) for secure storage of passwords. For extra security, you can also use a [personal access token](../docker-hub/access-tokens.md) to log in instead, which is still encoded in this file (without a Docker credential helper) but doesn't allow admin actions (such as changing the password).
 {:.warning}
+
+## Troubleshooting
+
+If you run into trouble with your Docker ID account, know that we are here to help!
+
+The most frequently asked questions regarding Docker ID accounts can be found on our [support troubleshooting FAQ](https://hub.docker.com/support/).
+
+The [Docker forums](https://forums.docker.com/) can be used in order to ask questions amongst other Docker customers while our [hub-feedback GitHub repository](https://github.com/docker/hub-feedback) allows you to provide feedback on how we can better improve the experience with Docker Hub.
+
+If all else fails and you still need help, we are eager to help you! [Create a support ticket](https://hub.docker.com/support/contact/)!

--- a/docker-id/index.md
+++ b/docker-id/index.md
@@ -29,7 +29,9 @@ Your Docker ID becomes your user namespace for hosted Docker services, and becom
 
 6. Verify your email address to complete the registration process.
 
-> **Note**: You have limited actions available to you until until you verify your email address.
+> **Note**
+>
+> You have limited actions available until you verify your email address.
 
 ## Log in
 

--- a/docker-id/index.md
+++ b/docker-id/index.md
@@ -52,6 +52,6 @@ If you run into trouble with your Docker ID account, know that we are here to he
 
 The most frequently asked questions regarding Docker ID accounts can be found on our [support troubleshooting FAQ](https://hub.docker.com/support/).
 
-The [Docker forums](https://forums.docker.com/) can be used in order to ask questions amongst other Docker customers while our [hub-feedback GitHub repository](https://github.com/docker/hub-feedback) allows you to provide feedback on how we can better improve the experience with Docker Hub.
+You can use the [Docker forums](https://forums.docker.com/) to ask questions amongst other Docker community members, while our [hub-feedback GitHub repository](https://github.com/docker/hub-feedback) allows you to provide feedback on how we can better improve the experience with Docker Hub.
 
 If all else fails and you still need help, we are eager to help you! [Create a support ticket](https://hub.docker.com/support/contact/)!

--- a/docker-id/index.md
+++ b/docker-id/index.md
@@ -54,4 +54,5 @@ The most frequently asked questions regarding Docker ID accounts can be found on
 
 You can use the [Docker forums](https://forums.docker.com/) to ask questions amongst other Docker community members, while our [hub-feedback GitHub repository](https://github.com/docker/hub-feedback) allows you to provide feedback on how we can better improve the experience with Docker Hub.
 
-If all else fails and you still need help, we are eager to help you! [Create a support ticket](https://hub.docker.com/support/contact/)!
+If you still need any help, [create a support ticket](https://hub.docker.com/support/contact/) and let us know how we can help you.
+


### PR DESCRIPTION
Signed-off-by: Alex Hokanson <571756+ingshtrom@users.noreply.github.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

After testing and responding to [this Hub Feedback issue](https://github.com/docker/hub-feedback/issues/631#issuecomment-993582213), I realized that finding the information customers need in order to trouble shoot their registry woes is not readily available. I also updated the facts surrounding when a user can log in and when they cannot (we used to not allow log in on Docker Hub until email verification was complete, but that has changed).

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

https://github.com/docker/hub-feedback/issues/631
