### PR TITLE
Fix typo in api-reference.md: OpenAPI -> OpenAI

### DIFF
--- a/content/manuals/ai/model-runner/api-reference.md
+++ b/content/manuals/ai/model-runner/api-reference.md
@@ -66,9 +66,9 @@ on how you run Docker:
   DELETE /models/{namespace}/{name}
   ```
 
-### Available OpenAPI endpoints
+### Available OpenAI endpoints
 
-DMR supports the following OpenAPI endpoints:
+DMR supports the following OpenAI endpoints:
 
 - [List models](https://platform.openai.com/docs/api-reference/models/list):
 


### PR DESCRIPTION
## Description

It appears that there is a typo on the DMR API [documentation page](https://docs.docker.com/ai/model-runner/api-reference/):
The section with **OpenAI**-compatible endpoints is named 'Available **OpenAPI** endpoints'.

## Related issues or tickets:

No related issues or tickets found.

## Reviews

- [ ] Editorial review