### PR TITLE
removed icon background

### DIFF
--- a/assets/images/description.svg
+++ b/assets/images/description.svg
@@ -1,10 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#677285"> <style>
-      svg {
-        color-scheme: #677285;
-      }
-      @media (prefers-color-scheme:dark) {
-        svg {
-          background-color: black;
-        }
-      }
-    </style><path d="M0 0h24v24H0z" fill="none"/><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#677285">
+  <path d="M0 0h24v24H0z" fill="none"/>
+  <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>
+</svg>


### PR DESCRIPTION
The icon for one of the tiles in the contribution section has a black background for people whose operating system is set to prefer dark color scheme.

This was caused by style properties in the SVG icon. I've updated the SVG to remove the background.

## Before

<img width="272" alt="before_dark" src="https://user-images.githubusercontent.com/35727626/188820573-9a607d9f-5668-45d3-b368-c3c94dc4fe3b.png">
<img width="271" alt="before_light" src="https://user-images.githubusercontent.com/35727626/188820582-60f1edf5-6600-4be4-869c-dcc2858a79aa.png">

## After

<img width="267" alt="after_dark" src="https://user-images.githubusercontent.com/35727626/188820588-203421b8-9bfc-4f56-bc1a-f50184bf5d58.png">
<img width="277" alt="after_light" src="https://user-images.githubusercontent.com/35727626/188820586-fe33ef72-f1ef-4bae-8939-3d98db37deba.png">

