### PR TITLE
WSL2 docs: add tip on how to move data on windows

### DIFF
--- a/content/desktop/wsl/_index.md
+++ b/content/desktop/wsl/_index.md
@@ -53,8 +53,8 @@ Now `docker` commands work from Windows using the new WSL 2 engine.
 
 >**Tip**
 >
-> By default, Docker Desktop will store the data for the WSL 2 engine at `C:\Users\[USERNAME]\AppData\Local\Docker\wsl`.
-> If you wish to change the location, e.g., to another drive you can do so via the `Settings -> Resources -> Advanced` page from the Docker Desktop dashboard.
+> By default, Docker Desktop stores the data for the WSL 2 engine at `C:\Users\[USERNAME]\AppData\Local\Docker\wsl`.
+> If you want to change the location, for example, to another drive you can do so via the `Settings -> Resources -> Advanced` page from the Docker Dashboard.
 > Read more about this and other Windows settings at [Changing Docker Desktop settings on Windows](../settings/windows.md)
 { .tip }
 


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description
Some customers want to move WSL data on a different location and many of those use crafty processes rather than using the feature we support. Making this feature more explicit.

This was reported on this public thread: https://github.com/docker/for-win/issues/14118#issuecomment-2160263230


## Related issues or tickets
https://github.com/docker/for-win/issues/14118#issuecomment-2160263230

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review