### PR TITLE
fix: use correct variable metrics-addr

### DIFF
--- a/content/manuals/engine/daemon/prometheus.md
+++ b/content/manuals/engine/daemon/prometheus.md
@@ -29,7 +29,7 @@ instance using Prometheus.
 ### Configure the daemon
 
 To configure the Docker daemon as a Prometheus target, you need to specify the
-`metrics-address` in the `daemon.json` configuration file. This daemon expects
+`metrics-addr` in the `daemon.json` configuration file. This daemon expects
 the file to be located at one of the following locations by default. If the
 file doesn't exist, create it.
 


### PR DESCRIPTION
rename metrics-address to metrics-addr

## Description

just a little correction on variable naming

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review