### PR TITLE
update Compose version to v2.5.0 and reference Compose CLI documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ exclude: ["_samples", "_scripts", "404.html", "datacenter", "ee", "index.html", 
 latest_engine_api_version: "1.41"
 docker_ce_version: "20.10"
 compose_v1_version: "1.29.2"
-compose_version: "v2.4.1"
+compose_version: "v2.5.0"
 compose_file_v3: "3.9"
 compose_file_v2: "2.4"
 machine_version: "0.16.0"

--- a/_data/compose-cli/docker_compose.yaml
+++ b/_data/compose-cli/docker_compose.yaml
@@ -98,6 +98,9 @@ long: |-
   and so does `COMPOSE_PROFILES` environment variable for to the `--profiles` flag.
 
   If flags are explicitly set on command line, associated environment variable is ignored
+
+  Setting the `COMPOSE_IGNORE_ORPHANS` environment variable to `true` will stop docker compose from detecting orphaned
+  containers for the project.
 usage: docker compose
 pname: docker
 plink: docker.yaml
@@ -126,6 +129,7 @@ cname:
 - docker compose top
 - docker compose unpause
 - docker compose up
+- docker compose version
 clink:
 - docker_compose_build.yaml
 - docker_compose_convert.yaml
@@ -151,6 +155,7 @@ clink:
 - docker_compose_top.yaml
 - docker_compose_unpause.yaml
 - docker_compose_up.yaml
+- docker_compose_version.yaml
 options:
 - option: ansi
   value_type: string
@@ -158,6 +163,17 @@ options:
   description: |
     Control when to print ANSI control characters ("never"|"always"|"auto")
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: compatibility
+  value_type: bool
+  default_value: "false"
+  description: Run compose in backward compatibility mode
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -166,6 +182,7 @@ options:
   value_type: string
   description: Specify an alternate environment file.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -176,6 +193,7 @@ options:
   default_value: '[]'
   description: Compose configuration files
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -185,6 +203,7 @@ options:
   default_value: "false"
   description: Do not print ANSI control characters (DEPRECATED)
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -194,6 +213,7 @@ options:
   default_value: '[]'
   description: Specify a profile to enable
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -204,6 +224,7 @@ options:
     Specify an alternate working directory
     (default: the path of the Compose file)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -213,6 +234,7 @@ options:
   value_type: string
   description: Project name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -222,6 +244,18 @@ options:
   default_value: "false"
   description: Show more output
   deprecated: false
+  hidden: true
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: version
+  shorthand: v
+  value_type: bool
+  default_value: "false"
+  description: Show the Docker Compose version information
+  deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -233,6 +267,7 @@ options:
     Specify an alternate working directory
     (default: the path of the Compose file)
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_convert.yaml
+++ b/_data/compose-cli/docker_compose_convert.yaml
@@ -16,6 +16,7 @@ options:
   default_value: yaml
   description: 'Format the output. Values: [yaml | json]'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -24,6 +25,17 @@ options:
   value_type: string
   description: Print the service config hash, one per line.
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: images
+  value_type: bool
+  default_value: "false"
+  description: Print the image names, one per line.
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -33,6 +45,27 @@ options:
   default_value: "false"
   description: Don't interpolate environment variables.
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: no-normalize
+  value_type: bool
+  default_value: "false"
+  description: Don't normalize compose model.
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: output
+  shorthand: o
+  value_type: string
+  description: Save to file (default to stdout)
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,6 +75,7 @@ options:
   default_value: "false"
   description: Print the profile names, one per line.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -52,6 +86,7 @@ options:
   default_value: "false"
   description: Only validate the configuration, don't print anything.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,6 +96,7 @@ options:
   default_value: "false"
   description: Pin image tags to digests.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -70,6 +106,7 @@ options:
   default_value: "false"
   description: Print the service names, one per line.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,6 +116,7 @@ options:
   default_value: "false"
   description: Print the volume names, one per line.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_cp.yaml
+++ b/_data/compose-cli/docker_compose_cp.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Copy to all the containers of the service.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   default_value: "false"
   description: Archive mode (copy all uid/gid information)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,6 +33,7 @@ options:
   default_value: "false"
   description: Always follow symbol link in SRC_PATH
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -41,6 +44,7 @@ options:
   description: |
     Index of the container if there are multiple instances of a service [default: 1].
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_create.yaml
+++ b/_data/compose-cli/docker_compose_create.yaml
@@ -10,6 +10,7 @@ options:
   default_value: "false"
   description: Build images before starting containers.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   description: |
     Recreate containers even if their configuration and image haven't changed.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   default_value: "false"
   description: Don't build an image, even if it's missing.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +42,7 @@ options:
   description: |
     If containers already exist, don't recreate them. Incompatible with --force-recreate.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_down.yaml
+++ b/_data/compose-cli/docker_compose_down.yaml
@@ -23,6 +23,7 @@ options:
   default_value: "false"
   description: Remove containers for services not defined in the Compose file.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,6 +33,7 @@ options:
   description: |
     Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,6 +44,7 @@ options:
   default_value: "10"
   description: Specify a shutdown timeout in seconds
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -53,6 +56,7 @@ options:
   description: |
     Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_events.yaml
+++ b/_data/compose-cli/docker_compose_events.yaml
@@ -29,6 +29,7 @@ options:
   default_value: "false"
   description: Output events as a stream of json objects
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_exec.yaml
+++ b/_data/compose-cli/docker_compose_exec.yaml
@@ -15,6 +15,7 @@ options:
   default_value: "false"
   description: 'Detached mode: Run command in the background.'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -25,6 +26,7 @@ options:
   default_value: '[]'
   description: Set environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -35,6 +37,18 @@ options:
   description: |
     index of the container if there are multiple instances of a service [default: 1].
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: interactive
+  shorthand: i
+  value_type: bool
+  default_value: "true"
+  description: Keep STDIN open even if not attached.
+  deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,10 +56,11 @@ options:
 - option: no-TTY
   shorthand: T
   value_type: bool
-  default_value: "false"
+  default_value: "true"
   description: |
     Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -55,6 +70,18 @@ options:
   default_value: "false"
   description: Give extended privileges to the process.
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: tty
+  shorthand: t
+  value_type: bool
+  default_value: "true"
+  description: Allocate a pseudo-TTY.
+  deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -64,6 +91,7 @@ options:
   value_type: string
   description: Run the command as this user.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -73,6 +101,7 @@ options:
   value_type: string
   description: Path to workdir directory for this command.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_images.yaml
+++ b/_data/compose-cli/docker_compose_images.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Only display IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_kill.yaml
+++ b/_data/compose-cli/docker_compose_kill.yaml
@@ -16,6 +16,7 @@ options:
   default_value: SIGKILL
   description: SIGNAL to send to the container.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_logs.yaml
+++ b/_data/compose-cli/docker_compose_logs.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Follow log output.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "false"
   description: Produce monochrome output.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   default_value: "false"
   description: Don't print prefix in logs.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   description: |
     Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -48,6 +52,7 @@ options:
   description: |
     Number of lines to show from the end of the logs for each container.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -58,6 +63,7 @@ options:
   default_value: "false"
   description: Show timestamps.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -67,6 +73,7 @@ options:
   description: |
     Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_ls.yaml
+++ b/_data/compose-cli/docker_compose_ls.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Show all stopped Compose projects
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: filter
   description: Filter output based on conditions provided.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   default_value: pretty
   description: 'Format the output. Values: [pretty | json].'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   default_value: "false"
   description: Only display IDs.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_pause.yaml
+++ b/_data/compose-cli/docker_compose_pause.yaml
@@ -1,5 +1,5 @@
 command: docker compose pause
-short: pause services
+short: Pause services
 long: |
   Pauses running containers of a service. They can be unpaused with `docker compose unpause`.
 usage: docker compose pause [SERVICE...]

--- a/_data/compose-cli/docker_compose_port.yaml
+++ b/_data/compose-cli/docker_compose_port.yaml
@@ -10,6 +10,7 @@ options:
   default_value: "1"
   description: index of the container if service has multiple replicas
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   default_value: tcp
   description: tcp or udp
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_ps.yaml
+++ b/_data/compose-cli/docker_compose_ps.yaml
@@ -2,12 +2,13 @@ command: docker compose ps
 short: List containers
 long: |-
   Lists containers for a Compose project, with current status and exposed ports.
+  By default, both running and stopped containers are shown:
 
   ```console
   $ docker compose ps
-  NAME                SERVICE             STATUS              PORTS
-  example_foo_1       foo                 running (healthy)   0.0.0.0:8000->80/tcp
-  example_bar_1       bar                 exited (1)
+  NAME           COMMAND                  SERVICE   STATUS       PORTS
+  example-bar-1  "/docker-entrypoint.…"   bar       exited (0)
+  example-foo-1  "/docker-entrypoint.…"   foo       running      0.0.0.0:8080->80/tcp
   ```
 usage: docker compose ps [SERVICE...]
 pname: docker compose
@@ -20,14 +21,17 @@ options:
   description: |
     Show all stopped containers (including those created by the run command)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: filter
   value_type: string
-  description: Filter services by a property
+  description: 'Filter services by a property (supported filters: status).'
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,7 +40,9 @@ options:
   value_type: string
   default_value: pretty
   description: 'Format the output. Values: [pretty | json]'
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -47,6 +53,7 @@ options:
   default_value: "false"
   description: Only display IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -56,18 +63,108 @@ options:
   default_value: "false"
   description: Display services
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: status
-  value_type: string
-  description: Filter services by status
+  value_type: stringArray
+  default_value: '[]'
+  description: |
+    Filter services by status. Values: [paused | restarting | removing | running | dead | created | exited]
+  details_url: '#status'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  ### Format the output (--format) {#format}
+
+  By default, the `docker compose ps` command uses a table ("pretty") format to
+  show the containers. The `--format` flag allows you to specify alternative
+  presentations for the output. Currently supported options are `pretty` (default),
+  and `json`, which outputs information about the containers as a JSON array:
+
+  ```console
+  $ docker compose ps --format json
+  [{"ID":"1553b0236cf4d2715845f053a4ee97042c4f9a2ef655731ee34f1f7940eaa41a","Name":"example-bar-1","Command":"/docker-entrypoint.sh nginx -g 'daemon off;'","Project":"example","Service":"bar","State":"exited","Health":"","ExitCode":0,"Publishers":null},{"ID":"f02a4efaabb67416e1ff127d51c4b5578634a0ad5743bd65225ff7d1909a3fa0","Name":"example-foo-1","Command":"/docker-entrypoint.sh nginx -g 'daemon off;'","Project":"example","Service":"foo","State":"running","Health":"","ExitCode":0,"Publishers":[{"URL":"0.0.0.0","TargetPort":80,"PublishedPort":8080,"Protocol":"tcp"}]}]
+  ```
+
+  The JSON output allows you to use the information in other tools for further
+  processing, for example, using the [`jq` utility](https://stedolan.github.io/jq/){:target="_blank" rel="noopener" class="_"}
+  to pretty-print the JSON:
+
+  ```console
+  $ docker compose ps --format json | jq .
+  [
+    {
+      "ID": "1553b0236cf4d2715845f053a4ee97042c4f9a2ef655731ee34f1f7940eaa41a",
+      "Name": "example-bar-1",
+      "Command": "/docker-entrypoint.sh nginx -g 'daemon off;'",
+      "Project": "example",
+      "Service": "bar",
+      "State": "exited",
+      "Health": "",
+      "ExitCode": 0,
+      "Publishers": null
+    },
+    {
+      "ID": "f02a4efaabb67416e1ff127d51c4b5578634a0ad5743bd65225ff7d1909a3fa0",
+      "Name": "example-foo-1",
+      "Command": "/docker-entrypoint.sh nginx -g 'daemon off;'",
+      "Project": "example",
+      "Service": "foo",
+      "State": "running",
+      "Health": "",
+      "ExitCode": 0,
+      "Publishers": [
+        {
+          "URL": "0.0.0.0",
+          "TargetPort": 80,
+          "PublishedPort": 8080,
+          "Protocol": "tcp"
+        }
+      ]
+    }
+  ]
+  ```
+
+  ### Filter containers by status (--status) {#status}
+
+  Use the `--status` flag to filter the list of containers by status. For example,
+  to show only containers that are running, or only containers that have exited:
+
+  ```console
+  $ docker compose ps --status=running
+  NAME           COMMAND                  SERVICE   STATUS       PORTS
+  example-foo-1  "/docker-entrypoint.…"   foo       running      0.0.0.0:8080->80/tcp
+
+  $ docker compose ps --status=exited
+  NAME           COMMAND                  SERVICE   STATUS       PORTS
+  example-bar-1  "/docker-entrypoint.…"   bar       exited (0)
+  ```
+
+  ### Filter containers by status (--filter) {#filter}
+
+  The [`--status` flag](#status) is a convenience shorthand for the `--filter status=<status>`
+  flag. The example below is the equivalent to the example from the previous section,
+  this time using the `--filter` flag:
+
+  ```console
+  $ docker compose ps --filter status=running
+  NAME           COMMAND                  SERVICE   STATUS       PORTS
+  example-foo-1  "/docker-entrypoint.…"   foo       running      0.0.0.0:8080->80/tcp
+
+  $ docker compose ps --filter status=running
+  NAME           COMMAND                  SERVICE   STATUS       PORTS
+  example-bar-1  "/docker-entrypoint.…"   bar       exited (0)
+  ```
+
+  The `docker compose ps` command currently only supports the `--filter status=<status>`
+  option, but additional filter options may be added in future.
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_pull.yaml
+++ b/_data/compose-cli/docker_compose_pull.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "false"
   description: Pull what it can and ignores images with pull failures
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   default_value: "false"
   description: Also pull services declared as dependencies
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,6 +32,7 @@ options:
   default_value: "true"
   description: DEPRECATED disable parallel pulling.
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +42,7 @@ options:
   default_value: "true"
   description: DEPRECATED pull multiple images in parallel.
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -49,10 +53,52 @@ options:
   default_value: "false"
   description: Pull without printing progress information
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
+examples: |-
+  suppose you have this `compose.yaml`:
+
+  ```yaml
+  services:
+    db:
+      image: postgres
+    web:
+      build: .
+      command: bundle exec rails s -p 3000 -b '0.0.0.0'
+      volumes:
+        - .:/myapp
+      ports:
+        - "3000:3000"
+      depends_on:
+        - db
+  ```
+
+  If you run `docker compose pull ServiceName` in the same directory as the `compose.yaml` file that defines the service,
+  Docker pulls the associated image. For example, to call the postgres image configured as the db service in our example,
+  you would run `docker compose pull db`.
+
+  ```console
+  $ docker compose pull db
+  [+] Running 1/15
+   ⠸ db Pulling                                                             12.4s
+     ⠿ 45b42c59be33 Already exists                                           0.0s
+     ⠹ 40adec129f1a Downloading  3.374MB/4.178MB                             9.3s
+     ⠹ b4c431d00c78 Download complete                                        9.3s
+     ⠹ 2696974e2815 Download complete                                        9.3s
+     ⠹ 564b77596399 Downloading  5.622MB/7.965MB                             9.3s
+     ⠹ 5044045cf6f2 Downloading  216.7kB/391.1kB                             9.3s
+     ⠹ d736e67e6ac3 Waiting                                                  9.3s
+     ⠹ 390c1c9a5ae4 Waiting                                                  9.3s
+     ⠹ c0e62f172284 Waiting                                                  9.3s
+     ⠹ ebcdc659c5bf Waiting                                                  9.3s
+     ⠹ 29be22cb3acc Waiting                                                  9.3s
+     ⠹ f63c47038e66 Waiting                                                  9.3s
+     ⠹ 77a0c198cde5 Waiting                                                  9.3s
+     ⠹ c8752d5b785c Waiting                                                  9.3s
+  ``̀`
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/compose-cli/docker_compose_push.yaml
+++ b/_data/compose-cli/docker_compose_push.yaml
@@ -28,6 +28,7 @@ options:
   default_value: "false"
   description: Push what it can and ignores images with push failures
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_restart.yaml
+++ b/_data/compose-cli/docker_compose_restart.yaml
@@ -1,6 +1,16 @@
 command: docker compose restart
 short: Restart containers
-long: Restart containers
+long: |-
+  Restarts all stopped and running services.
+
+  If you make changes to your `compose.yml` configuration, these changes are not reflected
+  after running this command. For example, changes to environment variables (which are added
+  after a container is built, but before the container's command is executed) are not updated
+  after restarting.
+
+  If you are looking to configure a service's restart policy, please refer to
+  [restart](https://github.com/compose-spec/compose-spec/blob/master/spec.md#restart)
+  or [restart_policy](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#restart_policy).
 usage: docker compose restart
 pname: docker compose
 plink: docker_compose.yaml
@@ -11,6 +21,7 @@ options:
   default_value: "10"
   description: Specify a shutdown timeout in seconds
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_rm.yaml
+++ b/_data/compose-cli/docker_compose_rm.yaml
@@ -26,6 +26,7 @@ options:
   default_value: "false"
   description: Deprecated - no effect
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,6 +37,7 @@ options:
   default_value: "false"
   description: Don't ask to confirm removal
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -46,6 +48,7 @@ options:
   default_value: "false"
   description: Stop the containers, if required, before removing
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -56,6 +59,7 @@ options:
   default_value: "false"
   description: Remove any anonymous volumes attached to containers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_run.yaml
+++ b/_data/compose-cli/docker_compose_run.yaml
@@ -65,6 +65,7 @@ options:
   default_value: "false"
   description: Run container in background and print container ID
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -73,6 +74,7 @@ options:
   value_type: string
   description: Override the entrypoint of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -83,16 +85,29 @@ options:
   default_value: '[]'
   description: Set environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
-- option: labels
+- option: interactive
+  shorthand: i
+  value_type: bool
+  default_value: "true"
+  description: Keep STDIN open even if not attached.
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: label
   shorthand: l
   value_type: stringArray
   default_value: '[]'
   description: Add or override a label
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -101,6 +116,7 @@ options:
   value_type: string
   description: Assign a name to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -108,10 +124,10 @@ options:
 - option: no-TTY
   shorthand: T
   value_type: bool
-  default_value: "false"
-  description: |
-    Disable pseudo-noTty allocation. By default docker compose run allocates a TTY
+  default_value: "true"
+  description: 'Disable pseudo-TTY allocation (default: auto-detected).'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -121,6 +137,7 @@ options:
   default_value: "false"
   description: Don't start linked services.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -131,6 +148,17 @@ options:
   default_value: '[]'
   description: Publish a container's port(s) to the host.
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet-pull
+  value_type: bool
+  default_value: "false"
+  description: Pull without printing progress information.
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -140,6 +168,7 @@ options:
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -150,6 +179,18 @@ options:
   description: |
     Run command with the service's ports enabled and mapped to the host.
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: tty
+  shorthand: t
+  value_type: bool
+  default_value: "true"
+  description: Allocate a pseudo-TTY.
+  deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -160,6 +201,7 @@ options:
   description: |
     Use the service's network useAliases in the network(s) the container connects to.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -169,6 +211,7 @@ options:
   value_type: string
   description: Run as specified username or uid
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -179,6 +222,7 @@ options:
   default_value: '[]'
   description: Bind mount a volume.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -188,6 +232,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_stop.yaml
+++ b/_data/compose-cli/docker_compose_stop.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "10"
   description: Specify a shutdown timeout in seconds
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_unpause.yaml
+++ b/_data/compose-cli/docker_compose_unpause.yaml
@@ -1,5 +1,5 @@
 command: docker compose unpause
-short: unpause services
+short: Unpause services
 long: Unpauses paused containers of a service.
 usage: docker compose unpause [SERVICE...]
 pname: docker compose

--- a/_data/compose-cli/docker_compose_up.yaml
+++ b/_data/compose-cli/docker_compose_up.yaml
@@ -5,7 +5,7 @@ long: |-
 
   Unless they are already running, this command also starts any linked services.
 
-  The `docker compose up` command aggregates the output of each container (liked `docker compose logs --follow` does).
+  The `docker compose up` command aggregates the output of each container (like `docker compose logs --follow` does).
   When the command exits, all containers are stopped. Running `docker compose up --detach` starts the containers in the
   background and leaves them running.
 
@@ -27,6 +27,7 @@ options:
   description: |
     Stops all containers if any container was stopped. Incompatible with -d
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,6 +37,7 @@ options:
   default_value: "false"
   description: Recreate dependent containers. Incompatible with --no-recreate.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,6 +47,7 @@ options:
   default_value: '[]'
   description: Attach to service output.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -54,6 +57,7 @@ options:
   default_value: "false"
   description: Attach to dependent containers.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -63,6 +67,7 @@ options:
   default_value: "false"
   description: Build images before starting containers.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -73,16 +78,7 @@ options:
   default_value: "false"
   description: 'Detached mode: Run containers in the background'
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: environment
-  shorthand: e
-  value_type: stringArray
-  default_value: '[]'
-  description: Environment variables
-  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -92,6 +88,7 @@ options:
   description: |
     Return the exit code of the selected service container. Implies --abort-on-container-exit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -102,6 +99,7 @@ options:
   description: |
     Recreate containers even if their configuration and image haven't changed.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -111,6 +109,7 @@ options:
   default_value: "false"
   description: Don't build an image, even if it's missing.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -120,6 +119,7 @@ options:
   default_value: "false"
   description: Produce monochrome output.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -129,6 +129,7 @@ options:
   default_value: "false"
   description: Don't start linked services.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -138,6 +139,7 @@ options:
   default_value: "false"
   description: Don't print prefix in logs.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -148,6 +150,7 @@ options:
   description: |
     If containers already exist, don't recreate them. Incompatible with --force-recreate.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -157,6 +160,7 @@ options:
   default_value: "false"
   description: Don't start the services after creating them.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -166,6 +170,7 @@ options:
   default_value: "false"
   description: Pull without printing progress information.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -175,6 +180,7 @@ options:
   default_value: "false"
   description: Remove containers for services not defined in the Compose file.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -186,6 +192,7 @@ options:
   description: |
     Recreate anonymous volumes instead of retrieving data from the previous containers.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -196,6 +203,7 @@ options:
   description: |
     Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -207,6 +215,17 @@ options:
   description: |
     Use this timeout in seconds for container shutdown when attached or when containers are already running.
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: wait
+  value_type: bool
+  default_value: "false"
+  description: Wait for services to be running|healthy. Implies detached mode.
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/compose-cli/docker_compose_version.yaml
+++ b/_data/compose-cli/docker_compose_version.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: 'Format the output. Values: [pretty | json]. (Default: pretty)'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   default_value: "false"
   description: Shows only Compose's version number.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false


### PR DESCRIPTION
### Proposed changes

Update Compose version and reference CLI documentation to match `v2.5.0` release of Docker Compose

