### PR TITLE
ci: fix aws s3 cmd on ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         name: Upload files to S3 bucket
         if: github.event_name != 'pull_request'
         run: |
-          aws s3 sync --acl public-read _site s3://${{ env.DOCS_S3_HOST }}/ --delete
+          aws --region us-east-1 s3 sync --acl public-read _site s3://${{ env.DOCS_S3_HOST }}/ --delete
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -190,7 +190,7 @@ Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/pro
 ### New
 
 - IT Administrators can now install Docker Desktop remotely using the command line.
-- Add  the Docker Software Bill of Materials (SBOM) CLI plugin. The new CLI plugin enables users to generate SBOMs for Docker images. For more information, see [Docker SBOM](../../../engine/sbom/index.md).
+- Add  the Docker Software Bill of Materials (SBOM) CLI plugin. The new CLI plugin enables users to generate SBOMs for Docker images. For more information, see [Docker SBOM](../engine/sbom/index.md).
 - Use [cri-dockerd](https://github.com/Mirantis/cri-dockerd){: target="_blank" rel="noopener" class="_"}  for new Kubernetes clusters instead of `dockershim`. The change is transparent from the user's point of view and Kubernetes containers run on the Docker Engine as before. `cri-dockerd` allows Kubernetes to manage Docker containers using the standard [Container Runtime Interface](https://github.com/kubernetes/cri-api#readme){: target="_blank" rel="noopener" class="_"}, the same interface used to control other container runtimes. For more information, see [The Future of Dockershim is cri-dockerd](https://www.mirantis.com/blog/the-future-of-dockershim-is-cri-dockerd/){: target="_blank" rel="noopener" class="_"}.
 
 ### Upgrades
@@ -442,7 +442,7 @@ This only affects users if they are on Docker Desktop 4.3.0, 4.3.1 and the user 
 ### New
 
 - Easy, Secure sign in with Auth0 and Single Sign-on
-  - Single Sign-on: Users with a Docker Business subscription can now configure SSO to authenticate using their identity providers (IdPs) to access Docker. For more information, see [Single Sign-on](../../../single-sign-on/index.md).
+  - Single Sign-on: Users with a Docker Business subscription can now configure SSO to authenticate using their identity providers (IdPs) to access Docker. For more information, see [Single Sign-on](../single-sign-on/index.md).
   - Signing in to Docker Desktop now takes you through the browser so that you get all the benefits of auto-filling from password managers.
 
 ### Upgrades
@@ -571,7 +571,7 @@ CVE-2021-44228](https://www.docker.com/blog/apache-log4j-2-cve-2021-44228/){: ta
 
 #### For Mac
 
-- Docker Desktop on Apple silicon no longer requires Rosetta 2, with the exception of [three optional command line tools](../mac/apple-silicon/#known-issues).
+- Docker Desktop on Apple silicon no longer requires Rosetta 2, with the exception of [three optional command line tools](mac/apple-silicon.md#known-issues).
 
 #### For Windows
 
@@ -581,7 +581,7 @@ CVE-2021-44228](https://www.docker.com/blog/apache-log4j-2-cve-2021-44228/){: ta
 
 Docker Dashboard incorrectly displays the container memory usage as zero on
 Hyper-V based machines.
-You can use the [`docker stats`](../../../engine/reference/commandline/stats.md)
+You can use the [`docker stats`](../engine/reference/commandline/stats.md)
 command on the command line as a workaround to view the
 actual memory usage. See
 [docker/for-mac#6076](https://github.com/docker/for-mac/issues/6076).
@@ -761,7 +761,7 @@ The updated [Docker Subscription Service Agreement](https://www.docker.com/legal
 - **No changes** to Docker Engine or any other upstream **open source** Docker or Moby project.
 
 To understand how these changes affect you, read the [FAQs](https://www.docker.com/pricing/faq){: target="*blank" rel="noopener" class="*" id="dkr_docs_relnotes_btl"}.
-For more information, see [Docker subscription overview](../../../subscription/index.md).
+For more information, see [Docker subscription overview](../subscription/index.md).
 
 ### Upgrades
 


### PR DESCRIPTION
encounter an issue while merging #14685 linked to aws cli used on newest runners (since Ubuntu 20.04):

```
Run aws s3 sync --acl public-read _site s3://docs.docker.com-stage-us-east-1/ --delete

<botocore.awsrequest.AWSRequest object at 0x7f919fe3bfa0>
Error: Process completed with exit code 255.
```

we need to explicitly specify the region.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>
