### PR TITLE
desktop: update init and debug cli

### DIFF
--- a/content/reference/cli/docker/debug.md
+++ b/content/reference/cli/docker/debug.md
@@ -6,3 +6,5 @@ layout: cli
 aliases:
 - /engine/reference/commandline/debug/
 ---
+
+{{< summary-bar feature_name="Docker Debug" >}}

--- a/content/reference/cli/docker/init.md
+++ b/content/reference/cli/docker/init.md
@@ -7,10 +7,4 @@ aliases:
 - /engine/reference/commandline/init/
 ---
 
-<!--
-This page is automatically generated from Docker's source code. If you want to
-suggest a change to the text that appears here, open a ticket or pull request
-in the source repository on GitHub:
-
-https://github.com/docker/docker-init
--->
+{{< summary-bar feature_name="Docker Init" >}}

--- a/data/debug-cli/docker_debug.yaml
+++ b/data/debug-cli/docker_debug.yaml
@@ -1,11 +1,6 @@
 command: docker debug
 short: Get a shell into any container or image. An alternative to debugging with `docker exec`.
 long: |-
-  > **Note**
-  >
-  > Docker Debug requires a [Pro, Team, or Business subcription](/subscription/details/).
-  > You must [sign in](/desktop/get-started/) to use this command.
-
   Docker Debug is a CLI command that helps you follow best practices by keeping your images small and secure. 
   With Docker Debug, you can debug your images while they contain the bare minimum to run your application.
   It does this by letting you create and work with slim images or containers that are often difficult to debug because all tools have been removed. 
@@ -27,7 +22,7 @@ long: |-
   - `entrypoint`: Print, lint, or run the entrypoint, see [example](#understanding-the-default-startup-command-of-a-container-entry-points).
   - `builtins`: Show custom builtin tools.
   
-  > **Note**
+  > [!NOTE]
   >
   > For images and stopped containers, all changes are discarded when leaving the shell. 
   > At no point, do changes affect the actual image or container. 

--- a/data/init-cli/docker_init.yaml
+++ b/data/init-cli/docker_init.yaml
@@ -16,12 +16,11 @@ long: |-
     init` can overwrite it, using `docker-compose.yaml` as the name for the
     Compose file.
     
-    > **Warning**
+    > [!WARNING]
     >
     > You can't recover overwritten files.
     > To back up an existing file before selecting to overwrite it, rename the file or copy it to another directory.
-    { .warning }
-  
+
   After running `docker init`, you can choose one of the following templates:
     
     * ASP.NET Core: Suitable for an ASP.NET Core application.

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -118,6 +118,9 @@ Docker CLI OpenTelemetry:
   requires: Docker Engine [26.1.0](/manuals/engine/release-notes/26.1.md#2610) and later
 docker compose alpha:
   availability: Experimental
+Docker Debug:
+  subscription: [Pro, Team, Business]
+  requires: Docker Desktop [4.33.0](/manuals/desktop/release-notes.md#4330) and later
 Docker Desktop Archlinux:
   availability: Experimental
 Docker Desktop CLI:
@@ -127,6 +130,8 @@ Docker Desktop CLI update:
   requires: Docker Desktop 4.38 and later
 Docker GitHub Copilot:
   availability: Early Access
+Docker Init:
+  requires: Docker Desktop [4.27](/manuals/desktop/release-notes.md#4270) and later
 Docker Scout exceptions:
   availability: Experimental
   requires: Docker Scout CLI [1.15.0](/manuals/scout/release-notes/cli.md#1150) and later


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Updated `docker debug` and `docker init` reference docs.

- Add summary callout based on GA dates
- Update note/warning callouts
- Remove the comment about init docs being auto-generated

https://deploy-preview-22094--docsdocker.netlify.app/reference/cli/docker/debug/
https://deploy-preview-22094--docsdocker.netlify.app/reference/cli/docker/init/

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
