### PR TITLE
Fix incorrect reference to "up -e" (fixes #18965)

### DIFF
--- a/content/compose/environment-variables/set-environment-variables.md
+++ b/content/compose/environment-variables/set-environment-variables.md
@@ -80,7 +80,7 @@ services:
 - You can place your `.env` file in a location other than the root of your project's directory, and then use one of the following methods so Compose can navigate to it:
   - The [`--env-file` option in the CLI](#substitute-with---env-file)
   - Using the [`env_file` attribute in the Compose file](../compose-file/05-services.md#env_file)
-- Values in your `.env` file can be overridden from the command line by using [`docker-compose up -e`](#set-environment-variables-with-docker-compose-run---env).
+- Values in your `.env` file can be overridden from the command line by using [`docker compose run -e`](#set-environment-variables-with-docker-compose-run---env).
 - Your `.env` file can be overridden by another `.env` if it is [substituted with `--env-file`](#substitute-with---env-file).
 
 > **Important**


### PR DESCRIPTION
The link goes to [Set environment variables with docker compose run --env](https://docs.docker.com/compose/environment-variables/set-environment-variables/#set-environment-variables-with-docker-compose-run---env), which is about `run` **not** `up`. CLI reference:

- [`run`](https://docs.docker.com/engine/reference/commandline/compose_run/#options) (`-e`/`--env` present)
- [`up`](https://docs.docker.com/engine/reference/commandline/compose_up/#options) (`-e`/`--env` **not** present)