### PR TITLE
DD4L: Remove package when upgrading on Fedora

### DIFF
--- a/desktop/linux/install/fedora.md
+++ b/desktop/linux/install/fedora.md
@@ -53,7 +53,7 @@ The post-install script:
 ## Upgrade Docker Desktop
 
 Once a new version for Docker Desktop is released, the Docker UI shows a notification. 
-You need to download the new package each time you want to upgrade Docker Desktop and run
+You need to first remove the previous version and then download the new package each time you want to upgrade Docker Desktop. Run:
 
 ```console
 $ sudo dnf remove docker-desktop

--- a/desktop/linux/install/fedora.md
+++ b/desktop/linux/install/fedora.md
@@ -56,6 +56,7 @@ Once a new version for Docker Desktop is released, the Docker UI shows a notific
 You need to download the new package each time you want to upgrade Docker Desktop and run
 
 ```console
+$ sudo dnf remove docker-desktop
 $ sudo dnf install ./docker-desktop-<version>-<arch>.rpm
 ```
 


### PR DESCRIPTION
### Proposed changes

The ordering of RPM scriptlets is a bit odd, which will cause upgrades
with our current package not to work correctly. So advise users to
remove docker-desktop explicitly rather than installing a new version
over it.
