### PR TITLE
fix: add layer to Dockerfile to fix issue 15394

### DIFF
--- a/get-started/09_image_best.md
+++ b/get-started/09_image_best.md
@@ -107,6 +107,7 @@ Let's look at the Dockerfile we were using one more time...
 ```dockerfile
 # syntax=docker/dockerfile:1
 FROM node:12-alpine
+RUN apk add --no-cache python2 g++ make
 WORKDIR /app
 COPY . .
 RUN yarn install --production
@@ -127,6 +128,7 @@ a change to the `package.json`. Make sense?
     ```dockerfile
     # syntax=docker/dockerfile:1
     FROM node:12-alpine
+    RUN apk add --no-cache python2 g++ make
     WORKDIR /app
     COPY package.json yarn.lock ./
     RUN yarn install --production


### PR DESCRIPTION
Fix for issue: [Build error in Getting-Started guide using a M1 Macbook](https://github.com/docker/docker.github.io/issues/15394)

As described in the issue, the docker build command is failing for M1 Macbooks.
If the layer `RUN apk add --no-cache python2 g++ make` is added, it works.

This has already been done in chapter [02_our_app.md#build-the-apps-container-image](https://github.com/docker/docker.github.io/blob/master/get-started/02_our_app.md#build-the-apps-container-image).
