### PR TITLE
Update compose-file-v3.md

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -659,10 +659,10 @@ services:
 
 > Added in [version 3](compose-versioning.md#version-3) file format.
 
-Specify configuration related to the deployment and running of services. This
-only takes effect when deploying to a [swarm](../../engine/swarm/index.md) with
+Specify configuration related to the deployment and running of services. The following  
+sub-options only takes effect when deploying to a [swarm](../../engine/swarm/index.md) with
 [docker stack deploy](../../engine/reference/commandline/stack_deploy.md), and is
-ignored by `docker-compose up` and `docker-compose run`.
+ignored by `docker-compose up` and `docker-compose run`, except for `resources`.
 
 ```yaml
 version: "{{ site.compose_file_v3 }}"


### PR DESCRIPTION
### Proposed changes

Update compose  file v3 reference.

The docs says `deploy` does not work for `docker-compose`, however, the `deploy.resources` do work.

ref: https://sourcegraph.com/github.com/docker/compose@v2/-/blob/pkg/compose/create.go?L511-514

