### PR TITLE
Specify that the first container is used for vm.cli.exec when multi container extension

### DIFF
--- a/desktop/extensions-sdk/dev/api/reference/interfaces/ExtensionVM.md
+++ b/desktop/extensions-sdk/dev/api/reference/interfaces/ExtensionVM.md
@@ -25,6 +25,11 @@ await ddClient.extension.vm.cli.exec(
 
 Streams the output of the command executed in the backend container.
 
+When the extension defines its own `docker-compose.yaml` file
+with multiple containers, the command is executed on the first container defined.
+Change the order in which containers are defined to execute commands on another
+container.
+
 Example: Spawn the command `ls -l` inside the **backend container**:
 
 ```typescript


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

This PR provides information about which container is used when ddClient.extension.vm?.cli.exec is used in an extension that provides its own docker-compose.yaml which contains many containers.

### Related issues (optional)

Closes https://github.com/docker/pinata/pull/18644

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
