### PR TITLE
dockerfile: new reference location

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -138,7 +138,6 @@ fetch-remote:
           - "docs/deprecated.md"
       - dest: "engine/reference"
         src:
-          - "docs/reference/builder.md"
           - "docs/reference/run.md"
       - dest: "engine/reference/commandline"
         src:
@@ -174,3 +173,11 @@ fetch-remote:
       - dest: "registry"
         src:
           - "docs/configuration.md"
+
+  - repo: "https://github.com/moby/buildkit"
+    default_branch: "master"
+    ref: "master"
+    paths:
+      - dest: "engine/reference/builder.md"
+        src:
+          - "frontend/dockerfile/docs/reference.md"

--- a/_plugins/fetch_remote.rb
+++ b/_plugins/fetch_remote.rb
@@ -6,38 +6,40 @@ require 'open-uri'
 require 'rake'
 
 module Jekyll
-  def self.download(url, dest)
-    uri = URI.parse(url)
-    result = File.join(dest, File.basename(uri.path))
-    puts "    Downloading #{url}"
-    IO.copy_stream(URI.open(url), result)
-    return result
-  end
+  class FetchRemote < Octopress::Hooks::Site
+    priority :highest
 
-  def self.copy(src, dest)
-    if (tmp = Array.try_convert(src))
-      tmp.each do |s|
-        s = File.path(s)
-        yield s, File.join(dest, File.basename(s))
-      end
-    else
-      src = File.path(src)
-      if File.directory?(dest)
-        yield src, File.join(dest, File.basename(src))
+    def self.download(url, dest)
+      uri = URI.parse(url)
+      result = File.join(dest, File.basename(uri.path))
+      puts "    Downloading #{url}"
+      IO.copy_stream(URI.open(url), result)
+      return result
+    end
+
+    def self.copy(src, dest)
+      if (tmp = Array.try_convert(src))
+        tmp.each do |s|
+          s = File.path(s)
+          yield s, File.join(dest, File.basename(s))
+        end
       else
-        yield src, File.path(dest)
+        src = File.path(src)
+        if File.directory?(dest)
+          yield src, File.join(dest, File.basename(src))
+        else
+          yield src, File.path(dest)
+        end
       end
     end
-  end
 
-  class FetchRemote < Octopress::Hooks::Site
     def pre_read(site)
       beginning_time = Time.now
       puts "Starting plugin fetch_remote.rb..."
       site.config['fetch-remote'].each do |entry|
         puts "  Repo #{entry['repo']} (#{entry['ref']})"
         Dir.mktmpdir do |tmpdir|
-          tmpfile = Jekyll.download("#{entry['repo']}/archive/#{entry['ref']}.zip", tmpdir)
+          tmpfile = FetchRemote.download("#{entry['repo']}/archive/#{entry['ref']}.zip", tmpdir)
           Dir.mktmpdir do |ztmpdir|
             puts "    Extracting #{tmpfile}"
             Archive::Zip.extract(
@@ -46,7 +48,15 @@ module Jekyll
               :create => true
             )
             entry['paths'].each do |path|
-              FileUtils.mkdir_p path['dest']
+              if File.extname(path['dest']) != ""
+                if path['src'].size > 1
+                  raise "Cannot use file destination #{path['dest']} with multiple sources"
+                end
+                FileUtils.mkdir_p File.dirname(path['dest'])
+              else
+                FileUtils.mkdir_p path['dest']
+              end
+
               puts "    Copying files"
 
               # prepare file list to be copied
@@ -60,7 +70,7 @@ module Jekyll
               end
 
               files.each do |file|
-                Jekyll.copy(file, path['dest']) do |s, d|
+                FetchRemote.copy(file, path['dest']) do |s, d|
                   s = File.realpath(s)
                   # traverse source directory
                   FileUtils::Entry_.new(s, nil, false).wrap_traverse(proc do |ent|

--- a/_plugins/fix_urls.rb
+++ b/_plugins/fix_urls.rb
@@ -2,7 +2,6 @@ require 'jekyll'
 require 'octopress-hooks'
 
 module Jekyll
-
   class FetchRemote < Octopress::Hooks::Site
     def post_read(site)
       beginning_time = Time.now
@@ -20,5 +19,4 @@ module Jekyll
       Jekyll.logger.info "done in #{(end_time - beginning_time)} seconds"
     end
   end
-
 end

--- a/_plugins/update_api_toc.rb
+++ b/_plugins/update_api_toc.rb
@@ -2,7 +2,6 @@ require 'jekyll'
 require 'octopress-hooks'
 
 module Jekyll
-
   class UpdateApiToc < Octopress::Hooks::Site
     def pre_read(site)
       beginning_time = Time.now
@@ -22,5 +21,4 @@ module Jekyll
       Jekyll.logger.info "done in #{(end_time - beginning_time)} seconds"
     end
   end
-
 end


### PR DESCRIPTION
~needs https://github.com/moby/buildkit/pull/2902~

Dockerfile reference is now located in the BuildKit repository.

Preview: https://deploy-preview-14948--docsdocker.netlify.app/engine/reference/builder/

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>