### PR TITLE
Fix secret mode in example

### DIFF
--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -1827,7 +1827,7 @@ services:
         target: server.cert
         uid: "103"
         gid: "103"
-        mode: "0o440"
+        mode: "0440"
 secrets:
   server-certificate:
     file: ./server.cert


### PR DESCRIPTION
## Description
Here I provide changes in public docs. I think, there is a mistake in `mode`. At least, `"0o444"` didn't work for my compose file.

## Related issues or tickets

N/A

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review