### PR TITLE
fix commands to create registry.json (ENGDOCS-844)

### DIFF
--- a/_includes/configure-registry-json.md
+++ b/_includes/configure-registry-json.md
@@ -83,8 +83,9 @@ $ sudo hdiutil detach /Volumes/Docker
 To manually create a `registry.json` file, run the following commands in a terminal and replace `myorg` with your organization's name.
 
 ```bash
-$ sudo touch /Library/Application Support/com.docker.docker/registry.json
-$ sudo echo '{"allowedOrgs":["myorg"]}' >> /Library/Application Support/com.docker.docker/registry.json
+$ sudo mkdir -p "/Library/Application Support/com.docker.docker"
+$ sudo touch "/Library/Application Support/com.docker.docker/registry.json"
+$ sudo echo '{"allowedOrgs":["myorg"]}' >> "/Library/Application Support/com.docker.docker/registry.json"
 ```
 
 This creates the `registry.json` file at `/Library/Application Support/com.docker.docker/registry.json` and includes the organization information the user belongs to. Make sure this file can't be edited by the user, only by the administrator.


### PR DESCRIPTION

### Proposed changes

The Mac commands for creating a registry.json do not work. 
- `touch` does not create directories. Added `mkdir -p` to create directories. 
- The directory path has a space. Added quotes around directory path.

### Related issues (optional)
ENGDOCS-844
