### PR TITLE
remove deprecated projects from TOC and add redirects

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1590,11 +1590,3 @@ manuals:
       title: Getting help
 - path: /release-notes/
   title: Release notes
-- sectiontitle: Superseded products and tools
-  section:
-  - path: /machine/
-    title: Docker Machine (deprecated)
-  - path: /toolbox/
-    title: Docker Toolbox (deprecated)
-  - path: /kitematic/
-    title: Kitematic (deprecated)

--- a/deprecated/kitematic.md
+++ b/deprecated/kitematic.md
@@ -2,7 +2,9 @@
 description: Kitematic userguide (deprecated)
 keywords: kitematic, deprecated
 title: Kitematic (deprecated)
+redirect_to: /desktop/
 redirect_from:
+- /kitematic/
 - /kitematic/faq/
 - /kitematic/known-issues/
 - /kitematic/minecraft-server/

--- a/deprecated/machine.md
+++ b/deprecated/machine.md
@@ -2,7 +2,9 @@
 description: Docker Machine
 keywords: docker, machine
 title: Docker Machine
+redirect_to: /desktop/
 redirect_from:
+- /machine/
 - /machine/overview/
 - /machine/AVAILABLE_DRIVER_PLUGINS/
 - /machine/DRIVER_SPEC/

--- a/deprecated/toolbox.md
+++ b/deprecated/toolbox.md
@@ -3,10 +3,12 @@ description: Docker Desktop for Windows and Docker Toolbox
 keywords: windows, alpha, beta, toolbox, docker-machine, tutorial
 sitemap: false
 title: Docker Toolbox
+redirect_to: /desktop/
 redirect_from:
 - /docker-for-mac/docker-toolbox/
 - /docker-for-windows/docker-toolbox/
 - /mackit/docker-toolbox/
+- /toolbox/
 - /toolbox/faqs/
 - /toolbox/faqs/troubleshoot/
 - /toolbox/overview/


### PR DESCRIPTION
- alternative to https://github.com/docker/docker.github.io/pull/15111
- closes https://github.com/docker/docker.github.io/pull/15111

This patch:

- moves the kitematic, machine, and toolbox stubs to a "deprecated"
  directory (to remove clutter at the root of the repository)
- adds "redirect_to" to each of them to redirect them to the Docker Desktop homepage
- removes the "superseded projects" from the TOC

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
