### PR TITLE
ADD env variables to db container

### DIFF
--- a/samples/django.md
+++ b/samples/django.md
@@ -75,6 +75,10 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
        image: postgres
        volumes:
          - ./data/db:/var/lib/postgresql/data
+       environment:
+         - POSTGRES_NAME=postgres
+         - POSTGRES_USER=postgres
+         - POSTGRES_PASSWORD=postgres
      web:
        build: .
        command: python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION

### Proposed changes

Closely following the current docker-compose django tutorial, will generate this error : 

FIX Error: Database is uninitialized and superuser password is not specified.

Indeed, postgres docker image documentation states :
"(POSTGRES_PASSWORD) This environment variable is required for you to use the PostgreSQL image. It must not be empty or undefined."
https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_password

Env variables needs to be defined in both the "db" and "web" containers 
In "db", so it can create the default user/password from it
In "web", so it can be used in settings.py to connect django to the postgres container

I suggest to add the env vars to the "db" container, solves the issue

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
