### PR TITLE
Ammend PAT setup section in Go language guide

### DIFF
--- a/language/golang/configure-ci-cd.md
+++ b/language/golang/configure-ci-cd.md
@@ -27,6 +27,32 @@ Let’s get started. This guide uses a simple Go project as an example. In fact,
 
 Thus, as long as you have a GitHub repo with a project and a `Dockerfile`, you can complete this part of the tutorial.
 
+## Enable access to Docker Hub
+
+The [Docker Hub](https://hub.docker.com/) is a hosted repository service provided by Docker for finding and sharing container images.
+
+Before we can publish our Docker image to Docker Hub, we must grant GitHub Actions access to Docker Hub API.
+
+To set up the access to Docker Hub API:
+
+1. Create a new Personal Access Token (PAT) for Docker Hub. 
+
+    * Go to the [Docker Hub Account Settings](https://hub.docker.com/settings/security) and then click **New Access Token**.
+    * Let's call this token `docker-gs-ping-ci`. Input the name and click **Create**.
+    * Copy the token value, we'll need it in a second.
+
+2. Add your Docker ID and PAT as secrets to your GitHub repo.
+
+    * Navigate to your GitHub repository and click **Settings** > **Secrets** > **New secret**.
+    * Create a new secret with the name `DOCKER_HUB_USERNAME` and your Docker ID as value.
+    * Create a new secret with the name `DOCKER_HUB_ACCESS_TOKEN` and use the token value from the step (1).
+
+Your GitHub repository **Secrets** section would look like the following.
+
+![GitHub Secrets](../../ci-cd/images/github-secrets.png){:width="500px"}
+
+Now it will be possible to refer to these two variables from our workflows. This will open up an opportunity to publish our image to Docker Hub.
+
 ## Set up the CI workflow
 
 In the previous section, we created a PAT and added it to GitHub to ensure we can access Docker Hub from any GitHub Actions workflow. But before setting out to build the images for releasing our software, let's build a CI pipeline to run the tests first.
@@ -119,32 +145,6 @@ Select **Actions** from the navigation bar for your repository. Since we've enab
 ![GitHub Secrets](images/runworkflow.png){:width="500px"}
 
 Should the run fail, you can click on the failing entry to see the logs and amend the workflow YAML file accordingly.
-
-## Enable access to Docker Hub
-
-The [Docker Hub](https://hub.docker.com/) is a hosted repository service provided by Docker for finding and sharing container images.
-
-Before we can publish our Docker image to Docker Hub, we must grant GitHub Actions access to Docker Hub API.
-
-To set up the access to Docker Hub API:
-
-1. Create a new Personal Access Token (PAT) for Docker Hub. 
-
-    * Go to the [Docker Hub Account Settings](https://hub.docker.com/settings/security) and then click **New Access Token**.
-    * Let's call this token `docker-gs-ping-ci`. Input the name and click **Create**.
-    * Copy the token value, we'll need it in a second.
-
-2. Add your Docker ID and PAT as secrets to your GitHub repo.
-
-    * Navigate to your GitHub repository and click **Settings** > **Secrets** > **New secret**.
-    * Create a new secret with the name `DOCKER_HUB_USERNAME` and your Docker ID as value.
-    * Create a new secret with the name `DOCKER_HUB_ACCESS_TOKEN` and use the token value from the step (1).
-
-Your GitHub repository **Secrets** section would look like the following.
-
-![GitHub Secrets](../../ci-cd/images/github-secrets.png){:width="500px"}
-
-Now it will be possible to refer to these two variables from our workflows. This will open up an opportunity to publish our image to Docker Hub.
 
 ## Set up the CD workflow
 


### PR DESCRIPTION

### Proposed changes

The **Set up the CI workflow** section start with `In the previous section, we created a PAT and added it to GitHub to ensure we can access Docker Hub from any GitHub Actions workflow. But before setting out to build the images for releasing our software, let’s build a CI pipeline to run the tests first.` but the section(**Enable access to Docker Hub**) that setups the PAT is after it not before.

This PR reorders the **Enable access to Docker Hub** section to be before **Set up the CI workflow** section.

### Unreleased project version (optional)

### Related issues (optional)

Fixes #14182 
