### PR TITLE
OpenAPI/DVP API: fix HubAuth securitySchemes type

### DIFF
--- a/content/reference/api/dvp/latest.yaml
+++ b/content/reference/api/dvp/latest.yaml
@@ -686,7 +686,7 @@ components:
       enum: [repo,namespace]
   securitySchemes:
     HubAuth:
-      type: https
+      type: http
       scheme: bearer
       bearerFormat: JWT
       description: |


### PR DESCRIPTION
## Description

<!-- Tell us what you did and why -->

Since c69c0b53dd46ec56dc63e43e9fe6bd279f910431,
securityScheme `HubAuth` is mentioned with type `https`, instead of `http`.

But this generate OpenAPI validity issues,
type of security schemes has to belong to this list: "apiKey", "http", "mutualTLS", "oauth2", "openIdConnect"

source: https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object-0


## Related issues or tickets

Noticed while trying to deploy last version of OpenAPI documents on Bump.sh demo space:

https://bump.sh/christophedujarric/hub/docker


## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review