### PR TITLE
docker-hub: fix link to logo asset

### DIFF
--- a/docker-hub/api/latest.yaml
+++ b/docker-hub/api/latest.yaml
@@ -3,7 +3,7 @@ info:
   title: Docker HUB API
   version: beta
   x-logo:
-    url: https://docs.docker.com/images/logo-docker-main.png
+    url: https://docs.docker.com/assets/images/logo-docker-main.png
     href: /reference
   description: |
     Docker Hub is a service provided by Docker for finding and sharing container


### PR DESCRIPTION
Looks like this one was missing in #15246

There is also the swagger api files fetched from moby repo that needs to be fixed on master, 20.10 and 22.06 branches.