### PR TITLE
Remove inconsistent space in Python example [trivial]

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -87,7 +87,7 @@ def hello_world():
   return 'Hello, Docker!'
 
 @app.route('/widgets')
-def get_widgets() :
+def get_widgets():
   mydb = mysql.connector.connect(
     host="mysqldb",
     user="root",


### PR DESCRIPTION
Inconsequential and trivial change to ensure code in tutorial is consistently styled.


### Proposed changes

Remove a space. PEP8, consistency, etc...