### PR TITLE
docs: Add documentation for IP:HOST_PORT:CONTAINER_PORT syntax

### DIFF
--- a/content/get-started/docker-concepts/running-containers/publishing-ports.md
+++ b/content/get-started/docker-concepts/running-containers/publishing-ports.md
@@ -36,7 +36,7 @@ Now, any traffic sent to port `8080` on your host machine will be forwarded to p
 
 > [!IMPORTANT]
 >
-> When a port is published, it's published to all network interfaces by default. This means any traffic that reaches your machine can access the published application. Be mindful of publishing databases or any sensitive information. [Learn more about published ports here](/engine/network/#published-ports).
+> When a port is published, it's published to all network interfaces by default. This means any traffic that reaches your machine can access the published application. Be mindful of publishing databases or any sensitive information. See [Binding to specific network interfaces](#binding-to-specific-network-interfaces) below, and [learn more about published ports here](/engine/network/#published-ports).
 
 ### Binding to specific network interfaces
 
@@ -86,7 +86,7 @@ services:
       - "127.0.0.1:5432:5432"
 ```
 
-This configuration ensures your database is only accessible from the host machine itself, adding a layer of security to your application stack.
+This configuration ensures your database is only accessible from the host machine itself, adding a layer of security to your application stack. You can also set a default bind address for all containers using the `host_binding_ipv4` configuration parameter. This allows you to change the default binding from `0.0.0.0` to a specific IP address. For more information, see [Setting the default bind address for containers](/engine/network/packet-filtering-firewalls/#setting-the-default-bind-address-for-containers).
 
 ### Publishing to ephemeral ports
 

--- a/content/get-started/docker-concepts/running-containers/publishing-ports.md
+++ b/content/get-started/docker-concepts/running-containers/publishing-ports.md
@@ -38,6 +38,56 @@ Now, any traffic sent to port `8080` on your host machine will be forwarded to p
 >
 > When a port is published, it's published to all network interfaces by default. This means any traffic that reaches your machine can access the published application. Be mindful of publishing databases or any sensitive information. [Learn more about published ports here](/engine/network/#published-ports).
 
+### Binding to specific network interfaces
+
+By default, when you publish a port, Docker binds to all network interfaces (`0.0.0.0`). However, there are scenarios where you might want to restrict access to a specific network interface or IP address. You can do this by using the extended port syntax:
+
+```console
+$ docker run -d -p IP:HOST_PORT:CONTAINER_PORT nginx
+```
+
+- `IP`: The specific IP address or network interface on your host to bind to
+- `HOST_PORT`: The port number on your host machine
+- `CONTAINER_PORT`: The port number within the container
+
+For example, if you want to make your container accessible only on localhost (127.0.0.1), you can use:
+
+```console
+$ docker run -d -p 127.0.0.1:8080:80 nginx
+```
+
+This restricts access to the container's port 80 to only local connections on your host's port 8080. External machines on your network would not be able to access this service. You can verify the binding with `docker ps`:
+
+```console
+$ docker ps
+CONTAINER ID   IMAGE     COMMAND                  CREATED          STATUS          PORTS                          NAMES
+a527355c9c53   nginx     "/docker-entrypoint.…"   4 seconds ago    Up 3 seconds    127.0.0.1:8080->80/tcp         elegant_newton
+```
+
+#### Common use cases for IP binding
+
+- **Security**: Binding to localhost (127.0.0.1) to prevent external access to services like databases
+- **Multi-homed hosts**: Binding to specific network interfaces on servers with multiple IP addresses
+- **Service isolation**: Limiting which network segments can access certain containers
+
+#### In Docker Compose
+You can also use the IP binding syntax in your Docker Compose files:
+
+```yaml
+services:
+  webapp:
+    image: nginx
+    ports:
+      - "127.0.0.1:8080:80"
+  
+  database:
+    image: postgres
+    ports:
+      - "127.0.0.1:5432:5432"
+```
+
+This configuration ensures your database is only accessible from the host machine itself, adding a layer of security to your application stack.
+
 ### Publishing to ephemeral ports
 
 At times, you may want to simply publish the port but don’t care which host port is used. In these cases, you can let Docker pick the port for you. To do so, simply omit the `HOST_PORT` configuration. 
@@ -125,6 +175,8 @@ If you’d like to dive in deeper on this topic, be sure to check out the follow
 
 * [`docker container port` CLI reference](/reference/cli/docker/container/port/)
 * [Published ports](/engine/network/#published-ports)
+* [Network drivers](/engine/network/drivers/) - Learn more about Docker's networking capabilities
+* [Docker network command](/engine/reference/commandline/network/) - Reference for the `docker network` command
 
 ## Next steps
 


### PR DESCRIPTION
Add explanation and examples for binding ports to specific network interfaces using the extended syntax. This addresses issue #22253.

<!--Delete sections as needed -->

## Description

Added documentation for the extended port publishing syntax `IP:HOST_PORT:CONTAINER_PORT`, which was missing from the current documentation. This change improves the "Publishing and exposing ports" page by explaining how to bind container ports to specific network interfaces on the host machine.

The additions include:

- Clear explanation of the extended syntax format
- Step-by-step examples with CLI commands and expected output
- Common use cases highlighting security benefits
- Docker Compose examples showing practical application
- Added relevant networking resources in the Additional Resources section

This documentation helps users understand how to restrict container access to specific network interfaces, which is especially important for securing sensitive services like databases.

<!-- Tell us what you did and why -->

## Related issues or tickets

Fixes #22253 

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review