### PR TITLE
Add label description for com.docker.extension.account-info

### DIFF
--- a/desktop/extensions-sdk/extensions/labels.md
+++ b/desktop/extensions-sdk/extensions/labels.md
@@ -18,6 +18,7 @@ keywords: Docker, extensions, sdk, labels
 | `com.docker.extension.publisher-url` | No | The publisher website URL to be displayed in the details dialog. | `https://foo.bar` |
 | `com.docker.extension.additional-urls` | No | A JSON array of titles and additional URLs displayed to users (in the order they appear in your metadata) in your extension's details page. We recommend you display the following links if they apply: documentation, support, terms of service, and privacy policy links. | `[{"title":"Documentation","url":"https://foo.bar/docs"},` `{"title":"Support","url":"https://foo.bar/support"},` `{"title":"Terms of Service","url":"https://foo.bar/tos"},` `{"title":"Privacy policy","url":"https://foo.bar/privacy-policy"}]` |
 | `com.docker.extension.changelog` | No | Changelog in plain text or HTML containing the change for the current version only. | `Extension changelog` or `<p>Extension changelog<ul>` `<li>New feature A</li>` `<li>Bug fix on feature B</li></ul></p>` |
+| `com.docker.extension.account-info` | No | Whether the user needs to sign up or login into a SaaS platform to use some features of the extension. | `required` in case it does, leave it empty otherwise. |
 
 > Missing required labels
 >

--- a/desktop/extensions-sdk/extensions/labels.md
+++ b/desktop/extensions-sdk/extensions/labels.md
@@ -18,7 +18,7 @@ keywords: Docker, extensions, sdk, labels
 | `com.docker.extension.publisher-url` | No | The publisher website URL to be displayed in the details dialog. | `https://foo.bar` |
 | `com.docker.extension.additional-urls` | No | A JSON array of titles and additional URLs displayed to users (in the order they appear in your metadata) in your extension's details page. We recommend you display the following links if they apply: documentation, support, terms of service, and privacy policy links. | `[{"title":"Documentation","url":"https://foo.bar/docs"},` `{"title":"Support","url":"https://foo.bar/support"},` `{"title":"Terms of Service","url":"https://foo.bar/tos"},` `{"title":"Privacy policy","url":"https://foo.bar/privacy-policy"}]` |
 | `com.docker.extension.changelog` | No | Changelog in plain text or HTML containing the change for the current version only. | `Extension changelog` or `<p>Extension changelog<ul>` `<li>New feature A</li>` `<li>Bug fix on feature B</li></ul></p>` |
-| `com.docker.extension.account-info` | No | Whether the user needs to sign up or login into a SaaS platform to use some features of the extension. | `required` in case it does, leave it empty otherwise. |
+| `com.docker.extension.account-info` | No | Whether the user needs to sign up or log in to a SaaS platform to use some features of the extension. | `required` in case it does, leave it empty otherwise. |
 
 > Missing required labels
 >


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

### Proposed changes

Document new label used to inform users about extensions requiring external login in order to use extension features.

The label will be used by Desktop version 4.10.0 and later (it can be safely added to extensions, will just be ignored by prior versions of Docker Desktop)

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
