### PR TITLE
Minor update Compose RN 2.7.0

### DIFF
--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -34,7 +34,6 @@ redirect_from:
 
 - Upgrade: compose-go [v1.2.8](https://github.com/compose-spec/compose-go/releases/tag/v1.2.8){:target="_blank" rel="noopener" class="_"}.
 - Upgrade: buildx [v0.8.2](https://github.com/docker/buildx/releases/tag/v0.8.2){:target="_blank" rel="noopener" class="_"}.
-- Upgrade: containerd [v1.6.6](https://github.com/containerd/containerd/releases/tag/v1.6.6){:target="_blank" rel="noopener" class="_"}.
 - Dependencies upgrade: bumped runc [to 1.1.2](https://github.com/opencontainers/runc/releases/tag/v1.1.2){:target="_blank" rel="noopener" class="_"}.
 - Dependencies upgrade: bumped golang to [1.18.3](https://go.dev/doc/devel/release#go1.18.minor){:target="_blank" rel="noopener" class="_"}.
 - Dependencies upgrade: bumped compose-go to [v1.2.8](https://github.com/compose-spec/compose-go/releases/tag/v1.2.8){:target="_blank" rel="noopener" class="_"}.


### PR DESCRIPTION
Removing bump to containerd from 2.7.0.
