### PR TITLE
[docker-hub-api] Fix listNamespaceRepositories max `page_size` : 1000 -> 100

### DIFF
--- a/content/reference/api/hub/latest.yaml
+++ b/content/reference/api/hub/latest.yaml
@@ -1014,9 +1014,9 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 1000
+            maximum: 100
             default: 10
-          description: Number of repositories to get per page. Defaults to 10. Max of 1000.
+          description: Number of repositories to get per page. Defaults to 10. Max of 100.
         - in: query
           name: name
           required: false


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

[docker-hub-api] Fix listNamespaceRepositories max `page_size` : 1000 -> 100

## Related issues or tickets

https://github.com/docker/docs/issues/23199

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review