### PR TITLE
Fix a typo in deploy.md

### DIFF
--- a/compose/compose-file/deploy.md
+++ b/compose/compose-file/deploy.md
@@ -117,7 +117,7 @@ running at any given time.
 
 ```yml
 services:
-  fronted:
+  frontend:
     image: awesome/webapp
     deploy:
       mode: replicated


### PR DESCRIPTION
### Proposed changes

The "fronted" service in an example was mispelled in `compose/compose-file/deploy.md`.
