### PR TITLE
DKP-91 add checksums to release notes

### DIFF
--- a/_includes/desktop-install.html
+++ b/_includes/desktop-install.html
@@ -12,7 +12,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" role="button">Download file</a> 
         <br>
         <br>
-        <b>Checksum:</b>
+        <b>Checksum:</b> fe430d19d41cc56fd9a4cd2e22fc0e3522bed910c219208345918c77bbbd2a65
         </div>
       </div>
     </div>
@@ -29,7 +29,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b>
+          <b>Checksum:</b> 8be8e5245d6a8dbf7b8cb580fb7d99f04cc143c95323695c0d9be4f85dd60b0e
         </div>
       </div>
     </div>
@@ -46,7 +46,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b>
+          <b>Checksum:</b> b3d4ef222325bde321045f3b8d946c849cd2812e9ad52a801000a95edb8af57b
         </div>
       </div>
     </div>
@@ -63,7 +63,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b>
+          <b>Checksum:</b> 9363bc584478c5c7654004bacb51429c275b58a868ef43c3bc6249d5844ec5be
         </div>
       </div>
     </div>
@@ -80,7 +80,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b>
+          <b>Checksum:</b> 9363bc584478c5c7654004bacb51429c275b58a868ef43c3bc6249d5844ec5be
         </div>
       </div>
     </div>
@@ -97,7 +97,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.pkg.tar.zst?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b>
+          <b>Checksum:</b> 9363bc584478c5c7654004bacb51429c275b58a868ef43c3bc6249d5844ec5be
         </div>
       </div>
     </div>

--- a/_includes/desktop-install.html
+++ b/_includes/desktop-install.html
@@ -4,6 +4,7 @@
         <h5 class="panel-title">
           <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
             Windows
+            <i class="fa fa-chevron-down"></i>
           </a>
         </h5>
       </div>
@@ -21,6 +22,7 @@
         <h5 class="panel-title">
           <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
             Mac with Intel chip
+            <i class="fa fa-chevron-down"></i>
           </a>
         </h5>
       </div>
@@ -38,6 +40,7 @@
         <h5 class="panel-title">
           <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
             Mac with Apple chip
+            <i class="fa fa-chevron-down"></i>
           </a>
         </h5>
       </div>
@@ -54,7 +57,8 @@
       <div class="panel-heading" role="tab" id="headingFour">
         <h5 class="panel-title">
           <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseFour" aria-expanded="true" aria-controls="collapseFour">
-            DEB
+            Linux DEB
+            <i class="fa fa-chevron-down"></i>
           </a>
         </h5>
       </div>
@@ -71,7 +75,8 @@
       <div class="panel-heading" role="tab" id="headingFive">
         <h5 class="panel-title">
           <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
-            RPM
+            Linux RPM
+            <i class="fa fa-chevron-down"></i>
           </a>
         </h5>
       </div>
@@ -88,7 +93,8 @@
       <div class="panel-heading" role="tab" id="headingSix">
         <h5 class="panel-title">
           <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseSix" aria-expanded="false" aria-controls="collapseSix">
-            Arch (experimental)
+            Linux Arch (experimental)
+            <i class="fa fa-chevron-down"></i>
           </a>
         </h5>
       </div>

--- a/_includes/desktop-install.html
+++ b/_includes/desktop-install.html
@@ -1,0 +1,103 @@
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingOne">
+        <h5 class="panel-title">
+          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+            Windows
+          </a>
+        </h5>
+      </div>
+      <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+        <div class="panel-body">
+          <a class="btn btn-primary" href="https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" role="button">Download file</a> 
+        <br>
+        <br>
+        <b>Checksum:</b>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingTwo">
+        <h5 class="panel-title">
+          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+            Mac with Intel chip
+          </a>
+        </h5>
+      </div>
+      <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
+        <div class="panel-body">
+          <a class="btn btn-primary" href="https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64" role="button">Download file</a> 
+          <br>
+          <br>
+          <b>Checksum:</b>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingThree">
+        <h5 class="panel-title">
+          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+            Mac with Apple chip
+          </a>
+        </h5>
+      </div>
+      <div id="collapseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
+        <div class="panel-body">
+          <a class="btn btn-primary" href="https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64" role="button">Download file</a> 
+          <br>
+          <br>
+          <b>Checksum:</b>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingFour">
+        <h5 class="panel-title">
+          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseFour" aria-expanded="true" aria-controls="collapseFour">
+            DEB
+          </a>
+        </h5>
+      </div>
+      <div id="collapseFour" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingFour">
+        <div class="panel-body">
+          <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
+          <br>
+          <br>
+          <b>Checksum:</b>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingFive">
+        <h5 class="panel-title">
+          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+            RPM
+          </a>
+        </h5>
+      </div>
+      <div id="collapseFive" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingFive">
+        <div class="panel-body">
+          <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
+          <br>
+          <br>
+          <b>Checksum:</b>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingSix">
+        <h5 class="panel-title">
+          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseSix" aria-expanded="false" aria-controls="collapseSix">
+            Arch (experimental)
+          </a>
+        </h5>
+      </div>
+      <div id="collapseSix" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingSix">
+        <div class="panel-body">
+          <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.pkg.tar.zst?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
+          <br>
+          <br>
+          <b>Checksum:</b>
+        </div>
+      </div>
+    </div>

