### PR TITLE
engine: add known issues to 20.10.15 release notes

### DIFF
--- a/engine/release-notes/index.md
+++ b/engine/release-notes/index.md
@@ -27,7 +27,16 @@ for Docker Engine.
 2022-05-05
 
 This release of Docker Engine comes with updated versions of the `compose`,
-`buildx`, `containerd`, and `runc` components, as well as some minor bugfixes.
+`buildx`, `containerd`, and `runc` components, as well as some minor bug fixes.
+
+> **Known issues**
+> 
+> We've identified an issue with the [macOS CLI binaries](https://download.docker.com/mac/static/stable/){:target="_blank" rel="noopener" class="_"}
+> in the 20.10.15 release. A [fix for this issue](https://github.com/docker/cli/pull/3592){:target="_blank" rel="noopener" class="_"}
+> has been merged and will be included in the next patch release (20.10.16). In
+> the meantime, we recommend using the 20.10.14 binaries for macOS instead. Other
+> platforms are not affected.
+{:.important}
 
 ### Daemon
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/issues/3595
- relates to https://github.com/docker/cli/pull/3592

With this PR:

<img width="999" alt="Screenshot 2022-05-10 at 11 15 55" src="https://user-images.githubusercontent.com/1804568/167594494-087af734-29a3-4c41-b82e-53d4ab947661.png">
