### PR TITLE
fix broken urls in swagger files for engine api

### DIFF
--- a/_plugins/fetch_remote.rb
+++ b/_plugins/fetch_remote.rb
@@ -49,14 +49,6 @@ module Jekyll
         end
       end
 
-      Jekyll.logger.info "  Fixing up URLs in swagger files"
-      Dir.glob("./engine/api/*.yaml") do |file_name|
-        Jekyll.logger.info "    #{file_name}"
-        text = File.read(file_name)
-        replace = text.gsub!("https://docs.docker.com/", "")
-        File.open(file_name, "w") { |file| file.puts replace }
-      end
-
       end_time = Time.now
       Jekyll.logger.info "done in #{(end_time - beginning_time)} seconds"
     end

--- a/_plugins/fix_urls.rb
+++ b/_plugins/fix_urls.rb
@@ -1,0 +1,24 @@
+require 'jekyll'
+require 'octopress-hooks'
+
+module Jekyll
+
+  class FetchRemote < Octopress::Hooks::Site
+    def post_read(site)
+      beginning_time = Time.now
+      Jekyll.logger.info "Starting plugin fix_urls.rb..."
+
+      Jekyll.logger.info "  Fixing up URLs in swagger files"
+      Dir.glob(%w[./docker-hub/api/*.yaml ./engine/api/*.yaml]) do |file_name|
+        Jekyll.logger.info "    #{file_name}"
+        text = File.read(file_name)
+        replace = text.gsub!("https://docs.docker.com", "")
+        File.open(file_name, "w") { |file| file.puts replace }
+      end
+
+      end_time = Time.now
+      Jekyll.logger.info "done in #{(end_time - beginning_time)} seconds"
+    end
+  end
+
+end


### PR DESCRIPTION
URLs of some images are broken for the engine api because of a missing leading slash: https://docs.docker.com/engine/api/v1.41/

![image](https://user-images.githubusercontent.com/1951866/169639547-dcbc28b0-77cf-44a8-96ad-ab51a4cd27a3.png)

I took the opportunity with this change to also move the logic in a dedicated plugin that will run in `post_read` (e.g., will be done after `pre_read` like the fetch remote resources plugin) and also added `./docker-hub/api/*.yaml` pattern which was not covered previously.

We didn't catch that because htmlproofer ignores this folder: https://github.com/docker/docker.github.io/blob/8d6bd6bdb5c1b7b23d196e62760b93b89a588661/Dockerfile#L77

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>