### PR TITLE
Add note for Ubuntu 24.04 users about docker-compose-plugin availability

### DIFF
--- a/content/manuals/compose/install/linux.md
+++ b/content/manuals/compose/install/linux.md
@@ -40,6 +40,14 @@ To install the Docker Compose plugin on Linux, you can either:
         $ sudo apt-get update
         $ sudo apt-get install docker-compose-plugin
         ```
+
+        > [!NOTE]
+        > 
+        > **Note for Ubuntu 24.04 users:** The `docker-compose-plugin` package may not be available in the default Ubuntu repositories. You can install Docker Compose using:
+
+        ```console
+        $ sudo apt-get install docker-compose
+        ```
     * For RPM-based distributions, run:
 
         ```console


### PR DESCRIPTION
## Description

On Ubuntu 24.04.3 LTS, I encountered an issue when following the official Docker Compose installation instructions. Specifically, the command:

```bash
sudo apt-get install docker-compose-plugin
```

returned the following error:

```bash
E: Unable to locate package docker-compose-plugin
```

After some investigation, it seems this package may not be available in the default Ubuntu repositories for this version. To help others avoid confusion, I’ve added a `[!NOTE]` block to the Linux installation guide suggesting the use of:

```bash
sudo apt-get install docker-compose
```

I am happy to adjust the wording or approach based on feedback.
 
## Related issues or tickets

None that I could find

## Reviews

- Docker Engine and Docker CLI were installed on the tested server
- sudo apt-get update was run as per the original documentation, but the installation still failed

- [x] Technical review
- [ ] Editorial review
- [ ] Product review