### PR TITLE
Remove the request new guide issue link

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -47,7 +47,7 @@ guides:
       path: /get-started/09_image_best/
     - title: "Part 10: What next?"
       path: /get-started/11_what_next/
-- sectiontitle: Language-specific guides (New)
+- sectiontitle: Language-specific guides
   section:
   - path: /language/
     title: Overview

--- a/language/index.md
+++ b/language/index.md
@@ -39,6 +39,4 @@ Learn how to set up your Docker environment and start containerizing your applic
     </div>
 </div>
 
-To request a guide in other programming languages, create an issue in the [Docker Docs github repository](https://github.com/docker/docker.github.io/issues/new?title=Language-specific%20guides%20request){:target="_blank" rel="noopener" class="_"}.
-
 <br />


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

- Remove the "New" label in the table of contents as the language guides aren't new anymore ;)
- Remove the link to request a guide in a programming language as we've received quite a lot of response on this already