### PR TITLE
[build-docs] build: create Docker Build section

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1398,6 +1398,12 @@ manuals:
     title: Docker Scan
   - path: /engine/sbom/
     title: Docker SBOM (Experimental)
+
+- sectiontitle: Docker Build
+  section:
+    - path: /build/
+      title: Overview
+
 - sectiontitle: Docker Compose
   section:
   - path: /compose/

--- a/build/index.md
+++ b/build/index.md
@@ -1,0 +1,50 @@
+---
+title: Overview of Docker Build
+description: Introduction and overview of Docker Build
+keywords: build, buildx, buildkit
+---
+
+Docker Build is one of the most used features of the Docker Engine - users
+ranging from developers, build teams, and release teams all use Docker Build.
+It uses a [client-server architecture](../get-started/overview.md#docker-architecture)
+that includes several tools. The most common method is to use the Docker CLI with
+[`docker build` command](../engine/reference/commandline/build.md) that sends
+requests to the Docker Engine that will execute your build.
+
+Starting with version 18.09, Docker supports a new backend for executing your
+builds that is provided by the [BuildKit](https://github.com/moby/buildkit)
+project. The BuildKit backend provides many benefits compared to the old
+implementation. As there is a new backend, there is also a new client called [Docker Buildx](../buildx/working-with-buildx.md),
+available as a CLI plugin that extends the docker command with the full
+support of the features provided by BuildKit.
+
+BuildKit is enabled by default for all users on [Docker Desktop](../desktop/index.md).
+If you have installed Docker Desktop, you don't have to manually enable BuildKit.
+If you have installed Docker as a [Linux package](../engine/install/index.md),
+you can enable BuildKit either by using an environment variable or by making
+BuildKit the default setting.
+
+To set the BuildKit environment variable when running the
+[`docker build` command](../engine/reference/commandline/build.md), run:
+
+```console
+$ DOCKER_BUILDKIT=1 docker build .
+```
+
+To enable BuildKit backend by default, set [daemon configuration](/engine/reference/commandline/dockerd/#daemon-configuration-file)
+in `/etc/docker/daemon.json` feature to `true` and restart the daemon. If the
+`daemon.json` file doesn't exist, create new file called `daemon.json` and then
+add the following to the file:
+
+```json
+{
+  "features": {
+    "buildkit": true
+  }
+}
+```
+
+If you're using the [`docker buildx build` command](../engine/reference/commandline/buildx_build.md),
+BuildKit will always being used regardless of the environment variable or backend
+configuration. See [Build with Buildx](../buildx/working-with-buildx.md#build-with-buildx) guide
+for more details.


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/14642

as discussed with @dockertopia we have created a dedicated [build-docs](https://github.com/docker/docker.github.io/tree/build-docs) branch so we can iterate changes over this one and when everything looks good on this branch, merge it to master.

Each PR targeting the build-docs branch should have `[build-docs]` as title prefix.

I have added this branch to netlify deployment so we will able to have an overview of the current progress:

![image](https://user-images.githubusercontent.com/1951866/171857016-619e4970-0930-4dde-adea-ce267b940d26.png)

Changes will be visible at https://build-docs--docsdocker.netlify.app/

cc @dockertopia @chris-crone @tonistiigi @thaJeztah @usha-mandya 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>