### PR TITLE
build: move buildx to build section

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1388,6 +1388,12 @@ manuals:
       title: Overview
     - path: /build/hellobuild/
       title: Hello Build
+    - sectiontitle: Buildx
+      section:
+        - path: /build/buildx/
+          title: Working with Buildx
+        - path: /build/buildx/install/
+          title: Install Buildx
 
 - sectiontitle: Docker Compose
   section:

--- a/build/buildx/index.md
+++ b/build/buildx/index.md
@@ -1,7 +1,9 @@
 ---
-title: Docker Buildx
+title: Buildx
 description: Working with Docker Buildx
-keywords: Docker, buildx, multi-arch
+keywords: build, buildx, buildkit
+redirect_from:
+- /buildx/working-with-buildx/
 ---
 
 ## Overview
@@ -12,79 +14,7 @@ builder toolkit. It provides the same user experience as docker build with many
 new features like creating scoped builder instances and building against
 multiple nodes concurrently.
 
-## Install
-
-### Docker Desktop
-
-Docker Buildx is included in [Docker Desktop](../desktop/index.md) for Windows, macOS, and Linux.
-
-### Static binaries
-
-Docker Linux packages also include Docker Buildx when installed using the [DEB or RPM packages](../engine/install/index.md).
-
-### Manual download
-
-> **Important**
->
-> This section is for unattended installation of the buildx component. These
-> instructions are mostly suitable for testing purposes. We do not recommend
-> installing buildx using manual download in production environments as they
-> will not be updated automatically with security updates.
->
-> On Windows, macOS, and Linux we recommend that you install [Docker Desktop](../desktop/index.md)
-> instead. 
-{: .important}
-
-You can also download the latest binary from the [releases page on GitHub](https://github.com/docker/buildx/releases/latest){:target="_blank" rel="noopener" class="_"}.
-
-Rename the relevant binary and copy it to the destination matching your OS:
-
-| OS       | Binary name          | Destination folder                       |
-| -------- | -------------------- | -----------------------------------------|
-| Linux    | `docker-buildx`      | `$HOME/.docker/cli-plugins`              |
-| macOS    | `docker-buildx`      | `$HOME/.docker/cli-plugins`              |
-| Windows  | `docker-buildx.exe`  | `%USERPROFILE%\.docker\cli-plugins`      |
-
-Or copy it into one of these folders for installing it system-wide.
-
-On Unix environments:
-
-* `/usr/local/lib/docker/cli-plugins` OR `/usr/local/libexec/docker/cli-plugins`
-* `/usr/lib/docker/cli-plugins` OR `/usr/libexec/docker/cli-plugins`
-
-On Windows:
-
-* `C:\ProgramData\Docker\cli-plugins`
-* `C:\Program Files\Docker\cli-plugins`
-
-> **Note**
-> 
-> On Unix environments, it may also be necessary to make it executable with `chmod +x`:
-> ```shell
-> $ chmod +x ~/.docker/cli-plugins/docker-buildx
-> ```
-
-### Dockerfile
-
-Here is how to install and use Buildx inside a Dockerfile through the
-[`docker/buildx-bin`](https://hub.docker.com/r/docker/buildx-bin) image:
-
-```dockerfile
-FROM docker
-COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
-RUN docker buildx version
-```
-
-## Set buildx as the default builder
-
-Running the command [`docker buildx install`](../engine/reference/commandline/buildx_install.md)
-sets up docker builder command as an alias to `docker buildx`. This results in
-the ability to have [`docker build`](../engine/reference/commandline/build.md)
-use the current buildx builder.
-
-To remove this alias, run [`docker buildx uninstall`](../engine/reference/commandline/buildx_uninstall.md).
-
-## Build with buildx
+## Build with Buildx
 
 To start a new build, run the command `docker buildx build .`
 
@@ -97,11 +27,12 @@ $ docker buildx build .
 Buildx builds using the BuildKit engine and does not require `DOCKER_BUILDKIT=1`
 environment variable to start the builds.
 
-The `docker buildx build` command supports features available for `docker build`,
-including features such as outputs configuration, inline build caching, and
-specifying target platform. In addition, Buildx also supports new features that
-are not yet available for regular `docker build` like building manifest lists,
-distributed caching, and exporting build results to OCI image tarballs.
+The [`docker buildx build` command](../../engine/reference/commandline/buildx_build.md)
+supports features available for `docker build`, including features such as
+outputs configuration, inline build caching, and specifying target platform.
+In addition, Buildx also supports new features that are not yet available for
+regular `docker build` like building manifest lists, distributed caching, and
+exporting build results to OCI image tarballs.
 
 You can run Buildx in different configurations that are exposed through a driver
 concept. Currently, Docker supports a "docker" driver that uses the BuildKit
@@ -128,23 +59,23 @@ the shared daemon, or for isolating builds for different projects. You can creat
 a new instance for a set of remote nodes, forming a build farm, and quickly
 switch between them.
 
-You can create new instances using the [`docker buildx create`](../engine/reference/commandline/buildx_create.md)
+You can create new instances using the [`docker buildx create`](../../engine/reference/commandline/buildx_create.md)
 command. This creates a new builder instance with a single node based on your
 current configuration.
 
 To use a remote node you can specify the `DOCKER_HOST` or the remote context name
 while creating the new builder. After creating a new instance, you can manage its
-lifecycle using the [`docker buildx inspect`](../engine/reference/commandline/buildx_inspect.md),
-[`docker buildx stop`](../engine/reference/commandline/buildx_stop.md), and
-[`docker buildx rm`](../engine/reference/commandline/buildx_rm.md) commands.
-To list all available builders, use [`docker buildx ls`](../engine/reference/commandline/buildx_ls.md).
+lifecycle using the [`docker buildx inspect`](../../engine/reference/commandline/buildx_inspect.md),
+[`docker buildx stop`](../../engine/reference/commandline/buildx_stop.md), and
+[`docker buildx rm`](../../engine/reference/commandline/buildx_rm.md) commands.
+To list all available builders, use [`docker buildx ls`](../../engine/reference/commandline/buildx_ls.md).
 After creating a new builder you can also append new nodes to it.
 
-To switch between different builders, use [`docker buildx use <name>`](../engine/reference/commandline/buildx_use.md).
+To switch between different builders, use [`docker buildx use <name>`](../../engine/reference/commandline/buildx_use.md).
 After running this command, the build commands will automatically use this
 builder.
 
-Docker also features a [`docker context`](../engine/reference/commandline/context.md)
+Docker also features a [`docker context`](../../engine/reference/commandline/context.md)
 command that you can use to provide names for remote Docker API endpoints. Buildx
 integrates with `docker context` to ensure all the contexts automatically get a
 default builder instance. You can also set the context name as the target when
@@ -163,8 +94,8 @@ platform for the build output, (for example, `linux/amd64`, `linux/arm64`, or
 When the current builder instance is backed by the `docker-container` driver,
 you can specify multiple platforms together. In this case, it builds a manifest
 list which contains images for all specified architectures. When you use this
-image in [`docker run`](../engine/reference/commandline/run.md) or
-[`docker service`](../engine/reference/commandline/service.md), Docker picks
+image in [`docker run`](../../engine/reference/commandline/run.md) or
+[`docker service`](../../engine/reference/commandline/service.md), Docker picks
 the correct image based on the node's platform.
 
 You can build multi-platform images using three different strategies that are
@@ -182,12 +113,13 @@ it automatically loads it through a binary registered in the `binfmt_misc`
 handler.
 
 For QEMU binaries registered with `binfmt_misc` on the host OS to work
-transparently inside containers, they must be statically compiled and registered with the `fix_binary` flag. 
-This requires a kernel >= 4.8 and binfmt-support >= 2.1.7. You can check
-for proper registration by checking if `F` is among the flags in
-`/proc/sys/fs/binfmt_misc/qemu-*`. While Docker Desktop comes preconfigured
-with `binfmt_misc` support for additional platforms, for other installations
-it likely needs to be installed using [`tonistiigi/binfmt`](https://github.com/tonistiigi/binfmt){:target="_blank" rel="noopener" class="_"}
+transparently inside containers, they must be statically compiled and registered
+with the `fix_binary` flag. This requires a kernel >= 4.8 and
+binfmt-support >= 2.1.7. You can check for proper registration by checking if
+`F` is among the flags in `/proc/sys/fs/binfmt_misc/qemu-*`. While Docker
+Desktop comes preconfigured with `binfmt_misc` support for additional platforms,
+for other installations it likely needs to be installed using
+[`tonistiigi/binfmt`](https://github.com/tonistiigi/binfmt){:target="_blank" rel="noopener" class="_"}
 image.
 
 ```console
@@ -207,7 +139,7 @@ $ docker buildx create --append --name mybuild node-arm64
 $ docker buildx build --platform linux/amd64,linux/arm64 .
 ```
 
-Finally, depending on your project, the language that you use may have good 
+Finally, depending on your project, the language that you use may have good
 support for cross-compilation. In that case, multi-stage builds in Dockerfiles
 can be effectively used to build binaries for the platform specified with
 `--platform` using the native architecture of the build node. A list of build
@@ -235,15 +167,15 @@ work. The build commands can be combined with general-purpose command runners
 (for example, `make`). However, these tools generally invoke builds in sequence
 and therefore cannot leverage the full potential of BuildKit parallelization,
 or combine BuildKit’s output for the user. For this use case, we have added a
-command called [`docker buildx bake`](../engine/reference/commandline/buildx_bake.md).
+command called [`docker buildx bake`](../../engine/reference/commandline/buildx_bake.md).
 
-The `bake` command supports building images from compose files, similar to 
-[`docker-compose build`](../engine/reference/commandline/compose_build.md), but allowing all the
-services to be built concurrently as part of a single request.
+The `bake` command supports building images from compose files, similar to
+[`docker-compose build`](../../engine/reference/commandline/compose_build.md),
+but allowing all the services to be built concurrently as part of a single
+request.
 
 There is also support for custom build rules from HCL/JSON files allowing
 better code reuse and different target groups. The design of bake is in very
-early stages and we are looking for feedback from users. Let us know your 
-feedback by creating an issue in the 
-[Docker buildx](https://github.com/docker/buildx/issues){:target="_blank" rel="noopener" class="_"} 
+early stages, and we are looking for feedback from users. Let us know your
+feedback by creating an issue in the [Docker Buildx](https://github.com/docker/buildx/issues){:target="_blank" rel="noopener" class="_"}
 GitHub repository.

--- a/build/buildx/install.md
+++ b/build/buildx/install.md
@@ -1,0 +1,78 @@
+---
+title: Install Docker Buildx
+description: How to install Docker Buildx
+keywords: build, buildx, buildkit
+---
+
+## Docker Desktop
+
+Docker Buildx is included in [Docker Desktop](../../desktop/index.md) for
+Windows, macOS, and Linux.
+
+## Linux packages
+
+Docker Linux packages also include Docker Buildx when installed using the
+[DEB or RPM packages](../../engine/install/index.md).
+
+## Dockerfile
+
+Here is how to install and use Buildx inside a Dockerfile through the
+[`docker/buildx-bin`](https://hub.docker.com/r/docker/buildx-bin) image:
+
+```dockerfile
+FROM docker
+COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+RUN docker buildx version
+```
+
+## Manual download
+
+> **Important**
+>
+> This section is for unattended installation of the buildx component. These
+> instructions are mostly suitable for testing purposes. We do not recommend
+> installing buildx using manual download in production environments as they
+> will not be updated automatically with security updates.
+>
+> On Windows, macOS, and Linux workstations we recommend that you install
+> [Docker Desktop](../../desktop/index.md) instead. For Linux servers, we recommend
+> that you follow the [instructions specific for your distribution](#linux-packages).
+{: .important}
+
+You can also download the latest binary from the [releases page on GitHub](https://github.com/docker/buildx/releases/latest){:target="_blank" rel="noopener" class="_"}.
+
+Rename the relevant binary and copy it to the destination matching your OS:
+
+| OS       | Binary name          | Destination folder                         |
+|----------|----------------------|--------------------------------------------|
+| Linux    | `docker-buildx`      | `$HOME/.docker/cli-plugins`                |
+| macOS    | `docker-buildx`      | `$HOME/.docker/cli-plugins`                |
+| Windows  | `docker-buildx.exe`  | `%USERPROFILE%\.docker\cli-plugins`        |
+
+Or copy it into one of these folders for installing it system-wide.
+
+On Unix environments:
+
+* `/usr/local/lib/docker/cli-plugins` OR `/usr/local/libexec/docker/cli-plugins`
+* `/usr/lib/docker/cli-plugins` OR `/usr/libexec/docker/cli-plugins`
+
+On Windows:
+
+* `C:\ProgramData\Docker\cli-plugins`
+* `C:\Program Files\Docker\cli-plugins`
+
+> **Note**
+>
+> On Unix environments, it may also be necessary to make it executable with `chmod +x`:
+> ```shell
+> $ chmod +x ~/.docker/cli-plugins/docker-buildx
+> ```
+
+## Set buildx as the default builder
+
+Running the command [`docker buildx install`](../../engine/reference/commandline/buildx_install.md)
+sets up docker builder command as an alias to `docker buildx`. This results in
+the ability to have [`docker build`](../../engine/reference/commandline/build.md)
+use the current buildx builder.
+
+To remove this alias, run [`docker buildx uninstall`](../../engine/reference/commandline/buildx_uninstall.md).

--- a/build/index.md
+++ b/build/index.md
@@ -4,13 +4,26 @@ description: Introduction and overview of Docker Build
 keywords: build, buildx, buildkit
 ---
 
-Docker Build is one of Docker Engine’s most used features. Whenever you are creating an image you are using Docker Build. Build is a key part of your software development life cycle allowing you to package and bundle your code and ship it anywhere.
+Docker Build is one of Docker Engine’s most used features. Whenever you are
+creating an image you are using Docker Build. Build is a key part of your
+software development life cycle allowing you to package and bundle your code
+and ship it anywhere.
 
-Engine uses a client-server architecture and is composed of multiple components and tools. The most common method of executing a build is by issuing a `docker build` command from the Docker CLI. The CLI sends the request to Docker Engine which, in turn, executes your build.
+Engine uses a client-server architecture and is composed of multiple components
+and tools. The most common method of executing a build is by issuing a
+`docker build` command from the Docker CLI. The CLI sends the request to Docker
+Engine which, in turn, executes your build.
 
-There are now two components in Engine that can be used to create the build. Starting with the 18.09 release, Engine is shipped with BuildKit, the new component for executing your builds by default.
+There are now two components in Engine that can be used to create the build.
+Starting with the 18.09 release, Engine is shipped with [Moby BuildKit](https://github.com/moby/buildkit){:target="_blank" rel="noopener" class="_"},
+the new component for executing your builds by default.
 
-With BuildKit, the new client Docker Buildx, becomes available as a CLI plugin. 
-<br/>Docker Buildx extends the docker build command - namely through the additional docker buildx build command - and fully supports the new features BuildKit offers.
+With BuildKit, the new client [Docker Buildx](buildx/index.md), becomes
+available as a CLI plugin. Docker Buildx extends the docker build command -
+namely through the additional `docker buildx build` command - and fully
+supports the new features BuildKit offers.
 
-BuildKit is the backend evolution from the Legacy Builder, it comes with new and much improved functionality that can be powerful tools for improving your builds' performance or reusability of your Dockerfiles and it also introduces support for complex scenarios.
+BuildKit is the backend evolution from the Legacy Builder, it comes with new
+and much improved functionality that can be powerful tools for improving your
+builds' performance or reusability of your Dockerfiles, and it also introduces
+support for complex scenarios.

--- a/desktop/multi-arch.md
+++ b/desktop/multi-arch.md
@@ -46,7 +46,7 @@ than just native images.  Buildx accomplishes this by adding new builder
 instances based on BuildKit, and leveraging Docker Desktop's technology stack
 to run non-native binaries.
 
-For more information about the Buildx CLI command, see [Buildx](../buildx/working-with-buildx.md)
+For more information about the Buildx CLI command, see [Buildx](../build/buildx/index.md)
 and the [`docker buildx` command line reference](../engine/reference/commandline/buildx.md).
 
 ### Build and run multi-architecture images

--- a/desktop/previous-versions/2.x-mac.md
+++ b/desktop/previous-versions/2.x-mac.md
@@ -435,7 +435,7 @@ Note that you must sign in and create a Docker ID in order to download Docker De
 Docker Desktop Community 2.1.0.0 contains the following experimental features.
 
 * Docker App: Docker App is a CLI plugin that helps configure, share, and install applications. For more information, see [Working with Docker App](/app/working-with-app/).
-* Docker Buildx: Docker Buildx is a CLI plugin for extended build capabilities with BuildKit. For more information, see [Working with Docker Buildx](/buildx/working-with-buildx/).
+* Docker Buildx: Docker Buildx is a CLI plugin for extended build capabilities with BuildKit. For more information, see [Buildx component](../../build/buildx/index.md).
 
 ### Bug fixes and minor changes
 

--- a/desktop/previous-versions/2.x-windows.md
+++ b/desktop/previous-versions/2.x-windows.md
@@ -557,7 +557,7 @@ Note that you must sign in and create a Docker ID in order to download Docker De
 Docker Desktop Community 2.1.0.0 contains the following experimental features:
 
 * Docker App: Docker App is a CLI plugin that helps configure, share, and install applications. For more information, see [Working with Docker App](/app/working-with-app/).
-* Docker Buildx: Docker Buildx is a CLI plugin for extended build capabilities with BuildKit. For more information, see [Working with Docker Buildx](/buildx/working-with-buildx/).
+* Docker Buildx: Docker Buildx is a CLI plugin for extended build capabilities with BuildKit. For more information, see [Buildx component](../../build/buildx/index.md).
 
 ### Bug fixes and minor changes
 

--- a/go/buildx.md
+++ b/go/buildx.md
@@ -1,6 +1,6 @@
 ---
 title: How to install Buildx
 description: Instructions on installing Buildx
-keywords: Docker, buildx, multi-arch
-redirect_to: /buildx/working-with-buildx/#install
+keywords: build, buildx, buildkit
+redirect_to: /build/buildx/install/
 ---


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/14642

Moved "Docker Buildx" section under "Docker Engine" to the new "Docker Build" section and split buildx page with an overview page and an install page. I think it makes sense to have a dedicated install page, specially for the /go redirect to install buildx.

This is just a move without any drastic changes for now. @dockertopia You can make some changes to the install page in a follow-up as you suggested to have something similar to the compose page.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>