### PR TITLE
Update protect-access.md with remote host Docker version requirement

### DIFF
--- a/engine/security/protect-access.md
+++ b/engine/security/protect-access.md
@@ -18,6 +18,8 @@ optionally communicate using SSH or a TLS (HTTPS) socket.
 > The given `USERNAME` must have permissions to access the docker socket on the
 > remote machine. Refer to [manage Docker as a non-root user](../install/linux-postinstall.md#manage-docker-as-a-non-root-user)
 > to learn how to give a non-root user access to the docker socket.
+> 
+> The remote host requires Docker 18.09 or higher to be installed.
 
 The following example creates a [`docker context`](../context/working-with-contexts.md)
 to connect with a remote `dockerd` daemon on `host1.example.com` using SSH, and


### PR DESCRIPTION
### Proposed changes

Update docs, expanding the note to include the minimum Docker version
that needs to be installed on the remote host.

This makes the existing error message more transparent:
>please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host