--- a/_includes/desktop-install.html
+++ b/_includes/desktop-install.html
@@ -12,7 +12,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" role="button">Download file</a> 
         <br>
         <br>
-        <b>Checksum:</b> fe430d19d41cc56fd9a4cd2e22fc0e3522bed910c219208345918c77bbbd2a65
+        <b>Checksum:</b> SHA-256 fe430d19d41cc56fd9a4cd2e22fc0e3522bed910c219208345918c77bbbd2a65
         </div>
       </div>
     </div>
@@ -80,7 +80,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b> 9363bc584478c5c7654004bacb51429c275b58a868ef43c3bc6249d5844ec5be
+          <b>Checksum:</b> 92371d1a1ae4b57921721da95dc0252aefa4c79eb12208760c800ac07c0ae1d2
         </div>
       </div>
     </div>
@@ -97,7 +97,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.pkg.tar.zst?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b> 9363bc584478c5c7654004bacb51429c275b58a868ef43c3bc6249d5844ec5be
+          <b>Checksum:</b> 799af244b05e8b08f03b6e0dbbc1dfcc027ff49f15506b3c460e0f9bae06ca5d
         </div>
       </div>
     </div>

--- a/_includes/desktop-install.html
+++ b/_includes/desktop-install.html
@@ -29,7 +29,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b> 8be8e5245d6a8dbf7b8cb580fb7d99f04cc143c95323695c0d9be4f85dd60b0e
+          <b>Checksum:</b> SHA-256 8be8e5245d6a8dbf7b8cb580fb7d99f04cc143c95323695c0d9be4f85dd60b0e
         </div>
       </div>
     </div>
@@ -46,7 +46,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b> b3d4ef222325bde321045f3b8d946c849cd2812e9ad52a801000a95edb8af57b
+          <b>Checksum:</b> SHA-256 b3d4ef222325bde321045f3b8d946c849cd2812e9ad52a801000a95edb8af57b
         </div>
       </div>
     </div>
@@ -63,7 +63,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b> 9363bc584478c5c7654004bacb51429c275b58a868ef43c3bc6249d5844ec5be
+          <b>Checksum:</b> SHA-256 9363bc584478c5c7654004bacb51429c275b58a868ef43c3bc6249d5844ec5be
         </div>
       </div>
     </div>
@@ -80,7 +80,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b> 92371d1a1ae4b57921721da95dc0252aefa4c79eb12208760c800ac07c0ae1d2
+          <b>Checksum:</b> SHA-256 92371d1a1ae4b57921721da95dc0252aefa4c79eb12208760c800ac07c0ae1d2
         </div>
       </div>
     </div>
@@ -97,7 +97,7 @@
           <a class="btn btn-primary" href="https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.pkg.tar.zst?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64" role="button">Download file</a> 
           <br>
           <br>
-          <b>Checksum:</b> 799af244b05e8b08f03b6e0dbbc1dfcc027ff49f15506b3c460e0f9bae06ca5d
+          <b>Checksum:</b> SHA-256 799af244b05e8b08f03b6e0dbbc1dfcc027ff49f15506b3c460e0f9bae06ca5d
         </div>
       </div>
     </div>

--- a/desktop/faqs/general.md
+++ b/desktop/faqs/general.md
@@ -24,6 +24,10 @@ By default, Docker Desktop is installed at the following location:
 - On Windows: `C:\Program Files\Docker\Docker`
 - On Linux: `/opt/docker-desktop`
 
