### PR TITLE
correct docker compose up command

### DIFF
--- a/get-started/08_using_compose.md
+++ b/get-started/08_using_compose.md
@@ -278,7 +278,7 @@ Now that we have our `docker-compose.yml` file, we can start it up!
    background.
 
     ```console
-    $ docker-compose up -d
+    $ docker compose up -d
     ```
 
     When we run this, we should see output like this:


### PR DESCRIPTION
On my pc the docker compose up command was without the dash I think on the wiki is wrong. The only think I changed was the dash on the comand I spend a lot of time until I figured out it was wrong.



