### PR TITLE
Add a link to Compose 2.0 install on Linux

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -136,7 +136,9 @@ also included below.
     ```
 
     > To install a different version of Compose, substitute `{{site.compose_version}}`
-    > with the version of Compose you want to use.
+    > with the version of Compose you want to use. For instructions on how to
+    > install Compose `{{site.compose_v2_version}}` on Linux, see [Install
+    > Compose 2.0.0 on Linux](../cli-command#install-on-linux)
 
     If you have problems installing with `curl`, see
     [Alternative Install Options](install.md#alternative-install-options) tab above.
@@ -146,8 +148,10 @@ also included below.
     ```console
     $ sudo chmod +x /usr/local/bin/docker-compose
     ```
-    
-> **Note**: If the command `docker-compose` fails after installation, check your path.
+
+> **Note**:
+>
+> If the command `docker-compose` fails after installation, check your path.
 > You can also create a symbolic link to `/usr/bin` or any other directory in your path.
 
 For example:


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Add a link to the Compose 2.0.0 Linux install instructions from the Compose Install docs. Looks like users are skipping info about Linux install instructions for Compose 2.0.0. Adding a link from the Linux section within the main Compose install topic for emphasis. 
