### PR TITLE
Updated Platform flag in Run cmd for ARM

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -59,7 +59,7 @@ For now, we will create the network first and attach the MySQL container at star
     ```console
     $ docker run -d \
         --network todo-app --network-alias mysql \
-        --platform "linux/amd64" \
+        --platform "linux/arm64" \
         -v todo-mysql-data:/var/lib/mysql \
         -e MYSQL_ROOT_PASSWORD=secret \
         -e MYSQL_DATABASE=todos \


### PR DESCRIPTION
For ARM chips, the platform flag mentioned as --platform "linux/amd64". It should've been --platform "linux/arm64"

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
