### PR TITLE
jekyll: fix not expanded DOMAIN env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ if [ "${JEKYLL_ENV}" = "production" ]; then
   (
     set -x
     bundle exec jekyll build --profile -d ${TARGET} --config _config.yml,_config_production.yml
-    sed -i 's#<loc>/#<loc>https://${DOMAIN}/#' "${TARGET}/sitemap.xml"
+    sed -i "s#<loc>/#<loc>https://${DOMAIN}/#" "${TARGET}/sitemap.xml"
   )
 else
   (
@@ -64,7 +64,7 @@ else
   )
 fi
 find ${TARGET} -type f -name '*.html' | while read i; do
-  sed -i 's#\(<a[^>]* href="\)https://${DOMAIN}/#\1/#g' "$i"
+  sed -i "s#\(<a[^>]* href=\"\)https://${DOMAIN}/#\1/#g" "$i"
 done
 EOT
 


### PR DESCRIPTION
follow-up https://github.com/docker/docker.github.io/pull/15250#issuecomment-1198060836

fix regression from https://github.com/docker/docker.github.io/pull/14685 where `DOMAIN` env var is not expanded, resulting with a broken sitemap: https://github.com/docker/docker.github.io/pull/15250#issuecomment-1198060836

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>