### PR TITLE
Fix hub api list tags page_size description

### DIFF
--- a/docker-hub/api/latest.yaml
+++ b/docker-hub/api/latest.yaml
@@ -2463,7 +2463,7 @@ components:
       required: false
       schema:
         type: integer
-      description: "Number of images to get per page. Defaults to 10. Max of 1000."
+      description: "Number of items to get per page. Defaults to 10. Max of 100."
 
   requestBodies:
     scim_create_user_request:


### PR DESCRIPTION
<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

Fixes the description of the list-tags page size parameter

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
