### PR TITLE
add upgrade CTA and warning about feature availability to all Automated Builds pages

### DIFF
--- a/docker-hub/builds/advanced.md
+++ b/docker-hub/builds/advanced.md
@@ -6,6 +6,12 @@ redirect_from:
 - /docker-cloud/builds/advanced/
 ---
 
+{% include upgrade-cta.html
+  body="The Automated Builds feature is available for Docker Pro, Team, and Business users. Upgrade now to automatically build and push your images. If you are using automated builds for an open-source project, you can join our [Open Source Community](https://www.docker.com/community/open-source/application){: target='_blank' rel='noopener' class='_'} program to learn how Docker can support your project on Docker Hub."
+  header-text="This feature requires a Docker subscription"
+  target-url="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade_auto_builds"
+%}
+
 The following options allow you to customize your automated build and automated
 test processes.
 

--- a/docker-hub/builds/automated-testing.md
+++ b/docker-hub/builds/automated-testing.md
@@ -7,6 +7,12 @@ redirect_from:
 title: Automated repository tests
 ---
 
+{% include upgrade-cta.html
+  body="The Automated Builds feature is available for Docker Pro, Team, and Business users. Upgrade now to automatically build and push your images. If you are using automated builds for an open-source project, you can join our [Open Source Community](https://www.docker.com/community/open-source/application){: target='_blank' rel='noopener' class='_'} program to learn how Docker can support your project on Docker Hub."
+  header-text="This feature requires a Docker subscription"
+  target-url="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade_auto_builds"
+%}
+
 Docker Hub can automatically test changes to your source code repositories
 using containers. You can enable `Autotest` on [any Docker Hub repository](../repos.md)
 to run tests on each pull request to the source code repository to create a

--- a/docker-hub/builds/link-source.md
+++ b/docker-hub/builds/link-source.md
@@ -8,6 +8,12 @@ redirect_from:
 - /docker-cloud/builds/link-source/
 ---
 
+{% include upgrade-cta.html
+  body="The Automated Builds feature is available for Docker Pro, Team, and Business users. Upgrade now to automatically build and push your images. If you are using automated builds for an open-source project, you can join our [Open Source Community](https://www.docker.com/community/open-source/application){: target='_blank' rel='noopener' class='_'} program to learn how Docker can support your project on Docker Hub."
+  header-text="This feature requires a Docker subscription"
+  target-url="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade_auto_builds"
+%}
+
 To automate building and testing of your images, you link to your hosted source
 code service to Docker Hub so that it can access your source code
 repositories. You can configure this link for user accounts or


### PR DESCRIPTION
Signed-off-by: Alex Hokanson <571756+ingshtrom@users.noreply.github.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

After looking at [this issue](https://github.com/docker/hub-feedback/issues/2185) I realized that
maybe adding this Upgrade CTA with the warning of Automated Build availability to plans will make it
clearer so that future customers do not think they can configure these settings without one of the
paid plans.

Alternatively, maybe the Hub UI should include the "Linked Accounts" section in the settings no
matter what, but provide an upgrade CTA there instead of putting it on all of the docs pages
🤔

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

- https://github.com/docker/hub-feedback/issues/2185
