### PR TITLE
The Alpine 3.5 image is no longer available

### DIFF
--- a/get-started/orchestration.md
+++ b/get-started/orchestration.md
@@ -43,7 +43,7 @@ Docker Desktop will set up Kubernetes for you quickly and easily. Follow the set
     spec:
       containers:
       - name: testpod
-        image: alpine:3.5
+        image: alpine:latest
         command: ["ping", "8.8.8.8"]
     ```
 
@@ -113,7 +113,7 @@ Docker Desktop will set up Kubernetes for you quickly and easily. Follow the set
     spec:
       containers:
       - name: testpod
-        image: alpine:3.5
+        image: alpine:latest
         command: ["ping", "8.8.8.8"]
     ```
 
@@ -201,7 +201,7 @@ Docker Desktop runs primarily on Docker Engine, which has everything you need to
 2.  Run a simple Docker service that uses an alpine-based filesystem, and isolates a ping to 8.8.8.8:
 
     ```console
-    $ docker service create --name demo alpine:3.5 ping 8.8.8.8
+    $ docker service create --name demo alpine:latest ping 8.8.8.8
     ```
 
 3.  Check that your service created one running container:
@@ -214,7 +214,7 @@ Docker Desktop runs primarily on Docker Engine, which has everything you need to
 
     ```shell
     ID                  NAME                IMAGE               NODE                DESIRED STATE       CURRENT STATE           ERROR               PORTS
-    463j2s3y4b5o        demo.1              alpine:3.5          docker-desktop      Running             Running 8 seconds ago
+    463j2s3y4b5o        demo.1              alpine:latest          docker-desktop      Running             Running 8 seconds ago
     ```
 
 4.  Check that you get the logs you'd expect for a ping process:
@@ -269,7 +269,7 @@ Docker Desktop runs primarily on Docker Engine, which has everything you need to
 2.  Run a simple Docker service that uses an alpine-based filesystem, and isolates a ping to 8.8.8.8:
 
     ```console
-    $ docker service create --name demo alpine:3.5 ping 8.8.8.8
+    $ docker service create --name demo alpine:latest ping 8.8.8.8
     ```
 
 3.  Check that your service created one running container:
@@ -282,7 +282,7 @@ Docker Desktop runs primarily on Docker Engine, which has everything you need to
 
     ```shell
     ID                  NAME                IMAGE               NODE                DESIRED STATE       CURRENT STATE           ERROR               PORTS
-    463j2s3y4b5o        demo.1              alpine:3.5          docker-desktop      Running             Running 8 seconds ago
+    463j2s3y4b5o        demo.1              alpine:latest          docker-desktop      Running             Running 8 seconds ago
     ```
 
 4.  Check that you get the logs you'd expect for a ping process:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The Alpine 3.5 image is no longer available, perhaps `latest` should be used.

REF:  [Official Alpine image on Docker Hub](https://hub.docker.com/_/alpine)

A versioned image could be used, but then this situation will simply occur again at some point.
