### PR TITLE
Update etwlogs.md

### DIFF
--- a/content/manuals/engine/logging/drivers/etwlogs.md
+++ b/content/manuals/engine/logging/drivers/etwlogs.md
@@ -25,7 +25,7 @@ before the provider has been registered with the system.
 Here is an example of how to listen to these events using the logman utility program
 included in most installations of Windows:
 
-1. `logman start -ets DockerContainerLogs -p {a3693192-9ed6-46d2-a981-f8226c8363bd} 0 0 -o trace.etl`
+1. `logman start -ets DockerContainerLogs -p "{a3693192-9ed6-46d2-a981-f8226c8363bd}" 0x0 -o trace.etl`
 2. Run your container(s) with the etwlogs driver, by adding
    `--log-driver=etwlogs` to the Docker run command, and generate log messages.
 3. `logman stop -ets DockerContainerLogs`


### PR DESCRIPTION
## Description

The command doesn't work as intended. Explanation for the fix:
1. Windows requires the GUID inside quotes because it's treated as a string (the provider name) in this context. Without quotes, the command parser may interpret the braces or hyphens incorrectly.
2. Passing 0x0 as the only flag after the provider GUID is valid. Supplying two numbers like 0 0 (as in some bad examples) misleads logman, which tries to interpret the second value as outputFormat.
3. The -o trace.etl must be at the end and not mistaken for a different parameter like -f (output format), unless you're also explicitly setting -f to text or xml.

## Related issues or tickets

Worked out in Case number: [00164653](https://docker.lightning.force.com/lightning/r/Case/500U100000VvQDdIAN/view)

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review