### PR TITLE
get-started: update node version

### DIFF
--- a/content/get-started/workshop/06_bind_mounts.md
+++ b/content/get-started/workshop/06_bind_mounts.md
@@ -181,7 +181,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
    ```console
    $ docker run -dp 127.0.0.1:3000:3000 \
        -w /app --mount type=bind,src="$(pwd)",target=/app \
-       node:18-alpine \
+       node:lts-alpine \
        sh -c "yarn install && yarn run dev"
    ```
 
@@ -192,7 +192,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
      command will run from
    - `--mount type=bind,src="$(pwd)",target=/app` - bind mount the current
      directory from the host into the `/app` directory in the container
-   - `node:18-alpine` - the image to use. Note that this is the base image for
+   - `node:lts-alpine` - the image to use. Note that this is the base image for
      your app from the Dockerfile
    - `sh -c "yarn install && yarn run dev"` - the command. You're starting a
      shell using `sh` (alpine doesn't have `bash`) and running `yarn install` to
@@ -227,7 +227,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
    ```powershell
    $ docker run -dp 127.0.0.1:3000:3000 `
        -w /app --mount "type=bind,src=$pwd,target=/app" `
-       node:18-alpine `
+       node:lts-alpine `
        sh -c "yarn install && yarn run dev"
    ```
 
@@ -238,7 +238,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
      command will run from
    - `--mount "type=bind,src=$pwd,target=/app"` - bind mount the current
      directory from the host into the `/app` directory in the container
-   - `node:18-alpine` - the image to use. Note that this is the base image for
+   - `node:lts-alpine` - the image to use. Note that this is the base image for
      your app from the Dockerfile
    - `sh -c "yarn install && yarn run dev"` - the command. You're starting a
      shell using `sh` (alpine doesn't have `bash`) and running `yarn install` to
@@ -273,7 +273,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
    ```console
    $ docker run -dp 127.0.0.1:3000:3000 ^
        -w /app --mount "type=bind,src=%cd%,target=/app" ^
-       node:18-alpine ^
+       node:lts-alpine ^
        sh -c "yarn install && yarn run dev"
    ```
 
@@ -284,7 +284,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
      command will run from
    - `--mount "type=bind,src=%cd%,target=/app"` - bind mount the current
      directory from the host into the `/app` directory in the container
-   - `node:18-alpine` - the image to use. Note that this is the base image for
+   - `node:lts-alpine` - the image to use. Note that this is the base image for
      your app from the Dockerfile
    - `sh -c "yarn install && yarn run dev"` - the command. You're starting a
      shell using `sh` (alpine doesn't have `bash`) and running `yarn install` to
@@ -319,7 +319,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
    ```console
    $ docker run -dp 127.0.0.1:3000:3000 \
        -w //app --mount type=bind,src="/$(pwd)",target=/app \
-       node:18-alpine \
+       node:lts-alpine \
        sh -c "yarn install && yarn run dev"
    ```
 
@@ -330,7 +330,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
      command will run from
    - `--mount type=bind,src="/$(pwd)",target=/app` - bind mount the current
      directory from the host into the `/app` directory in the container
-   - `node:18-alpine` - the image to use. Note that this is the base image for
+   - `node:lts-alpine` - the image to use. Note that this is the base image for
      your app from the Dockerfile
    - `sh -c "yarn install && yarn run dev"` - the command. You're starting a
      shell using `sh` (alpine doesn't have `bash`) and running `yarn install` to

--- a/content/get-started/workshop/07_multi_container.md
+++ b/content/get-started/workshop/07_multi_container.md
@@ -218,7 +218,7 @@ You can now start your dev-ready container.
      -e MYSQL_USER=root \
      -e MYSQL_PASSWORD=secret \
      -e MYSQL_DB=todos \
-     node:18-alpine \
+     node:lts-alpine \
      sh -c "yarn install && yarn run dev"
    ```
    
@@ -234,7 +234,7 @@ You can now start your dev-ready container.
      -e MYSQL_USER=root `
      -e MYSQL_PASSWORD=secret `
      -e MYSQL_DB=todos `
-     node:18-alpine `
+     node:lts-alpine `
      sh -c "yarn install && yarn run dev"
    ```
 
@@ -250,7 +250,7 @@ You can now start your dev-ready container.
      -e MYSQL_USER=root ^
      -e MYSQL_PASSWORD=secret ^
      -e MYSQL_DB=todos ^
-     node:18-alpine ^
+     node:lts-alpine ^
      sh -c "yarn install && yarn run dev"
    ```
 
@@ -265,7 +265,7 @@ You can now start your dev-ready container.
      -e MYSQL_USER=root \
      -e MYSQL_PASSWORD=secret \
      -e MYSQL_DB=todos \
-     node:18-alpine \
+     node:lts-alpine \
      sh -c "yarn install && yarn run dev"
    ```
    

--- a/content/get-started/workshop/08_using_compose.md
+++ b/content/get-started/workshop/08_using_compose.md
@@ -46,7 +46,7 @@ $ docker run -dp 127.0.0.1:3000:3000 \
   -e MYSQL_USER=root \
   -e MYSQL_PASSWORD=secret \
   -e MYSQL_DB=todos \
-  node:18-alpine \
+  node:lts-alpine \
   sh -c "yarn install && yarn run dev"
 ```
 
@@ -58,7 +58,7 @@ You'll now define this service in the `compose.yaml` file.
    ```yaml
    services:
      app:
-       image: node:18-alpine
+       image: node:lts-alpine
    ```
 
 2. Typically, you will see `command` close to the `image` definition, although there is no requirement on ordering. Add the `command` to your `compose.yaml` file.
@@ -66,7 +66,7 @@ You'll now define this service in the `compose.yaml` file.
    ```yaml
    services:
      app:
-       image: node:18-alpine
+       image: node:lts-alpine
        command: sh -c "yarn install && yarn run dev"
    ```
 
@@ -75,7 +75,7 @@ You'll now define this service in the `compose.yaml` file.
    ```yaml
    services:
      app:
-       image: node:18-alpine
+       image: node:lts-alpine
        command: sh -c "yarn install && yarn run dev"
        ports:
          - 127.0.0.1:3000:3000
@@ -89,7 +89,7 @@ You'll now define this service in the `compose.yaml` file.
    ```yaml
    services:
      app:
-       image: node:18-alpine
+       image: node:lts-alpine
        command: sh -c "yarn install && yarn run dev"
        ports:
          - 127.0.0.1:3000:3000
@@ -103,7 +103,7 @@ You'll now define this service in the `compose.yaml` file.
    ```yaml
    services:
      app:
-       image: node:18-alpine
+       image: node:lts-alpine
        command: sh -c "yarn install && yarn run dev"
        ports:
          - 127.0.0.1:3000:3000
@@ -185,7 +185,7 @@ At this point, your complete `compose.yaml` should look like this:
 ```yaml
 services:
   app:
-    image: node:18-alpine
+    image: node:lts-alpine
     command: sh -c "yarn install && yarn run dev"
     ports:
       - 127.0.0.1:3000:3000


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Updated image to `node:lts-alpine` and tested in bind mounts, multi-container, and compose topics.

`node:18-alpine` is no longer available.
The image was already updated to `node:lts-alpine` in the initial topics of the workshop.
lts (version 22) should be good until April 2027

## Related issues or tickets

https://docker.slack.com/archives/C04BMTUC41E/p1758903149468219

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
