### PR TITLE
Bump `registry` image references to `3`

### DIFF
--- a/content/manuals/build/ci/github-actions/local-registry.md
+++ b/content/manuals/build/ci/github-actions/local-registry.md
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       registry:
-        image: registry:2
+        image: registry:3
         ports:
           - 5000:5000
     steps:

--- a/content/manuals/build/ci/github-actions/named-contexts.md
+++ b/content/manuals/build/ci/github-actions/named-contexts.md
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       registry:
-        image: registry:2
+        image: registry:3
         ports:
           - 5000:5000
     steps:

--- a/content/manuals/engine/security/trust/trust_sandbox.md
+++ b/content/manuals/engine/security/trust/trust_sandbox.md
@@ -91,7 +91,7 @@ the `trustsandbox` container, the Notary server, and the Registry server.
          - NOTARY_SERVER_STORAGE_TYPE=memory
          - NOTARY_SERVER_TRUST_SERVICE_TYPE=local
      sandboxregistry:
-       image: registry:2.4.1
+       image: registry:3
        networks:
          - sandbox
        container_name: sandboxregistry


### PR DESCRIPTION
[The last `2` update was 7 months ago](https://hub.docker.com/_/registry/tags?name=2).