### PR TITLE
Move Release Notes in TOC for consistency

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1339,9 +1339,6 @@ manuals:
       title: Install binaries
   - path: /engine/install/linux-postinstall/
     title: Optional post-installation steps
-  - path: /engine/release-notes/
-    title: Release notes
-  - sectiontitle: Previous versions
     section:
     - path: /engine/release-notes/19.03/
       title: Engine 19.03 release notes
@@ -1389,7 +1386,9 @@ manuals:
     title: Docker Scan
   - path: /engine/sbom/
     title: Docker SBOM (Experimental)
-
+  - path: /engine/release-notes/
+    title: Release notes
+  - sectiontitle: Previous versions
 - sectiontitle: Docker Build
   section:
     - path: /build/

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1465,10 +1465,10 @@ manuals:
     title: Control startup order
   - path: /compose/samples-for-compose/
     title: Sample apps with Compose
-  - path: /compose/release-notes/
-    title: Release notes
   - path: /compose/cli-command-compatibility/
     title: Compose v2 compatibility
+  - path: /compose/release-notes/
+    title: Release notes
 
 - sectiontitle: Docker Hub
   section:

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1339,43 +1339,6 @@ manuals:
       title: Install binaries
   - path: /engine/install/linux-postinstall/
     title: Optional post-installation steps
-    section:
-    - path: /engine/release-notes/19.03/
-      title: Engine 19.03 release notes
-    - path: /engine/release-notes/18.09/
-      title: Engine 18.09 release notes
-    - path: /engine/release-notes/18.06/
-      title: Engine 18.06 release notes
-    - path: /engine/release-notes/18.05/
-      title: Engine 18.05 release notes
-    - path: /engine/release-notes/18.04/
-      title: Engine 18.04 release notes
-    - path: /engine/release-notes/18.03/
-      title: Engine 18.03 release notes
-    - path: /engine/release-notes/18.02/
-      title: Engine 18.02 release notes
-    - path: /engine/release-notes/18.01/
-      title: Engine 18.01 release notes
-    - path: /engine/release-notes/17.12/
-      title: Engine 17.12 release notes
-    - path: /engine/release-notes/17.11/
-      title: Engine 17.11 release notes
-    - path: /engine/release-notes/17.10/
-      title: Engine 17.10 release notes
-    - path: /engine/release-notes/17.09/
-      title: Engine 17.09 release notes
-    - path: /engine/release-notes/17.07/
-      title: Engine 17.07 release notes
-    - path: /engine/release-notes/17.06/
-      title: Engine 17.06 release notes
-    - path: /engine/release-notes/17.05/
-      title: Engine 17.05 release notes
-    - path: /engine/release-notes/17.04/
-      title: Engine 17.04 release notes
-    - path: /engine/release-notes/17.03/
-      title: Engine 17.03 release notes
-    - path: /engine/release-notes/prior-releases/
-      title: Engine 1.13 and earlier
   - path: /engine/deprecated/
     title: Deprecated features
   - path: /buildx/working-with-buildx/
@@ -1389,6 +1352,43 @@ manuals:
   - path: /engine/release-notes/
     title: Release notes
   - sectiontitle: Previous versions
+    section:
+      - path: /engine/release-notes/19.03/
+        title: Engine 19.03 release notes
+      - path: /engine/release-notes/18.09/
+        title: Engine 18.09 release notes
+      - path: /engine/release-notes/18.06/
+        title: Engine 18.06 release notes
+      - path: /engine/release-notes/18.05/
+        title: Engine 18.05 release notes
+      - path: /engine/release-notes/18.04/
+        title: Engine 18.04 release notes
+      - path: /engine/release-notes/18.03/
+        title: Engine 18.03 release notes
+      - path: /engine/release-notes/18.02/
+        title: Engine 18.02 release notes
+      - path: /engine/release-notes/18.01/
+        title: Engine 18.01 release notes
+      - path: /engine/release-notes/17.12/
+        title: Engine 17.12 release notes
+      - path: /engine/release-notes/17.11/
+        title: Engine 17.11 release notes
+      - path: /engine/release-notes/17.10/
+        title: Engine 17.10 release notes
+      - path: /engine/release-notes/17.09/
+        title: Engine 17.09 release notes
+      - path: /engine/release-notes/17.07/
+        title: Engine 17.07 release notes
+      - path: /engine/release-notes/17.06/
+        title: Engine 17.06 release notes
+      - path: /engine/release-notes/17.05/
+        title: Engine 17.05 release notes
+      - path: /engine/release-notes/17.04/
+        title: Engine 17.04 release notes
+      - path: /engine/release-notes/17.03/
+        title: Engine 17.03 release notes
+      - path: /engine/release-notes/prior-releases/
+        title: Engine 1.13 and earlier
 - sectiontitle: Docker Build
   section:
     - path: /build/


### PR DESCRIPTION
Moved Release Notes to last place in section's TOC for consistency in Engine and Compose.

