### PR TITLE
Use host port 8000 to avoid conflicts on macOS Monterey

### DIFF
--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -102,7 +102,7 @@ Example:
     web:
       build: .
       ports:
-       - "5000:5000"
+       - "8000:5000"
       volumes:
        - .:/code
       links:
@@ -151,7 +151,7 @@ Simple example:
       web:
         build: .
         ports:
-         - "5000:5000"
+         - "8000:5000"
         volumes:
          - .:/code
       redis:
@@ -164,7 +164,7 @@ A more extended example, defining volumes and networks:
       web:
         build: .
         ports:
-         - "5000:5000"
+         - "8000:5000"
         volumes:
          - .:/code
         networks:

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -125,7 +125,7 @@ services:
   web:
     build: .
     ports:
-      - "5000:5000"
+      - "8000:5000"
   redis:
     image: "redis:alpine"
 ```
@@ -135,7 +135,7 @@ This Compose file defines two services: `web` and `redis`.
 ### Web service
 
 The `web` service uses an image that's built from the `Dockerfile` in the current directory.
-It then binds the container and the host machine to the exposed port, `5000`. This example service uses the default port for 
+It then binds the container and the host machine to the exposed port, `8000`. This example service uses the default port for 
 the Flask web server, `5000`.
 
 ### Redis service
@@ -173,17 +173,13 @@ image pulled from the Docker Hub registry.
    Compose pulls a Redis image, builds an image for your code, and starts the
    services you defined. In this case, the code is statically copied into the image at build time.
 
-2. Enter http://localhost:5000/ in a browser to see the application running.
+2. Enter http://localhost:8000/ in a browser to see the application running.
 
    If you're using Docker natively on Linux, Docker Desktop for Mac, or Docker Desktop for
-   Windows, then the web app should now be listening on port 5000 on your
-   Docker daemon host. Point your web browser to http://localhost:5000 to
+   Windows, then the web app should now be listening on port 8000 on your
+   Docker daemon host. Point your web browser to http://localhost:8000 to
    find the `Hello World` message. If this doesn't resolve, you can also try
-   http://127.0.0.1:5000.
-
-   If you're using Docker Machine on a Mac or Windows, use `docker-machine ip
-   MACHINE_VM` to get the IP address of your Docker host. Then, open
-   `http://MACHINE_VM_IP:5000` in a browser.
+   http://127.0.0.1:8000.
 
    You should see a message in your browser saying:
 
@@ -233,7 +229,7 @@ services:
   web:
     build: .
     ports:
-      - "5000:5000"
+      - "8000:5000"
     volumes:
       - .:/code
     environment:
@@ -322,7 +318,7 @@ $ docker-compose ps
        Name                      Command               State           Ports         
 -------------------------------------------------------------------------------------
 composetest_redis_1   docker-entrypoint.sh redis ...   Up      6379/tcp              
-composetest_web_1     flask run                        Up      0.0.0.0:5000->5000/tcp
+composetest_web_1     flask run                        Up      0.0.0.0:8000->5000/tcp
 ```
 
 The `docker-compose run` command allows you to run one-off commands for your

--- a/compose/index.md
+++ b/compose/index.md
@@ -44,7 +44,7 @@ services:
   web:
     build: .
     ports:
-      - "5000:5000"
+      - "8000:5000"
     volumes:
       - .:/code
       - logvolume01:/var/log

--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -163,15 +163,15 @@ $ docker run \
   --rm -d \
   --network mysqlnet \
   --name rest-server \
-  -p 5000:5000 \
+  -p 8000:5000 \
   python-docker-dev
 ```
 
 Let’s test that our application is connected to the database and is able to add a note.
 
 ```console
-$ curl http://localhost:5000/initdb
-$ curl http://localhost:5000/widgets
+$ curl http://localhost:8000/initdb
+$ curl http://localhost:8000/widgets
 ```
 
 You should receive the following JSON back from our service.
