### PR TITLE
fix mailto links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,14 +1,15 @@
 {{ $url := .Destination }}
 {{- if (strings.HasPrefix $url "http") -}}
   {{/* external link, add icon */}}
-  <a
-    class="link"
-    href="{{ $url | safeURL }}"
-    rel="noopener">
-      {{- .Text | safeHTML -}}
-      <span class="pl-1 icon-svg icon-sm">
-        {{- partialCached "icon" "open_in_new" "open_in_new" -}}
-      </span></a>
+  <a class="link" href="{{ $url | safeURL }}" rel="noopener">
+    {{ .Text | safeHTML }}
+    <span class="pl-1 icon-svg icon-sm">
+      {{ partialCached "icon" "open_in_new" "open_in_new" }}
+    </span>
+  </a>
+{{- else if (strings.HasPrefix $url "mailto:") -}}
+  {{/* mailto link, render as normal link */}}
+  <a class="link" href="{{ $url }}">{{ .Text | safeHTML }}</a>
 {{- else if (strings.HasPrefix $url "/") -}}
   {{ if (strings.HasSuffix (urls.Parse $url).Path ".md") }}
     {{/* abs path to markdown file, use ref */}}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Fix mailto links to work with the following syntax:

`[email me](mailto:example@example.com)`

Can verify at https://deploy-preview-22715--docsdocker.netlify.app/desktop/enterprise/ 

## Related issues or tickets

https://docker.slack.com/archives/C039ZM6GH4Z/p1748022452990369

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
