### PR TITLE
Show hostname in hub API examples

### DIFF
--- a/_layouts/hub-api.html
+++ b/_layouts/hub-api.html
@@ -16,7 +16,7 @@
     <link rel="canonical" href="{{ site.docs_url }}/docker-hub/api/latest/" />
 </head>
 <body>
-    <redoc spec-url="/docker-hub/api/{{ page.name | replace: '.md'}}.yaml" hide-hostname="false" suppress-warnings="false" class="hub-api"></redoc>
+    <redoc spec-url="/docker-hub/api/{{ page.name | replace: '.md'}}.yaml" class="hub-api"></redoc>
     <script src="/js/redoc.standalone.js"></script>
 </body>
 </html>

--- a/docker-hub/api/latest.yaml
+++ b/docker-hub/api/latest.yaml
@@ -16,6 +16,7 @@ info:
     Docker provides an API that allows you to interact with Docker Hub.
 
     Browse through the Docker Hub API documentation to explore the supported endpoints.
+
 tags:
   - name: resources
     x-displayName: Resources
@@ -1275,7 +1276,7 @@ components:
                 type: array
                 items:
                   type: string
-                example: [ urn:ietf:params:scim:api:messages:2.0:ListResponse ]
+                example: [ "urn:ietf:params:scim:api:messages:2.0:ListResponse" ]
               totalResults:
                 type: integer
                 example: 1
@@ -1302,7 +1303,7 @@ components:
                 type: array
                 items:
                   type: string
-                example: [ urn:ietf:params:scim:api:messages:2.0:ListResponse ]
+                example: [ "urn:ietf:params:scim:api:messages:2.0:ListResponse" ]
               totalResults:
                 type: integer
                 example: 1
@@ -2300,7 +2301,7 @@ components:
           type: array
           items:
             type: string
-          example: [ urn:ietf:params:scim:schemas:core:2.0:Schema ]
+          example: [ "urn:ietf:params:scim:schemas:core:2.0:Schema" ]
         id:
           type: string
           example: urn:ietf:params:scim:schemas:core:2.0:User


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

Fixes some minor syntax issues with the Hub API yaml file and updates the redoc entry so that the full endpoint URL is shown in the drop-down next to each endpoint (the one on the right).
This was requested by some users who are trying to migrate to our new API which uses a different domain URL.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
