### PR TITLE
Update kube-deploy.md

### DIFF
--- a/get-started/kube-deploy.md
+++ b/get-started/kube-deploy.md
@@ -45,6 +45,7 @@ All containers in Kubernetes are scheduled as _pods_, which are groups of co-loc
           containers:
           - name: bb-site
             image: getting-started
+            imagePullPolicy: Never
     ---
     apiVersion: v1
     kind: Service


### PR DESCRIPTION
Add `imagePullPolicy` as `Never` so that Kubernetes will use local `getting-started` image built from previous step

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
