### PR TITLE
Fix URL of automatic Compose Switch installation script

### DIFF
--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -104,7 +104,7 @@ from the [project release page](https://github.com/docker/compose/releases){:tar
 To install Compose Switch automatically, run:
 
 ```console
-$ curl -fL https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
+$ curl -fL https://raw.githubusercontent.com/docker/compose-switch/master/install_on_linux.sh | sh
 ```
 
 To install Compose Switch manually:


### PR DESCRIPTION
### Proposed changes

Fixes the URL of the automatic Compose Switch installation script, which linked to the one of Compose CLI instead.