### PR TITLE
move "page generated" comment to prevent rendering in quirks mode

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,10 +1,10 @@
+<!DOCTYPE html>
 <!-- Page generated {{ site.time }}
 {%- if page.edit_url -%}
     {%- assign edit_url = page.edit_url -%}
 {%- else -%}
     {%- assign edit_url = "https://github.com/docker/docker.github.io/edit/master/" | append: page.path -%}
 {%- endif -%} -->
-<!DOCTYPE html>
 <html lang="en">
 {%- include head.html -%}
 <body class="colums">

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -1,5 +1,5 @@
-<!-- Page generated {{ site.time }} -->
 <!DOCTYPE html>
+<!-- Page generated {{ site.time }} -->
 <html lang="en">
 {%- include head.html -%}
 <body id="landing" class="landing">


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/14195

As described on https://en.wikipedia.org/wiki/Quirks_mode, a comment
preceding the `<!DOCTYPE html>` can cause some browsers to render the
HTML in quirks mode.

This patch moves the comment after the doctype to prevent this.
