### PR TITLE
Move Docker Desktop release security note to correct version

### DIFF
--- a/desktop/windows/release-notes/index.md
+++ b/desktop/windows/release-notes/index.md
@@ -32,10 +32,6 @@ Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/pro
 > Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64){:
 > .button .primary-btn }
 
-### Security
-
-- Fixed [CVE-2022-23774](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23774){: target="_blank" rel="noopener" class="_"} where Docker Desktop allows attackers to move arbitrary files.
-
 ### Bug fixes and minor changes
 
 - Fixed an issue that caused new installations to default to the Hyper-V backend instead of WSL 2.
@@ -46,6 +42,10 @@ Alternatively, you can edit the Docker Desktop settings file located at `%APPDAT
 
 ## Docker Desktop 4.5.0
 2022-02-10
+
+### Security
+
+- Fixed [CVE-2022-23774](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23774){: target="_blank" rel="noopener" class="_"} where Docker Desktop allows attackers to move arbitrary files.
 
 ### New
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

Moved the security note from 4.5.1 to 4.5.0 which is the correct version where the CVE was fixed.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
