### PR TITLE
Update rhel.md

### DIFF
--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -82,7 +82,7 @@ from the repository.
 
 #### Set up the repository
 
-{% assign download-url-base = "https://download.docker.com/linux/rhel" %}
+{% assign download-url-base = "https://download.docker.com/linux/centos" %}
 
 Install the `yum-utils` package (which provides the `yum-config-manager`
 utility) and set up the **stable** repository.


### PR DESCRIPTION
The dockerrepo only provides "centos" (not rhel) as distribution. 

So the url must like `https://download.docker.com/linux/centos/docker-ce.repo`

More: https://access.redhat.com/discussions/6249651