### PR TITLE
Fix typo on PGDATABASE environment variable

### DIFF
--- a/language/golang/develop.md
+++ b/language/golang/develop.md
@@ -548,7 +548,7 @@ services:
       - PGPASSWORD=${PGPASSWORD:?database password not set}
       - PGHOST=${PGHOST:-db}
       - PGPORT=${PGPORT:-26257}
-      - PGDATABASE=${PGDATABASE-mydb}
+      - PGDATABASE=${PGDATABASE:-mydb}
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
Add colon on PGDATABASE

### Proposed changes

- Page: https://docs.docker.com/language/golang/develop/

Colon is missed for assigning default value on enviroment varilab.
