### PR TITLE
Updates docs for s390x for latest version

### DIFF
--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -28,7 +28,7 @@ To get started with Docker Engine on RHEL, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need a maintained version of RHEL 7 or 8 on s390x (IBM Z).
+To install Docker Engine, you need a maintained version of RHEL 7, RHEL 8 or RHEL 9 on s390x (IBM Z).
 Archived versions aren't supported or tested.
 
 The `overlay2` storage driver is recommended.

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -34,10 +34,10 @@ To get started with Docker Engine on SLES, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need a maintained version of SLES 15-SP2 or SLES 15-SP3 on s390x (IBM Z).
+To install Docker Engine, you need a maintained version of SLES 15-SP3 on s390x (IBM Z).
 Archived versions aren't supported or tested.
 
-The [`SCC SUSE`](https://scc.suse.com/packages?name=SUSE%20Linux%20Enterprise%20Server&version=15.2&arch=s390x)
+The [`SCC SUSE`](https://scc.suse.com/packages?name=SUSE%20Linux%20Enterprise%20Server&version=15.3&arch=s390x)
 repositories must be enabled.
 
 The [OpenSUSE `SELinux` repository](https://download.opensuse.org/repositories/security)

--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -66,7 +66,7 @@ testuser:231072:65536
 - `overlay2` storage driver  is enabled by default
   ([Ubuntu-specific kernel patch](https://kernel.ubuntu.com/git/ubuntu/ubuntu-bionic.git/commit/fs/overlayfs?id=3b7da90f28fe1ed4b79ef2d994c81efbc58f1144)).
 
-- Known to work on Ubuntu 18.04, 20.04, and 21.04.
+- Known to work on Ubuntu 18.04, 20.04, and 22.04.
 </div>
 <div id="hint-debian" class="tab-pane fade in" markdown="1">
 - Install `dbus-user-session` package if not installed. Run `sudo apt-get install -y dbus-user-session` and relogin.


### PR DESCRIPTION
- carry of https://github.com/docker/docker.github.io/pull/15031 (only rebased)
- replaces https://github.com/docker/docker.github.io/pull/15031
- closes https://github.com/docker/docker.github.io/pull/15031