### PR TITLE
update docker-compose.yml for compose v2, and remove temporary fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,15 @@
 services:
   docs:
-    # By default, docker-compose up --build builds docs for a development
+    # By default, docker compose up --build builds docs for a development
     # environment (no Google Analytics, omitting some enterprise redirects,
-    # etc.
+    # etc.)
     #
     # To test a "production" build, override the environment using:
     #
-    # JEKYLL_ENV=production docker-compose up --build
+    # JEKYLL_ENV=production docker compose up --build
     build:
       args:
-        # FIXME: docker-compose should behave the same as the docker CLI here
-        # and if `JEKYLL_ENV` is not set in the current environment, ignore
-        # the --build-arg, and use the default that's defined in the Dockerfile.
-        # Setting a default here as a workaround.
-        # - JEKYLL_ENV
-        - JEKYLL_ENV=${JEKYLL_ENV:-development}
+        - JEKYLL_ENV
       context: .
     image: docs/docstage
     ports:


### PR DESCRIPTION
relates to https://github.com/docker/docker.github.io/pull/14495#issuecomment-1091497286

This updates the instructions in the docker-compose.yml to use "docker compose" (v2) instead of "docker-compose".

Also removing a workaround for a bug in older versions of compose, where build-args did not properly inherit their value from the current environment. Testing this scenario on a current version of compose shows that that problem has been resolved:

Using this compose-file:

```yaml
services:
  docs:
    build:
      args:
        - JEKYLL_ENV
      context: .
```

And this Dockerfile:

```dockerfile
ARG JEKYLL_ENV=default

FROM alpine
ARG JEKYLL_ENV
RUN echo $JEKYLL_ENV >> /result.txt
CMD cat /result.txt
```

It looks like this issue has been resolved:

Without setting the `JEKYLL_ENV` environment variable, the Dockerfile correctly uses the default value from the Dockerfile:

```console
docker compose build
[+] Building 0.6s (6/6) FINISHED
 => [internal] load build definition from Dockerfile                                         0.1s
 => => transferring dockerfile: 31B                                                          0.0s
 => [internal] load .dockerignore                                                            0.0s
 => => transferring context: 2B                                                              0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                             0.0s
 => CACHED [1/2] FROM docker.io/library/alpine                                               0.0s
 => [2/2] RUN echo default >> /result.txt                                                    0.3s
 => exporting to image                                                                       0.0s
 => => exporting layers                                                                      0.0s
 => => writing image sha256:c22cfa2355a910991d1bd4f4d83a0b9d4fad7dc73b1ea83fba05f8949e564591 0.0s
 => => naming to docker.io/library/composeenv_docs                                           0.0s

docker compose run --rm docs
default
```

And when setting `JEKYLL_ENV`, it's used to override the default in the Dockerfile:

```console
JEKYLL_ENV=production docker compose build
[+] Building 2.6s (6/6) FINISHED
 => [internal] load build definition from Dockerfile                                         0.5s
 => => transferring dockerfile: 120B                                                         0.0s
 => [internal] load .dockerignore                                                            0.4s
 => => transferring context: 2B                                                              0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                             0.0s
 => [1/2] FROM docker.io/library/alpine                                                      0.0s
 => [2/2] RUN echo production >> /result.txt                                                 1.6s
 => exporting to image                                                                       0.1s
 => => exporting layers                                                                      0.1s
 => => writing image sha256:a05ca33d07d411660bd26f817a3d9201f3d7f15d198879cadc70e83e5d1f7fd5 0.0s
 => => naming to docker.io/library/composeenv_docs                                           0.0s

docker compose run --rm docs
production
```
