### PR TITLE
dhi: add homepage banner

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -161,27 +161,27 @@
             >
               <div class="flex flex-col gap-4">
                 <h2 class="font-medium">
-                  Gen AI catalog
+                  Docker Hardened Images
                   {{ partial
                     "components/badge.html" (dict "color" "blue" "content" "New")
                   }}
                 </h2>
                 <p class="text-xl">
-                  Integrate AI solutions into your apps with minimal effort
+                  Secure, minimal, production-ready images with near-zero known CVEs.
                 </p>
               </div>
               <div class="flex flex-col items-start gap-4 xl:flex-row">
                 <a
-                  href="https://hub.docker.com/catalogs/gen-ai"
+                  href="/dhi/get-started/"
                   class="bg-blue dark:bg-blue rounded-sm p-2 px-4 text-white transition duration-300 hover:bg-blue-500 dark:hover:bg-blue-500"
                 >
-                  Explore on Docker Hub
+                  Start your free trial
                 </a>
                 <a
-                  href="/docker-hub/image-library/catalogs/"
+                  href="https://hub.docker.com/hardened-images/catalog"
                   class="bg-blue dark:bg-blue rounded-sm p-2 px-4 text-white transition duration-300 hover:bg-blue-500 dark:hover:bg-blue-500"
                 >
-                  Read the docs
+                  Explore images
                 </a>
               </div>
             </div>


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Updated old GenAI homepage banner to promote DHI free trial.
https://deploy-preview-23451--docsdocker.netlify.app/

## Related issues or tickets

ENGDOCS-3014
Pending #23420 as this requires the quickstart to have the free trial flow.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
