### PR TITLE
network/proxy: add a note pointing at docker engine and Docker Desktop

### DIFF
--- a/network/proxy.md
+++ b/network/proxy.md
@@ -7,7 +7,8 @@ keywords: network, networking, proxy, client
 > **Note**
 >
 > This page describes how to configure the Docker CLI to configure proxies via environment variables in containers.
-> For information on configuring Docker Desktop to use HTTP/HTTPS proxies, see [proxies on Mac](../desktop/mac/index.md#proxies) and [proxies on Windows](../desktop/windows/index.md#proxies).
+> For information on configuring Docker Desktop to use HTTP/HTTPS proxies, see [proxies on Mac](../desktop/mac/index.md#proxies), [proxies on Windows](../desktop/windows/index.md#proxies), and [proxies on Linux](../desktop/linux/index.md#proxies).
+
 > If you are not running Docker Desktop, and have installed the Docker Engine in
 > other ways, refer to the "HTTP/HTTPS proxy" section in
 > [configuring the Docker daemon with systemd](../config/daemon/systemd.md#httphttps-proxy).

--- a/network/proxy.md
+++ b/network/proxy.md
@@ -4,6 +4,12 @@ description: How to configure the Docker client to use a proxy server
 keywords: network, networking, proxy, client
 ---
 
+> **Note**
+>
+> This page describes how to configure the Docker CLI to configure proxies via environment variables in containers.
+> For information on configuring Docker Desktop to use HTTP/HTTPS proxies, see [proxies on Mac](../desktop/mac/index.md#proxies) and [proxies on Windows](../desktop/windows/index.md#proxies).
+> To configure the native Docker engine to use HTTP/HTTPS proxies for pulls and pushes, set the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables for the engine process, see for example [configuring the Docker daemon with systemd](../config/daemon/systemd.md#httphttps-proxy).
+
 If your container needs to use an HTTP, HTTPS, or FTP proxy server, you can
 configure it in different ways:
 

--- a/network/proxy.md
+++ b/network/proxy.md
@@ -8,7 +8,9 @@ keywords: network, networking, proxy, client
 >
 > This page describes how to configure the Docker CLI to configure proxies via environment variables in containers.
 > For information on configuring Docker Desktop to use HTTP/HTTPS proxies, see [proxies on Mac](../desktop/mac/index.md#proxies) and [proxies on Windows](../desktop/windows/index.md#proxies).
-> To configure the native Docker engine to use HTTP/HTTPS proxies for pulls and pushes, set the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables for the engine process, see for example [configuring the Docker daemon with systemd](../config/daemon/systemd.md#httphttps-proxy).
+> If you are not running Docker Desktop, and have installed the Docker Engine in
+> other ways, refer to the "HTTP/HTTPS proxy" section in
+> [configuring the Docker daemon with systemd](../config/daemon/systemd.md#httphttps-proxy).
 
 If your container needs to use an HTTP, HTTPS, or FTP proxy server, you can
 configure it in different ways:


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

Add references from network/proxy.md to the other places in the docs where we discuss HTTP proxy configuration.

The title is "Configure Docker to use a proxy server" which is generic and implies this is the page which describes everything. However the scope of the instructions is limited to containers:

> If your container needs ...

The limited scope is easy to miss.

There are other HTTP proxy cases, for example

- for Docker Desktop to log into Docker
- for pulling and pushing containers
- for docker scan

Add a note at the top of this page to clarify the scope and link to instructions for other cases.


### Related issues (optional)

#15044 #15045

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
