### PR TITLE
Add Chipper CI Docker auth instructions

### DIFF
--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -126,6 +126,7 @@ If you are using any third-party platforms, follow your provider’s instruction
 - [AWS CodeBuild](https://aws.amazon.com/blogs/devops/how-to-use-docker-images-from-a-private-registry-in-aws-codebuild-for-your-build-environment/){: target="_blank" rel="noopener" class="_"}
 - [AWS ECS/Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html){: target="_blank" rel="noopener" class="_"}
 - [Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#sep-docreg){: target="_blank" rel="noopener" class="_"}
+- [Chipper CI](https://docs.chipperci.com/builds/docker/#rate-limit-auth){: target="_blank" rel="noopener" class="_"}
 - [CircleCI](https://circleci.com/docs/2.0/private-images/){: target="_blank" rel="noopener" class="_"}
 - [Codefresh](https://codefresh.io/docs/docs/docker-registries/external-docker-registries/docker-hub/){: target="_blank" rel="noopener" class="_"}
 - [Drone.io](https://docs.drone.io/pipeline/docker/syntax/images/#pulling-private-images){: target="_blank" rel="noopener" class="_"}


### PR DESCRIPTION
### Proposed changes

Keeping alphabetical order, added Chipper CI docker auth instructions as recommended by Docker staff


