### PR TITLE
reformat "get started" 06 - bind-mounts

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -66,7 +66,7 @@ So, let's do it!
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,
       we'll see that the `dev` script is starting `nodemon`.
 
-3. You can watch the logs using `docker logs -f <container-id>`. You'll know you're ready to go when you see this:
+3. You can watch the logs using `docker logs`. You'll know you're ready to go when you see this:
 
     ```console
     $ docker logs -f <container-id>
@@ -96,7 +96,11 @@ So, let's do it!
     {: .text-center }
 
 6. Feel free to make any other changes you'd like to make. When you're done, stop the container and build your new image
-   using `docker build -t getting-started .`.
+   using:
+
+    ```console
+    $ docker build -t getting-started .
+    ```
 
 Using bind mounts is _very_ common for local development setups. The advantage is that the dev machine doesn't need to have
 all of the build tools and environments installed. With a single `docker run` command, the dev environment is pulled and ready


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/14146

The "docker build" example was written as an in-line example, but directly
followed by a full-stop at the end of the sentence, which made it easy to
confuse the extra `.` to be part of the command to run.

This moves it to a code block to allow the example to be highlighted, and
less confusing.

Before this patch:

<img width="898" alt="Screenshot 2022-03-31 at 23 54 37" src="https://user-images.githubusercontent.com/1804568/161155772-d8b66b7f-eff0-4152-b488-c6c187d675b8.png">


With this patch:

<img width="996" alt="Screenshot 2022-04-01 at 00 00 27" src="https://user-images.githubusercontent.com/1804568/161156409-c9933843-29b9-40e2-baec-e6a3f31e22e3.png">


