### PR TITLE
build: git remote authentication secrets

### DIFF
--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -215,7 +215,7 @@ BuildKit supports two Git authentication secrets:
 - **`GIT_AUTH_TOKEN`**: Uses Basic authentication with a fixed username of `x-access-token` (the GitHub-style default)
 - **`GIT_AUTH_HEADER`**: Uses the raw authorization header value you provide (works with any Git provider)
 
-#### Using GIT_AUTH_TOKEN (f.ex. GitHub)
+#### Using GIT_AUTH_TOKEN (for example, GitHub)
 
 When you use `GIT_AUTH_TOKEN`, BuildKit automatically constructs a Basic authentication header using `x-access-token` as the user:
 

--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -217,7 +217,7 @@ BuildKit supports two Git authentication secrets:
 
 #### Using GIT_AUTH_TOKEN (for example, GitHub)
 
-When you use `GIT_AUTH_TOKEN`, BuildKit automatically constructs a Basic authentication header using `x-access-token` as the user:
+When you use `GIT_AUTH_TOKEN`, BuildKit constructs a Basic authentication header using `x-access-token` as the user:
 
 ```http
 Authorization: Basic <base64("x-access-token:<GIT_AUTH_TOKEN>")>

--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -223,7 +223,7 @@ When you use `GIT_AUTH_TOKEN`, BuildKit constructs a Basic authentication header
 Authorization: Basic <base64("x-access-token:<GIT_AUTH_TOKEN>")>
 ```
 
-This method works with GitHub. Example usage:
+This method works for providers that accept the `x-access-token` Basic auth pattern, such as GitHub. Example usage:
 
 ```console
 $ export GIT_AUTH_TOKEN=$(gh auth token)

--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -234,7 +234,7 @@ $ docker build \
 
 #### Using GIT_AUTH_HEADER (custom authorization header)
 
-When you use `GIT_AUTH_HEADER`, BuildKit uses the exact value you provide as the authorization header:
+When you use `GIT_AUTH_HEADER`, BuildKit uses the exact value you provide as the `Authorization` header:
 
 ```http
 Authorization: <GIT_AUTH_HEADER>

--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -212,7 +212,7 @@ ADD https://github.com/example/todo-app.git /src
 
 BuildKit supports two Git authentication secrets:
 
-- **`GIT_AUTH_TOKEN`**: Uses Basic authentication with a fixed username of `x-access-token` (GitHub-specific)
+- **`GIT_AUTH_TOKEN`**: Uses Basic authentication with a fixed username of `x-access-token` (the GitHub-style default)
 - **`GIT_AUTH_HEADER`**: Uses the raw authorization header value you provide (works with any Git provider)
 
 #### Using GIT_AUTH_TOKEN (f.ex. GitHub)

--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -210,7 +210,7 @@ ADD https://github.com/example/todo-app.git /src
 
 ### HTTP authentication scheme
 
-BuildKit supports two types of Git authentication secrets, and you should use either one or the other, not both:
+BuildKit supports two Git authentication secrets:
 
 - **`GIT_AUTH_TOKEN`**: Uses Basic authentication with a fixed username of `x-access-token` (GitHub-specific)
 - **`GIT_AUTH_HEADER`**: Uses the raw authorization header value you provide (works with any Git provider)

--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -232,7 +232,7 @@ $ docker build \
   https://github.com/example/todo-app.git
 ```
 
-#### Using GIT_AUTH_HEADER (Any Git provider)
+#### Using GIT_AUTH_HEADER (custom authorization header)
 
 When you use `GIT_AUTH_HEADER`, BuildKit uses the exact value you provide as the authorization header:
 


### PR DESCRIPTION
## Description
I fixed the documentation, because it was wrong. See the issues and buildkit PR for details.

## Related issues or tickets

- BuildKit issue: https://github.com/moby/buildkit/issues/5703
- Docs issue: https://github.com/docker/docs/issues/22834
- Another BuildKit issue: https://github.com/moby/buildkit/issues/6046
- PR that introduced the behaviour: https://github.com/moby/buildkit/pull/1533
- PR that introduced the docs: https://github.com/docker/docs/pull/19739

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
