### PR TITLE
upgrade compose version to v2.6.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ exclude:
 latest_engine_api_version: "1.41"
 docker_ce_version: "20.10"
 compose_v1_version: "1.29.2"
-compose_version: "v2.6.0"
+compose_version: "v2.6.1"
 compose_file_v3: "3.9"
 compose_file_v2: "2.4"
 machine_version: "0.16.0"


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

### Proposed changes

Bump Compose version to `v2.6.1`
