### PR TITLE
storage: remove mention of "named volumes" for mount propagation

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -284,7 +284,7 @@ only configurable for bind mounts, and only on Linux host machines. Bind
 propagation is an advanced topic and many users never need to configure it.
 
 Bind propagation refers to whether or not mounts created within a given
-bind-mount or named volume can be propagated to replicas of that mount. Consider
+bind-mount can be propagated to replicas of that mount. Consider
 a mount point `/mnt`, which is also mounted on `/tmp`. The propagation settings
 control whether a mount on `/tmp/a` would also be available on `/mnt/a`. Each
 propagation setting has a recursive counterpoint. In the case of recursion,


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/26051#issuecomment-739109835
- addresses https://github.com/moby/moby/issues/26051#issuecomment-739115798


Mount propagation is not supported for named volumes, as mentioned in the paragraph before this one, so let's remove it here.

