### PR TITLE
How to load extensions not in the Marketplace

### DIFF
--- a/desktop/extensions.md
+++ b/desktop/extensions.md
@@ -108,18 +108,18 @@ If an extension does not provide a way for you to give feedback, contact us and 
 
 The Extensions Marketplace is the trusted and official place to install extensions from within Docker Desktop. These extensions have gone through a review process by Docker. However, other extensions can also be installed in Docker Desktop if you trust the extension author.
 
-Given the nature of a Docker Extension (i.e. a Docker image) you could find other places where users have their extensions' source code published: GitHub, GitLab or even hosted in image registries like DockerHub or GHCR.
-You can install Docker Extensions that have been developed by the community or internally at your company from a teammate: you are not limited to install extensions from the Marketplace only.
+Given the nature of a Docker Extension (i.e. a Docker image) you can find other places where users have their extension's source code published. For example on GitHub, GitLab or even hosted in image registries like DockerHub or GHCR.
+You can install an extension that has been developed by the community or internally at your company from a teammate. You are not limited to installing extensions just from the Marketplace.
 
 > **Note**
 >
-> Ensure the option "Allow only extensions distributed through the Docker Marketplace" is disabled. Otherwise this will This will prevent to install any extension not listed in the Marketplace via the Extension SDK tools.
+> Ensure the option **Allow only extensions distributed through the Docker Marketplace** is disabled. Otherwise, this prevents any extension not listed in the Marketplace, via the Extension SDK tools from, being installed.
 > You can change this option in the Settings > Extensions.
 
 
 > **Warning**
 >
-> Docker Extensions that are not in the Marketplace haven't been gone through a review process by Docker.
+> Docker Extensions that are not in the Marketplace haven't gone through Docker's review process.
 > Extensions can install binaries, invoke commands and access files on your machine. Installing them is at your own risk.
 
 To install an extension which is not present in the Marketplace, you can use the Extensions CLI that is bundled with Docker Desktop.
@@ -131,7 +131,7 @@ Go to the Docker Dashboard to see the new extension installed.
 ## List installed extensions
 
 Regardless whether the extension was installed from the Marketplace or manually by using the Extensions CLI, you can use the `docker extension ls` command to display the list of extensions installed.
-As part of the output you could see the extension ID, the provider, version, the title and whether it runs a backend container or has deployed binaries to the host, for example:
+As part of the output you'll see the extension ID, the provider, version, the title and whether it runs a backend container or has deployed binaries to the host, for example:
 
 ```
 $ docker extension ls
@@ -139,8 +139,8 @@ ID                  PROVIDER            VERSION             UI                  
 john/my-extension   John                latest              1 tab(My-Extension)   Running(1)          -
 ```
 
-Go to the Docker Dashboard, click on "Add Extensions" and on the "Installed" tab to see the new extension installed.
-Notice that it will display an `UNPUBLISHED` label indicating that the extension has not been installed from the Marketplace.
+Go to the Docker Dashboard, click on **Add Extensions** and on the **Installed** tab to see the new extension installed.
+Notice that an `UNPUBLISHED` label displays which indicates that the extension has not been installed from the Marketplace.
 
 ## Update an extension which is not in the Marketplace
 
@@ -155,4 +155,4 @@ Go to the Docker Dashboard to see the new extension updated.
 
 ## Uninstall an extension which is not in the Marketplace
 
-To uninstall an extension which is not present in the Marketplace, you could either navigate to the "Installed" tab in the Marketplace and click the "Uninstall" button, or from a terminal type `docker extension uninstall IMAGE[:TAG]`.
+To uninstall an extension which is not present in the Marketplace, you can either navigate to the **Installed** tab in the Marketplace and select the **Uninstall** button, or from a terminal type `docker extension uninstall IMAGE[:TAG]`.

--- a/desktop/extensions.md
+++ b/desktop/extensions.md
@@ -135,8 +135,8 @@ As part of the output you could see the extension ID, the provider, version, the
 
 ```
 $ docker extension ls
-ID                                       PROVIDER            VERSION             UI                              VM                  HOST
-docker/volumes-backup-extension          Docker Inc.         1.0.0               1 tab(Volumes Backup & Share)   Running(1)          1 binarie(s)
+ID                  PROVIDER            VERSION             UI                    VM                  HOST
+john/my-extension   John                latest              1 tab(My-Extension)   Running(1)          -
 ```
 
 Go to the Docker Dashboard, click on "Add Extensions" and on the "Installed" tab to see the new extension installed.
