### PR TITLE
Fix for Issue 12375

### DIFF
--- a/_config_production.yml
+++ b/_config_production.yml
@@ -52,6 +52,26 @@ defaults:
   # Set the correct edit-URL for upstream resources. We usually don't create a direct
   # edit link for these, and instead point to the directory that contains the file.
   - scope:
+      path: cloud/aci-compose-features.md
+    values:
+      edit_url: "https://github.com/docker/compose-cli/tree/master/docs/"
+  - scope:
+      path: cloud/aci-container-features.md
+    values:
+      edit_url: "https://github.com/docker/compose-cli/tree/master/docs/"
+  - scope:
+      path: cloud/ecs-architecture.md
+    values:
+      edit_url: "https://github.com/docker/compose-cli/tree/master/docs/"
+  - scope:
+      path: cloud/ecs-compose-features.md
+    values:
+      edit_url: "https://github.com/docker/compose-cli/tree/master/docs/"
+  - scope:
+      path: cloud/ecs-compose-examples.md
+    values:
+      edit_url: "https://github.com/docker/compose-cli/tree/master/docs/"
+  - scope:
       path: engine/deprecated.md
     values:
       edit_url: "https://github.com/docker/cli/tree/master/docs/"


### PR DESCRIPTION
### Proposed changes

Fixed broken links for the "Edit this page" link for some upstream files under /cloud/.
- https://docs.docker.com/cloud/aci-container-features/
- https://docs.docker.com/cloud/aci-compose-features/
- https://docs.docker.com/cloud/ecs-architecture/
- https://docs.docker.com/cloud/ecs-compose-features/
- https://docs.docker.com/cloud/ecs-compose-examples/

### Related issues (optional)

Fixes #12375
