### PR TITLE
Fix: .docker hidden folder instead of docker

### DIFF
--- a/content/manuals/compose/install/linux.md
+++ b/content/manuals/compose/install/linux.md
@@ -111,7 +111,7 @@ To update the Compose plugin, run the following commands:
     or, if you chose to install Compose for all users:
 
     ```console
-    $ sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+    $ sudo chmod +x /usr/local/lib/.docker/cli-plugins/docker-compose
     ```
 
 3. Test the installation.


### PR DESCRIPTION
Following the steps you end up with a hidden folder `.docker`, not a normal `docker` folder.

## Description

To avoid errors and debugging steps when installing docker compose

## Related issues or tickets

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review