### PR TITLE
Fix x-aws-keys field name

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -370,7 +370,7 @@ services:
 secrets:
   foo:
     name: "arn:aws:secretsmanager:eu-west-3:1234:secret:foo-ABC123"
-    keys:
+    x-aws-keys:
       - "bar"
 ```
 


### PR DESCRIPTION
The current compose-cli documentation suggests listing SecretsManager secret JSON keys in a `keys` field, but this is not correct.
The correct field is `x-aws-keys`.

The `keys` field as written is not supported by the [compose spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md), and attempting most `docker compose` commands would result in failure if one named the field as written.

### Proposed changes

Replace the incorrect `keys` field with `x-aws-keys`.
