### PR TITLE
Add Contribute to the Guides section

### DIFF
--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -180,6 +180,61 @@ Guides:
 - path: /get-started/resources/
   title: "Educational resources"
 
+- sectiontitle: Contribute
+  section:
+  - path: /contribute/overview/
+    title: Contribute to Docker's docs
+  - path: /contribute/contribute-guide/
+    title: Contribution guidelines
+  - sectiontitle: Style guide
+    section:
+    - path: /contribute/style/grammar/
+      title: Grammar and style
+    - path: /contribute/style/formatting/
+      title: Formatting
+    - path: /contribute/style/recommended-words/
+      title: Recommended word list
+    - path: /contribute/style/terminology/
+      title: Docker terminology
+    - path: /contribute/style/voice-tone/
+      title: Voice and tone
+  - path: /contribute/file-conventions/
+    title: Source file conventions
+  - path: /contribute/ui/
+    title: UI elements in content
+  - sectiontitle: Useful components
+    section:
+    - path: /contribute/components/accordions/
+      title: Accordions
+    - path: /contribute/components/badges/
+      title: Badges
+    - path: /contribute/components/call-outs/
+      title: Callouts
+    - path: /contribute/components/cards/
+      title: Cards
+    - path: /contribute/components/code-blocks/
+      title: Code blocks
+    - path: /contribute/components/icons/
+      title: Icons
+    - path: /contribute/components/images/
+      title: Images
+    - path: /contribute/components/links/
+      title: Links
+    - path: /contribute/components/lists/
+      title: Lists
+    - path: /contribute/components/tables/
+      title: Tables
+    - path: /contribute/components/tabs/
+      title: Tabs
+    - path: /contribute/components/tooltips/
+      title: Tooltips
+    - path: /contribute/components/videos/
+      title: Videos
+    - path: /contribute/components/buttons/
+      title: Buttons
+  - path: /contribute/checklist/
+    title: Writing checklist
+
 Reference:
 - path: /reference/
   title: Reference documentation
@@ -2155,59 +2210,6 @@ Manuals:
   title: Get support
 - path: /release-lifecycle/
   title: Product release lifecycle
-Contribute:
-  - path: /contribute/overview/
-    title: Contribute to Docker's docs
-  - path: /contribute/contribute-guide/
-    title: Contribution guidelines
-  - sectiontitle: Style guide
-    section:
-    - path: /contribute/style/grammar/
-      title: Grammar and style
-    - path: /contribute/style/formatting/
-      title: Formatting
-    - path: /contribute/style/recommended-words/
-      title: Recommended word list
-    - path: /contribute/style/terminology/
-      title: Docker terminology
-    - path: /contribute/style/voice-tone/
-      title: Voice and tone
-  - path: /contribute/file-conventions/
-    title: Source file conventions
-  - path: /contribute/ui/
-    title: UI elements in content
-  - sectiontitle: Useful components
-    section:
-    - path: /contribute/components/accordions/
-      title: Accordions
-    - path: /contribute/components/badges/
-      title: Badges
-    - path: /contribute/components/call-outs/
-      title: Callouts
-    - path: /contribute/components/cards/
-      title: Cards
-    - path: /contribute/components/code-blocks/
-      title: Code blocks
-    - path: /contribute/components/icons/
-      title: Icons
-    - path: /contribute/components/images/
-      title: Images
-    - path: /contribute/components/links/
-      title: Links
-    - path: /contribute/components/lists/
-      title: Lists
-    - path: /contribute/components/tables/
-      title: Tables
-    - path: /contribute/components/tabs/
-      title: Tabs
-    - path: /contribute/components/tooltips/
-      title: Tooltips
-    - path: /contribute/components/videos/
-      title: Videos
-    - path: /contribute/components/buttons/
-      title: Buttons
-  - path: /contribute/checklist/
-    title: Writing checklist
 
 FAQ:
   - path: /faq/

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -124,9 +124,6 @@ menus:
   - name: FAQ
     url: /faq/
     weight: 5
-  - name: Contribute
-    url: /contribute/overview/
-    weight: 6
 
   footer:
     - url: https://www.docker.com/products


### PR DESCRIPTION
Remove "Contribute" from the top navigation and move it under Guides.