### PR TITLE
Changed log-opt to log-opts

### DIFF
--- a/config/containers/logging/journald.md
+++ b/config/containers/logging/journald.md
@@ -26,7 +26,7 @@ stores the following metadata in the journal with each message:
 ## Usage
 
 To use the `journald` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
+and `log-opts` keys to appropriate values in the `daemon.json` file, which is
 located in `/etc/docker/` on Linux hosts or
 `C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
 configuring Docker using `daemon.json`, see


### PR DESCRIPTION
### Proposed changes

Changed text `log-opt` to `log-opts` because this is how the JSON key must be named in `daemon.json`. `log-opt` is wrong and using it leads docker to fail with its starting routine.
