### PR TITLE
go/buildx redirect

### DIFF
--- a/buildx/working-with-buildx.md
+++ b/buildx/working-with-buildx.md
@@ -14,24 +14,66 @@ multiple nodes concurrently.
 
 ## Install
 
-Docker Buildx is included in Docker Desktop and Docker Linux packages when
-installed using the [DEB or RPM packages](../engine/install/index.md).
+### Windows and macOS
 
-You can also download the latest `buildx` binary from the
-[Docker buildx](https://github.com/docker/buildx/releases/latest){:target="_blank" rel="noopener" class="_"} releases page
-on GitHub, copy it to `~/.docker/cli-plugins` folder with name
-`docker-buildx` and change the permission to execute:
+Docker Buildx is included in [Docker Desktop](../desktop/index.md) for Windows
+and macOS.
 
-```console
-$ chmod a+x ~/.docker/cli-plugins/docker-buildx
-```
+### Linux packages
 
-Here is how to use buildx inside a Dockerfile through the
+Docker Linux packages also include Docker Buildx when installed using the
+[DEB or RPM packages](../engine/install/index.md).
+
+### Manual download
+
+> **Important**
+>
+> This section is for unattended installation of the buildx component. These
+> instructions are mostly suitable for testing purposes. We do not recommend
+> installing buildx using manual download in production environments as they
+> will not be updated automatically with security updates.
+>
+> On Windows and macOS, we recommend that you install [Docker Desktop](../desktop/index.md)
+> instead. For Linux, we recommend that you follow the [instructions specific for your distribution](#linux-packages).
+{: .important}
+
+You can also download the latest binary from the [releases page on GitHub](https://github.com/docker/buildx/releases/latest){:target="_blank" rel="noopener" class="_"}.
+
+Rename the relevant binary and copy it to the destination matching your OS:
+
+| OS       | Binary name          | Destination folder                       |
+| -------- | -------------------- | -----------------------------------------|
+| Linux    | `docker-buildx`      | `$HOME/.docker/cli-plugins`              |
+| macOS    | `docker-buildx`      | `$HOME/.docker/cli-plugins`              |
+| Windows  | `docker-buildx.exe`  | `%USERPROFILE%\.docker\cli-plugin`       |
+
+Or copy it into one of these folders for installing it system-wide.
+
+On Unix environments:
+
+* `/usr/local/lib/docker/cli-plugins` OR `/usr/local/libexec/docker/cli-plugins`
+* `/usr/lib/docker/cli-plugins` OR `/usr/libexec/docker/cli-plugins`
+
+On Windows:
+
+* `C:\ProgramData\Docker\cli-plugins`
+* `C:\Program Files\Docker\cli-plugins`
+
+> **Note**
+> 
+> On Unix environments, it may also be necessary to make it executable with `chmod +x`:
+> ```shell
+> $ chmod +x ~/.docker/cli-plugins/docker-buildx
+> ```
+
+### Dockerfile
+
+Here is how to install and use Buildx inside a Dockerfile through the
 [`docker/buildx-bin`](https://hub.docker.com/r/docker/buildx-bin) image:
 
 ```dockerfile
 FROM docker
-COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 RUN docker buildx version
 ```
 

--- a/go/buildx.md
+++ b/go/buildx.md
@@ -1,0 +1,6 @@
+---
+title: How to install Buildx
+description: Instructions on installing Buildx
+keywords: Docker, buildx, multi-arch
+redirect_to: /buildx/working-with-buildx/#install
+---


### PR DESCRIPTION
This URL will used in https://github.com/docker/cli/pull/3314 to direct users to instructions on installing buildx. Maybe `go/buildx-install` would be better?

The last commit updates the install instructions for buildx (will also be changed upstream on buildx repo). Atm the instructions for `Manual download` redirect to the GitHub releases page but in the future we might change that to use our `download.docker.com` front. See https://github.com/docker/docker-ce-packaging/issues/618.

cc @chris-crone @tonistiigi @thaJeztah @errordeveloper