### PR TITLE
WEB-1041: Adds TrustArc CMP tool to the footer area

### DIFF
--- a/_includes/consent-management/trustarc.html
+++ b/_includes/consent-management/trustarc.html
@@ -1,0 +1,1 @@
+<script async="async" src="//consent.trustarc.com/notice?domain=docker.com&c=teconsent&js=nj&noticeType=bb&gtm=1"></script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -84,7 +84,7 @@
         <div class="bottom_footer">
             <div class="footer-copyright col-xs-12 col-md-8">
                 <p class="copyright">
-                    Copyright &copy; 2013-2021 Docker Inc. All rights reserved. </p>
+                    Copyright &copy; 2013-2022 Docker Inc. All rights reserved. </p>
             </div>
             <div class="footer_social_nav">
                 <ul class="nav-social">
@@ -96,6 +96,10 @@
                     <li class="fa fa-slideshare"><a href="https://www.slideshare.net/docker">Slideshare</a></li>
                     <li class="fa fa-reddit"><a href="https://www.reddit.com/r/docker">Reddit</a></li>
                 </ul>
+            </div>
+            <div id="footer-cmp">
+                <div id="consent_blackbar"></div>
+                <div id="teconsent"></div>
             </div>
         </div>
     </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,6 +33,9 @@
   {%- if page.sitemap == false or site.GH_ENV == "gh_pages" %}
   <meta name="robots" content="noindex"/>
   {%- endif %}
+  {%- if jekyll.environment != 'production' -%}<!-- TrustArc CMP -->
+  <script async="async" src="//consent.trustarc.com/notice?domain=docker.com&c=teconsent&js=nj&noticeType=bb&gtm=1"></script>
+  {%- endif -%}
   {%- if jekyll.environment == 'production' and site.google_analytics != '' -%}{%- include analytics/google_analytics.html GOOGLE_ID=site.google_analytics -%}{%- endif -%}
   <title>{{ page.title | default: page_title }} | Docker Documentation</title>
   <meta name="description" content="{{ page.description | default: page_description | escape}}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,9 +33,7 @@
   {%- if page.sitemap == false or site.GH_ENV == "gh_pages" %}
   <meta name="robots" content="noindex"/>
   {%- endif %}
-  {%- if jekyll.environment != 'production' -%}<!-- TrustArc CMP -->
   <script async="async" src="//consent.trustarc.com/notice?domain=docker.com&c=teconsent&js=nj&noticeType=bb&gtm=1"></script>
-  {%- endif -%}
   {%- if jekyll.environment == 'production' and site.google_analytics != '' -%}{%- include analytics/google_analytics.html GOOGLE_ID=site.google_analytics -%}{%- endif -%}
   <title>{{ page.title | default: page_title }} | Docker Documentation</title>
   <meta name="description" content="{{ page.description | default: page_description | escape}}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,7 +33,7 @@
   {%- if page.sitemap == false or site.GH_ENV == "gh_pages" %}
   <meta name="robots" content="noindex"/>
   {%- endif %}
-  <script async="async" src="//consent.trustarc.com/notice?domain=docker.com&c=teconsent&js=nj&noticeType=bb&gtm=1"></script>
+  {%- if jekyll.environment == 'production' -%}{%- include consent-management/trustarc.html -%}{%- endif -%}
   {%- if jekyll.environment == 'production' and site.google_analytics != '' -%}{%- include analytics/google_analytics.html GOOGLE_ID=site.google_analytics -%}{%- endif -%}
   <title>{{ page.title | default: page_title }} | Docker Documentation</title>
   <meta name="description" content="{{ page.description | default: page_description | escape}}" />

--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -219,3 +219,8 @@ footer {
     text-indent: 9999px;
     overflow: hidden;
 }
+
+#footer-cmp {
+  padding-left: 15px;
+  float: left;
+}


### PR DESCRIPTION
### Proposed changes
Adds the TrustArc Consent Management tool to the footer of the site.

### Screenshot
![image](https://user-images.githubusercontent.com/1005023/161357387-83d431d7-9fd9-4de9-9502-8beacb0b5f73.png)

### Related issues (optional)
Addressses WEB-1041 
https://docker.atlassian.net/browse/WEB-1041
