### PR TITLE
Fix other dead link in compose doc

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -486,7 +486,7 @@ The long syntax provides more granularity in how the config is created within th
   task containers. Defaults to `/<source>` if not specified.
 - `uid` and `gid`: The numeric UID or GID that owns the mounted config file
   within the service's task containers. Default value when not specified is USER running container.
-- `mode`: The [permissions](http://permissions-calculator.org/) for the file that is mounted within the service's
+- `mode`: The [permissions](https://web.archive.org/web/20220310140126/http://permissions-calculator.org/) for the file that is mounted within the service's
   task containers, in octal notation. Default value is world-readable (`0444`).
   Writable bit MUST be ignored. The executable bit can be set.
 


### PR DESCRIPTION
Turns out the dead-link to a permissions calculator fixed in PR #14985 only fixed one of two links.
This pull request fixes the other one.

### Related issues (optional)
PR #14985
