### PR TITLE
engine: remove CAP_PERFMON, CAP_BPF, CAP_CHECKPOINT_RESTORE from relnotes

### DIFF
--- a/engine/release-notes/index.md
+++ b/engine/release-notes/index.md
@@ -735,7 +735,6 @@ For an overview of all deprecated features, refer to the [Deprecated Engine Feat
 - The `--device` flag in `docker run` will now be honored when the container is started in privileged mode [moby/moby#40291](https://github.com/moby/moby/pull/40291)
 - Enforce reserved internal labels [moby/moby#40394](https://github.com/moby/moby/pull/40394)
 - Raise minimum memory limit to 6M, to account for higher memory use by runtimes during container startup [moby/moby#41168](https://github.com/moby/moby/pull/41168)
-- Add support for `CAP_PERFMON`, `CAP_BPF`, and `CAP_CHECKPOINT_RESTORE` on supported kernels [moby/moby#41460](https://github.com/moby/moby/pull/41460)
 - vendor runc v1.0.0-rc92 [moby/moby#41344](https://github.com/moby/moby/pull/41344) [moby/moby#41317](https://github.com/moby/moby/pull/41317)
 - info: add warnings about missing blkio cgroup support [moby/moby#41083](https://github.com/moby/moby/pull/41083)
 - Accept platform spec on container create [moby/moby#40725](https://github.com/moby/moby/pull/40725)


### PR DESCRIPTION
- closes https://github.com/docker/docker.github.io/issues/13731
- closes https://github.com/docker/docker.github.io/issues/14124

These capabilities were reverted in https://github.com/moby/moby/commit/a38b96b8cdc4d345a050b417c4c492b75329e5a6 (https://github.com/moby/moby/pull/41563),
because the version of containerd and runc that shipped together with
docker 20.10.0 did not support them.

Current versions of containerd and runc support these, so possibly we can
include them again in a patch release, but otherwise support will come in
the next (22.06) release of docker engine.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
