### PR TITLE
Reword 'audit log' to 'audit logs'

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1482,7 +1482,7 @@ manuals:
   - path: /docker-hub/vulnerability-scanning/
     title: Vulnerability scanning
   - path: /docker-hub/audit-log/
-    title: Audit log
+    title: Audit logs
   - sectiontitle: Security and authentication
     section:
       - path: /docker-hub/access-tokens/

--- a/docker-hub/audit-log.md
+++ b/docker-hub/audit-log.md
@@ -1,50 +1,50 @@
 ---
-description: Audit log
+description: Audit logs
 keywords: Team, organization, activity, log, audit, activities
-title: Audit log
+title: Audit logs
 ---
 
 {% include upgrade-cta.html
-  body="Audit log is available for users subscribed to a Docker Team or a Business subscription. Upgrade now to start tracking events across your organization."
+  body="Audit logs are available for users subscribed to a Docker Team or a Business subscription. Upgrade now to start tracking events across your organization."
   header-text="This feature requires a paid Docker subscription"
   target-url="https://www.docker.com/pricing?utm_source=docker&utm_medium=webreferral&utm_campaign=docs_driven_upgrade_audit_log"
 %}
 
-Audit log displays a chronological list of activities that occur at organization and repository levels. It provides owners of Docker Team accounts a report of all their team member activities. This allows the team owners to view and track what changes were made, the date when a change was made, and who initiated the change. For example, the audit log displays activities such as the date when a repository was created or deleted, the team member who created the repository, the name of the repository, and when there was a change to the privacy settings.
+Audit logs display a chronological list of activities that occur at organization and repository levels. It provides owners of Docker Team accounts a report of all their team member activities. This allows the team owners to view and track what changes were made, the date when a change was made, and who initiated the change. For example, the audit logs display activities such as the date when a repository was created or deleted, the team member who created the repository, the name of the repository, and when there was a change to the privacy settings.
 
-Team owners can also see the audit log for their repository if the repository is part of the organization subscribed to a Docker Team plan.
+Team owners can also see the audit logs for their repository if the repository is part of the organization subscribed to a Docker Team plan.
 
-## View the audit log
+## View the audit logs
 
-To view the audit log:
+To view the audit logs:
 
 1. Sign into an owner account for the organization in Docker Hub.
 2. Select your organization from the list and then click on the **Activity** tab.
 
     ![Organization activity tab](images/org-activity-tab.png){:width="700px"}
 
-The audit log begins tracking activities from the date the feature is live, that is from **25 January 2021**. Activities that took place before this date are not captured.
+The audit logs begin tracking activities from the date the feature is live, that is from **25 January 2021**. Activities that took place before this date are not captured.
 
 > **Note**
 >
-> Docker will retain the audit log activity data for a period of three months.
+> Docker will retain the activity data for a period of three months.
 
-## Customize the audit log
+## Customize the audit logs
 
-By default, all activities that occur at organization and repository levels are displayed on the **Activity** tab. Use the calendar option to select a date range and customize your results. After you have selected a date range, the **Activity** tab displays the audit log of all the activities that occurred during that period.
+By default, all activities that occur at organization and repository levels are displayed on the **Activity** tab. Use the calendar option to select a date range and customize your results. After you have selected a date range, the **Activity** tab displays the audit logs of all the activities that occurred during that period.
 
 ![Activities list](images/activity-list.png){:width="600px"}
 
 > **Note**
 >
-> Activities created by the Docker Support team as part of resolving customer issues appear in the audit log as **dockersupport**.
+> Activities created by the Docker Support team as part of resolving customer issues appear in the audit logs as **dockersupport**.
 
 Click the **All Activities** drop-down list to view activities that are specific to an organization or a repository. After choosing **Organization** or **Repository**, you can further refine the results using the **All Actions** drop-down list. If you select the **Activities** tab from the **Repository** view, you can only filter repository-level activities.
 
 ![Refine org activities](images/org-all-actions.png){:width="600px"}
 
 
-## Audit log event definitions
+## Audit logs event definitions
 
 Refer to the following section for a list of events and their descriptions:
 

--- a/docker-hub/orgs.md
+++ b/docker-hub/orgs.md
@@ -100,9 +100,9 @@ configure your organization.
   organization. See [Repositories](repos.md) for detailed information about
   working with repositories.
 
-- **Activity** Displays the audit log, a chronological list of activities that
+- **Activity** Displays the audit logs, a chronological list of activities that
   occur at organization and repository levels. It provides the org owners a
-  report of all their team member activities. See [Audit log](audit-log.md) for
+  report of all their team member activities. See [Audit logs](audit-log.md) for
   details.
 
 - **Settings**: Displays information about your

--- a/docker-hub/release-notes.md
+++ b/docker-hub/release-notes.md
@@ -101,9 +101,9 @@ Docker introduces the Advanced Image Management dashboard that enables you to vi
 
 ### New feature
 
-Docker introduces Audit log, a new feature that allows team owners to view a list of activities that occur at organization and repository levels. This feature begins tracking the activities from the release date, that is, **from 25 January 2021**.
+Docker introduces Audit logs, a new feature that allows team owners to view a list of activities that occur at organization and repository levels. This feature begins tracking the activities from the release date, that is, **from 25 January 2021**.
 
-For more information about this feature and for instructions on how to use it, see [Audit log](audit-log.md).
+For more information about this feature and for instructions on how to use it, see [Audit logs](audit-log.md).
 
 ## 2020-11-10
 

--- a/subscription/index.md
+++ b/subscription/index.md
@@ -45,7 +45,7 @@ For a list of features available in each tier, see [Docker Pricing](https://www.
 
 **Docker Team** offers capabilities for collaboration, productivity, and security across organizations. It enables groups of developers to unlock the full power of collaboration and sharing combined with essential security features and team management capabilities.
 
-Docker Team includes everything included in Docker Pro, plus unlimited private repositories, [Auto Builds](../docker-hub/builds/index.md) with 15 concurrent builds, unlimited [Scoped Access Tokens](../docker-hub/access-tokens.md), advanced collaboration and management tools, including organization and team management with Role Based Access Control (RBAC) for the whole team, an [audit log](../docker-hub/audit-log.md), and more.
+Docker Team includes everything included in Docker Pro, plus unlimited private repositories, [Auto Builds](../docker-hub/builds/index.md) with 15 concurrent builds, unlimited [Scoped Access Tokens](../docker-hub/access-tokens.md), advanced collaboration and management tools, including organization and team management with Role Based Access Control (RBAC) for the whole team, [audit logs](../docker-hub/audit-log.md), and more.
 
 For a list of features available in each tier, see [Docker Pricing](https://www.docker.com/pricing/){: target="_blank" rel="noopener" class="_" id="dkr_docs_subscription_btl"}.
 


### PR DESCRIPTION
### Proposed changes

Marketing material and our API docs use plural for "audit logs". Proposing to update the docs for better alignment.

### Related issues (optional)
ENGDOCS-972