### PR TITLE
engine/install: add note for service start on deb flavors

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -173,6 +173,21 @@ Docker from the repository.
    {{< /tab >}}
    {{< /tabs >}}
 
+    > [!NOTE]
+    >
+    > The Docker service starts automatically after installation. To verify that
+    > Docker is running, use:
+    > 
+    > ```console
+    > $ sudo systemctl status docker
+    > ```
+    >
+    > Some systems may have this behavior disabled and will require a manual start:
+    >
+    > ```console
+    > $ sudo systemctl start docker
+    > ```
+
 3. Verify that the installation is successful by running the `hello-world` image:
 
    ```console
@@ -226,12 +241,24 @@ download a new file each time you want to upgrade Docker Engine.
      ./docker-compose-plugin_<version>_<arch>.deb
    ```
 
-   The Docker daemon starts automatically.
+    > [!NOTE]
+    >
+    > The Docker service starts automatically after installation. To verify that
+    > Docker is running, use:
+    > 
+    > ```console
+    > $ sudo systemctl status docker
+    > ```
+    >
+    > Some systems may have this behavior disabled and will require a manual start:
+    >
+    > ```console
+    > $ sudo systemctl start docker
+    > ```
 
 6. Verify that the installation is successful by running the `hello-world` image:
 
    ```console
-   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 

--- a/content/manuals/engine/install/raspberry-pi-os.md
+++ b/content/manuals/engine/install/raspberry-pi-os.md
@@ -160,6 +160,21 @@ Docker from the repository.
    {{< /tab >}}
    {{< /tabs >}}
 
+    > [!NOTE]
+    >
+    > The Docker service starts automatically after installation. To verify that
+    > Docker is running, use:
+    > 
+    > ```console
+    > $ sudo systemctl status docker
+    > ```
+    >
+    > Some systems may have this behavior disabled and will require a manual start:
+    >
+    > ```console
+    > $ sudo systemctl start docker
+    > ```
+
 3. Verify that the installation is successful by running the `hello-world` image:
 
    ```console
@@ -213,12 +228,24 @@ download a new file each time you want to upgrade Docker Engine.
      ./docker-compose-plugin_<version>_<arch>.deb
    ```
 
-   The Docker daemon starts automatically.
+    > [!NOTE]
+    >
+    > The Docker service starts automatically after installation. To verify that
+    > Docker is running, use:
+    > 
+    > ```console
+    > $ sudo systemctl status docker
+    > ```
+    >
+    > Some systems may have this behavior disabled and will require a manual start:
+    >
+    > ```console
+    > $ sudo systemctl start docker
+    > ```
 
 6. Verify that the installation is successful by running the `hello-world` image:
 
    ```console
-   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -175,6 +175,21 @@ Docker from the repository.
    {{< /tab >}}
    {{< /tabs >}}
 
+    > [!NOTE]
+    >
+    > The Docker service starts automatically after installation. To verify that
+    > Docker is running, use:
+    > 
+    > ```console
+    > $ sudo systemctl status docker
+    > ```
+    >
+    > Some systems may have this behavior disabled and will require a manual start:
+    >
+    > ```console
+    > $ sudo systemctl start docker
+    > ```
+
 3. Verify that the installation is successful by running the `hello-world` image:
 
    ```console
@@ -228,12 +243,24 @@ download a new file each time you want to upgrade Docker Engine.
      ./docker-compose-plugin_<version>_<arch>.deb
    ```
 
-   The Docker daemon starts automatically.
+    > [!NOTE]
+    >
+    > The Docker service starts automatically after installation. To verify that
+    > Docker is running, use:
+    > 
+    > ```console
+    > $ sudo systemctl status docker
+    > ```
+    >
+    > Some systems may have this behavior disabled and will require a manual start:
+    >
+    > ```console
+    > $ sudo systemctl start docker
+    > ```
 
 6. Verify that the installation is successful by running the `hello-world` image:
 
    ```console
-   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 


### PR DESCRIPTION
## Description

This change is to address some feedback from a Ubuntu user that installed Docker Engine using the apt repository but had to start the service before they were able to run containers.

While autostart is the convention on Debian systems, some users might have this behavior disabled for more fine grained control. This change adds a note to the installation step across all the debian flavors to note the service should start by default with explicit instructions how to enable the service if not.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review - @vvoland
- [ ] Editorial review - @usha-mandya 
- [ ] Product review