### PR TITLE
Removed outdated disclaimer about mysql/arm64

### DIFF
--- a/desktop/mac/apple-silicon.md
+++ b/desktop/mac/apple-silicon.md
@@ -32,7 +32,7 @@ $ softwareupdate --install-rosetta
   - The old version 1.x of `docker-compose`. We recommend that you use Compose V2 instead. Either type `docker compose` or enable the **Use Docker Compose V2** option in the [General preferences tab](../settings/mac.md#general).
   - The `docker scan` command and the underlying `snyk` binary.
   - The `docker-credential-ecr-login` credential helper.
-- Not all images are available for ARM64 architecture. You can add `--platform linux/amd64` to run an Intel image under emulation. In particular, the [mysql](https://hub.docker.com/_/mysql?tab=tags&page=1&ordering=last_updated) image is not available for ARM64. You can work around this issue by using a [mariadb](https://hub.docker.com/_/mariadb?tab=tags&page=1&ordering=last_updated) image.
+- Some images do not support the ARM64 architecture. You can add `--platform linux/amd64` to run (or build) an Intel image using emulation.
 
    However, attempts to run Intel-based containers on Apple silicon machines under emulation can crash as qemu sometimes fails to run the container. In addition, filesystem change notification APIs (`inotify`) do not work under qemu emulation. Even when the containers do run correctly under emulation, they will be slower and use more memory than the native equivalent.
 


### PR DESCRIPTION
Docs about Docker on Apple Silicon wrongly stated that the MySQL image does not support ARM64 architecture. This is no longer the case, hence we're removing this disclaimer

closes #14888