### PR TITLE
Adding additional note for apple silicon users

### DIFF
--- a/desktop/mac/apple-silicon.md
+++ b/desktop/mac/apple-silicon.md
@@ -18,6 +18,11 @@ Download Docker Desktop for Mac on Apple silicon:
 >
 > [Mac with Apple chip](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn }
 
+```Note
+ℹ️ If the binary from following page doesn't have .dmg extension, rename the file to Docker.dmg and double click the same to install
+https://docs.docker.com/desktop/mac/apple-silicon/
+```
+
 ### System requirements
 
 Beginning with Docker Desktop 4.3.0, we have removed the hard requirement to install **Rosetta 2**. There are a few optional command line tools that still require Rosetta 2 when using Darwin/AMD64. See the Known issues section below. However, to get the best experience, we recommend that you install Rosetta 2. To install Rosetta 2 manually from the command line, run the following command:


### PR DESCRIPTION
### Proposed changes

I have downloaded the Docker Desktop from the following page and the binary doesn't have the ".dmg" extension so I could not double-click and install it on my mac running on M1 chip. 

Please add this instruction to the primary documentation. Otherwise, update the release repository with a proper extension. 