### PR TITLE
add /go/storage-driver/ redirect

### DIFF
--- a/go/storage-driver.md
+++ b/go/storage-driver.md
@@ -1,0 +1,6 @@
+---
+title: Information on how configure storage drivers
+description: Instructions for configuring (or switching between) storage-drivers.
+keywords: Docker, Engine, Daemon, storage-driver
+redirect_to: /storage/storagedriver/select-storage-driver/
+---


### PR DESCRIPTION
Currently pointing to "select a storage driver", but we may be adding
a section about migrating to a different storage driver (for users
that are currently using a deprecated storage driver).

relates to https://github.com/moby/moby/pull/43378 https://github.com/moby/moby/pull/43378#discussion_r826267907

