### PR TITLE
fix redirects

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2,7 +2,7 @@
 description: Compose file reference
 keywords: fig, composition, compose, docker
 redirect_from:
-- /compose/yaml
+- /compose/yaml/
 - /compose/compose-file/compose-file-v1/
 title: Compose specification
 toc_max: 4

--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -3,8 +3,8 @@ title: Environment variables in Compose
 description: How to set, use and manage environment variables in Compose
 keywords: compose, orchestration, environment, env file
 redirect_from:
-- /compose/env
-- /compose/link-env-deprecated
+- /compose/env/
+- /compose/link-env-deprecated/
 ---
 
 There are multiple parts of Compose that deal with environment variables in one

--- a/config/containers/runmetrics.md
+++ b/config/containers/runmetrics.md
@@ -3,8 +3,8 @@ description: Measure the behavior of running containers
 keywords: docker, metrics, CPU, memory, disk, IO, run, runtime, stats
 redirect_from:
 - /articles/runmetrics/
-- /engine/articles/run_metrics
-- /engine/articles/runmetrics
+- /engine/articles/run_metrics/
+- /engine/articles/runmetrics/
 - /engine/admin/runmetrics/
 title: Runtime metrics
 ---

--- a/engine/reference/commandline/compose_events.md
+++ b/engine/reference/commandline/compose_events.md
@@ -3,7 +3,7 @@ datafolder: compose-cli
 datafile: docker_compose_events
 title: docker compose events
 redirect_from:
-- /compose/reference/events
+- /compose/reference/events/
 ---
 <!--
 Sorry, but the contents of this page are automatically generated from


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/15109

some redirects are malformed so they could not be found in the bucket:

```
+ aws --region us-east-1 s3 cp s3://docs.docker.com-stage-us-east-1/compose/reference/events/index.html s3://docs.docker.com-stage-us-east-1/compose/reference/events/index.html --website-redirect /engine/reference/commandline/compose_events/ --metadata-directive REPLACE
fatal error: An error occurred (404) when calling the HeadObject operation: Key "compose/reference/events/index.html" does not exist
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>