### PR TITLE
Fix permissions in buildkit ssh forwarding example.

### DIFF
--- a/develop/develop-images/build_enhancements.md
+++ b/develop/develop-images/build_enhancements.md
@@ -222,7 +222,7 @@ FROM alpine
 RUN apk add --no-cache openssh-client git
 
 # Download public key for github.com
-RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 # Clone private repository
 RUN --mount=type=ssh git clone git@github.com:myorg/myproject.git myproject


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Updates the permissions in the [buildkit ssh forwarding example](https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds) to set the `.ssh` directory to 0700 instead of 0600. Directories need the executable bit set to be traversible.

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
