### PR TITLE
Fix horizontal scroll for mobile view

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -851,7 +851,11 @@ parts of your image.
 
 If a service can run without privileges, use `USER` to change to a non-root
 user. Start by creating the user and group in the `Dockerfile` with something
-like `RUN groupadd -r postgres && useradd --no-log-init -r -g postgres postgres`.
+like:
+
+```dockerfile
+RUN groupadd -r postgres && useradd --no-log-init -r -g postgres postgres
+```
 
 > Consider an explicit UID/GID
 >


### PR DESCRIPTION
### Issue description

An inline code block (single back-ticks) was too long, causing the page-width to be exceeded and a horizontal scrollbar to be included.

The issue was found for:
- Browser: Firefox Daylight 101.2.0
- OS: Android 10
- Phone resolution: 1440x2880 pixels

> When previewing the file on github, the inline code is properly split over multiple lines. However, this is not the case for the [docker docs webpage](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user).

### Proposed changes

Transform the inline code statement (single case) to a distinct code block (using triple back-ticks), which does not produce the same issue.