### PR TITLE
engine: remove some redundant information

### DIFF
--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -80,7 +80,7 @@ from the repository.
 {% assign download-url-base = "https://download.docker.com/linux/centos" %}
 
 Install the `yum-utils` package (which provides the `yum-config-manager`
-utility) and set up the **stable** repository.
+utility) and set up the repository.
 
 ```console
 $ sudo yum install -y yum-utils
@@ -90,35 +90,10 @@ $ sudo yum-config-manager \
     {{ download-url-base }}/docker-ce.repo
 ```
 
-> **Optional**: Enable the **nightly** or **test** repositories.
->
-> These repositories are included in the `docker.repo` file above but are disabled
-> by default. You can enable them alongside the stable repository.  The following
-> command enables the **nightly** repository.
->
-> ```console
-> $ sudo yum-config-manager --enable docker-ce-nightly
-> ```
->
-> To enable the **test** channel, run the following command:
->
-> ```console
-> $ sudo yum-config-manager --enable docker-ce-test
-> ```
->
-> You can disable the **nightly** or **test** repository by running the
-> `yum-config-manager` command with the `--disable` flag. To re-enable it, use
-> the `--enable` flag. The following command disables the **nightly** repository.
->
-> ```console
-> $ sudo yum-config-manager --disable docker-ce-nightly
-> ```
->
-> [Learn about **nightly** and **test** channels](index.md).
-
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose
+    or go to the next step to install a specific version:
 
     ```console
     $ sudo yum install docker-ce docker-ce-cli containerd.io docker-compose-plugin
@@ -126,13 +101,6 @@ $ sudo yum-config-manager \
 
     If prompted to accept the GPG key, verify that the fingerprint matches
     `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
-
-    > Got multiple Docker repositories?
-    >
-    > If you have multiple Docker repositories enabled, installing
-    > or updating without specifying a version in the `yum install` or
-    > `yum update` command always installs the highest possible version,
-    > which may not be appropriate for your stability needs.
 
     This command installs Docker, but it doesn't start Docker. It also creates a
     `docker` group, however, it doesn't add any users to the group by default.
@@ -203,12 +171,6 @@ a new file each time you want to upgrade Docker Engine.
     and choose your version of CentOS. Then browse to `x86_64/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
 
-    > **Note**
-    >
-    > To install a **nightly** or **test** (pre-release) package,
-    > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](index.md).
-
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
@@ -253,7 +215,7 @@ instead of `yum -y install`, and point to the new file.
 1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -41,7 +41,9 @@ $ sudo apt-get remove docker docker-engine docker.io containerd runc
 It's OK if `apt-get` reports that none of these packages are installed.
 
 The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine package is now called `docker-ce`.
+networks, are preserved. If you do not need to save your existing data, and want to
+start with a clean installation, refer to the [uninstall Docker Engine](#uninstall-docker-engine)
+section at the bottom of this page.
 
 ## Installation methods
 
@@ -96,9 +98,7 @@ from the repository.
     $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     ```
 
-3.  Use the following command to set up the **stable** repository. To add the
-    **nightly** or **test** repository, add the word `nightly` or `test` (or both)
-    after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](index.md).
+3.  Use the following command to set up the repository:
 
     ```console
     $ echo \
@@ -117,13 +117,6 @@ This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and Ras
     $ sudo apt-get update
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
-
-    > Got multiple Docker repositories?
-    >
-    > If you have multiple Docker repositories enabled, installing
-    > or updating without specifying a version in the `apt-get install` or
-    > `apt-get update` command always installs the highest possible version,
-    > which may not be appropriate for your stability needs.
 
     > Receiving a GPG error when running `apt-get update`?
     >  
@@ -183,12 +176,6 @@ a new file each time you want to upgrade Docker.
     choose your Debian version, then browse to `pool/stable/`, choose `amd64`,
     `armhf`, or `arm64`, and download the `.deb` file for the Docker Engine
     version you want to install.
-
-    > **Note**
-    >
-    > To install a **nightly** or **test** (pre-release) package,
-    > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](index.md).
 
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -75,7 +75,7 @@ from the repository.
 {% assign download-url-base = "https://download.docker.com/linux/fedora" %}
 
 Install the `dnf-plugins-core` package (which provides the commands to manage
-your DNF repositories) and set up the **stable** repository.
+your DNF repositories) and set up the repository.
 
 ```console
 $ sudo dnf -y install dnf-plugins-core
