### PR TITLE
Remove Slack integration from toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1326,8 +1326,6 @@ manuals:
         title: Link to GitHub and BitBucket
   - path: /docker-hub/webhooks/
     title: Webhooks
-  - path: /docker-hub/slack_integration/
-    title: Slack integration
   - path: /docker-hub/image-access-management/
     title: Image Access Management
   - path: /docker-hub/vulnerability-scanning/

--- a/docker-hub/slack_integration.md
+++ b/docker-hub/slack_integration.md
@@ -5,6 +5,7 @@ redirect_from:
 - /docker-cloud/tutorials/slack-integration/
 - /docker-cloud/slack-integration/
 title: Set up Docker Hub notifications in Slack
+sitemap: false
 ---
 
 Docker Hub can integrate with your **Slack** team to provide notifications about builds.


### PR DESCRIPTION
Docker Hub Slack integration isn't working and the UI is currently disabled on Docker Hub. This PR removes the topic from the table of contents to avoid confusion. We can revert this PR when the UI is reinstated.