### PR TITLE
add Deprecated warning to --log-level argument

### DIFF
--- a/compose/reference/index.md
+++ b/compose/reference/index.md
@@ -28,7 +28,7 @@ Options:
                               (default: directory name)
   --profile NAME              Specify a profile to enable
   --verbose                   Show more output
-  --log-level LEVEL           Set log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+  --log-level LEVEL           DEPRECATED and not working from 2.0 - Set log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
   --no-ansi                   Do not print ANSI control characters
   -v, --version               Print version and exit
   -H, --host HOST             Daemon socket to connect to


### PR DESCRIPTION
see https://github.com/docker/compose-cli/issues/1891

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add a warning that `--log-level` on `docker-compose` is deprecated and removed from 2.0 on.
Because it was not available for my updated docker-compose anymore, but our Admin pointed just to this documentation and said it should work.

There is likely a better way to describe it, but its likely removed completely from here anyway, as soon as the 1.x version is not supported anymore.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
https://github.com/docker/compose-cli/issues/1891
https://github.com/docker/compose-cli/pull/1978
