### PR TITLE
Add read-only and read-write user auth to Nginx recipe

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -167,7 +167,7 @@ Review the [requirements](index.md#requirements), then follow these steps.
     The following command creates both for "testuser" with password "testpassword".
 
     ```console
-    $ docker run --rm --entrypoint htpasswd registry:2 -Bbn testuser testpassword | tee -a auth/nginx-ro.htpasswd auth/nginx-rw.htpasswd > /dev/null
+    $ docker run --rm --entrypoint htpasswd httpd:2.4-alpine -Bbn testuser testpassword | tee -a auth/nginx-ro.htpasswd auth/nginx-rw.htpasswd > /dev/null
     ```
 
     > **Note**: If you do not want to use `bcrypt`, you can omit the `-B` parameter.


### PR DESCRIPTION
### Proposed changes

It is mentioned at the top of the page of the [nginx recipe](https://github.com/docker/docker.github.io/blob/c3cb5785f17896727fca90d71347bc08cccbfa2e/registry/recipes/nginx.md?plain=1#L35) that there somewhere would be an example about read-only and read-write user authentication. This is missing, so I do like to fill this gap with this.
I have also changed the image used by the password file creation example because `registry:2` does not have the `htpasswd` utility.

### Related issues
Related: #11060, docker/distribution-library-image#106 (and probably fixes these)