### PR TITLE
Add command for M1/arm64 users

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -58,6 +58,15 @@ So, let's do it!
         sh -c "yarn install && yarn run dev"
     ```
 
+    If you are using an Apple Silicon Mac or another ARM64 device then use this command.
+
+    ```bash
+    $ docker run -dp 3000:3000 \
+        -w /app -v "$(pwd):/app" \
+        node:12-alpine \
+        sh -c "apk add --no-cache python2 g++ make && yarn install && yarn run dev"
+    ```
+
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
     - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory

--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -58,7 +58,7 @@ So, let's do it!
         sh -c "yarn install && yarn run dev"
     ```
 
-    If you are using an Apple Silicon Mac or another ARM64 device then use this command.
+    If you are using an Apple silicon Mac or another ARM64 device, then use the following command.
 
     ```bash
     $ docker run -dp 3000:3000 \


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

This PR adds the bind mount command for Apple silicon users (or users running another arm64 device). This is a follow-up of this comment https://github.com/docker/getting-started/issues/231#issuecomment-1110175000 and synchronises with the similar example used in the getting-started guide.

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
