### PR TITLE
[Do not merge until 11 May] DKP-168 Remove support for Windows versions which are not supported by Microsoft anymore

### DIFF
--- a/desktop/windows/install.md
+++ b/desktop/windows/install.md
@@ -41,7 +41,7 @@ Your Windows machine must meet the following requirements to successfully instal
 ### WSL 2 backend
 
 - Windows 11 64-bit: Home or Pro version 21H2 or higher, or Enterprise or Education version 21H2 or higher.
-- Windows 10 64-bit: Home or Pro 2004 (build 19041) or higher, or Enterprise or Education 1909 (build 18363) or higher.
+- Windows 10 64-bit: Home or Pro 21H1 (build 19043) or higher, or Enterprise or Education 20H2 (build 19042) or higher.
 - Enable the WSL 2 feature on Windows. For detailed instructions, refer to the
     [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10){: target="_blank" rel="noopener" class="_"}.
 - The following hardware prerequisites are required to successfully run
@@ -60,7 +60,7 @@ WSL 2 on Windows 10 or Windows 11:
 ### Hyper-V backend and Windows containers
 
 - Windows 11 64-bit: Pro version 21H2 or higher, or Enterprise or Education version 21H2 or higher.
-- Windows 10 64-bit: Pro 2004 (build 19041) or higher, or Enterprise or Education 1909 (build 18363) or higher.
+- Windows 10 64-bit: Pro 21H1 (build 19043) or higher, or Enterprise or Education 20H2 (build 19042) or higher.
 
   For Windows 10 and Windows 11 Home, see [System requirements for WSL 2 backend](#wsl-2-backend).
 - Hyper-V and Containers Windows features must be enabled.


### PR DESCRIPTION
### Proposed changes

Remove support for obsolete Windows versions, according to https://docs.microsoft.com/en-us/windows/release-health/supported-versions-windows-client#servicing-channels

The actual end of support date for these is May 10, 2022. Do we want to wait until then before merging? @usha-mandya @stephen-turner ?

### Related issues (optional)

https://docker.atlassian.net/browse/DKP-168