### PR TITLE
reference: update buildx to v0.8.0

### DIFF
--- a/_data/buildx/docker_buildx.yaml
+++ b/_data/buildx/docker_buildx.yaml
@@ -35,6 +35,7 @@ options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_bake.yaml
+++ b/_data/buildx/docker_buildx_bake.yaml
@@ -22,6 +22,7 @@ options:
   description: Build definition file
   details_url: '#file'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,6 +32,7 @@ options:
   default_value: "false"
   description: Shorthand for `--set=*.output=type=docker`
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +41,7 @@ options:
   value_type: string
   description: Write build result metadata to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -49,6 +52,7 @@ options:
   description: Do not use cache when building the image
   details_url: '#no-cache'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -59,6 +63,7 @@ options:
   description: Print the options without building
   details_url: '#print'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -70,6 +75,7 @@ options:
     Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output
   details_url: '#progress'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -77,9 +83,10 @@ options:
 - option: pull
   value_type: bool
   default_value: "false"
-  description: Always attempt to pull a newer version of the image
+  description: Always attempt to pull all referenced images
   details_url: '#pull'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -89,6 +96,7 @@ options:
   default_value: "false"
   description: Shorthand for `--set=*.output=type=registry`
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -99,6 +107,7 @@ options:
   description: Override target value (e.g., `targetpattern.key=value`)
   details_url: '#set'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -109,6 +118,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -170,10 +180,10 @@ examples: |-
   You can also use a remote `git` bake definition:
 
   ```console
-  $ docker buildx bake "git://github.com/docker/cli#v20.10.11" --print
-  #1 [internal] load git source git://github.com/docker/cli#v20.10.11
+  $ docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
+  #1 [internal] load git source https://github.com/docker/cli.git#v20.10.11
   #1 0.745 e8f1871b077b64bcb4a13334b7146492773769f7       refs/tags/v20.10.11
-  #1 2.022 From git://github.com/docker/cli
+  #1 2.022 From https://github.com/docker/cli
   #1 2.022  * [new tag]         v20.10.11  -> v20.10.11
   #1 DONE 2.9s
   {
@@ -186,7 +196,7 @@ examples: |-
     },
     "target": {
       "binary": {
-        "context": "git://github.com/docker/cli#v20.10.11",
+        "context": "https://github.com/docker/cli.git#v20.10.11",
         "dockerfile": "Dockerfile",
         "args": {
           "BASE_VARIANT": "alpine",
@@ -205,7 +215,7 @@ examples: |-
   }
   ```
 
