### PR TITLE
[build-docs] build: add guides and bake section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -150,6 +150,17 @@ fetch-remote:
           - "!docs/README.md" # readme to make things nice in the compose-cli repo, but meaningless here
           - "!docs/architecture.md" # Compose-CLI architecture, unrelated to cloud integration
 
+  - repo: "https://github.com/crazy-max/buildx" # FIXME: Use https://github.com/docker/buildx
+    ref: "bake-docs" # FIXME: Use master
+    paths:
+      - dest: "build/guides"
+        src:
+          - "docs/guides/*.md"
+          - "!docs/guides/cicd.md" # CI/CD documentation is already handled in ci-cd/github-actions
+      - dest: "build/bake"
+        src:
+          - "docs/guides/bake/**"
+
   - repo: "https://github.com/docker/extensions-sdk"
     ref: "main"
     paths:

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1401,8 +1401,38 @@ manuals:
 
 - sectiontitle: Docker Build
   section:
-    - path: /build/
+  - path: /build/
+    title: Overview
+  - sectiontitle: Bake
+    section:
+    - path: /build/bake/
       title: Overview
+    - path: /build/bake/file-definition/
+      title: File definition
+    - path: /build/bake/configuring-build/
+      title: Configuring builds
+    - path: /build/bake/hcl-funcs/
+      title: User defined HCL functions
+    - path: /build/bake/build-contexts/
+      title: Build contexts and linking targets
+    - path: /build/bake/compose-file/
+      title: Building from Compose file
+  - sectiontitle: Guides
+    section:
+    - path: /build/guides/cni-networking/
+      title: CNI networking
+    - path: /build/guides/custom-network/
+      title: Using a custom network
+    - path: /build/guides/custom-registry-config/
+      title: Using a custom registry config
+    - path: /build/guides/opentelemetry/
+      title: OpenTelemetry support
+    - path: /build/guides/registry-mirror/
+      title: Define a registry mirror
+    - path: /build/guides/remote-builder/
+      title: Remote builder
+    - path: /build/guides/resource-limiting/
+      title: Resource limiting
 
 - sectiontitle: Docker Compose
   section:


### PR DESCRIPTION
follow-up #14644

needs https://github.com/docker/buildx/pull/1140

Fetch build guides and bake from upstream buildx repo in https://github.com/docker/buildx/tree/master/docs/guides

> **Note**
> Use my fork as upstream repo atm so I can also include bake docs from https://github.com/docker/buildx/pull/1140