### PR TITLE
[ENGDOCS-861][Issue-15141][Issue-13159] Align branch name with example

### DIFF
--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -70,16 +70,20 @@ name: ci
 {% endraw %}
 
 Then, we will choose when we run this workflow. In our example, we are going to
-do it for every push against the main branch of our project:
+do it for every push against the master branch of our project:
 
 {% raw %}
 ```yaml
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
 ```
 {% endraw %}
+
+> **Note**
+>
+> The branch name may be `main` or `master`. Verify the name of the branch for your repository and update the configuration accordingly.
 
 Now, we need to specify what we actually want to happen within our workflow
 (what jobs), we are going to add our build one and select that it runs on the
@@ -191,7 +195,7 @@ tags and pull requests:
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
     tags:
       - 'v*'
 ```
@@ -221,12 +225,12 @@ First we have to handle pull request events:
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
     tags:
       - 'v*'
   pull_request:
     branches:
-      - 'main'
+      - 'master'
 ```
 {% endraw %}
 

--- a/language/java/configure-ci-cd.md
+++ b/language/java/configure-ci-cd.md
@@ -58,13 +58,16 @@ First, we will name this workflow:
 name: CI to Docker Hub
  ```
 
-Then, we will choose when we run this workflow. In our example, we are going to do it for every push against the main branch of our project:
+Then, we will choose when we run this workflow. In our example, we are going to do it for every push against the master branch of our project:
 
 ```yaml
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 ```
+> **Note**
+>
+> The branch name may be `main` or `master`. Verify the name of the branch for your repository and update the configuration accordingly.
 
 Now, we need to specify what we actually want to happen within our action (what jobs), we are going to add our build one and select that it runs on the latest Ubuntu instances available:
 

--- a/language/nodejs/configure-ci-cd.md
+++ b/language/nodejs/configure-ci-cd.md
@@ -57,13 +57,17 @@ First, we will name this workflow:
 name: CI to Docker Hub
  ```
 
-Then, we will choose when we run this workflow. In our example, we are going to do it for every push against the main branch of our project:
+Then, we will choose when we run this workflow. In our example, we are going to do it for every push against the master branch of our project:
 
 ```yaml
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 ```
+
+> **Note**
+>
+> The branch name may be `main` or `master`. Verify the name of the branch for your repository and update the configuration accordingly.
 
 Now, we need to specify what we actually want to happen within our action (what jobs), we are going to add our build one and select that it runs on the latest Ubuntu instances available:
 

--- a/language/python/configure-ci-cd.md
+++ b/language/python/configure-ci-cd.md
@@ -57,13 +57,17 @@ First, we will name this workflow:
 name: CI to Docker Hub
  ```
 
-Then, we will choose when we run this workflow. In our example, we are going to do it for every push against the main branch of our project:
+Then, we will choose when we run this workflow. In our example, we are going to do it for every push against the master branch of our project:
 
 ```yaml
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 ```
+
+> **Note**
+>
+> The branch name may be `main` or `master`. Verify the name of the branch for your repository and update the configuration accordingly.
 
 Now, we need to specify what we actually want to happen within our action (what jobs), we are going to add our build one and select that it runs on the latest Ubuntu instances available:
 


### PR DESCRIPTION
### Proposed changes

The example repo and images use `master` as the branch, but the code blocks used `main`.
As many people will probably clone the repo to follow the example, they'll use `master`. 

- Updated code to `master`.
- Added note for users who create a new repo to verify the name.

### Related issues (optional)
ENGDOCS-861
Fixes #15141 
Fixes #13159
