### PR TITLE
Add missing argument to registry launch command

### DIFF
--- a/registry/recipes/osx/com.docker.registry.plist
+++ b/registry/recipes/osx/com.docker.registry.plist
@@ -15,6 +15,7 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/usr/local/libexec/registry</string>
+		<string>serve</string>
 		<string>/Users/Shared/Registry/config.yml</string>
 	</array>
 	<key>Sockets</key>


### PR DESCRIPTION
### Proposed changes
The instructions do not work as the program launch command has a missing argument.