@@ -194,7 +194,7 @@ services:
   build:
    context: .
   ports:
-  - 5000:5000
+  - 8000:5000
   volumes:
   - ./:/app
 
@@ -215,7 +215,7 @@ volumes:
 
 This Compose file is super convenient as we do not have to type all the parameters to pass to the `docker run` command. We can declaratively do that using a Compose file.
 
-We expose port 5000 so that we can reach the dev web server inside the container. We also map our local source code into the running container to make changes in our text editor and have those changes picked up in the container.
+We expose port 8000 so that we can reach the dev web server inside the container. We also map our local source code into the running container to make changes in our text editor and have those changes picked up in the container.
 
 Another really cool feature of using a Compose file is that we have service resolution set up to use the service names. Therefore, we are now able to use “mysqldb” in our connection string. The reason we use “mysqldb” is because that is what we've named our MySQL service as in the Compose file.
 
@@ -230,8 +230,8 @@ We pass the `--build` flag so Docker will compile our image and then start the c
 Now let’s test our API endpoint. Open a new terminal then make a GET request to the server using the curl commands:
 
 ```console
-$ curl http://localhost:5000/initdb
-$ curl http://localhost:5000/widgets
+$ curl http://localhost:8000/initdb
+$ curl http://localhost:8000/widgets
 ```
 
 You should receive the following response:

--- a/language/python/run-containers.md
+++ b/language/python/run-containers.md
@@ -37,20 +37,20 @@ To stop the container, press ctrl-c. This will return you to the terminal prompt
 
 To publish a port for our container, we’ll use the `--publish flag` (`-p` for short) on the `docker run` command. The format of the `--publish` command is `[host port]:[container port]`. So, if we wanted to expose port 5000 inside the container to port 3000 outside the container, we would pass `3000:5000` to the `--publish` flag.
 
-We did not specify a port when running the flask application in the container and the default is 5000. If we want our previous request going to port 5000 to work we can map the host's port 5000 to the container's port 5000:
+We did not specify a port when running the flask application in the container and the default is 5000. If we want our previous request going to port 5000 to work we can map the host's port 8000 to the container's port 5000:
 
 ```console
-$ docker run --publish 5000:5000 python-docker
+$ docker run --publish 8000:5000 python-docker
 ```
 
 Now, let’s rerun the curl command from above. Remember to open a new terminal.
 
 ```console
-$ curl localhost:5000
+$ curl localhost:8000
 Hello, Docker!
 ```
 
-Success! We were able to connect to the application running inside of our container on port 5000. Switch back to the terminal where your container is running and you should see the GET request logged to the console.
+Success! We were able to connect to the application running inside of our container on port 8000. Switch back to the terminal where your container is running and you should see the GET request logged to the console.
 
 ```shell
 [31/Jan/2021 23:39:31] "GET / HTTP/1.1" 200 -
@@ -63,7 +63,7 @@ Press ctrl-c to stop the container.
 This is great so far, but our sample application is a web server and we don't have to be connected to the container. Docker can run your container in detached mode or in the background. To do this, we can use the `--detach` or `-d` for short. Docker starts your container the same as before but this time will “detach” from the container and return you to the terminal prompt.
 
 ```console
-$ docker run -d -p 5000:5000 python-docker
+$ docker run -d -p 8000:5000 python-docker
 ce02b3179f0f10085db9edfccd731101868f58631bdf918ca490ff6fd223a93b
 ```
 
@@ -72,7 +72,7 @@ Docker started our container in the background and printed the Container ID on t
 Again, let’s make sure that our container is running properly. Run the same curl command from above.
 
 ```console
