### PR TITLE
update links

### DIFF
--- a/content/manuals/build/ci/github-actions/secrets.md
+++ b/content/manuals/build/ci/github-actions/secrets.md
@@ -14,7 +14,7 @@ Docker Build supports two forms of secrets:
 - [SSH mounts](#ssh-mounts) add SSH agent sockets or keys into the build container.
 
 This page shows how to use secrets with GitHub Actions.
-For an introduction to secrets in general, see [Build secrets](../../building/secrets.md).
+For an introduction to secrets in general, see [Build secrets](/manuals/build/building/secrets.md).
 
 ## Secret mounts
 

--- a/content/manuals/desktop/setup/install/enterprise-deployment/msi-install-and-configure.md
+++ b/content/manuals/desktop/setup/install/enterprise-deployment/msi-install-and-configure.md
@@ -250,4 +250,4 @@ When analytics is disabled, this key is set to `1`.
 
 ## Additional resources
 
-- [Explore the FAQs](faq.md)
+- [Explore the FAQs](/manuals/desktop/setup/install/enterprise-deployment/faq.md)

--- a/content/manuals/security/for-admins/enforce-sign-in/_index.md
+++ b/content/manuals/security/for-admins/enforce-sign-in/_index.md
@@ -16,7 +16,7 @@ weight: 30
 By default, members of your organization can use Docker Desktop without signing
 in. When users don’t sign in as a member of your organization, they don’t
 receive the [benefits of your organization’s
-subscription](../../../subscription/details.md) and they can circumvent
+subscription](/manuals/subscription/details.md) and they can circumvent
 [Docker’s
 security features](/manuals/security/for-admins/hardened-desktop/_index.md) for
 your organization.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Pages that have both a tag and a page-relative link cause `ref_not_found` in newer versions of hugo and intermittently in older versions.
This quick fix replaces the page-relative links on those pages.
Still not sure which layout causes it.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
