### PR TITLE
Update `debian.md`, `fedora.md`, `ubuntu.md`

### DIFF
--- a/desktop/install/debian.md
+++ b/desktop/install/debian.md
@@ -49,7 +49,7 @@ Recommended approach to install Docker Desktop on Debian:
 
 1. Set up [Docker's package repository](../../engine/install/debian.md#set-up-the-repository). 
 
-2. Download latest [DEB package](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.11.0-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
+2. Download latest [DEB package](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.12.0-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
 
 3. Install the package with apt as follows:
 

--- a/desktop/install/fedora.md
+++ b/desktop/install/fedora.md
@@ -29,7 +29,7 @@ To install Docker Desktop on Fedora:
 
 1. Set up [Docker's package repository](../../engine/install/fedora.md#set-up-the-repository). 
 
-2. Download latest [RPM package](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.11.0-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
+2. Download latest [RPM package](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.12.0-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
 
 3. Install the package with dnf as follows:
 

--- a/desktop/install/ubuntu.md
+++ b/desktop/install/ubuntu.md
@@ -48,7 +48,7 @@ Recommended approach to install Docker Desktop on Ubuntu:
 
 1. Set up [Docker's package repository](../../engine/install/ubuntu.md#set-up-the-repository).
 
-2. Download latest [DEB package](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.11.0-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
+2. Download latest [DEB package](https://desktop.docker.com/linux/main/amd64/docker-desktop-4.12.0-amd64.deb?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
 
 3. Install the package with apt as follows:
 


### PR DESCRIPTION
### Proposed changes

- Docker Desktop 4.12.0 was released on 2022-09-01.
- Update Linux pages' latest download links.
  - debian.md
  - fedora.md
  - ubuntu.md

### Related issues (optional)

issues: #15678 