### PR TITLE
troubleshooting: include the support form link in terminal section

### DIFF
--- a/desktop/mac/troubleshoot.md
+++ b/desktop/mac/troubleshoot.md
@@ -115,6 +115,8 @@ To view the contents of the diagnostic file, run:
 $ open /tmp/BE9AFAAF-F68B-41D0-9D12-84760E6B8740/20190905152051.zip
 ```
 
+If you have a paid Docker subscription, open the [Docker Desktop support](https://hub.docker.com/support/desktop/){:target="_blank" rel="noopener" class="_"} form. Fill in the information required and add the ID to the Diagnostics ID field. Click **Submit** to request Docker Desktop support.
+
 ### Self-diagnose tool
 
 Docker Desktop contains a self-diagnose tool which helps you to identify some common problems. Before you run the self-diagnose tool, locate `com.docker.diagnose`. If you have installed Docker Desktop

--- a/desktop/windows/troubleshoot.md
+++ b/desktop/windows/troubleshoot.md
@@ -82,6 +82,8 @@ Diagnostics Bundle: C:\Users\User\AppData\Local\Temp\CD6CF862-9CBD-4007-9C2F-5FB
 Diagnostics ID:     CD6CF862-9CBD-4007-9C2F-5FBE0572BBC2/20180720152545 (uploaded)
 ```
 
+If you have a paid Docker subscription, open the [Docker Desktop support](https://hub.docker.com/support/desktop/){:target="_blank" rel="noopener" class="_"} form. Fill in the information required and add the ID to the Diagnostics ID field. Click **Submit** to request Docker Desktop support.
+
 ### Self-diagnose tool
 
 Docker Desktop contains a self-diagnose tool which helps you to identify some common


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

If Docker Desktop doesn't start properly, to file a support ticket the user needs to
1. gather diagnostics from the "Troubleshooting from the terminal" section
2. open the link to the support form which is elsewhere on the page.

This patch includes the link to the support form in the "Troubleshooting from the terminal" section to make it more complete.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
