### PR TITLE
engine: remove debian 13 (trixie) from supported list

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -29,7 +29,6 @@ To get started with Docker Engine on Debian, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Debian
 versions:
 
-- Debian Trixie 13 (testing)
 - Debian Bookworm 12 (stable)
 - Debian Bullseye 11 (oldstable)
 


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/17561


Commit d0e6a33bbc978b5c6a616c216249b0be54c9aefd updated the list of Debian versions in the prerequisites. While "Bookworm" is the new stable, we don't yet build packages for debian 13 (trixie), which is the current "testing".

Packages will arrive at some point, but aren't there yet, so let's remove it for now.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
