### PR TITLE
Update "docker run" command

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -46,7 +46,7 @@ So, let's do it!
     $ docker run -dp 3000:3000 \
         -w /app -v "$(pwd):/app" \
         node:12-alpine \
-        sh -c "yarn install && yarn run dev"
+        sh -c "apk add --no-cache python2 g++ make && yarn install && yarn run dev"
     ```
 
     If you are using PowerShell then use this command:
@@ -55,14 +55,15 @@ So, let's do it!
     PS> docker run -dp 3000:3000 `
         -w /app -v "$(pwd):/app" `
         node:12-alpine `
-        sh -c "yarn install && yarn run dev"
+        sh -c "apk add --no-cache python2 g++ make && yarn install && yarn run dev"
     ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
     - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory
     - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
-    - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
+    - `sh -c "apk add --no-cache python2 g++ make && yarn install && yarn run dev"` - the command. We're starting a shell using
+      `sh` (alpine doesn't have `bash`), running `apk add --no-cache python2 g++ make` to install build dependencies for SQLite,
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,
       we'll see that the `dev` script is starting `nodemon`.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The `Dockerfile` in `get-started/02_our_app.md` was updated to include the installation of SQLite build dependencies (`python2`, `g++` and `make`) to make the guide compatible with non-amd64 computers.
The `docker run` command in `get-started/06_bind_mounts.md` was not updated, so the command does not work as is. This PR brings the SQLite build dependencies into the the `docker run` command as well.

### Related issues

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

https://github.com/docker/getting-started/issues/36#issuecomment-753847145
docker/getting-started#104
https://github.com/docker/getting-started/issues/124#issuecomment-782028688