### PR TITLE
replace deprecated flask debug environment flag

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -233,7 +233,7 @@ services:
     volumes:
       - .:/code
     environment:
-      FLASK_ENV: development
+      FLASK_DEBUG: True
   redis:
     image: "redis:alpine"
 ```


### PR DESCRIPTION


<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes
update documentation to use `FLASK_DEBUG: True` in place of the depreciated `FLASK_ENV: development`
<!--Tell us what you did and why-->

### Related issues (optional)
fixes #15571

