### PR TITLE
vendor: cli, moby v26.1.0

### DIFF
--- a/_vendor/github.com/docker/cli/docs/reference/dockerd.md
+++ b/_vendor/github.com/docker/cli/docs/reference/dockerd.md
@@ -1236,6 +1236,15 @@ The list of feature options include:
   snapshotters instead of the classic storage drivers for storing image and
   container data. For more information, see
   [containerd storage](https://docs.docker.com/storage/containerd/).
+- `windows-dns-proxy`: when set to `true`, the daemon's internal DNS resolver
+  will forward requests to external servers. Without this, most applications
+  running in the container will still be able to use secondary DNS servers
+  configured in the container itself, but `nslookup` won't be able to resolve
+  external names. The current default is `false`, it will change to `true` in
+  a future release. This option is only allowed on Windows.
+
+  > **Warning**
+  > The `windows-dns-proxy` feature flag will be removed in a future release.
 
 #### Configuration reload behavior
 

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v26.1.0+incompatible
 # github.com/moby/buildkit v0.13.1
 # github.com/docker/buildx v0.14.0
-# github.com/docker/cli v26.0.1-0.20240410153731-b6c552212837+incompatible
+# github.com/docker/cli v26.1.0+incompatible
 # github.com/docker/compose/v2 v2.0.0-00010101000000-000000000000
 # github.com/docker/scout-cli v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.1
 
 require (
 	github.com/docker/buildx v0.14.0 // indirect
-	github.com/docker/cli v26.0.1-0.20240410153731-b6c552212837+incompatible // indirect
+	github.com/docker/cli v26.1.0+incompatible // indirect
 	github.com/docker/compose/v2 v2.0.0-00010101000000-000000000000 // indirect
 	github.com/docker/scout-cli v1.7.0 // indirect
 	github.com/moby/buildkit v0.13.1 // indirect
@@ -15,7 +15,7 @@ require (
 
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.14.0
-	github.com/docker/cli => github.com/docker/cli v26.0.0+incompatible
+	github.com/docker/cli => github.com/docker/cli v26.1.0+incompatible
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.26.1
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.7.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240402103816-7cd12732690e

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/docker/cli v25.0.4+incompatible h1:DatRkJ+nrFoYL2HZUzjM5Z5sAmcA5XGp+A
 github.com/docker/cli v25.0.4+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v26.0.0+incompatible h1:90BKrx1a1HKYpSnnBFR6AgDq/FqkHxwlUyzJVPxD30I=
 github.com/docker/cli v26.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v26.1.0+incompatible h1:+nwRy8Ocd8cYNQ60mozDDICICD8aoFGtlPXifX/UQ3Y=
+github.com/docker/cli v26.1.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose-cli v1.0.35 h1:uZyEHLalfqBS2PiTpA1LAULyJmuQ+YtZg7nG4Xl3/Cc=
 github.com/docker/compose-cli v1.0.35/go.mod h1:mSXI4hFLpRU3EtI8NTo32bNwI0UXSr8jnq+/rYjGAUU=
 github.com/docker/compose/v2 v2.22.0 h1:3rRz4L7tPU75wRsV8JZh2/aTgerQvPa1cpzZN+tHqUY=


### PR DESCRIPTION
## Description

- **vendor: github.com/moby/moby v26.1.0**
- **vendor: github.com/docker/cli v26.1.0**

## Related issues or tickets

- Follow up to: 749870a500813d215fa740328280f11262382783
