### PR TITLE
Fix bridge example

### DIFF
--- a/network/bridge.md
+++ b/network/bridge.md
@@ -219,11 +219,11 @@ the settings you need to customize.
 
 ```json
 {
-  "bip": "192.168.1.5/24",
-  "fixed-cidr": "192.168.1.5/25",
+  "bip": "192.168.1.1/24",
+  "fixed-cidr": "192.168.1.0/25",
   "fixed-cidr-v6": "2001:db8::/64",
   "mtu": 1500,
-  "default-gateway": "10.20.1.1",
+  "default-gateway": "192.168.1.254",
   "default-gateway-v6": "2001:db8:abcd::89",
   "dns": ["10.20.1.2","10.20.1.3"]
 }


### PR DESCRIPTION
### Proposed changes

Fix bridge example in docs

### Related issues (optional)

This is a followup of #6891


`default-gateway` must be included inside the `bip` network, otherwise restarting docker gives:

    dockerd: failed to start daemon: Error initializing network controller: Error creating default "bridge" network: auxiliary address: (DefaultGatewayIPv4:10.20.1.1) must belong to the master pool: 192.168.1.0/24


I moved `bip` to be the 1st address  (.1), and `default-gateway` to be the last one (.254).

I also changed `fixed-cidr` to .0/25 instead of .5/25, as I think this makes more sense: the fixed network is the first 128 addresses of the network (0-127).