### PR TITLE
Update working-with-buildx.md to mention QEMU must be statically compiled to work with binfmt_misc

### DIFF
--- a/buildx/working-with-buildx.md
+++ b/buildx/working-with-buildx.md
@@ -184,8 +184,8 @@ it automatically loads it through a binary registered in the `binfmt_misc`
 handler.
 
 For QEMU binaries registered with `binfmt_misc` on the host OS to work
-transparently inside containers they must be registered with the `fix_binary`
-flag and QEMU must be staticaly compiled. This requires a kernel >= 4.8 and binfmt-support >= 2.1.7. You can check
+transparently inside containers they must be statically compiled and registered with the the `fix_binary`. 
+This requires a kernel >= 4.8 and binfmt-support >= 2.1.7. You can check
 for proper registration by checking if `F` is among the flags in
 `/proc/sys/fs/binfmt_misc/qemu-*`. While Docker Desktop comes preconfigured
 with `binfmt_misc` support for additional platforms, for other installations

--- a/buildx/working-with-buildx.md
+++ b/buildx/working-with-buildx.md
@@ -185,7 +185,7 @@ handler.
 
 For QEMU binaries registered with `binfmt_misc` on the host OS to work
 transparently inside containers they must be registered with the `fix_binary`
-flag. This requires a kernel >= 4.8 and binfmt-support >= 2.1.7. You can check
+flag and QEMU must be staticaly compiled. This requires a kernel >= 4.8 and binfmt-support >= 2.1.7. You can check
 for proper registration by checking if `F` is among the flags in
 `/proc/sys/fs/binfmt_misc/qemu-*`. While Docker Desktop comes preconfigured
 with `binfmt_misc` support for additional platforms, for other installations

--- a/buildx/working-with-buildx.md
+++ b/buildx/working-with-buildx.md
@@ -184,7 +184,7 @@ it automatically loads it through a binary registered in the `binfmt_misc`
 handler.
 
 For QEMU binaries registered with `binfmt_misc` on the host OS to work
-transparently inside containers they must be statically compiled and registered with the the `fix_binary`. 
+transparently inside containers, they must be statically compiled and registered with the `fix_binary` flag. 
 This requires a kernel >= 4.8 and binfmt-support >= 2.1.7. You can check
 for proper registration by checking if `F` is among the flags in
 `/proc/sys/fs/binfmt_misc/qemu-*`. While Docker Desktop comes preconfigured


### PR DESCRIPTION
The current wording is a little misleading on QEMU and binfmt_misc.  This is a problem Ubuntu and, maybe, other distributions.

### Proposed changes

> For QEMU binaries registered with `binfmt_misc` on the host OS to work transparently inside containers they must be registered with the `fix_binary` flag.  This requires a kernel >= 4.8 and binfmt-support >= 2.1.7. You can check for proper registration by checking if `F` is among the flags in `/proc/sys/fs/binfmt_misc/qemu-*`.

This implies that setting the fix_binary flag on otherwise installed QEMU & binfmt_misc will work; it probably wont. 

Eg installing Ubuntu packages `qemu-user` `qemu-user-binfmt` will install dynamically linked QEMU and binfmt_misc entries without the `F` flag.  Manually adding `F` to the flags will break because `F` (fix_binary) is incompatible with dynamically linked binaries.  (Referenced in [this Redhat issue](https://bugzilla.redhat.com/show_bug.cgi?id=1470397))  It actually results in really hard to diagnose "No such file or directory" errors.  Instead you must install the ubuntu package `qemu-user-static`.

Obviously this page can't document every distribution so I'm not going to recommend describing how to do it under Ubuntu.  My suggestion is to simply state that QEMU must be statically compiled.  At least this gives readers a chance to figure it out.


