### PR TITLE
Fix a crossreference to the compose file spec page

### DIFF
--- a/compose/compose-file/deploy.md
+++ b/compose/compose-file/deploy.md
@@ -253,7 +253,7 @@ deploy:
 - `max_attempts`: How many times to attempt to restart a container before giving up (default: never give up). If the restart does not
   succeed within the configured `window`, this attempt doesn't count toward the configured `max_attempts` value.
   For example, if `max_attempts` is set to '2', and the restart fails on the first attempt, more than two restarts MUST be attempted.
-- `window`: How long to wait before deciding if a restart has succeeded, specified as a [duration](#specifying-durations) (default:
+- `window`: How long to wait before deciding if a restart has succeeded, specified as a [duration](index.md#specifying-durations) (default:
   decide immediately).
 
 ```yml


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Fixed a broken cross-reference that caused the link checker to fail on other PRs. For example

- https://github.com/docker/docker.github.io/pull/14505
- https://github.com/docker/docker.github.io/pull/14502