### PR TITLE
ci: split build and publish workflows and set up cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,36 +2,15 @@ name: build
 
 on:
   push:
+    # needs push event on default branch otherwise cache is evicted when pull request is merged
     branches:
       - master
-      - published
   pull_request:
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-20.04
     steps:
-      -
-        name: Prepare
-        run: |
-          JEKYLL_ENV=development
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            DOCS_S3_HOST="docs.docker.com-stage-us-east-1"
-            DOCS_AWS_LAMBDA="arn:aws:lambda:us-east-1:710015040892:function:docs-stage-cache-invalidator"
-            DOCS_SLACK_MSG="Successfully promoted docs-stage from master. https://docs-stage.docker.com/"
-            DOCS_WEBCONFIG="_website-config-docs-stage.json"
-          elif [ "${{ github.ref }}" = "refs/heads/published" ]; then
-            JEKYLL_ENV=production
-            DOCS_S3_HOST="docs.docker.com-us-east-1"
-            DOCS_AWS_LAMBDA="arn:aws:lambda:us-east-1:710015040892:function:docs-cache-invalidator"
-            DOCS_SLACK_MSG="Successfully published docs. https://docs.docker.com/"
-            DOCS_WEBCONFIG="_website-config-docs.json"
-          fi
-          echo "JEKYLL_ENV=$JEKYLL_ENV" >> $GITHUB_ENV
-          echo "DOCS_S3_HOST=$DOCS_S3_HOST" >> $GITHUB_ENV
-          echo "DOCS_AWS_LAMBDA=$DOCS_AWS_LAMBDA" >> $GITHUB_ENV
-          echo "DOCS_SLACK_MSG=$DOCS_SLACK_MSG" >> $GITHUB_ENV
-          echo "DOCS_WEBCONFIG=$DOCS_WEBCONFIG" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v3
@@ -43,51 +22,28 @@ jobs:
         uses: docker/bake-action@v2
         with:
           targets: release
-      -
-        name: Upload files to S3 bucket
-        if: github.event_name != 'pull_request'
-        run: |
-          aws --region us-east-1 s3 sync --acl public-read _site s3://${{ env.DOCS_S3_HOST }}/ --delete
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      -
-        name: Update S3 website config
-        if: github.event_name != 'pull_request'
-        uses: ./.github/actions/update-website-config
-        with:
-          bucketName: ${{ env.DOCS_S3_HOST }}
-          regionName: us-east-1
-          websiteConfig: ${{ env.DOCS_WEBCONFIG }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      -
-        name: Invalidate docs website cache
-        if: github.event_name != 'pull_request'
-        run: |
-          aws --region us-east-1 lambda invoke --function-name ${{ env.DOCS_AWS_LAMBDA }} response.json
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      -
-        name: Send Slack notification
-        if: github.event_name != 'pull_request'
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ env.DOCS_SLACK_MSG }}"}' ${{ secrets.SLACK_WEBHOOK }}
+          set: |
+            *.cache-from=type=gha,scope=build
+            *.cache-to=type=gha,scope=build,mode=max
 
   validate:
     runs-on: ubuntu-20.04
-    if: github.event_name == 'pull_request'
     steps:
       -
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
         name: Check for broken links
         uses: docker/bake-action@v2
         with:
           targets: htmlproofer
+          set: |
+            *.cache-from=type=gha,scope=build
+            *.cache-from=type=gha,scope=validate
+            *.cache-to=type=gha,scope=validate,mode=max
 
       # Disabled netlify-deploy due to flakey 502 http errors
       # - name: copy static files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - master
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Prepare
+        run: |
+          JEKYLL_ENV=development
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            DOCS_S3_HOST="docs.docker.com-stage-us-east-1"
+            DOCS_AWS_LAMBDA="arn:aws:lambda:us-east-1:710015040892:function:docs-stage-cache-invalidator"
+            DOCS_SLACK_MSG="Successfully promoted docs-stage from master. https://docs-stage.docker.com/"
+            DOCS_WEBCONFIG="_website-config-docs-stage.json"
+          elif [ "${{ github.ref }}" = "refs/heads/published" ]; then
+            JEKYLL_ENV=production
+            DOCS_S3_HOST="docs.docker.com-us-east-1"
+            DOCS_AWS_LAMBDA="arn:aws:lambda:us-east-1:710015040892:function:docs-cache-invalidator"
+            DOCS_SLACK_MSG="Successfully published docs. https://docs.docker.com/"
+            DOCS_WEBCONFIG="_website-config-docs.json"
+          fi
+          echo "JEKYLL_ENV=$JEKYLL_ENV" >> $GITHUB_ENV
+          echo "DOCS_S3_HOST=$DOCS_S3_HOST" >> $GITHUB_ENV
+          echo "DOCS_AWS_LAMBDA=$DOCS_AWS_LAMBDA" >> $GITHUB_ENV
+          echo "DOCS_SLACK_MSG=$DOCS_SLACK_MSG" >> $GITHUB_ENV
+          echo "DOCS_WEBCONFIG=$DOCS_WEBCONFIG" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build
+        uses: docker/bake-action@v2
+        with:
+          targets: release
+          set: |
+            *.cache-from=type=gha,scope=publish
+            *.cache-to=type=gha,scope=publish,mode=max
+      -
+        name: Upload files to S3 bucket
+        run: |
+          aws --region us-east-1 s3 sync --acl public-read _site s3://${{ env.DOCS_S3_HOST }}/ --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      -
+        name: Update S3 website config
+        uses: ./.github/actions/update-website-config
+        with:
+          bucketName: ${{ env.DOCS_S3_HOST }}
+          regionName: us-east-1
+          websiteConfig: ${{ env.DOCS_WEBCONFIG }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      -
+        name: Invalidate docs website cache
+        run: |
+          aws --region us-east-1 lambda invoke --function-name ${{ env.DOCS_AWS_LAMBDA }} response.json
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      -
+        name: Send Slack notification
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ env.DOCS_SLACK_MSG }}"}' ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
the new workflow introduced in #14685 takes quite some time to build (~5m). the gem stage is the culprit here as it takes almost 4m to build some native extensions. this PR introduces GitHub Cache backend for our workflows and now it takes ~37s to build: https://github.com/crazy-max/docker.github.io/runs/6492119592?check_suite_focus=true#step:4:1

![image](https://user-images.githubusercontent.com/1951866/169081176-078303e2-50de-48bc-88e9-350dcba1a859.png)

also as discussed with @thaJeztah, split build workflow and create a dedicated publish one to have better separation of concerns.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>