### PR TITLE
Improve WSL 2 docs

### DIFF
--- a/desktop/windows/wsl.md
+++ b/desktop/windows/wsl.md
@@ -46,7 +46,16 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     If you have installed Docker Desktop on a system that supports WSL 2, this option will be enabled by default.
 5. Click **Apply & Restart**.
-6. Ensure the distribution runs in WSL 2 mode. WSL can run distributions in both v1 or v2 mode.
+
+That's it! Now `docker` commands will work from Windows using the new WSL 2 engine.
+
+## Enabling Docker support in WSL 2 distros
+
+WSL 2 adds support for "Linux distros" to Windows, where each distro behaves like a VM except they all run on top of a single shared Linux kernel.
+
+Docker Desktop does not require any particular Linux distros to be installed. The `docker` CLI and UI all work fine from Windows without any additinoal Linux distros. However for the best developer experience, we recommend installing at least one additional distro and enabling Docker support by:
+
+1. Ensure the distribution runs in WSL 2 mode. WSL can run distributions in both v1 or v2 mode.
 
     To check the WSL mode, run:
 
@@ -60,7 +69,7 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     `wsl.exe --set-default-version 2`
 
-7. When Docker Desktop restarts, go to **Settings** > **Resources** > **WSL Integration**.
+2. When Docker Desktop starts, go to **Settings** > **Resources** > **WSL Integration**.
 
     The Docker-WSL integration will be enabled on your default WSL distribution. To change your default WSL distro, run `wsl --set-default <distro name>`.
 
@@ -74,7 +83,11 @@ Ensure you have completed the steps described in the Prerequisites section **bef
 
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 
-8. Click **Apply & Restart**.
+3. Click **Apply & Restart**.
+
+> **Note**
+>
+> Docker Desktop installs 2 special-purpose internal Linux distros `docker-desktop` and `docker-desktop-data`. The first (`docker-desktop`) is used to run the Docker engine (`dockerd`) while the second (`docker-desktop-data`) stores containers and images. Neither can be used for general development.
 
 ## Best practices
 

--- a/desktop/windows/wsl.md
+++ b/desktop/windows/wsl.md
@@ -14,7 +14,7 @@ title: Docker Desktop WSL 2 backend
 > subscription.
 {: .important}
 
-Windows Subsystem for Linux (WSL) 2 introduces a significant architectural change as it is a full Linux kernel built by Microsoft, allowing Linux containers to run natively without emulation. With Docker Desktop running on WSL 2, users can leverage Linux workspaces and avoid having to maintain both Linux and Windows build scripts. In addition, WSL 2 provides improvements to file system sharing, boot time, and allows access to some cool new features for Docker Desktop users.
+Windows Subsystem for Linux (WSL) 2 introduces a significant architectural change as it is a full Linux kernel built by Microsoft, allowing Linux distributions to run without having to manage Virtual Machines. With Docker Desktop running on WSL 2, users can leverage Linux workspaces and avoid having to maintain both Linux and Windows build scripts. In addition, WSL 2 provides improvements to file system sharing, boot time, and allows access to some cool new features for Docker Desktop users.
 
 Docker Desktop uses the dynamic memory allocation feature in WSL 2 to greatly improve the resource consumption. This means, Docker Desktop only uses the required amount of CPU and memory resources it needs, while enabling CPU and memory-intensive tasks such as building a container to run much faster.
 

