### PR TITLE
makefile: remove buildx-yaml goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,6 @@ else
 	$(error "Buildx is required: https://github.com/docker/buildx#installing")
 endif
 
-BUILDX_REPO ?= https://github.com/docker/buildx.git
-BUILDX_REF ?= master
-
-# Generate YAML docs from remote bake definition
-# Usage BUILDX_REF=v0.7.0 make buildx-yaml
-buildx-yaml:
-	$(eval $@_TMP_OUT := $(shell mktemp -d -t docs-output.XXXXXXXXXX))
-	DOCS_FORMATS=yaml $(BUILDX_CMD) bake --set "*.output=$($@_TMP_OUT)" "$(BUILDX_REPO)#$(BUILDX_REF)" update-docs
-	rm -rf ./_data/buildx/*
-	cp -R "$($@_TMP_OUT)"/out/reference/*.yaml ./_data/buildx/
-	rm -rf $($@_TMP_OUT)/*
-
 # Build website and output to _site folder
 release:
 	rm -rf _site


### PR DESCRIPTION
not needed anymore since we automatically open a PR from buildx repo, see https://github.com/docker/buildx/pull/1184.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>