### PR TITLE
jekyll(css): fix social icons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -88,13 +88,13 @@
             </div>
             <div class="footer_social_nav">
                 <ul class="nav-social">
-                    <li class="fa fa-twitter"><a href="https://twitter.com/docker">Twitter</a></li>
-                    <li class="fa fa-youtube"><a href="https://www.youtube.com/user/dockerrun">Youtube</a></li>
-                    <li class="fa fa-github"><a href="https://github.com/docker">GitHub</a></li>
-                    <li class="fa fa-linkedin"><a href="https://www.linkedin.com/company/docker">Linkedin</a></li>
-                    <li class="fa fa-facebook"><a href="https://www.facebook.com/docker.run">Facebook</a></li>
-                    <li class="fa fa-slideshare"><a href="https://www.slideshare.net/docker">Slideshare</a></li>
-                    <li class="fa fa-reddit"><a href="https://www.reddit.com/r/docker">Reddit</a></li>
+                    <li class="fa-brands fa-twitter"><a href="https://twitter.com/docker">Twitter</a></li>
+                    <li class="fa-brands fa-youtube"><a href="https://www.youtube.com/user/dockerrun">Youtube</a></li>
+                    <li class="fa-brands fa-github"><a href="https://github.com/docker">GitHub</a></li>
+                    <li class="fa-brands fa-linkedin-in"><a href="https://www.linkedin.com/company/docker">Linkedin</a></li>
+                    <li class="fa-brands fa-facebook-f"><a href="https://www.facebook.com/docker.run">Facebook</a></li>
+                    <li class="fa-brands fa-slideshare"><a href="https://www.slideshare.net/docker">Slideshare</a></li>
+                    <li class="fa-brands fa-reddit-alien"><a href="https://www.reddit.com/r/docker">Reddit</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
related #15223 

Upgrading Font Awesome has broken our social icons:

![image](https://user-images.githubusercontent.com/1951866/181344230-b8b2132a-996c-44b1-95de-abf5238b1ed7.png)

Before we had:

![image](https://user-images.githubusercontent.com/1951866/181344331-62f60f05-4aa7-4e20-9f84-8f9bfcfda67f.png)

With these changes:

![image](https://user-images.githubusercontent.com/1951866/181344437-5285fbc8-ed00-4d05-a274-ca19a79ccb9f.png)


Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>