### PR TITLE
add start command to run hello-world image

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -195,6 +195,7 @@ a new file each time you want to upgrade Docker.
     image.
 
     ```console
+    $ sudo service docker start
     $ sudo docker run hello-world
     ```
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

I added start command before running `sudo docker run hello-world` because we can't run `docker image` after installing docker following guide without running `docker`.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
