### PR TITLE
hub: remove old limit

### DIFF
--- a/content/manuals/docker-hub/image-library/mirror.md
+++ b/content/manuals/docker-hub/image-library/mirror.md
@@ -79,10 +79,6 @@ Multiple registry caches can be deployed over the same back-end. A single
 registry cache ensures that concurrent requests do not pull duplicate data,
 but this property does not hold true for a registry cache cluster.
 
-> [!NOTE]
->
-> When using Docker Hub, all paid Docker subscriptions are limited to 5000 pulls per day. If you require a higher number of pulls, you can purchase an Enhanced Service Account add-on. See [Service Accounts](/docker-hub/service-accounts/) for more details.
-
 ### Configure the cache
 
 To configure a Registry to run as a pull through cache, the addition of a


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Missed updating one occurrence of hub pull limits.

Removed old limit of 5k a day for paid users.
Users on new paid plans now have unlimited pulls.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
