### PR TITLE
Update 06_bind_mounts.md

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -57,6 +57,15 @@ So, let's do it!
         node:12-alpine `
         sh -c "yarn install && yarn run dev"
     ```
+    
+    For Chinese developers, you may need to modify the resource repository to download yarn dependencies, the command needs to be like this:
+
+    ```powershell
+    PS> docker run -dp 3000:3000 `
+        -w /app -v "$(pwd):/app" `
+        node:12-alpine `
+        sh -c "npm config set registry https://registry.npm.taobao.org && npm config set disturl https://npm.taobao.org/dist && yarn install && yarn run dev"
+    ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from


### PR DESCRIPTION
### Proposed changes

When I run the powershell command it gives an error like this:

> error An unexpected error occurred: "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz: connect ECONNREFUSED 104.16.25.35:443".
> info If you think this is a bug, please open a bug report with the information provided in "/app/yarn-error.log".
> info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

I finally found out that the reason is that the npm resource repository cannot be accessed normally in China. 
Changing the resource repository solves.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->