### PR TITLE
ENGDOCS-813 remove link to topic that no longer exists

### DIFF
--- a/docker-id/index.md
+++ b/docker-id/index.md
@@ -50,8 +50,6 @@ stored in your home directory in `.docker/config.json`. The password is base64-e
 
 If you run into trouble with your Docker ID account, know that we are here to help! If you want to retrieve or reset your password, [enter your email address](https://id.docker.com/reset-password/){: target="_blank" rel="noopener" class="_"} for additional instructions.
 
- The most frequently asked questions regarding Docker ID accounts can be found on our [support troubleshooting FAQ](https://hub.docker.com/support/).
-
 You can use the [Docker forums](https://forums.docker.com/) to ask questions amongst other Docker community members, while our [hub-feedback GitHub repository](https://github.com/docker/hub-feedback) allows you to provide feedback on how we can better improve the experience with Docker Hub.
 
 If you still need any help, [create a support ticket](https://hub.docker.com/support/contact/) and let us know how we can help you.


### PR DESCRIPTION
### Proposed changes

The information was removed with the support form migration. The current link now redirects to the Hub docs.

### Related issues (optional)

ENGDOCS-813