### PR TITLE
Updated networking.md to remove sent word used twice

### DIFF
--- a/engine/swarm/networking.md
+++ b/engine/swarm/networking.md
@@ -391,8 +391,8 @@ the `--data-path-addr` flag when initializing or joining the swarm. If there are
 multiple interfaces, `--advertise-addr` must be specified explicitly, and
 `--data-path-addr` defaults to `--advertise-addr` if not specified. Traffic about
 joining, leaving, and managing the swarm is sent over the
-`--advertise-addr` interface, and traffic among a service's containers is sent
-sent over the `--data-path-addr` interface. These flags can take an IP address or
+`--advertise-addr` interface, and traffic among a service's containers is sent 
+over the `--data-path-addr` interface. These flags can take an IP address or
 a network device name, such as `eth0`.
 
 This example initializes a swarm with a separate `--data-path-addr`. It assumes


### PR DESCRIPTION
There was a small error where we see sent sent, so removed one of the sent word. Line 395.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
