### PR TITLE
FIX broken download links

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -98,7 +98,7 @@ on Microsoft Windows Server and want to install Docker Compose.
     Compose (v{{site.compose_version}}):
 
     ```powershell
-    Invoke-WebRequest "https://github.com/docker/compose/releases/download/v{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\Docker\docker-compose.exe
+    Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\Docker\docker-compose.exe
     ```
 
 **Note**: On Windows Server 2019, you can add the Compose executable to `$Env:ProgramFiles\Docker`. Because this directory is  registered in the system `PATH`, you can run the `docker-compose --version` command on the subsequent step with no additional configuration.
@@ -132,7 +132,7 @@ also included below.
 1.  Run this command to download the current stable release of Docker Compose:
 
     ```console
-    $ sudo curl -L "https://github.com/docker/compose/releases/download/v{{site.compose_version}}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    $ sudo curl -L "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     ```
 
     > To install a different version of Compose, substitute `{{site.compose_version}}`


### PR DESCRIPTION
### Proposed changes

Fix docker-compose download links for Windows server and Linux installation
The "v" in front of {{site.compose_version}} must be removed

Download links for windows server :

Broken (current) link -> 404  :
https://github.com/docker/compose/releases/download/v1.29.2/docker-compose-Windows-x86_64.exe

Repaired link :
https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Windows-x86_64.exe

The same applies to Linux install download link