### PR TITLE
cloud: add redirect

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -227,6 +227,7 @@
   - /go/run-cloud-eap/
 "/desktop/setup/vm-vdi/":
   - /go/docker-cloud/
+  - /go/docker-cloud-gpu/
 
 # CLI backlinks
 "/engine/cli/filter/":


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- Added new redirect for GUI to explain Docker Cloud GPU. (/go/docker-cloud-gpu/)
   Currently pointing at the only page that references Docker Cloud to avoid a 404 in pre-release product. Will change the page once docs are ready for the feature.


## Related issues or tickets

ENGDOCS-2714

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
