### PR TITLE
fix(docs): correct 'Stop your container' instructions

### DIFF
--- a/content/get-started/docker-concepts/running-containers/sharing-local-files.md
+++ b/content/get-started/docker-concepts/running-containers/sharing-local-files.md
@@ -182,7 +182,7 @@ The container continues to run until you stop it.
 
 2. Locate the container you'd like to stop.
 
-3. Select the **Delete** action in the Actions column.
+3. Select the **blue square Stop button** in the Actions column to stop the container.
 
 ![A screenshot of Docker Desktop Dashboard showing how to delete the container](images/delete-the-container.webp?border=true)
 


### PR DESCRIPTION
## Description

Updated the Stop your container section in the Docker documentation to correct the instructions. Replaced the incorrect direction to "select the Delete action" with the accurate instruction to click the blue square Stop button in the Actions column. This fix improves clarity and prevents confusion between stopping and deleting a container.

## Reviews
- [ ] Editorial review