### PR TITLE
add redirect

### DIFF
--- a/content/manuals/subscription/details.md
+++ b/content/manuals/subscription/details.md
@@ -141,7 +141,7 @@ Legacy Docker Pro includes:
 - [Auto Builds](/docker-hub/builds/) with 5 concurrent builds
 - 300 [Vulnerability Scans](/docker-hub/vulnerability-scanning/)
 
-For a list of features available in each legacy tier, see [Legacy Docker Pricing](https://www.docker.com/legacy-pricing/).
+For a list of features available in each legacy tier, see [Legacy Docker Pricing](/go/legacy-pricing/).
 
 ### Upgrade your Legacy Docker Pro subscription
 
@@ -172,7 +172,7 @@ Legacy Docker Team includes:
 
 There are also advanced collaboration and management tools, including organization and team management with [Role Based Access Control (RBAC)](/security/for-admins/roles-and-permissions/), [activity logs](/admin/organization/activity-logs/), and more.
 
-For a list of features available in each legacy tier, see [Legacy Docker Pricing](https://www.docker.com/legacy-pricing/).
+For a list of features available in each legacy tier, see [Legacy Docker Pricing](/go/legacy-pricing/).
 
 ### Upgrade your Legacy Docker Team subscription
 
@@ -204,7 +204,7 @@ Legacy Docker Business includes:
 - [Single Sign-On](/security/for-admins/single-sign-on/)
 - [System for Cross-domain Identity Management](/security/for-admins/provisioning/scim/) and more.
 
-For a list of features available in each tier, see [Legacy Docker Pricing](https://www.docker.com/legacy-pricing/).
+For a list of features available in each tier, see [Legacy Docker Pricing](/go/legacy-pricing/).
 
 ### Upgrade your Legacy Docker Business subscription
 

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -357,3 +357,8 @@
 
 "/dhi/how-to/customize/#create-an-oci-artifact-image":
   - /go/dhi-customization-artifacts/
+
+
+# Legacy pricing PDF (external link bypassing analytics)
+"http://www.docker.com/legacy-pricing.pdf/":
+  - /go/legacy-pricing/


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added go redirect as a workaround to GA modifying a pdf link causing it to 404 on www.

It's kind of hacky (and not very sure it's going to work), but only necessary for like 3 more months, then can be nuked. Very open to other alternatives.

For example, https://www.docker.com/legacy-pricing/ 
gets turned into 
https://www.docker.com/legacy-pricing/?_gl=1*hre2s0*_gcl_au*NzE2MTg4NDg0LjE3NTUwNDA1MjU.*_ga*MjM4NDM0NjYxLjE3MjcxMDM2OTk.*_ga_XJWPQMJYHQ*czE3NTY1MDE3MzgkbzEwMDMkZzEkdDE3NTY1MDE3OTYkajIkbDAkaDA.


## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
