### PR TITLE
Remove extension prerequisite for separate CLI

### DIFF
--- a/desktop/extensions-sdk/build/get-started.md
+++ b/desktop/extensions-sdk/build/get-started.md
@@ -3,7 +3,7 @@ title: "Step one: Get started"
 description: The first step to building an extension.
 keywords: Docker, Extensions, sdk, prerequisites
 redirect_from:
-- desktop/extensions-sdk/tutorials/initialize/
+  - desktop/extensions-sdk/tutorials/initialize/
 ---
 
 To start creating your extension, you first need a directory with files which range from the extension’s source code to the required extension-specific files.
@@ -12,73 +12,7 @@ To start creating your extension, you first need a directory with files which ra
 
 Before you create your own extension, you need to install [Docker Desktop](../../release-notes.md).
 
-You also need the latest [Extensions CLI](https://github.com/docker/extensions-sdk/releases/latest), which is used to manage extensions later on.
-
-> Using the CLI to install unpublished extensions
->
-> Extensions can install binaries, invoke commands and access files on your machine. Make sure you trust extensions before installing them on your machine.
-> {: .warning}
-
-Once you've downloaded the Extensions CLI, extract the binary in to `~/.docker/cli-plugins`.
-
-In your terminal, run:
-
-<ul class="nav nav-tabs">
-  <li class="active"><a data-toggle="tab" data-target="#prereq-macos-intel">MacOS (intel)</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-macos-m1">MacOS (M1)</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-windows">Windows</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-wsl2">WSL2</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-linux">Linux</a></li>
-</ul>
-<div class="tab-content">
-  <div id="prereq-macos-intel" class="tab-pane fade in active" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-darwin-amd64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-macos-m1" class="tab-pane fade" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-darwin-arm64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-windows" class="tab-pane fade" markdown="1">
-
-```console
-PS> tar -xvzf desktop-extension-cli-windows-amd64.tar.gz
-PS> mkdir -p ~/.docker/cli-plugins
-PS> mv docker-extension.exe ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-wsl2" class="tab-pane fade" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-linux" class="tab-pane fade" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-</div>
-
-You can now list installed extensions (the list should be empty if you have not installed extensions already):
+You can list installed extensions (the list should be empty if you have not installed extensions already):
 
 ```console
 $ docker extension ls
@@ -87,11 +21,12 @@ ID                  PROVIDER            VERSION             UI                  
 
 ![Extensions enabled](images/extensions-enabled.png)
 
-You can now continue to step two and set up your directory. 
+You can now continue to step two and set up your directory.
 
 ## What’s next?
 
 Explore how to set up:
+
 - [A frontend extension based on plain HTML](set-up/minimal-frontend-extension.md)
 - [A simple Docker extension that contains only a UI part and is based on ReactJS](set-up/react-extension.md)
 - [An extension that invokes Docker CLI commands](set-up/minimal-frontend-using-docker-cli.md)

--- a/desktop/extensions-sdk/quickstart.md
+++ b/desktop/extensions-sdk/quickstart.md
@@ -4,79 +4,19 @@ description: Guide on how to build an extension quickly
 keywords: quickstart, extensions
 ---
 
-Follow the guide below to build a basic Docker Extension quickly. The Quickstart guide automatically generates boilerplate files for you. 
+Follow the guide below to build a basic Docker Extension quickly. The Quickstart guide automatically generates boilerplate files for you.
 
->Note
+> Note
 >
->NodeJS and Go are only required when you follow the quickstart guide to build an extension. It uses the `docker extension init` command to automatically generate boilerplate files. This command uses a template based on a ReactJS and Go application.
+> NodeJS and Go are only required when you follow the quickstart guide to build an extension. It uses the `docker extension init` command to automatically generate boilerplate files. This command uses a template based on a ReactJS and Go application.
 
 ## Prerequisites
 
 - [Docker Desktop](../release-notes.md)
 - [NodeJS](https://nodejs.org/)
 - [Go](https://go.dev/dl/)
-- [Extensions CLI](https://github.com/docker/extensions-sdk/releases/latest)
 
-Once you've downloaded the Extensions CLI, extract the binary in to `~/.docker/cli-plugins`.
-
-In your terminal, run:
-
-<ul class="nav nav-tabs">
-  <li class="active"><a data-toggle="tab" data-target="#prereq-macos-intel">MacOS (intel)</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-macos-m1">MacOS (M1)</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-windows">Windows</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-wsl2">WSL2</a></li>
-  <li><a data-toggle="tab" data-target="#prereq-linux">Linux</a></li>
-</ul>
-<div class="tab-content">
-  <div id="prereq-macos-intel" class="tab-pane fade in active" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-darwin-amd64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-macos-m1" class="tab-pane fade" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-darwin-arm64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-windows" class="tab-pane fade" markdown="1">
-
-```console
-PS> tar -xvzf desktop-extension-cli-windows-amd64.tar.gz
-PS> mkdir -p ~/.docker/cli-plugins
-PS> mv docker-extension.exe ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-wsl2" class="tab-pane fade" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-  <div id="prereq-linux" class="tab-pane fade" markdown="1">
-
-```console
-$ tar -xvzf desktop-extension-cli-linux-amd64.tar.gz
-$ mkdir -p ~/.docker/cli-plugins
-$ mv docker-extension ~/.docker/cli-plugins
-```
-
-  <hr></div>
-</div>
-
-## Step one: Set up your directory 
+## Step one: Set up your directory
 
 To set up your directory, use the `init` subcommand and provide a name for your extension.
 
@@ -111,7 +51,7 @@ To install the extension in Docker Desktop, run:
 
 To preview the extension in Docker Desktop, close and open Docker Dashboard once the installation is complete.
 
-During UI development, it’s helpful to use hot reloading to test your changes without rebuilding your entire extension. See [Preview whilst developing the UI](build/test-debug.md#hot-reloading-whilst-developing-the-ui) for more information. 
+During UI development, it’s helpful to use hot reloading to test your changes without rebuilding your entire extension. See [Preview whilst developing the UI](build/test-debug.md#hot-reloading-whilst-developing-the-ui) for more information.
 
 ## Step four: Submit and publish your extension to the Marketplace
 
@@ -123,9 +63,10 @@ To remove the extension, run:
 
 `docker extension rm <name-of-your-extension>`
 
-## What's next 
+## What's next
 
 Learn more about:
+
 - [Building and installing an extension](build/build-install.md)
 - [Testing and debugging](build/test-debug.md)
 - [Setting up authentication](dev/oauth2-flow.md)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

### Proposed changes

remove prerequisite steps about installing extension CLI, this is now shipped by default with Docker desktop 4.10. 
The extension prerequisites just ask users to download the latest Docker Desktop

To be merged after Desktop 4.10 is out

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