-  As you can see the context is fixed to `git://github.com/docker/cli` even if
+  As you can see the context is fixed to `https://github.com/docker/cli.git` even if
   [no context is actually defined](https://github.com/docker/cli/blob/2776a6d694f988c0c1df61cad4bfac0f54e481c8/docker-bake.hcl#L17-L26)
   in the definition.
 
@@ -226,7 +236,7 @@ examples: |-
   ```
 
   ```console
-  $ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" --print
+  $ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" --print
   {
     "target": {
       "default": {
@@ -240,7 +250,7 @@ examples: |-
 
   ```console
   $ touch foo bar
-  $ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test"
+  $ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test"
   ...
    > [4/4] RUN ls -l && stop:
   #8 0.101 total 0
@@ -250,14 +260,14 @@ examples: |-
   ```
 
   ```console
-  $ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" "git://github.com/docker/cli#v20.10.11" --print
-  #1 [internal] load git source git://github.com/tonistiigi/buildx#remote-test
+  $ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" "https://github.com/docker/cli.git#v20.10.11" --print
+  #1 [internal] load git source https://github.com/tonistiigi/buildx.git#remote-test
   #1 0.429 577303add004dd7efeb13434d69ea030d35f7888       refs/heads/remote-test
   #1 CACHED
   {
     "target": {
       "default": {
-        "context": "git://github.com/docker/cli#v20.10.11",
+        "context": "https://github.com/docker/cli.git#v20.10.11",
         "dockerfile": "Dockerfile",
         "dockerfile-inline": "FROM alpine\nWORKDIR /src\nCOPY . .\nRUN ls -l \u0026\u0026 stop\n"
       }
@@ -266,7 +276,7 @@ examples: |-
   ```
 
   ```console
-  $ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" "git://github.com/docker/cli#v20.10.11"
+  $ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" "https://github.com/docker/cli.git#v20.10.11"
   ...
    > [4/4] RUN ls -l && stop:
   #8 0.136 drwxrwxrwx    5 root     root          4096 Jul 27 18:31 kubernetes
@@ -335,7 +345,6 @@ examples: |-
   ...
   ```
 
-
   ### Always attempt to pull a newer version of the image (--pull) {#pull}
 
   Same as `build --pull`.
@@ -348,9 +357,6 @@ examples: |-
 
   Override target configurations from command line. The pattern matching syntax
   is defined in https://golang.org/pkg/path/#Match.
-
-
-  **Examples**
 
   ```console
   $ docker buildx bake --set target.args.mybuildarg=value
@@ -384,8 +390,7 @@ examples: |-
   Note: Design of bake command is work in progress, the user experience may change
   based on feedback.
 
-
-  **Example HCL definition**
+  HCL definition example:
 
   ```hcl
   group "default" {
@@ -410,8 +415,8 @@ examples: |-
 
   Complete list of valid target fields:
 
-  `args`, `cache-from`, `cache-to`, `context`, `dockerfile`, `inherits`, `labels`,
-  `no-cache`, `output`, `platform`, `pull`, `secrets`, `ssh`, `tags`, `target`
+  `args`, `cache-from`, `cache-to`, `context`, `contexts`, `dockerfile`, `inherits`, `labels`,
+  `no-cache`, `no-cache-filter`, `output`, `platform`, `pull`, `secrets`, `ssh`, `tags`, `target`
 
   ### Global scope attributes
 
@@ -518,6 +523,28 @@ examples: |-
 
   target "webapp" {
       tags = ["docker.io/username/webapp:${TAG}"]
+  }
+  ```
+
+  alternatively, in json format:
+
+  ```json
+  {
+    "variable": {
+      "TAG": {
+        "default": "latest"
+      }
+    }
+    "group": {
+      "default": {
+        "targets": ["webapp"]
+      }
+    },
+    "target": {
+      "webapp": {
+        "tags": ["docker.io/username/webapp:${TAG}"]
+      }
+    }
   }
   ```
 
@@ -848,6 +875,77 @@ examples: |-
   }
   ```
 
+  ### Defining additional build contexts and linking targets
+
+  In addition to the main `context` key that defines the build context each target can also define additional named contexts with a map defined with key `contexts`. These values map to the `--build-context` flag in the [build command](buildx_build.md#build-context).
+
+  Inside the Dockerfile these contexts can be used with the `FROM` instruction or `--from` flag.
+
+  The value can be a local source directory, container image (with docker-image:// prefix), Git URL, HTTP URL or a name of another target in the Bake file (with target: prefix).
+
+  #### Pinning alpine image
+
+  ```Dockerfile
+  # Dockerfile
+  FROM alpine
+  RUN echo "Hello world"
+  ```
+
+  ```hcl
+  # docker-bake.hcl
+  target "app" {
+      contexts = {
+          alpine = "docker-image://alpine:3.13"
+      }
+  }
+  ```
+
+  #### Using a secondary source directory
+
+  ```Dockerfile
+  # Dockerfile
+
+  FROM scratch AS src
+
+  FROM golang
+  COPY --from=src . .
+  ```
+
+  ```hcl
+  # docker-bake.hcl
+  target "app" {
+      contexts = {
+          src = "../path/to/source"
+      }
+  }
+  ```
+
+  #### Using a result of one target as a base image in another target
+
+  To use a result of one target as a build context of another, specity the target name with `target:` prefix.
+
+  ```Dockerfile
+  # Dockerfile
+  FROM baseapp
+  RUN echo "Hello world"
+  ```
+
+  ```hcl
+  # docker-bake.hcl
+
+  target "base" {
+      dockerfile = "baseapp.Dockerfile"
+  }
+
+  target "app" {
+      contexts = {
+          baseapp = "target:base"
+      }
+  }
+  ```
+
+  Please note that in most cases you should just use a single multi-stage Dockerfile with multiple targets for similar behavior. This case is recommended when you have multiple Dockerfiles that can't be easily merged into one.
+
   ### Extension field with Compose
 
   [Special extension](https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension)
@@ -959,7 +1057,7 @@ examples: |-
   Complete list of valid fields for `x-bake`:
 
   `tags`, `cache-from`, `cache-to`, `secret`, `ssh`, `platforms`, `output`,
-  `pull`, `no-cache`
+  `pull`, `no-cache`, `no-cache-filter`
 
   ### Built-in variables
 

--- a/_data/buildx/docker_buildx_build.yaml
+++ b/_data/buildx/docker_buildx_build.yaml
@@ -7,7 +7,7 @@ long: |-
 
   For documentation on most of these flags, refer to the [`docker build`
   documentation](/engine/reference/commandline/build/). In
-  here we’ll document a subset of the new flags.
+  here we'll document a subset of the new flags.
 usage: docker buildx build [OPTIONS] PATH | URL | -
 pname: docker buildx
 plink: docker_buildx.yaml
@@ -18,6 +18,7 @@ options:
   description: 'Add a custom host-to-IP mapping (format: `host:ip`)'
   details_url: /engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +30,7 @@ options:
     Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`)
   details_url: '#allow'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,8 +39,20 @@ options:
   value_type: stringArray
   default_value: '[]'
   description: Set build-time variables
-  details_url: /engine/reference/commandline/build/#set-build-time-variables---build-arg
+  details_url: '#build-arg'
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: build-context
+  value_type: stringArray
+  default_value: '[]'
+  description: Additional build contexts (e.g., name=path)
+  details_url: '#build-context'
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -50,6 +64,7 @@ options:
     External cache sources (e.g., `user/app:cache`, `type=local,src=path/to/dir`)
   details_url: '#cache-from'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,6 +76,7 @@ options:
     Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`)
   details_url: '#cache-to'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -70,6 +86,7 @@ options:
   description: Optional parent cgroup for the container
   details_url: /engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,6 +96,7 @@ options:
   default_value: "false"
   description: Compress the build context using gzip
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -88,6 +106,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -97,6 +116,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -107,6 +127,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -115,6 +136,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (`0-3`, `0,1`)
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -123,6 +145,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (`0-3`, `0,1`)
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -133,6 +156,7 @@ options:
   description: 'Name of the Dockerfile (default: `PATH/Dockerfile`)'
   details_url: /engine/reference/commandline/build/#specify-a-dockerfile--f
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -142,6 +166,7 @@ options:
   default_value: "false"
   description: Always remove intermediate containers
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -150,6 +175,7 @@ options:
   value_type: string
   description: Write the image ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -158,6 +184,7 @@ options:
   value_type: string
   description: Container isolation technology
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -167,6 +194,7 @@ options:
   default_value: '[]'
   description: Set metadata for an image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -177,6 +205,7 @@ options:
   description: Shorthand for `--output=type=docker`
   details_url: '#load'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -186,6 +215,7 @@ options:
   value_type: string
   description: Memory limit
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -195,6 +225,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: `-1` to enable unlimited swap
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -202,7 +233,9 @@ options:
 - option: metadata-file
   value_type: string
   description: Write build result metadata to the file
+  details_url: '#metadata-file'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -210,8 +243,9 @@ options:
 - option: network
   value_type: string
   default_value: default
-  description: Set the networking mode for the RUN instructions during build
+  description: Set the networking mode for the `RUN` instructions during build
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -221,6 +255,17 @@ options:
   default_value: "false"
   description: Do not use cache when building the image
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-cache-filter
+  value_type: stringArray
+  default_value: '[]'
+  description: Do not cache specified stages
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -232,6 +277,7 @@ options:
   description: 'Output destination (format: `type=local,dest=path`)'
   details_url: '#output'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -242,6 +288,7 @@ options:
   description: Set target platform for build
   details_url: '#platform'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -253,6 +300,7 @@ options:
     Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output
   details_url: '#progress'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -260,8 +308,9 @@ options:
 - option: pull
   value_type: bool
   default_value: "false"
-  description: Always attempt to pull a newer version of the image
+  description: Always attempt to pull all referenced images
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -272,6 +321,7 @@ options:
   description: Shorthand for `--output=type=registry`
   details_url: '#push'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -282,6 +332,7 @@ options:
   default_value: "false"
   description: Suppress the build output and print image ID on success
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -291,6 +342,7 @@ options:
   default_value: "true"
   description: Remove intermediate containers after a successful build
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -299,8 +351,10 @@ options:
   value_type: stringArray
   default_value: '[]'
   description: |
-    Secret file to expose to the build (format: `id=mysecret,src=/local/secret`)
+    Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`)
+  details_url: '#secret'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -310,6 +364,7 @@ options:
   default_value: '[]'
   description: Security options
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -320,6 +375,7 @@ options:
   description: Size of `/dev/shm`
   details_url: '#shm-size'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -329,6 +385,7 @@ options:
   default_value: "false"
   description: Squash newly built layers into a single new layer
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -338,7 +395,9 @@ options:
   default_value: '[]'
   description: |
     SSH agent socket or keys to expose to the build (format: `default|<id>[=<socket>|<key>[,<key>]]`)
+  details_url: '#ssh'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -350,15 +409,17 @@ options:
   description: 'Name and optionally a tag (format: `name:tag`)'
   details_url: /engine/reference/commandline/build/#tag-an-image--t
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: target
   value_type: string
-  description: Set the target build stage to build.
+  description: Set the target build stage to build
   details_url: /engine/reference/commandline/build/#specifying-target-build-stage---target
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -369,6 +430,7 @@ options:
   description: Ulimit options
   details_url: '#ulimit'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -379,81 +441,202 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 examples: |-
-  ### Override the configured builder instance (--builder) {#builder}
-
-  Same as [`buildx --builder`](buildx.md#builder).
-
-  ### Set the target platforms for the build (--platform) {#platform}
+  ### Allow extra privileged entitlement (--allow) {#allow}
 
   ```
-  --platform=value[,value]
+  --allow=ENTITLEMENT
   ```
 
-  Set the target platform for the build. All `FROM` commands inside the Dockerfile
-  without their own `--platform` flag will pull base images for this platform and
-  this value will also be the platform of the resulting image. The default value
-  will be the current platform of the buildkit daemon.
+  Allow extra privileged entitlement. List of entitlements:
 
-  When using `docker-container` driver with `buildx`, this flag can accept multiple
-  values as an input separated by a comma. With multiple values the result will be
-  built for all of the specified platforms and joined together into a single manifest
-  list.
+  - `network.host` - Allows executions with host networking.
+  - `security.insecure` - Allows executions without sandbox. See
+    [related Dockerfile extensions](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#run---securityinsecuresandbox).
 
-  If the `Dockerfile` needs to invoke the `RUN` command, the builder needs runtime
-  support for the specified platform. In a clean setup, you can only execute `RUN`
-  commands for your system architecture.
-  If your kernel supports [`binfmt_misc`](https://en.wikipedia.org/wiki/Binfmt_misc)
-  launchers for secondary architectures, buildx will pick them up automatically.
-  Docker desktop releases come with `binfmt_misc` automatically configured for `arm64`
-  and `arm` architectures. You can see what runtime platforms your current builder
-  instance supports by running `docker buildx inspect --bootstrap`.
-
-  Inside a `Dockerfile`, you can access the current platform value through
-  `TARGETPLATFORM` build argument. Please refer to the [`docker build`
-  documentation](/engine/reference/builder/#automatic-platform-args-in-the-global-scope)
-  for the full description of automatic platform argument variants .
-
-  The formatting for the platform specifier is defined in the [containerd source
-  code](https://github.com/containerd/containerd/blob/v1.4.3/platforms/platforms.go#L63).
+  For entitlements to be enabled, the `buildkitd` daemon also needs to allow them
+  with `--allow-insecure-entitlement` (see [`create --buildkitd-flags`](buildx_create.md#buildkitd-flags))
 
   **Examples**
 
   ```console
-  $ docker buildx build --platform=linux/arm64 .
-  $ docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7 .
-  $ docker buildx build --platform=darwin .
+  $ docker buildx create --use --name insecure-builder --buildkitd-flags '--allow-insecure-entitlement security.insecure'
+  $ docker buildx build --allow security.insecure .
   ```
 
-  ### Set type of progress output (--progress) {#progress}
+  ### Set build-time variables (--build-arg) {#build-arg}
 
-  ```
-  --progress=VALUE
-  ```
+  Same as [`docker build` command](/engine/reference/commandline/build/#set-build-time-variables---build-arg).
 
-  Set type of progress output (auto, plain, tty). Use plain to show container
-  output (default "auto").
+  There are also useful built-in build args like:
 
-  > You can also use the `BUILDKIT_PROGRESS` environment variable to set
-  > its value.
-
-  The following example uses `plain` output during the build:
+  * `BUILDKIT_CONTEXT_KEEP_GIT_DIR=<bool>` trigger git context to keep the `.git` directory
+  * `BUILDKIT_INLINE_BUILDINFO_ATTRS=<bool>` inline build info attributes in image config or not
+  * `BUILDKIT_INLINE_CACHE=<bool>` inline cache metadata to image config or not
+  * `BUILDKIT_MULTI_PLATFORM=<bool>` opt into determnistic output regardless of multi-platform output or not
 
   ```console
-  $ docker buildx build --load --progress=plain .
+  $ docker buildx build --build-arg BUILDKIT_MULTI_PLATFORM=1 .
+  ```
 
-  #1 [internal] load build definition from Dockerfile
-  #1 transferring dockerfile: 227B 0.0s done
-  #1 DONE 0.1s
+  More built-in build args can be found in [dockerfile frontend docs](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#built-in-build-args).
 
-  #2 [internal] load .dockerignore
-  #2 transferring context: 129B 0.0s done
-  #2 DONE 0.0s
-  ...
+  ### Additional build contexts (--build-context) {#build-context}
+
+  ```
+  --build-context=name=VALUE
+  ```
+
+  Define additional build context with specified contents. In Dockerfile the context can be accessed when `FROM name` or `--from=name` is used.
+  When Dockerfile defines a stage with the same name it is overwritten.
+
+  The value can be a local source directory, container image (with docker-image:// prefix), Git or HTTP URL.
+
+  Replace `alpine:latest` with a pinned one:
+
+  ```console
+  $ docker buildx build --build-context alpine=docker-image://alpine@sha256:0123456789 .
+  ```
+
+  Expose a secondary local source directory:
+
+  ```console
+  $ docker buildx build --build-context project=path/to/project/source .
+  # docker buildx build --build-context project=https://github.com/myuser/project.git .
+  ```
+
+  ```Dockerfile
+  FROM alpine
+  COPY --from=project myfile /
+  ```
+
+  ### Override the configured builder instance (--builder) {#builder}
+
+  Same as [`buildx --builder`](buildx.md#builder).
+
+  ### Use an external cache source for a build (--cache-from) {#cache-from}
+
+  ```
+  --cache-from=[NAME|type=TYPE[,KEY=VALUE]]
+  ```
+
+  Use an external cache source for a build. Supported types are `registry`,
+  `local` and `gha`.
+
+  - [`registry` source](https://github.com/moby/buildkit#registry-push-image-and-cache-separately)
+    can import cache from a cache manifest or (special) image configuration on the
+    registry.
+  - [`local` source](https://github.com/moby/buildkit#local-directory-1) can
+    import cache from local files previously exported with `--cache-to`.
+  - [`gha` source](https://github.com/moby/buildkit#github-actions-cache-experimental)
+    can import cache from a previously exported cache with `--cache-to` in your
+    GitHub repository
+
+  If no type is specified, `registry` exporter is used with a specified reference.
+
+  `docker` driver currently only supports importing build cache from the registry.
+
+  ```console
+  $ docker buildx build --cache-from=user/app:cache .
+  $ docker buildx build --cache-from=user/app .
+  $ docker buildx build --cache-from=type=registry,ref=user/app .
+  $ docker buildx build --cache-from=type=local,src=path/to/cache .
+  $ docker buildx build --cache-from=type=gha .
+  ```
+
+  More info about cache exporters and available attributes: https://github.com/moby/buildkit#export-cache
+
+  ### Export build cache to an external cache destination (--cache-to) {#cache-to}
+
+  ```
+  --cache-to=[NAME|type=TYPE[,KEY=VALUE]]
+  ```
+
+  Export build cache to an external cache destination. Supported types are
+  `registry`, `local`, `inline` and `gha`.
+
+  - [`registry` type](https://github.com/moby/buildkit#registry-push-image-and-cache-separately) exports build cache to a cache manifest in the registry.
+  - [`local` type](https://github.com/moby/buildkit#local-directory-1) type
+    exports cache to a local directory on the client.
+  - [`inline` type](https://github.com/moby/buildkit#inline-push-image-and-cache-together)
+    type writes the cache metadata into the image configuration.
+  - [`gha` type](https://github.com/moby/buildkit#github-actions-cache-experimental)
+    type exports cache through the [Github Actions Cache service API](https://github.com/tonistiigi/go-actions-cache/blob/master/api.md#authentication).
+
+  `docker` driver currently only supports exporting inline cache metadata to image
+  configuration. Alternatively, `--build-arg BUILDKIT_INLINE_CACHE=1` can be used
+  to trigger inline cache exporter.
+
+  Attribute key:
+
+  - `mode` - Specifies how many layers are exported with the cache. `min` on only
+    exports layers already in the final build stage, `max` exports layers for
+    all stages. Metadata is always exported for the whole build.
+
+  ```console
+  $ docker buildx build --cache-to=user/app:cache .
+  $ docker buildx build --cache-to=type=inline .
+  $ docker buildx build --cache-to=type=registry,ref=user/app .
+  $ docker buildx build --cache-to=type=local,dest=path/to/cache .
+  $ docker buildx build --cache-to=type=gha .
+  ```
+
+  More info about cache exporters and available attributes: https://github.com/moby/buildkit#export-cache
+
+  ### Load the single-platform build result to `docker images` (--load) {#load}
+
+  Shorthand for [`--output=type=docker`](#docker). Will automatically load the
+  single-platform build result to `docker images`.
+
+  ### Write build result metadata to the file (--metadata-file) {#metadata-file}
+
+  To output build metadata such as the image digest, pass the `--metadata-file` flag.
+  The metadata will be written as a JSON object to the specified file. The
+  directory of the specified file must already exist and be writable.
+
+  ```console
+  $ docker buildx build --load --metadata-file metadata.json .
+  $ cat metadata.json
+  ```
+  ```json
+  {
+    "containerimage.buildinfo": {
+      "frontend": "dockerfile.v0",
+      "attrs": {
+        "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+        "filename": "Dockerfile",
+        "source": "docker/dockerfile:master"
+      },
+      "sources": [
+        {
+          "type": "docker-image",
+          "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+          "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
+        },
+        {
+          "type": "docker-image",
+          "ref": "docker.io/library/alpine:3.13",
+          "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
+        }
+      ]
+    },
+    "containerimage.config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
+    "containerimage.descriptor": {
+      "annotations": {
+        "config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
+        "org.opencontainers.image.created": "2022-02-08T21:28:03Z"
+      },
+      "digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 506
+    },
+    "containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3"
+  }
   ```
 
   ### Set the export action for the build result (-o, --output) {#output}
@@ -473,8 +656,6 @@ examples: |-
   If just the path is specified as a value, `buildx` will use the local exporter
   with this path as the destination. If the value is "-", `buildx` will use `tar`
   exporter and write to `stdout`.
-
-  **Examples**
 
   ```console
   $ docker buildx build -o . .
@@ -529,7 +710,7 @@ examples: |-
   Attribute keys:
 
   - `dest` - destination path where tarball will be written. If not specified the
-  tar will be loaded automatically to the current docker instance.
+    tar will be loaded automatically to the current docker instance.
   - `context` - name for the docker context where to import the result
 
   #### `image`
@@ -547,117 +728,162 @@ examples: |-
 
   The `registry` exporter is a shortcut for `type=image,push=true`.
 
+  ### Set the target platforms for the build (--platform) {#platform}
+
+  ```
+  --platform=value[,value]
+  ```
+
+  Set the target platform for the build. All `FROM` commands inside the Dockerfile
+  without their own `--platform` flag will pull base images for this platform and
+  this value will also be the platform of the resulting image. The default value
+  will be the current platform of the buildkit daemon.
+
+  When using `docker-container` driver with `buildx`, this flag can accept multiple
+  values as an input separated by a comma. With multiple values the result will be
+  built for all of the specified platforms and joined together into a single manifest
+  list.
+
+  If the `Dockerfile` needs to invoke the `RUN` command, the builder needs runtime
+  support for the specified platform. In a clean setup, you can only execute `RUN`
+  commands for your system architecture.
+  If your kernel supports [`binfmt_misc`](https://en.wikipedia.org/wiki/Binfmt_misc)
+  launchers for secondary architectures, buildx will pick them up automatically.
+  Docker desktop releases come with `binfmt_misc` automatically configured for `arm64`
+  and `arm` architectures. You can see what runtime platforms your current builder
+  instance supports by running `docker buildx inspect --bootstrap`.
+
+  Inside a `Dockerfile`, you can access the current platform value through
+  `TARGETPLATFORM` build argument. Please refer to the [`docker build`
+  documentation](/engine/reference/builder/#automatic-platform-args-in-the-global-scope)
+  for the full description of automatic platform argument variants .
+
+  The formatting for the platform specifier is defined in the [containerd source
+  code](https://github.com/containerd/containerd/blob/v1.4.3/platforms/platforms.go#L63).
+
+  ```console
+  $ docker buildx build --platform=linux/arm64 .
+  $ docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7 .
+  $ docker buildx build --platform=darwin .
+  ```
+
+  ### Set type of progress output (--progress) {#progress}
+
+  ```
+  --progress=VALUE
+  ```
+
+  Set type of progress output (auto, plain, tty). Use plain to show container
+  output (default "auto").
+
+  > You can also use the `BUILDKIT_PROGRESS` environment variable to set
+  > its value.
+
+  The following example uses `plain` output during the build:
+
+  ```console
+  $ docker buildx build --load --progress=plain .
+
+  #1 [internal] load build definition from Dockerfile
+  #1 transferring dockerfile: 227B 0.0s done
+  #1 DONE 0.1s
+
+  #2 [internal] load .dockerignore
+  #2 transferring context: 129B 0.0s done
+  #2 DONE 0.0s
+  ...
+  ```
 
   ### Push the build result to a registry (--push) {#push}
 
   Shorthand for [`--output=type=registry`](#registry). Will automatically push the
   build result to registry.
 
-  ### Load the single-platform build result to `docker images` (--load) {#load}
-
-  Shorthand for [`--output=type=docker`](#docker). Will automatically load the
-  single-platform build result to `docker images`.
-
-  ### Use an external cache source for a build (--cache-from) {#cache-from}
+  ### Secret to expose to the build (--secret) {#secret}
 
   ```
-  --cache-from=[NAME|type=TYPE[,KEY=VALUE]]
+  --secret=[type=TYPE[,KEY=VALUE]
   ```
 
-  Use an external cache source for a build. Supported types are `registry`,
-  `local` and `gha`.
+  Exposes secret to the build. The secret can be used by the build using
+  [`RUN --mount=type=secret` mount](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypesecret).
 
-  - [`registry` source](https://github.com/moby/buildkit#registry-push-image-and-cache-separately)
-  can import cache from a cache manifest or (special) image configuration on the
-  registry.
-  - [`local` source](https://github.com/moby/buildkit#local-directory-1) can
-  import cache from local files previously exported with `--cache-to`.
-  - [`gha` source](https://github.com/moby/buildkit#github-actions-cache-experimental)
-  can import cache from a previously exported cache with `--cache-to` in your
-  GitHub repository
+  If `type` is unset it will be detected. Supported types are:
 
-  If no type is specified, `registry` exporter is used with a specified reference.
+  #### `file`
 
-  `docker` driver currently only supports importing build cache from the registry.
+  Attribute keys:
 
-  **Examples**
+  - `id` - ID of the secret. Defaults to basename of the `src` path.
+  - `src`, `source` - Secret filename. `id` used if unset.
+
+  ```dockerfile
+  # syntax=docker/dockerfile:1.3
+  FROM python:3
+  RUN pip install awscli
+  RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
+    aws s3 cp s3://... ...
+  ```
 
   ```console
-  $ docker buildx build --cache-from=user/app:cache .
-  $ docker buildx build --cache-from=user/app .
-  $ docker buildx build --cache-from=type=registry,ref=user/app .
-  $ docker buildx build --cache-from=type=local,src=path/to/cache .
-  $ docker buildx build --cache-from=type=gha .
+  $ docker buildx build --secret id=aws,src=$HOME/.aws/credentials .
   ```
 
-  More info about cache exporters and available attributes: https://github.com/moby/buildkit#export-cache
+  #### `env`
 
-  ### Export build cache to an external cache destination (--cache-to) {#cache-to}
+  Attribute keys:
 
+  - `id` - ID of the secret. Defaults to `env` name.
+  - `env` - Secret environment variable. `id` used if unset, otherwise will look for `src`, `source` if `id` unset.
+
+  ```dockerfile
+  # syntax=docker/dockerfile:1.3
+  FROM node:alpine
+  RUN --mount=type=bind,target=. \
+    --mount=type=secret,id=SECRET_TOKEN \
+    SECRET_TOKEN=$(cat /run/secrets/SECRET_TOKEN) yarn run test
   ```
-  --cache-to=[NAME|type=TYPE[,KEY=VALUE]]
-  ```
-
-  Export build cache to an external cache destination. Supported types are
-  `registry`, `local`, `inline` and `gha`.
-
-  - [`registry` type](https://github.com/moby/buildkit#registry-push-image-and-cache-separately) exports build cache to a cache manifest in the registry.
-  - [`local` type](https://github.com/moby/buildkit#local-directory-1) type
-  exports cache to a local directory on the client.
-  - [`inline` type](https://github.com/moby/buildkit#inline-push-image-and-cache-together)
-  type writes the cache metadata into the image configuration.
-  - [`gha` type](https://github.com/moby/buildkit#github-actions-cache-experimental)
-  type exports cache through the [Github Actions Cache service API](https://github.com/tonistiigi/go-actions-cache/blob/master/api.md#authentication).
-
-  `docker` driver currently only supports exporting inline cache metadata to image
-  configuration. Alternatively, `--build-arg BUILDKIT_INLINE_CACHE=1` can be used
-  to trigger inline cache exporter.
-
-  Attribute key:
-
-  - `mode` - Specifies how many layers are exported with the cache. `min` on only
-  exports layers already in the final build stage, `max` exports layers for
-  all stages. Metadata is always exported for the whole build.
-
-  **Examples**
 
   ```console
-  $ docker buildx build --cache-to=user/app:cache .
-  $ docker buildx build --cache-to=type=inline .
-  $ docker buildx build --cache-to=type=registry,ref=user/app .
-  $ docker buildx build --cache-to=type=local,dest=path/to/cache .
-  $ docker buildx build --cache-to=type=gha .
+  $ SECRET_TOKEN=token docker buildx build --secret id=SECRET_TOKEN .
   ```
 
-  More info about cache exporters and available attributes: https://github.com/moby/buildkit#export-cache
-
-  ### Allow extra privileged entitlement (--allow) {#allow}
-
-  ```
-  --allow=ENTITLEMENT
-  ```
-
-  Allow extra privileged entitlement. List of entitlements:
-
-  - `network.host` - Allows executions with host networking.
-  - `security.insecure` - Allows executions without sandbox. See
-  [related Dockerfile extensions](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#run---securityinsecuresandbox).
-
-  For entitlements to be enabled, the `buildkitd` daemon also needs to allow them
-  with `--allow-insecure-entitlement` (see [`create --buildkitd-flags`](buildx_create.md#buildkitd-flags))
-
-  **Examples**
-
-  ```console
-  $ docker buildx create --use --name insecure-builder --buildkitd-flags '--allow-insecure-entitlement security.insecure'
-  $ docker buildx build --allow security.insecure .
-  ```
-
-  ### Size of `/dev/shm` (--shm-size) {#shm-size}
+  ### Size of /dev/shm (--shm-size) {#shm-size}
 
   The format is `<number><unit>`. `number` must be greater than `0`. Unit is
   optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes), or `g`
   (gigabytes). If you omit the unit, the system uses bytes.
+
+  ### SSH agent socket or keys to expose to the build (--ssh) {#ssh}
+
+  ```
+  --ssh=default|<id>[=<socket>|<key>[,<key>]]
+  ```
+
+  This can be useful when some commands in your Dockerfile need specific SSH
+  authentication (e.g., cloning a private repository).
+
+  `--ssh` exposes SSH agent socket or keys to the build and can be used with the
+  [`RUN --mount=type=ssh` mount](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypessh).
+
+  Example to access Gitlab using an SSH agent socket:
+
+  ```dockerfile
+  # syntax=docker/dockerfile:1.3
+  FROM alpine
+  RUN apk add --no-cache openssh-client
+  RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+  RUN --mount=type=ssh ssh -q -T git@gitlab.com 2>&1 | tee /hello
+  # "Welcome to GitLab, @GITLAB_USERNAME_ASSOCIATED_WITH_SSHKEY" should be printed here
+  # with the type of build progress is defined as `plain`.
+  ```
+
+  ```console
+  $ eval $(ssh-agent)
+  $ ssh-add ~/.ssh/id_rsa
+  (Input your passphrase here)
+  $ docker buildx build --ssh default=$SSH_AUTH_SOCK .
+  ```
 
   ### Set ulimits (--ulimit) {#ulimit}
 

--- a/_data/buildx/docker_buildx_create.yaml
+++ b/_data/buildx/docker_buildx_create.yaml
@@ -20,6 +20,7 @@ options:
   description: Append a node to builder instead of changing it
   details_url: '#append'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +30,7 @@ options:
   default_value: "false"
   description: Boot builder after creation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +40,7 @@ options:
   description: Flags for buildkitd daemon
   details_url: '#buildkitd-flags'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -47,6 +50,7 @@ options:
   description: BuildKit config file
   details_url: '#config'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -57,6 +61,7 @@ options:
     Driver to use (available: `docker`, `docker-container`, `kubernetes`)
   details_url: '#driver'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -67,6 +72,7 @@ options:
   description: Options for the driver
   details_url: '#driver-opt'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -77,6 +83,7 @@ options:
   description: Remove a node from builder instead of changing it
   details_url: '#leave'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -86,6 +93,7 @@ options:
   description: Builder instance name
   details_url: '#name'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -95,6 +103,7 @@ options:
   description: Create/modify node with given name
   details_url: '#node'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -105,6 +114,7 @@ options:
   description: Fixed platforms for current node
   details_url: '#platform'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -115,6 +125,7 @@ options:
   description: Set the current builder instance
   details_url: '#use'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -124,6 +135,7 @@ inherited_options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -134,8 +146,6 @@ examples: |-
   The `--append` flag changes the action of the command to append a new node to an
   existing builder specified by `--name`. Buildx will choose an appropriate node
   for a build based on the platforms it supports.
-
-  **Examples**
 
   ```console
   $ docker buildx create mycontext1
@@ -154,8 +164,6 @@ examples: |-
   Adds flags when starting the buildkitd daemon. They take precedence over the
   configuration file specified by [`--config`](#config). See `buildkitd --help`
   for the available flags.
-
-  **Example**
 
   ```
   --buildkitd-flags '--debug --debugaddr 0.0.0.0:6666'
@@ -220,54 +228,28 @@ examples: |-
 
   - `docker` - No driver options
   - `docker-container`
-      - `image=IMAGE` - Sets the container image to be used for running buildkit.
-      - `network=NETMODE` - Sets the network mode for running the buildkit container.
-      - `cgroup-parent=CGROUP` - Sets the cgroup parent of the buildkit container if docker is using the "cgroupfs" driver. Defaults to `/docker/buildx`.
+    - `image=IMAGE` - Sets the container image to be used for running buildkit.
+    - `network=NETMODE` - Sets the network mode for running the buildkit container.
+    - `cgroup-parent=CGROUP` - Sets the cgroup parent of the buildkit container if docker is using the "cgroupfs" driver. Defaults to `/docker/buildx`.
   - `kubernetes`
-      - `image=IMAGE` - Sets the container image to be used for running buildkit.
-      - `namespace=NS` - Sets the Kubernetes namespace. Defaults to the current namespace.
-      - `replicas=N` - Sets the number of `Pod` replicas. Defaults to 1.
-      - `requests.cpu` - Sets the request CPU value specified in units of Kubernetes CPU. Example `requests.cpu=100m`, `requests.cpu=2`
-      - `requests.memory` - Sets the request memory value specified in bytes or with a valid suffix. Example `requests.memory=500Mi`, `requests.memory=4G`
-      - `limits.cpu` - Sets the limit CPU value specified in units of Kubernetes CPU. Example `limits.cpu=100m`, `limits.cpu=2`
-      - `limits.memory` - Sets the limit memory value specified in bytes or with a valid suffix. Example `limits.memory=500Mi`, `limits.memory=4G`
-      - `nodeselector="label1=value1,label2=value2"` - Sets the kv of `Pod` nodeSelector. No Defaults. Example `nodeselector=kubernetes.io/arch=arm64`
-      - `rootless=(true|false)` - Run the container as a non-root user without `securityContext.privileged`. [Using Ubuntu host kernel is recommended](https://github.com/moby/buildkit/blob/master/docs/rootless.md). Defaults to false.
-      - `loadbalance=(sticky|random)` - Load-balancing strategy. If set to "sticky", the pod is chosen using the hash of the context path. Defaults to "sticky"
-      - `qemu.install=(true|false)` - Install QEMU emulation for multi platforms support.
-      - `qemu.image=IMAGE` - Sets the QEMU emulation image. Defaults to `tonistiigi/binfmt:latest`
-
-  **Examples**
-
-  #### Use a custom network
-
-  ```console
-  $ docker network create foonet
-  $ docker buildx create --name builder --driver docker-container --driver-opt network=foonet --use
-  $ docker buildx inspect --bootstrap
-  $ docker inspect buildx_buildkit_builder0 --format={{.NetworkSettings.Networks}}
-  map[foonet:0xc00018c0c0]
-  ```
-
-  #### OpenTelemetry support
-
-  To capture the trace to [Jaeger](https://github.com/jaegertracing/jaeger), set
-  `JAEGER_TRACE` environment variable to the collection address using the `driver-opt`:
-
-  ```console
-  $ docker run -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one
-  $ docker buildx create --name builder --driver docker-container --driver-opt network=host --driver-opt env.JAEGER_TRACE=localhost:6831 --use
-  $ docker buildx inspect --bootstrap
-  # buildx command should be traced at http://127.0.0.1:16686/
-  ```
+    - `image=IMAGE` - Sets the container image to be used for running buildkit.
+    - `namespace=NS` - Sets the Kubernetes namespace. Defaults to the current namespace.
+    - `replicas=N` - Sets the number of `Pod` replicas. Defaults to 1.
+    - `requests.cpu` - Sets the request CPU value specified in units of Kubernetes CPU. Example `requests.cpu=100m`, `requests.cpu=2`
+    - `requests.memory` - Sets the request memory value specified in bytes or with a valid suffix. Example `requests.memory=500Mi`, `requests.memory=4G`
+    - `limits.cpu` - Sets the limit CPU value specified in units of Kubernetes CPU. Example `limits.cpu=100m`, `limits.cpu=2`
+    - `limits.memory` - Sets the limit memory value specified in bytes or with a valid suffix. Example `limits.memory=500Mi`, `limits.memory=4G`
+    - `nodeselector="label1=value1,label2=value2"` - Sets the kv of `Pod` nodeSelector. No Defaults. Example `nodeselector=kubernetes.io/arch=arm64`
+    - `rootless=(true|false)` - Run the container as a non-root user without `securityContext.privileged`. [Using Ubuntu host kernel is recommended](https://github.com/moby/buildkit/blob/master/docs/rootless.md). Defaults to false.
+    - `loadbalance=(sticky|random)` - Load-balancing strategy. If set to "sticky", the pod is chosen using the hash of the context path. Defaults to "sticky"
+    - `qemu.install=(true|false)` - Install QEMU emulation for multi platforms support.
+    - `qemu.image=IMAGE` - Sets the QEMU emulation image. Defaults to `tonistiigi/binfmt:latest`
 
   ### Remove a node from a builder (--leave) {#leave}
 
   The `--leave` flag changes the action of the command to remove a node from a
   builder. The builder needs to be specified with `--name` and node that is removed
   is set with `--node`.
-
-  **Examples**
 
   ```console
   $ docker buildx create --name mybuilder --node mybuilder0 --leave
@@ -292,7 +274,7 @@ examples: |-
   none is specified, it is the name of the builder it belongs to, with an index
   number suffix.
 
-  ### Set the platforms supported by the node {#platform}
+  ### Set the platforms supported by the node (--platform) {#platform}
 
   ```
   --platform PLATFORMS
@@ -304,14 +286,12 @@ examples: |-
   priority over the detected ones and can be used when multiple nodes support
   building for the same platform.
 
-  **Examples**
-
   ```console
   $ docker buildx create --platform linux/amd64
   $ docker buildx create --platform linux/arm64,linux/arm/v8
   ```
 
-  ### Automatically switch to the newly created builder {#use}
+  ### Automatically switch to the newly created builder (--use) {#use}
 
   The `--use` flag automatically switches the current builder to the newly created
   one. Equivalent to running `docker buildx use $(docker buildx create ...)`.

--- a/_data/buildx/docker_buildx_du.yaml
+++ b/_data/buildx/docker_buildx_du.yaml
@@ -9,6 +9,7 @@ options:
   value_type: filter
   description: Provide filter values
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -18,6 +19,7 @@ options:
   default_value: "false"
   description: Provide a more verbose output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_imagetools.yaml
+++ b/_data/buildx/docker_buildx_imagetools.yaml
@@ -17,6 +17,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_imagetools_create.yaml
+++ b/_data/buildx/docker_buildx_imagetools_create.yaml
@@ -1,9 +1,6 @@
 command: docker buildx imagetools create
 short: Create a new image based on source images
 long: |-
-  Imagetools contains commands for working with manifest lists in the registry.
-  These commands are useful for inspecting multi-platform build results.
-
   Create a new manifest list based on source manifests. The source manifests can
   be manifest lists or single platform distribution manifests and must already
   exist in the registry where the new manifest is created. If only one source is
@@ -18,6 +15,7 @@ options:
   description: Append to existing manifest
   details_url: '#append'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +26,7 @@ options:
   description: Show final image instead of pushing
   details_url: '#dry-run'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +38,7 @@ options:
   description: Read source descriptor from file
   details_url: '#file'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -50,6 +50,7 @@ options:
   description: Set reference for new image
   details_url: '#tag'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -60,6 +61,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -90,15 +92,14 @@ examples: |-
   In order to define annotations or additional platform properties like `os.version` and
   `os.features` you need to add them in the OCI descriptor object encoded in JSON.
 
-  ```
-  docker buildx imagetools inspect --raw alpine | jq '.manifests[0] | .platform."os.version"="10.1"' > descr.json
-  docker buildx imagetools create -f descr.json myuser/image
+  ```console
+  $ docker buildx imagetools inspect --raw alpine | jq '.manifests[0] | .platform."os.version"="10.1"' > descr.json
+  $ docker buildx imagetools create -f descr.json myuser/image
   ```
 
   The descriptor in the file is merged with existing descriptor in the registry if it exists.
 
   The supported fields for the descriptor are defined in [OCI spec](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties) .
-
 
   ### Set reference for new image  (-t, --tag) {#tag}
 
@@ -108,11 +109,8 @@ examples: |-
 
   Use the `-t` or `--tag` flag to set the name of the image to be created.
 
-  **Examples**
-
   ```console
   $ docker buildx imagetools create --dry-run alpine@sha256:5c40b3c27b9f13c873fefb2139765c56ce97fd50230f1f2d5c91e55dec171907 sha256:c4ba6347b0e4258ce6a6de2401619316f982b7bcc529f73d2a410d0097730204
-
   $ docker buildx imagetools create -t tonistiigi/myapp -f image1 -f image2
   ```
 deprecated: false

--- a/_data/buildx/docker_buildx_imagetools_inspect.yaml
+++ b/_data/buildx/docker_buildx_imagetools_inspect.yaml
@@ -1,37 +1,65 @@
 command: docker buildx imagetools inspect
-short: Show details of image in the registry
+short: Show details of an image in the registry
 long: |-
-  Show details of image in the registry.
-
-  Example:
+  Show details of an image in the registry.
 
   ```console
   $ docker buildx imagetools inspect alpine
-
   Name:      docker.io/library/alpine:latest
   MediaType: application/vnd.docker.distribution.manifest.list.v2+json
-  Digest:    sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913
+  Digest:    sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
   Manifests:
-    Name:      docker.io/library/alpine:latest@sha256:5c40b3c27b9f13c873fefb2139765c56ce97fd50230f1f2d5c91e55dec171907
+    Name:      docker.io/library/alpine:latest@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3
     MediaType: application/vnd.docker.distribution.manifest.v2+json
     Platform:  linux/amd64
 
-    Name:      docker.io/library/alpine:latest@sha256:c4ba6347b0e4258ce6a6de2401619316f982b7bcc529f73d2a410d0097730204
+    Name:      docker.io/library/alpine:latest@sha256:e047bc2af17934d38c5a7fa9f46d443f1de3a7675546402592ef805cfa929f9d
     MediaType: application/vnd.docker.distribution.manifest.v2+json
     Platform:  linux/arm/v6
-   ...
+
+    Name:      docker.io/library/alpine:latest@sha256:8483ecd016885d8dba70426fda133c30466f661bb041490d525658f1aac73822
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/arm/v7
+
+    Name:      docker.io/library/alpine:latest@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/arm64/v8
+
+    Name:      docker.io/library/alpine:latest@sha256:2689e157117d2da668ad4699549e55eba1ceb79cb7862368b30919f0488213f4
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/386
+
+    Name:      docker.io/library/alpine:latest@sha256:2042a492bcdd847a01cd7f119cd48caa180da696ed2aedd085001a78664407d6
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/ppc64le
+
+    Name:      docker.io/library/alpine:latest@sha256:49e322ab6690e73a4909f787bcbdb873631264ff4a108cddfd9f9c249ba1d58e
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/s390x
   ```
 usage: docker buildx imagetools inspect [OPTIONS] NAME
 pname: docker buildx imagetools
 plink: docker_buildx_imagetools.yaml
 options:
+- option: format
+  value_type: string
+  default_value: '`{{.Manifest}}`'
+  description: Format the output using the given Go template
+  details_url: '#format'
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: raw
   value_type: bool
   default_value: "false"
-  description: Show original JSON manifest
+  description: Show original, unformatted JSON manifest
   details_url: '#raw'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,6 +70,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -51,10 +80,572 @@ examples: |-
 
   Same as [`buildx --builder`](buildx.md#builder).
 
+  ### Format the output (--format) {#format}
+
+  Format the output using the given Go template. Defaults to `{{.Manifest}}` if
+  unset. Following fields are available:
+
+  * `.Name`: provides the reference of the image
+  * `.Manifest`: provides the manifest or manifest list
+  * `.Image`: provides the image config
+  * `.BuildInfo`: provides [build info from image config](https://github.com/moby/buildkit/blob/master/docs/build-repro.md#image-config)
+
+  #### `.Name`
+
+  ```console
+  $ docker buildx imagetools inspect alpine --format "{{.Name}}"
+  Name: docker.io/library/alpine:latest
+  ```
+
+  #### `.Manifest`
+
+  ```console
+  $ docker buildx imagetools inspect crazymax/loop --format "{{.Manifest}}"
+  Name:      docker.io/crazymax/loop:latest
+  MediaType: application/vnd.docker.distribution.manifest.v2+json
+  Digest:    sha256:08602e7340970e92bde5e0a2e887c1fde4d9ae753d1e05efb4c8ef3b609f97f1
+  ```
+
+  ```console
+  $ docker buildx imagetools inspect moby/buildkit:master --format "{{.Manifest}}"
+  Name:      docker.io/moby/buildkit:master
+  MediaType: application/vnd.docker.distribution.manifest.list.v2+json
+  Digest:    sha256:3183f7ce54d1efb44c34b84f428ae10aaf141e553c6b52a7ff44cc7083a05a66
+
+  Manifests:
+    Name:      docker.io/moby/buildkit:master@sha256:667d28c9fb33820ce686887a717a148e89fa77f9097f9352996bbcce99d352b1
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/amd64
+
+    Name:      docker.io/moby/buildkit:master@sha256:71789527b64ab3d7b3de01d364b449cd7f7a3da758218fbf73b9c9aae05a6775
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/arm/v7
+
+    Name:      docker.io/moby/buildkit:master@sha256:fb64667e1ce6ab0d05478f3a8402af07b27737598dcf9a510fb1d792b13a66be
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/arm64
+
+    Name:      docker.io/moby/buildkit:master@sha256:1c3ddf95a0788e23f72f25800c05abc4458946685e2b66788c3d978cde6da92b
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/s390x
+
+    Name:      docker.io/moby/buildkit:master@sha256:05bcde6d460a284e5bc88026cd070277e8380355de3126cbc8fe8a452708c6b1
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/ppc64le
+
+    Name:      docker.io/moby/buildkit:master@sha256:c04c57765304ab84f4f9807fff3e11605c3a60e16435c734b02c723680f6bd6e
+    MediaType: application/vnd.docker.distribution.manifest.v2+json
+    Platform:  linux/riscv64
+  ```
+
+  #### `.BuildInfo`
+
+  ```console
+  $ docker buildx imagetools inspect crazymax/buildx:buildinfo --format "{{.BuildInfo}}"
+  Name: docker.io/crazymax/buildx:buildinfo
+  Frontend: dockerfile.v0
+  Attrs:
+    filename:      Dockerfile
+    source:        docker/dockerfile-upstream:master-labs
+    build-arg:bar: foo
+    build-arg:foo: bar
+  Sources:
+    Type: docker-image
+    Ref:  docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0
+    Pin:  sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0
+
+    Type: docker-image
+    Ref:  docker.io/library/alpine:3.13
+    Pin:  sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c
+
+    Type: docker-image
+    Ref:  docker.io/moby/buildkit:v0.9.0
+    Pin:  sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab
+
+    Type: docker-image
+    Ref:  docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04
+    Pin:  sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04
+
+    Type: http
+    Ref:  https://raw.githubusercontent.com/moby/moby/master/README.md
+    Pin:  sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c
+  ```
+
+  #### JSON output
+
+  A `json` go template func is also available if you want to render fields as
+  JSON bytes:
+
+  ```console
+  $ docker buildx imagetools inspect crazymax/loop --format "{{json .Manifest}}"
+  ```
+  ```json
+  {
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "digest": "sha256:08602e7340970e92bde5e0a2e887c1fde4d9ae753d1e05efb4c8ef3b609f97f1",
+    "size": 949
+  }
+  ```
+
+  ```console
+  $ docker buildx imagetools inspect moby/buildkit:master --format "{{json .Manifest}}"
+  ```
+  ```json
+  {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+    "digest": "sha256:79d97f205e2799d99a3a8ae2a1ef17acb331e11784262c3faada847dc6972c52",
+    "size": 2010,
+    "manifests": [
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:bd1e78f06de26610fadf4eb9d04b1a45a545799d6342701726e952cc0c11c912",
+        "size": 1158,
+        "platform": {
+          "architecture": "amd64",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:d37dcced63ec0965824fca644f0ac9efad8569434ec15b4c83adfcb3dcfc743b",
+        "size": 1158,
+        "platform": {
+          "architecture": "arm",
+          "os": "linux",
+          "variant": "v7"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:ce142eb2255e6af46f2809e159fd03081697c7605a3de03b9cbe9a52ddb244bf",
+        "size": 1158,
+        "platform": {
+          "architecture": "arm64",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:f59bfb5062fff76ce464bfa4e25ebaaaac887d6818238e119d68613c456d360c",
+        "size": 1158,
+        "platform": {
+          "architecture": "s390x",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:cc96426e0c50a78105d5637d31356db5dd6ec594f21b24276e534a32da09645c",
+        "size": 1159,
+        "platform": {
+          "architecture": "ppc64le",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:39f9c1e2878e6c333acb23187d6b205ce82ed934c60da326cb2c698192631478",
+        "size": 1158,
+        "platform": {
+          "architecture": "riscv64",
+          "os": "linux"
+        }
+      }
+    ]
+  }
+  ```
+
+  ```console
+  $ docker buildx imagetools inspect crazymax/buildx:buildinfo --format "{{json .BuildInfo}}"
+  ```
+  ```json
+  {
+    "frontend": "dockerfile.v0",
+    "attrs": {
+      "build-arg:bar": "foo",
+      "build-arg:foo": "bar",
+      "filename": "Dockerfile",
+      "source": "crazymax/dockerfile:buildattrs"
+    },
+    "sources": [
+      {
+        "type": "docker-image",
+        "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+        "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
+      },
+      {
+        "type": "docker-image",
+        "ref": "docker.io/library/alpine:3.13@sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c",
+        "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
+      },
+      {
+        "type": "docker-image",
+        "ref": "docker.io/moby/buildkit:v0.9.0@sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+        "pin": "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab"
+      },
+      {
+        "type": "docker-image",
+        "ref": "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+        "pin": "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04"
+      },
+      {
+        "type": "http",
+        "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
+        "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
+      }
+    ]
+  }
+  ```
+
+  ```console
+  $ docker buildx imagetools inspect crazymax/buildx:buildinfo --format "{{json .}}"
+  ```
+  ```json
+  {
+    "name": "crazymax/buildx:buildinfo",
+    "manifest": {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "digest": "sha256:899d2c7acbc124d406820857bb51d9089717bbe4e22b97eb4bc5789e99f09f83",
+      "size": 2628
+    },
+    "image": {
+      "created": "2022-02-24T12:27:43.627154558Z",
+      "architecture": "amd64",
+      "os": "linux",
+      "config": {
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "DOCKER_TLS_CERTDIR=/certs",
+          "DOCKER_CLI_EXPERIMENTAL=enabled"
+        ],
+        "Entrypoint": [
+          "docker-entrypoint.sh"
+        ],
+        "Cmd": [
+          "sh"
+        ]
+      },
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:7fcb75871b2101082203959c83514ac8a9f4ecfee77a0fe9aa73bbe56afdf1b4",
+          "sha256:d3c0b963ff5684160641f936d6a4aa14efc8ff27b6edac255c07f2d03ff92e82",
+          "sha256:3f8d78f13fa9b1f35d3bc3f1351d03a027c38018c37baca73f93eecdea17f244",
+          "sha256:8e6eb1137b182ae0c3f5d40ca46341fda2eaeeeb5fa516a9a2bf96171238e2e0",
+          "sha256:fde4c869a56b54dd76d7352ddaa813fd96202bda30b9dceb2c2f2ad22fa2e6ce",
+          "sha256:52025823edb284321af7846419899234b3c66219bf06061692b709875ed0760f",
+          "sha256:50adb5982dbf6126c7cf279ac3181d1e39fc9116b610b947a3dadae6f7e7c5bc",
+          "sha256:9801c319e1c66c5d295e78b2d3e80547e73c7e3c63a4b71e97c8ca357224af24",
+          "sha256:dfbfac44d5d228c49b42194c8a2f470abd6916d072f612a6fb14318e94fde8ae",
+          "sha256:3dfb74e19dedf61568b917c19b0fd3ee4580870027ca0b6054baf239855d1322",
+          "sha256:b182e707c23e4f19be73f9022a99d2d1ca7bf1ca8f280d40e4d1c10a6f51550e"
+        ]
+      },
+      "history": [
+        {
+          "created": "2021-11-12T17:19:58.698676655Z",
+          "created_by": "/bin/sh -c #(nop) ADD file:5a707b9d6cb5fff532e4c2141bc35707593f21da5528c9e71ae2ddb6ba4a4eb6 in / "
+        },
+        {
+          "created": "2021-11-12T17:19:58.948920855Z",
+          "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+          "empty_layer": true
+        },
+        {
+          "created": "2022-02-24T12:27:38.285594601Z",
+          "created_by": "RUN /bin/sh -c apk --update --no-cache add     bash     ca-certificates     openssh-client   \u0026\u0026 rm -rf /tmp/* /var/cache/apk/* # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:41.061874167Z",
+          "created_by": "COPY /opt/docker/ /usr/local/bin/ # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:41.174098947Z",
+          "created_by": "COPY /usr/bin/buildctl /usr/local/bin/buildctl # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:41.320343683Z",
+          "created_by": "COPY /usr/bin/buildkit* /usr/local/bin/ # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:41.447149933Z",
+          "created_by": "COPY /buildx /usr/libexec/docker/cli-plugins/docker-buildx # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:43.057722191Z",
+          "created_by": "COPY /opt/docker-compose /usr/libexec/docker/cli-plugins/docker-compose # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:43.145224134Z",
+          "created_by": "ADD https://raw.githubusercontent.com/moby/moby/master/README.md / # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:43.422212427Z",
+          "created_by": "ENV DOCKER_TLS_CERTDIR=/certs",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2022-02-24T12:27:43.422212427Z",
+          "created_by": "ENV DOCKER_CLI_EXPERIMENTAL=enabled",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2022-02-24T12:27:43.422212427Z",
+          "created_by": "RUN /bin/sh -c docker --version   \u0026\u0026 buildkitd --version   \u0026\u0026 buildctl --version   \u0026\u0026 docker buildx version   \u0026\u0026 docker compose version   \u0026\u0026 mkdir /certs /certs/client   \u0026\u0026 chmod 1777 /certs /certs/client # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:43.514320155Z",
+          "created_by": "COPY rootfs/modprobe.sh /usr/local/bin/modprobe # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:43.627154558Z",
+          "created_by": "COPY rootfs/docker-entrypoint.sh /usr/local/bin/ # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2022-02-24T12:27:43.627154558Z",
+          "created_by": "ENTRYPOINT [\"docker-entrypoint.sh\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2022-02-24T12:27:43.627154558Z",
+          "created_by": "CMD [\"sh\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ]
+    },
+    "buildinfo": {
+      "frontend": "dockerfile.v0",
+      "attrs": {
+        "build-arg:bar": "foo",
+        "build-arg:foo": "bar",
+        "filename": "Dockerfile",
+        "source": "docker/dockerfile-upstream:master-labs"
+      },
+      "sources": [
+        {
+          "type": "docker-image",
+          "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+          "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
+        },
+        {
+          "type": "docker-image",
+          "ref": "docker.io/library/alpine:3.13",
+          "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
+        },
+        {
+          "type": "docker-image",
+          "ref": "docker.io/moby/buildkit:v0.9.0",
+          "pin": "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab"
+        },
+        {
+          "type": "docker-image",
+          "ref": "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+          "pin": "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04"
+        },
+        {
+          "type": "http",
+          "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
+          "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
+        }
+      ]
+    }
+  }
+  ```
+
+  #### Multi-platform
+
+  Multi-platform images are supported for `.Image` and `.BuildInfo` fields. If
+  you want to pick up a specific platform, you can specify it using the `index`
+  go template function:
+
+  ```console
+  $ docker buildx imagetools inspect --format '{{json (index .Image "linux/s390x")}}' moby/buildkit:master
+  ```
+  ```json
+  {
+    "created": "2022-02-25T17:13:27.89891722Z",
+    "architecture": "s390x",
+    "os": "linux",
+    "config": {
+      "Env": [
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      ],
+      "Entrypoint": [
+        "buildkitd"
+      ],
+      "Volumes": {
+        "/var/lib/buildkit": {}
+      }
+    },
+    "rootfs": {
+      "type": "layers",
+      "diff_ids": [
+        "sha256:41048e32d0684349141cf05f629c5fc3c5915d1f3426b66dbb8953a540e01e1e",
+        "sha256:2651209b9208fff6c053bc3c17353cb07874e50f1a9bc96d6afd03aef63de76a",
+        "sha256:6741ed7e73039d853fa8902246a4c7e8bf9dd09652fd1b08251bc5f9e8876a7f",
+        "sha256:92ac046adeeb65c86ae3f0b458dee04ad4a462e417661c04d77642c66494f69b"
+      ]
+    },
+    "history": [
+      {
+        "created": "2021-11-24T20:41:23.709681315Z",
+        "created_by": "/bin/sh -c #(nop) ADD file:cd24c711a2ef431b3ff94f9a02bfc42f159bc60de1d0eceecafea4e8af02441d in / "
+      },
+      {
+        "created": "2021-11-24T20:41:23.94211262Z",
+        "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+        "empty_layer": true
+      },
+      {
+        "created": "2022-01-26T18:15:21.449825391Z",
+        "created_by": "RUN /bin/sh -c apk add --no-cache fuse3 git openssh pigz xz   \u0026\u0026 ln -s fusermount3 /usr/bin/fusermount # buildkit",
+        "comment": "buildkit.dockerfile.v0"
+      },
+      {
+        "created": "2022-02-24T00:34:00.924540012Z",
+        "created_by": "COPY examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/ # buildkit",
+        "comment": "buildkit.dockerfile.v0"
+      },
+      {
+        "created": "2022-02-25T17:13:27.89891722Z",
+        "created_by": "VOLUME [/var/lib/buildkit]",
+        "comment": "buildkit.dockerfile.v0",
+        "empty_layer": true
+      },
+      {
+        "created": "2022-02-25T17:13:27.89891722Z",
+        "created_by": "COPY / /usr/bin/ # buildkit",
+        "comment": "buildkit.dockerfile.v0"
+      },
+      {
+        "created": "2022-02-25T17:13:27.89891722Z",
+        "created_by": "ENTRYPOINT [\"buildkitd\"]",
+        "comment": "buildkit.dockerfile.v0",
+        "empty_layer": true
+      }
+    ]
+  }
+  ```
+
   ### Show original, unformatted JSON manifest (--raw) {#raw}
 
-  Use the `--raw` option to print the original JSON bytes instead of the formatted
-  output.
+  Use the `--raw` option to print the unformatted JSON manifest bytes.
+
+  > `jq` is used here to get a better rendering of the output result.
+
+  ```console
+  $ docker buildx imagetools inspect --raw crazymax/loop | jq
+  ```
+  ```json
+  {
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "schemaVersion": 2,
+    "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "digest": "sha256:7ace7d324e79b360b2db8b820d83081863d96d22e734cdf297a8e7fd83f6ceb3",
+      "size": 2298
+    },
+    "layers": [
+      {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:5843afab387455b37944e709ee8c78d7520df80f8d01cf7f861aae63beeddb6b",
+        "size": 2811478
+      },
+      {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:726d3732a87e1c430d67e8969de6b222a889d45e045ebae1a008a37ba38f3b1f",
+        "size": 1776812
+      },
+      {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:5d7cf9b33148a8f220c84f27dd2cfae46aca019a3ea3fbf7274f6d6dbfae8f3b",
+        "size": 382855
+      }
+    ]
+  }
+  ```
+
+  ```console
+  $ docker buildx imagetools inspect --raw moby/buildkit:master | jq
+  ```
+  ```json
+  {
+    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+    "schemaVersion": 2,
+    "manifests": [
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:667d28c9fb33820ce686887a717a148e89fa77f9097f9352996bbcce99d352b1",
+        "size": 1158,
+        "platform": {
+          "architecture": "amd64",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:71789527b64ab3d7b3de01d364b449cd7f7a3da758218fbf73b9c9aae05a6775",
+        "size": 1158,
+        "platform": {
+          "architecture": "arm",
+          "os": "linux",
+          "variant": "v7"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:fb64667e1ce6ab0d05478f3a8402af07b27737598dcf9a510fb1d792b13a66be",
+        "size": 1158,
+        "platform": {
+          "architecture": "arm64",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:1c3ddf95a0788e23f72f25800c05abc4458946685e2b66788c3d978cde6da92b",
+        "size": 1158,
+        "platform": {
+          "architecture": "s390x",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:05bcde6d460a284e5bc88026cd070277e8380355de3126cbc8fe8a452708c6b1",
+        "size": 1159,
+        "platform": {
+          "architecture": "ppc64le",
+          "os": "linux"
+        }
+      },
+      {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "digest": "sha256:c04c57765304ab84f4f9807fff3e11605c3a60e16435c734b02c723680f6bd6e",
+        "size": 1158,
+        "platform": {
+          "architecture": "riscv64",
+          "os": "linux"
+        }
+      }
+    ]
+  }
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/buildx/docker_buildx_inspect.yaml
+++ b/_data/buildx/docker_buildx_inspect.yaml
@@ -11,6 +11,7 @@ options:
   description: Ensure builder has booted before inspecting
   details_url: '#bootstrap'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_install.yaml
+++ b/_data/buildx/docker_buildx_install.yaml
@@ -9,6 +9,7 @@ inherited_options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_ls.yaml
+++ b/_data/buildx/docker_buildx_ls.yaml
@@ -3,21 +3,20 @@ short: List builder instances
 long: |-
   Lists all builder instances and the nodes for each instance
 
-  **Example**
-
   ```console
   $ docker buildx ls
 
   NAME/NODE       DRIVER/ENDPOINT             STATUS  PLATFORMS
   elated_tesla *  docker-container
     elated_tesla0 unix:///var/run/docker.sock running linux/amd64
-    elated_tesla1 ssh://ubuntu@1.2.3.4        running linux/arm64, linux/arm/v7, linux/arm/v6
+    elated_tesla1 ssh://ubuntu@1.2.3.4        running linux/arm64*, linux/arm/v7, linux/arm/v6
   default         docker
     default       default                     running linux/amd64
   ```
 
   Each builder has one or more nodes associated with it. The current builder's
-  name is marked with a `*`.
+  name is marked with a `*` in `NAME/NODE` and explicit node to build against for
+  the target platform marked with a `*` in the `PLATFORMS` column.
 usage: docker buildx ls
 pname: docker buildx
 plink: docker_buildx.yaml
@@ -26,6 +25,7 @@ inherited_options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_prune.yaml
+++ b/_data/buildx/docker_buildx_prune.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Remove all unused images, not just dangling ones
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: filter
   description: Provide filter values (e.g., `until=24h`)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   default_value: "0"
   description: Amount of disk space to keep for cache
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -47,6 +51,7 @@ options:
   default_value: "false"
   description: Provide a more verbose output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -57,6 +62,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_rm.yaml
+++ b/_data/buildx/docker_buildx_rm.yaml
@@ -7,12 +7,47 @@ usage: docker buildx rm [NAME]
 pname: docker buildx
 plink: docker_buildx.yaml
 options:
+- option: all-inactive
+  value_type: bool
+  default_value: "false"
+  description: Remove all inactive builders
+  details_url: '#all-inactive'
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: force
+  shorthand: f
+  value_type: bool
+  default_value: "false"
+  description: Do not prompt for confirmation
+  details_url: '#force'
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: keep-daemon
+  value_type: bool
+  default_value: "false"
+  description: Keep the buildkitd daemon running
+  details_url: '#keep-daemon'
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: keep-state
   value_type: bool
   default_value: "false"
   description: Keep BuildKit state
   details_url: '#keep-state'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -23,14 +58,37 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 examples: |-
+  ### Remove all inactive builders (--all-inactive) {#all-inactive}
+
+  Remove builders that are not in running state.
+
+  ```console
+  $ docker buildx rm --all-inactive
+  WARNING! This will remove all builders that are not in running state. Are you sure you want to continue? [y/N] y
+  ```
+
   ### Override the configured builder instance (--builder) {#builder}
 
   Same as [`buildx --builder`](buildx.md#builder).
+
+  ### Do not prompt for confirmation (--force) {#force}
+
+  Do not prompt for confirmation before removing inactive builders.
+
+  ```console
+  $ docker buildx rm --all-inactive --force
+  ```
+
+  ### Keep the buildkitd daemon running (--keep-daemon) {#keep-daemon}
+
+  Keep the buildkitd daemon running after the buildx context is removed. This is useful when you manage buildkitd daemons and buildx contexts independently.
+  Currently, only supported by the [`docker-container` and `kubernetes` drivers](buildx_create.md#driver).
 
   ### Keep BuildKit state (--keep-state) {#keep-state}
 

--- a/_data/buildx/docker_buildx_stop.yaml
+++ b/_data/buildx/docker_buildx_stop.yaml
@@ -12,6 +12,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_uninstall.yaml
+++ b/_data/buildx/docker_buildx_uninstall.yaml
@@ -9,6 +9,7 @@ inherited_options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_use.yaml
+++ b/_data/buildx/docker_buildx_use.yaml
@@ -13,6 +13,7 @@ options:
   default_value: "false"
   description: Set builder as default for current context
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -22,6 +23,7 @@ options:
   default_value: "false"
   description: Builder persists context changes
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,6 +34,7 @@ inherited_options:
   description: Override the configured builder instance
   details_url: '#builder'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/buildx/docker_buildx_version.yaml
+++ b/_data/buildx/docker_buildx_version.yaml
@@ -1,6 +1,12 @@
 command: docker buildx version
 short: Show buildx version information
-long: Show buildx version information
+long: |-
+  View version information
+
+  ```console
+  $ docker buildx version
+  github.com/docker/buildx v0.5.1-docker 11057da37336192bfc57d81e02359ba7ba848e4a
+  ```
 usage: docker buildx version
 pname: docker buildx
 plink: docker_buildx.yaml
@@ -9,18 +15,11 @@ inherited_options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: |-
-  ### View version information
-
-
-  ```console
-  $ docker buildx version
-  github.com/docker/buildx v0.5.1-docker 11057da37336192bfc57d81e02359ba7ba848e4a
-  ```
 deprecated: false
 experimental: false
 experimentalcli: false


### PR DESCRIPTION
https://github.com/docker/buildx/releases/tag/v0.8.0

```shell
BUILDX_REF=v0.8.0 make buildx-yaml
```

We should also see how to reorg the build docs before integrating our guides https://github.com/docker/buildx/tree/master/docs/guides as discussed. cc @usha-mandya @thaJeztah.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>