### PR TITLE
Add new step 1 "Exit MySQL"

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -110,13 +110,20 @@ address)?
 To figure it out, we're going to make use of the [nicolaka/netshoot](https://github.com/nicolaka/netshoot) container,
 which ships with a _lot_ of tools that are useful for troubleshooting or debugging networking issues.
 
-1. Start a new container using the nicolaka/netshoot image. Make sure to connect it to the same network.
+
+1. Exit MySQL if you haven't already (if you have typed any thing before press `;` and hit enter).
+
+    ```console
+    mysql> exit
+    ```
+
+2. Start a new container using the nicolaka/netshoot image. Make sure to connect it to the same network.
 
     ```console
     $ docker run -it --network todo-app nicolaka/netshoot
     ```
 
-2. Inside the container, we're going to use the `dig` command, which is a useful DNS tool. We're going to look up
+3. Inside the container, we're going to use the `dig` command, which is a useful DNS tool. We're going to look up
    the IP address for the hostname `mysql`.
 
     ```console

--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -98,8 +98,13 @@ For now, we will create the network first and attach the MySQL container at star
     +--------------------+
     5 rows in set (0.00 sec)
     ```
+Exit the MySQL shell to return to the shell on our machine.
 
-    Hooray! We have our `todos` database and it's ready for us to use!
+   ```console
+   mysql> exit
+   ```
+
+   Hooray! We have our `todos` database and it's ready for us to use!
 
 ## Connect to MySQL
 
@@ -110,20 +115,13 @@ address)?
 To figure it out, we're going to make use of the [nicolaka/netshoot](https://github.com/nicolaka/netshoot) container,
 which ships with a _lot_ of tools that are useful for troubleshooting or debugging networking issues.
 
-
-1. Exit MySQL if you haven't already (if you have typed any thing before press `;` and hit enter).
-
-    ```console
-    mysql> exit
-    ```
-
-2. Start a new container using the nicolaka/netshoot image. Make sure to connect it to the same network.
+1. Start a new container using the nicolaka/netshoot image. Make sure to connect it to the same network.
 
     ```console
     $ docker run -it --network todo-app nicolaka/netshoot
     ```
 
-3. Inside the container, we're going to use the `dig` command, which is a useful DNS tool. We're going to look up
+2. Inside the container, we're going to use the `dig` command, which is a useful DNS tool. We're going to look up
    the IP address for the hostname `mysql`.
 
     ```console


### PR DESCRIPTION
## Can't proceed with creating container

### Changes:
Added new step 1 In the "Connect to MySQL" section, "Exit MySQL", and substituted the enumeration of the following steps to 2 and 3

### Why:
If you don't exit MySQL with the command `exit`, you can't proceed to create the container on the next step