### PR TITLE
ci: update redirects with replace directive in s3 bucket

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,21 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       -
+        name: Update redirects
+        run: |
+          for redirect in $(jq -c '. | to_entries | .[]' ./_site/redirects.json); do
+            from=$(echo "$redirect" | jq -r '.key')
+            to=$(echo "$redirect" | jq -r '.value')
+            from="${from%/}/index.html"
+            (
+              set -x
+              aws --region us-east-1 s3 cp "s3://${{ env.DOCS_S3_HOST }}${from}" "s3://${{ env.DOCS_S3_HOST }}${from}" --website-redirect "${to}" --metadata-directive REPLACE
+            )
+          done
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      -
         name: Update S3 website config
         uses: ./.github/actions/update-website-config
         with:


### PR DESCRIPTION
Handles redirects generated by https://docs.docker.com/redirects.json in our s3 bucket by setting redirect requests for the objects. As our bucket is configured as a website, objects with redirects should have the proper 301 redirect status.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>