### PR TITLE
hide the compose completion page until it's available for v2

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -914,8 +914,6 @@ reference:
       title: Overview of docker-compose CLI
     - path: /compose/reference/envvars/
       title: CLI environment variables
-    - path: /compose/completion/
-      title: Command-line completion
     - path: /compose/reference/build/
       title: docker-compose build
     - path: /compose/reference/config/

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -329,7 +329,7 @@ services. For example, to see what environment variables are available to the
 $ docker-compose run web env
 ```
 
-See `docker-compose --help` to see other available commands. You can also install [command completion](completion.md) for the bash and zsh shell, which also shows you available commands.
+See `docker-compose --help` to see other available commands.
 
 If you started Compose with `docker-compose up -d`, stop
 your services once you've finished with them:


### PR DESCRIPTION
### Proposed changes

Hide the `completion.md` page until we have a completion script available for Compose v2


### Related issues (optional)
fix #14692 and https://github.com/docker/compose/issues/8550
