### PR TITLE
jekyll: create plugin to update sitemap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,18 +15,21 @@ jobs:
         run: |
           JEKYLL_ENV=development
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            DOCS_URL="https://docs-stage.docker.com"
             DOCS_S3_HOST="docs.docker.com-stage-us-east-1"
             DOCS_AWS_LAMBDA="arn:aws:lambda:us-east-1:710015040892:function:docs-stage-cache-invalidator"
             DOCS_SLACK_MSG="Successfully promoted docs-stage from master. https://docs-stage.docker.com/"
             DOCS_WEBCONFIG="_website-config-docs-stage.json"
           elif [ "${{ github.ref }}" = "refs/heads/published" ]; then
             JEKYLL_ENV=production
+            DOCS_URL="https://docs.docker.com"
             DOCS_S3_HOST="docs.docker.com-us-east-1"
             DOCS_AWS_LAMBDA="arn:aws:lambda:us-east-1:710015040892:function:docs-cache-invalidator"
             DOCS_SLACK_MSG="Successfully published docs. https://docs.docker.com/"
             DOCS_WEBCONFIG="_website-config-docs.json"
           fi
           echo "JEKYLL_ENV=$JEKYLL_ENV" >> $GITHUB_ENV
+          echo "DOCS_URL=$DOCS_URL" >> $GITHUB_ENV
           echo "DOCS_S3_HOST=$DOCS_S3_HOST" >> $GITHUB_ENV
           echo "DOCS_AWS_LAMBDA=$DOCS_AWS_LAMBDA" >> $GITHUB_ENV
           echo "DOCS_SLACK_MSG=$DOCS_SLACK_MSG" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG RUBY_VERSION=2.6.10
 ARG BUNDLER_VERSION=2.3.13
 
 ARG JEKYLL_ENV=development
-ARG DOMAIN=docs.docker.com
+ARG DOCS_URL=http://localhost:4000
 
 # Base stage for building
 FROM ruby:${RUBY_VERSION}-alpine AS base
@@ -44,7 +44,7 @@ COPY --from=vendored /out /
 # After building with jekyll, fix up some links
 FROM gem AS generate
 ARG JEKYLL_ENV
-ARG DOMAIN
+ARG DOCS_URL
 ENV TARGET=/out
 RUN --mount=type=bind,target=.,rw \
   --mount=type=cache,target=/src/.jekyll-cache <<EOT
@@ -53,7 +53,6 @@ if [ "${JEKYLL_ENV}" = "production" ]; then
   (
     set -x
     bundle exec jekyll build --profile -d ${TARGET} --config _config.yml,_config_production.yml
-    sed -i 's#<loc>/#<loc>https://${DOMAIN}/#' "${TARGET}/sitemap.xml"
   )
 else
   (
@@ -64,7 +63,7 @@ else
   )
 fi
 find ${TARGET} -type f -name '*.html' | while read i; do
-  sed -i 's#\(<a[^>]* href="\)https://${DOMAIN}/#\1/#g' "$i"
+  sed -i 's#\(<a[^>]* href="\)${DOCS_URL}/#\1/#g' "$i"
 done
 EOT
 

--- a/_config.yml
+++ b/_config.yml
@@ -63,11 +63,11 @@ compose_switch_version:  "1.0.4"
 min_api_threshold: 1.40
 
 # List of plugins to enable for local development builds. Mostly the same as
-# for production, but without the "jekyll-sitemap" plugin, which is not needed
-# for previewing, and excluding saves some time to build
+# for production.
 plugins:
   - jekyll-redirect-from
   - jekyll-relative-links
+  - jekyll-sitemap
 
 # Assets
 #
@@ -96,7 +96,6 @@ defaults:
       type: "pages"
     values:
       layout: docs
-      sitemap: false
       toc_min: 2
       toc_max: 4
 

--- a/_plugins/update_sitemap.rb
+++ b/_plugins/update_sitemap.rb
@@ -1,0 +1,19 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  beginning_time = Time.now
+  Jekyll.logger.info "Starting plugin update_sitemap.rb..."
+
+  sitemap_path = File.join(site.dest, 'sitemap.xml')
+  # DEPLOY_URL is from Netlify for preview of sitemap on PR
+  # https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata
+  docs_url = ENV['DEPLOY_URL'] || ENV['DOCS_URL'] || 'http://localhost:4000'
+
+  if File.exist?(sitemap_path)
+    sitemap_file = File.read(sitemap_path)
+    replace = sitemap_file.gsub!("<loc>/", "<loc>#{docs_url}/")
+    Jekyll.logger.info "  Replacing '<loc>/' with '<loc>#{docs_url}/' in #{sitemap_path}"
+    File.open(sitemap_path, "w") { |file| file.puts replace }
+  end
+
+  end_time = Time.now
+  Jekyll.logger.info "done in #{(end_time - beginning_time)} seconds"
+end

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,16 +1,24 @@
 variable "JEKYLL_ENV" {
   default = "development"
 }
