### PR TITLE
dockerfile: create stub file with frontmatter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -179,6 +179,6 @@ fetch-remote:
     default_branch: "master"
     ref: "master"
     paths:
-      - dest: "engine/reference/builder.md"
+      - dest: "_includes/dockerfile/reference.md"
         src:
           - "frontend/dockerfile/docs/reference.md"

--- a/_plugins/include_remote.rb
+++ b/_plugins/include_remote.rb
@@ -1,0 +1,54 @@
+module Jekyll
+  class IncludeRemoteTag < Liquid::Tag
+    def initialize(tag_name, params, tokens)
+      @page, @line_start, @line_end = params.split
+      @line_start, @line_end = resolve_line_numbers(@line_start, @line_end)
+      super
+    end
+
+    def render(context)
+      site = context.registers[:site]
+      page = context.registers[:page]
+
+      beginning_time = Time.now
+      Jekyll.logger.info "Starting plugin include_remote.rb..."
+
+      if context[@page.strip]
+        @page = context[@page.strip]
+      end
+
+      inc = File.join("_includes", @page)
+      Jekyll.logger.info "  Inject #{inc} to #{page['path']}"
+
+      lines = File.readlines(inc)[@line_start..@line_end]
+
+      site.config['defaults'].each do |default|
+        if default['scope']['path'] == inc
+          page['edit_url'] = default['values']['edit_url']
+          page['issue_url'] = default['values']['issue_url']
+          Jekyll.logger.info "    edit_url:  #{page['edit_url']}"
+          Jekyll.logger.info "    issue_url: #{page['issue_url']}"
+          break
+        end
+      end
+
+      end_time = Time.now
+      Jekyll.logger.info "done in #{(end_time - beginning_time)} seconds"
+
+      lines.join
+    end
+
+    def resolve_line_numbers(first, last)
+      if first.nil? && last.nil?
+        first = 0
+        last  = -1
+      elsif last.nil?
+        last = first
+      end
+      [first.to_i, last.to_i]
+    end
+  end
+
+end
+
+Liquid::Template.register_tag('include_remote', Jekyll::IncludeRemoteTag)

--- a/engine/reference/builder.md
+++ b/engine/reference/builder.md
@@ -1,0 +1,10 @@
+---
+title: Dockerfile reference
+description: "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
+keywords: build, dockerfile, reference
+toc_max: 3
+redirect_from:
+- /reference/builder/
+---
+
+{% include_remote dockerfile/reference.md 2 -1 -%}


### PR DESCRIPTION
needs https://github.com/moby/buildkit/pull/2970

as discussed, it's better to have the frontmatter section here instead of the buildkit repo. ~needs to fetch remote reference in the same folder otherwise we can't include it in the stub file. will be fixed anyway when we are going to move to the new location in https://github.com/docker/docker.github.io/pull/15110~