### PR TITLE
Fix use of bullet list

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -144,8 +144,7 @@ capabilities approachable and easy to use. To summarize, a container:
 - is a runnable instance of an image. You can create, start, stop, move, or delete a container using the DockerAPI or CLI.
 - can be run on local machines, virtual machines or deployed to the cloud.
 - is portable (can be run on any OS).
-
-Containers are isolated from each other and run their own software, binaries, and configurations.
+- is isolated from other containers and runs its own software, binaries, and configurations.
 
 > **Creating containers from scratch**
 >

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -143,8 +143,9 @@ capabilities approachable and easy to use. To summarize, a container:
 
 - is a runnable instance of an image. You can create, start, stop, move, or delete a container using the DockerAPI or CLI.
 - can be run on local machines, virtual machines or deployed to the cloud.
-- is portable (can be run on any OS)
-- Containers are isolated from each other and run their own software, binaries, and configurations.
+- is portable (can be run on any OS).
+
+Containers are isolated from each other and run their own software, binaries, and configurations.
 
 > **Creating containers from scratch**
 >


### PR DESCRIPTION
### Otherwise it would read like so:

To summarize, a container: Containers are isolated from each other and run their own software, binaries, and configurations.

### Alternatively, to keep it as a bullet point:

To summarize, a container: 
...
is isolated from other containers and runs its own software, binaries, and configurations.

### Both are correct. I can change the PR to the above if preferred.