+variable "DOCS_URL" {
+  default = "http://localhost:4000"
+}
+
+target "_common" {
+  args = {
+    JEKYLL_ENV = JEKYLL_ENV
+    DOCS_URL = DOCS_URL
+  }
+}
 
 group "default" {
   targets = ["release"]
 }
 
 target "release" {
+  inherits = ["_common"]
   target = "release"
-  args = {
-    JEKYLL_ENV = JEKYLL_ENV
-  }
   no-cache-filter = ["generate"]
   output = ["./_site"]
 }
@@ -21,9 +29,7 @@ target "vendor" {
 }
 
 target "htmlproofer" {
+  inherits = ["_common"]
   target = "htmlproofer"
-  args = {
-    JEKYLL_ENV = JEKYLL_ENV
-  }
   output = ["type=cacheonly"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     build:
       args:
         - JEKYLL_ENV
+        - DOCS_URL
       context: .
     image: docs/docstage
     ports:

--- a/sitemap.xsl
+++ b/sitemap.xsl
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+                xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+                xmlns:html="http://www.w3.org/TR/REC-html40">
+  <xsl:output version="1.0" method="html" encoding="UTF-8" />
+  <xsl:template match="/">
+    <html xmlns="http://www.w3.org/1999/xhtml">
+      <head>
+        <title>Docker Docs XML Sitemap</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <style type="text/css">
+          html, body {
+            font-family: Arial, sans-serif;
+            font-size: 16px;
+            line-height: 1.0;
+          }
+          a {
+            color: #000;
+          }
+          .intro {
+            background-color: #CFEBF7;
+            border: 1px #2580B2 solid;
+            padding: 5px 13px 5px 13px;
+            margin: 10px;
+            width: 800px;
+          }
+          .intro p {
+            line-height: 0.5;
+          }
+          .list td, .list th {
+            padding: 5px;
+            font-size: 13px;
+            line-height: 1.5;
+          }
+          .list th {
+            text-align: left;
+          }
+          tr.high {
+            background-color: whitesmoke;
+          }
+        </style>
+      </head>
+      <body>
+        <h1>Docker Docs XML Sitemap</h1>
+        <div class="intro">
+          <p>This is an XML Sitemap which is supposed to be processed by search engines like <a href="https://www.google.com">Google</a>, <a href="https://www.bing.com">Bing</a>, ...</p>
+          <p>You can find more information about XML sitemaps on <a href="https://sitemaps.org/">sitemaps.org</a> and Google's <a href="https://code.google.com/archive/p/sitemap-generators/wikis/SitemapGenerators.wiki">list of sitemap programs</a>.</p>
+          <p>This sitemap contains <strong><xsl:value-of select="count(sitemap:urlset/sitemap:url)"/></strong> URLs.</p>
+        </div>
+        <div id="content">
+          <table class="list" cellpadding="5">
+            <tr style="border-bottom:1px black solid;">
+              <th>Location</th>
+              <th>Last Modification</th>
+            </tr>
+            <xsl:for-each select="sitemap:urlset/sitemap:url">
+              <tr>
+                <xsl:if test="position() mod 2 != 1">
+                  <xsl:attribute  name="class">high</xsl:attribute>
+                </xsl:if>
+                <td>
+                  <xsl:variable name="itemURL">
+                    <xsl:value-of select="sitemap:loc"/>
+                  </xsl:variable>
+                  <a href="{$itemURL}">
+                    <xsl:value-of select="sitemap:loc"/>
+                  </a>
+                </td>
+                <td>
+                  <xsl:value-of select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)))"/>
+                </td>
+              </tr>
+            </xsl:for-each>
+          </table>
+        </div>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/14688

In the same spirit as the plugin to fetch remote resources, create a new one to update our sitemap.

Also enables sitemap generation in development so we can preview sitemap changes. Since Jekyll 4, sitemap generation is pretty well optimized and takes less than 3 seconds for our docs so I think we can enable it.

I also added another commit which adds a sitemap xsl, so we can easily browse our sitemap:

![image](https://user-images.githubusercontent.com/1951866/169455013-b867910e-6fcb-446d-9f36-599b6692cad8.png)
