### PR TITLE
Remove DD mentions in swarm tutorial

### DIFF
--- a/engine/swarm/swarm-tutorial/create-swarm.md
+++ b/engine/swarm/swarm-tutorial/create-swarm.md
@@ -18,13 +18,6 @@ machines.
     $ docker swarm init --advertise-addr <MANAGER-IP>
     ```
 
-    > **Note**: If you are using Docker Desktop for Mac or Docker Desktop for Windows to test
-    > single-node swarm, simply run `docker swarm init` with no arguments. There is no
-    > need to specify `--advertise-addr` in this case. To learn more, see the topic
-    > on how to
-    > [Use Docker Desktop for Mac or Docker Desktop for Windows](index.md#use-docker-desktop-for-mac-or-docker-desktop-for-windows)
-    > with Swarm.
-
     In the tutorial, the following command creates a swarm on the `manager1`
     machine:
 

--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -53,18 +53,6 @@ hosts, simply follow the [Linux install instructions](../../install/index.md)
 for your platform. Spin up the three machines, and you are ready. You can test both
 single-node and multi-node swarm scenarios on Linux machines.
 
-#### Use Docker Desktop for Mac or Docker Desktop for Windows
-
-Alternatively, install the latest [Docker Desktop](../../../desktop/index.md) application on one
-computer. You can test both single-node and multi-node swarm from this computer.
-
-* You can use Docker Desktop for Mac or Windows to test _single-node_ features
-  of swarm mode, including initializing a swarm with a single node, creating
-  services, and scaling services.
-* Currently, you cannot use Docker Desktop for Mac or Docker Desktop for Windows
-  alone to test a _multi-node_ swarm, but many examples are applicable to a
-  single-node Swarm setup.
-
 ### The IP address of the manager machine
 
 The IP address must be assigned to a network interface available to the host


### PR DESCRIPTION
### Proposed changes

Quick fix to remove some information about using swarm with Docker Desktop based on internal discussion linked in Jira issue below.

There are still some mentions of using swarm with Docker Desktop in `/get-started/orchestration` and `/get-started/swarm-deploy` that need to be addressed.

### Related issues (optional)

ENGDOCS-1082