### PR TITLE
Update code example for pre-existing network

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -185,8 +185,8 @@ services:
   # ...
 networks:
   default:
-    external:
-      name: my-pre-existing-network
+    name: my-pre-existing-network
+    external: true
 ```
 
 Instead of attempting to create a network called `[projectname]_default`, Compose looks for a network called `my-pre-existing-network` and connect your app's containers to it.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes
> "network default: network.external.name is deprecated in favor of network.name"

Update the code example to match the new syntax.


### Related issues (optional)

Fixes https://github.com/docker/docker.github.io/issues/14683
