### PR TITLE
Update reference to the contribution guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 
 This repository is for reporting issues related to Docker Documentation. Before submitting a new issue, check whether the issue has already been reported. You can join the discussion using an emoji, or by adding a comment to an existing issue.
 
-You can ask general questions and get community support through the Docker Community Slack - http://dockr.ly/slack. Personalized support is available through the Docker Pro, Team, and Business subscriptions. See https://www.docker.com/pricing for details.
+You can ask general questions and get community support through the Docker Community Forums - https://forums.docker.com/ and Slack - http://dockr.ly/slack. Personalized support is available through the Docker Pro, Team, and Business subscriptions. See https://www.docker.com/pricing for details.
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
-    for this project's contribution guidelines. Remove these comments
-    as you go.-->
+<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->
 
 ### Proposed changes
 

--- a/opensource/index.md
+++ b/opensource/index.md
@@ -71,9 +71,5 @@ We've made it really easy for you to file new issues.
 We value your contribution. We'd like to make it as easy as possible to submit
 your contributions to the Docker docs repository. Changes to the docs are
 handled through pull requests against the `master` branch. To learn how to
-contribute, see
-[CONTRIBUTING.md](https://github.com/docker/docker.github.io/blob/master/CONTRIBUTING.md).
-
-For a demo of the components, tags, Markdown syntax, styles, used in Docker
-documentation, see
-[test.md](https://github.com/docker/docker.github.io/blob/master/test.md).
+contribute, see the
+[Contribution guidelines](../contribute/overview.md).


### PR DESCRIPTION
Signed-off-by: Usha Mandya <usha.mandya@docker.com

- Update the PR template to point to the new contribution guidelines section
- Update the issue template to add a link to the Docker Community Forums