### PR TITLE
dhi: update fips attestation

### DIFF
--- a/content/manuals/dhi/core-concepts/attestations.md
+++ b/content/manuals/dhi/core-concepts/attestations.md
@@ -61,7 +61,9 @@ tooling or security platforms.
 While every DHI variant includes a set of attestations, the attestations may
 vary based on the image variant. For example, some images may include a STIG
 scan attestation. The following table is a comprehensive list of all
-attestations that may be included with a DHI:
+attestations that may be included with a DHI. To see which attestations are
+available for a specific image variant, you can [view the image variant
+details](../how-to/explore.md#view-image-variant-details) in Docker Hub.
 
 | Attestation type           | Description                                                                                                                                                                                                                     | Predicate type URI                                 |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
@@ -79,6 +81,7 @@ attestations that may be included with a DHI:
 | SLSA provenance            | A standard [SLSA](https://slsa.dev/) provenance statement describing how the image was built, including build tool, parameters, and source.                                               | `https://slsa.dev/provenance/v0.2`                |
 | SLSA verification summary  | A summary attestation indicating the image's compliance with SLSA requirements.                                                                                                          | `https://slsa.dev/verification_summary/v1`        |
 | SPDX SBOM                  | An SBOM in [SPDX](https://spdx.dev/) format, widely adopted in open-source ecosystems.                                                                                                   | `https://spdx.dev/Document`                       |
+| FIPS compliance            | An attestation that verifies the image uses FIPS 140-validated cryptographic modules.                              | `https://docker.com/dhi/fips/v0.1`                |
 
 ## View and verify attestations
 

--- a/content/manuals/dhi/core-concepts/fips.md
+++ b/content/manuals/dhi/core-concepts/fips.md
@@ -67,42 +67,43 @@ These indicators help you quickly locate repositories that support FIPS-based
 compliance needs. Image variants that include FIPS support will have a tag
 ending with `-fips`, such as `3.13-fips`.
 
-## Validate FIPS-related tests using attestations
+## View the FIPS attestation
 
-Docker Hardened Images include a signed [test
-attestation](../core-concepts/attestations.md) that documents the results of
-automated image validation. For FIPS variants, this includes test cases that
-verify whether the image uses FIPS-validated cryptographic modules.
+The FIPS variants of Docker Hardened Images contain a FIPS attestation that
+lists the actual cryptographic modules included in the image.
 
-You can retrieve and inspect this attestation using the Docker Scout CLI:
+You can retrieve and inspect the FIPS attestation using the Docker Scout CLI:
 
 ```console
 $ docker scout attest get \
-  --predicate-type https://scout.docker.com/tests/v0.1 \
+  --predicate-type https://docker.com/dhi/fips/v0.1 \
   --predicate \
-  <your-namespace>/dhi-<image>:<tag> --platform <platform>
+  <your-namespace>/dhi-<image>:<tag>
 ```
 
 For example:
 
 ```console
 $ docker scout attest get \
-  --predicate-type https://scout.docker.com/tests/v0.1 \
+  --predicate-type https://docker.com/dhi/fips/v0.1 \
   --predicate \
-  docs/dhi-python:3.13-fips --platform linux/amd64
+  docs/dhi-python:3.13-fips
 ```
 
-The output is a structured JSON report. Individual test outputs are
-base64-encoded under fields like `stdout`. You can decode them to review the raw
-test output.
+The attestation output is a JSON array describing the cryptographic modules
+included in the image and their compliance status. For example:
 
-To decode and view test results:
-
-```console
-$ docker scout attest get \
-  --predicate-type https://scout.docker.com/tests/v0.1 \
-  --predicate \
-  docs/dhi-python:3.13-fips --platform linux/amd64 \
-  | jq -r '.results.tests[].extra.stdout' \
-  | base64 -d
+```json
+[
+  {
+    "certification": "CMVP #4985",
+    "certificationUrl": "https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4985",
+    "name": "OpenSSL FIPS Provider",
+    "package": "pkg:dhi/openssl-provider-fips@3.1.2",
+    "standard": "FIPS 140-3",
+    "status": "active",
+    "sunsetDate": "2030-03-10",
+    "version": "3.1.2"
+  }
+]
 ```


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Updated the DHI FIPS topic to get the FIPS attestation instead of the FIPS tests from the test attestation. 
Added FIPS attestation to attestation table.

https://deploy-preview-23163--docsdocker.netlify.app/dhi/core-concepts/fips/#view-the-fips-attestation
https://deploy-preview-23163--docsdocker.netlify.app/dhi/core-concepts/attestations/#available-attestations

## Related issues or tickets

ENGDOCS-2876

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
- [ ] Product review