### PR TITLE
config: update version configs, and remove unused ones

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,8 +69,8 @@ example_golangci_lint_version: "v1.52"
 # API version if it requires a relatively recent version of the Engine.
 #
 # The "min_api_threshold" option specifies the minimum required API version for
-# which we show a badge (currently: API v1.40, or "Docker 19.03").
-min_api_threshold: 1.40
+# which we show a badge (currently: API v1.41, or "Docker 20.10").
+min_api_threshold: 1.41
 
 # Enable search autocompletion (requires metadata.json to be generated)
 local_search: true


### PR DESCRIPTION
### config: remove machine_version as docker machine is deprecated

This variable was no longer used anywhere, so we can remove it.

### config: update docker_ce_version to 24.0.2

Latest patch release

### config: update compose v3 version to 3.11 (compose_file_v3)

The current version of the v3 schema for docker 24.0.2;
https://github.com/docker/cli/blob/v24.0.2/cli/compose/schema/schema.go#L14

We could consider changing these to "3" (which now defaults to v3.latest)

### config: remove distribution_version as it's unused

### config: remove compose_v1_version as it's unused

### config: remove compose_switch_version as it's unused

### config: update min_api_threshold to v1.41 (docker 20.10)

Update the threshold for showing minimum API version required badges
to v1.41, which corresponds with docker engine 20.10. Docker Engine
20.10 is EOL, and users running versions older than that should
really upgrade.

https://github.com/moby/moby/blob/v20.10.25/api/common.go#L6


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
