### PR TITLE
Fix Dead Link in the Compose specification documentation

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1657,7 +1657,7 @@ the service's containers.
   service's task containers. Defaults to `source` if not specified.
 - `uid` and `gid`: The numeric UID or GID that owns the file within
   `/run/secrets/` in the service's task containers. Default value is USER running container.
-- `mode`: The [permissions](http://permissions-calculator.org/) for the file to be mounted in `/run/secrets/`
+- `mode`: The [permissions](https://web.archive.org/web/20220310140126/http://permissions-calculator.org/) for the file to be mounted in `/run/secrets/`
   in the service's task containers, in octal notation.
   Default value is world-readable permissions (mode `0444`).
   The writable bit MUST be ignored if set. The executable bit MAY be set.


### PR DESCRIPTION
Fix dead link to a Permissions Calculator in the Compose specification documentation.

### Proposed changes

Replace the dead link to the http://permissions-calculator.org with one to a [working copy](https://web.archive.org/web/20220310140126/http://permissions-calculator.org/) of the page hosted on the Internet Archive.
