### PR TITLE
Fixed 404 for Edit this page link on some upstream repo topics

### DIFF
--- a/_config_production.yml
+++ b/_config_production.yml
@@ -80,6 +80,10 @@ defaults:
     values:
       edit_url: "https://github.com/docker/cli/tree/master/docs/extend"
   - scope:
+      path: engine/extend
+    values:
+      edit_url: "https://github.com/docker/cli/tree/master/docs/extend"
+  - scope:
       path: engine/reference
     values:
       edit_url: "https://github.com/docker/cli/tree/master/docs/reference"


### PR DESCRIPTION
### Proposed changes

Fixed "Edit this page" link for topics under https://docs.docker.com/engine/extend/

### Related issues (optional)

ENGDOCS-673
