### PR TITLE
The E in ECS is Elastic, not EC2 

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -10,7 +10,7 @@ toc_max: 2
 
 ## Overview
 
-The Docker Compose CLI enables developers to use native Docker commands to run applications in Amazon EC2 Container Service (ECS) when building cloud-native applications.
+The Docker Compose CLI enables developers to use native Docker commands to run applications in Amazon Elastic Container Service (ECS) when building cloud-native applications.
 
 The integration between Docker and Amazon ECS allows developers to use the Docker Compose CLI to:
 


### PR DESCRIPTION
File: [cloud/ecs-integration.md](https://docs.docker.com/cloud/ecs-integration/)

The Docker Compose CLI enables developers to use native Docker commands to run applications in Amazon EC2 Container Service (ECS) when building cloud-native applications.