### PR TITLE
Add missing mac installation link on get-docker.md

### DIFF
--- a/get-docker.md
+++ b/get-docker.md
@@ -31,7 +31,7 @@ section and choose the best installation path for you.
         <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
-                    <a href=""><img src="/images/apple_48.svg" alt="Docker Desktop for Mac" width="70" height="70"></a>
+                    <a href="/desktop/install/mac-install/"><img src="/images/apple_48.svg" alt="Docker Desktop for Mac" width="70" height="70"></a>
                 </div>
                 <h2 id="docker-for-mac"><a href="/desktop/install/mac-install/">Docker Desktop for Mac</a></h2>
                 <p>A native application using the macOS sandbox security model which delivers all Docker tools to your Mac.</p>


### PR DESCRIPTION
### Proposed changes

Added missing mac installation link on the apple icon link on get-docker.md page.

### Related issues (optional)

None - I just found the issue when trying to download Docker for mac. I was clicking the apple icon as it contains a link but the href was missing.
