### PR TITLE
Fix for issue #14686 and #12662

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -49,7 +49,7 @@ So, let's do it!
         sh -c "yarn install && yarn run dev"
     ```
 
-    If you are using PowerShell then use this command:
+    If you are using Windows then use this command in PowerShell:
 
     ```powershell
     PS> docker run -dp 3000:3000 `

--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -66,7 +66,7 @@ For now, we will create the network first and attach the MySQL container at star
         mysql:5.7
     ```
 
-    If you are using PowerShell then use this command.
+    If you are using Windows then use this command in PowerShell.
 
     ```powershell
     PS> docker run -d `
@@ -214,7 +214,7 @@ With all of that explained, let's start our dev-ready container!
       sh -c "yarn install && yarn run dev"
     ```
 
-    If you are using PowerShell then use this command.
+    If you are using Windows then use this command in PowerShell.
 
     ```powershell
     PS> docker run -dp 3000:3000 `


### PR DESCRIPTION
### Proposed changes

Some users on Windows were running the commands in Command Prompt, since the first command did not specify which shell or operating system (other than the prompt symbol).
Modified wording of second command to make it clearer that if using Windows, then users should use PowerShell.

### Related issues (optional)

Fix for #14686 and #12662
