### PR TITLE
Environment variable POSTGRES_NAME should be POSTGRES_DB for the db service

### DIFF
--- a/samples/django.md
+++ b/samples/django.md
@@ -76,7 +76,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
        volumes:
          - ./data/db:/var/lib/postgresql/data
        environment:
-         - POSTGRES_NAME=postgres
+         - POSTGRES_DB=postgres
          - POSTGRES_USER=postgres
          - POSTGRES_PASSWORD=postgres
      web:


### PR DESCRIPTION
### Proposed changes
POSTGRES_NAME should be POSTGRES_DB for the db service


<!--Tell us what you did and why-->
For postgres service the environment variable name should be POSTGRES_DB if you want to create custom db name
