### PR TITLE
Add link to official registry image in local mirror documentation.

### DIFF
--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -68,7 +68,7 @@ be configured to use the `filesystem` driver for storage.
 ## Run a Registry as a pull-through cache
 
 The easiest way to run a registry as a pull through cache is to run the official
-Registry image.
+[Registry](https://hub.docker.com/_/registry) image.
 At least, you need to specify `proxy.remoteurl` within `/etc/docker/registry/config.yml`
 as described in the following subsection.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

I was confused why the image wasn't referenced until I realized the image is called "registry". Adding a link will make it easier to understand.
