### PR TITLE
Fix dead link for Docker Support

### DIFF
--- a/engine/security/trust/index.md
+++ b/engine/security/trust/index.md
@@ -99,7 +99,7 @@ The following image depicts the various signing keys and their relationships:
 >
 > Loss of the root key is **very difficult** to recover from.
 > Correcting this loss requires intervention from [Docker
-> Support](https://support.docker.com) to reset the repository state. This loss
+> Support](/support/) to reset the repository state. This loss
 > also requires **manual intervention** from every consumer that used a signed
 > tag from this repository prior to the loss.
 {:.warning}


### PR DESCRIPTION
As `https://support.docker.com` looks unavailable any more, we can use `https://docs.docker.com/support/` instead.