### PR TITLE
Add initial SBOM docs

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1270,6 +1270,8 @@ manuals:
     title: Docker Context
   - path: /engine/scan/
     title: Docker Scan
+  - path: /engine/sbom/
+    title: Docker SBOM
 
 - sectiontitle: Docker Compose
   section:

--- a/engine/sbom/index.md
+++ b/engine/sbom/index.md
@@ -1,0 +1,91 @@
+---
+title: Viewing the SBOM for Docker images
+description: Viewing the Software Bill of Materials (SBOM) for Docker images
+keywords: Docker, sbon, Anchore, images, Syft, security
+toc_min: 1
+toc_max: 2
+---
+
+A Software Bill Of Materials (SBOM) is analogous to a packing list for a shipment; it’s all the components that make up the software, or were used to build it. For container images this includes the operating system packages that are installed (e.g.: ca-certificates) along with language specific packages that the software depends on (e.g.: log4j). The SBOM could include only some of this information or even more details, like the versions of components and where they came from.
+
+> :warning: *Note:* This command is considered _experimental_ and may change or be removed in the future.
+> Please leave feedback and report issues on [its repository](https://github.com/docker/sbom-cli-plugin).
+
+The experimental `docker sbom` command allows you to view the SBOM of a container image. Today, it does this today by scanning the layers of the image using the [Syft project](https://github.com/anchore/syft) but in future it may read the SBOM from the image itself or elsewhere.
+
+
+## Simple use
+
+To output a tabulated SBOM for an image simply run `docker sbom <image>:<tag>`:
+
+```console
+$ docker sbom neo4j:4.4.5
+Syft v0.43.0
+ ✔ Loaded image            
+ ✔ Parsed image            
+ ✔ Cataloged packages      [385 packages]
+
+NAME                      VERSION                        TYPE
+... 
+bsdutils                  1:2.36.1-8+deb11u1             deb
+ca-certificates           20210119                       deb
+...
+log4j-api                 2.17.1                         java-archive  
+log4j-core                2.17.1                         java-archive  
+...
+```
+
+Note that the output includes not only system packages but also software libraries used by applications in the container image.
+
+## Output formatting and saving outputs
+
+You can output the SBOM in standard formats like [SPDX](https://spdx.dev) and [CycloneDX](https://cyclonedx.org) along with the Syft and GitHub formats using the `--format` option.
+
+```console
+$ docker sbom --format spdx-json alpine:3.15
+{
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "name": "alpine-3.15",
+ "spdxVersion": "SPDX-2.2",
+ "creationInfo": {
+  "created": "2022-04-06T21:13:32.035571Z",
+  "creators": [
+   "Organization: Anchore, Inc",
+   "Tool: syft-[not provided]"
+  ],
+  "licenseListVersion": "3.16"
+ },
+ "dataLicense": "CC0-1.0",
+ "documentNamespace": "https://anchore.com/syft/image/alpine-3.15-4b1b99d8-bbb5-4426-af8e-c510189134ab",
+ "packages": [
+  {
+   "SPDXID": "SPDXRef-1e3f3285636676f3",
+   "name": "alpine-baselayout",
+   "licenseConcluded": "GPL-2.0-only",
+   "description": "Alpine base dir structure and init scripts",
+   "downloadLocation": "https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout",
+   "externalRefs": [
+    {
+...
+}
+```
+
+You will notice that these outputs are more verbose and contain more information than the default tabulated output.
+
+By default, the command outputs the SBOM to stdout. You can save the output to a file by specifying one with the `--output` flag.
+
+```console
+$ docker sbom --format spdx-json --output sbom.json alpine:3.15
+Syft v0.43.0
+ ✔ Loaded image            
+ ✔ Parsed image            
+ ✔ Cataloged packages      [14 packages]
+
+$ cat sbom.json
+{
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "name": "alpine-3.15",
+ "spdxVersion": "SPDX-2.2",
+...
+}
+```


### PR DESCRIPTION
### Proposed changes

Add initial `docker sbom` docs. It would be great to add some practical examples in a follow up like diffing images or checking for vulnerable libraries.

<!--Tell us what you did and why-->

### Unreleased project version (optional)

The command will be available with Docker Desktop 4.7.0.

### Related issues (optional)

N/A
