### PR TITLE
Include extensions-sdk docs from upstream repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ARG DISTRIBUTION_BRANCH="release/2.7"
 # Compose CLI
 ARG COMPOSE_CLI_BRANCH="main"
 
+# extensions SDK
+ARG EXTENSIONS_SDK_BRANCH="main"
+
 ###
 # Set up base stages for building and deploying
 ###
@@ -40,6 +43,9 @@ ENV DISTRIBUTION_BRANCH=${DISTRIBUTION_BRANCH}
 ARG COMPOSE_CLI_BRANCH
 ENV COMPOSE_CLI_BRANCH=${COMPOSE_CLI_BRANCH}
 
+ARG EXTENSIONS_SDK_BRANCH
+ENV EXTENSIONS_SDK_BRANCH=${EXTENSIONS_SDK_BRANCH}
+
 # Fetch upstream resources (reference documentation)
 # Only add the files that are needed to build these reference docs, so that these
 # docs are only rebuilt if changes were made to ENGINE_BRANCH or DISTRIBUTION_BRANCH.
@@ -51,6 +57,7 @@ COPY ./_scripts/fetch-upstream-resources.sh ./_scripts/
 ARG ENGINE_BRANCH
 ARG DISTRIBUTION_BRANCH
 ARG COMPOSE_CLI_BRANCH
+ARG EXTENSIONS_SDK_BRANCH
 RUN ./_scripts/fetch-upstream-resources.sh .
 
 
@@ -65,14 +72,14 @@ RUN ./_scripts/update-api-toc.sh
 ARG JEKYLL_ENV
 RUN echo "Building docs for ${JEKYLL_ENV} environment"
 RUN set -eu; \
- if [ "${JEKYLL_ENV}" = "production" ]; then \
-    jekyll build --profile -d ${TARGET} --config _config.yml,_config_production.yml; \
-    sed -i 's#<loc>/#<loc>https://docs.docker.com/#' "${TARGET}/sitemap.xml"; \
- else \
-    jekyll build --profile -d ${TARGET}; \
-    echo '[]' > ${TARGET}/js/metadata.json; \
- fi; \
- find ${TARGET} -type f -name '*.html' | while read i; do sed -i 's#\(<a[^>]* href="\)https://docs.docker.com/#\1/#g' "$i"; done;
+   if [ "${JEKYLL_ENV}" = "production" ]; then \
+   jekyll build --profile -d ${TARGET} --config _config.yml,_config_production.yml; \
+   sed -i 's#<loc>/#<loc>https://docs.docker.com/#' "${TARGET}/sitemap.xml"; \
+   else \
+   jekyll build --profile -d ${TARGET}; \
+   echo '[]' > ${TARGET}/js/metadata.json; \
+   fi; \
+   find ${TARGET} -type f -name '*.html' | while read i; do sed -i 's#\(<a[^>]* href="\)https://docs.docker.com/#\1/#g' "$i"; done;
 
 
 # This stage only contains the generated files. It can be used to host the

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1034,7 +1034,7 @@ reference:
     path: /docker-hub/api/latest/
   - title: Registry API
     path: /registry/spec/api/
-  - sectiontitle: Docker Extension SDK API
+  - sectiontitle: Docker Extension SDK API (Beta)
     section:
       - path:
         title:
@@ -1239,8 +1239,8 @@ manuals:
     - path: /desktop/dev-environments/
       title: Dev Environments (Preview)
     - path: /desktop/extensions/
-      title: Extensions (Preview)
-    - sectiontitle: Extensions SDK (Preview)
+      title: Extensions (Beta)
+    - sectiontitle: Extensions SDK (Beta)
       section:
         - path: /desktop/extensions-sdk/
           title: Introduction

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1034,6 +1034,56 @@ reference:
     path: /docker-hub/api/latest/
   - title: Registry API
     path: /registry/spec/api/
+  - sectiontitle: Docker Extension SDK API
+    section:
+      - path:
+        title:
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/DesktopUI/
+        title: DesktopUI
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/Dialog/
+        title: Dialog
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/Docker/
+        title: Docker
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/DockerCommand/
+        title: DockerCommand
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/DockerDesktopClient/
+        title: DockerDesktopClient
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/Exec/
+        title: Exec
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/ExecProcess/
+        title: ExecProcess
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/ExecResult/
+        title: ExecResult
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/ExecStreamOptions/
+        title: ExecStreamOptions
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/Extension/
+        title: Extension
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/ExtensionCli/
+        title: ExtensionCli
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/ExtensionHost/
+        title: ExtensionHost
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/ExtensionVM/
+        title: ExtensionVM
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/Host/
+        title: Host
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/HttpService/
+        title: HttpService
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/NavigationIntents/
+        title: NavigationIntents
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/OpenDialogResult/
+        title: OpenDialogResult
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/RawExecResult/
+        title: RawExecResult
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/RequestConfig/
+        title: RequestConfig
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/RequestConfigV0/
+        title: RequestConfigV0
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/Toast/
+        title: Toast
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/ExecResultV0/
+        title: ExecResultV0
+      - path: /desktop/extensions-sdk/dev/api/reference/interfaces/BackendV0/
+        title: BackendV0  
 - title: Dockerfile reference
   path: /engine/reference/builder/
 - sectiontitle: Compose file reference
