### PR TITLE
fix linking to desktop support

### DIFF
--- a/desktop/linux/troubleshoot.md
+++ b/desktop/linux/troubleshoot.md
@@ -57,7 +57,7 @@ Before you get started, we recommend that you sign into your Docker Desktop appl
 6. If you have a paid Docker subscription, click **Contact Support**. This opens the [Docker Desktop support](https://hub.docker.com/support/desktop/){:target="_blank" rel="noopener" class="_"} form. Fill in the information required and add the ID you copied earlier to the Diagnostics ID field. Click **Submit** to request Docker Desktop support.
    > **Note**
     >
-    > You must be signed in to Docker Desktop using your Pro, Team, or Business tier credentials to access the support form. For information on what's covered as part of Docker Desktop support, see [Support](#support).
+    > You must be signed in to Docker Desktop using your Pro, Team, or Business tier credentials to access the support form. For information on what's covered as part of Docker Desktop support, see [Support](../../support/index.md).
 7. If you don't have a paid Docker subscription, you can click **Upgrade to benefit from Docker Support** to upgrade your existing account.
     Alternatively, click **Report a Bug** to open a new Docker Desktop issue on GitHub. This opens Docker Desktop [for Linux](https://github.com/docker/desktop-linux/issues/) on GitHub in your web browser in a 'New issue' template. Complete the information required and ensure you add the diagnostic ID you copied earlier. Click **submit new issue** to create a new issue.
 

--- a/desktop/mac/troubleshoot.md
+++ b/desktop/mac/troubleshoot.md
@@ -77,7 +77,7 @@ Before you get started, we recommend that you sign into your Docker Desktop appl
 6. If you have a paid Docker subscription, click **Contact Support**. This opens the [Docker Desktop support](https://hub.docker.com/support/desktop/){:target="_blank" rel="noopener" class="_"} form. Fill in the information required and add the ID you copied earlier to the Diagnostics ID field. Click **Submit** to request Docker Desktop support.
    > **Note**
     >
-    > You must be signed in to Docker Desktop using your Pro, Team, or Business tier credentials to access the support form. For information on what's covered as part of Docker Desktop support, see [Support](#support).
+    > You must be signed in to Docker Desktop using your Pro, Team, or Business tier credentials to access the support form. For information on what's covered as part of Docker Desktop support, see [Support](../../support/index.md).
 7. If you don't have a paid Docker subscription, you can click **Upgrade to benefit from Docker Support** to upgrade your existing account.
     Alternatively, click **Report a Bug** to open a new Docker Desktop issue on GitHub. This opens Docker Desktop [for Mac](https://github.com/docker/for-mac/issues/) on GitHub in your web browser in a 'New issue' template. Complete the information required and ensure you add the diagnostic ID you copied earlier. Click **submit new issue** to create a new issue.
 

--- a/desktop/windows/troubleshoot.md
+++ b/desktop/windows/troubleshoot.md
@@ -56,7 +56,7 @@ from the menu.
 
    > **Note**
    >
-   > You must be signed in to Docker Desktop using your Pro or Team plan credentials to access the support form. For information on what's covered as part of Docker Desktop support, see [Support](#support).
+   > You must be signed in to Docker Desktop using your Pro or Team plan credentials to access the support form. For information on what's covered as part of Docker Desktop support, see [Support](../../support/index.md).
 7. If you don't have a paid Docker subscription, click **Upgrade to benefit from Docker Support** to upgrade your existing account.
     Alternatively, click **Report a Bug** to open a new Docker Desktop issue on GitHub. This opens Docker Desktop [for Windows](https://github.com/docker/for-win/issues/) on GitHub in your web browser in a 'New issue' template. Complete the information required and ensure you add the diagnostic ID you copied earlier. Click **submit new issue** to create a new issue.
 


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/15156#issuecomment-1188822964

```
#16 144.2 - ./_site/desktop/linux/troubleshoot/index.html
#16 144.2   *  linking to internal hash #support that does not exist (line 176)
#16 144.2      <a href="#support">Support</a>
```
> https://github.com/docker/docker.github.io/runs/7406248205?check_suite_focus=true#step:4:556

also looks like `published` branch was not protected by required check status before merging. added this protection so we avoid merging PRs with faulty links:

![image](https://user-images.githubusercontent.com/1951866/179719950-15807191-beaa-47cb-8d9c-9d345dcc6468.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>