### PR TITLE
Add Wait4X

### DIFF
--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -29,7 +29,7 @@ need this level of resilience, you can work around the problem with a wrapper
 script:
 
 - Use a tool such as [wait-for-it](https://github.com/vishnubob/wait-for-it),
-  [dockerize](https://github.com/powerman/dockerize), sh-compatible
+  [dockerize](https://github.com/powerman/dockerize), [Wait4X](https://github.com/atkrad/wait4x), sh-compatible
   [wait-for](https://github.com/Eficode/wait-for), or [RelayAndContainers](https://github.com/jasonsychau/RelayAndContainers) template. These are small
   wrapper scripts which you can include in your application's image to
   poll a given host and port until it's accepting TCP connections.


### PR DESCRIPTION
### Proposed changes
I want to introduce the [**Wait4X**](https://github.com/atkrad/wait4x) as a waiting tool and also it has a lot of features.

Wait4X allows you to wait for a port or a service to enter the requested state, with a customizable timeout and interval time.

- It supports various protocols: **TCP**, **HTTP** and various services: **Redis**, **MySQL**, **PostgreSQL**, **InfluxDB**, **MongoDB**, **RabbitMQ**
- Reverse Checking: Invert the sense of checking to find a free port or non-ready services
- Parallel Checking: You can define multiple inputs to be checked
- Cross Platform: One single pre-built binary for Linux, Mac OSX, and Windows
- Command execution: Execute your desired command after a successful wait

