### PR TITLE
Webhooks: remove images property, drop scientific notation for timestamps

### DIFF
--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -36,12 +36,7 @@ Docker Hub Webhook payloads have the following payload JSON format:
 {
   "callback_url": "https://registry.hub.docker.com/u/svendowideit/testhook/hook/2141b5bi5i5b02bec211i4eeih0242eg11000a/",
   "push_data": {
-    "images": [
-        "27d47432a69bca5f2700e4dff7de0388ed65f9d3fb1ec645e2bc24c223dc1cc3",
-        "51a9c7c1f8bb2fa19bcd09789a34e63f35abb80044bc10196e304f6634cc582c",
-        "..."
-    ],
-    "pushed_at": 1.417566161e+09,
+    "pushed_at": 1417566161,
     "pusher": "trustedbuilder",
     "tag": "latest"
   },

--- a/docker-hub/webhooks.md
+++ b/docker-hub/webhooks.md
@@ -42,7 +42,7 @@ Docker Hub Webhook payloads have the following payload JSON format:
   },
   "repository": {
     "comment_count": 0,
-    "date_created": 1.417494799e+09,
+    "date_created": 1417494799,
     "description": "",
     "dockerfile": "#\n# BUILD\u0009\u0009docker build -t svendowideit/apt-cacher .\n# RUN\u0009\u0009docker run -d -p 3142:3142 -name apt-cacher-run apt-cacher\n#\n# and then you can run containers with:\n# \u0009\u0009docker run -t -i -rm -e http_proxy http://192.168.1.2:3142/ debian bash\n#\nFROM\u0009\u0009ubuntu\n\n\nVOLUME\u0009\u0009[/var/cache/apt-cacher-ng]\nRUN\u0009\u0009apt-get update ; apt-get install -yq apt-cacher-ng\n\nEXPOSE \u0009\u00093142\nCMD\u0009\u0009chmod 777 /var/cache/apt-cacher-ng ; /etc/init.d/apt-cacher-ng start ; tail -f /var/log/apt-cacher-ng/*\n",
     "full_description": "Docker Hub based automated build from a GitHub repo",


### PR DESCRIPTION
### Proposed changes

This PR updates the webhooks documentation, removing the deprecated `images` property from the payload and dropping the scientific notation from the `pushed_at`, `date_created` properties since it's not used (e.g. `1.417566161e+09` → `1417566161`).