### PR TITLE
Add GitHub Actions annotations for linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,56 @@ jobs:
         name: Validate
         uses: docker/bake-action@v2
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.target }}-output
           set: |
+            *.cache-to=type=gha,scope=validate-${{ matrix.target }},mode=max
+            *.cache-from=type=gha,scope=validate-${{ matrix.target }}
             *.cache-from=type=gha,scope=build
+      -
+        name: Annotate
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('lint/results', 'utf-8');
+            if (results.length == 0) {
+              process.exit(0);
+            }
+
+            // print results
+            console.log(results);
+            process.exitCode = 1;
+
+            // construct annotations by parsing output
+            switch ("${{ matrix.target }}") {
+            case "htmlproofer":
+              const re = /^- (.+)\n  \*  (.+) \(line (\d+)\)\n(.+)$/gm;
+              while (true) {
+                const result = re.exec(results);
+                if (result === null) {
+                  break;
+                }
+
+                core.error(`${result[2]}\n${result[4]}`, {
+                  title: 'Link check failed',
+                  // file: result[1],
+                  // startLine: result[3],
+                });
+              }
+              break;
+            case "mdl":
+              const jsonResults = JSON.parse(results);
+              for (const result of jsonResults) {
+                const title = result.rule + (result.aliases.length > 0 ? ` (${result.aliases[0]})` : ``);
+                console.log(`${result.filename}:${result.line}; ${title} - ${result.description}`);
+                core.error(result.description, {
+                  title: title,
+                  file: result.filename,
+                  startLine: result.line,
+                });
+              }
+              break;
+            }
 
   # build-releaser job will just build _releaser app used for Netlify and
   # AWS deployment in publish workflow. it's just to be sure it builds correctly.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _site/**
 CNAME
 _kbase/**
 /vendor
+/lint

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,13 @@
+{
+  "default": false,
+  "hr-style": true,
+  "no-missing-space-atx": true,
+  "no-multiple-space-atx": true,
+  "no-missing-space-closed-atx": true,
+  "no-multiple-space-closed-atx": true,
+  "no-space-in-emphasis": true,
+  "no-space-in-code": true,
+  "no-space-in-links": true,
+  "ol-prefix": {"style": "ordered"},
+  "no-reversed-links": true
+}

--- a/.markdownlint.rb
+++ b/.markdownlint.rb
@@ -1,4 +1,7 @@
 # https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+#
+# When updating rules in this file, ensure the corresponding rule list in
+# .markdownlint.json is also updated.
 
 # style
 rule 'header-style'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ as possible for you to work in this repository. The documentation for Docker is 
 ## Table of Contents
 
 - [Contribution guidelines](#contribution-guidelines)
-  - [Files not edited here](#files-not-edited-here)
   - [Important files](#important-files)
+  - [Files not edited here](#files-not-edited-here)
   - [Per-page front-matter](#per-page-front-matter)
 - [Pull request guidelines](#pull-request-guidelines)
 - [Collaborate on a pull request](#collaborate-on-a-pull-request)
@@ -192,7 +192,18 @@ repository. Compressing images after adding them to the repository actually wors
 
 ### Style guide
 
-Docker does not currently maintain a style guide. Follow the examples set by the existing documentation and use your best judgment.
+Docker does not currently maintain a style guide. Follow the examples set by
+the existing documentation and use your best judgment.
+
+We use [markdownlint](https://github.com/markdownlint/markdownlint) to ensure
+consistent markdown source, and to catch potential formatting issues as early
+as possible. While CI/CD will catch these during the PR review process, you may
+wish to configure your IDE to catch these while writing.
+
+For VSCode, you can use the [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+plugin, which will automatically detect and apply the pre-made rules in
+`.markdownlint.json`. This plugin also comes with auto-fix functionality, see
+the plugin documentation for more information.
 
 ## Build and preview the docs locally
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ FROM gem AS mdl-base
 ARG MDL_JSON
 ARG MDL_STYLE
 RUN --mount=type=bind,target=. <<EOF
-  mdl --ignore-front-matter ${MDL_JSON:+'--json'} --style=${MDL_STYLE:-'.mdlrc.style.rb'} $( \
+  mdl --ignore-front-matter ${MDL_JSON:+'--json'} --style=${MDL_STYLE:-'.markdownlint.rb'} $( \
     find '.' -name '*.md' \
       -not -path './registry/*' \
       -not -path './desktop/extensions-sdk/*' \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -41,10 +41,25 @@ target "htmlproofer" {
   output = ["type=cacheonly"]
 }
 
+target "htmlproofer-output" {
+  inherits = ["_common"]
+  target = "htmlproofer-output"
+  output = ["./lint"]
+}
+
 target "mdl" {
   inherits = ["_common"]
   target = "mdl"
   output = ["type=cacheonly"]
+}
+
+target "mdl-output" {
+  inherits = ["_common"]
+  target = "mdl-output"
+  output = ["./lint"]
+  args = {
+    MDL_JSON = 1
+  }
 }
 
 #


### PR DESCRIPTION
### Proposed changes

This PR introduces annotations for the failed linters - these are more easily human readable summaries of the errors encountered during the run, instead of requiring digging manually through the logs.

[For example](https://github.com/jedevc/docker.github.io/actions/runs/2761986305):

![image](https://user-images.githubusercontent.com/7352848/181805994-0aa34d82-3923-4724-9a1f-6d80d6a44c32.png)

and inline with the Files Changed tab:

![image](https://user-images.githubusercontent.com/7352848/181806109-495a9357-9399-40ef-b212-e648483c76fb.png)

This should hopefully make the linter a little less painful to deal with, and should hopefully avoid needing to manually bring up the linting issues in reviews.

### Notes

The markdown linter is nice and easy - it has dedicated JSON output, with exact line numbers and everything.

The link checker is not so great. It only produces text output, which we need to parse with regex, but since it's run over the resulting html in `_site`, we can't easily work out the original markdown file and line to raise the issue on. For now, the extraction of the filename and line number occurs, but we deliberately comment them out since they won't work as expected.

### Related issues

This PR is dependent on #15227 to actually fix the linting first.
