### PR TITLE
jekyll: keep paragraph of reading time and use include

### DIFF
--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,4 +1,6 @@
+{%- unless page.skip_read_time == true -%}
 {%- assign words = content | number_of_words -%}
 {%- if words >= 360 -%}
-<p><em class="reading-time">Estimated reading time: {{ words | divided_by:180 }} minutes</em></p>
+<em class="reading-time">Estimated reading time: {{ words | divided_by:180 }} minutes</em>
 {%- endif -%}
+{%- endunless -%}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -28,12 +28,7 @@
                             {%- if page.advisory -%}
                             <blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>
                             {%- endif -%}
-                            {%- unless page.skip_read_time == true -%}
-                            {%- assign words = content | number_of_words -%}
-                            {%- if words >= 360 -%}
-                            <p><em class="reading-time">Estimated reading time: {{ words | divided_by:180 }} minutes</em></p>
-                            {%- endif -%}
-                            {%- endunless -%}
+                            <p>{%- include read_time.html -%}</p>
                             {{ content }}
                             {%- unless page.notags == true -%}
                             {%- assign keywords = page.keywords | split:"," -%}


### PR DESCRIPTION
While working on #15194 I found out there was no proper spacing after the title of some pages:

![image](https://user-images.githubusercontent.com/1951866/181126472-29b44f79-0121-4858-8ae5-07594c91e6e7.png)
> https://deploy-preview-15194--docsdocker.netlify.app/build/bake/

Looking at the layout it seems it was done on purpose to handle the [estimated reading time](https://github.com/docker/docker.github.io/blob/f540f58541b02236262f93272790b706c2c48b24/_layouts/docs.html#L34) of page so rendering looks right:

![image](https://user-images.githubusercontent.com/1951866/181126719-e52e6aca-9d72-4649-a928-ff2f6fcf2f4c.png)
> https://docs.docker.com/desktop/

This PR now keeps the paragraph even if the estimated reading time is not rendered so we are consistent across pages:

![image](https://user-images.githubusercontent.com/1951866/181126975-e29e849b-bff7-4b73-8eed-e05e54b61b58.png)

I also found out that this block was duplicated and available as an include in https://github.com/docker/docker.github.io/blob/f540f58541b02236262f93272790b706c2c48b24/_includes/read_time.html so switch to the include instead.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>