### PR TITLE
Add compose install engine

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,8 @@ exclude: ["_samples", "_scripts", "404.html", "datacenter", "ee", "index.html", 
 # You can't have - characters in these for non-YAML reasons
 latest_engine_api_version: "1.41"
 docker_ce_version: "20.10"
-compose_version: "1.29.2"
-compose_v2_version: "2.2.3"
+compose_v1_version: "1.29.2"
+compose_version: "v2.4.1"
 compose_file_v3: "3.9"
 compose_file_v2: "2.4"
 machine_version: "0.16.0"

--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -13,144 +13,19 @@ title: Compose V2
 > Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous `docker-compose` features and flags. You can test the Compose V2 by simply replacing the dash (`-`) with a space, and by running `docker compose`, instead of `docker-compose`.
 {: .important}
 
-Starting with Docker Desktop 3.4.0, you can run Compose V2 commands without modifying your invocations, by enabling the drop-in replacement of the previous `docker-compose` with the new command.  See the section [Installing Compose V2](#installing-compose-v2) for detailed instructions how to enable the drop-in replacement.
+Starting with Docker Desktop 3.4.0, you can run Compose V2 commands without modifying your invocations, by enabling the drop-in replacement of the previous `docker-compose` with the new command.  See the section [Installing Compose](install.md) for detailed instructions.
 
 ## Context of Docker Compose evolution
 
 Introduction of the [Compose specification](https://github.com/compose-spec/compose-spec){:target="_blank" rel="noopener" class="_"} makes a clean distinction between the Compose YAML file model and the `docker-compose` implementation. Making this change has enabled a number of enhancements, including adding the `compose` command directly into the Docker CLI,  being able to “up” a Compose application on cloud platforms by simply switching the Docker context, and launching of [Amazon ECS](/cloud/ecs-integration) and [Microsoft ACI](/cloud/aci-integration). As the Compose specification evolves, new features land faster in the Docker CLI.
 
-While `docker-compose` is still supported and maintained, Compose V2 implementation relies directly on the compose-go bindings which are maintained as part of the specification. This allows us to include community proposals, experimental implementations by the Docker CLI and/or Engine, and deliver features faster to users. Compose V2 also  supports some of the newer additions to the Compose specification, such as [profiles](profiles.md) and [GPU](gpu-support.md) devices.
+Compose V2 implementation relies directly on the compose-go bindings which are maintained as part of the specification. This allows us to include community proposals, experimental implementations by the Docker CLI and/or Engine, and deliver features faster to users. Compose V2 also  supports some of the newer additions to the Compose specification, such as [profiles](profiles.md) and [GPU](gpu-support.md) devices.
 
 Additionally, Compose V2 also supports [Apple silicon](../desktop/mac/apple-silicon.md).
 
 For more information about the flags that are supported in the new compose command, see the [docker-compose compatibility list](cli-command-compatibility.md).
 
-## Transitioning to GA for Compose V2
+## Where to go next
 
-We are currently working towards providing a standard way to install Compose V2 on Linux. When this is available, Compose V2 will be marked as Generally Available (GA).
-
-**Compose V2 GA** means:
-
-- New features and bug fixes will only be considered in the Compose V2 code base.
-- Docker Compose V2 will be the default setting in Docker Desktop for Mac and Windows. You can still opt out through the Docker Desktop UI and the CLI. This means, when you run `docker-compose`, you will actually be running`docker compose`.
-- Compose V2 will be included with the latest version of the Docker CLI. You can use [Compose Switch](#compose-switch) to redirect `docker-compose` to `docker compose`.
-- [Compose V2 branch](https://github.com/docker/compose/tree/v2) will become the default branch.
-- Docker Compose V1 will be maintained to address any security issues.
-
-> **Important**
->
-> We would like to make the Compose V2 transition to be as smooth as possible for all users. We currently don't have a concrete timeline to deprecate Compose V1. We will review the feedback from the community on the GA and the adoption on Linux, and come up with a plan to deprecate Compose V1. We are not planning to remove the aliasing of `docker-compose` to `docker compose`. We would like to make it easier for users to switch to V2 without breaking any existing scripts. We will follow up with a blog post with more information on the exact timeline on V1 deprecation and the end of support policies for security issues.
->
-> Your feedback is important to us. Reach out to us and let us know your feedback on our [Public Roadmap](https://github.com/docker/roadmap/issues/257){:target="_blank" rel="noopener" class="_"}.
-{: .important}
-
-## Installing Compose V2
-
-This section contains instructions on how to install Compose V2.
-
-### Install on Mac and Windows
-
-Docker Desktop for Mac and for Windows version 3.2.1 and above includes the new Compose command along with the Docker CLI. Therefore, Windows and Mac users do not need to install Compose V2 separately.
-
-We will progressively turn Docker Compose V2 on automatically for Docker Desktop users, so that users can seamlessly move to Docker Compose V2 without the need to change any of their scripts. If you run into any problems with Compose V2, you can simply switch back to Compose v1, either in Docker Desktop, or in the CLI.
-
-For Docker Desktop installation instructions, see:
-
-- [Install Docker Desktop on Mac](../desktop/mac/install.md)
-- [Install Docker Desktop on Windows](../desktop/windows/install.md)
-
-To disable Docker Compose V2 using Docker Desktop:
-
-1. From the Docker menu, click **Preferences** (**Settings** on Windows) > **General**.
-2. Clear the **Use Docker Compose V2** check box.
-
-To disable Docker Compose V2 using the CLI, run:
-
-```console
-$ docker-compose disable-v2
-```
-
-### Install on Linux
-
-You can install Compose V2 by downloading the appropriate binary for your system
-from the [project release page](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"} and copying it into `$HOME/.docker/cli-plugins` as `docker-compose`.
-
-1. Run the following command to download the current stable release of Docker Compose:
-
-    ```console
-    $ DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-    $ mkdir -p $DOCKER_CONFIG/cli-plugins
-    $ curl -SL https://github.com/docker/compose/releases/download/v{{site.compose_v2_version}}/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
-    ```
-
-    This command installs Compose V2 for the active user under `$HOME` directory. To install Docker Compose for all users on your system, replace `~/.docker/cli-plugins` with `/usr/local/lib/docker/cli-plugins`.
-
-2. Apply executable permissions to the binary:
-
-    ```console
-    $ chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-    ```
-
-3. Test your installation
-
-    ```console
-    $ docker compose version
-    Docker Compose version {{site.compose_v2_version}}
-    ```
-
-### Compose Switch
-
-[Compose Switch](https://github.com/docker/compose-switch/){:target="_blank" rel="noopener" class="_"} is a replacement to the Compose V1 `docker-compose` (python) executable. Compose switch translates the command line into Compose V2 `docker compose` and then runs the latter.
-
-To install Compose Switch automatically, run:
-
-```console
-$ curl -fL https://raw.githubusercontent.com/docker/compose-switch/master/install_on_linux.sh | sh
-```
-
-To install Compose Switch manually:
-
-1. Download the `compose-switch` binary for your architecture
-
-    ```console
-    $ curl -fL https://github.com/docker/compose-switch/releases/download/v{{site.compose_switch_version}}/docker-compose-linux-amd64 -o /usr/local/bin/compose-switch
-    ```
-
-2. Run the following command to make it an executable:
-
-    ```console
-    $ chmod +x /usr/local/bin/compose-switch
-    ```
-
-3. Rename the `docker-compose` binary if you've already installed it as `/usr/local/bin/docker-compose`
-
-    ```console
-    $ mv /usr/local/bin/docker-compose /usr/local/bin/docker-compose-v1
-    ```
-
-4. Define an **alternatives** group for the `docker-compose` command:
-
-    ```console
-    $ update-alternatives --install /usr/local/bin/docker-compose docker-compose <PATH_TO_DOCKER_COMPOSE_V1> 1
-    $ update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/compose-switch 99
-    ```
-
-5. Verify your installation:
-
-    ```console
-    $ update-alternatives --display docker-compose
-    docker-compose - auto mode
-        link best version is /usr/local/bin/compose-switch
-        link currently points to /usr/local/bin/compose-switch
-        link docker-compose is /usr/local/bin/docker-compose
-    /usr/bin/docker-compose - priority 1
-    /usr/local/bin/compose-switch - priority 99
-    ```
-
-#### Uninstall Docker Compose
-
-If you installed Docker Compose using curl, run the following command to uninstall:
-
-```console
-$ sudo rm ~/.docker/cli-plugins/docker-compose
-```
+- [User guide](index.md)
+- [Installing Compose](install.md)

--- a/compose/install.md
+++ b/compose/install.md
@@ -31,8 +31,7 @@ Linux systems.
 
 ## Install Compose
 
-Follow the instructions below to install Compose on Mac, Windows, Windows Server
-2016, or Linux systems.
+Follow the instructions below to install Compose on Mac, Windows, Windows Server, or Linux systems.
 
 > Install a different version
 >
@@ -42,6 +41,8 @@ Follow the instructions below to install Compose on Mac, Windows, Windows Server
 >
 > Compose releases are also listed and available for direct download on the
 > [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"}.
+> 
+> To install the Python version of Compose, follow instructions in the [Compose v1 GitHub branch](https://github.com/docker/compose/blob/master/INSTALL.md){: target="_blank" rel="noopener" class="_"}.
 
 <ul class="nav nav-tabs">
 <li class="active"><a data-toggle="tab" data-target="#macOS">Mac</a></li>
@@ -98,15 +99,16 @@ on Microsoft Windows Server and want to install Docker Compose.
     Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\Docker\docker-compose.exe
     ```
 
-    >**Note**:  
+    > **Note**
+    >
     > On Windows Server 2019, you can add the Compose executable to `$Env:ProgramFiles\Docker`. Because this directory is  registered in the system `PATH`, you can run the `docker-compose --version` command on the subsequent step with no additional configuration.
 
-    > To install a different version of Compose, substitute `{{site.compose_version}}` 
+    > To install a different version of Compose, substitute `{{site.compose_version}}`
     > with the version of Compose you want to use.
 
 3.  Test the installation.
 
-    ```powershell
+    ```console
     $ docker compose version
     Docker Compose version {{site.compose_version}}
     ```
@@ -198,15 +200,15 @@ You can use Compose as a standalone binary without installing the Docker CLI.
 
 To uninstall Docker Compose if you installed using `curl`:
 
-  ```console
-  $ rm $DOCKER_CONFIG/cli-plugins/docker-compose
-  ```
+```console
+$ rm $DOCKER_CONFIG/cli-plugins/docker-compose
+```
     
-  or if you choose to install Compose for all users  
+or if you choose to install Compose for all users  
 
-  ```console
-  $ sudo rm /usr/local/lib/docker/cli-plugins/docker-compose
-  ```
+```console
+$ sudo rm /usr/local/lib/docker/cli-plugins/docker-compose
+```
 
 > Got a "Permission denied" error?
 >

--- a/compose/install.md
+++ b/compose/install.md
@@ -20,9 +20,10 @@ have Docker Engine installed either locally or remote, depending on your setup.
 - On desktop systems like Docker Desktop for Mac and Windows, Docker Compose is
 included as part of those desktop installs.
 
-- On Linux systems, first install the
-[Docker Engine](../engine/install/index.md#server){: target="_blank" rel="noopener" class="_"}
-for your OS as described on the Get Docker page, then come back here for
+- On Linux systems, you can install Docker Compose with the Docker Engine using the 
+[convenience script](../engine/install/index.md#server){: target="_blank" rel="noopener" class="_"}. Select the install Docker Engine page for your distribution and then look for instructions on installing using the convenience script.  
+Otherwise, you should first install the [Docker Engine](../engine/install/index.md#server){: target="_blank" rel="noopener" class="_"}
+for your OS and then refer to this page for
 instructions on installing Compose on
 Linux systems.
 
@@ -31,27 +32,23 @@ Linux systems.
 ## Install Compose
 
 Follow the instructions below to install Compose on Mac, Windows, Windows Server
-2016, or Linux systems, or find out about alternatives like using the `pip`
-Python package manager or installing Compose as a container.
+2016, or Linux systems.
 
 > Install a different version
 >
 > The instructions below outline installation of the current stable release
-> (**v{{site.compose_version}}**) of Compose. To install a different version of
-> Compose, replace the given release number with the one that you want. For instructions to install Compose 2.0.0 on Linux, see [Install Compose 2.0.0 on Linux](cli-command.md#install-on-linux).
+> (**{{site.compose_version}}**) of Compose. To install a different version of
+> Compose, replace the given release number with the one that you want.
 >
 > Compose releases are also listed and available for direct download on the
 > [Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"}.
-> To install a **pre-release** of Compose, refer to the [install pre-release builds](#install-pre-release-builds)
-> section.
 
 <ul class="nav nav-tabs">
 <li class="active"><a data-toggle="tab" data-target="#macOS">Mac</a></li>
 <li><a data-toggle="tab" data-target="#windows">Windows</a></li>
 <li><a data-toggle="tab" data-target="#windows-server">Windows Server</a></li>
 <li><a data-toggle="tab" data-target="#linux">Linux</a></li>
-<li><a data-toggle="tab" data-target="#alternatives">Alternative install options</a></li>
-<li><a data-toggle="tab" data-target="#pre-release">Pre-release builds</a></li>
+<li><a data-toggle="tab" data-target="#linux-standalone">Linux Standalone binary</a></li>
 </ul>
 <div class="tab-content">
 <div id="macOS" class="tab-pane fade in active" markdown="1">
@@ -95,185 +92,121 @@ on Microsoft Windows Server and want to install Docker Compose.
     ```
 
     Then run the following command to download the current stable release of
-    Compose (v{{site.compose_version}}):
+    Compose ({{site.compose_version}}):
 
     ```powershell
     Invoke-WebRequest "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\Docker\docker-compose.exe
     ```
 
-**Note**: On Windows Server 2019, you can add the Compose executable to `$Env:ProgramFiles\Docker`. Because this directory is  registered in the system `PATH`, you can run the `docker-compose --version` command on the subsequent step with no additional configuration.
+    >**Note**:  
+    > On Windows Server 2019, you can add the Compose executable to `$Env:ProgramFiles\Docker`. Because this directory is  registered in the system `PATH`, you can run the `docker-compose --version` command on the subsequent step with no additional configuration.
 
-    > To install a different version of Compose, substitute `{{site.compose_version}}`
+    > To install a different version of Compose, substitute `{{site.compose_version}}` 
     > with the version of Compose you want to use.
 
 3.  Test the installation.
 
     ```powershell
-    docker-compose --version
-
-    docker-compose version {{site.compose_version}}, build 01110ad01
+    $ docker compose version
+    Docker Compose version {{site.compose_version}}
     ```
-
 </div>
 <div id="linux" class="tab-pane fade" markdown="1">
 
 ### Install Compose on Linux systems
 
 On Linux, you can download the Docker Compose binary from the
-[Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"}.
+[Compose repository release page on GitHub](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"} and copying it into `$HOME/.docker/cli-plugins` as `docker-compose`.
 Follow the instructions from the link, which involve running the `curl` command
 in your terminal to download the binaries. These step-by-step instructions are
 also included below.
 
-> For `alpine`, the following dependency packages are needed:
-> `py-pip`, `python3-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, `rust`, `cargo` and `make`.
-{: .important}
-
 1.  Run this command to download the current stable release of Docker Compose:
 
     ```console
-    $ sudo curl -L "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    $ DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+    $ mkdir -p $DOCKER_CONFIG/cli-plugins
+    $ curl -SL https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
     ```
+
+    This command installs Compose for the active user under `$HOME` directory. To install Docker Compose for all users on your system, replace `~/.docker/cli-plugins` with `/usr/local/lib/docker/cli-plugins`.
+
 
     > To install a different version of Compose, substitute `{{site.compose_version}}`
-    > with the version of Compose you want to use. For instructions on how to
-    > install Compose `{{site.compose_v2_version}}` on Linux, see [Install
-    > Compose 2.0.0 on Linux](../cli-command#install-on-linux)
+    > with the version of Compose you want to use.
 
-    If you have problems installing with `curl`, see
-    [Alternative Install Options](install.md#alternative-install-options) tab above.
+2. Apply executable permissions to the binary:
 
-2.  Apply executable permissions to the binary:
-
+     ```console
+    $ chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+    ```
+    or if you choose to install Compose for all users
     ```console
-    $ sudo chmod +x /usr/local/bin/docker-compose
+    $ sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
     ```
 
-    > **Note**:
-    >
-    > If the command `docker-compose` fails after installation, check your path.
-    > You can also create a symbolic link to `/usr/bin` or any other directory in your path.
-    >
-    > For example:
-    > ```console
-    > $ sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-    > ```
+3. Test the installation.
 
-3.  Optionally, install [command completion](completion.md) for the
-    `bash` and `zsh` shell.
+    ```console
+    $ docker compose version
+    Docker Compose version {{site.compose_version}}
+    ```
+</div>
+<div id="linux-standalone" class="tab-pane fade" markdown="1">
 
-4.  Test the installation.
+### Install Compose as standalone binary on Linux systems
+
+You can use Compose as a standalone binary without installing the Docker CLI.
+
+1. Run this command to download the current stable release of Docker Compose:
+
+  ```console
+  $ curl -SL https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+  ```
+
+  > To install a different version of Compose, substitute `{{site.compose_version}}`
+  > with the version of Compose you want to use.
+
+2. Apply executable permissions to the binary:
+
+  ```console
+  $ sudo chmod +x /usr/local/bin/docker-compose
+  ```
+  
+  > **Note**:
+  >
+  > If the command `docker-compose` fails after installation, check your path.
+  > You can also create a symbolic link to `/usr/bin` or any other directory in your path.
+  >
+  > For example:
+  > ```console
+  > $ sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+  > ```
+
+3. Test the installation.
 
     ```console
     $ docker-compose --version
-    docker-compose version {{site.compose_version}}, build 1110ad01
+    Docker Compose version {{site.compose_version}}
     ```
-
-</div>
-<div id="alternatives" class="tab-pane fade" markdown="1">
-
-### Alternative install options
-
-- [Install using pip](#install-using-pip)
-- [Install as a container](#install-as-a-container)
-
-#### Install using pip
-
-> For `alpine`, the following dependency packages are needed:
-> `py-pip`, `python3-dev`, `libffi-dev`, `openssl-dev`, `gcc`, `libc-dev`, `rust`, `cargo`, and `make`.
-{: .important}
-
-Compose can be installed from
-[pypi](https://pypi.python.org/pypi/docker-compose) using `pip`. If you install
-using `pip`, we recommend that you use a
-[virtualenv](https://virtualenv.pypa.io/en/latest/) because many operating
-systems have python system packages that conflict with docker-compose
-dependencies. See the [virtualenv
-tutorial](https://docs.python-guide.org/dev/virtualenvs/) to get
-started.
-
-```console
-$ pip3 install docker-compose
-```
-
-If you are not using virtualenv,
-
-```console
-$ sudo pip install docker-compose
-```
-
-> pip version 6.0 or greater is required.
-
-#### Install as a container
-
-Compose can also be run inside a container, from a small bash script wrapper. To
-install compose as a container run this command:
-
-```console
-$ sudo curl -L --fail https://github.com/docker/compose/releases/download/{{site.compose_version}}/run.sh -o /usr/local/bin/docker-compose
-$ sudo chmod +x /usr/local/bin/docker-compose
-```
-
-</div>
-
-<div id="pre-release" class="tab-pane fade" markdown="1">
-
-### Install pre-release builds
-
-If you're interested in trying out a pre-release build, you can download release
-candidates from the [Compose repository release page on GitHub](https://github.com/docker/compose/releases){: target="_blank" rel="noopener" class="_"}.
-Follow the instructions from the link, which involves running the `curl` command
-in your terminal to download the binaries.
-
-Pre-releases built from the "master" branch are also available for download at
-[https://dl.bintray.com/docker-compose/master/](https://dl.bintray.com/docker-compose/master/){: target="_blank" rel="noopener" class="_"}.
-
-> Pre-release builds allow you to try out new features before they are released,
-> but may be less stable.
-{: .important}
-
 </div>
 </div>
 
 ----
 
-## Upgrading
-
-If you're upgrading from Compose 1.2 or earlier, remove or
-migrate your existing containers after upgrading Compose. This is because, as of
-version 1.3, Compose uses Docker labels to keep track of containers, and your
-containers need to be recreated to add the labels.
-
-If Compose detects containers that were created without labels, it refuses
-to run, so that you don't end up with two sets of them. If you want to keep using
-your existing containers (for example, because they have data volumes you want
-to preserve), you can use Compose 1.5.x to migrate them with the following
-command:
-
-```console
-$ docker-compose migrate-to-labels
-```
-
-Alternatively, if you're not worried about keeping them, you can remove them.
-Compose just creates new ones.
-
-```console
-$ docker container rm -f -v myapp_web_1 myapp_db_1 ...
-```
-
 ## Uninstallation
 
 To uninstall Docker Compose if you installed using `curl`:
 
-```console
-$ sudo rm /usr/local/bin/docker-compose
-```
+  ```console
+  $ rm $DOCKER_CONFIG/cli-plugins/docker-compose
+  ```
+    
+  or if you choose to install Compose for all users  
 
-To uninstall Docker Compose if you installed using `pip`:
-
-```console
-$ pip uninstall docker-compose
-```
+  ```console
+  $ sudo rm /usr/local/lib/docker/cli-plugins/docker-compose
+  ```
 
 > Got a "Permission denied" error?
 >

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -253,7 +253,7 @@ instead of `yum -y install`, and point to the new file.
 1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -118,10 +118,10 @@ $ sudo yum-config-manager \
 
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose or go to the next step to install a specific version:
 
     ```console
-    $ sudo yum install docker-ce docker-ce-cli containerd.io
+    $ sudo yum install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
     If prompted to accept the GPG key, verify that the fingerprint matches
@@ -161,7 +161,7 @@ $ sudo yum-config-manager \
        a hyphen (`-`). For example, `docker-ce-18.09.1`.
 
     ```console
-    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
+    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-compose-plugin
     ```
 
     This command installs Docker, but it doesn't start Docker. It also creates a
@@ -250,10 +250,10 @@ instead of `yum -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -35,7 +35,7 @@ Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+$ sudo apt-get remove docker docker-engine docker.io containerd runc docker-compose-plugin
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.
@@ -110,11 +110,11 @@ from the repository.
 This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and Raspbian.
 
 1. Update the `apt` package index, and install the _latest version_ of Docker
-   Engine and containerd, or go to the next step to install a specific version:
+   Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
 
     ```console
     $ sudo apt-get update
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io
+    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
     > Got multiple Docker repositories?
@@ -148,7 +148,7 @@ This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and Ras
        for example, `5:18.09.1~3-0~debian-stretch `.
 
     ```console
-    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
+    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io docker-compose-plugin
     ```
 
 3.  Verify that Docker Engine is installed correctly by running the `hello-world`
@@ -223,10 +223,10 @@ To upgrade Docker Engine, download the newer package file and repeat the
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io
+    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -35,7 +35,7 @@ Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc docker-compose-plugin
+$ sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -38,8 +38,7 @@ $ sudo dnf remove docker \
                   docker-logrotate \
                   docker-selinux \
                   docker-engine-selinux \
-                  docker-engine \
-                  docker-compose-plugin
+                  docker-engine
 ```
 
 It's OK if `dnf` reports that none of these packages are installed.

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -38,7 +38,8 @@ $ sudo dnf remove docker \
                   docker-logrotate \
                   docker-selinux \
                   docker-engine-selinux \
-                  docker-engine
+                  docker-engine \
+                  docker-compose-plugin
 ```
 
 It's OK if `dnf` reports that none of these packages are installed.
@@ -116,7 +117,7 @@ $ sudo dnf config-manager \
 1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
 
     ```console
-    $ sudo dnf install docker-ce docker-ce-cli containerd.io
+    $ sudo dnf install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
     If prompted to accept the GPG key, verify that the fingerprint matches
@@ -156,7 +157,7 @@ $ sudo dnf config-manager \
        `docker-ce-3:18.09.1`.
 
     ```console
-    $ sudo dnf -y install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
+    $ sudo dnf -y install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-compose-plugin
     ```
 
     This command installs Docker, but it doesn't start Docker. It also creates a
@@ -245,10 +246,10 @@ instead of `dnf -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+1.  Uninstall the Docker Engine, CLI, Containerd and Docker Compose packages:
 
     ```console
-    $ sudo dnf remove docker-ce docker-ce-cli containerd.io
+    $ sudo dnf remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -49,7 +49,8 @@ $ sudo yum remove docker \
                   docker-logrotate \
                   docker-engine \
                   podman \
-                  runc
+                  docker-compose-plugin
+                  runc \
 ```
 
 It's OK if `yum` reports that none of these packages are installed.
@@ -123,10 +124,10 @@ $ sudo yum-config-manager \
 
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
 
     ```console
-    $ sudo yum install docker-ce docker-ce-cli containerd.io
+    $ sudo yum install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
     If prompted to accept the GPG key, verify that the fingerprint matches
@@ -165,7 +166,7 @@ $ sudo yum-config-manager \
        a hyphen (`-`). For example, `docker-ce-20.10.7`.
 
     ```console
-    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
+    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-compose-plugin
     ```
 
     This command installs Docker, but it doesn't start Docker. It also creates a
@@ -254,10 +255,10 @@ instead of `yum -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -49,8 +49,7 @@ $ sudo yum remove docker \
                   docker-logrotate \
                   docker-engine \
                   podman \
-                  docker-compose-plugin
-                  runc \
+                  runc
 ```
 
 It's OK if `yum` reports that none of these packages are installed.

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -66,8 +66,7 @@ $ sudo zypper remove docker \
                   docker-latest-logrotate \
                   docker-logrotate \
                   docker-engine \
-                  docker-compose-plugin
-                  runc \
+                  runc
 ```
 
 It's OK if `zypper` reports that none of these packages are installed.

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -66,7 +66,8 @@ $ sudo zypper remove docker \
                   docker-latest-logrotate \
                   docker-logrotate \
                   docker-engine \
-                  runc
+                  docker-compose-plugin
+                  runc \
 ```
 
 It's OK if `zypper` reports that none of these packages are installed.
@@ -133,10 +134,10 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
 
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
 
     ```console
-    $ sudo zypper install docker-ce docker-ce-cli containerd.io
+    $ sudo zypper install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
     If prompted to accept the GPG key, verify that the fingerprint matches
@@ -173,7 +174,7 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
        separated by a hyphen (`-`). For example, `docker-ce-3:20.10.8`.
 
     ```console
-    $ sudo zypper install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io
+    $ sudo zypper install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-compose-plugin
     ```
 
     This command installs Docker, but it doesn't start Docker. It also creates a
@@ -262,10 +263,10 @@ instead of `zypper -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo zypper remove docker-ce docker-ce-cli containerd.io
+    $ sudo zypper remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -57,7 +57,7 @@ Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc docker-compose-plugin
+$ sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -57,7 +57,7 @@ Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+$ sudo apt-get remove docker docker-engine docker.io containerd runc docker-compose-plugin
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.
@@ -134,11 +134,11 @@ from the repository.
 #### Install Docker Engine
 
 1. Update the `apt` package index, and install the _latest version_ of Docker
-   Engine and containerd, or go to the next step to install a specific version:
+   Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
 
     ```console
     $ sudo apt-get update
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io
+    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
     > Got multiple Docker repositories?
@@ -166,7 +166,7 @@ from the repository.
        for example, `5:18.09.1~3-0~ubuntu-xenial`.
 
     ```console
-    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
+    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io docker-compose-plugin
     ```
 
 3.  Verify that Docker Engine is installed correctly by running the `hello-world`
@@ -241,10 +241,10 @@ To upgrade Docker Engine, download the newer package file and repeat the
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, and Containerd packages:
+1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io
+    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host


### PR DESCRIPTION
### Proposed changes

Adapt Engine and Compose installation docs to use Compose V2 version as default

- Remove reference to Compose v1 python installation
- Move Compose CLI command docs to the main Compose install page
- Add a dedicated page for Compose switch and Compose v1

