### PR TITLE
Clarify that Windows containers are only available in some Windows editions

### DIFF
--- a/desktop/windows/install.md
+++ b/desktop/windows/install.md
@@ -98,6 +98,11 @@ Looking for information on using Windows containers?
 * Docker Container Platform for Windows [articles and blog
   posts](https://www.docker.com/microsoft/) on the Docker website.
 
+> **Note**
+>
+> For you to be able to run Windows containers, you will need to be running Windows 10 Professional or Enterprise, with Windows update 1809, or
+Windows Server 2019. Windows editions Home or Education will only allow you to run Linux containers.
+
 ## Install Docker Desktop on Windows
 
 ### Install interactively

--- a/desktop/windows/install.md
+++ b/desktop/windows/install.md
@@ -100,8 +100,8 @@ Looking for information on using Windows containers?
 
 > **Note**
 >
-> For you to be able to run Windows containers, you will need to be running Windows 10 Professional or Enterprise, with Windows update 1809, or
-Windows Server 2019. Windows editions Home or Education will only allow you to run Linux containers.
+> To run Windows containers, you need Windows 10 or Windows 11 Professional or Enterprise edition. 
+Windows Home or Education editions will only allow you to run Linux containers.
 
 ## Install Docker Desktop on Windows
 


### PR DESCRIPTION
### Proposed changes

On the [docs section](https://docs.docker.com/desktop/windows/install/#system-requirements) describing **System requirements** for **Docker Desktop on Windows**, one can see that Windows Home and Education can be used to run Docker on Windows. But it appears that in that case, only Linux containers will be available. 

It appears that one can only run Windows containers when running versions of Windows Pro, Enterprise or Server (as suggested on this [doc's lab](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md)).

This **PR** adds a note to make this Windows edition limitation clearer - already from the main Docker Desktop on Windows page.

If this limitation does not exist, I apologize, but I've tried to run Windows containers on Home edition, with no success.

_ps._: This appears to have confused some other users before, as shown in this [stackoverflow question](https://stackoverflow.com/questions/65149702/docker-desktop-cannot-switch-to-windows-container/67712712)


### Related issues (optional)
