### PR TITLE
Update 02_our_app.md: Fix copy command

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -47,7 +47,7 @@ see a few flaws in the Dockerfile below. But, don't worry. We'll go over them.
    FROM node:12-alpine
    RUN apk add --no-cache python2 g++ make
    WORKDIR /app
-   COPY . .
+   COPY . /
    RUN yarn install --production
    CMD ["node", "src/index.js"]
    ```


### PR DESCRIPTION
Running `Copy .  .` leads to a file not found error because the files are copied to the wrong path(see the image attached). 


<img width="681" alt="Screenshot 2022-01-10 at 07 41 48" src="https://user-images.githubusercontent.com/32474285/148726909-7224b607-28c5-48a9-9105-79bec31d77b7.png">

Running `Copy .  /` fixes this. 
