### PR TITLE
mysql volume path is not correct

### DIFF
--- a/get-started/08_using_compose.md
+++ b/get-started/08_using_compose.md
@@ -259,7 +259,7 @@ services:
   mysql:
     image: mysql:5.7
     volumes:
-      - todo-mysql-data:/var/lib/mysql
+      - todo-mysql-data:/etc/todos
     environment:
       MYSQL_ROOT_PASSWORD: secret
       MYSQL_DATABASE: todos


### PR DESCRIPTION
Path should be like below:
/etc/todos

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
