### PR TITLE
Add /go/linux-credentials/ redirect

### DIFF
--- a/go/linux-credentials.md
+++ b/go/linux-credentials.md
@@ -1,0 +1,5 @@
+---
+title: How to set up and configure the pass credentials helper for Docker Desktop for Linux
+description: How to set up and configure the pass credentials helper for Docker Desktop for Linux
+redirect_to: /desktop/get-started/#credentials-management-for-linux-users
+---


### PR DESCRIPTION
- relates to https://github.com/docker/docker.github.io/issues/15229
- relates to https://github.com/docker/docker.github.io/pull/15231
- relates to https://github.com/docker/docker.github.io/pull/15219


Docker Desktop for Linux currently has a link to;
https://docs.docker.com/desktop/linux/#credentials-management

which has moved, and didn't have a redirect, causing the link to break;
unfortunately we can't fix existing versions of Docker Desktop; redirects
are being added (but won't be able to redirect to the correct anchor).

This patch adds a https://docs.docker.com/go/linux-credentials/ redirect,
so that we can continue using that URL even if content moves around.


