### PR TITLE
Add link to Docker Compose repo to fix reference text

### DIFF
--- a/engine/reference/commandline/README.md
+++ b/engine/reference/commandline/README.md
@@ -14,9 +14,9 @@ The output files are composed from two sources:
   the CLI source code in that repository.
 
 - The **Extended Description** and **Examples** sections are pulled into the
-  YAML from the files in [https://github.com/docker/cli/tree/master/docs/reference/commandline](https://github.com/docker/cli/tree/master/docs/reference/commandline)
+  YAML from the files in [https://github.com/docker/cli/tree/master/docs/reference/commandline](https://github.com/docker/cli/tree/master/docs/reference/commandline) for Docker CLI commands and [https://github.com/docker/compose/tree/v2/docs/reference](https://github.com/docker/compose/tree/v2/docs/reference) for Docker Compose commands.
   Specifically, the Markdown inside the `## Description` and `## Examples`
-  headings are parsed. Submit corrections to the text in that repository.
+  headings are parsed. Submit corrections to the text in those repositories.
 
 # Updating the YAML files
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

When looking for how to fix #14255 in this repo, the [README](https://github.com/docker/docker.github.io/blob/master/engine/reference/commandline/README.md) at [engine/reference/commandline](https://github.com/docker/docker.github.io/tree/master/engine/reference/commandline) only suggested the repo for fixing Docker CLI reference typos but not the repo for fixing Docker Compose reference typos.

This PR adds tells readers where to go to for fixing Docker Compose reference typos by linking the repo.

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