@@ -1190,6 +1240,58 @@ manuals:
       title: Dev Environments (Preview)
     - path: /desktop/extensions/
       title: Extensions (Preview)
+    - sectiontitle: Extensions SDK (Preview)
+      section:
+        - path: /desktop/extensions-sdk/
+          title: Introduction
+        - sectiontitle: Tutorials
+          section:
+            - title: Create your first extension
+              path: /desktop/extensions-sdk/tutorials/initialize/
+            - title: Create a minimal frontend extension
+              path: /desktop/extensions-sdk/tutorials/minimal-frontend-extension/
+            - title: Create a ReactJS-based extension
+              path: /desktop/extensions-sdk/tutorials/react-extension/
+            - title: Create a minimal extension invoking docker commands
+              path: /desktop/extensions-sdk/tutorials/minimal-frontend-using-docker-cli/
+            - title: Create a minimal backend extension
+              path: /desktop/extensions-sdk/tutorials/minimal-backend-extension/
+        - title: Design Guidelines
+          path: /desktop/extensions-sdk/design/design-overview/
+        - sectiontitle: Extensions
+          section:
+            - title: Metadata
+              path: /desktop/extensions-sdk/extensions/METADATA/
+            - title: Labels
+              path: /desktop/extensions-sdk/extensions/labels/
+            - title: Validation
+              path: /desktop/extensions-sdk/extensions/validation/
+            - title: Distribution
+              path: /desktop/extensions-sdk/extensions/DISTRIBUTION/
+            - title: Building multi-arch extensions
+              path: /desktop/extensions-sdk/extensions/multi-arch/
+        - sectiontitle: Developer guide
+          section:
+            - title: Overview
+              path: /desktop/extensions-sdk/dev/overview/
+            - title: CLI overview
+              path: /desktop/extensions-sdk/dev/cli/usage/
+            - title: Build, test and install an extension
+              path: /desktop/extensions-sdk/dev/cli/build-test-install-extension/
+        - sectiontitle: UI API
+          section:
+            - title: Overview
+              path: /desktop/extensions-sdk/dev/api/overview/
+            - title: Extension Backend
+              path: /desktop/extensions-sdk/dev/api/backend/
+            - title: Docker
+              path: /desktop/extensions-sdk/dev/api/docker/
+            - title: Dashboard
+              path: /desktop/extensions-sdk/dev/api/dashboard/
+            - title: Navigation
+              path: /desktop/extensions-sdk/dev/api/dashboard-routes-navigation/
+            - title: API Reference
+              path: /desktop/extensions-sdk/dev/api/reference/README/
     - path: /desktop/multi-arch/
       title: Multi-arch support
     - path: /desktop/kubernetes/

--- a/_scripts/fetch-upstream-resources.sh
+++ b/_scripts/fetch-upstream-resources.sh
@@ -7,6 +7,7 @@
 : "${ENGINE_BRANCH?No release branch set for docker/docker and docker/cli}"
 : "${DISTRIBUTION_BRANCH?No release branch set for distribution/distribution}"
 : "${COMPOSE_CLI_BRANCH?No release branch set for docker/compose-cli}"
+: "${EXTENSIONS_SDK_BRANCH?No release branch set for docker/extensions-sdk}"
 
 # Translate branches for use by svn
 engine_svn_branch="branches/${ENGINE_BRANCH}"
@@ -21,11 +22,16 @@ compose_cli_svn_branch="branches/${COMPOSE_CLI_BRANCH}"
 if [ "${compose_cli_svn_branch}" = "branches/main" ]; then
 	compose_cli_svn_branch=trunk
 fi
+extensions_sdk_svn_branch="branches/${EXTENSIONS_SDK_BRANCH}"
+if [ "${extensions_sdk_svn_branch}" = "branches/main" ]; then
+	extensions_sdk_svn_branch=trunk
+fi
 
 # Directories to get via SVN. We use this because you can't use git to clone just a portion of a repository
 svn co "https://github.com/docker/cli/${engine_svn_branch}/docs/extend"                    ./engine/extend || (echo "Failed engine/extend download" && exit 1)
 svn co "https://github.com/docker/docker/${engine_svn_branch}/docs/api"                    ./engine/api    || (echo "Failed engine/api download" && exit 1)
 svn co "https://github.com/docker/compose-cli/${compose_cli_svn_branch}/docs"              ./cloud         || (echo "Failed compose-cli/docs download" && exit 1)
+svn co "https://github.com/docker/extensions-sdk/${extensions_sdk_svn_branch}/docs"              		   ./desktop/extensions-sdk         || (echo "Failed extensions-sdk/docs download" && exit 1)
 svn co "https://github.com/distribution/distribution/${distribution_svn_branch}/docs/spec" ./registry/spec || (echo "Failed registry/spec download" && exit 1)
 
 # Fix up URls in swagger files


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

Add first version of extensions SDK docs from upstream repo
* Add TOC sections under /manual/desktop, next to "extensions"
* Add TOC sections under /reference (note there are links between pages from the "manual" docs to the "reference" docs 

This can be tested locally with `docker compose up -d --build`

<img width="1318" alt="Screenshot 2022-05-04 at 10 11 13" src="https://user-images.githubusercontent.com/437958/166644381-2fa870de-863d-4a86-a27d-c6baa27a2988.png">

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
