### PR TITLE
Update kube deploy yaml

### DIFF
--- a/get-started/kube-deploy.md
+++ b/get-started/kube-deploy.md
@@ -45,6 +45,7 @@ All containers in Kubernetes are scheduled as _pods_, which are groups of co-loc
           containers:
           - name: bb-site
             image: getting-started
+            imagePullPolicy: IfNotPresent
     ---
     apiVersion: v1
     kind: Service


### PR DESCRIPTION
Fixes #15749

The demo does not work as it always looks for a remote image by default.
Updated yaml to look for the local image.