### PR TITLE
issue 15167 - add direct download link for getting-started app

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -24,7 +24,7 @@ Before we can run the application, we need to get the application source code on
 our machine. For real projects, you will typically clone the repo. But, for this tutorial,
 we have created a ZIP file containing the application.
 
-1. [Download the App contents](https://github.com/docker/getting-started/tree/master/app){:target="_blank" rel="noopener" class="_"}. You can either pull the entire project or download it as a zip and extract the app folder out to get started with.
+1. Download the App contents from the [getting-started repository](https://github.com/docker/getting-started/tree/master){:target="_blank" rel="noopener" class="_"}. You can either pull the entire project or [download it as a zip](https://github.com/docker/getting-started/archive/refs/heads/master.zip) and extract the app folder out to get started with.
 
 2. Once extracted, use your favorite code editor to open the project. If you're in need of
     an editor, you can use [Visual Studio Code](https://code.visualstudio.com/){:target="_blank" rel="noopener" class="_"}. You should


### PR DESCRIPTION
For [getting started part 2](https://docs.docker.com/get-started/02_our_app/), added direct download link  for zip and updated the repo link as there is no way to download from within the linked directory.

### Related issues 

Fixes #15167 
ENGDOCS-826
