### PR TITLE
bake: fix hcl syntax

### DIFF
--- a/content/manuals/build/bake/expressions.md
+++ b/content/manuals/build/bake/expressions.md
@@ -62,7 +62,7 @@ target "default" {
   dockerfile="Dockerfile"
   tags = [
     "my-image:latest",
-    notequal("",TAG) ? "my-image:${TAG}": "",
+    notequal("",TAG) ? "my-image:${TAG}": ""
   ]
 }
 ```

--- a/content/manuals/build/bake/targets.md
+++ b/content/manuals/build/bake/targets.md
@@ -81,8 +81,8 @@ target "api" {
 target "tests" {
   dockerfile = "tests.Dockerfile"
   contexts = {
-    webapp = "target:webapp",
-    api = "target:api",
+    webapp = "target:webapp"
+    api = "target:api"
   }
   output = ["type=local,dest=build/tests"]
   context = "."


### PR DESCRIPTION
## Description

Commas should not be used in object blocks.

## Related issues or tickets

Similar to similar to https://github.com/docker/buildx/pull/3177

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review