### PR TITLE
Variable presence indication

### DIFF
--- a/network/iptables.md
+++ b/network/iptables.md
@@ -41,7 +41,7 @@ negated rule at the top of the `DOCKER-USER` filter chain. For example, the
 following rule restricts external access from all IP addresses except `192.168.1.1`:
 
 ```console
-$ iptables -I DOCKER-USER -i ext_if ! -s 192.168.1.1 -j DROP
+$ iptables -I DOCKER-USER -i "$ext_if" ! -s 192.168.1.1 -j DROP
 ```
 
 Please note that you will need to change `ext_if` to correspond with your
@@ -49,14 +49,14 @@ host's actual external interface. You could instead allow connections from a
 source subnet. The following rule only allows access from the subnet `192.168.1.0/24`:
 
 ```console
-$ iptables -I DOCKER-USER -i ext_if ! -s 192.168.1.0/24 -j DROP
+$ iptables -I DOCKER-USER -i "$ext_if" ! -s 192.168.1.0/24 -j DROP
 ```
 
 Finally, you can specify a range of IP addresses to accept using `--src-range`
 (Remember to also add `-m iprange` when using `--src-range` or `--dst-range`):
 
 ```console
-$ iptables -I DOCKER-USER -m iprange -i ext_if ! --src-range 192.168.1.1-192.168.1.3 -j DROP
+$ iptables -I DOCKER-USER -m iprange -i "$ext_if" ! --src-range 192.168.1.1-192.168.1.3 -j DROP
 ```
 
 You can combine `-s` or `--src-range` with `-d` or `--dst-range` to control both
@@ -77,7 +77,7 @@ router, you can add explicit `ACCEPT` rules to the `DOCKER-USER` chain to
 allow it:
 
 ```console
-$ iptables -I DOCKER-USER -i src_if -o dst_if -j ACCEPT
+$ iptables -I DOCKER-USER -i "$src_if" -o "$dst_if" -j ACCEPT
 ```
 
 ## Prevent Docker from manipulating iptables


### PR DESCRIPTION
The following may cause some misunderstanding:
```console
$ iptables -I DOCKER-USER -i ext_if # ...
```
I have met people who literally tried searching for `iptables`'s `-i` option argument `ext_if` and returned with no useful enough results considering it an actually defined argument in the scope of iptables. Please consider highlighting the variable presence. For example, "$ext_if", <ext_if>, or <EXT_IF>.

Perhaps, it's worth to mention the `man` conventions:
> For manual pages that describe a command (typically in Sections 1 and 8), the arguments are always specified using italics, even in the SYNOPSIS section.
The name of the command, and its options, should always be formatted in bold.

Source: <https://man7.org/linux/man-pages/man7/man-pages.7.html>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