@@ -148,6 +148,10 @@ To update an extension which is not present in the Marketplace, in a terminal ty
 
 For instance, if you installed an extension with `docker extension install john/my-extension:0.0.1`, you can update it by running `docker extension update john/my-extension:0.0.2`.
 Go to the Docker Dashboard to see the new extension updated.
+
+> **Note**
+>
+> Extensions that have not been installed through the Marketplace will not receive update notifications from Docker Desktop.
 
 ## Uninstall an extension which is not in the Marketplace
 

--- a/desktop/extensions.md
+++ b/desktop/extensions.md
@@ -104,16 +104,16 @@ If an extension does not provide a way for you to give feedback, contact us and 
 2. Click **Manage Extensions**. This displays a list of extensions you've installed.
 3. Click **Uninstall**.
 
-## Install an extension which is not in the Marketplace
+## Install an extension not available in the Marketplace
 
-The Extensions Marketplace is the trusted and official place to install extensions from within Docker Desktop. These extensions have gone through a review process and thus meet a minimum set of requirements. However, the Marketplace it is not the only place where to install extensions from.
+The Extensions Marketplace is the trusted and official place to install extensions from within Docker Desktop. These extensions have gone through a review process by Docker. However, other extensions can also be installed in Docker Desktop if you trust the extension author.
 
 Given the nature of a Docker Extension (i.e. a Docker image) you could find other places where users have their extensions' source code published: GitHub, GitLab or even hosted in image registries like DockerHub or GHCR.
 You can install Docker Extensions that have been developed by the community or internally at your company from a teammate: you are not limited to install extensions from the Marketplace only.
 
 > **Note**
 >
-> Ensure the option "Allow only extensions distributed through the Docker Marketplace" is disabled. Otherwise this will This will prevent to install any other extension via the Extension SDK tools.
+> Ensure the option "Allow only extensions distributed through the Docker Marketplace" is disabled. Otherwise this will This will prevent to install any extension not listed in the Marketplace via the Extension SDK tools.
 > You can change this option in the Settings > Extensions.
 
 
@@ -122,9 +122,9 @@ You can install Docker Extensions that have been developed by the community or i
 > Docker Extensions that are not in the Marketplace haven't been gone through a review process by Docker.
 > Extensions can install binaries, invoke commands and access files on your machine. Installing them is at your own risk.
 
-To install an extension which is not present in the Marketplace, you can use the Extensions CLI that is bundled as part of Docker Desktop.
+To install an extension which is not present in the Marketplace, you can use the Extensions CLI that is bundled with Docker Desktop.
 
-In a terminal, type `docker extension install IMAGE[:TAG]` to install an extension by its image reference and optionally a tag. Use the `-f` or `--force` flag to not prompt for confirmation.
+In a terminal, type `docker extension install IMAGE[:TAG]` to install an extension by its image reference and optionally a tag. Use the `-f` or `--force` flag to avoid interactive confirmation.
 
 Go to the Docker Dashboard to see the new extension installed.
 
@@ -151,4 +151,4 @@ Go to the Docker Dashboard to see the new extension updated.
 
 ## Uninstall an extension which is not in the Marketplace
 
-To uninstall an extension which is not present in the Marketplace, you could either navigate to the "Installed" tab in the Marketplace and press on the "Uninstall" button, or from a terminal type `docker extension rm IMAGE[:TAG]`.
+To uninstall an extension which is not present in the Marketplace, you could either navigate to the "Installed" tab in the Marketplace and click the "Uninstall" button, or from a terminal type `docker extension uninstall IMAGE[:TAG]`.

--- a/desktop/extensions.md
+++ b/desktop/extensions.md
@@ -106,6 +106,12 @@ If an extension does not provide a way for you to give feedback, contact us and 
 
 ## Install an extension not available in the Marketplace
 
+> **Warning**
+>
+> Docker Extensions that are not in the Marketplace haven't gone through Docker's review process.
+> Extensions can install binaries, invoke commands and access files on your machine. Installing them is at your own risk.
+{: .warning}
+
 The Extensions Marketplace is the trusted and official place to install extensions from within Docker Desktop. These extensions have gone through a review process by Docker. However, other extensions can also be installed in Docker Desktop if you trust the extension author.
 
 Given the nature of a Docker Extension (i.e. a Docker image) you can find other places where users have their extension's source code published. For example on GitHub, GitLab or even hosted in image registries like DockerHub or GHCR.
