### PR TITLE
Fix homebrew paths to work with Apple silicon macs as well.

### DIFF
--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -368,9 +368,10 @@ these files need to be copied or symlinked to your Zsh `site-functions/`
 directory. For example, if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="nooopener" class="_"}:
 
 ```bash
+eval "$(brew shellenv)"
 etc=/Applications/Docker.app/Contents/Resources/etc
-ln -s $etc/docker.zsh-completion /usr/local/share/zsh/site-functions/_docker
-ln -s $etc/docker-compose.zsh-completion /usr/local/share/zsh/site-functions/_docker-compose
+ln -s $etc/docker.zsh-completion "$HOMEBREW_PREFIX/share/zsh/site-functions/_docker"
+ln -s $etc/docker-compose.zsh-completion "$HOMEBREW_PREFIX/share/zsh/site-functions/_docker-compose"
 ```
 
 ### Fish-Shell

--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -348,7 +348,7 @@ ln -s $etc/docker-compose.bash-completion $(brew --prefix)/etc/bash_completion.d
 Add the following to your `~/.bash_profile`:
 
 ```bash
-[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
+[ -f $(brew --prefix)/etc/bash_completion ] && . $(brew --prefix)/etc/bash_completion
 ```
 
 OR
@@ -368,10 +368,9 @@ these files need to be copied or symlinked to your Zsh `site-functions/`
 directory. For example, if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="nooopener" class="_"}:
 
 ```bash
-eval "$(brew shellenv)"
 etc=/Applications/Docker.app/Contents/Resources/etc
-ln -s $etc/docker.zsh-completion "$HOMEBREW_PREFIX/share/zsh/site-functions/_docker"
-ln -s $etc/docker-compose.zsh-completion "$HOMEBREW_PREFIX/share/zsh/site-functions/_docker-compose"
+ln -s $etc/docker.zsh-completion "$(brew --prefix)/share/zsh/site-functions/_docker"
+ln -s $etc/docker-compose.zsh-completion "$(brew --prefix)/share/zsh/site-functions/_docker-compose"
 ```
 
 ### Fish-Shell


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

on Apple silicon, `$(brew --prefix)` is `/opt/homebrew` and not `/usr/local`
This change makes it work on intel and apple silicon.

This is already done in the bash examples above in the doc. 

see https://docs.brew.sh/Installation

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
