### PR TITLE
Fix spelling

### DIFF
--- a/compose/compose-file/build.md
+++ b/compose/compose-file/build.md
@@ -99,7 +99,7 @@ Alternatively `build` can be an object with fields defined as follow
 
 When the value supplied is a relative path, it MUST be interpreted as relative to the location of the Compose file.
 Compose implementations MUST warn user about absolute path used to define build context as those prevent Compose file
-for being portable.
+from being portable.
 
 ```yml
 build:
@@ -110,7 +110,7 @@ build:
 
 `dockerfile` allows to set an alternate Dockerfile. A relative path MUST be resolved from the build context.
 Compose implementations MUST warn user about absolute path used to define Dockerfile as those prevent Compose file
-for being portable.
+from being portable.
 
 ```yml
 build:


### PR DESCRIPTION
### Proposed changes

Fixed word choice on the docker-compose file documentation.
"prevent... _for_ being portable" --> "prevent... _from_ being portable"