### PR TITLE
Add documentation for redirecting 443 SSL traffic to any container port

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -496,6 +496,28 @@ x-aws-cloudformation:
         Port: 443
 ```
 
+#### Setting SSL termination by Load Balancer (non-privileged ports)
+
+Non privileged ports create a network load balancer, but you can use the `x-aws-protocol` flag to instead create an application load balancer, and an overlay can then direct HTTPS traffic to your container. This example forwards port 443 traffic to port 8080.
+
+```yaml
+services:
+  webapp:
+    image: acme/webapp
+    ports:
+      - target: 8080
+        x-aws-protocol: http # enable an application load balancer
+
+x-aws-cloudformation:
+  Resources:
+    WebappTCP8080Listener:
+      Properties:
+        Certificates:
+          - CertificateArn: "arn:aws:acm:certificate/123abc"
+        Protocol: HTTPS
+        Port: 443
+```
+
 ## Using existing AWS network resources
 
 By default, the Docker Compose CLI creates an ECS cluster for your Compose application, a Security Group per network in your Compose file on your AWS account’s default VPC, and a LoadBalancer to route traffic to your services.


### PR DESCRIPTION
What does this extra example show? How to forward HTTPS 443 traffic to a container's port 8080.

At first glance, this may look like a redundant documentation entry. After all, we just showed SSL termination right above this example. We're cluttering the docs! Let me directly address this:

- This literally took me 3 straight days to figure out how to do. I arrived at a custom 120 line CloudFormation yaml file before I realized I could do it this way.
- There is not a single mention of the `x-aws-protocol` flag on this entire page. This adds a very helpful use case.
- The jump to overriding a network load balancer and learning the `x-aws-protocol` flag, plus learning the correct `x-aws-cloudformation` overlay, plus understanding the difference between all the load balancer sub objects (TargetGroup, Listener, LoadBalancer) and knowing which fields to override is non-trivial. 
- Many web frameworks actively discourage running your server on port 80. It requires root user (sudo) permissions to bind to port 80. You could even argue the port 80 example above this one is encouraging bad practices (see this Digital Ocean explanation https://www.digitalocean.com/community/tutorials/how-to-use-pm2-to-setup-a-node-js-production-environment-on-an-ubuntu-vps#give-safe-user-permission-to-use-port-80 )


I think forwarding HTTPS traffic to a non-privileged container `443:8080` is a VERY common use case, and well worth the extra example here in the docs.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
