### PR TITLE
Update to use "/etc/apt/keyrings" per APT maintainers recommendations

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -92,7 +92,8 @@ from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    $ sudo mkdir -p /etc/apt/keyrings
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     ```
 
 3.  Use the following command to set up the **stable** repository. To add the
@@ -101,7 +102,7 @@ from the repository.
 
     ```console
     $ echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
@@ -128,7 +129,7 @@ This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and Ras
     >  
     > Your default umask may not be set correctly, causing the public key file
     > for the repo to not be detected. Run the following command and then try to
-    > update your repo again: `sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg`.
+    > update your repo again: `sudo chmod a+r /etc/apt/keyrings/docker.gpg`.
 
 2.  To install a _specific version_ of Docker Engine, list the available versions
     in the repo, then select and install:

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -118,7 +118,8 @@ from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    $ sudo mkdir -p /etc/apt/keyrings
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     ```
 
 3.  Use the following command to set up the **stable** repository. To add the
@@ -127,7 +128,7 @@ from the repository.
 
     ```console
     $ echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ download-url-base }} \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 


### PR DESCRIPTION
See https://tracker.debian.org/news/1305679/accepted-apt-240-source-into-unstable/:

    * Install an empty /etc/apt/keyrings directory.
      This directory is intended to provide an alternative to
      /usr/share/keyrings for placing keys used with signed-by.

See also https://wiki.debian.org/DebianRepository/UseThirdParty?action=diff&rev2=47&rev1=46 (which was edited following a discussion with the APT maintainers about the expected usage):

> If future updates to the key will be managed by an apt/dpkg package as recommended below, then it SHOULD be downloaded into `/usr/share/keyrings` using the same filename that will be provided by the package. If it will be managed locally , it SHOULD be downloaded into `/etc/apt/keyrings` instead.