### PR TITLE
WEB-1276: Adds OneTrust consent manager JS snippet and footer button

### DIFF
--- a/_config_production.yml
+++ b/_config_production.yml
@@ -16,6 +16,7 @@ exclude:
 # Google Analytics, etc.
 google_analytics: GTM-WL2QLG5
 polldaddy_id:     8453675
+onetrust_id:      8e0ebfd9-035d-4ec2-9b2f-a2de9c09f906
 
 # Assets
 #

--- a/_includes/analytics/onetrust.html
+++ b/_includes/analytics/onetrust.html
@@ -1,0 +1,7 @@
+{% if include.ONETRUST_ID and include.ONETRUST_ID != '' %}<!-- OneTrust Cookies Consent Notice start for http://docs.docker.com  -->
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="{{ include.ONETRUST_ID }}" ></script>
+<script type="text/javascript">
+  function OptanonWrapper() { }
+</script>
+<!-- OneTrust Cookies Consent Notice end for http://docs.docker.com  -->
+{% else %}<!-- No consent manager configured -->{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -86,6 +86,11 @@
                 <p class="copyright">
                     Copyright &copy; 2013-{{ site.time | date: '%Y' }} Docker Inc. All rights reserved.
                 </p>
+                {%- if jekyll.environment == 'production' and site.onetrust_id != '' -%}
+                <!-- OneTrust Cookies Settings button start -->
+                <button id="ot-sdk-btn" class="ot-sdk-show-settings">Cookie Settings</button>
+                <!-- OneTrust Cookies Settings button end -->
+                {%- endif -%}
             </div>
             <div class="footer_social_nav">
                 <ul class="nav-social">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,7 +29,10 @@
   {%- if page.sitemap == false or jekyll.environment != 'production' %}
   <meta name="robots" content="noindex"/>
   {%- endif %}
-  {%- if jekyll.environment == 'production' and site.google_analytics != '' -%}{%- include analytics/google_analytics.html GOOGLE_ID=site.google_analytics -%}{%- endif -%}
+  {%- if jekyll.environment == 'production' -%}
+    {%- if site.onetrust_id != '' -%}{%- include analytics/onetrust.html ONETRUST_ID=site.onetrust_id -%}{%- endif -%}
+    {%- if site.google_analytics != '' -%}{%- include analytics/google_analytics.html GOOGLE_ID=site.google_analytics -%}{%- endif -%}
+  {%- endif -%}
   <title>{{ page.title | default: page_title }} | Docker Documentation</title>
   <meta name="description" content="{{ page.description | default: page_description | escape}}" />
   <meta name="keywords" content="{{ page.keywords | default: 'docker, docker open source, docker platform, distributed applications, microservices, containers, docker containers, docker software, docker virtualization' }}">


### PR DESCRIPTION
### Proposed changes
This PR adds the OneTrust consent management tools to the docs website. There is a JS snippet that is supposed to be in the header ahead of any other scripts that may set a non-Strictly Necessary cookie. There is also a button added to the footer of the page. The button's behaviors are enabled by the script snippet added at the top of the `<head>` area.

### Related issues
https://docker.atlassian.net/browse/WEB-1276

### Screenshots
![image](https://user-images.githubusercontent.com/1005023/186039723-dd83a730-fa9e-40d9-9069-44fb1812174b.png)
![image](https://user-images.githubusercontent.com/1005023/186039751-b5f320c3-e80a-437e-a1b9-737784ce0765.png)
![image](https://user-images.githubusercontent.com/1005023/186039770-0a7aa62b-958d-4226-b4fd-4dc262ca93ad.png)
