### PR TITLE
get-started: update write a dockerfile

### DIFF
--- a/content/get-started/docker-concepts/building-images/writing-a-dockerfile.md
+++ b/content/get-started/docker-concepts/building-images/writing-a-dockerfile.md
@@ -90,7 +90,7 @@ Now that you have the project, you’re ready to create the `Dockerfile`.
    For this exercise, you'll pretend you're starting from scratch and will
    create a new `Dockerfile`.
 
-4. Create a file named `Dockerfile` in `getting-started-todo-app/app/` folder.
+4. Create a file named `Dockerfile` in the `getting-started-todo-app/app/` folder.
 
     > **Dockerfile file extensions**
     >


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Current issues:
 - There are several `package.json` files, so it's ambiguous.
 - There is already a `Dockerfile`, so it must be deleted if asking the user to create one. Also, the existing Dockerfile has a different image version than the one the user is asked to create.

Fixes:
 - Added step to explore the existing Dockerfile to have a smoother transition into deleting it. 
 - Added step to delete the Dockerfile.
 - Updated step to specify the exact folder where to create the new Dockerfile.


https://deploy-preview-23478--docsdocker.netlify.app/get-started/docker-concepts/building-images/writing-a-dockerfile/#creating-the-dockerfile

## Related issues or tickets

https://docker.slack.com/archives/C04BMTUC41E/p1759261212446019

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
