### PR TITLE
added misssing "driver"

### DIFF
--- a/engine/swarm/networking.md
+++ b/engine/swarm/networking.md
@@ -330,7 +330,7 @@ services which publish ports, such as a WordPress service which publishes port
       --ingress \
       --subnet=10.11.0.0/16 \
       --gateway=10.11.0.2 \
-      --opt com.docker.network.mtu=1200 \
+      --opt com.docker.network.driver.mtu=1200 \
       my-ingress
     ```
 


### PR DESCRIPTION
The example for setting the MTU on the swarm ingress network uses the wrong property:

`--opt com.docker.network.mtu=1200`

instead of

`--opt com.docker.network.driver.mtu=1200`

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
