### PR TITLE
Added note for using bind mount on Windows host systems

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -23,7 +23,7 @@ manage bind mounts.
 
 > Using bind mounts on a Windows host system
 > 
-> Before using bind mounts on a Windows host system through Docker Desktop for Windows, make sure to [<u>enable File Sharing</u>](desktop/windows/#file-sharing). You may also want to take a look at the [<u>Volumes section</u>](desktop/windows/troubleshoot/#volumes) under Logs and troubleshooting to quickly identify other known issues.
+> Before using bind mounts on a Windows host system through Docker Desktop for Windows, make sure to [<u>enable File Sharing</u>](/desktop/settings/windows/#file-sharing). You may also want to take a look at the [<u>Volumes section</u>](/desktop/troubleshoot/topics/#volumes) under Troubleshoot topics to quickly identify other known issues.
 
 ![Bind mounts on the Docker host](images/types-of-mounts-bind.png)
 

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -23,7 +23,7 @@ manage bind mounts.
 
 > Using bind mounts on a Windows host system
 > 
-> Before using bind mounts on a Windows host system through Docker Desktop for Windows, make sure to [<u>enable File Sharing</u>](/desktop/settings/windows/#file-sharing). You may also want to take a look at the [<u>Volumes section</u>](/desktop/troubleshoot/topics/#volumes) under Troubleshoot topics to quickly identify other known issues.
+> Before using bind mounts on a Windows host system through Docker Desktop for Windows, make sure to [<u>enable File Sharing</u>](/desktop/settings/windows/#file-sharing). You may also want to take a look at the [<u>Volumes section</u>](/desktop/troubleshoot/topics/#volumes) under Troubleshoot topics to identify other known issues.
 
 ![Bind mounts on the Docker host](images/types-of-mounts-bind.png)
 

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -21,6 +21,10 @@ available. If you are developing new Docker applications, consider using
 [named volumes](volumes.md) instead. You can't use Docker CLI commands to directly
 manage bind mounts.
 
+> Using bind mounts on a Windows host system
+> 
+> Before using bind mounts on a Windows host system through Docker Desktop for Windows, make sure to [<u>enable File Sharing</u>](desktop/windows/#file-sharing). You may also want to take a look at the [<u>Volumes section</u>](desktop/windows/troubleshoot/#volumes) under Logs and troubleshooting to quickly identify other known issues.
+
 ![Bind mounts on the Docker host](images/types-of-mounts-bind.png)
 
 ## Choose the -v or --mount flag


### PR DESCRIPTION
### Proposed changes

Added a note to the bind mounts page pointing developers to first turn on File Sharing in Docker Desktop and also to a page highlighting path differences for Volumes in Windows.

This information was not apparent to me and so I want to make it clear for others.