### PR TITLE
Issue-15170 specify arch for command

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -40,7 +40,9 @@ So, let's do it!
 
 1. Make sure you don't have any previous `getting-started` containers running.
 
-2. Run the following command from the app directory. We'll explain what's going on afterwards:
+2. Run the following command from the app directory. We'll explain what's going on afterwards.
+
+    If you are using an x86-64 Mac or Linux device, then use the following command.
 
     ```console
     $ docker run -dp 3000:3000 \
@@ -49,7 +51,7 @@ So, let's do it!
         sh -c "yarn install && yarn run dev"
     ```
 
-    If you are using Windows then use this command in PowerShell:
+    If you are using Windows, then use the following command in PowerShell.
 
     ```powershell
     PS> docker run -dp 3000:3000 `
@@ -60,7 +62,7 @@ So, let's do it!
 
     If you are using an Apple silicon Mac or another ARM64 device, then use the following command.
 
-    ```bash
+    ```console
     $ docker run -dp 3000:3000 \
         -w /app -v "$(pwd):/app" \
         node:12-alpine \


### PR DESCRIPTION
### Proposed changes

In /get-started/06_bind_mounts.md:
- specified arch for command because it was ambiguous
- made wording and grammar more consistent among the commands
- changed codeblock from bash to console to be more copy-paste friendly

### Related issues (optional)

Fixes #15170 
ENGDOCS-830