### PR TITLE
doi: add note about dct retirement

### DIFF
--- a/content/manuals/docker-hub/image-library/trusted-content.md
+++ b/content/manuals/docker-hub/image-library/trusted-content.md
@@ -18,6 +18,22 @@ Source Software images.
 
 ## Docker Official Images
 
+> [!NOTE]
+>
+> Docker is retiring Docker Content Trust (DCT) for Docker Official Images
+> (DOI). Starting on August 8th, 2025, the oldest of DOI DCT signing
+> certificates will begin to expire. You may have already started seeing expiry
+> warnings if you use the `docker trust` commands with DOI. These certificates,
+> once cached by the Docker client, are not subsequently refreshed, making
+> certificate rotation impractical. If you have set the `DOCKER_CONTENT_TRUST`
+> environment variable to true (`DOCKER_CONTENT_TRUST=1`), DOI pulls will start to
+> fail. The workaround is to unset the `DOCKER_CONTENT_TRUST` environment
+> variable. The use of  `docker trust inspect` will also start to fail and should
+> no longer be used for DOI.
+>
+> For more details, see
+> https://www.docker.com/blog/retiring-docker-content-trust/.
+
 The Docker Official Images are a curated set of Docker repositories hosted on
 Docker Hub.
 

--- a/content/manuals/docker-hub/repos/manage/trusted-content/official-images.md
+++ b/content/manuals/docker-hub/repos/manage/trusted-content/official-images.md
@@ -10,6 +10,18 @@ aliases:
 - /docker-hub/official_images/
 ---
 
+> [!NOTE]
+>
+> Docker is retiring Docker Content Trust (DCT) for Docker Official Images
+> (DOI). You should start planning to transition to a different image signing
+> and verification solution (like [Sigstore](https://www.sigstore.dev/) or
+> [Notation](https://github.com/notaryproject/notation#readme)). Docker will
+> publish migration guides soon to help you in that effort. Timelines for the
+> complete deprecation of DCT are being finalized and will be published soon.
+>
+> For more details, see
+> https://www.docker.com/blog/retiring-docker-content-trust/.
+
 Docker, Inc. sponsors a dedicated team that's responsible for reviewing and
 publishing all content in Docker Official Images. This team works in
 collaboration with upstream software maintainers, security experts, and the


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added note in the 2 DOI topics noting that:
 - For consumers, DOI DCT signing certificates will begin to expire
 - For builders, transition to a new signing solution
 
https://deploy-preview-23246--docsdocker.netlify.app/docker-hub/image-library/trusted-content/
https://deploy-preview-23246--docsdocker.netlify.app/docker-hub/repos/manage/trusted-content/official-images/
 
## Related issues or tickets

DHI-621

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
- [ ] Product review