### PR TITLE
extension SDK : cannot chain commands in exec()

### DIFF
--- a/desktop/extensions-sdk/dev/api/backend.md
+++ b/desktop/extensions-sdk/dev/api/backend.md
@@ -173,4 +173,4 @@ window.ddClient.spawnHostCmd(
 
 > You cannot use this to chain commands in a single `exec()` invocation (like `cmd1 $(cmd2)` or using pipe between commands).
 >
-> You need to invoke `exec() for each commands, and parse results to pass parameters to the next command if needed.
+> You need to invoke `exec()` for each command and parse results to pass parameters to the next command if needed.

--- a/desktop/extensions-sdk/dev/api/backend.md
+++ b/desktop/extensions-sdk/dev/api/backend.md
@@ -170,3 +170,7 @@ window.ddClient.spawnHostCmd(
   }
 );
 ```
+
+> You cannot use this to chain commands in a single `exec()` invocation (like `cmd1 $(cmd2)` or using pipe between commands).
+>
+> You need to invoke `exec() for each commands, and parse results to pass parameters to the next command if needed.

--- a/desktop/extensions-sdk/dev/api/docker.md
+++ b/desktop/extensions-sdk/dev/api/docker.md
@@ -130,7 +130,7 @@ await ddClient.docker.cli.exec(
 
 > You cannot use this to chain commands in a single `exec()` invocation (like `docker kill $(docker ps -q)` or using pipe between commands).
 >
-> You need to invoke `exec() for each commands, and parse results to pass parameters to the next command if needed.
+> You need to invoke `exec()` for each command and parse results to pass parameters to the next command if needed.
 
 See the [Exec API reference](reference/interfaces/Exec.md) for details about these methods.
 

--- a/desktop/extensions-sdk/dev/api/docker.md
+++ b/desktop/extensions-sdk/dev/api/docker.md
@@ -1,5 +1,5 @@
 ---
-title: Docker 
+title: Docker
 description: Docker extension API
 keywords: Docker, extensions, sdk, API
 ---
@@ -127,6 +127,10 @@ await ddClient.docker.cli.exec(
   }
 );
 ```
+
+> You cannot use this to chain commands in a single `exec()` invocation (like `docker kill $(docker ps -q)` or using pipe between commands).
+>
+> You need to invoke `exec() for each commands, and parse results to pass parameters to the next command if needed.
 
 See the [Exec API reference](reference/interfaces/Exec.md) for details about these methods.
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

Detail limitation of extension SDK exec() : cannot chain commands, need to invoke commands one by one

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
