### PR TITLE
Engdocs 641

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,7 +66,7 @@ defaults:
       layout: docs
       sitemap: false
       toc_min: 2
-      toc_max: 3
+      toc_max: 4
 
   - scope:
       path: engine/reference/commandline

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -47,7 +47,7 @@ defaults:
     values:
       layout: docs
       toc_min: 2
-      toc_max: 3
+      toc_max: 4
 
   # Set the correct edit-URL for upstream resources. We usually don't create a direct
   # edit link for these, and instead point to the directory that contains the file.

--- a/desktop/dashboard.md
+++ b/desktop/dashboard.md
@@ -5,8 +5,6 @@ title: Docker Dashboard
 redirect_from:
 - /docker-for-mac/dashboard/
 - /docker-for-windows/dashboard/
-toc_min: 2
-toc_max: 3
 ---
 
 The Docker Dashboard provides a simple interface that enables you to manage your containers, applications, and images directly from your machine without having to use the CLI to perform core actions.

--- a/desktop/dev-environments.md
+++ b/desktop/dev-environments.md
@@ -2,8 +2,6 @@
 description: Dev Environments
 keywords: Dev Environments, share, collaborate, local
 title: Development Environments Preview
-toc_min: 1
-toc_max: 2
 ---
 
 Dev Environments enable you to collaborate easily by allowing you to share work-in-progress code with your team members. When using Dev Environments, you can easily set up repeatable development environments, keeping the environment details versioned along with your code. You can also share your work-in-progress code with your team members in just one click and without having to deal with any merge conflicts while moving between Git branches to get your code on to their machine.

--- a/desktop/faqs.md
+++ b/desktop/faqs.md
@@ -6,7 +6,6 @@ redirect_from:
 - /docker-for-mac/faqs/
 - /docker-for-windows/faqs/
 title: Frequently asked questions
-toc_max: 2
 ---
 
 ## General

--- a/desktop/index.md
+++ b/desktop/index.md
@@ -2,8 +2,6 @@
 description: Docker Desktop overview
 keywords: Desktop, Docker, GUI, run, docker, local, machine
 title: Docker Desktop overview
-toc_min: 1
-toc_max: 2
 redirect_from:
 - /desktop/opensource/
 - /docker-for-mac/opensource/

--- a/desktop/linux/index.md
+++ b/desktop/linux/index.md
@@ -2,8 +2,6 @@
 description: Docker Desktop for Linux (Beta)
 keywords: docker, Desktop for linux, beta, tech preview
 title: Docker Desktop for Linux (Beta)
-toc_min: 1
-toc_max: 2
 ---
 
 Welcome to the Docker Desktop for Linux (Beta). The Beta program is aimed at early adopters who would like to try Docker Desktop for Linux and provide feedback.

--- a/desktop/mac/apple-silicon.md
+++ b/desktop/mac/apple-silicon.md
@@ -2,8 +2,6 @@
 description: Docker Desktop for Apple silicon
 keywords: Docker Desktop, M1, Silicon, Apple,
 title: Docker Desktop for Apple silicon
-toc_min: 2
-toc_max: 3
 redirect_from:
 - /docker-for-mac/apple-m1/
 - /docker-for-mac/apple-silicon/

--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -17,8 +17,6 @@ redirect_from:
 - /docker-for-mac/osxfs/
 - /docker-for-mac/osxfs-caching/
 title: Docker Desktop for Mac user manual
-toc_min: 1
-toc_max: 2
 ---
 
 Welcome to Docker Desktop! The Docker Desktop for Mac user manual provides information on how to configure and manage your Docker Desktop settings.

--- a/desktop/mac/networking.md
+++ b/desktop/mac/networking.md
@@ -5,6 +5,7 @@ redirect_from:
 - /docker-for-mac/networking/
 - /mackit/networking/
 title: Networking features in Docker Desktop for Mac
+
 ---
 {% assign Arch = 'Mac' %}
 

--- a/desktop/mac/networking.md
+++ b/desktop/mac/networking.md
@@ -5,7 +5,6 @@ redirect_from:
 - /docker-for-mac/networking/
 - /mackit/networking/
 title: Networking features in Docker Desktop for Mac
-
 ---
 {% assign Arch = 'Mac' %}
 

--- a/desktop/mac/troubleshoot.md
+++ b/desktop/mac/troubleshoot.md
@@ -5,7 +5,6 @@ redirect_from:
 - /docker-for-mac/troubleshoot/
 - /mackit/troubleshoot/
 title: Logs and troubleshooting
-toc_max: 2
 ---
 
 {% include upgrade-cta.html

--- a/desktop/windows/index.md
+++ b/desktop/windows/index.md
@@ -12,10 +12,7 @@ redirect_from:
 - /windows/started/
 - /winkit/
 - /winkit/getting-started/
-
 title: Docker Desktop for Windows user manual
-toc_min: 1
-toc_max: 2
 ---
 
 Welcome to Docker Desktop! The Docker Desktop for Windows user manual provides information on how to configure and manage your Docker Desktop settings.

--- a/desktop/windows/troubleshoot.md
+++ b/desktop/windows/troubleshoot.md
@@ -6,7 +6,6 @@ redirect_from:
 - /docker-for-win/troubleshoot/
 - /docker-for-windows/troubleshoot/
 title: Logs and troubleshooting
-toc_max: 2
 ---
 
 {% include upgrade-cta.html

--- a/desktop/windows/wsl.md
+++ b/desktop/windows/wsl.md
@@ -5,8 +5,6 @@ redirect_from:
 - /docker-for-windows/wsl/
 - /docker-for-windows/wsl-tech-preview/
 title: Docker Desktop WSL 2 backend
-toc_min: 2
-toc_max: 3
 ---
 
 > **Update to the Docker Desktop terms**


### PR DESCRIPTION
Changes to docs settings that allow all headings up to level 4 to show in the right-hand nav panel. 
Before this change, not all the info would show so users might miss something that is relevant. This change will increase usability/information discovery of our docs. 
