### PR TITLE
desktop: add missing redirects for dashboard

### DIFF
--- a/_includes/landing-page/volume-management.html
+++ b/_includes/landing-page/volume-management.html
@@ -10,7 +10,7 @@
         </h5>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-4 text-center">
-        <a class="btn" href="/desktop/dashboard/#explore-volumes" target="_blank" rel="noopener">
+        <a class="btn" href="/desktop/use-desktop/volumes/" target="_blank" rel="noopener">
           Learn more
         </a>
       </div>

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -233,7 +233,7 @@
               <h6>Popular articles</h6>
               <p class="only-win"><a href="/desktop/windows/wsl/">Docker Desktop WSL 2 backend</a></p>
               <p class="only-mac"><a href="/desktop/install/mac-install/">Install Docker Desktop on Mac</a></p>
-              <p><a href="/desktop/dashboard/">Docker Desktop Dashboard</a></p>
+              <p><a href="/desktop/#overview-of-docker-dashboard">Docker Desktop Dashboard</a></p>
               <p class="only-win"><a href="/desktop/kubernetes/">Deploy on Kubernetes</a></p>
               <p class="only-win"><a href="/desktop/windows/release-notes/">Release notes</a></p>
               <p class="only-win"><a href="/desktop/windows/troubleshoot/">Logs and troubleshooting</a></p>

--- a/desktop/index.md
+++ b/desktop/index.md
@@ -3,10 +3,12 @@ description: Docker Desktop overview
 keywords: Desktop, Docker, GUI, run, docker, local, machine, dashboard
 title: Docker Desktop
 redirect_from:
-- /desktop/opensource/
-- /docker-for-mac/opensource/
-- /docker-for-windows/opensource/
 - /desktop/dashboard/
+- /desktop/opensource/
+- /docker-for-mac/dashboard/
+- /docker-for-mac/opensource/
+- /docker-for-windows/dashboard/
+- /docker-for-windows/opensource/
 ---
 
 > **Update to the Docker Desktop terms**


### PR DESCRIPTION
The dashboard topic was rolled up into the "get-started" section in commit ab0dee78a2835162b0c69af567cf00276e46da09 (https://github.com/docker/docker.github.io/pull/15145), which removed links from the TOC. The page itself was removed in 13ee3ff42626a64dddf8e2a119bbbd77505738c5 (https://github.com/docker/docker.github.io/pull/15363), but forgot to add/copy the redirects.

This patch adds the redirects back, and fixes some links to the page that's now missing.

- fixes https://github.com/docker/docker.github.io/issues/15387
- fixes https://github.com/docker/docker.github.io/issues/15391
- fixes https://github.com/docker/docker.github.io/issues/15410
- fixes https://github.com/docker/docker.github.io/issues/15414
- fixes https://github.com/docker/docker.github.io/issues/15415
- fixes https://github.com/docker/docker.github.io/issues/15417
- fixes https://github.com/docker/docker.github.io/issues/15445
- fixes https://github.com/docker/docker.github.io/issues/15458
- fixes https://github.com/docker/docker.github.io/issues/15464
- fixes https://github.com/docker/docker.github.io/issues/15476
- fixes https://github.com/docker/docker.github.io/issues/15478
- fixes https://github.com/docker/docker.github.io/issues/15481
- fixes https://github.com/docker/docker.github.io/issues/15482
- fixes https://github.com/docker/docker.github.io/issues/15495
- fixes https://github.com/docker/docker.github.io/issues/15497
- fixes https://github.com/docker/docker.github.io/issues/15504
- relates to https://github.com/docker/docker.github.io/issues/13023
- relates to https://github.com/docker/docker.github.io/issues/13038
 