### PR TITLE
switch to ruby markdownlint and add ci validation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-webpack.config.js
-server/index.js
-server/env.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,12 @@ jobs:
 
   validate:
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - htmlproofer
+          - mdl
     steps:
       -
         name: Checkout
@@ -36,14 +42,12 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Check for broken links
+        name: Validate
         uses: docker/bake-action@v2
         with:
-          targets: htmlproofer
+          targets: ${{ matrix.target }}
           set: |
             *.cache-from=type=gha,scope=build
-            *.cache-from=type=gha,scope=validate
-            *.cache-to=type=gha,scope=validate,mode=max
 
       # Disabled netlify-deploy due to flakey 502 http errors
       # - name: copy static files

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,0 @@
-{
-    "default": true,
-    "MD013": { "line_length": -1 },
-    "MD030": { "ol_multi": 2 }
-}

--- a/.mdlrc.style.rb
+++ b/.mdlrc.style.rb
@@ -1,0 +1,7 @@
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+
+# Start with all built-in rules.
+all
+
+rule 'MD013', :line_length => -1
+rule 'MD030', :ol_multi => 2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,0 @@
-# It's pretty common for devs to have prettier configured to format on save,
-# so let's include some config to prevent it messing up files in this repo
-
-# Prettier struggles with the kramdown extensions
-*.md
-
-# Our stylesheets use a particular in-house(?) style
-*.scss

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,11 @@ RUN --mount=type=bind,from=generate,source=/out,target=_site \
     --file-ignore="/^./_site/engine/api/.*$/,./_site/registry/configuration/index.html" \
     --url-ignore="/^/docker-hub/api/latest/.*$/,/^/engine/api/v.+/#.*$/,/^/glossary/.*$/"
 
+# mdl is a lint tool for markdown files
+FROM gem AS mdl
+RUN --mount=type=bind,target=. \
+  mdl --rules .mdlrc.style.rb .
+
 # Release the generated files in a scratch image
 # Can be output to your host with:
 # > make release

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,6 @@ gem 'rouge', '3.27.0'
 
 gem 'archive-zip', '0.12.0'
 gem 'html-proofer', '3.19.4'
+gem 'mdl', '0.11.0'
 gem 'octopress-hooks', '2.6.2'
 gem 'rake', '13.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
+    chef-utils (17.10.0)
+      concurrent-ruby
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
     em-websocket (0.5.3)
@@ -60,8 +62,19 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    mdl (0.11.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
     mercenary (0.4.0)
     mini_portile2 (2.8.0)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.9)
+      tomlrb
+    mixlib-shellout (3.2.7)
+      chef-utils
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -88,6 +101,7 @@ GEM
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    tomlrb (2.0.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (1.8.0)
@@ -105,6 +119,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-relative-links
   jekyll-sitemap
+  mdl (= 0.11.0)
   octopress-hooks (= 2.6.2)
   rake (= 13.0.6)
   rouge (= 3.27.0)

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,13 @@ vendor:
 htmlproofer:
 	$(BUILDX_CMD) bake htmlproofer
 
+# Lint tool for markdown files
+mdl:
+	$(BUILDX_CMD) bake mdl
+
 # Deploy website and run it through Docker compose
 # Available in your browser at http://localhost:4000
 deploy:
 	docker compose up --build
 
-.PHONY: buildx-yaml release vendor htmlproofer deploy
+.PHONY: buildx-yaml release vendor htmlproofer mdl deploy

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,16 +2,20 @@ variable "JEKYLL_ENV" {
   default = "development"
 }
 
+target "_common" {
+  args = {
+    JEKYLL_ENV = JEKYLL_ENV
+  }
+  no-cache-filter = ["generate"]
+}
+
 group "default" {
   targets = ["release"]
 }
 
 target "release" {
+  inherits = ["_common"]
   target = "release"
-  args = {
-    JEKYLL_ENV = JEKYLL_ENV
-  }
-  no-cache-filter = ["generate"]
   output = ["./_site"]
 }
 
@@ -20,10 +24,18 @@ target "vendor" {
   output = ["."]
 }
 
+group "validate" {
+  targets = ["htmlproofer", "mdl"]
+}
+
 target "htmlproofer" {
+  inherits = ["_common"]
   target = "htmlproofer"
-  args = {
-    JEKYLL_ENV = JEKYLL_ENV
-  }
+  output = ["type=cacheonly"]
+}
+
+target "mdl" {
+  inherits = ["_common"]
+  target = "mdl"
   output = ["type=cacheonly"]
 }


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/10305

like htmlproofer, switch to ruby markdownlint gem and add a matrix in the validate job to run markdownlint on ci.

```shell
$ make mdl
# or
$ docker buildx bake mdl
```