### PR TITLE
run vale in docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,17 +68,6 @@ jobs:
           AWS_CLOUDFRONT_ID: 0123456789ABCD
           AWS_LAMBDA_FUNCTION: DockerDocsRedirectFunction-dummy
 
-  vale:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@reviewdog
-        env:
-          PIP_BREAK_SYSTEM_PACKAGES: 1
-        with:
-          files: content
-
   validate:
     runs-on: ubuntu-24.04
     strategy:
@@ -86,6 +75,7 @@ jobs:
       matrix:
         target:
           - lint
+          - vale
           - test
           - unused-media
           - test-go-redirects
@@ -94,14 +84,27 @@ jobs:
           - validate-vendor
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Validate
         uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             docker-bake.hcl
           targets: ${{ matrix.target }}
-          set: |
-            *.args.BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+      -
+        name: Install reviewdog
+        if: ${{ matrix.target == 'vale' && github.event_name == 'pull_request' }}
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
+      -
+        name: Run reviewdog for vale
+        if: ${{ matrix.target == 'vale' && github.event_name == 'pull_request' }}
+        run: |
+          cat ./tmp/vale.out | reviewdog -f=rdjsonl -name=vale -reporter=github-pr-annotations -fail-on-error=false -filter-mode=added -level=info
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vale-rdjsonl.tmpl
+++ b/.vale-rdjsonl.tmpl
@@ -1,0 +1,31 @@
+{{- /* Range over the linted files */ -}}
+
+{{- range .Files}}
+
+{{- $path := .Path -}}
+
+{{- /* Range over the file's alerts */ -}}
+
+{{- range .Alerts -}}
+
+{{- $error := "" -}}
+{{- if eq .Severity "error" -}}
+    {{- $error = "ERROR" -}}
+{{- else if eq .Severity "warning" -}}
+    {{- $error = "WARNING" -}}
+{{- else -}}
+    {{- $error = "INFO" -}}
+{{- end}}
+
+{{- /* Variables setup */ -}}
+
+{{- $line := printf "%d" .Line -}}
+{{- $col := printf "%d" (index .Span 0) -}}
+{{- $check := printf "%s" .Check -}}
+{{- $message := printf "%s" .Message -}}
+
+{{- /* Output */ -}}
+
+{"message": "[{{ $check }}] {{ $message | jsonEscape }}", "location": {"path": "{{ $path }}", "range": {"start": {"line": {{ $line }}, "column": {{ $col }}}}}, "severity": "{{ $error }}"}
+{{end -}}
+{{end -}}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,6 +14,10 @@ variable "DRY_RUN" {
   default = null
 }
 
+variable "GITHUB_ACTIONS" {
+  default = null
+}
+
 group "default" {
   targets = ["release"]
 }
@@ -36,7 +40,7 @@ target "release" {
 }
 
 group "validate" {
-  targets = ["lint", "test", "unused-media", "test-go-redirects", "dockerfile-lint", "path-warnings", "validate-vendor"]
+  targets = ["lint", "vale", "test", "unused-media", "test-go-redirects", "dockerfile-lint", "path-warnings", "validate-vendor"]
 }
 
 target "test" {
@@ -48,6 +52,15 @@ target "test" {
 target "lint" {
   target = "lint"
   output = ["type=cacheonly"]
+  provenance = false
+}
+
+target "vale" {
+  target = "vale"
+  args = {
+    GITHUB_ACTIONS = GITHUB_ACTIONS
+  }
+  output = ["./tmp"]
   provenance = false
 }
 


### PR DESCRIPTION
## Description

Atm vale only runs in GitHub Actions: https://github.com/docker/docs/blob/c69c0b53dd46ec56dc63e43e9fe6bd279f910431/.github/workflows/build.yml#L71-L80

With this change we are now able to run vale locally using bake:

```
$ docker buildx bake vale
...
#12 15.64  content/reference/compose-file/build.md
#12 15.64  256:58  error  Did you really mean 'inlined'?  Vale.Spelling
#12 15.64
#12 15.64
#12 15.64  content/reference/compose-file/services.md
#12 15.64  1730:33   error       Did you really mean             Vale.Spelling
#12 15.64                        'post_start'?
#12 15.64  1914:208  suggestion  Consider using 'let' instead    Docker.RecommendedWords
#12 15.64                        of 'allow'
#12 15.64  2008:35   error       Did you really mean             Vale.Spelling
#12 15.64                        'namespaced'?
#12 15.64  2010:59   error       Did you really mean             Vale.Spelling
#12 15.64                        'namespaced'?
#12 15.64  2130:10   error       Did you really mean 'SELinux'?  Vale.Spelling
#12 15.64  2131:10   error       Did you really mean 'SELinux'?  Vale.Spelling
#12 15.64  2135:7    error       Did you really mean 'SELinux'?  Vale.Spelling
#12 15.64  2135:77   error       Did you really mean 'SELinux'?  Vale.Spelling
#12 15.64  2163:20   error       Did you really mean 'SELinux'?  Vale.Spelling
#12 15.64
#12 15.64 ✖ 5489 errors, 2404 warnings and 1541 suggestions in 1367 files.
#12 DONE 17.5s

#13 [vale 1/1] COPY --from=vale-run /out/vale.out /
#13 DONE 0.0s

#14 exporting to client directory
#14 copying files 1.23MB 0.0s done
#14 DONE 0.0s
```

When running in GitHub Actions it will change the output format so reviewdog can create GitHub Annotations on pull request event. Having a dedicated step running reviewdog avoids the clunky output we have when running vale-action. Now are just displayed issues related to the pull request opened.

See for example: https://github.com/docker/docs/actions/runs/16320531091/job/46096850578#step:6:1

<img width="1552" height="1176" alt="image" src="https://github.com/user-attachments/assets/77d7be84-a72a-4cfa-b465-ee42570e9c6c" />

cc @dvdksn if you are interested to review this :hugs:

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review