### PR TITLE
docs(apparmor): add warning about profile persistence

### DIFF
--- a/content/manuals/engine/security/apparmor.md
+++ b/content/manuals/engine/security/apparmor.md
@@ -197,6 +197,13 @@ profile docker-nginx flags=(attach_disconnected,mediate_deleted) {
 
 You just deployed a container secured with a custom apparmor profile.
 
+> [!WARNING]
+>
+> The activation of the custom AppArmor profile in `/etc/apparmor.d/containers/docker-nginx` will not persist across restarts.
+> After a reboot the container will fail to start, as it expects the `docker-nginx` profile to be loaded.
+>
+> Only profiles directly located in `/etc/appamor.d/` will be automatically applied in enforce mode.
+> For more information about the AppArmor directory structure, have a look at [Policy Layout](https://gitlab.com/apparmor/apparmor/-/wikis/Policy_Layout).
 
 ## Debug AppArmor
 


### PR DESCRIPTION
across reboots, as `/etc/apparmor.d/containers` will not be loaded, leading to the example `nginx` container not being able to start.

## Description

Following the example to set up a custom apparmor profile.
I was suprised, that the profile suggested being located in `/etc/apparmor.d/containers` was not automatically loaded after a reboot.
This is because apparmor only loads files directly located in `/etc/apparmor.d/*` or known folder locations according to the [Policy Layout](https://gitlab.com/apparmor/apparmor/-/wikis/Policy_Layout).

This led to my container not being able to start with error:
```
Failed starting container: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: unable to apply apparmor profile: apparmor failed to apply profile: write /proc/thread-self/attr/apparmor/exec: no such file or directory: unknown
```
For this reason, I've added a warning section in the docs.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review