### PR TITLE
IAM: fix missing prompt, causing code to not be selectable

### DIFF
--- a/_includes/configure-registry-json.md
+++ b/_includes/configure-registry-json.md
@@ -52,13 +52,13 @@ To create your `registry.json` file on macOS:
 3. Open a new terminal and type the following command:
 
     ```console
-    sudo mkdir -p /Library/Application\ Support/com.docker.docker
+    $ sudo mkdir -p /Library/Application\ Support/com.docker.docker
     ```
 
     If prompted, type your password associated with your local computer.
 
 4. Type the following command:
 
-     ```console
-    sudo cp Documents/registry.json /Library/Application\ Support/com.docker.docker/registry.json
+    ```console
+    $ sudo cp Documents/registry.json /Library/Application\ Support/com.docker.docker/registry.json
     ```


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/14332

This code-block uses the "console" highlighting, which considers lines that do
not start with a prompt to be "output" of the command, and non-selectable.


With this, the blocks are now copy/paste-able:

<img width="600" alt="Screenshot 2022-03-31 at 22 35 29" src="https://user-images.githubusercontent.com/1804568/161144855-6a0c3263-83a9-443e-b014-982c19bb9d80.png">

