### PR TITLE
desktop/mac: add missing prompt and highlighting for install

### DIFF
--- a/desktop/mac/install.md
+++ b/desktop/mac/install.md
@@ -94,12 +94,10 @@ Your Mac must meet the following requirements to install Docker Desktop successf
 
 After downloading `Docker.dmg`, run the following commands in a terminal to install Docker Desktop in the Applications folder:
 
-
-
-```
-sudo hdiutil attach Docker.dmg
-sudo /Volumes/Docker/Docker.app/Contents/MacOS/install
-sudo hdiutil detach /Volumes/Docker
+```console
+$ sudo hdiutil attach Docker.dmg
+$ sudo /Volumes/Docker/Docker.app/Contents/MacOS/install
+$ sudo hdiutil detach /Volumes/Docker
 ```
 
 The `install` command accepts the following flags:


### PR DESCRIPTION
- relates to https://github.com/docker/docker.github.io/pull/14542#discussion_r848722200
- relates to https://github.com/docker/docker.github.io/pull/14541


Before this change, the example was not highlighted;

<img width="1005" alt="Screenshot 2022-04-12 at 20 10 16" src="https://user-images.githubusercontent.com/1804568/163026672-2bee0653-cbb3-47f9-9b09-c434a9c4fc62.png">


After this change:

<img width="1005" alt="Screenshot 2022-04-12 at 20 07 44" src="https://user-images.githubusercontent.com/1804568/163026713-cef1b16e-f6ff-4429-936d-c76d90333abf.png">

The commands in the example are still selectable (the `$` prompt will be skipped in the selection);

<img width="990" alt="Screenshot 2022-04-12 at 20 07 55" src="https://user-images.githubusercontent.com/1804568/163026718-e0b57fe7-86bf-4b34-b0fb-7bd796aa1fd8.png">



<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
