### PR TITLE
docs: context refers to desktop-linux

### DIFF
--- a/desktop/linux/install.md
+++ b/desktop/linux/install.md
@@ -202,12 +202,12 @@ default
 Current context is now "default"
 ```
 
-And use the `docker-desktop` context to interact with Docker Desktop:
+And use the `desktop-linux` context to interact with Docker Desktop:
 
 ```console
-$ docker context use docker-desktop
-docker-desktop
-Current context is now "docker-desktop"
+$ docker context use desktop-linux
+desktop-linux
+Current context is now "desktop-linux"
 ```
 
 Refer to the [Docker Context documentation](../../engine/context/working-with-contexts.md) for more details.


### PR DESCRIPTION
The docker context ls command shows the output as desktop-linux but the context use command doesn't match this.

### Proposed changes

The output from the context ls command does not match the context use command later in the documentation.

### Related issues (optional)
