### PR TITLE
[ENGDOCS-829] Add pull image to hub quickstart

### DIFF
--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -134,7 +134,6 @@ You'll need to download Docker Desktop to  build, push, and pull container image
 ### Step 4: Pull and run a container image from Docker Hub
 
 1. Run `docker pull hello-world` to pull the image from Docker Hub. You should see output similar to:
-
 ```console
 $ docker pull hello-world
 Using default tag: latest
@@ -144,7 +143,6 @@ Digest: sha256:7d246653d0511db2a6b2e0436cfd0e52ac8c066000264b3ce63331ac66dca625
 Status: Downloaded newer image for hello-world:latest
 docker.io/library/hello-world:latest
 ```
-
 2. Run `docker run hellow-world` to run the image locally. You should see output similar to:
 
 ```console

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -125,14 +125,53 @@ To create a repository:
 
 ### Step 3: Download and install Docker Desktop
 
-We'll need to download Docker Desktop to build and push a container image to
-Docker Hub.
+You'll need to download Docker Desktop to  build, push, and pull container images.
 
 1. Download and install [Docker Desktop](../desktop/#download-and-install).
 
 2. Sign in to the Docker Desktop application using the Docker ID you've just created.
 
-### Step 4: Build and push a container image to Docker Hub from your computer
+### Step 4: Pull and run a container image from Docker Hub
+
+1. Run `docker pull hello-world` to pull the image from Docker Hub. You should see output similar to:
+
+```console
+$ docker pull hello-world
+Using default tag: latest
+latest: Pulling from library/hello-world
+2db29710123e: Pull complete
+Digest: sha256:7d246653d0511db2a6b2e0436cfd0e52ac8c066000264b3ce63331ac66dca625
+Status: Downloaded newer image for hello-world:latest
+docker.io/library/hello-world:latest
+```
+
+2. Run `docker run hellow-world` to run the image locally. You should see output similar to:
+
+```console
+$ docker run hellow-world
+Hello from Docker!
+This message shows that your installation appears to be working correctly.
+
+To generate this message, Docker took the following steps:
+ 1. The Docker client contacted the Docker daemon.
+ 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+    (amd64)
+ 3. The Docker daemon created a new container from that image which runs the
+    executable that produces the output you are currently reading.
+ 4. The Docker daemon streamed that output to the Docker client, which sent it
+    to your terminal.
+
+To try something more ambitious, you can run an Ubuntu container with:
+ $ docker run -it ubuntu bash
+
+Share images, automate workflows, and more with a free Docker ID:
+ https://hub.docker.com/
+
+For more examples and ideas, visit:
+ https://docs.docker.com/get-started/
+```
+
+### Step 5: Build and push a container image to Docker Hub from your computer
 
 1. Start by creating a [Dockerfile](../engine/reference/builder/) to specify your application as shown below:
 
@@ -164,7 +203,8 @@ Congratulations! You've successfully:
 
 - Signed up for a Docker account
 - Created your first repository
-- Built a Docker container image on your computer
+- Pulled an existing container image from Docker Hub
+- Built your own container image on your computer
 - Pushed it successfully to Docker Hub
 
 ### Next steps

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -154,7 +154,7 @@ You'll need to download Docker Desktop to  build, push, and pull container image
 
     To generate this message, Docker took the following steps:
      1. The Docker client contacted the Docker daemon.
-     2. The Docker daemon pulled the "hello-world" image from the Docker Hub
+     2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
      (amd64)
      3. The Docker daemon created a new container from that image which runs the
      executable that produces the output you are currently reading.

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -134,40 +134,42 @@ You'll need to download Docker Desktop to  build, push, and pull container image
 ### Step 4: Pull and run a container image from Docker Hub
 
 1. Run `docker pull hello-world` to pull the image from Docker Hub. You should see output similar to:
-```console
-$ docker pull hello-world
-Using default tag: latest
-latest: Pulling from library/hello-world
-2db29710123e: Pull complete
-Digest: sha256:7d246653d0511db2a6b2e0436cfd0e52ac8c066000264b3ce63331ac66dca625
-Status: Downloaded newer image for hello-world:latest
-docker.io/library/hello-world:latest
-```
+
+   ```console
+   $ docker pull hello-world
+   Using default tag: latest
+   latest: Pulling from library/hello-world
+   2db29710123e: Pull complete
+   Digest:   sha256:7d246653d0511db2a6b2e0436cfd0e52ac8c066000264b3ce63331ac66dca625
+   Status: Downloaded newer image for hello-world:latest
+   docker.io/library/hello-world:latest
+   ```
+
 2. Run `docker run hellow-world` to run the image locally. You should see output similar to:
 
-```console
-$ docker run hellow-world
-Hello from Docker!
-This message shows that your installation appears to be working correctly.
+    ```console
+    $ docker run hello-world
+    Hello from Docker!
+    This message shows that your installation appears to be working correctly.
 
-To generate this message, Docker took the following steps:
- 1. The Docker client contacted the Docker daemon.
- 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-    (amd64)
- 3. The Docker daemon created a new container from that image which runs the
-    executable that produces the output you are currently reading.
- 4. The Docker daemon streamed that output to the Docker client, which sent it
-    to your terminal.
+    To generate this message, Docker took the following steps:
+     1. The Docker client contacted the Docker daemon.
+     2. The Docker daemon pulled the "hello-world" image from the Docker Hub
+     (amd64)
+     3. The Docker daemon created a new container from that image which runs the
+     executable that produces the output you are currently reading.
+     4. The Docker daemon streamed that output to the Docker client, which sent
+     it to your terminal.
 
-To try something more ambitious, you can run an Ubuntu container with:
- $ docker run -it ubuntu bash
+    To try something more ambitious, you can run an Ubuntu container with:
+     $ docker run -it ubuntu bash
 
-Share images, automate workflows, and more with a free Docker ID:
- https://hub.docker.com/
+    Share images, automate workflows, and more with a free Docker ID:
+     https://hub.docker.com/
 
-For more examples and ideas, visit:
- https://docs.docker.com/get-started/
-```
+    For more examples and ideas, visit:
+     https://docs.docker.com/get-started/
+    ```
 
 ### Step 5: Build and push a container image to Docker Hub from your computer
 

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -145,7 +145,7 @@ You'll need to download Docker Desktop to  build, push, and pull container image
    docker.io/library/hello-world:latest
    ```
 
-2. Run `docker run hellow-world` to run the image locally. You should see output similar to:
+2. Run `docker run hello-world` to run the image locally. You should see output similar to:
 
     ```console
     $ docker run hello-world

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -125,7 +125,7 @@ To create a repository:
 
 ### Step 3: Download and install Docker Desktop
 
-You'll need to download Docker Desktop to  build, push, and pull container images.
+You'll need to download Docker Desktop to build, push, and pull container images.
 
 1. Download and install [Docker Desktop](../desktop/#download-and-install).
 


### PR DESCRIPTION
### Proposed changes

As part of re-organizing the Hub Repositories topic, we noticed info about pushing images exists in [Hub quickstart](https://docs.docker.com/docker-hub/) and [Repositories](https://docs.docker.com/docker-hub/repos/#pushing-a-docker-container-image-to-docker-hub), but info about pulling images does not exist in the Docker Hub topics.

Since we plan to re-organize the Repository topic and remove push, it doesn't make sense to add pull there. Instead, added to [Hub quickstart](https://docs.docker.com/docker-hub/).

### Related issues (optional)
ENGDOCS-829
