### PR TITLE
Add documentation for the new --installation-dir flag for the Windows Docker Desktop installer

### DIFF
--- a/desktop/install/windows-install.md
+++ b/desktop/install/windows-install.md
@@ -151,13 +151,14 @@ If using the Windows Command Prompt:
 start /w "" "Docker Desktop Installer.exe" install
 ```
 
-The install command accepts the following flags:
+The `install` command accepts the following flags:
 
 - `--quiet`: suppresses information output when running the installer
 - `--accept-license`: accepts the [Docker Subscription Service Agreement](https://www.docker.com/legal/docker-subscription-service-agreement){: target="_blank" rel="noopener" class="_"} now, rather than requiring it to be accepted when the application is first run
 - `--no-windows-containers`: disables Windows containers integration
 - `--allowed-org=<org name>`: requires the user to sign in and be part of the specified Docker Hub organization when running the application
 - `--backend=<backend name>`: selects the default backend to use for Docker Desktop, `hyper-v`, `windows` or `wsl-2` (default)
+- `--installation-dir=<path>`: changes the default installation location (`C:\Program Files\Docker\Docker`)
 
 If your admin account is different to your user account, you must add the user to the **docker-users** group:
 


### PR DESCRIPTION
<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

Added documentation for the new `--installation-dir` flag for the Windows Docker Desktop installer.
This will be released in Docker Desktop 4.13.

### Related issues (optional)

First step for https://github.com/docker/roadmap/issues/94

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