+### Where can I find the checksums for the download files?
+
+You can find the checksums on the [release notes](../release-notes.md) page.
+
 ### Do I need to pay to use Docker Desktop?
 
 Docker Desktop remains free for small businesses (fewer than 250 employees AND less than $10 million in annual revenue), personal use, education, and non-commercial open-source projects. It requires a paid subscription for professional use in larger enterprises.

--- a/desktop/linux/install.md
+++ b/desktop/linux/install.md
@@ -11,6 +11,8 @@ Welcome to Docker Desktop for Linux. This page contains information about system
 > [DEB](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64){: .button .primary-btn }
 > [RPM](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64){: .button .primary-btn }
 
+*For checksums, see [Release notes](../release-notes.md)*
+
 ## System requirements
 
 To install Docker Desktop successfully, your Linux host must meet the following requirements:

--- a/desktop/mac/install.md
+++ b/desktop/mac/install.md
@@ -20,6 +20,8 @@ Welcome to Docker Desktop for Mac. This page contains information about Docker D
 > [Mac with Intel chip](https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64){: .button .primary-btn }
 > [Mac with Apple chip](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn }
 
+*For checksums, see [Release notes](../release-notes.md)*
+
 ## System requirements
 
 Your Mac must meet the following requirements to install Docker Desktop successfully.

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -29,12 +29,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 
 > Download Docker Desktop
 >
-> [Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64){: .button .primary-btn }
-> [Mac with Intel chip](https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64){: .button .primary-btn }
-> [Mac with Apple chip](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn }
-> [DEB](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64){: .button .primary-btn }
-> [RPM](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64){: .button .primary-btn }
-> [Arch (experimental)](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.10.1-x86_64.pkg.tar.zst?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64){: .button .primary-btn }
+> {% include desktop-install.html %}
 
 ### Bug fixes and minor changes
 

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -59,12 +59,18 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
         <h5 class="panel-title">
           <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseSeven" aria-expanded="true" aria-controls="collapseSeven">
             Checksums
+            <i class="fa fa-chevron-down"></i>
           </a>
         </h5>
       </div>
       <div id="collapseSeven" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingSeven">
         <div class="panel-body">
-        <li>Windows: SHA-256 ....</li>
+        <li><b>Windows:</b> SHA-256 10615f4425e59eef7a22ce79ec13e41057df278547aa81c9fe4d623a848e80d8</li>
+        <li><b>Mac Intel:</b> SHA-256 07bfe00296b724e4e772e268217bc8169a8b23ad98e6da419b13ebfe31b54643</li>
+        <li><b>Mac Arm:</b> SHA-256 c9d2e72e5438726ab5a94c227d9130a65719f8fd09b877860ca2dcd86cfc188e</li>
+        <li><b>Linux DEB:</b> SHA-256 c5f10b3d902b4ea10c8f75c17ba174e8838fc75889f76bc27abcab6afaf1969c</li>
+        <li><b>Linux RPM:</b> SHA-256 a8ad3f8d4e93dfb6f28559f7dc84b7652e651fd6a49506e18958f1e69b51d9be</li>
+        <li><b>Linux Arch:</b> SHA-256 37131c48df6436c1066c41ec0beda039e726e33bee689f751648c473f4abd96e</li>
         </div>
       </div>
     </div>

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -53,6 +53,23 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 > [RPM](https://desktop.docker.com/linux/main/amd64/82025/docker-desktop-4.10.0-x86_64.rpm) |
 > [Arch package](https://desktop.docker.com/linux/main/amd64/82025/docker-desktop-4.10.0-x86_64.pkg.tar.zst)
 
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingSeven">
+        <h5 class="panel-title">
+          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseSeven" aria-expanded="true" aria-controls="collapseSeven">
+            Checksums
+          </a>
+        </h5>
+      </div>
+      <div id="collapseSeven" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingSeven">
+        <div class="panel-body">
+        <li>Windows: SHA-256 ....</li>
+        </div>
+      </div>
+    </div>
+  </div>
+
 ### New
 
 - You can now add environment variables before running an image in Docker Desktop.

--- a/desktop/windows/install.md
+++ b/desktop/windows/install.md
@@ -25,6 +25,8 @@ Welcome to Docker Desktop for Windows. This page contains information about Dock
 >
 > [Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe){: .button .primary-btn }
 
+*For checksums, see [Release notes](../release-notes.md)*
+
 ## System requirements
 
 Your Windows machine must meet the following requirements to successfully install Docker Desktop.


### PR DESCRIPTION
This replaces https://github.com/docker/docker.github.io/pull/15075

HTML components are added to the release notes page as an _includes link. 
