### PR TITLE
add description of 'initial_sync' attribute in Compose watch documentation

### DIFF
--- a/content/manuals/compose/how-tos/file-watch.md
+++ b/content/manuals/compose/how-tos/file-watch.md
@@ -120,7 +120,7 @@ The `ignore` patterns are relative to the `path` defined in the current `watch` 
 
 ### `initial_sync`
 
-When using a `sync+x` action, the `initial_sync` attribute indicates Compose to ensure files part of the defined `path` to be up to date before starting a new watch session.
+When using a `sync+x` action, the `initial_sync` attribute tells Compose to ensure files that are part of the defined `path` are up to date before starting a new watch session.
 
 ## Example 1
 

--- a/content/reference/compose-file/develop.md
+++ b/content/reference/compose-file/develop.md
@@ -124,6 +124,12 @@ services:
 > In many cases `include` patterns start with a wildcard (`*`) character. This has special meaning in YAML syntax
 > to define an [alias node](https://yaml.org/spec/1.2.2/#alias-nodes) so you have to wrap pattern expression with quotes.
 
+#### `initial_sync`
+
+When using `sync+x` actions, it can be useful to ensure that files inside containers are up to date at the start of a new watch session.
+
+The `initial_sync` attribute instructs the Compose runtime, if containers for the service already exist, to check that the files from the path attribute are in sync within the service containers.
+
 #### `path`
 
 `path` attribute defines the path to source code (relative to the project directory) to monitor for changes. Updates to any file


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Describe the new added `initial_sync` attribute of Compose watch configuration 

## Related issues or tickets
Fix #23345

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review