### PR TITLE
desktop kubernetes: add missing image for kubernetesImagesRepository

### DIFF
--- a/content/manuals/desktop/features/kubernetes.md
+++ b/content/manuals/desktop/features/kubernetes.md
@@ -140,6 +140,7 @@ For example, in `kind` mode it requires the following images:
 
 ```console
 docker.io/kindest/node:<tag>
+docker.io/envoyproxy/envoy:<tag>
 docker.io/docker/desktop-cloud-provider-kind:<tag>
 docker.io/docker/desktop-containerd-registry-mirror:<tag>
 ```
@@ -176,6 +177,7 @@ Docker Desktop will pull the images from:
 
 ```console
 my-registry:5000/kind-images/node:<tag>
+my-registry:5000/kind-images/envoy:<tag>
 my-registry:5000/kind-images/desktop-cloud-provider-kind:<tag>
 my-registry:5000/kind-images/desktop-containerd-registry-mirror:<tag>
 ```


### PR DESCRIPTION
## Description

This doc only listed 3 of the 4 images that Docker Desktop pulls when starting kind

## Related issues or tickets

N/A

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

cc @andrewb-ontheinternet @ctalledo 

- [X] Technical review
- [ ] Editorial review
- [ ] Product review