### PR TITLE
Add missing `/v2/` in `proxy_pass`

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -141,7 +141,7 @@ Review the [requirements](index.md#requirements), then follow these steps.
           ## See the map directive above where this variable is defined.
           add_header 'Docker-Distribution-Api-Version' $docker_distribution_api_version always;
 
-          proxy_pass                          http://docker-registry;
+          proxy_pass                          http://docker-registry/v2/;
           proxy_set_header  Host              $http_host;   # required for docker client's sake
           proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
           proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### Proposed changes

I have added a `/v2/` to the end of the `proxy_pass` path to avoid getting 404 errors on push/pull of images.

Some day ago, I deployed my first registry by following the docs. The error I ran into is the following: 
`Error response from daemon: error parsing HTTP 404 response body: invalid character 'p' after top-level value: "404 page not found\n"`.
I come to this solution by looking at the [apache version](https://github.com/docker/docker.github.io/blob/c3cb5785f17896727fca90d71347bc08cccbfa2e/registry/recipes/apache.md?plain=1#L132) of this recipe.