### PR TITLE
Simplify Fedora repo setup

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -80,12 +80,10 @@ Docker from the repository.
 
 #### Set up the repository
 
-Install the `dnf-plugins-core` package (which provides the commands to manage
-your DNF repositories) and set up the repository.
+To set up the repository, run:
 
 ```console
-$ sudo dnf -y install dnf-plugins-core
-$ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
+$ sudo dnf config-manager addrepo --from-repofile {{% param "download-url-base" %}}/docker-ce.repo
 ```
 
 #### Install Docker Engine


### PR DESCRIPTION
Update repo set up to use [dnf 5 syntax](https://docs.fedoraproject.org/en-US/quick-docs/adding-or-removing-software-repositories-in-fedora/#_for_fedora_41_or_later_dnf_5), which is supported from Fedora 41.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review