### PR TITLE
Fix formatting of notification HTTP request

### DIFF
--- a/registry/notifications.md
+++ b/registry/notifications.md
@@ -159,7 +159,7 @@ request coming to an endpoint.
 
 An example of a full event may look as follows:
 
-```http request
+```http
 GET /callback HTTP/1.1
 Host: application/vnd.docker.distribution.events.v1+json
 Authorization: Bearer <your token, if needed>


### PR DESCRIPTION


### Proposed changes

Fix formatting of notification HTTP request.
The syntax highlighting hint was wrong, which prevented the snippet from rendering with the correct highlighting.

#### Before:

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/2944/149808310-0bb51c3d-9b19-4e9c-9b61-3472539ec5f5.png">

#### After:

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/2944/149808353-9e8aad07-60bb-41b1-bb5f-1d9210f6e58e.png">