### PR TITLE
Update note about the availability of DD4L

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -5,11 +5,6 @@ title: Install Docker Compose
 toc_max: 2
 ---
 
-> **Accelerating new features in Docker Desktop**
->
-> Docker Desktop helps you build, share, and run containers easily on Mac and Windows as you do on Linux. Docker handles the complex setup and allows you to focus on writing the code. Thanks to the positive support we received on the [subscription updates](https://www.docker.com/blog/updating-product-subscriptions/){: target="_blank" rel="noopener" class="_" id="dkr_docs_cta"}, we've started working on [Docker Desktop for Linux](https://www.docker.com/blog/accelerating-new-features-in-docker-desktop/){: target="_blank" rel="noopener" class="_" id="dkr_docs_cta"} which is the second-most popular feature request in our public roadmap. If you are interested in early access, sign up for our [Developer Preview program](https://www.docker.com/community/get-involved/developer-preview){: target="_blank" rel="noopener" class="_" id="dkr_docs_cta"}.
-{: .important}
-
 This page contains information on how to install Docker Compose. You can run Compose on macOS, Windows, and 64-bit Linux.
 
 ## Prerequisites

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -32,8 +32,8 @@ redirect_from:
 >
 > Docker Desktop helps you build, share, and run containers easily on Mac and
 > Windows as you do on Linux. We are excited to share that Docker Desktop for
-> Linux is now available for you to test. For more information, see
-[Docker Desktop for Linux](../../desktop/linux/index.md).
+> Linux is now GA. For more information, see
+[Docker Desktop for Linux](../../desktop/linux/install.md).
 {: .important}
 
 ## Supported platforms

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -20,8 +20,8 @@ toc_max: 4
 >
 > Docker Desktop helps you build, share, and run containers easily on Mac and
 > Windows as you do on Linux. We are excited to share that Docker Desktop for
-> Linux (Beta) is now available for you to test. For more information, see
-[Docker Desktop for Linux](../../desktop/linux/index.md).
+> Linux is now GA. For more information, see
+[Docker Desktop for Linux](../../desktop/linux/install.md).
 {: .important}
 
 To get started with Docker Engine on Ubuntu, make sure you


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com>

Docker Desktop for Linux is now GA. Updated the note to reflect this change.