### PR TITLE
rename docs repository

### DIFF
--- a/404.md
+++ b/404.md
@@ -9,18 +9,18 @@ skip_read_time: true
 
 There might be a mistake in the URL or you might've clicked a link to content
 that no longer exists. If you think it's the latter, please file an issue in
-our [issue tracker on GitHub](https://github.com/docker/docker.github.io/issues/new)
+our [issue tracker on GitHub]({{ site.repo }}/issues/new)
 and let us know what happened. Please also include a link to where the error
 occurred, if applicable.
 
-[**Click here to create a new ticket**](https://github.com/docker/docker.github.io/issues/new){:.newissue.button.primary-btn}
+[**Click here to create a new ticket**]({{ site.repo }}/issues/new){:.newissue.button.primary-btn}
 
 [![404 page not found](/assets/images/404-docs.png)](/ "Go to the homepage")
 
 <script>
 let el = document.querySelector("a.newissue");
 if (el) {
-    let url = new URL("https://github.com/docker/docker.github.io/issues/new");
+    let url = new URL("{{ site.repo }}/issues/new");
     url.searchParams.set("title", "404 at " + window.location.pathname);
     let body = "I found a broken link : " + window.location.href;
     if (document.referrer !== "") {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # This Dockerfile builds the docs for https://docs.docker.com/
-# from the master branch of https://github.com/docker/docker.github.io
+# from the master branch of https://github.com/docker/docs
 
 # Use same ruby version as the one in .ruby-version
 # that is used by Netlify

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 # FIXME: This is a workaround for a bug in rouge console lexer
 #  introduced by https://github.com/rouge-ruby/rouge/pull/1779
-#  more info: https://github.com/docker/docker.github.io/issues/14788
+#  more info: https://github.com/docker/docs/issues/14788
 gem 'rouge', '3.27.0'
 
 gem 'archive-zip', '0.12.0'

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@
 ##
 
 name: Docker Documentation
+repo: https://github.com/docker/docs
 
 markdown: kramdown
 highlighter: rouge
@@ -116,7 +117,7 @@ defaults:
   - scope:
       path: glossary.md
     values:
-      edit_url: "https://github.com/docker/docker.github.io/blob/master/_data/glossary.yaml"
+      edit_url: "https://github.com/docker/docs/blob/master/_data/glossary.yaml"
 
 # Fetch upstream resources (reference documentation) used by _plugins/fetch_remote.rb
 # - repo is the GitHub repository to fetch from

--- a/_includes/analytics/polldaddy.html
+++ b/_includes/analytics/polldaddy.html
@@ -7,7 +7,7 @@
         "font_family": "Open Sans, sans serif",
         "font_color": "b9c2cc",
         "font_align": "center",
-        "permalink": "https://github.com/docker/docker.github.io/blob/master/{{ page.path }}"
+        "permalink": "{{ site.repo }}/blob/master/{{ page.path }}"
     };
     (function (d, c, j) {
         if (!document.getElementById(j)) {

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,12 +3,12 @@
 {%- if page.edit_url -%}
     {%- assign edit_url = page.edit_url -%}
 {%- else -%}
-    {%- assign edit_url = "https://github.com/docker/docker.github.io/edit/master/" | append: page.path -%}
+    {% capture edit_url %}{{ site.repo }}/edit/edit/master/{{ page.path }}{% endcapture %}
 {%- endif -%}
 {%- if page.issue_url -%}
     {%- assign issue_url = page.issue_url -%}
 {%- else -%}
-    {%- assign issue_url = "https://github.com/docker/docker.github.io/issues/new?body=File: [" | append: page.path | append: "](" | append: site.docs_url | append: page.url | append: ")" -%}
+    {% capture issue_url %}{{ site.repo }}/issues/new?body=File: [{{ page.path }}]({{ site.docs_url }}{{ page.url }}){% endcapture %}
 {%- endif -%} -->
 <html lang="en">
 {%- include head.html -%}

--- a/_releaser/go.mod
+++ b/_releaser/go.mod
@@ -1,4 +1,4 @@
-module github.com/docker/docker.github.io/_releaser
+module github.com/docker/docs/_releaser
 
 go 1.18
 

--- a/compose/cli-command-compatibility.md
+++ b/compose/cli-command-compatibility.md
@@ -90,7 +90,7 @@ we can use flags to display the stopped projects, to filter by conditions and ch
 
 ```console
 $ docker compose ls --all --format json
-[{"Name":"dockergithubio","Status":"exited(1)","ConfigFiles":"/path/to/docker.github.io/docker-compose.yml"}]
+[{"Name":"dockergithubio","Status":"exited(1)","ConfigFiles":"/path/to/docs/docker-compose.yml"}]
 ```
 
 ## Use `--project-name` with Compose commands

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -33,7 +33,7 @@ Compose release is compatible, refer to the [Compose release
 notes](https://github.com/docker/compose/releases/). Each set of release notes
 gives details on which versions of Docker Engine are supported, along
 with compatible Compose file format versions. (See also, the discussion in
-[issue #3404](https://github.com/docker/docker.github.io/issues/3404).)
+[issue #3404]({{ site.repo }}/issues/3404).)
 
 
 For details on versions and how to upgrade, see

--- a/contribute/checklist.md
+++ b/contribute/checklist.md
@@ -39,7 +39,7 @@ For example, 'Install Docker Desktop'.
 
 ##### Checked for broken links and images
 
-Use relative links to link to other pages or images within the docker.github.io repository.
+Use relative links to link to other pages or images within the GitHub repository.
 
 For more information, see the [formatting](style/formatting.md#links) page, or see the [components](components/links.md) for examples.
 

--- a/contribute/components/links.md
+++ b/contribute/components/links.md
@@ -12,10 +12,9 @@ It is best practice if [a link opens in a new window](https://docker.com/){: tar
 An example of a link to an auto-generated reference page that we pull in during docs builds:
 [/engine/reference/builder/#env](/engine/reference/builder/#env).
 
-  - If you can't find a reference page in the `docker.github.io`
-  GitHub repository, but see it out on `docs.docker.com`, you can
-  surmise that it's probably auto-generated from the codebase.
-  (FYI, to view the Markdown source for the file, just click
+  - If you can't find a reference page in the GitHub repository, but see it
+  out on `docs.docker.com`, you can surmise that it's probably auto-generated 
+  from the codebase. (FYI, to view the Markdown source for the file, just click
   **Edit this page** on `docs.docker.com`. But don't use that URL in your docs.)
 
   - Go to the file in a web browser, grab everything after the domain name

--- a/contribute/contribute-guide.md
+++ b/contribute/contribute-guide.md
@@ -17,7 +17,7 @@ There are two ways to contribute a pull request to the docs repository:
 
     This opens the GitHub editor, which means you don't need to know a lot about Git, or even about Markdown. When you save, Git prompts you to create a fork if you don't already have one, and to create a branch in your fork and submit the pull request.
 
-2. Fork the [docs GitHub repository](https://github.com/docker/docker.github.io). Suggest changes or add new content on your local branch, and submit a pull request (PR) to the `master` branch.
+2. Fork the [docs GitHub repository]({{ site.repo }}). Suggest changes or add new content on your local branch, and submit a pull request (PR) to the `master` branch.
 
     This is the manual, more advanced version of clicking 'Edit this page' on a published docs page. Initiating a docs changes in a PR from your own branch gives you more flexibility, as you can submit changes to multiple pages or files under a single pull request, and even create new topics.
 
@@ -67,8 +67,8 @@ A Netlify test runs for each PR created against the `master` branch and deploys 
 On your local machine, clone the docs repository:
 
 ```bash
-git clone --recursive https://github.com/docker/docker.github.io.git
-cd docker.github.io
+git clone {{ site.repo }}.git
+cd docs
 ```
 
 Then, build and run the documentation using [Docker Compose](../compose/index.md)

--- a/develop/dev-best-practices.md
+++ b/develop/dev-best-practices.md
@@ -7,7 +7,7 @@ keywords: application, development
 The following development patterns have proven to be helpful for people
 building applications with Docker. If you have discovered something we should
 add,
-[let us know](https://github.com/docker/docker.github.io/issues/new){: target="_blank" rel="noopener" class="_"}.
+[let us know]({{ site.repo }}/issues/new){: target="_blank" rel="noopener" class="_"}.
 
 ## How to keep your images small
 

--- a/docsarchive.md
+++ b/docsarchive.md
@@ -17,7 +17,7 @@ If you are using a version of the documentation that is no longer supported,
 you can still access that documentation in the following ways:
 
 - By entering your version number and selecting it from the branch selection list for this repo
-- By directly accessing the Github URL for your version. For example, https://github.com/docker/docker.github.io/tree/v1.9 for `v1.9`
+- By directly accessing the Github URL for your version. For example, {{ site.repo }}/tree/v1.9 for `v1.9`
 - By running a container of the specific [tag for your documentation version](https://hub.docker.com/r/docs/docker.github.io)
   in Docker Hub. For example, run the following to access `v1.9`:
 

--- a/engine/reference/commandline/README.md
+++ b/engine/reference/commandline/README.md
@@ -25,5 +25,5 @@ The process for generating the YAML files is still in flux. Check with
 release branch of `docker/cli`, for example, the `19.03` branch.
 
 After generating the YAML files, replace the YAML files in
-[https://github.com/docker/docker.github.io/tree/master/_data/engine-cli](https://github.com/docker/docker.github.io/tree/master/_data/engine-cli)
+[https://github.com/docker/docs/tree/master/_data/engine-cli](https://github.com/docker/docs/tree/master/_data/engine-cli)
 with the newly-generated files. Submit a pull request.

--- a/glossary.md
+++ b/glossary.md
@@ -11,7 +11,7 @@ redirect_from:
 ---
 <!--
 To edit/add/remove glossary entries, visit the YAML file at:
-https://github.com/docker/docker.github.io/blob/master/_data/glossary.yaml
+https://github.com/docker/docs/blob/master/_data/glossary.yaml
 
 To get a specific entry while writing a page in the docs, enter Liquid text
 like so:

--- a/language/golang/build-images.md
+++ b/language/golang/build-images.md
@@ -497,6 +497,6 @@ how to:
 ## Feedback
 
 Help us improve this topic by providing your feedback. Let us know what you
-think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"}
-GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"}
+think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"}
+GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"}
 to suggest updates.

--- a/language/golang/configure-ci-cd.md
+++ b/language/golang/configure-ci-cd.md
@@ -346,4 +346,4 @@ In the next module, we’ll look into some options for doing so:
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/golang/deploy.md
+++ b/language/golang/deploy.md
@@ -10,4 +10,4 @@ description: Learn how to deploy your application
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/golang/develop.md
+++ b/language/golang/develop.md
@@ -744,4 +744,4 @@ In the next module, we’ll take a look at one possible approach to running func
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/golang/run-containers.md
+++ b/language/golang/run-containers.md
@@ -202,4 +202,4 @@ In this module, we learned how to run containers and publish ports. We also lear
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Golang %20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Golang %20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/golang/run-tests.md
+++ b/language/golang/run-tests.md
@@ -106,4 +106,4 @@ In the next module, we’ll take a look at how to set up a CI/CD pipeline using 
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Golang%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/java/build-images.md
+++ b/language/java/build-images.md
@@ -245,4 +245,4 @@ In this module, we took a look at setting up our example Java application that w
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/java/configure-ci-cd.md
+++ b/language/java/configure-ci-cd.md
@@ -303,4 +303,4 @@ You can also consider deploying your application. For detailed instructions, see
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/java/deploy.md
+++ b/language/java/deploy.md
@@ -10,4 +10,4 @@ description: Learn how to deploy your application
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/java/develop.md
+++ b/language/java/develop.md
@@ -229,4 +229,4 @@ In the next module, we’ll take a look at how to run unit tests in Docker. See
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/java/run-containers.md
+++ b/language/java/run-containers.md
@@ -180,4 +180,4 @@ In the next module, we’ll learn how to run a database in a container and conne
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/java/run-tests.md
+++ b/language/java/run-tests.md
@@ -175,4 +175,4 @@ In the next module, we’ll take a look at how to set up a CI/CD pipeline using 
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Java%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -275,4 +275,4 @@ In this module, we took a look at setting up our example Node application that w
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/nodejs/configure-ci-cd.md
+++ b/language/nodejs/configure-ci-cd.md
@@ -246,4 +246,4 @@ You can also consider deploying your application. For detailed instructions, see
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/nodejs/deploy.md
+++ b/language/nodejs/deploy.md
@@ -10,4 +10,4 @@ description: Learn how to deploy your application
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -226,4 +226,4 @@ In the next module, we’ll take a look at how to run unit tests in Docker. See:
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/nodejs/run-containers.md
+++ b/language/nodejs/run-containers.md
@@ -197,4 +197,4 @@ In this module, we took a look at running containers, publishing ports, and runn
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/nodejs/run-tests.md
+++ b/language/nodejs/run-tests.md
@@ -291,4 +291,4 @@ In the next module, we’ll take a look at how to set up a CI/CD pipeline using 
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Node.js%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/python/build-images.md
+++ b/language/python/build-images.md
@@ -237,4 +237,4 @@ In this module, we took a look at setting up our example Python application that
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/python/configure-ci-cd.md
+++ b/language/python/configure-ci-cd.md
@@ -246,4 +246,4 @@ You can also consider deploying your application. For detailed instructions, see
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/python/deploy.md
+++ b/language/python/deploy.md
@@ -10,4 +10,4 @@ description: Learn how to deploy your application
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -252,4 +252,4 @@ In the next module, we’ll take a look at how to set up a CI/CD pipeline using 
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/language/python/run-containers.md
+++ b/language/python/run-containers.md
@@ -184,4 +184,4 @@ In this module, we took a look at running containers, publishing ports, and runn
 
 ## Feedback
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.
+Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs]({{ site.repo }}/issues/new?title=[Python%20docs%20feedback]){:target="_blank" rel="noopener" class="_"} GitHub repository. Alternatively, [create a PR]({{ site.repo }}/pulls){:target="_blank" rel="noopener" class="_"} to suggest updates.

--- a/opensource/ways.md
+++ b/opensource/ways.md
@@ -114,7 +114,7 @@ Docker users are people using Docker in their daily work. To help Docker users, 
 * the [Docker Community Forum](https://forums.docker.com/){: target="_blank" rel="noopener" class="_"}
 * [StackOverflow](https://stackoverflow.com/questions/tagged/docker){: target="_blank" rel="noopener" class="_"}
 
-You can also check the lists of [open issues on the Docker docs](https://github.com/docker/docker.github.io/issues){: target="_blank" rel="noopener" class="_"} and [open issues on the Moby project](https://github.com/moby/moby/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fquestion+-label%3Astatus%2Fclaimed+-label%3Astatus%2Fassigned+no%3Aassignee){: target="_blank" rel="noopener" class="_"}.
+You can also check the lists of [open issues on the Docker docs]({{ site.repo }}/issues){: target="_blank" rel="noopener" class="_"} and [open issues on the Moby project](https://github.com/moby/moby/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fquestion+-label%3Astatus%2Fclaimed+-label%3Astatus%2Fassigned+no%3Aassignee){: target="_blank" rel="noopener" class="_"}.
 
 
 ### Docker contributors


### PR DESCRIPTION
Replace `https://github.com/docker/docker.github.io` with `https://github.com/docker/docs`. Also adds a new `repo` var in `_config.yml`.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>