### PR TITLE
Fix typos, tone and brevity

### DIFF
--- a/language/golang/run-containers.md
+++ b/language/golang/run-containers.md
@@ -97,9 +97,9 @@ CONTAINER ID   IMAGE            COMMAND             CREATED          STATUS     
 d75e61fcad1e   docker-gs-ping   "/docker-gs-ping"   41 seconds ago   Up 40 seconds   0.0.0.0:8080->8080/tcp   inspiring_ishizaka
 ```
 
-The `ps` command tells a bunch of stuff about our running containers. We can see the container ID, the image running inside the container, the command that was used to start the container, when it was created, the status, ports that are exposed, and the name of the container.
+The `ps` command tells us a bunch of stuff about our running containers. We can see the container ID, the image running inside the container, the command that was used to start the container, when it was created, the status, ports that are exposed, and the names of the container.
 
-You are probably wondering where the name of our container is coming from. Since we didn’t provide a name for the container when we started it, Docker generated a random name. We’ll fix this in a minute but first we need to stop the container. To stop the container, run the `docker stop` command which does just that, stops the container. You will need to pass the name of the container or you can use the container ID.
+You are probably wondering where the name of our container is coming from. Since we didn’t provide a name for the container when we started it, Docker generated a random name. We’ll fix this in a minute but first we need to stop the container. To stop the container, run the `docker stop` command, passing the container's name or ID.
 
 ```console
 $ docker stop inspiring_ishizaka


### PR DESCRIPTION
### Proposed changes

Change "tells a bunch of stuff" to "tells us a bunch of stuff"

While I don't think this is a grammatical issue, it reads better and is generally how someone would use it in a conversation (the docs have a very conversational tone, which is why I chose with "tells us" instead of replacing "tells" with "reveals", for example.)

Change "name" to "names", because a container can have multiple names (the docker ps command displays the column as "NAMES".  It's also more in line with the author using "ports" to refer to the list of exposed ports (even though there is only one exposed port.)

Change the following:

  "To stop the container, run the `docker stop` command which does just that, stops the container. You will need to pass 
  the name of the container or you can use the container ID."

To:

    "To stop the container, run the `docker stop` command, passing the container's name or ID."

Because I feel like the the former is overly repetitious and lengthy without being more understandable or providing more insight. I understand the docs tend to have a very conversational, easy-to-read tone, but I think the latter fits with the tone well enough and is nice and concise.

