### PR TITLE
desktop/linux: Emphasise requirement for Gnome extension to support t…

### DIFF
--- a/desktop/linux/install.md
+++ b/desktop/linux/install.md
@@ -26,7 +26,7 @@ To install Docker Desktop successfully, your Linux host must meet the following 
 - systemd init system.
 
 - Gnome or KDE Desktop environment.
-  - On many distros the Gnome environment does not support tray icons. In such cases you will need to install a Gnome extension to add support for tray icons (e.g. [AppIndicator](https://extensions.gnome.org/extension/615/appindicator-support/)).
+  -For many Linux distros, the Gnome environment does not support tray icons. To add support for tray icons, you need to install a Gnome extension. For example, [AppIndicator](https://extensions.gnome.org/extension/615/appindicator-support/)).
 
 - At least 4 GB of RAM.
 

--- a/desktop/linux/install.md
+++ b/desktop/linux/install.md
@@ -26,6 +26,7 @@ To install Docker Desktop successfully, your Linux host must meet the following 
 - systemd init system.
 
 - Gnome or KDE Desktop environment.
+  - On many distros the Gnome environment does not support tray icons. In such cases you will need to install a Gnome extension to add support for tray icons (e.g. [AppIndicator](https://extensions.gnome.org/extension/615/appindicator-support/)).
 
 - At least 4 GB of RAM.
 


### PR DESCRIPTION
### Proposed changes

On some distros a gnome extension is required to display the "whale
menu". This is already describet in distro-specific instructions, but
that makes is somewhat easier to miss. So call it out in the top level
requirement list.

### Related issues (optional)

https://github.com/docker/desktop-linux/issues/16
