### PR TITLE
Update 06_bind_mounts.md

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -45,7 +45,7 @@ So, let's do it!
     ```console
     $ docker run -dp 3000:3000 \
         -w /app -v "$(pwd):/app" \
-        node:12-alpine \
+        getting-started \
         sh -c "yarn install && yarn run dev"
     ```
 
@@ -54,14 +54,14 @@ So, let's do it!
     ```powershell
     PS> docker run -dp 3000:3000 `
         -w /app -v "$(pwd):/app" `
-        node:12-alpine `
+        getting-started `
         sh -c "yarn install && yarn run dev"
     ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
     - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory
-    - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
+    - `getting-started` - the image to use.
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,
       we'll see that the `dev` script is starting `nodemon`.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

I believe that we want to be using the `getting-started` image here that we created earlier in the tutorial, since using the `node:12-alpine` image will cause an error since there are missing dependencies when trying to run `yarn install` in the container.

### Related issues (optional)

Fixes #12778