@@ -85,36 +85,10 @@ $ sudo dnf config-manager \
     {{ download-url-base }}/docker-ce.repo
 ```
 
-> **Optional**: Enable the **nightly** or **test** repositories.
->
-> These repositories are included in the `docker.repo` file above but are disabled
-> by default. You can enable them alongside the stable repository.  The following
-> command enables the **nightly** repository.
->
-> ```console
-> $ sudo dnf config-manager --set-enabled docker-ce-nightly
-> ```
->
-> To enable the **test** channel, run the following command:
->
-> ```console
-> $ sudo dnf config-manager --set-enabled docker-ce-test
-> ```
->
-> You can disable the **nightly** or **test** repository by running the
-> `dnf config-manager` command with the `--set-disabled` flag. To re-enable it,
-> use the `--set-enabled` flag. The following command disables the **nightly**
-> repository.
->
-> ```console
-> $ sudo dnf config-manager --set-disabled docker-ce-nightly
-> ```
->
-> [Learn about **nightly** and **test** channels](index.md).
-
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine and containerd, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose
+    or go to the next step to install a specific version:
 
     ```console
     $ sudo dnf install docker-ce docker-ce-cli containerd.io docker-compose-plugin
@@ -122,13 +96,6 @@ $ sudo dnf config-manager \
 
     If prompted to accept the GPG key, verify that the fingerprint matches
     `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
-
-    > Got multiple Docker repositories?
-    >
-    > If you have multiple Docker repositories enabled, installing
-    > or updating without specifying a version in the `dnf install` or
-    > `dnf update` command always installs the highest possible version,
-    > which may not be appropriate for your stability needs.
 
     This command installs Docker, but it doesn't start Docker. It also creates a
     `docker` group, however, it doesn't add any users to the group by default.
@@ -199,12 +166,6 @@ a new file each time you want to upgrade Docker Engine.
     and choose your version of Fedora. Then browse to `x86_64/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
 
-    > **Note**
-    >
-    > To install a **nightly** or **test** (pre-release) package,
-    > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](index.md).
-
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.
 
@@ -246,7 +207,7 @@ instead of `dnf -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, Containerd and Docker Compose packages:
+1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
     $ sudo dnf remove docker-ce docker-ce-cli containerd.io docker-compose-plugin

--- a/engine/install/index.md
+++ b/engine/install/index.md
@@ -98,14 +98,11 @@ These binaries are statically linked and can be used on any Linux distribution.
 
 ## Release channels
 
-Docker Engine has three types of update channels, **stable**, **test**,
-and **nightly**:
+Docker Engine has two types of update channels, **stable** and **test**:
 
 * The **Stable** channel gives you latest releases for general availability.
 * The **Test** channel gives pre-releases that are ready for testing before
   general availability (GA).
-* The **Nightly** channel gives you latest builds of work in progress for the
-  next major release.
 
 ### Stable
 
@@ -124,20 +121,6 @@ Docker for the release have achieved feature-complete. Pre-releases
 such as betas and release candidates are conducted from their respective release
 branches. Patch releases and the corresponding pre-releases are performed
 from within the corresponding release branch.
-
-### Nightly
-
-Nightly builds give you the latest builds of work in progress for the next major
-release. They are created once per day from the master branch with the version
-format:
-
-    0.0.0-YYYYmmddHHMMSS-abcdefabcdef
-
-where the time is the commit time in UTC and the final suffix is the prefix
-of the commit hash, for example `0.0.0-20180720214833-f61e0f7`.
-
-These builds allow for testing from the latest code on the master branch. No
-qualifications or guarantees are made for the nightly builds.
 
 ## Support
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -85,7 +85,7 @@ from the repository.
 {% assign download-url-base = "https://download.docker.com/linux/rhel" %}
 
 Install the `yum-utils` package (which provides the `yum-config-manager`
-utility) and set up the **stable** repository.
+utility) and set up the repository.
 
 ```console
 $ sudo yum install -y yum-utils
