### PR TITLE
Add instructions to show Docker extension system container

### DIFF
--- a/desktop/extensions.md
+++ b/desktop/extensions.md
@@ -39,9 +39,19 @@ The Extensions Marketplace opens.
 3. Click **Install**.<br>
 From here, you can click **Open** to access the extension or install additional extensions. The extension also appears in the menu bar.
 
+## See containers created by extensions
+
+By default, containers created by extensions are hidden from the list of containers in the dashboard and the Docker CLI. To make them visible 
+update your settings:
+
+1. Navigate to  **Settings**, or **Preferences** if you're a Mac user.
+2. Select the **Extensions** tab.
+3. Next to **Show Docker Extensions system containers**, select or clear the checkbox to set your desired state.
+4. In the bottom-right corner, click **Apply & Restart**.
+
 ## Enable or disable extensions available in the Marketplace
 
- Docker Extensions are switched on by default. To change your settings:
+Docker Extensions are switched on by default. To change your settings:
 
 1. Navigate to  **Settings**, or **Preferences** if you're a Mac user.
 2. Select the **Extensions** tab.

--- a/desktop/extensions.md
+++ b/desktop/extensions.md
@@ -41,7 +41,7 @@ From here, you can click **Open** to access the extension or install additional 
 
 ## See containers created by extensions
 
-By default, containers created by extensions are hidden from the list of containers in the dashboard and the Docker CLI. To make them visible 
+By default, containers created by extensions are hidden from the list of containers in Docker Dashboard and the Docker CLI. To make them visible 
 update your settings:
 
 1. Navigate to  **Settings**, or **Preferences** if you're a Mac user.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

This PR adds an explanation about how to show containers created by extension as Docker desktop users rather than Docker extension developers.

<img width="1487" alt="Screenshot 2022-06-27 at 16 44 37" src="https://user-images.githubusercontent.com/212269/175970205-20325c78-09e3-44d8-a161-9259a033ed38.png">


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
