### PR TITLE
DD 4.4.x release notes: Add scan cli plugin 0.16.0 version bump

### DIFF
--- a/desktop/mac/release-notes/index.md
+++ b/desktop/mac/release-notes/index.md
@@ -51,6 +51,7 @@ This only affects users if they are on Docker Desktop 4.3.0, 4.3.1 and the user 
 - [Docker Engine v20.10.12](https://docs.docker.com/engine/release-notes/#201012)
 - [Compose v2.2.3](https://github.com/docker/compose/releases/tag/v2.2.3)
 - [Kubernetes 1.22.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.22.5)
+- [docker scan v0.16.0](https://github.com/docker/scan-cli-plugin/releases/tag/v0.16.0){: target="_blank" rel="noopener" class="_"}
 
 ### Bug fixes and minor changes
 

--- a/desktop/windows/release-notes/index.md
+++ b/desktop/windows/release-notes/index.md
@@ -88,6 +88,7 @@ This only affects users if they are on Docker Desktop 4.3.0, 4.3.1 and the user 
 - [Docker Engine v20.10.12](https://docs.docker.com/engine/release-notes/#201012)
 - [Compose v2.2.3](https://github.com/docker/compose/releases/tag/v2.2.3)
 - [Kubernetes 1.22.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.22.5)
+- [docker scan v0.16.0](https://github.com/docker/scan-cli-plugin/releases/tag/v0.16.0){: target="_blank" rel="noopener" class="_"}
 
 ### Bug fixes and minor changes
 


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

In the release notes for Docker Desktop 4.4.2 we missed to mention the version bump for the docker scan cli plugin to version 0.16.0.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
