### PR TITLE
Desktop: improve enable kubernetes section

### DIFF
--- a/desktop/kubernetes.md
+++ b/desktop/kubernetes.md
@@ -39,8 +39,12 @@ The status of Kubernetes shows in the Docker menu and the context points to
 
 ## Use the kubectl command
 
-The Kubernetes client command `kubectl` is included and configured to connect
-to the local Kubernetes server. If you have already installed `kubectl` and
+Kubernetes integration provides the Kubernetes CLI command
+at `/usr/local/bin/kubectl` on Mac and at `C:\>Program Files\Docker\Docker\Resources\bin\kubectl.exe` on Windows. This location may not be in your shell's `PATH`
+variable, so you may need to type the full path of the command or add it to
+the `PATH`.
+
+If you have already installed `kubectl` and
 pointing to some other environment, such as `minikube` or a GKE cluster, ensure you change the context so that `kubectl` is pointing to `docker-desktop`:
 
 ```console
@@ -50,11 +54,6 @@ $ kubectl config use-context docker-desktop
 
 If you installed `kubectl` using Homebrew, or by some other method, and
 experience conflicts, remove `/usr/local/bin/kubectl`.
-
-Kubernetes integration provides the Kubernetes CLI command
-at `/usr/local/bin/kubectl` on Mac and at `C:\>Program Files\Docker\Docker\Resources\bin\kubectl.exe` on Windows. This location may not be in your shell's `PATH`
-variable, so you may need to type the full path of the command or add it to
-the `PATH`.
 
 You can test the command by listing the available nodes:
 

--- a/desktop/kubernetes.md
+++ b/desktop/kubernetes.md
@@ -33,8 +33,7 @@ experience conflicts, remove `/usr/local/bin/kubectl`.
 
 To enable Kubernetes in Docker Desktop, go to **Preferences** > **Kubernetes** and then click **Enable Kubernetes**.
 
-By default, Kubernetes containers are hidden from commands like `docker
-service ls`, because managing them manually is not supported. To see these internal containers, select **Show system containers (advanced)**. Most users do not need this option.
+By default, Kubernetes containers are hidden from commands like `docker ps`, because managing them manually is not supported. To see these internal containers, select **Show system containers (advanced)**. Most users do not need this option.
 
 Click **Apply & Restart** to save the settings and then click **Install** to confirm. This instantiates images required to run the Kubernetes server as containers, and installs the `/usr/local/bin/kubectl` command on your machine.
 

--- a/desktop/kubernetes.md
+++ b/desktop/kubernetes.md
@@ -31,8 +31,7 @@ experience conflicts, remove `/usr/local/bin/kubectl`.
 
 ## Enable Kubernetes
 
-To enable Kubernetes support and install a standalone instance of Kubernetes
-running as a Docker container, go to **Preferences** > **Kubernetes** and then click **Enable Kubernetes**.
+To enable Kubernetes in Docker Desktop, go to **Preferences** > **Kubernetes** and then click **Enable Kubernetes**.
 
 By default, Kubernetes containers are hidden from commands like `docker
 service ls`, because managing them manually is not supported. To see these internal containers, select **Show system containers (advanced)**. Most users do not need this option.

--- a/desktop/kubernetes.md
+++ b/desktop/kubernetes.md
@@ -15,20 +15,6 @@ is only for local testing. Enabling Kubernetes allows you to deploy
 your workloads in parallel, on Kubernetes, Swarm, and as standalone containers. Enabling or disabling the Kubernetes server does not affect your other
 workloads.
 
-## Prerequisites
-
-The Kubernetes client command `kubectl` is included and configured to connect
-to the local Kubernetes server. If you have already installed `kubectl` and
-pointing to some other environment, such as `minikube` or a GKE cluster, ensure you change the context so that `kubectl` is pointing to `docker-desktop`:
-
-```console
-$ kubectl config get-contexts
-$ kubectl config use-context docker-desktop
-```
-
-If you installed `kubectl` using Homebrew, or by some other method, and
-experience conflicts, remove `/usr/local/bin/kubectl`.
-
 ## Enable Kubernetes
 
 To enable Kubernetes in Docker Desktop, go to **Preferences** > **Kubernetes** and then click **Enable Kubernetes**.
@@ -52,6 +38,18 @@ The status of Kubernetes shows in the Docker menu and the context points to
 > Docker Desktop does not upgrade your Kubernetes cluster automatically after a new update. To upgrade your Kubernetes cluster to the latest version, select **Reset Kubernetes Cluster**.
 
 ## Use the kubectl command
+
+The Kubernetes client command `kubectl` is included and configured to connect
+to the local Kubernetes server. If you have already installed `kubectl` and
+pointing to some other environment, such as `minikube` or a GKE cluster, ensure you change the context so that `kubectl` is pointing to `docker-desktop`:
+
+```console
+$ kubectl config get-contexts
+$ kubectl config use-context docker-desktop
+```
+
+If you installed `kubectl` using Homebrew, or by some other method, and
+experience conflicts, remove `/usr/local/bin/kubectl`.
 
 Kubernetes integration provides the Kubernetes CLI command
 at `/usr/local/bin/kubectl` on Mac and at `C:\>Program Files\Docker\Docker\Resources\bin\kubectl.exe` on Windows. This location may not be in your shell's `PATH`

--- a/desktop/kubernetes.md
+++ b/desktop/kubernetes.md
@@ -33,11 +33,11 @@ experience conflicts, remove `/usr/local/bin/kubectl`.
 
 To enable Kubernetes in Docker Desktop, go to **Preferences** > **Kubernetes** and then click **Enable Kubernetes**.
 
-By default, Kubernetes containers are hidden from commands like `docker ps`, because managing them manually is not supported. To see these internal containers, select **Show system containers (advanced)**. Most users do not need this option.
-
 Click **Apply & Restart** to save the settings and then click **Install** to confirm. This instantiates images required to run the Kubernetes server as containers, and installs the `/usr/local/bin/kubectl` command on your machine.
 
 ![Enable Kubernetes](images/kube-enable.png){:width="750px"}
+
+By default, Kubernetes containers are hidden from commands like `docker ps`, because managing them manually is not supported. To see these internal containers, select **Show system containers (advanced)**. Most users do not need this option.
 
 When Kubernetes is enabled and running, an additional status bar item displays
   at the bottom right of the Docker Desktop Settings dialog.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

I'd like to link to the Kubernetes section to show how easy it is to enable. This PR fixes a few issues:

1. the step about the `docker-desktop` context can't be done until after Kubernetes has been enabled, because the context doesn't exist until then. So it can't be done as a pre-req, it has to be checked afterwards. (Note that you might have an old `docker-desktop` context lying around if you have ever enabled Kubernetes before, but new users won't have one)
2. to see Kube docker containers you need `docker ps` (or `docker container ls`) not `docker service ls`

and makes a few simplifications:

1. the note about seeing internal Kube containers is an advanced option so doesn't need to be presented until later -- this keeps the enable Kubernetes section small (reflecting how easy it is)
2. the note about managing conflicts with minikube is an uncommon case, so can be pushed to the kubectl section

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
