### PR TITLE
ENGDOCS-1953

### DIFF
--- a/content/desktop/install/windows-install.md
+++ b/content/desktop/install/windows-install.md
@@ -174,7 +174,7 @@ The `install` command accepts the following flags:
   - It must be used together with the `--allowed-org=<org name>` flag. 
   - For example:
 
-    ```console
+    ```text
     --allowed-org=<org name> --admin-settings='{"configurationFileVersion": 2, "enhancedContainerIsolation": {"value": true, "locked": false}}'
     ```
 


### PR DESCRIPTION
addresses https://docker.slack.com/archives/C04300R4G5U/p1705695450299939
and fixes another formatting issue on the same page
