### PR TITLE
hub: add base url to api paths

### DIFF
--- a/layouts/_default/api-baseof.html
+++ b/layouts/_default/api-baseof.html
@@ -50,7 +50,7 @@
 
 <body>
   {{ $specURL := urls.Parse (printf "/%s%s.yaml" .File.Dir .File.ContentBaseName) }}
-  {{ if strings.HasPrefix .RelPermalink "/reference/api/hub/" }}
+  {{ if or (strings.HasPrefix .RelPermalink "/reference/api/hub/") (strings.HasPrefix .RelPermalink "/reference/api/registry/") }}
     <redoc spec-url="{{ $specURL.String }}" suppress-warnings="true" lazy-rendering></redoc>
   {{ else }}
     <redoc spec-url="{{ $specURL.String }}" hide-hostname="true" suppress-warnings="true" lazy-rendering></redoc>


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Display the base url specifically for Hub API and Registry API docs. 

Is this enough, or do we also need to write something about it in the description at the top?

![image](https://github.com/user-attachments/assets/666a4605-c131-4593-8a67-132481785a3e)


## Related issues or tickets

ENGDOCS-2748

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
