### PR TITLE
add `kvm-ok` diagnostics suggestion

### DIFF
--- a/desktop/linux/install.md
+++ b/desktop/linux/install.md
@@ -77,7 +77,7 @@ $ modprobe kvm_intel  # Intel processors
 $ modprobe kvm_amd    # AMD processors
 ```
 
-If the above commands fail, diagnostic info can be surfaced by running:
+If the above commands fail, you can view the diagnostics by running:
 
 ```console
 $ kvm-ok

--- a/desktop/linux/install.md
+++ b/desktop/linux/install.md
@@ -77,6 +77,12 @@ $ modprobe kvm_intel  # Intel processors
 $ modprobe kvm_amd    # AMD processors
 ```
 
+If the above commands fail, diagnostic info can be surfaced by running:
+
+```console
+$ kvm-ok
+```
+
 To check if the KVM modules are enabled, run:
 
 ```console


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->
Added a diagnostic command.

### ~Related issues~

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
No related issue, sorry. This is a drive-by addition of instruction that would have saved me a fair bit of time in my own install. My own issue was that my machine's BIOS had virtualization disabled. `modprobe kvm_intel` was failing with non-instructive error messages (`Operation not supported`), and searching for those messages online was not very useful. `kvm-ok` surfaced

```
INFO: /dev/kvm does notexist
HINT:   sudo modprobe kvm_intel
INFO: Your CPU supports KVM extensions
INFO: KVM (vmx) is disabled by your BIOS
HINT: Enter your BIOS setup and enable Virtualization Technology (VT)
      and then hard poweroff/poweron your system
```

which is extremely instructive.
