### PR TITLE
update nav dropdown behavior

### DIFF
--- a/layouts/partials/sidebar/sections.html
+++ b/layouts/partials/sidebar/sections.html
@@ -79,6 +79,9 @@
           </button>
         {{- end }}
       </div>
+      {{/* Only show expand group button if section has children */}}
+      {{- $hasChildren := gt (len (where .Pages "Params.sitemap" "ne" "false")) 0 }}
+      {{- if $hasChildren }}
       <!-- Expand group button -->
       <button
         @click="expanded = !expanded"
@@ -97,6 +100,7 @@
           {{ partialCached "icon" "arrow_drop_up" "arrow_drop_up" }}
         </span>
       </button>
+      {{- end }}
     </div>
     <ul
       :class="{ 'hidden' : !expanded }"


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Change how the section drop-down arrows are rendered in the side-nav.

Currently, they generate for any folder, even if it just contains an index. To not generate the arrow, the index would have to be taken out of the folder and renamed as the folder.

This change now counts how many children under the index, and only generates the arrow if it has children (that aren't hidden from the nav).

For example, see how there is an arrow for the mcp gateway, but it expands to nothing.
Current: https://docs.docker.com/ai/mcp-gateway/
Updated: https://deploy-preview-23436--docsdocker.netlify.app/ai/mcp-gateway/

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
