### PR TITLE
Add a note that local is a bash keyword

### DIFF
--- a/config/containers/logging/local.md
+++ b/config/containers/logging/local.md
@@ -54,6 +54,8 @@ $ docker run \
       alpine echo hello world
 ```
 
+Note that `local` is a bash reserved keyword, so you may need to quote it in scripts.
+
 ### Options
 
 The `local` logging driver supports the following logging options:


### PR DESCRIPTION
The example will run from the command line, but not as part of a bash script.  It took me an embarrassing several minutes to figure out why my start script wouldn't run with the cryptic error "docker: invalid reference format," so I thought a one-line note was worth making in the documentation.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
