### PR TITLE
ci: add lab branch to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: publish
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - lab
@@ -31,6 +32,9 @@ jobs:
             DOCS_S3_BUCKET=""
             DOCS_LAMBDA_FUNCTION_CACHE=""
             DOCS_S3_CONFIG="_website-config-docs-lab.json"
+          else
+            echo >&2 "ERROR: unknown branch ${{ github.ref }}"
+            exit 1
           fi
           echo "JEKYLL_ENV=$JEKYLL_ENV" >> $GITHUB_ENV
           echo "DOCS_AWS_REGION=$DOCS_AWS_REGION" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: publish
 on:
   push:
     branches:
+      - lab
       - master
       - published
 
@@ -26,6 +27,10 @@ jobs:
             DOCS_S3_CONFIG="_website-config-docs.json"
             DOCS_LAMBDA_FUNCTION_CACHE="arn:aws:lambda:us-east-1:710015040892:function:docs-cache-invalidator"
             DOCS_SLACK_MSG="Successfully published docs. https://docs.docker.com/"
+          elif [ "${{ github.ref }}" = "refs/heads/lab" ]; then
+            DOCS_S3_BUCKET=""
+            DOCS_LAMBDA_FUNCTION_CACHE=""
+            DOCS_S3_CONFIG="_website-config-docs-lab.json"
           fi
           echo "JEKYLL_ENV=$JEKYLL_ENV" >> $GITHUB_ENV
           echo "DOCS_AWS_REGION=$DOCS_AWS_REGION" >> $GITHUB_ENV
@@ -69,6 +74,7 @@ jobs:
           AWS_S3_CONFIG: ${{ env.DOCS_S3_CONFIG }}
       -
         name: Invalidate docs website cache
+        if: ${{ env.DOCS_LAMBDA_FUNCTION_CACHE != '' }}
         uses: docker/bake-action@v2
         with:
           targets: aws-lambda-invoke
@@ -81,5 +87,6 @@ jobs:
           AWS_LAMBDA_FUNCTION: ${{ env.DOCS_LAMBDA_FUNCTION_CACHE }}
       -
         name: Send Slack notification
+        if: ${{ env.DOCS_SLACK_MSG != '' }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ env.DOCS_SLACK_MSG }}"}' ${{ secrets.SLACK_WEBHOOK }}

--- a/_releaser/_website-config-docs-lab.json
+++ b/_releaser/_website-config-docs-lab.json
@@ -1,0 +1,388 @@
+{
+  "ErrorDocument": {
+    "Key": "404.html"
+  },
+  "IndexDocument": {
+    "Suffix": "index.html"
+  },
+  "RedirectAllRequestsTo": null,
+  "RoutingRules": [
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.4/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.5/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.6/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.7/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.8/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.9/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.10/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.11/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.12/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v1.13/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.03/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.09/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.12/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/licensing/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/get-support/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/cluster/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/supported-platforms/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/ucp/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/dtr/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "compliance/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "datacenter/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.09/ee/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.03/ee/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.06/enterprise/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/docker-ee/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "ee/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": null,
+        "ReplaceKeyWith": ""
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v17.06/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.03/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    },
+    {
+      "Condition": {
+        "HttpErrorCodeReturnedEquals": null,
+        "KeyPrefixEquals": "v18.09/"
+      },
+      "Redirect": {
+        "HostName": "docs-lab.docker.com",
+        "HttpRedirectCode": null,
+        "Protocol": "https",
+        "ReplaceKeyPrefixWith": "",
+        "ReplaceKeyWith": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/15151

We are working with @VictorBersy to add a new environment to test advanced features on docs repo without impacting staging (https://docs-stage.docker.com/) and production (https://docs.docker.com/) environment.

This environment will be published to `https://docs-lab.docker.com/`.

I have created a lab branch where we are going to make some tests with https://github.com/docker/docker.github.io/pull/15151.

This PR adds the necessary configuration to our publish workflow to allow manual invocations on lab branch (see last commit).

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>