### PR TITLE
[ENGDOCS-952] Update get started video

### DIFF
--- a/_includes/landing-page/popular-videos.html
+++ b/_includes/landing-page/popular-videos.html
@@ -8,7 +8,7 @@
     </div>
     <div class="row">
       <div class="col-xs-12 col-md-6 col-lg-12">
-        <a class="video-item" href="https://youtu.be/iqqDU2crIEQ?t=30" target="_blank" rel="noopener">
+        <a class="video-item" href="https://youtu.be/gAGEar5HQoU" target="_blank" rel="noopener">
           <img class="video-image" src="/images/video.svg" alt="video: How to get started with Docker" width="65" height="44" />
           <div class="video-title">How to get started with Docker</div>
         </a>

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -77,9 +77,15 @@ In addition, you'll also learn about the best practices for building images, inc
 
 If you are looking for information on how to containerize an application using your favorite language, see [Language-specific getting started guides](../language/index.md).
 
-We also recommend the video walkthrough from DockerCon 2020.
+We also recommend the video workshop from DockerCon 2022. Watch the video below or use the links to open the video at a particular section.
 
-<iframe src="https://www.youtube-nocookie.com/embed/iqqDU2crIEQ?start=30" style="max-width: 100%; aspect-ratio: 16 / 9;" width="560" height="auto" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+* <a href="https://youtu.be/gAGEar5HQoU">Docker overview and installation</a>
+* <a href="https://youtu.be/gAGEar5HQoU?t=1400">Pull, run, and explore containers</a>
+* <a href="https://youtu.be/gAGEar5HQoU?t=3185">Containerize an app</a>
+* <a href="https://youtu.be/gAGEar5HQoU?t=6305">Connect a DB and set up a bind mount</a>
+* <a href="https://youtu.be/gAGEar5HQoU?t=8280">Deploy a container to the cloud</a>
+
+<iframe src="https://www.youtube-nocookie.com/embed/gAGEar5HQoU" style="max-width: 100%; aspect-ratio: 16 / 9;" width="560" height="auto" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Download and install Docker
 

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -79,11 +79,10 @@ If you are looking for information on how to containerize an application using y
 
 We also recommend the video workshop from DockerCon 2022. Watch the video below or use the links to open the video at a particular section.
 
-* <a href="https://youtu.be/gAGEar5HQoU">Docker overview and installation</a>
-* <a href="https://youtu.be/gAGEar5HQoU?t=1400">Pull, run, and explore containers</a>
-* <a href="https://youtu.be/gAGEar5HQoU?t=3185">Containerize an app</a>
-* <a href="https://youtu.be/gAGEar5HQoU?t=6305">Connect a DB and set up a bind mount</a>
-* <a href="https://youtu.be/gAGEar5HQoU?t=8280">Deploy a container to the cloud</a>
+* [Docker overview and installation](https://youtu.be/gAGEar5HQoU)
+* [Pull, run, and explore containers](https://youtu.be/gAGEar5HQoU?t=1400)
+* [Connect a DB and set up a bind mount](https://youtu.be/gAGEar5HQoU?t=3185)
+* [Deploy a container to the cloud](https://youtu.be/gAGEar5HQoU?t=8280)
 
 <iframe src="https://www.youtube-nocookie.com/embed/gAGEar5HQoU" style="max-width: 100%; aspect-ratio: 16 / 9;" width="560" height="auto" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -81,7 +81,9 @@ We also recommend the video workshop from DockerCon 2022. Watch the video below 
 
 * [Docker overview and installation](https://youtu.be/gAGEar5HQoU)
 * [Pull, run, and explore containers](https://youtu.be/gAGEar5HQoU?t=1400)
-* [Connect a DB and set up a bind mount](https://youtu.be/gAGEar5HQoU?t=3185)
+* [Build a container image](https://youtu.be/gAGEar5HQoU?t=3185)
+* [Containerize an app](https://youtu.be/gAGEar5HQoU?t=4683)
+* [Connect a DB and set up a bind mount](https://youtu.be/gAGEar5HQoU?t=6305)
 * [Deploy a container to the cloud](https://youtu.be/gAGEar5HQoU?t=8280)
 
 <iframe src="https://www.youtube-nocookie.com/embed/gAGEar5HQoU" style="max-width: 100%; aspect-ratio: 16 / 9;" width="560" height="auto" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
### Proposed changes
On landing page and get-started page, updated get started video to a newer video from DockerCon 2022. 
On get started page, added links to different sections of the video.

- https://deploy-preview-15516--docsdocker.netlify.app/
- https://deploy-preview-15516--docsdocker.netlify.app/get-started/

### Related issues (optional)
ENGDOCS-952