### PR TITLE
docs: added note on populating builds tab when building windows container images

### DIFF
--- a/content/manuals/desktop/use-desktop/builds.md
+++ b/content/manuals/desktop/use-desktop/builds.md
@@ -15,9 +15,10 @@ the Builds view also lists any active or completed cloud builds by other team me
 connected to the same cloud builder.
 
 > [!NOTE]
-> When building Windows container images using the `docker build` command, the legacy builder is used which does not populate the **Builds** view. To switch to using the BuildKit engine, you can:
-- Set `DOCKER_BUILDKIT=1` in the build command, such as `DOCKER_BUILDKIT=1 docker build .` or
-- Use the `docker buildx build` command
+>
+> When building Windows container images using the `docker build` command, the legacy builder is used which does not populate the **Builds** view. To switch to using BuildKit, you can either:
+> - Set `DOCKER_BUILDKIT=1` in the build command, such as `DOCKER_BUILDKIT=1 docker build .` or
+> - Use the `docker buildx build` command
 
 ## Show build list
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
If a user switches to Windows containers and builds an image using the `docker build` command as it (using the legacy builder), the Builds tab is not populated. This is because the build history is provided by Buildkit. To populate the Builds tab, the customer must either set `DOCKER_BUILDKIT=1` or use the `buildx build` command. 

Current documentation does not mention this and a support ticket was raised.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
- SEG-1116 (Slack thread linked in ticket for context)

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [X] Technical review @karman-docker 
- [X] Editorial review
- [ ] Product review