### PR TITLE
Terminate the console fix-width example for --output on the SBOM page

### DIFF
--- a/engine/sbom/index.md
+++ b/engine/sbom/index.md
@@ -90,6 +90,7 @@ $ cat sbom.json
  "spdxVersion": "SPDX-2.2",
 ...
 }
+```
 
 ## Feedback
 


### PR DESCRIPTION
### Proposed changes

Terminating the `--output` flag example on the [SBOM page](https://docs.docker.com/engine/sbom/#output-formatting-and-saving-outputs).  It currently isn't showing up correct in the documentation as seen below.

![Screen Shot 2022-04-07 at 3 59 52 PM](https://user-images.githubusercontent.com/16943066/162327097-6884d0c7-f256-4ec6-a630-fb95dd60837e.png)


### Unreleased project version (optional)

_N/A._

### Related issues (optional)

Related to #14516 which created this documentation.
