### PR TITLE
engine: fix orphan entry in toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1335,8 +1335,6 @@ manuals:
     title: Optional post-installation steps
   - path: /engine/deprecated/
     title: Deprecated features
-  - path: /buildx/working-with-buildx/
-    title: Docker Buildx
   - path: /engine/context/working-with-contexts/
     title: Docker Context
   - path: /engine/scan/

--- a/build/index.md
+++ b/build/index.md
@@ -4,6 +4,7 @@ description: Introduction and overview of Docker Build
 keywords: build, buildx, buildkit
 redirect_from:
 - /build/buildx/
+- /buildx/working-with-buildx/
 ---
 
 ## Overview


### PR DESCRIPTION
fixes #15660 

Looks like htmlproofer doesn't check toc for dead links. That's because toc is generated through javascript. We should generate toc during build. Will take a look on that in a follow-up.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>