### PR TITLE
added back insights and analytics to toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1528,6 +1528,8 @@ manuals:
     section:
       - path: /docker-hub/publish/
         title: Overview
+      - path: /docker-hub/publish/insights-and-analytics/
+        title: Insights & analytics
       - path: /docker-hub/publish/publisher-center-migration/
         title: Migrate content from the Publisher Center
   - path: /docker-hub/release-notes/

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1528,7 +1528,7 @@ manuals:
     section:
       - path: /docker-hub/publish/
         title: Overview
-      - path: /docker-hub/publish/insights-and-analytics/
+      - path: /docker-hub/publish/insights-analytics/
         title: Insights & analytics
       - path: /docker-hub/publish/publisher-center-migration/
         title: Migrate content from the Publisher Center


### PR DESCRIPTION
The insights and analytics page has somehow disappeared from the sidenav. This pull request adds it back.