### PR TITLE
engine: fix typo in release notes for 20.10.15

### DIFF
--- a/engine/release-notes/index.md
+++ b/engine/release-notes/index.md
@@ -40,7 +40,7 @@ This release of Docker Engine comes with updated versions of the `compose`,
 - Update Docker Compose to [v2.5.0](https://github.com/docker/compose/releases/tag/v2.5.0).
 - Update Docker Buildx to [v0.8.2](https://github.com/docker/buildx/releases/tag/v0.8.2).
 - Update Go runtime to [1.17.9](https://go.dev/doc/devel/release#go1.17.minor).
-- Update containerd (`containerd.io` package) to [v1.6.4](https://github.com/containerd/containerd/releases/tag/v1.6.3).
+- Update containerd (`containerd.io` package) to [v1.6.4](https://github.com/containerd/containerd/releases/tag/v1.6.4).
 - Update runc version to [v1.1.1](https://github.com/opencontainers/runc/releases/tag/v1.1.1).
 - Add packages for CentOS 9 stream and Fedora 36.
 


### PR DESCRIPTION
Fix a typo introduced in #14671

#### double check
```
$ docker run docker:20.10.15 containerd --version
containerd github.com/containerd/containerd v1.6.4 212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
```

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>