### PR TITLE
dockerfile: add buildkit syntax reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -127,7 +127,6 @@ fetch-remote:
           - "docs/deprecated.md"
       - dest: "engine/reference"
         src:
-          - "docs/reference/builder.md"
           - "docs/reference/run.md"
       - dest: "engine/reference/commandline"
         src:
@@ -160,3 +159,10 @@ fetch-remote:
       - dest: "registry"
         src:
           - "docs/configuration.md"
+
+  - repo: "https://github.com/crazy-max/buildkit" # FIXME: Use https://github.com/moby/buildkit
+    ref: "dockerfile-ref" # FIXME: Use master
+    paths:
+      - dest: "dockerfile"
+        src:
+          - "frontend/dockerfile/docs/**"

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1082,8 +1082,26 @@ reference:
         title: ExecResultV0
       - path: /desktop/extensions-sdk/dev/api/reference/interfaces/BackendV0/
         title: BackendV0  
-- title: Dockerfile reference
-  path: /engine/reference/builder/
+
+- sectiontitle: Dockerfile reference
+  section:
+    - path: /dockerfile/reference/
+      title: Dockerfile specification
+    - sectiontitle: BuildKit Dockerfile syntax
+      section:
+        - path: /dockerfile/buildkit-syntax/
+          title: Overview
+        - path: /dockerfile/buildkit-syntax/copy-link/
+          title: Linked copies
+        - path: /dockerfile/buildkit-syntax/run-mount/
+          title: Build mounts
+        - path: /dockerfile/buildkit-syntax/run-network/
+          title: Network modes
+        - path: /dockerfile/buildkit-syntax/heredocs/
+          title: Here-Documents
+        - path: /dockerfile/buildkit-syntax/run-security/
+          title: Security context
+
 - sectiontitle: Compose file reference
   section:
     - path: /compose/compose-file/


### PR DESCRIPTION
depends on https://github.com/moby/buildkit/pull/2902 so keeping in draft

Fetch dockerfile reference from buildkit repo as well as the buildkit syntax in https://github.com/crazy-max/buildkit/tree/dockerfile-ref/frontend/dockerfile/docs (use my fork for now):

![image](https://user-images.githubusercontent.com/1951866/172617764-2599bed0-ddfd-4eaa-a74d-009525b140ee.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>