### PR TITLE
ASP.NET Core does not run on .NET Framework

### DIFF
--- a/samples/dotnetcore.md
+++ b/samples/dotnetcore.md
@@ -17,8 +17,6 @@ This example demonstrates how to dockerize an ASP.NET Core application.
   Linux
 - Great for modern cloud-based apps, such as web apps, IoT apps, and mobile
   backends
-- ASP.NET Core apps can run on [.NET Core](https://www.microsoft.com/net/core/platform)
-  or on the full [.NET Framework](https://www.microsoft.com/net/framework)
 - Designed to provide an optimized development framework for apps that are
   deployed to the cloud or run on-premises
 - Modular components with minimal overhead retain flexibility while


### PR DESCRIPTION
ASP.NET Core is almost a complete rewrite and an ASP.NET Core app does not run on .NET Framework. See e.g. https://docs.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core?view=aspnetcore-6.0#why-choose-aspnet-core.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
