### PR TITLE
styles: fix inline images

### DIFF
--- a/layouts/shortcodes/inline-image.html
+++ b/layouts/shortcodes/inline-image.html
@@ -11,5 +11,5 @@
   src="{{ $src }}"
   alt="{{ $alt }}"
   {{ with $title }}title="{{ . }}"{{ end }}
-  class="inline my-0"
+  class="inline my-0 not-prose"
 />


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Inline images have large margins. 
Example: https://docs.docker.com/desktop/setup/vm-vdi/#use-docker-cloud.

This classifies inline images as not prose to not tack on the extra margin since it's inline.

Fixed example: https://deploy-preview-22835--docsdocker.netlify.app/desktop/setup/vm-vdi/#use-docker-cloud


## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