@@ -115,12 +121,6 @@ You can install an extension that has been developed by the community or interna
 >
 > Ensure the option **Allow only extensions distributed through the Docker Marketplace** is disabled. Otherwise, this prevents any extension not listed in the Marketplace, via the Extension SDK tools from, being installed.
 > You can change this option in the Settings > Extensions.
-
-
-> **Warning**
->
-> Docker Extensions that are not in the Marketplace haven't gone through Docker's review process.
-> Extensions can install binaries, invoke commands and access files on your machine. Installing them is at your own risk.
 
 To install an extension which is not present in the Marketplace, you can use the Extensions CLI that is bundled with Docker Desktop.
 

--- a/desktop/extensions.md
+++ b/desktop/extensions.md
@@ -103,3 +103,52 @@ If an extension does not provide a way for you to give feedback, contact us and 
 1. From the menu bar, select the ellipsis to the right of **Extensions**.
 2. Click **Manage Extensions**. This displays a list of extensions you've installed.
 3. Click **Uninstall**.
+
+## Install an extension which is not in the Marketplace
+
+The Extensions Marketplace is the trusted and official place to install extensions from within Docker Desktop. These extensions have gone through a review process and thus meet a minimum set of requirements. However, the Marketplace it is not the only place where to install extensions from.
+
+Given the nature of a Docker Extension (i.e. a Docker image) you could find other places where users have their extensions' source code published: GitHub, GitLab or even hosted in image registries like DockerHub or GHCR.
+You can install Docker Extensions that have been developed by the community or internally at your company from a teammate: you are not limited to install extensions from the Marketplace only.
+
+> **Note**
+>
+> Ensure the option "Allow only extensions distributed through the Docker Marketplace" is disabled. Otherwise this will This will prevent to install any other extension via the Extension SDK tools.
+> You can change this option in the Settings > Extensions.
+
+
+> **Warning**
+>
+> Docker Extensions that are not in the Marketplace haven't been gone through a review process by Docker.
+> Extensions can install binaries, invoke commands and access files on your machine. Installing them is at your own risk.
+
+To install an extension which is not present in the Marketplace, you can use the Extensions CLI that is bundled as part of Docker Desktop.
+
+In a terminal, type `docker extension install IMAGE[:TAG]` to install an extension by its image reference and optionally a tag. Use the `-f` or `--force` flag to not prompt for confirmation.
+
+Go to the Docker Dashboard to see the new extension installed.
+
+## List installed extensions
+
+Regardless whether the extension was installed from the Marketplace or manually by using the Extensions CLI, you can use the `docker extension ls` command to display the list of extensions installed.
+As part of the output you could see the extension ID, the provider, version, the title and whether it runs a backend container or has deployed binaries to the host, for example:
+
+```
+$ docker extension ls
+ID                                       PROVIDER            VERSION             UI                              VM                  HOST
+docker/volumes-backup-extension          Docker Inc.         1.0.0               1 tab(Volumes Backup & Share)   Running(1)          1 binarie(s)
+```
+
+Go to the Docker Dashboard, click on "Add Extensions" and on the "Installed" tab to see the new extension installed.
+Notice that it will display an `UNPUBLISHED` label indicating that the extension has not been installed from the Marketplace.
+
+## Update an extension which is not in the Marketplace
+
+To update an extension which is not present in the Marketplace, in a terminal type `docker extension update IMAGE[:TAG]` where the `TAG` should be different from the extension that is already installed.
+
+For instance, if you installed an extension with `docker extension install john/my-extension:0.0.1`, you can update it by running `docker extension update john/my-extension:0.0.2`.
+Go to the Docker Dashboard to see the new extension updated.
+
+## Uninstall an extension which is not in the Marketplace
+
+To uninstall an extension which is not present in the Marketplace, you could either navigate to the "Installed" tab in the Marketplace and press on the "Uninstall" button, or from a terminal type `docker extension rm IMAGE[:TAG]`.


### PR DESCRIPTION
### Proposed changes

Extend https://docs.docker.com/desktop/extensions/ to include how to load extensions not in the Marketplace.

Preview: https://deploy-preview-15573--docsdocker.netlify.app/desktop/extensions/#install-an-extension-which-is-not-in-the-marketplace