-$ curl localhost:5000
+$ curl localhost:8000
 Hello, Docker!
 ```
 
@@ -83,7 +83,7 @@ Since we ran our container in the background, how do we know if our container is
 ```console
 $ docker ps
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
-ce02b3179f0f        python-docker         "python3 -m flask ru…"   6 minutes ago       Up 6 minutes        0.0.0.0:5000->5000/tcp   wonderful_kalam
+ce02b3179f0f        python-docker         "python3 -m flask ru…"   6 minutes ago       Up 6 minutes        0.0.0.0:8000->5000/tcp   wonderful_kalam
 ```
 
 The `docker ps` command provides a bunch of information about our running containers. We can see the container ID, The image running inside the container, the command that was used to start the container, when it was created, the status, ports that exposed and the name of the container.
@@ -127,12 +127,12 @@ Now list all the containers again using the `docker ps` command.
 ```console
 $ docker ps --all
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                      PORTS                    NAMES
-ce02b3179f0f        python-docker         "python3 -m flask ru…"   19 minutes ago      Up 8 seconds                0.0.0.0:5000->5000/tcp   wonderful_kalam
+ce02b3179f0f        python-docker         "python3 -m flask ru…"   19 minutes ago      Up 8 seconds                0.0.0.0:8000->5000/tcp   wonderful_kalam
 ec45285c456d        python-docker         "python3 -m flask ru…"   31 minutes ago      Exited (0) 23 minutes ago                            agitated_moser
 fb7a41809e5d        python-docker         "python3 -m flask ru…"   40 minutes ago      Exited (0) 39 minutes ago                            goofy_khayyam
 ```
 
-Notice that the container we just restarted has been started in detached mode and has port 5000 exposed. Also, observe the status of the container is “Up X seconds”. When you restart a container, it starts with the same flags or commands that it was originally started with.
+Notice that the container we just restarted has been started in detached mode and has port 8000 exposed. Also, observe the status of the container is “Up X seconds”. When you restart a container, it starts with the same flags or commands that it was originally started with.
 
 Now, let’s stop and remove all of our containers and take a look at fixing the random naming issue. Stop the container we just started. Find the name of your running container and replace the name in the command below with the name of the container on your system.
 
@@ -146,7 +146,7 @@ Now that all of our containers are stopped, let’s remove them. When you remove
 ```console
 $ docker ps --all
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                      PORTS                    NAMES
-ce02b3179f0f        python-docker         "python3 -m flask ru…"   19 minutes ago      Up 8 seconds                0.0.0.0:5000->5000/tcp   wonderful_kalam
+ce02b3179f0f        python-docker         "python3 -m flask ru…"   19 minutes ago      Up 8 seconds                0.0.0.0:8000->5000/tcp   wonderful_kalam
 ec45285c456d        python-docker         "python3 -m flask ru…"   31 minutes ago      Exited (0) 23 minutes ago                            agitated_moser
 fb7a41809e5d        python-docker         "python3 -m flask ru…"   40 minutes ago      Exited (0) 39 minutes ago                            goofy_khayyam
 ```
@@ -167,11 +167,11 @@ Now, let’s address the random naming issue. Standard practice is to name your 
 To name a container, we just need to pass the `--name` flag to the `docker run` command.
 
 ```console
-$ docker run -d -p 5000:5000 --name rest-server python-docker
+$ docker run -d -p 8000:5000 --name rest-server python-docker
 1aa5d46418a68705c81782a58456a4ccdb56a309cb5e6bd399478d01eaa5cdda
 $ docker ps
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
-1aa5d46418a6        python-docker         "python3 -m flask ru…"   3 seconds ago       Up 3 seconds        0.0.0.0:5000->5000/tcp   rest-server
+1aa5d46418a6        python-docker         "python3 -m flask ru…"   3 seconds ago       Up 3 seconds        0.0.0.0:8000->5000/tcp   rest-server
 ```
 
 That’s better! We can now easily identify our container based on the name.


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Use a different port than 5000 on the host to avoid port conflicts when running the Python example or the getting started guide on macOS Monterey. By default the AirPlay Receiver is enabled in the Sharing System Preferences and it listens on port 5000. Use eg. port 8000 instead for exposing a container port to the host to avoid this situation.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Fixes #14226
