### PR TITLE
Fix: remove unsupported Font Awesome icons from toggle theme

### DIFF
--- a/_includes/theme-switch.html
+++ b/_includes/theme-switch.html
@@ -1,6 +1,6 @@
 <div class="toggle-mode">
   <div class="icon">
-      <i class="fa fa-sun-o" aria-hidden="true"></i>
+      <i class="fa fa-sun" aria-hidden="true"></i>
   </div>
   <div class="toggle-switch">
       <label class="switch">
@@ -9,6 +9,6 @@
       </label>
   </div>
   <div class="icon">
-      <i class="fa fa-moon-o" aria-hidden="true"></i>
+      <i class="fa fa-moon" aria-hidden="true"></i>
   </div>
 </div>


### PR DESCRIPTION
### Proposed changes
removed -o suffix from theme toggle icons, which was making it being empty. see the before x after my changes

![image](https://user-images.githubusercontent.com/62514607/184512022-f7f6675e-be22-4e43-b19a-985f66f4fc7c.png)
![image](https://user-images.githubusercontent.com/62514607/184512035-593551fb-0700-4ebc-999f-850d21a79469.png)
### Related issues (optional)