### PR TITLE
reference: remove duplicate compose navigation

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -484,6 +484,10 @@ reference:
       title: docker commit
     - sectiontitle: docker compose
       section:
+        - path: /compose/reference/
+          title: overview
+        - path: /compose/reference/envvars/
+          title: environment variables
         - path: /engine/reference/commandline/compose/
           title: docker compose
         - path: /engine/reference/commandline/compose_build/
@@ -910,60 +914,9 @@ reference:
         title: docker volume rm
     - path: /engine/reference/commandline/wait/
       title: docker wait
-  - sectiontitle: Docker Compose CLI reference
-    section:
-    - path: /compose/reference/
-      title: Overview of docker compose CLI
-    - path: /compose/reference/envvars/
-      title: CLI environment variables
-    - path: /compose/reference/build/
-      title: docker compose build
-    - path: /compose/reference/config/
-      title: docker compose config
-    - path: /compose/reference/create/
-      title: docker compose create
-    - path: /compose/reference/down/
-      title: docker compose down
-    - path: /compose/reference/events/
-      title: docker compose events
-    - path: /compose/reference/exec/
-      title: docker compose exec
-    - path: /compose/reference/help/
-      title: docker compose help
-    - path: /compose/reference/images/
-      title: docker compose images
-    - path: /compose/reference/kill/
-      title: docker compose kill
-    - path: /compose/reference/logs/
-      title: docker compose logs
-    - path: /compose/reference/pause/
-      title: docker compose pause
-    - path: /compose/reference/port/
-      title: docker compose port
-    - path: /compose/reference/ps/
-      title: docker compose ps
-    - path: /compose/reference/pull/
-      title: docker compose pull
-    - path: /compose/reference/push/
-      title: docker compose push
-    - path: /compose/reference/restart/
-      title: docker compose restart
-    - path: /compose/reference/rm/
-      title: docker compose rm
-    - path: /compose/reference/run/
-      title: docker compose run
-    - path: /compose/reference/scale/
-      title: docker compose scale
-    - path: /compose/reference/start/
-      title: docker compose start
-    - path: /compose/reference/stop/
-      title: docker compose stop
-    - path: /compose/reference/top/
-      title: docker compose top
-    - path: /compose/reference/unpause/
-      title: docker compose unpause
-    - path: /compose/reference/up/
-      title: docker compose up
+  - title: Docker Compose CLI reference
+    # using old URL that redirects to the new location
+    path: /compose/reference/overview/
   - title: Daemon CLI (dockerd)
     path: /engine/reference/commandline/dockerd/
 - sectiontitle: API reference


### PR DESCRIPTION
The compose cli reference section contained links to all compose
commands, but all of them were redirects to the "compose" section
in the Docker CLI reference.

This patch:

- removes the duplicated navigation
- changes the Docker Compose CLI reference section into a link to
  the new location
- moves the "overview" and "environment variables" pages inside
  the new section (this page should possibly be merged into the
  CLI overview, which lists all environment variables).


Before:

<img width="264" alt="Screenshot 2022-07-08 at 17 28 59" src="https://user-images.githubusercontent.com/1804568/178024101-841ba67f-aacd-4cac-918b-33812eb2db61.png">

<img width="271" alt="Screenshot 2022-07-08 at 17 33 26" src="https://user-images.githubusercontent.com/1804568/178024371-5336d9ec-a12e-4f11-a8e4-6a9e52f3f653.png">

After:


<img width="284" alt="Screenshot 2022-07-08 at 17 28 40" src="https://user-images.githubusercontent.com/1804568/178024089-765ccfb8-fb73-4810-bb86-7cea3459b9e4.png">

<img width="281" alt="Screenshot 2022-07-08 at 17 34 06" src="https://user-images.githubusercontent.com/1804568/178024364-fb4e896f-4033-4914-9ec8-3a1aa9e7dc5a.png">

