### PR TITLE
Issue 15094 - how to access get started

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -106,9 +106,9 @@ $ docker run -d -p 80:80 docker/getting-started
 
 You'll notice a few flags being used. Here's some more info on them:
 
-- `-d` - run the container in detached mode (in the background)
-- `-p 80:80` - map port 80 of the host to port 80 in the container
-- `docker/getting-started` - the image to use
+- `-d` - Run the container in detached mode (in the background).
+- `-p 80:80` - Map port 80 of the host to port 80 in the container. To access the tutorial, open a web browser and navigate to `http://localhost:80`. If you already have a service listening on port 80 on your host machine, you can specify another port. For example, specify `-p 3000:80` and then access the tutorial via a web browser at  `http://localhost:3000`.
+- `docker/getting-started` - Specify the image to use.
 
 > **Tip**
 >

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -107,7 +107,7 @@ $ docker run -d -p 80:80 docker/getting-started
 You'll notice a few flags being used. Here's some more info on them:
 
 - `-d` - Run the container in detached mode (in the background).
-- `-p 80:80` - Map port 80 of the host to port 80 in the container. To access the tutorial, open a web browser and navigate to `http://localhost:80`. If you already have a service listening on port 80 on your host machine, you can specify another port. For example, specify `-p 3000:80` and then access the tutorial via a web browser at  `http://localhost:3000`.
+- `-p 80:80` - Map port 80 of the host to port 80 in the container. To access the tutorial, open a web browser and navigate to `http://localhost:80`. If you already have a service listening on port 80 on your host machine, you can specify another port. For example, specify `-p 3000:80` and then access the tutorial via a web browser at `http://localhost:3000`.
 - `docker/getting-started` - Specify the image to use.
 
 > **Tip**


### PR DESCRIPTION
### Proposed changes

Added info on how to access get started tutorial after running the image. Also added info about changing ports if users already have something listening on port 80.

### Related issues (optional)

Fixes #15094
ENGDOCS-817
