### PR TITLE
desktop proxies: clarify situation on Mac and Windows

### DIFF
--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -127,26 +127,26 @@ File share settings are:
 
 #### Proxies
 
-HTTP/HTTPS proxies can be used when
+HTTP/HTTPS proxies can be used when:
 
 - logging in to Docker
 - pulling or pushing images
 - fetching artifacts during image builds
 - containers interact with the external network
-- scanning images.
+- scanning images
 
-These are configured slightly differently.
+Each use case above is configured slightly differently.
 
-If the host uses a static HTTP/HTTPS proxy configuration then Docker Desktop reads this configuration
+If the host uses a static HTTP/HTTPS proxy configuration, Docker Desktop reads this configuration
 and automatically uses these settings for logging into Docker and for pulling and pushing images.
-If the host uses a more sophisticated HTTP/HTTPS configuration then enable "Manual proxy configuration"
-in the Settings / Resources / Proxies in the Docker Desktop UI and enter a single upstream proxy URL
+If the host uses a more sophisticated HTTP/HTTPS configuration, enable **Manual proxy configuration**
+in the **Settings > Resources > Proxies** in Docker Dashboard and enter a single upstream proxy URL
 of the form `http://username:password@proxy:port`.
 
 HTTP/HTTPS traffic from image builds and running containers is forwarded transparently to the same
 upstream proxy used for logging in and image pulls.
