### PR TITLE
Fix spacing in Nero ratings display

### DIFF
--- a/_scss/_navigation.scss
+++ b/_scss/_navigation.scss
@@ -293,7 +293,7 @@ input:checked+.slider:before {
 /* remove polldaddy ratings */
 
 .rating-nero-value {
-    display: none;
+    visibility: hidden
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Attempt to fix the spacing issue when the ratings up/down icon are displayed on each page