### PR TITLE
[Bug] - Updated chmod permission calculator links

### DIFF
--- a/desktop/faqs/windowsfaqs.md
+++ b/desktop/faqs/windowsfaqs.md
@@ -44,7 +44,7 @@ Desktop. For more information, see [Docker Desktop fails to start when anti-viru
 Docker Desktop does not enable you to control (`chmod`)
 the Unix-style permissions on [shared volumes](../settings/windows.md#file-sharing) for
 deployed containers, but rather sets permissions to a default value of
-[0777](http://permissions-calculator.org/decode/0777/){: target="_blank" rel="noopener" class="_"}
+[0777](https://chmodcommand.com/chmod-0777/){: target="_blank" rel="noopener" class="_"}
 (`read`, `write`, `execute` permissions for `user` and for
 `group`) which is not configurable.
 

--- a/desktop/settings/windows.md
+++ b/desktop/settings/windows.md
@@ -117,7 +117,7 @@ File share settings are:
 >   better if they are stored in the Linux VM, using a [data volume](../../storage/volumes.md)
 >   (named volume) or [data container](../../storage/volumes.md).
 > * Docker Desktop sets permissions to read/write/execute for users, groups and
->   others [0777 or a+rwx](http://permissions-calculator.org/decode/0777/).
+>   others [0777 or a+rwx](https://chmodcommand.com/chmod-0777/).
 >   This is not configurable. See [Permissions errors on data directories for shared volumes](../troubleshoot/topics.md).
 > * Windows presents a case-insensitive view of the filesystem to applications while Linux is case-sensitive.
 >   On Linux, it is possible to create two separate files: `test` and `Test`,

--- a/desktop/troubleshoot/topics.md
+++ b/desktop/troubleshoot/topics.md
@@ -71,7 +71,7 @@ in the Apple documentation, and Docker Desktop [Mac system requirements](../inst
 #### Permissions errors on data directories for shared volumes
 
 When sharing files from Windows, Docker Desktop sets permissions on [shared volumes](../settings/windows.md#file-sharing)
-to a default value of [0777](http://permissions-calculator.org/decode/0777/)
+to a default value of [0777](https://chmodcommand.com/chmod-0777/)
 (`read`, `write`, `execute` permissions for `user` and for `group`).
 
 The default permissions on shared volumes are not configurable. If you are


### PR DESCRIPTION
Signed-off-by: Adithya Krishna <adikrish@redhat.com>

### Proposed changes

The 0777 file permission links were broken at,

- https://docs.docker.com/desktop/faqs/windowsfaqs/#can-i-change-permissions-on-shared-volumes-for-container-specific-deployment-requirements
- https://docs.docker.com/desktop/troubleshoot/topics/#topics-for-windows
- https://docs.docker.com/desktop/settings/windows/#file-sharing

hence updated them to new links for the 0777 file permissions
