### PR TITLE
Capitalizing the proper noun / product name

### DIFF
--- a/reference/index.md
+++ b/reference/index.md
@@ -37,5 +37,5 @@ various APIs, CLIs, and file formats.
 | Driver                                                 | Description                                                                        |
 |:-------------------------------------------------------|:-----------------------------------------------------------------------------------|
 | [Image specification](/registry/spec/manifest-v2-2/)   | Describes the various components of a Docker image                                 |
-| [Registry token authentication](/registry/spec/auth/)  | Outlines the Docker registry authentication scheme                                 |
+| [Registry token authentication](/registry/spec/auth/)  | Outlines the Docker Registry authentication scheme                                 |
 | [Registry storage drivers](/registry/storage-drivers/) | Enables support for given cloud providers when storing images with Registry        |


### PR DESCRIPTION
'Docker Registry' instead of 'Docker registry'

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes
'Docker Registry' instead of 'Docker registry' as Docker Registry is a product name
<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
