### PR TITLE
ci: invalidate cloudfront cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,13 @@ jobs:
           AWS_CLOUDFRONT_ID: ${{ env.DOCS_CLOUDFRONT_ID }}
           AWS_LAMBDA_FUNCTION: ${{ env.DOCS_LAMBDA_FUNCTION_REDIRECTS }}
       -
+        name: Invalidate Cloudfront cache
+        if: ${{ env.DOCS_CLOUDFRONT_ID != '' }}
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ env.DOCS_CLOUDFRONT_ID }} --paths "/*"
+        env:
+          AWS_REGION: us-east-1 # cloudfront is only available in us-east-1 region
+      -
         name: Send Slack notification
         if: ${{ env.SEND_SLACK_MSG == 'true' }}
         run: |


### PR DESCRIPTION
Atm cloudfront cache is not invalidated when deploying the website and relies on default TTL for the distribution. This PR ensures cache is invalidated after each deployment.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>