@@ -95,35 +95,10 @@ $ sudo yum-config-manager \
     {{ download-url-base }}/docker-ce.repo
 ```
 
-> **Optional**: Enable the **nightly** or **test** repositories.
->
-> These repositories are included in the `docker.repo` file above but are disabled
-> by default. You can enable them alongside the stable repository.  The following
-> command enables the **nightly** repository.
->
-> ```console
-> $ sudo yum-config-manager --enable docker-ce-nightly
-> ```
->
-> To enable the **test** channel, run the following command:
->
-> ```console
-> $ sudo yum-config-manager --enable docker-ce-test
-> ```
->
-> You can disable the **nightly** or **test** repository by running the
-> `yum-config-manager` command with the `--disable` flag. To re-enable it, use
-> the `--enable` flag. The following command disables the **nightly** repository.
->
-> ```console
-> $ sudo yum-config-manager --disable docker-ce-nightly
-> ```
->
-> [Learn about **nightly** and **test** channels](index.md).
-
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose
+    or go to the next step to install a specific version:
 
     ```console
     $ sudo yum install docker-ce docker-ce-cli containerd.io docker-compose-plugin
@@ -131,13 +106,6 @@ $ sudo yum-config-manager \
 
     If prompted to accept the GPG key, verify that the fingerprint matches
     `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
-
-    > Got multiple Docker repositories?
-    >
-    > If you have multiple Docker repositories enabled, installing
-    > or updating without specifying a version in the `yum install` or
-    > `yum update` command always installs the highest possible version,
-    > which may not be appropriate for your stability needs.
 
     This command installs Docker, but it doesn't start Docker. It also creates a
     `docker` group, however, it doesn't add any users to the group by default.
@@ -206,12 +174,6 @@ a new file each time you want to upgrade Docker Engine.
 1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
     and choose your version of RHEL. Then browse to `s390x/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
-
-    > **Note**
-    >
-    > To install a **nightly** or **test** (pre-release) package,
-    > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](index.md).
 
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -101,39 +101,16 @@ from the repository.
 
 {% assign download-url-base = "https://download.docker.com/linux/sles" %}
 
-Set up the **stable** repository.
+Set up the repository.
 
 ```console
 $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
 ```
 
-> **Optional**: Enable the **nightly** or **test** repositories.
->
-> These repositories are included in the `docker.repo` file above but are disabled
-> by default. You can enable them alongside the stable repository.  The following
-> command enables the **nightly** repository.
->
-> ```console
-> $ sudo zypper mr -e docker-ce-nightly
-> ```
->
-> To enable the **test** channel, run the following command:
->
-> ```console
-> $ sudo zypper mr -e docker-ce-test
-> ```
->
-> You can disable the **nightly** or **test** repository by running the
-> ```console
-> $ sudo zypper mr -d docker-ce-nightly
-> $ sudo zypper mr -d docker-ce-test
-> ```
->
-> [Learn about **nightly** and **test** channels](index.md).
-
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
+1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose
+    or go to the next step to install a specific version:
 
     ```console
     $ sudo zypper install docker-ce docker-ce-cli containerd.io docker-compose-plugin
@@ -141,13 +118,6 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
 
     If prompted to accept the GPG key, verify that the fingerprint matches
     `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
-
-    > Got multiple Docker repositories?
-    >
-    > If you have multiple Docker repositories enabled, installing
-    > or updating without specifying a version in the `zypper install` or
-    > `zypper update` command always installs the highest possible version,
-    > which may not be appropriate for your stability needs.
 
     This command installs Docker, but it doesn't start Docker. It also creates a
     `docker` group, however, it doesn't add any users to the group by default.
@@ -214,12 +184,6 @@ a new file each time you want to upgrade Docker Engine.
 1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
     and choose your version of SLES. Then browse to `15/s390x/stable/Packages/`
     and download the `.rpm` file for the Docker version you want to install.
-
-    > **Note**
-    >
-    > To install a **nightly** or **test** (pre-release) package,
-    > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](index.md).
 
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -42,15 +42,6 @@ versions:
 
 Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, `arm64`, and `s390x` architectures.
 
-> Ubuntu 16.04 LTS "Xenial Xerus" end-of-life
-> 
-> Ubuntu Linux 16.04 LTS reached the end of its five-year LTS window on April
-> 30th 2021 and is no longer supported. Docker no longer releases packages for
-> this distribution (including patch- and security releases). Users running
-> Docker on Ubuntu 16.04 are recommended to update their system to a currently
-> supported LTS version of Ubuntu.
-{: .important }
-
 ### Uninstall old versions
 
 Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
