### PR TITLE
chore: fix s3 redirects with prefixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,6 @@ jobs:
             DOCS_S3_CONFIG="s3-config.json"
             DOCS_CLOUDFRONT_ID="E1MYDYF65FW3HG"
             DOCS_LAMBDA_FUNCTION_REDIRECTS="DockerDocsRedirectFunction-labs"
-            DOCS_SLACK_MSG="Successfully deployed docs-labs from lab branch. $DOCS_URL"
           else
             echo >&2 "ERROR: unknown branch ${{ github.ref }}"
             exit 1

--- a/_releaser/cloudfront-lambda-redirects.js
+++ b/_releaser/cloudfront-lambda-redirects.js
@@ -25,9 +25,15 @@ exports.handler = (event, context, callback) => {
     }
 
     const redirectsPrefixes = JSON.parse(`{{.RedirectsPrefixesJSON}}`);
-    for (let key in redirectsPrefixes) {
-        if (!request.uri.startsWith(key)) {
+    for (let x in redirectsPrefixes) {
+        const rp = redirectsPrefixes[x];
+        if (!request.uri.startsWith(`/${rp['prefix']}`)) {
             continue;
+        }
+        let newlocation = "/";
+        if (rp['strip']) {
+            let re = new RegExp(`(^/${rp['prefix']})`, 'gi');
+            newlocation = request.uri.replace(re,'/');
         }
         //console.log(`redirect: ${request.uri} to ${redirectsPrefixes[key]}`);
         const response = {
@@ -36,7 +42,7 @@ exports.handler = (event, context, callback) => {
             headers: {
                 location: [{
                     key: 'Location',
-                    value: redirectsPrefixes[key],
+                    value: newlocation,
                 }],
             },
         }

--- a/_releaser/redirects-prefixes.json
+++ b/_releaser/redirects-prefixes.json
@@ -1,21 +1,90 @@
-{
-  "/compliance/": "/",
-  "/datacenter/": "/",
-  "/ee/": "/",
-  "/v1.4/": "/",
-  "/v1.5/": "/",
-  "/v1.6/": "/",
-  "/v1.7/": "/",
-  "/v1.8/": "/",
-  "/v1.9/": "/",
-  "/v1.10/": "/",
-  "/v1.11/": "/",
-  "/v1.12/": "/",
-  "/v1.13/": "/",
-  "/v17.03/": "/",
-  "/v17.06/": "/",
-  "/v17.09/": "/",
-  "/v17.12/": "/",
-  "/v18.03/": "/",
-  "/v18.09/": "/"
-}
+[
+  {
+    "prefix": "compliance/",
+    "strip": false
+  },
+  {
+    "prefix": "datacenter/",
+    "strip": false
+  },
+  {
+    "prefix": "ee/",
+    "strip": false
+  },
+  {
+    "prefix": "v1.4/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.5/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.6/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.7/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.8/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.9/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.10/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.11/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.12/",
+    "strip": true
+  },
+  {
+    "prefix": "v1.13/",
+    "strip": true
+  },
+  {
+    "prefix": "v17.03/",
+    "strip": true
+  },
+  {
+    "prefix": "v17.06/enterprise/",
+    "strip": false
+  },
+  {
+    "prefix": "v17.06/",
+    "strip": true
+  },
+  {
+    "prefix": "v17.09/",
+    "strip": true
+  },
+  {
+    "prefix": "v17.12/",
+    "strip": true
+  },
+  {
+    "prefix": "v18.03/ee/",
+    "strip": false
+  },
+  {
+    "prefix": "v18.03/",
+    "strip": true
+  },
+  {
+    "prefix": "v18.09/ee/",
+    "strip": false
+  },
+  {
+    "prefix": "v18.09/",
+    "strip": true
+  }
+]


### PR DESCRIPTION
follow-up #15151

found wrong redirects with @thaJeztah ported from s3 config to cloudfront lambda.

looks like in the s3 config some redirects just strip the key prefix and don't just redirect to `/`. this PR adds a new bool field `strip` to handle that behavior.

can be tested on labs:

```
$ curl -s -D - https://docs-labs.docker.com/v17.06/enterprise/ -o /dev/null
HTTP/2 301 
content-length: 0
server: CloudFront
date: Wed, 17 Aug 2022 16:18:58 GMT
location: /enterprise/
x-cache: LambdaGeneratedResponse from cloudfront
via: 1.1 89cec266da5afe1c0fd332f7f04e94e2.cloudfront.net (CloudFront)
x-amz-cf-pop: CDG3-C2
x-amz-cf-id: yjyoCPapgzOBKtOHWgmDUOTvXUhLkf1B2Vl_sWSnL36NmpnzRkf2kA==
```

```
$ curl -s -D - https://docs-labs.docker.com/ee/sqdsqdsqdsqds -o /dev/null
HTTP/2 301 
content-length: 0
server: CloudFront
date: Wed, 17 Aug 2022 16:20:14 GMT
location: /
x-cache: LambdaGeneratedResponse from cloudfront
via: 1.1 ef7ace463c0659c94b8e007b4dc9ae9a.cloudfront.net (CloudFront)
x-amz-cf-pop: CDG3-C2
x-amz-cf-id: iT3UxQIdBi1TiqP6imgPm3Jbicl4wYJdXQoTS7usqmS25RpBq-C9QA==
```

```
$ curl -s -D - https://docs-labs.docker.com/get-started/part2/ -o /dev/null
HTTP/2 301 
content-length: 0
server: CloudFront
date: Wed, 17 Aug 2022 16:19:30 GMT
location: /get-started/02_our_app/
x-cache: LambdaGeneratedResponse from cloudfront
via: 1.1 bfb83f89a06636844c21e465f3ea5ace.cloudfront.net (CloudFront)
x-amz-cf-pop: CDG3-C2
x-amz-cf-id: L8gGrTkItVxWT9mRVziKUP1OUPdU5UPUoAH2km56F_Wt8RLDbXtIGA==
```

also disable slack notif for labs env as it seems a bit too noisy.