### PR TITLE
Issue-15646: Java language specific guide issue

### DIFF
--- a/language/java/develop.md
+++ b/language/java/develop.md
@@ -140,6 +140,8 @@ services:
      - MYSQL_URL=jdbc:mysql://mysqlserver/petclinic
    volumes:
      - ./:/app
+    depends_on:
+      - mysqlserver
 
  mysqlserver:
     image: mysql:8.0


### PR DESCRIPTION
### Proposed changes

There's an error in the example Compose file.
Added `depends_on` to the Compose file in the Java language-specific guide.

### Related issues (optional)

Fixes #15646 
