### PR TITLE
update Compose v2.27.3 and v2.28.0 release notes

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v26.1.2+incompatible
 # github.com/moby/buildkit v0.14.1
 # github.com/docker/buildx v0.15.1
-# github.com/docker/cli v26.1.4+incompatible
-# github.com/docker/compose/v2 v2.27.2
+# github.com/docker/cli v27.0.1-rc.1+incompatible
+# github.com/docker/compose/v2 v2.28.0
 # github.com/docker/scout-cli v1.9.3

--- a/content/compose/release-notes.md
+++ b/content/compose/release-notes.md
@@ -10,6 +10,24 @@ aliases:
 
 For more detailed information, see the [release notes in the Compose repo](https://github.com/docker/compose/releases/).
 
+## 2.28.0
+
+{{< release-date date="2024-06-21" >}}
+
+### Update
+
+- Dependencies upgrade: bump compose-go to v2.1.3
+- Dependencies upgrade: bump docker engine and cli to v27.0.1-rc.1
+
+## 2.27.3
+
+{{< release-date date="2024-06-21" >}}
+
+### Update
+
+- Dependencies upgrade: bump buildx to 0.15.1
+- Dependencies upgrade: bump buildkit to 0.14.1
+
 ## 2.27.2
 
 {{< release-date date="2024-06-20" >}}

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.21.1
 
 require (
 	github.com/docker/buildx v0.15.1 // indirect
-	github.com/docker/cli v26.1.4+incompatible // indirect
-	github.com/docker/compose/v2 v2.27.2 // indirect
+	github.com/docker/cli v27.0.1-rc.1+incompatible // indirect
+	github.com/docker/compose/v2 v2.28.0 // indirect
 	github.com/docker/scout-cli v1.9.3 // indirect
 	github.com/moby/buildkit v0.14.1 // indirect
 	github.com/moby/moby v26.1.2+incompatible // indirect
@@ -16,7 +16,7 @@ require (
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.15.1
 	github.com/docker/cli => github.com/docker/cli v26.1.3-0.20240513184838-60f2d38d5341+incompatible
-	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.27.2
+	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.28.0
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.9.3
 	github.com/moby/buildkit => github.com/moby/buildkit v0.14.0-rc2.0.20240611065153-eed17a45c62b
 	github.com/moby/moby => github.com/moby/moby v26.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/docker/compose/v2 v2.27.0 h1:FKyClQdErCxUZULC2zo6Jn5ve+epFPe/Y0HaxjmU
 github.com/docker/compose/v2 v2.27.0/go.mod h1:uaqwmY6haO8wXWHk+LAsqqDapX6boH4izRKqj/E7+Bo=
 github.com/docker/compose/v2 v2.27.2 h1:8uvz019AZIPmw8+rnLBubAuyt9SEoU/pyCcAJPXMq0A=
 github.com/docker/compose/v2 v2.27.2/go.mod h1:c6QJ/VVZrzVu97Ur1jylFLivvTkFdef1rSzmnQAO3DA=
+github.com/docker/compose/v2 v2.28.0 h1:GSE/IC/cgWsv7KA5uoBrwVdHQbWS1R5XvvcEgoAQUOY=
+github.com/docker/compose/v2 v2.28.0/go.mod h1:YDhEGZHuiXEqJu5Clc8N4si/CJIXHWU0Lf1ph9NxFYA=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -98,7 +98,7 @@ params:
 
   latest_engine_api_version: "1.45"
   docker_ce_version: "26.1.4"
-  compose_version: "v2.27.2"
+  compose_version: "v2.28.0"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"
   buildkit_version: "0.13.1"


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Add release notes for Compose releases `v2.27.3` and `v2.28.0`

## Related issues or tickets
https://docker.atlassian.net/browse/COMP-625

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review