--- a/desktop/windows/wsl.md
+++ b/desktop/windows/wsl.md
@@ -28,21 +28,6 @@ Before you install the Docker Desktop WSL 2 backend, you must complete the follo
 2. Enable WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10){:target="_blank" rel="noopener" class="_"}.
 3. Download and install the [Linux kernel update package](https://docs.microsoft.com/windows/wsl/wsl2-kernel){:target="_blank" rel="noopener" class="_"}.
 
-## Best practices
-
-- To get the best out of the file system performance when bind-mounting files, we recommend storing source code and other data that is bind-mounted into Linux containers (i.e., with `docker run -v <host-path>:<container-path>`) in the Linux file system, rather than the Windows file system. You can also refer to the [recommendation](https://docs.microsoft.com/en-us/windows/wsl/compare-versions){:target="_blank" rel="noopener" class="_"} from Microsoft.
-
-  - Linux containers only receive file change events ("inotify events") if the
-      original files are stored in the Linux filesystem. For example, some web development workflows rely on inotify events for automatic reloading when files have changed.
-  - Performance is much higher when files are bind-mounted from the Linux
-      filesystem, rather than remoted from the Windows host. Therefore avoid
-      `docker run -v /mnt/c/users:/users` (where `/mnt/c` is mounted from Windows).
-  - Instead, from a Linux shell use a command like `docker run -v ~/my-project:/sources <my-image>`
-      where `~` is expanded by the Linux shell to `$HOME`.
-- If you have concerns about the size of the docker-desktop-data VHDX, or need to change it, take a look at the [WSL tooling built into Windows](https://docs.microsoft.com/en-us/windows/wsl/vhd-size){:target="_blank" rel="noopener" class="_"}.
-- If you have concerns about CPU or memory usage, you can configure limits on the memory, CPU, Swap size allocated to the [WSL 2 utility VM](https://docs.microsoft.com/en-us/windows/wsl/wsl-config#global-configuration-options-with-wslconfig){:target="_blank" rel="noopener" class="_"}.
-- To avoid any potential conflicts with using WSL 2 on Docker Desktop, you must [uninstall any previous versions of Docker Engine](../../engine/install/ubuntu.md#uninstall-docker-engine) and CLI installed directly through Linux distributions before installing Docker Desktop.
-
 ## Download
 
 Download [Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe).
@@ -90,6 +75,21 @@ Ensure you have completed the steps described in the Prerequisites section **bef
     ![WSL 2 Choose Linux distro](images/wsl2-choose-distro.png)
 
 8. Click **Apply & Restart**.
+
+## Best practices
+
+- To get the best out of the file system performance when bind-mounting files, we recommend storing source code and other data that is bind-mounted into Linux containers (i.e., with `docker run -v <host-path>:<container-path>`) in the Linux file system, rather than the Windows file system. You can also refer to the [recommendation](https://docs.microsoft.com/en-us/windows/wsl/compare-versions){:target="_blank" rel="noopener" class="_"} from Microsoft.
+
+  - Linux containers only receive file change events ("inotify events") if the
+      original files are stored in the Linux filesystem. For example, some web development workflows rely on inotify events for automatic reloading when files have changed.
+  - Performance is much higher when files are bind-mounted from the Linux
+      filesystem, rather than remoted from the Windows host. Therefore avoid
+      `docker run -v /mnt/c/users:/users` (where `/mnt/c` is mounted from Windows).
+  - Instead, from a Linux shell use a command like `docker run -v ~/my-project:/sources <my-image>`
+      where `~` is expanded by the Linux shell to `$HOME`.
+- If you have concerns about the size of the docker-desktop-data VHDX, or need to change it, take a look at the [WSL tooling built into Windows](https://docs.microsoft.com/en-us/windows/wsl/vhd-size){:target="_blank" rel="noopener" class="_"}.
+- If you have concerns about CPU or memory usage, you can configure limits on the memory, CPU, Swap size allocated to the [WSL 2 utility VM](https://docs.microsoft.com/en-us/windows/wsl/wsl-config#global-configuration-options-with-wslconfig){:target="_blank" rel="noopener" class="_"}.
+- To avoid any potential conflicts with using WSL 2 on Docker Desktop, you must [uninstall any previous versions of Docker Engine](../../engine/install/ubuntu.md#uninstall-docker-engine) and CLI installed directly through Linux distributions before installing Docker Desktop.
 
 ## Develop with Docker and WSL 2
 

--- a/desktop/windows/wsl.md
+++ b/desktop/windows/wsl.md
@@ -45,11 +45,11 @@ Before you install the Docker Desktop WSL 2 backend, you must complete the follo
 
 ## Download
 
-Download [Docker Desktop 2.3.0.2](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe) or a later release.
+Download [Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe).
 
 ## Install
 
-Ensure you have completed the steps described in the Prerequisites section **before** installing the Docker Desktop Stable 2.3.0.2 release.
+Ensure you have completed the steps described in the Prerequisites section **before** installing the Docker Desktop release.
 
 1. Follow the usual installation instructions to install Docker Desktop. If you are running a supported system, Docker Desktop prompts you to enable WSL 2 during installation. Read the information displayed on the screen and enable WSL 2 to continue.
 2. Start Docker Desktop from the Windows Start menu.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

- described that having additional Linux distros is recommended, but is not a pre-req. I've split the Install section into 2: the basic install which is all you need for `docker` to work on Windows; and a separate section on enabling it for user Linux distros since that's optional (but recommended)
- added a note describing that the built-in distros `docker-desktop` and `docker-desktop-data` are implementation details and not suitable for general use.
- re-ordered the page slightly so now it's: why do I want this, the pre-reqs, download link, install steps and then best-practices. Previously the best-practices were before the download which was (IMHO) too early, we'd like to help the user get installed first + not make it look too complicated
- removed references to a very old Docker Desktop 2.3.0.2 (but the link was to latest, which is fine)
- fixed a reference to "running natively without emulation" to "run without having to manage Virtual Machines" <- before WSL 2 the state of the art was to run Hyper-V VMs yourself; with WSL 2 there is a VM which Windows manages automatically


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
