### PR TITLE
Fix markdown syntax error

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1613,7 +1613,7 @@ web:
 
 ### scale
 
--DEPRECATED: use [deploy/replicas](deploy.md#replicas)_
+_DEPRECATED: use [deploy/replicas](deploy.md#replicas)_
 
 `scale` specifies the default number of containers to deploy for this service.
 


### PR DESCRIPTION
### Proposed changes

Fixed an italic marker on the [_Compose specification_](https://docs.docker.com/compose/compose-file/) page.

Marker was `-TEXT_`, and fixed to `_TEXT_`
