### PR TITLE
Include the `vscode` explanation in dev envs

### DIFF
--- a/desktop/dev-environments.md
+++ b/desktop/dev-environments.md
@@ -258,10 +258,13 @@ Next, you have to define the dependencies you want to include in your `Dockerfil
 While any images or Dockerfiles will include a non-root user with a UID/GID of `1000`, many base images and Dockerfiles do not. Fortunately, you can add a non-root user named `vscode`. If you were to include the Docker tooling (e.g. `docker` cli, `docker compose`, etc.) in the `Dockerfile.devenv`, you would need the `vscode` user to be included in the `docker` group. Finally, remember to set `sleep infinity` in the entrypoint to keep the dev container running indefinitely.
 
 ```dockerfile
+# syntax=docker/dockerfile:1
+
 FROM <your base image>
 
-RUN useradd -s /bin/bash -m vscode
-RUN groupadd docker && usermod -aG docker vscode
+RUN useradd -s /bin/bash -m vscode \
+ && groupadd docker \
+ && usermod -aG docker vscode
 
 USER vscode
 

--- a/desktop/dev-environments.md
+++ b/desktop/dev-environments.md
@@ -267,8 +267,6 @@ RUN useradd -s /bin/bash -m vscode \
  && usermod -aG docker vscode
 
 USER vscode
-
-ENTRYPOINT ["sleep", "infinity"]
 ```
 
 ## Specify a base image

--- a/desktop/dev-environments.md
+++ b/desktop/dev-environments.md
@@ -255,7 +255,7 @@ In this preview, Dev Environments support a JSON file which allows you to specif
 
 Next, you have to define the dependencies you want to include in your `Dockerfile.devenv`, alongside the following requisites:
 
-While some images or Dockerfiles will include a non-root user, many base images and Dockerfiles do not. Fortunately, you can add a non-root user named `vscode`. If you were to include the Docker tooling (e.g. `docker` cli, `docker compose`, etc.) in the `Dockerfile.devenv`, you would need the `vscode` user to be included in the `docker` group. Finally, remember to set `sleep infinity` in the entrypoint to keep the dev container running indefinitely.
+While some images or Dockerfiles will include a non-root user, many base images and Dockerfiles do not. Fortunately, you can add a non-root user named `vscode`. If you were to include the Docker tooling (e.g. `docker` cli, `docker compose`, etc.) in the `Dockerfile.devenv`, you would need the `vscode` user to be included in the `docker` group.
 
 ```dockerfile
 # syntax=docker/dockerfile:1

--- a/desktop/dev-environments.md
+++ b/desktop/dev-environments.md
@@ -255,7 +255,7 @@ In this preview, Dev Environments support a JSON file which allows you to specif
 
 Next, you have to define the dependencies you want to include in your `Dockerfile.devenv`, alongside the following requisites:
 
-While any images or Dockerfiles will include a non-root user with a UID/GID of `1000`, many base images and Dockerfiles do not. Fortunately, you can add a non-root user named `vscode`. If you were to include the Docker tooling (e.g. `docker` cli, `docker compose`, etc.) in the `Dockerfile.devenv`, you would need the `vscode` user to be included in the `docker` group. Finally, remember to set `sleep infinity` in the entrypoint to keep the dev container running indefinitely.
+While some images or Dockerfiles will include a non-root user, many base images and Dockerfiles do not. Fortunately, you can add a non-root user named `vscode`. If you were to include the Docker tooling (e.g. `docker` cli, `docker compose`, etc.) in the `Dockerfile.devenv`, you would need the `vscode` user to be included in the `docker` group. Finally, remember to set `sleep infinity` in the entrypoint to keep the dev container running indefinitely.
 
 ```dockerfile
 # syntax=docker/dockerfile:1

--- a/desktop/dev-environments.md
+++ b/desktop/dev-environments.md
@@ -253,6 +253,21 @@ In this preview, Dev Environments support a JSON file which allows you to specif
 }
 ```
 
+Next, you have to define the dependencies you want to include in your `Dockerfile.devenv`, alongside the following requisites:
+
+While any images or Dockerfiles will include a non-root user with a UID/GID of `1000`, many base images and Dockerfiles do not. Fortunately, you can add a non-root user named `vscode`. If you were to include the Docker tooling (e.g. `docker` cli, `docker compose`, etc.) in the `Dockerfile.devenv`, you would need the `vscode` user to be included in the `docker` group. Finally, remember to set `sleep infinity` in the entrypoint to keep the dev container running indefinitely.
+
+```Dockerfile
+FROM <your base image>
+
+RUN useradd -s /bin/bash -m vscode
+RUN groupadd docker && usermod -aG docker vscode
+
+USER vscode
+
+ENTRYPOINT ["sleep", "infinity"]
+```
+
 ## Specify a base image
 
 If you already have an image built, you can specify it as a base image to define your Dev Environment. You must include this as part of the `.docker` folder and then add it as a `config.json` file. For example, to use the Jekyll base image, add:

--- a/desktop/dev-environments.md
+++ b/desktop/dev-environments.md
@@ -257,7 +257,7 @@ Next, you have to define the dependencies you want to include in your `Dockerfil
 
 While any images or Dockerfiles will include a non-root user with a UID/GID of `1000`, many base images and Dockerfiles do not. Fortunately, you can add a non-root user named `vscode`. If you were to include the Docker tooling (e.g. `docker` cli, `docker compose`, etc.) in the `Dockerfile.devenv`, you would need the `vscode` user to be included in the `docker` group. Finally, remember to set `sleep infinity` in the entrypoint to keep the dev container running indefinitely.
 
-```Dockerfile
+```dockerfile
 FROM <your base image>
 
 RUN useradd -s /bin/bash -m vscode


### PR DESCRIPTION
### Proposed changes

Update docs to include the `vscode` user in the Dockerfile section.

/cc @glours @rumpl @gtardif @chris-crone 