### PR TITLE
DDL: add `gnome-terminal` as prerequisite

### DIFF
--- a/desktop/linux/install/archlinux.md
+++ b/desktop/linux/install/archlinux.md
@@ -11,6 +11,13 @@ This topic discusses installation of Docker Desktop from an [Arch package](https
 
 Your Arch-based Linux distribution must meet the [system requirements](../install.md#system-requirements) to install and launch Docker Desktop successfully.
 
+Additionally, for non-Gnome Desktop environments, `gnome-terminal` must be installed:
+
+```console
+$ sudo pacman -S gnome-terminal
+```
+
+
 ## Install Docker Desktop 
 
 1. Install client binaries.

--- a/desktop/linux/install/debian.md
+++ b/desktop/linux/install/debian.md
@@ -16,6 +16,12 @@ Your Debian distribution must meet the [system requirements](../install.md#syste
 
 Additionally, for a Gnome Desktop environment you must install AppIndicator and KStatusNotifierItem [Gnome extensions](https://extensions.gnome.org/extension/615/appindicator-support/).
 
+For non-Gnome Desktop environments, `gnome-terminal` must be installed:
+
+```console
+$ sudo apt install gnome-terminal
+```
+
 ### OS requirements
 
 To install Docker Desktop, you need the 64-bit version of one of these Debian

--- a/desktop/linux/install/fedora.md
+++ b/desktop/linux/install/fedora.md
@@ -15,6 +15,11 @@ Your Fedora distribution must meet the [system requirements](../install.md#syste
 
 Additionally, for a Gnome Desktop environment you must install AppIndicator and KStatusNotifierItem [Gnome extensions](https://extensions.gnome.org/extension/615/appindicator-support/).
 
+For non-Gnome Desktop environments, `gnome-terminal` must be installed:
+
+```console
+$ sudo dnf install gnome-terminal
+```
 
 ### OS requirements
 

--- a/desktop/linux/install/ubuntu.md
+++ b/desktop/linux/install/ubuntu.md
@@ -14,6 +14,12 @@ To get started with Docker Desktop on Ubuntu, make sure you
 
 Your Ubuntu distribution must meet the [system requirements](../install.md#system-requirements) to install and launch Docker Desktop successfully.
 
+Additionally, for non-Gnome Desktop environments, `gnome-terminal` must be installed:
+
+```console
+$ sudo apt install gnome-terminal
+```
+
 ### OS requirements
 
 To install Docker Desktop, you need the 64-bit version of one of these Ubuntu


### PR DESCRIPTION
The CLI button in the container menu from the Docker Dashboard is running a `gnome-terminal` cmd. If this is not installed, the Docker UI crashes.

### Proposed changes
For now, document the installation of gnome-terminal as a prerequisite. We'll remove it once we add it as a package dependency or update the UI to look for the default terminal of the host distro.
