### PR TITLE
Add ipv6 switch to network creation

### DIFF
--- a/network/ipvlan.md
+++ b/network/ipvlan.md
@@ -388,7 +388,7 @@ unless the upstream network is explicitly routing it on VLAN `139`.
 ```console
 # Create a v6 network
 $ docker network create -d ipvlan \
-    --subnet=2001:db8:abc2::/64 --gateway=2001:db8:abc2::22 \
+    --ipv6 --subnet=2001:db8:abc2::/64 --gateway=2001:db8:abc2::22 \
     -o parent=eth0.139 v6ipvlan139
     
 # Start a container on the network


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add the `--ipv6` switch to the first example in the "Dual stack IPv4 IPv6 IPvlan L2 mode"
section. WIthout that, the created network has the property EnableIPv6 set to false and the
example wouldn't work properly.