-If you wish to override this behaviour and use different HTTP/HTTPS proxies for image builds and
-running containers then see [Configure the Docker client](/network/proxy#configure-the-docker-client).
+If you want to override this behaviour and use different HTTP/HTTPS proxies for image builds and
+running containers, see [Configure the Docker client](/network/proxy#configure-the-docker-client).
 
 The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY` environment variable.
 

--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -127,29 +127,28 @@ File share settings are:
 
 #### Proxies
 
-Docker Desktop detects HTTP/HTTPS Proxy Settings from macOS and automatically
-propagates these to Docker. For example, if you set your
-proxy settings to `http://proxy.example.com`, Docker uses this proxy when
-pulling containers.
+HTTP/HTTPS proxies can be used when
 
-If you want to configure proxies manually, turn on the **Manual proxy configuration** setting.
+- logging in to Docker
+- pulling or pushing images
+- fetching artifacts during image builds
+- containers interact with the external network
+- scanning images.
 
-Your proxy settings, however, will not be propagated into the containers you start.
-If you wish to set the proxy settings for your containers, you need to define
-environment variables for them, just like you would do on Linux, for example:
+These are configured slightly differently.
 
-```console
-$ docker run -e HTTP_PROXY=http://proxy.example.com:3128 alpine env
+If the host uses a static HTTP/HTTPS proxy configuration then Docker Desktop reads this configuration
+and automatically uses these settings for logging into Docker and for pulling and pushing images.
+If the host uses a more sophisticated HTTP/HTTPS configuration then enable "Manual proxy configuration"
+in the Settings / Resources / Proxies in the Docker Desktop UI and enter a single upstream proxy URL
+of the form `http://username:password@proxy:port`.
 
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-HOSTNAME=b7edf988b2b5
-TERM=xterm
-HOME=/root
-HTTP_PROXY=http://proxy.example.com:3128
-```
+HTTP/HTTPS traffic from image builds and running containers is forwarded transparently to the same
+upstream proxy used for logging in and image pulls.
+If you wish to override this behaviour and use different HTTP/HTTPS proxies for image builds and
+running containers then see [Configure the Docker client](/network/proxy#configure-the-docker-client).
 
-For more information on setting environment variables for running containers,
-see [Set environment variables](/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
+The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY` environment variable.
 
 #### Network
 

--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -129,11 +129,11 @@ File share settings are:
 
 HTTP/HTTPS proxies can be used when:
 
-- logging in to Docker
-- pulling or pushing images
-- fetching artifacts during image builds
-- containers interact with the external network
-- scanning images
+- Logging in to Docker
+- Pulling or pushing images
+- Fetching artifacts during image builds
+- Containers interact with the external network
+- Scanning images
 
 Each use case above is configured slightly differently.
 

--- a/desktop/windows/index.md
+++ b/desktop/windows/index.md
@@ -145,18 +145,18 @@ containers. Alternatively, you can opt not to share it by selecting **Cancel**.
 
 HTTP/HTTPS proxies can be used when
 
-- logging in to Docker
-- pulling or pushing images
-- fetching artifacts during image builds
-- containers interact with the external network
-- scanning images.
+- Logging in to Docker
+- Pulling or pushing images
+- Fetching artifacts during image builds
+- Containers interact with the external network
+- Scanning images.
 
 These are configured slightly differently.
 
-If the host uses a static HTTP/HTTPS proxy configuration then Docker Desktop reads this configuration
+If the host uses a static HTTP/HTTPS proxy configuration, Docker Desktop reads this configuration
 and automatically uses these settings for logging into Docker and for pulling and pushing images.
-If the host uses a more sophisticated HTTP/HTTPS configuration then enable "Manual proxy configuration"
-in the Settings / Resources / Proxies in the Docker Desktop UI and enter a single upstream proxy URL
+If the host uses a more sophisticated HTTP/HTTPS configuration, enable **Manual proxy configuration**
+in the **Settings** > **Resources** **Proxies** in the Docker Dashboard and enter a single upstream proxy URL
 of the form `http://username:password@proxy:port`.
 
 The HTTP/HTTPS proxy settings used for fetching artifacts during builds and for running containers

--- a/desktop/windows/index.md
+++ b/desktop/windows/index.md
@@ -142,26 +142,27 @@ containers. Alternatively, you can opt not to share it by selecting **Cancel**.
 
 #### Proxies
 
-Docker Desktop detects the HTTP/HTTPS proxy settings and
-automatically propagates these to Docker. For example, if you set your proxy
-settings to `http://proxy.example.com`, Docker uses this proxy when pulling containers.
 
-Your proxy settings, however, will not be propagated into the containers you start.
-If you wish to set the proxy settings for your containers, you need to define
-environment variables for them, just like you would do on Linux, for example:
+HTTP/HTTPS proxies can be used when
 
-```ps
-> docker run -e HTTP_PROXY=http://proxy.example.com:3128 alpine env
+- logging in to Docker
+- pulling or pushing images
+- fetching artifacts during image builds
+- containers interact with the external network
+- scanning images.
 
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-HOSTNAME=b7edf988b2b5
-TERM=xterm
-HOME=/root
-HTTP_PROXY=http://proxy.example.com:3128
-```
+These are configured slightly differently.
 
-For more information on setting environment variables for running containers,
-see [Set environment variables](/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
+If the host uses a static HTTP/HTTPS proxy configuration then Docker Desktop reads this configuration
+and automatically uses these settings for logging into Docker and for pulling and pushing images.
+If the host uses a more sophisticated HTTP/HTTPS configuration then enable "Manual proxy configuration"
+in the Settings / Resources / Proxies in the Docker Desktop UI and enter a single upstream proxy URL
+of the form `http://username:password@proxy:port`.
+
+The HTTP/HTTPS proxy settings used for fetching artifacts during builds and for running containers
+are set via the `.docker/config.json` file, see [Configure the Docker client](/network/proxy#configure-the-docker-client).
+
+The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY` environment variable.
 
 #### Network
 


### PR DESCRIPTION



<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

1. there are multiple different places proxies are configured (unfortunately). Clarify that multiple different configuration steps are needed depending on what you're trying to achieve.
2. there are behaviour differences between Mac and Windows (currently Mac performs transparent proxying but Windows does not)
3. rather than manually setting environment variables for containers we should use the CLI's new config.json support.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

#15044