### PR TITLE
desktop: add buildx to docker desktop components list

### DIFF
--- a/desktop/index.md
+++ b/desktop/index.md
@@ -45,6 +45,7 @@ It provides a simple interface that enables you to manage your containers, appli
 
 - [Docker Engine](../engine/index.md)
 - Docker CLI client
+- [Docker Buildx](../build/buildx/index.md)
 - [Docker Compose](../compose/index.md)
 - [Docker Content Trust](../engine/security/trust/index.md)
 - [Kubernetes](https://github.com/kubernetes/kubernetes/)


### PR DESCRIPTION
Looks like buildx was missing from components list included in Docker Desktop.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>