### PR TITLE
dd: add missing redirect for old content

### DIFF
--- a/desktop/faqs/linuxfaqs.md
+++ b/desktop/faqs/linuxfaqs.md
@@ -3,7 +3,7 @@ description: Frequently asked questions
 keywords: desktop, linux, faqs
 title: Frequently asked questions for Linux
 redirect_from:
-- desktop/linux/space
+- /desktop/linux/space/
 ---
 
 ## Where does Docker Desktop store Linux containers?

--- a/desktop/faqs/macfaqs.md
+++ b/desktop/faqs/macfaqs.md
@@ -3,7 +3,8 @@ description: Frequently asked questions
 keywords: desktop, mac, faqs
 title: Frequently asked questions for Mac
 redirect_from:
-- desktop/mac/space
+- /desktop/mac/space/
+- /docker-for-mac/space/
 ---
 
 ### What is Docker.app?

--- a/desktop/get-started.md
+++ b/desktop/get-started.md
@@ -3,33 +3,28 @@ description: Docker Dashboard
 keywords: Docker Dashboard, manage, containers, gui, dashboard, images, user manual
 title: Sign in and get started
 redirect_from:
+- /desktop/linux/
+- /desktop/linux/index/
+- /desktop/mac/
+- /desktop/mac/index/
+- /desktop/windows/
+- /desktop/windows/index/
+- /docker-for-mac/
+- /docker-for-mac/index/
+- /docker-for-mac/osx/
+- /docker-for-mac/started/
 - /docker-for-windows/
 - /docker-for-windows/index/
 - /docker-for-windows/started/
-- /engine/installation/windows/
-- /installation/windows/
+- /mac/
+- /mac/started/
+- /mackit/
+- /mackit/getting-started/
 - /win/
 - /windows/
 - /windows/started/
 - /winkit/
 - /winkit/getting-started/
-- /desktop/linux/index/
-- /desktop/windows/index/
-- /docker-for-mac/
-- /docker-for-mac/index/
-- /docker-for-mac/mutagen/
-- /docker-for-mac/mutagen-caching/
-- /docker-for-mac/osx/
-- /docker-for-mac/started/
-- /engine/installation/mac/
-- /installation/mac/
-- /mac/
-- /mac/started/
-- /mackit/
-- /mackit/getting-started/
-- /docker-for-mac/osxfs/
-- /docker-for-mac/osxfs-caching/
-- /desktop/mac/index/
 ---
 
 ## Quick Start Guide

--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -3,8 +3,10 @@ description: How to install Docker Desktop on Mac
 keywords: mac, install, download, run, docker, local
 title: Install Docker Desktop on Mac
 redirect_from:
-- /docker-for-mac/install/
 - /desktop/mac/install/
+- /docker-for-mac/install/
+- /engine/installation/mac/
+- /installation/mac/
 ---
 
 > **Update to the Docker Desktop terms**

--- a/desktop/install/windows-install.md
+++ b/desktop/install/windows-install.md
@@ -3,14 +3,16 @@ description: How to install Docker Desktop for Windows
 keywords: windows, install, download, run, docker, local
 title: Install Docker Desktop on Windows
 redirect_from:
-- /docker-for-windows/install/
+- /desktop/windows/install/
 - /docker-ee-for-windows/install/
 - /docker-for-windows/install-windows-home/
+- /docker-for-windows/install/
 - /ee/docker-ee/windows/docker-ee/
+- /engine/installation/windows/
 - /engine/installation/windows/docker-ee/
 - /install/windows/docker-ee/
 - /install/windows/ee-preview/
-- /desktop/windows/install/
+- /installation/windows/
 ---
 
 > **Update to the Docker Desktop terms**

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -11,6 +11,7 @@ redirect_from:
 - /docker-for-windows/release-notes/
 - /desktop/windows/release-notes/
 - /desktop/linux/release-notes/
+- /mackit/release-notes/
 ---
 
 This page contains information about the new features, improvements, known issues, and bug fixes in Docker Desktop releases.

--- a/desktop/settings/mac.md
+++ b/desktop/settings/mac.md
@@ -2,6 +2,11 @@
 description: Docker Desktop settings
 keywords: settings, preferences, proxy, file sharing, resources, kubernetes, Docker Desktop, Mac
 title: Change Docker Desktop preferences on Mac
+redirect_from:
+- /docker-for-mac/mutagen-caching/
+- /docker-for-mac/mutagen/
+- /docker-for-mac/osxfs-caching/
+- /docker-for-mac/osxfs/
 ---
 
 This page provides information on how to configure and manage your Docker Desktop settings.


### PR DESCRIPTION
- relates to https://github.com/docker/docker.github.io/pull/15219
- fixes https://github.com/docker/docker.github.io/issues/15229
- fixes https://github.com/docker/docker.github.io/issues/15230
- fixes https://github.com/docker/docker.github.io/issues/15232
- fixes https://github.com/docker/docker.github.io/issues/15233
- fixes https://github.com/docker/docker.github.io/issues/15237
- fixes https://github.com/docker/docker.github.io/issues/15238

Adds redirects for content that was removed in cab9f914bf5185dedb8c4cdd8c7705e5c390c43d

I tried to pick the most logical location, or following existing redirects (some of them
I wasn't sure about, e.g. most of the old "landing" page URLs looked to be redirected to
"get-started", not "desktop overview").


