### PR TITLE
Updates Step 9 `docker inspect` commands in Copy-on-write strategy section of About storage drivers page

### DIFF
--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -339,7 +339,7 @@ layers are the same.
 
     {% raw %}
     ```console
-    $ docker image inspect --format "{{json .RootFS.Layers}}" acme/my-final-image:1.0
+    $ docker image inspect --format "{{json .RootFS.Layers}}" acme/my-base-image:1.0
     [
       "sha256:72e830a4dff5f0d5225cdc0a320e85ab1ce06ea5673acfe8d83a7645cbd0e9cf",
       "sha256:07b4a9068b6af337e8b8f1f1dae3dd14185b2c0003a9a1f0a6fd2587495b204a"
@@ -349,7 +349,7 @@ layers are the same.
 
     {% raw %}
     ```console
-    $ docker image inspect --format "{{json .RootFS.Layers}}" acme/my-base-image:1.0
+    $ docker image inspect --format "{{json .RootFS.Layers}}" acme/my-final-image:1.0
     [
       "sha256:72e830a4dff5f0d5225cdc0a320e85ab1ce06ea5673acfe8d83a7645cbd0e9cf",
       "sha256:07b4a9068b6af337e8b8f1f1dae3dd14185b2c0003a9a1f0a6fd2587495b204a",


### PR DESCRIPTION
There is an error in the example commands of Step 9 in the copy on write strategy section of the [About storage drivers](https://docs.docker.com/storage/storagedriver/#the-copy-on-write-cow-strategy) page. The first command should reference the `acme/my-base-image:1.0` image and the second command should reference the `acme/my-final-image:1.0`.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
