### PR TITLE
Updates to the Compose Release Notes

### DIFF
--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -7,6 +7,90 @@ redirect_from:
   - /release-notes/docker-compose/
 ---
 
+# 2.5.0
+(2022-04-29)
+
+### Bug Fixes
+- Fixing panic with `compose down` command when -p flag specified. Closes [#9353](https://github.com/docker/compose/issues/9353){:target="_blank" rel="noopener" class="_"}.
+- Pass newly created project as input to start services (`docker compose up`). Closes [#9356](https://github.com/docker/compose/issues/9356){:target="_blank" rel="noopener" class="_"}.
+- Including services declared under links in docker-compose file as implicit dependencies. Closes [#9301](https://github.com/docker/compose/issues/9301){:target="_blank" rel="noopener" class="_"}.
+- Changes to `docker-compose pull` command to respect defined policy: 1)skip services configured as `pull_policy: never` and 2)ignore those with an existing image and `pull_policy: missing`. Closes [#3660](https://github.com/docker/compose/issues/3660){:target="_blank" rel="noopener" class="_"}.
+- Error building project from resources is no longer ignored in order to prevent `down`panic. Closes [#9383](https://github.com/docker/compose/issues/9383){:target="_blank" rel="noopener" class="_"}.
+- Enforcing project name to be lowercase. Closes [#9378](https://github.com/docker/compose/issues/9378){:target="_blank" rel="noopener" class="_"}.
+- Adding support to build-time secrets. Closes [#6358](https://github.com/docker/compose/issues/6358){:target="_blank" rel="noopener" class="_"}.
+- Changing `compose-go` to allow (re)building volume string to be used by engine bind API when mount can't be used. Closes [#9380](https://github.com/docker/compose/issues/9380){:target="_blank" rel="noopener" class="_"}.
+- Providing checksums.txt file and adding --binary to allow verification in different OS. Closes [#9388](https://github.com/docker/compose/issues/9388){:target="_blank" rel="noopener" class="_"}.
+- Changes added so locally pulled image's ID is inspected and persisted to `com.docker.compose.image`. Closes [#9357](https://github.com/docker/compose/issues/9357){:target="_blank" rel="noopener" class="_"}.
+- Fixing issue regarding IPAM gateway setup. Closes [#9330](https://github.com/docker/compose/issues/9330){:target="_blank" rel="noopener" class="_"}.
+
+### Changes
+- Adding support for ppc64le archictecture for docker compose binary.
+- Fixing search/replace typo in --no-TTY documentation.
+
+For the full change log or additional information, check the [Compose repository 2.5.0 release page](https://github.com/docker/compose/releases/tag/v2.5.0){:target="_blank" rel="noopener" class="_"}.
+
+## 2.4.1
+(2022-04-04)
+
+### Bug Fixes
+- Passing the `--rm flag` value as is to the Docker CLI when running a container with this flag. Closes [#9314](https://github.com/docker/compose/issues/9314){:target="_blank" rel="noopener" class="_"}.
+- Adding ssh config to the build options when building an image from a `docker compose up` command. Closes [#9338](https://github.com/docker/compose/issues/9338){:target="_blank" rel="noopener" class="_"}.
+- Inspecting container to check if a TTY is required. Running services with `tty:true` specified now show console output. Closes [#9288](https://github.com/docker/compose/issues/9288){:target="_blank" rel="noopener" class="_".
+
+For the full change log or additional information, check the [Compose repository 2.4.1 release page](https://github.com/docker/compose/releases/tag/v2.4.1){:target="_blank" rel="noopener" class="_"}.  
+
+
+## 2.4.0 
+(2022-04-1)
+
+### Bug Fixes
+- Passing the interactive flag from the Compose CLI to the Docker one to run exec command. Closes [#9315](https://github.com/docker/compose/issues/9315){:target="_blank" rel="noopener" class="_"}.
+
+- Compose commands now take value of `COMPOSE_PROJECT_NAME` environmental variable into consideration. Closes [#9316](https://github.com/docker/compose/issues/9316){:target="_blank" rel="noopener" class="_"}.
+- Fixed issue of `compose down` command that when executed in contexts without any services started/resources to deleted war returning an error. Error was due to command trying to delete inexistent network. Closes [#9333](https://github.com/docker/compose/issues/9333){:target="_blank" rel="noopener" class="_"}.
+
+
+### Changes
+- Introducing support for `cache_from`, `cache_to`, `no_cache` and `pull` attributes in the build section. These attributes allow forcing a complete rebuild from sources and checking with registry for images used. These changes provide the basis for offering `--no-cache` and `--pull` options for compose build (or equivalent) command down the line.
+- Introducing support of an `--ssh `flag for the `build` command from CLI and Compose file. Closes [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
+- Fixed typo in ssh flag description. Related to [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
+- Pinning Kubernetes dependencies to the same version as in Buildx.
+- Dependencies update: Bumping Buildx to v0.8.1. to fix possible panic on handling build context scanning errors.
+- Pass the interactive flag from the Compose CLI to the Docker one to run exec command.
+- Fixed race condition on start-stop end-to-end tests running in parrallel.
+- Removing code regarding an obsolete warning.
+- Vendor: github.com/containerd/containerd v1.6.2. Includes a fix for CVE-2022-24769 (doesn't affect our codebase).
+
+For the full change log or additional information, check the [Compose repository 2.4.0 release page](https://github.com/docker/compose/releases/tag/v2.4.0){:target="_blank" rel="noopener" class="_"}.  
+
+
+## 2.3.4 
+(2022-03-25)
+
+### Bug Fixes
+
+- Removing a container with no candidate now produces a warning instead of an error. Closes [#9255](https://github.com/docker/compose/issues/9255){:target="_blank" rel="noopener" class="_"}.
+- Recovering behavior for 'compose up -d' of recreating containers of compose file images with refreshed content. Closes [#9259](https://github.com/docker/compose/issues/9259){:target="_blank" rel="noopener" class="_"}.
+- Removing the "Deprecated" mentions from -i and -t options to run and exec commands. These options are on by default and in use. Closes [#9229](https://github.com/docker/compose/pull/9229#discussion_r819730788){:target="_blank" rel="noopener" class="_"}. 
+
+### Changes
+
+- Removing the "Deprecated" mention from the --filter flag, to keep consistency with other commands. 
+- Docker compose --status, --filter and --format flags documentation updates.
+- Dependencies update: Bumping github.com/spf13/cobra from 1.3.0 to 1.4.0. Cobra library no longer requires Viper and all of its indirect dependencies [See cobra's release page](https://github.com/spf13/cobra/releases){:target="_blank" rel="noopener" class="_"}.
+- Dependencies update: Bumping Buildx from v0.7.1 to v0.8.0.
+- Removing the need to get the original compose.yaml file to run 'docker compose kill'.
+- `docker-compose down -v` now does not remove external volumes and networks as per the option's expected and documented behavior. Whenever project is specified it is also now used to enforce down to only remove resources listed in compose.yaml file.
+Closes [#9172](https://github.com/docker/compose/issues/9172){:target="_blank" rel="noopener" class="_"}, [#9145](https://github.com/docker/compose/issues/9145){:target="_blank" rel="noopener" class="_"}.
+- Using RunExec and RunStart from docker/cli to handle all the interactive/tty/* terminal logic.
+- Changing Compose API reference docs automation to pick up diffs code vs. docs.
+
+For the full change log or additional information, check the [Compose repository 2.3.4 release page](https://github.com/docker/compose/releases/tag/v2.3.4){:target="_blank" rel="noopener" class="_"}.  
+
+## Other Releases 
+(2022-03-8 to 2022-04-14)
+For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Compose repository release pages](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"}.  
+
 ## 1.29.2
 (2021-05-10)
 

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -7,15 +7,17 @@ redirect_from:
   - /release-notes/docker-compose/
 ---
 
-# 2.5.0
+## 2.5.0
+
 (2022-04-29)
 
 ### Bug Fixes
-- Fixed panic with `compose down` command when -p flag specified. Fixes [#9353](https://github.com/docker/compose/issues/9353){:target="_blank" rel="noopener" class="_"}.
+
+- Fixed panic with `compose down` command when `-p` flag specified. Fixes [#9353](https://github.com/docker/compose/issues/9353){:target="_blank" rel="noopener" class="_"}.
 - Passed newly created project as input to start services (`docker compose up`). Fixes [#9356](https://github.com/docker/compose/issues/9356){:target="_blank" rel="noopener" class="_"}.
 - Included services declared under links in docker-compose file as implicit dependencies. Fixes [#9301](https://github.com/docker/compose/issues/9301){:target="_blank" rel="noopener" class="_"}.
 - Added changes `docker-compose pull` command to respect defined policy: 1) skip services configured as `pull_policy: never` and 2) ignore those with an existing image and `pull_policy: missing`. Fixes [#3660](https://github.com/docker/compose/issues/3660){:target="_blank" rel="noopener" class="_"}.
-- Error building project from resources is no longer ignored in order to prevent `down`panic. Fixes [#9383](https://github.com/docker/compose/issues/9383){:target="_blank" rel="noopener" class="_"}.
+- Error building project from resources is no longer ignored in order to prevent `down` panic. Fixes [#9383](https://github.com/docker/compose/issues/9383){:target="_blank" rel="noopener" class="_"}.
 - Enforced project name to be lowercase. Fixes [#9378](https://github.com/docker/compose/issues/9378){:target="_blank" rel="noopener" class="_"}.
 - Added support to build-time secrets. Fixes [#6358](https://github.com/docker/compose/issues/6358){:target="_blank" rel="noopener" class="_"}.
 - Changed `compose-go` to allow (re)building volume string to be used by engine `bind` API when mount can't be used. Fixes [#9380](https://github.com/docker/compose/issues/9380){:target="_blank" rel="noopener" class="_"}.
@@ -24,15 +26,18 @@ redirect_from:
 - Fixed issue regarding IPAM gateway setup. Fixes [#9330](https://github.com/docker/compose/issues/9330){:target="_blank" rel="noopener" class="_"}.
 
 ### Changes
+
 - Added support for ppc64le archictecture for docker compose binary.
 - Fixed search/replace typo in `--no-TTY` documentation.
 
 For the full change log or additional information, check the [Compose repository 2.5.0 release page](https://github.com/docker/compose/releases/tag/v2.5.0){:target="_blank" rel="noopener" class="_"}.
 
 ## 2.4.1
+
 (2022-04-04)
 
 ### Bug Fixes
+
 - Passed the `--rm flag` value as is to the Docker CLI when running a container with this flag. Fixes [#9314](https://github.com/docker/compose/issues/9314){:target="_blank" rel="noopener" class="_"}.
 - Added ssh config to the build options when building an image from a `docker compose up` command. Fixes [#9338](https://github.com/docker/compose/issues/9338){:target="_blank" rel="noopener" class="_"}.
 - Added inspection to container checking if a TTY is required. Running services with `tty:true` specified now show console output. Fixes [#9288](https://github.com/docker/compose/issues/9288){:target="_blank" rel="noopener" class="_"}.
@@ -41,21 +46,23 @@ For the full change log or additional information, check the [Compose repository
 
 
 ## 2.4.0 
+
 (2022-04-1)
 
 ### Bug Fixes
-- Passed the interactive flag from the Compose CLI to the Docker one to run exec command. Fixes [#9315](https://github.com/docker/compose/issues/9315){:target="_blank" rel="noopener" class="_"}.
 
+- Passed the interactive flag '-i' from the Compose CLI to the Docker one to run exec command. Fixes [#9315](https://github.com/docker/compose/issues/9315){:target="_blank" rel="noopener" class="_"}.
 - Compose commands now take the value of `COMPOSE_PROJECT_NAME` environmental variable into consideration. Fixes [#9316](https://github.com/docker/compose/issues/9316){:target="_blank" rel="noopener" class="_"}.
 - Fixed issue of `compose down` command that when executed in contexts without any services started or resources to be deleted was returning an error. Error was due to command trying to delete an inexistent default network. Fixes [#9333](https://github.com/docker/compose/issues/9333){:target="_blank" rel="noopener" class="_"}.
 
 
 ### Changes
+
 - Introduced support for `cache_from`, `cache_to`, `no_cache` and `pull` attributes in the build section. These attributes allow forcing a complete rebuild from sources and checking with registry for images used. These changes provide the basis for offering `--no-cache` and `--pull` options for compose build (or equivalent) command down the line.
-- Introduced support of an `--ssh `flag for the `build` command from CLI and Compose file. Fixes [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
-- Fixed typo in ssh flag description. Related to [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
-- Pinned Kubernetes dependencies to the same version as in Buildx.
-- Dependencies update: Bumped Buildx to v0.8.1. to fix possible panic on handling build context scanning errors.
+- Introduced support of an `--ssh ` flag for the `build` command from CLI and Compose file. Fixes [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
+- Fixed typo in `--ssh` flag description. Related to [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
+- Pinned Kubernetes dependencies to the same version as in buildx.
+- Dependencies update: Bumped buildx to v0.8.1. to fix possible panic on handling build context scanning errors.
 - Passed the interactive flag from the Compose CLI to the Docker one to run exec command.
 - Fixed race condition on start-stop end-to-end tests running in parrallel.
 - Removed code regarding an obsolete warning.
@@ -65,6 +72,7 @@ For the full change log or additional information, check the [Compose repository
 
 
 ## 2.3.4 
+
 (2022-03-25)
 
 ### Bug Fixes
@@ -78,7 +86,7 @@ For the full change log or additional information, check the [Compose repository
 - Removed the "Deprecated" mention from the --filter flag, to keep consistency with other commands. 
 - Docker compose --status, --filter and --format flags documentation updates.
 - Dependencies update: Bumped github.com/spf13/cobra from 1.3.0 to 1.4.0. Cobra library no longer requires Viper and all of its indirect dependencies [See cobra's release page](https://github.com/spf13/cobra/releases){:target="_blank" rel="noopener" class="_"}.
-- Dependencies update: Bumped Buildx from v0.7.1 to v0.8.0.
+- Dependencies update: Bumped buildx from v0.7.1 to v0.8.0.
 - Removed the need to get the original compose.yaml file to run 'docker compose kill'.
 - `docker-compose down -v` now does not remove external volumes and networks as per the option's expected and documented behavior. Whenever project is specified it is also now used to enforce down to only remove resources listed in compose.yaml file.
 Fixes [#9172](https://github.com/docker/compose/issues/9172){:target="_blank" rel="noopener" class="_"}, [#9145](https://github.com/docker/compose/issues/9145){:target="_blank" rel="noopener" class="_"}.
@@ -88,7 +96,9 @@ Fixes [#9172](https://github.com/docker/compose/issues/9172){:target="_blank" re
 For the full change log or additional information, check the [Compose repository 2.3.4 release page](https://github.com/docker/compose/releases/tag/v2.3.4){:target="_blank" rel="noopener" class="_"}.  
 
 ## Other Releases 
+
 (2022-03-8 to 2022-04-14)
+
 For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Compose repository release pages](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"}.  
 
 ## 1.29.2
@@ -135,6 +145,7 @@ For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Com
 - Bumped python-dotenv to 0.17.0.
 
 ## 1.28.6
+
 (2021-03-23)
 
 ### Bug fixes

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -11,21 +11,21 @@ redirect_from:
 (2022-04-29)
 
 ### Bug Fixes
-- Fixing panic with `compose down` command when -p flag specified. Closes [#9353](https://github.com/docker/compose/issues/9353){:target="_blank" rel="noopener" class="_"}.
-- Pass newly created project as input to start services (`docker compose up`). Closes [#9356](https://github.com/docker/compose/issues/9356){:target="_blank" rel="noopener" class="_"}.
-- Including services declared under links in docker-compose file as implicit dependencies. Closes [#9301](https://github.com/docker/compose/issues/9301){:target="_blank" rel="noopener" class="_"}.
-- Changes to `docker-compose pull` command to respect defined policy: 1)skip services configured as `pull_policy: never` and 2)ignore those with an existing image and `pull_policy: missing`. Closes [#3660](https://github.com/docker/compose/issues/3660){:target="_blank" rel="noopener" class="_"}.
-- Error building project from resources is no longer ignored in order to prevent `down`panic. Closes [#9383](https://github.com/docker/compose/issues/9383){:target="_blank" rel="noopener" class="_"}.
-- Enforcing project name to be lowercase. Closes [#9378](https://github.com/docker/compose/issues/9378){:target="_blank" rel="noopener" class="_"}.
-- Adding support to build-time secrets. Closes [#6358](https://github.com/docker/compose/issues/6358){:target="_blank" rel="noopener" class="_"}.
-- Changing `compose-go` to allow (re)building volume string to be used by engine bind API when mount can't be used. Closes [#9380](https://github.com/docker/compose/issues/9380){:target="_blank" rel="noopener" class="_"}.
-- Providing checksums.txt file and adding --binary to allow verification in different OS. Closes [#9388](https://github.com/docker/compose/issues/9388){:target="_blank" rel="noopener" class="_"}.
-- Changes added so locally pulled image's ID is inspected and persisted to `com.docker.compose.image`. Closes [#9357](https://github.com/docker/compose/issues/9357){:target="_blank" rel="noopener" class="_"}.
-- Fixing issue regarding IPAM gateway setup. Closes [#9330](https://github.com/docker/compose/issues/9330){:target="_blank" rel="noopener" class="_"}.
+- Fixed panic with `compose down` command when -p flag specified. Fixes [#9353](https://github.com/docker/compose/issues/9353){:target="_blank" rel="noopener" class="_"}.
+- Passed newly created project as input to start services (`docker compose up`). Fixes [#9356](https://github.com/docker/compose/issues/9356){:target="_blank" rel="noopener" class="_"}.
+- Included services declared under links in docker-compose file as implicit dependencies. Fixes [#9301](https://github.com/docker/compose/issues/9301){:target="_blank" rel="noopener" class="_"}.
+- Added changes `docker-compose pull` command to respect defined policy: 1) skip services configured as `pull_policy: never` and 2) ignore those with an existing image and `pull_policy: missing`. Fixes [#3660](https://github.com/docker/compose/issues/3660){:target="_blank" rel="noopener" class="_"}.
+- Error building project from resources is no longer ignored in order to prevent `down`panic. Fixes [#9383](https://github.com/docker/compose/issues/9383){:target="_blank" rel="noopener" class="_"}.
+- Enforced project name to be lowercase. Fixes [#9378](https://github.com/docker/compose/issues/9378){:target="_blank" rel="noopener" class="_"}.
+- Added support to build-time secrets. Fixes [#6358](https://github.com/docker/compose/issues/6358){:target="_blank" rel="noopener" class="_"}.
+- Changed `compose-go` to allow (re)building volume string to be used by engine `bind` API when mount can't be used. Fixes [#9380](https://github.com/docker/compose/issues/9380){:target="_blank" rel="noopener" class="_"}.
+- Provided checksums.txt file and added `--binary` to allow verification in different OS. Fixes [#9388](https://github.com/docker/compose/issues/9388){:target="_blank" rel="noopener" class="_"}.
+- Added changes so locally pulled image's ID is inspected and persisted to `com.docker.compose.image`. Fixes [#9357](https://github.com/docker/compose/issues/9357){:target="_blank" rel="noopener" class="_"}.
+- Fixed issue regarding IPAM gateway setup. Fixes [#9330](https://github.com/docker/compose/issues/9330){:target="_blank" rel="noopener" class="_"}.
 
 ### Changes
-- Adding support for ppc64le archictecture for docker compose binary.
-- Fixing search/replace typo in --no-TTY documentation.
+- Added support for ppc64le archictecture for docker compose binary.
+- Fixed search/replace typo in `--no-TTY` documentation.
 
 For the full change log or additional information, check the [Compose repository 2.5.0 release page](https://github.com/docker/compose/releases/tag/v2.5.0){:target="_blank" rel="noopener" class="_"}.
 
@@ -33,9 +33,9 @@ For the full change log or additional information, check the [Compose repository
 (2022-04-04)
 
 ### Bug Fixes
-- Passing the `--rm flag` value as is to the Docker CLI when running a container with this flag. Closes [#9314](https://github.com/docker/compose/issues/9314){:target="_blank" rel="noopener" class="_"}.
-- Adding ssh config to the build options when building an image from a `docker compose up` command. Closes [#9338](https://github.com/docker/compose/issues/9338){:target="_blank" rel="noopener" class="_"}.
-- Inspecting container to check if a TTY is required. Running services with `tty:true` specified now show console output. Closes [#9288](https://github.com/docker/compose/issues/9288){:target="_blank" rel="noopener" class="_"}.
+- Passed the `--rm flag` value as is to the Docker CLI when running a container with this flag. Fixes [#9314](https://github.com/docker/compose/issues/9314){:target="_blank" rel="noopener" class="_"}.
+- Added ssh config to the build options when building an image from a `docker compose up` command. Fixes [#9338](https://github.com/docker/compose/issues/9338){:target="_blank" rel="noopener" class="_"}.
+- Added inspection to container checking if a TTY is required. Running services with `tty:true` specified now show console output. Fixes [#9288](https://github.com/docker/compose/issues/9288){:target="_blank" rel="noopener" class="_"}.
 
 For the full change log or additional information, check the [Compose repository 2.4.1 release page](https://github.com/docker/compose/releases/tag/v2.4.1){:target="_blank" rel="noopener" class="_"}.  
 
@@ -44,21 +44,21 @@ For the full change log or additional information, check the [Compose repository
 (2022-04-1)
 
 ### Bug Fixes
-- Passing the interactive flag from the Compose CLI to the Docker one to run exec command. Closes [#9315](https://github.com/docker/compose/issues/9315){:target="_blank" rel="noopener" class="_"}.
+- Passed the interactive flag from the Compose CLI to the Docker one to run exec command. Fixes [#9315](https://github.com/docker/compose/issues/9315){:target="_blank" rel="noopener" class="_"}.
 
-- Compose commands now take value of `COMPOSE_PROJECT_NAME` environmental variable into consideration. Closes [#9316](https://github.com/docker/compose/issues/9316){:target="_blank" rel="noopener" class="_"}.
-- Fixed issue of `compose down` command that when executed in contexts without any services started/resources to deleted war returning an error. Error was due to command trying to delete inexistent network. Closes [#9333](https://github.com/docker/compose/issues/9333){:target="_blank" rel="noopener" class="_"}.
+- Compose commands now take the value of `COMPOSE_PROJECT_NAME` environmental variable into consideration. Fixes [#9316](https://github.com/docker/compose/issues/9316){:target="_blank" rel="noopener" class="_"}.
+- Fixed issue of `compose down` command that when executed in contexts without any services started or resources to be deleted was returning an error. Error was due to command trying to delete an inexistent default network. Fixes [#9333](https://github.com/docker/compose/issues/9333){:target="_blank" rel="noopener" class="_"}.
 
 
 ### Changes
-- Introducing support for `cache_from`, `cache_to`, `no_cache` and `pull` attributes in the build section. These attributes allow forcing a complete rebuild from sources and checking with registry for images used. These changes provide the basis for offering `--no-cache` and `--pull` options for compose build (or equivalent) command down the line.
-- Introducing support of an `--ssh `flag for the `build` command from CLI and Compose file. Closes [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
+- Introduced support for `cache_from`, `cache_to`, `no_cache` and `pull` attributes in the build section. These attributes allow forcing a complete rebuild from sources and checking with registry for images used. These changes provide the basis for offering `--no-cache` and `--pull` options for compose build (or equivalent) command down the line.
+- Introduced support of an `--ssh `flag for the `build` command from CLI and Compose file. Fixes [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
 - Fixed typo in ssh flag description. Related to [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
-- Pinning Kubernetes dependencies to the same version as in Buildx.
-- Dependencies update: Bumping Buildx to v0.8.1. to fix possible panic on handling build context scanning errors.
-- Pass the interactive flag from the Compose CLI to the Docker one to run exec command.
+- Pinned Kubernetes dependencies to the same version as in Buildx.
+- Dependencies update: Bumped Buildx to v0.8.1. to fix possible panic on handling build context scanning errors.
+- Passed the interactive flag from the Compose CLI to the Docker one to run exec command.
 - Fixed race condition on start-stop end-to-end tests running in parrallel.
-- Removing code regarding an obsolete warning.
+- Removed code regarding an obsolete warning.
 - Vendor: github.com/containerd/containerd v1.6.2. Includes a fix for CVE-2022-24769 (doesn't affect our codebase).
 
 For the full change log or additional information, check the [Compose repository 2.4.0 release page](https://github.com/docker/compose/releases/tag/v2.4.0){:target="_blank" rel="noopener" class="_"}.  
@@ -69,21 +69,21 @@ For the full change log or additional information, check the [Compose repository
 
 ### Bug Fixes
 
-- Removing a container with no candidate now produces a warning instead of an error. Closes [#9255](https://github.com/docker/compose/issues/9255){:target="_blank" rel="noopener" class="_"}.
-- Recovering behavior for 'compose up -d' of recreating containers of compose file images with refreshed content. Closes [#9259](https://github.com/docker/compose/issues/9259){:target="_blank" rel="noopener" class="_"}.
-- Removing the "Deprecated" mentions from -i and -t options to run and exec commands. These options are on by default and in use. Closes [#9229](https://github.com/docker/compose/pull/9229#discussion_r819730788){:target="_blank" rel="noopener" class="_"}. 
+- Removed a container with no candidate now produces a warning instead of an error. Fixes [#9255](https://github.com/docker/compose/issues/9255){:target="_blank" rel="noopener" class="_"}.
+- Recovered behavior for 'compose up -d' of recreating containers of compose file images with refreshed content. Fixes [#9259](https://github.com/docker/compose/issues/9259){:target="_blank" rel="noopener" class="_"}.
+- Removed the "Deprecated" mentions from -i and -t options to run and exec commands. These options are on by default and in use. Fixes [#9229](https://github.com/docker/compose/pull/9229#discussion_r819730788){:target="_blank" rel="noopener" class="_"}. 
 
 ### Changes
 
-- Removing the "Deprecated" mention from the --filter flag, to keep consistency with other commands. 
+- Removed the "Deprecated" mention from the --filter flag, to keep consistency with other commands. 
 - Docker compose --status, --filter and --format flags documentation updates.
-- Dependencies update: Bumping github.com/spf13/cobra from 1.3.0 to 1.4.0. Cobra library no longer requires Viper and all of its indirect dependencies [See cobra's release page](https://github.com/spf13/cobra/releases){:target="_blank" rel="noopener" class="_"}.
-- Dependencies update: Bumping Buildx from v0.7.1 to v0.8.0.
-- Removing the need to get the original compose.yaml file to run 'docker compose kill'.
+- Dependencies update: Bumped github.com/spf13/cobra from 1.3.0 to 1.4.0. Cobra library no longer requires Viper and all of its indirect dependencies [See cobra's release page](https://github.com/spf13/cobra/releases){:target="_blank" rel="noopener" class="_"}.
+- Dependencies update: Bumped Buildx from v0.7.1 to v0.8.0.
+- Removed the need to get the original compose.yaml file to run 'docker compose kill'.
 - `docker-compose down -v` now does not remove external volumes and networks as per the option's expected and documented behavior. Whenever project is specified it is also now used to enforce down to only remove resources listed in compose.yaml file.
-Closes [#9172](https://github.com/docker/compose/issues/9172){:target="_blank" rel="noopener" class="_"}, [#9145](https://github.com/docker/compose/issues/9145){:target="_blank" rel="noopener" class="_"}.
-- Using RunExec and RunStart from docker/cli to handle all the interactive/tty/* terminal logic.
-- Changing Compose API reference docs automation to pick up diffs code vs. docs.
+Fixes [#9172](https://github.com/docker/compose/issues/9172){:target="_blank" rel="noopener" class="_"}, [#9145](https://github.com/docker/compose/issues/9145){:target="_blank" rel="noopener" class="_"}.
+- Introduced changes to use RunExec and RunStart from docker/cli to handle all the interactive/tty/* terminal logic.
+- Changed Compose API reference docs automation to pick up diffs code vs. docs.
 
 For the full change log or additional information, check the [Compose repository 2.3.4 release page](https://github.com/docker/compose/releases/tag/v2.3.4){:target="_blank" rel="noopener" class="_"}.  
 

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -35,7 +35,7 @@ For the full change log or additional information, check the [Compose repository
 ### Bug Fixes
 - Passing the `--rm flag` value as is to the Docker CLI when running a container with this flag. Closes [#9314](https://github.com/docker/compose/issues/9314){:target="_blank" rel="noopener" class="_"}.
 - Adding ssh config to the build options when building an image from a `docker compose up` command. Closes [#9338](https://github.com/docker/compose/issues/9338){:target="_blank" rel="noopener" class="_"}.
-- Inspecting container to check if a TTY is required. Running services with `tty:true` specified now show console output. Closes [#9288](https://github.com/docker/compose/issues/9288){:target="_blank" rel="noopener" class="_".
+- Inspecting container to check if a TTY is required. Running services with `tty:true` specified now show console output. Closes [#9288](https://github.com/docker/compose/issues/9288){:target="_blank" rel="noopener" class="_"}.
 
 For the full change log or additional information, check the [Compose repository 2.4.1 release page](https://github.com/docker/compose/releases/tag/v2.4.1){:target="_blank" rel="noopener" class="_"}.  
 


### PR DESCRIPTION
Updating Compose release notes with latest information.

What I did:
- Expanded description for each line, tracked down related issues and linked them;
- Every change in the log with a referenced issue went into Bug Fixes section, all others into a "Changes" section. 
- Added releases later than 2.3.4 inclusive. 
- Added cross-references(xref) to compose release notes(RN) pages in repos for each release/tag
- Added a section for a mixed bag of previous releases with xref to RN in Compose repo.

@usha-mandya tagging Nicolas instead of Ulysses having listed PRs authoring in mind, assuming this is better for reviewing said lines. Let me know if this is a good approach.