### PR TITLE
Fix `What is a registry?` formatting

### DIFF
--- a/content/get-started/docker-concepts/the-basics/what-is-a-registry.md
+++ b/content/get-started/docker-concepts/the-basics/what-is-a-registry.md
@@ -19,7 +19,7 @@ Well, you can store your container images on your computer system, but what if y
 
 An image registry is a centralized location for storing and sharing your container images. It can be either public or private. [Docker Hub](https://hub.docker.com) is a public registry that anyone can use and is the default registry. 
 
-While Docker Hub is a popular option, there are many other available container registries available today, including [Amazon Elastic Container Registry(ECR)](https://aws.amazon.com/ecr/), [Azure Container Registry (ACR)](https://azure.microsoft.com/en-in/products/container-registry), and [Google Container Registry (GCR)](https://cloud.google.com/artifact-registry). You can even run your private registry on your local system or inside your organization. For example, Harbor, JFrog Artifactory, GitLab Container registry etc.
+While Docker Hub is a popular option, there are many other available container registries available today, including [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/), [Azure Container Registry (ACR)](https://azure.microsoft.com/en-in/products/container-registry), and [Google Container Registry (GCR)](https://cloud.google.com/artifact-registry). You can even run your private registry on your local system or inside your organization. For example, Harbor, JFrog Artifactory, GitLab Container registry etc.
 
 ### Registry vs. repository
 


### PR DESCRIPTION
Fixes missing space on https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-a-registry/

<img width="923" alt="image" src="https://github.com/user-attachments/assets/e92e3f6b-d0a0-4f2c-8ed3-7720d771f090" />
