### PR TITLE
Removes is_private from UpdateRepo docs

### DIFF
--- a/docker-hub/api/latest.yaml
+++ b/docker-hub/api/latest.yaml
@@ -1638,10 +1638,6 @@ components:
             This message shows that your installation appears to be working correctly.
 
             ```
-        is_private:
-          type: boolean
-          description: Allow to change visibility of the repository.
-          example: true
     repository:
       type: object
       properties:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

The UpdateRepository endpoint in the Hub API does not have the ability to set a repository's privacy. This removes mention of the field so as not to cause confusion

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
