### PR TITLE
Note about Windows paths for self-signed certificates

### DIFF
--- a/desktop/windows/index.md
+++ b/desktop/windows/index.md
@@ -417,6 +417,7 @@ in the Docker Engine topics.
 You can add your client certificates
 in `~/.docker/certs.d/<MyRegistry>:<Port>/client.cert` and
 `~/.docker/certs.d/<MyRegistry>:<Port>/client.key`. You do not need to push your certificates with `git` commands.
+Note that the colon is not allowed in Windows paths so you can just omit it.
 
 When the Docker Desktop application starts, it copies the
 `~/.docker/certs.d` folder on your Windows system to the `/etc/docker/certs.d`

--- a/desktop/windows/index.md
+++ b/desktop/windows/index.md
@@ -415,9 +415,8 @@ in the Docker Engine topics.
 ### How do I add client certificates?
 
 You can add your client certificates
-in `~/.docker/certs.d/<MyRegistry>:<Port>/client.cert` and
-`~/.docker/certs.d/<MyRegistry>:<Port>/client.key`. You do not need to push your certificates with `git` commands.
-Note that the colon is not allowed in Windows paths so you can just omit it.
+in `~/.docker/certs.d/<MyRegistry><Port>/client.cert` and
+`~/.docker/certs.d/<MyRegistry><Port>/client.key`. You do not need to push your certificates with `git` commands.
 
 When the Docker Desktop application starts, it copies the
 `~/.docker/certs.d` folder on your Windows system to the `/etc/docker/certs.d`


### PR DESCRIPTION
The documentation is misleading as colons are not allowed in paths in Windows, so it might be useful to be explicit about it.

### Proposed changes

Add a small note to the documentation about Docker Desktop self-signed certificates. Looks like colon are not possible in Windows folder names, and the documentation does not explain that it will work just fine if the colon is ommited in the path.
