### PR TITLE
Fix typo in long syntax section of compose spec

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1662,7 +1662,7 @@ the service's containers.
   Default value is world-readable permissions (mode `0444`).
   The writable bit MUST be ignored if set. The executable bit MAY be set.
 
-The following example sets the name of the `server-certificate` secret file to `server.crt`
+The following example sets the name of the `server-certificate` secret file to `server.cert`
 within the container, sets the mode to `0440` (group-readable) and sets the user and group
 to `103`. The value of `server-certificate` secret is provided by the platform through a lookup and
 the secret lifecycle is not directly managed by the Compose implementation.


### PR DESCRIPTION
Description of code snippet in long syntax example of [secrets](https://docs.docker.com/compose/compose-file/#secrets) states that a name of a secret file is set to `server.crt` whereas in the snippet it is configured to `server.cert`.

### Proposed changes

Fix description of code snippet so that it adheres to the code ([secrets](https://docs.docker.com/compose/compose-file/#secrets), long syntax).

### Related issues (optional)