@@ -146,14 +137,14 @@ from the repository.
     ```console
     $ apt-cache madison docker-ce
 
-      docker-ce | 5:18.09.1~3-0~ubuntu-xenial | {{ download-url-base }}  xenial/stable amd64 Packages
-      docker-ce | 5:18.09.0~3-0~ubuntu-xenial | {{ download-url-base }}  xenial/stable amd64 Packages
-      docker-ce | 18.06.1~ce~3-0~ubuntu       | {{ download-url-base }}  xenial/stable amd64 Packages
-      docker-ce | 18.06.0~ce~3-0~ubuntu       | {{ download-url-base }}  xenial/stable amd64 Packages
+    docker-ce | 5:20.10.16~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
+    docker-ce | 5:20.10.15~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
+    docker-ce | 5:20.10.14~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
+    docker-ce | 5:20.10.13~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
     ```
 
     b. Install a specific version using the version string from the second column,
-       for example, `5:18.09.1~3-0~ubuntu-xenial`.
+       for example, `5:20.10.16~3-0~ubuntu-jammy`.
 
     ```console
     $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io docker-compose-plugin

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -67,14 +67,6 @@ networks, are preserved. If you do not need to save your existing data, and want
 start with a clean installation, refer to the [uninstall Docker Engine](#uninstall-docker-engine)
 section at the bottom of this page.
 
-### Supported storage drivers
-
-Docker Engine on Ubuntu supports `overlay2`, `aufs` and `btrfs` storage drivers.
-
-Docker Engine uses the `overlay2` storage driver by default. If you need to use
-`aufs` instead, you need to configure it manually.
-See [use the AUFS storage driver](../../storage/storagedriver/aufs-driver.md)
-
 ## Installation methods
 
 You can install Docker Engine in different ways, depending on your needs:
@@ -122,9 +114,7 @@ from the repository.
     $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     ```
 
-3.  Use the following command to set up the **stable** repository. To add the
-    **nightly** or **test** repository, add the word `nightly` or `test` (or both)
-    after the word `stable` in the commands below. [Learn about **nightly** and **test** channels](index.md).
+3.  Use the following command to set up the repository:
 
     ```console
     $ echo \
@@ -142,12 +132,11 @@ from the repository.
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
-    > Got multiple Docker repositories?
-    >
-    > If you have multiple Docker repositories enabled, installing
-    > or updating without specifying a version in the `apt-get install` or
-    > `apt-get update` command always installs the highest possible version,
-    > which may not be appropriate for your stability needs.
+    > Receiving a GPG error when running `apt-get update`?
+    >  
+    > Your default umask may not be set correctly, causing the public key file
+    > for the repo to not be detected. Run the following command and then try to
+    > update your repo again: `sudo chmod a+r /etc/apt/keyrings/docker.gpg`.
 
 2.  To install a _specific version_ of Docker Engine, list the available versions
     in the repo, then select and install:
@@ -201,12 +190,6 @@ a new file each time you want to upgrade Docker.
     choose your Ubuntu version, then browse to `pool/stable/`, choose `amd64`,
     `armhf`, `arm64`, or `s390x`, and download the `.deb` file for the Docker Engine
     version you want to install.
-
-    > **Note**
-    >
-    > To install a **nightly** or **test** (pre-release) package,
-    > change the word `stable` in the above URL to `nightly` or `test`.
-    > [Learn about **nightly** and **test** channels](index.md).
 
 2.  Install Docker Engine, changing the path below to the path where you downloaded
     the Docker package.

--- a/engine/release-notes/18.09.md
+++ b/engine/release-notes/18.09.md
@@ -5,6 +5,19 @@ toc_max: 2
 skip_read_time: true
 ---
 
+> **Note:**
+>
+> With this release, the daemon, client and container runtime are now all shipped
+> in separate packages. When updating, you need to update all packages at the same
+> time to get the latest patch releases for each. For example, on Ubuntu:
+> 
+> ```console
+> $ sudo apt-get install docker-ce docker-ce-cli containerd.io
+> ```
+> 
+> See the [installation instructions](../install/index.md) for the corresponding
+> Linux distro for details.
+
 ## 18.09.9
 2019-09-03
 

--- a/engine/release-notes/index.md
+++ b/engine/release-notes/index.md
@@ -13,14 +13,6 @@ redirect_from:
 This document describes the latest changes, additions, known issues, and fixes
 for Docker Engine.
 
-> **Note:**
->
-> The client and container runtime are now in separate packages from the daemon
-> in Docker Engine 18.09. Users should install and update all three packages at
-> the same time to get the latest patch releases. For example, on Ubuntu:
-> `sudo apt install docker-ce docker-ce-cli containerd.io`. See the install
-> instructions for the corresponding linux distro for details.
-
 # Version 20.10
 
 ## 20.10.16

--- a/engine/security/apparmor.md
+++ b/engine/security/apparmor.md
@@ -215,9 +215,6 @@ looks like the following:
 In the above example, you can see `profile=/usr/bin/docker`. This means the
 user has the `docker-engine` (Docker Engine Daemon) profile loaded.
 
-> **Note**: On version of Ubuntu > 14.04 this is all fine and well, but Trusty
-> users might run into some issues when trying to `docker container exec`.
-
 Look at another log line:
 
 ```

