### PR TITLE
Compose: Add guidance for using host network in Swarm mode and Docker Stack

### DIFF
--- a/content/reference/compose-file/networks.md
+++ b/content/reference/compose-file/networks.md
@@ -191,6 +191,7 @@ networks:
 ```
 
 #### Accessing host network in Swarm mode with Stack
+
 If you need to access the Docker host's network when using Swarm mode with `docker stack deploy`, 
 you can reference the network by declaring it as an external network:
 


### PR DESCRIPTION
## Description
This PR adds a new how-to section explaining how to use the host network when deploying services in Swarm mode via `docker stack deploy`.

Key additions:
- YAML example showing how to reference the built-in `host` network as an external network.
- A note outlining key limitations when using host networking with Swarm, such as:
  - Only supported in global service mode
  - No support for Swarm ingress networking or service discovery
  - Port-binding limitations

This is meant to clarify a niche but important case for users deploying Compose files to Swarm clusters that need access to the host's network. Let me know if there are other cross-references I should do in other parts of the docs.

## Related issues or tickets
[Issue 22684](https://github.com/docker/docs/issues/22684)
## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
