### PR TITLE
releaser: simplify access to env or secrets

### DIFF
--- a/_releaser/Dockerfile
+++ b/_releaser/Dockerfile
@@ -24,7 +24,6 @@ FROM base AS netlify-remove
 ARG NETLIFY_SITE_NAME
 RUN --mount=type=bind,from=releaser,source=/out/releaser,target=/usr/bin/releaser \
   --mount=type=secret,id=NETLIFY_AUTH_TOKEN \
-  NETLIFY_AUTH_TOKEN=$(cat /run/secrets/NETLIFY_AUTH_TOKEN) \
   releaser netlify remove
 
 FROM base AS netlify-deploy
@@ -33,10 +32,7 @@ RUN --mount=type=bind,from=sitedir,target=/site \
   --mount=type=bind,from=releaser,source=/out/releaser,target=/usr/bin/releaser \
   --mount=type=secret,id=NETLIFY_AUTH_TOKEN \
   --mount=type=secret,id=NETLIFY_ACCOUNT_SLUG \
-  NETLIFY_AUTH_TOKEN=$(cat /run/secrets/NETLIFY_AUTH_TOKEN) \
-  NETLIFY_ACCOUNT_SLUG=$(cat /run/secrets/NETLIFY_ACCOUNT_SLUG) \
-  NETLIFY_DIR=/site \
-  releaser netlify deploy
+  NETLIFY_DIR=/site releaser netlify deploy
 
 FROM base AS aws-s3-update-config
 ARG AWS_REGION
@@ -46,8 +42,6 @@ RUN --mount=type=bind,target=. \
   --mount=type=bind,from=releaser,source=/out/releaser,target=/usr/bin/releaser \
   --mount=type=secret,id=AWS_ACCESS_KEY_ID \
   --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
-  AWS_ACCESS_KEY_ID=$(cat /run/secrets/AWS_ACCESS_KEY_ID) \
-  AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/AWS_SECRET_ACCESS_KEY) \
   releaser aws s3-update-config
 
 FROM base AS aws-lambda-invoke
@@ -56,6 +50,4 @@ ARG AWS_LAMBDA_FUNCTION
 RUN --mount=type=bind,from=releaser,source=/out/releaser,target=/usr/bin/releaser \
   --mount=type=secret,id=AWS_ACCESS_KEY_ID \
   --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
-  AWS_ACCESS_KEY_ID=$(cat /run/secrets/AWS_ACCESS_KEY_ID) \
-  AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/AWS_SECRET_ACCESS_KEY) \
   releaser aws lambda-invoke

--- a/_releaser/main.go
+++ b/_releaser/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"log"
+	"os"
+	"path/filepath"
 
 	"github.com/alecthomas/kong"
 )
@@ -28,4 +30,16 @@ func main() {
 			Summary: true,
 		}))
 	ctx.FatalIfErrorf(ctx.Run())
+}
+
+// getEnvOrSecret retrieves secret's value from secret file or env
+func getEnvOrSecret(name string) string {
+	if v, ok := os.LookupEnv(name); ok {
+		return v
+	}
+	b, err := os.ReadFile(filepath.Join("/run/secrets", name))
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }

--- a/_releaser/netlify.go
+++ b/_releaser/netlify.go
@@ -23,8 +23,7 @@ type NetlifyCmd struct {
 }
 
 type netlifyGlobalFlags struct {
-	SiteName  string `kong:"name='site-name',env='NETLIFY_SITE_NAME'"`
-	AuthToken string `kong:"name='auth-token',env='NETLIFY_AUTH_TOKEN'"`
+	SiteName string `kong:"name='site-name',env='NETLIFY_SITE_NAME'"`
 }
 
 type NetlifyRemoveCmd struct {
@@ -33,7 +32,7 @@ type NetlifyRemoveCmd struct {
 
 func (s *NetlifyRemoveCmd) Run() error {
 	siteName := cleanSiteName(s.SiteName)
-	c := newNetlifyClient(s.AuthToken)
+	c := newNetlifyClient(getEnvOrSecret("NETLIFY_AUTH_TOKEN"))
 	site, err := c.getSite(siteName)
 	if err != nil {
 		return fmt.Errorf("failed to get site %q: %w", siteName, err)
@@ -47,8 +46,7 @@ func (s *NetlifyRemoveCmd) Run() error {
 
 type NetlifyDeployCmd struct {
 	netlifyGlobalFlags
-	AccountSlug string `kong:"name='account-slug',env='NETLIFY_ACCOUNT_SLUG'"`
-	PublishDir  string `kong:"name='publish-dir',env='NETLIFY_PUBLISH_DIR'"`
+	PublishDir string `kong:"name='publish-dir',env='NETLIFY_PUBLISH_DIR'"`
 }
 
 func (s *NetlifyDeployCmd) Run() error {
@@ -59,11 +57,11 @@ func (s *NetlifyDeployCmd) Run() error {
 	}
 
 	siteName := cleanSiteName(s.SiteName)
-	c := newNetlifyClient(s.AuthToken)
+	c := newNetlifyClient(getEnvOrSecret("NETLIFY_AUTH_TOKEN"))
 
 	site, err := c.CreateSite(c.ctx, &netlify.SiteSetup{
 		Site: netlify.Site{
-			AccountSlug: s.AccountSlug,
+			AccountSlug: getEnvOrSecret("NETLIFY_ACCOUNT_SLUG"),
 			Name:        siteName,
 		},
 	}, false)


### PR DESCRIPTION
To avoid dealing with `cat` in our Dockerfile and also be able to retrieve secrets as env or file can be useful. We encounter that issue while working on lab branch as `AWS_SESSION_TOKEN` needs to be defined for this environment (OIDC auth) but can be optional for prod and stage.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>