### PR TITLE
Update 06_bind_mounts.md

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -55,7 +55,7 @@ So, let's do it!
     PS> docker run -dp 3000:3000 `
         -w /app -v "$(pwd):/app" `
         node:12-alpine `
-        sh -c "yarn install && yarn run dev"
+        sh -c "apk --no-cache --virtual build-dependencies add python make g++ && yarn install && yarn run dev"
     ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping


### PR DESCRIPTION
I encountered the same issue talked on this thread https://github.com/docker/getting-started/issues/124
By modifying the Dockerfile:
```
# syntax=docker/dockerfile:1
FROM node:12-alpine
RUN apk add --no-cache python2 g++ make
WORKDIR /app
COPY . .
RUN apk --no-cache --virtual build-dependencies add \
    python2 \
    make \
    g++
RUN yarn install --production
CMD ["node", "src/index.js"]
EXPOSE 3000
```
and the command line proposed in the change, I could manage the issue.
I hope the official tutorial will fix this page!!

I also post the error message with the original code:
```
yarn install v1.22.18

[1/4] Resolving packages...

[2/4] Fetching packages...

[3/4] Linking dependencies...

[4/4] Building fresh packages...

info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

warning Resolution field "ansi-regex@5.0.1" is incompatible with requested version "ansi-regex@^2.0.0"

warning Resolution field "ansi-regex@5.0.1" is incompatible with requested version "ansi-regex@^3.0.0"

error /app/node_modules/sqlite3: Command failed.

Exit code: 1

Command: node-pre-gyp install --fallback-to-build

Arguments: 

Directory: /app/node_modules/sqlite3

Output:

node-pre-gyp info it worked if it ends with ok

node-pre-gyp info using node-pre-gyp@0.11.0

node-pre-gyp info using node@12.22.12 | linux | arm64

node-pre-gyp WARN Using request for node-pre-gyp https download 

node-pre-gyp info check checked for "/app/node_modules/sqlite3/lib/binding/napi-v3-linux-arm64/node_sqlite3.node" (not found)

node-pre-gyp http GET https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v5.0.2/napi-v3-linux-arm64.tar.gz

node-pre-gyp http 403 https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v5.0.2/napi-v3-linux-arm64.tar.gz

node-pre-gyp WARN Tried to download(403): https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v5.0.2/napi-v3-linux-arm64.tar.gz 

node-pre-gyp WARN Pre-built binaries not found for sqlite3@5.0.2 and node@12.22.12 (node-v72 ABI, musl) (falling back to source compile with node-gyp) 

node-pre-gyp http 403 status code downloading tarball https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v5.0.2/napi-v3-linux-arm64.tar.gz 

gyp info it worked if it ends with ok

gyp info using node-gyp@3.8.0

gyp info using node@12.22.12 | linux | arm64

gyp info ok 

gyp info it worked if it ends with ok

gyp info using node-gyp@3.8.0

gyp info using node@12.22.12 | linux | arm64

gyp ERR! configure error 

gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.

gyp ERR! stack     at PythonFinder.failNoPython (/app/node_modules/node-gyp/lib/configure.js:484:19)

gyp ERR! stack     at PythonFinder.<anonymous> (/app/node_modules/node-gyp/lib/configure.js:406:16)

gyp ERR! stack     at F (/app/node_modules/which/which.js:68:16)

gyp ERR! stack     at E (/app/node_modules/which/which.js:80:29)

gyp ERR! stack     at /app/node_modules/which/which.js:89:16

gyp ERR! stack     at /app/node_modules/isexe/index.js:42:5

gyp ERR! stack     at /app/node_modules/isexe/mode.js:8:5

gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:168:21)

gyp ERR! System Linux 5.10.104-linuxkit

gyp ERR! command "/usr/local/bin/node" "/app/node_modules/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build" "--module=/app/node_modules/sqlite3/lib/binding/napi-v3-linux-arm64/node_sqlite3.node" "--module_name=node_sqlite3" "--module_path=/app/node_modules/sqlite3/lib/binding/napi-v3-linux-arm64" "--napi_version=8" "--node_abi_napi=napi" "--napi_build_version=3" "--node_napi_label=napi-v3"

gyp ERR! cwd /app/node_modules/sqlite3

gyp ERR! node -v v12.22.12

gyp ERR! node-gyp -v v3.8.0

gyp ERR! not ok 

node-pre-gyp ERR! build error 

node-pre-gyp ERR! stack Error: Failed to execute '/usr/local/bin/node /app/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/app/node_modules/sqlite3/lib/binding/napi-v3-linux-arm64/node_sqlite3.node --module_name=node_sqlite3 --module_path=/app/node_modules/sqlite3/lib/binding/napi-v3-linux-arm64 --napi_version=8 --node_abi_napi=napi --napi_build_version=3 --node_napi_label=napi-v3' (1)

node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/app/node_modules/node-pre-gyp/lib/util/compile.js:83:29)

node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:314:20)

node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:1022:16)

node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)

node-pre-gyp ERR! System Linux 5.10.104-linuxkit

node-pre-gyp ERR! command "/usr/local/bin/node" "/app/node_modules/sqlite3/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"

node-pre-gyp ERR! cwd /app/node_modules/sqlite3

node-pre-gyp ERR! node -v v12.22.12

node-pre-gyp ERR! node-pre-gyp -v v0.11.0

node-pre-gyp ERR! not ok 

Failed to execute '/usr/local/bin/node /app/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/app/node_modules/sqlite3/lib/binding/napi-v3-linux-arm64/node_sqlite3.node --module_name=node_sqlite3 --module_path=/app/node_modules/sqlite3/lib/binding/napi-v3-linux-arm64 --napi_version=8 --node_abi_napi=napi --napi_build_version=3 --node_napi_label=napi-v3' (1)
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
