### PR TITLE
Fix Small Typo

### DIFF
--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -86,7 +86,7 @@ $ docker run \
   node-docker
 ```
 
-The `yoda_notes` at the end of the connection string is the desired name for our database.
+The `notes` at the end of the connection string is the desired name for our database.
 
 Let’s test that our application is connected to the database and is able to add a note.
 


### PR DESCRIPTION
### Proposed changes

There is a typo in Local database and containers:

> The `yoda_notes` at the end of the connection string is the desired name for our database.

Should be The `notes` at the end of the connection string is the desired name for our database.
