### PR TITLE
fix broken bullet indentation on the 'Docker Desktop overview' page

### DIFF
--- a/desktop/index.md
+++ b/desktop/index.md
@@ -26,7 +26,7 @@ Docker Desktop includes:
 - [Docker Engine](../engine/index.md)
 - Docker CLI client
 - [Docker Compose](../compose/index.md)
--[Docker Content Trust](../engine/security/trust/index.md)
+- [Docker Content Trust](../engine/security/trust/index.md)
 - [Kubernetes](https://github.com/kubernetes/kubernetes/)
 - [Credential Helper](https://github.com/docker/docker-credential-helpers/).
 


### PR DESCRIPTION
### Proposed changes

Fixed broken bullet indentation on the "Docker Desktop Overview" page

![docker-desktop-overview](https://user-images.githubusercontent.com/6629813/180591992-2577fdfb-282a-4a56-b8e6-8076396c8e5a.png)

