### PR TITLE
Fix theme switch button styling in header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -67,7 +67,7 @@
         <button
           aria-label="Theme switch"
           id="theme-switch"
-          class="topbar-button-clear"
+          class="topbar-button rounded-full w-13"
           x-data="{ theme: localStorage.getItem('theme-preference') }"
           x-init="$watch('theme', value => {
                 localStorage.setItem('theme-preference', value);


### PR DESCRIPTION
## Description
Updated the theme toggle button styling to improve usability and hover visibility.  
- Added `rounded-full` to make the button circular.  
- Added `w-13` to increase the button size and ensure a consistent clickable area.  
- Now the hover background is clearly visible, giving users better feedback that the button is interactive.  

## Related issues or tickets
N/A

## Reviews
- [ ] Technical review  
- [ ] Editorial review  
- [ ] Product review 