--- a/engine/security/seccomp.md
+++ b/engine/security/seccomp.md
@@ -18,11 +18,6 @@ $ grep CONFIG_SECCOMP= /boot/config-$(uname -r)
 CONFIG_SECCOMP=y
 ```
 
-> **Note**: `seccomp` profiles require seccomp 2.2.1 which is not available on
-> Ubuntu 14.04, Debian Wheezy, or Debian Jessie. To use `seccomp` on these
-> distributions, you must download the [latest static Linux binaries](../install/binaries.md)
-> (rather than packages).
-
 ## Pass a profile for a container
 
 The default `seccomp` profile provides a sane default for running containers with

--- a/storage/storagedriver/zfs-driver.md
+++ b/storage/storagedriver/zfs-driver.md
@@ -29,14 +29,6 @@ use unless you have substantial experience with ZFS on Linux.
 
 - ZFS requires one or more dedicated block devices, preferably solid-state
   drives (SSDs).
-- ZFS is only supported on Docker Engine - Community with Ubuntu 14.04 or higher, with the `zfs`
-  package (16.04 and higher) or `zfs-native` and `ubuntu-zfs` packages (14.04)
-  installed.
-  - For Ubuntu 14.04, you need to enable a supplemental package repository
-    `ppa:zfs-native/stable` before you can install the package. See
-    [https://launchpad.net/~zfs-native/+archive/ubuntu/stable](https://launchpad.net/~zfs-native/+archive/ubuntu/stable){: target="_blank" rel="noopener" class="_" }
-    for instructions.
-- ZFS is not supported on Docker EE or CS-Engine, or any other Linux platforms.
 - The `/var/lib/docker/` directory must be mounted on a ZFS-formatted
   filesystem.
 - Changing the storage driver makes any containers you have already
@@ -46,8 +38,8 @@ use unless you have substantial experience with ZFS on Linux.
 
 > **Note**
 >
-> There is no need to use `MountFlags=slave` with Docker Engine 18.09 or
-> later because `dockerd` and `containerd` are in different mount namespaces. 
+> There is no need to use `MountFlags=slave` because `dockerd` and `containerd`
+> are in different mount namespaces. 
 
 ## Configure Docker with the `zfs` storage driver
 


### PR DESCRIPTION
### engine: remove instructions for "nightly" and "test" channels

The "nightly" channel hasn't been updated for a long time, so while it's
not actively updated, we should not show instructions for it.

The "test" channel is still updated in preparation of new releases, but
including the instructions in between the regular installation procedure
introduced quite some "noise" that's irrelevant to most users (who would
be installing the "stable" channel).

This patch removes the instructions to enable the nightly and test channels
from the installation instructions.

While making these changes, I also synced somme wording between distros
for consistency, and removed a stray section about storage-drivers, as
that's already outlined in the "optional post-installation steps".

### engine: remove warning about Ubuntu 16.04 "xenial" EOL

This warning has been in place for a Year, and while there's
still users running on this version of Ubuntu, it's not really
our responsibility to notify them about their distro version
being EOL.

### engine: move note about package split to 18.09 release notes

containerd, docker engine and the docker cli were split into separate
packages in the 18.09 release. We kept this note on the release-notes
for current releases, but by now it's mostly "old news", so move the
warning to the 18.09 release notes page (which was the release in which
this change was made).


### engine: remove some mentions of old Ubuntu and Engine versions

These were notes about distro versions that have been EOL for a long
time, and an old version of docker engine that's EOL as well.
