### PR TITLE
Update Go SDK installation command in documentation

### DIFF
--- a/content/reference/api/engine/sdk/_index.md
+++ b/content/reference/api/engine/sdk/_index.md
@@ -26,7 +26,7 @@ installed and coexist together.
 ### Go SDK
 
 ```console
-$ go get github.com/docker/docker/client
+$ go get github.com/moby/moby/client
 ```
 
 The client requires a recent version of Go. Run `go version` and ensure that you're running a currently supported version of Go.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Updated `go get` install instruction since the repository is moved?

When using the current install instruction is get the following error:
```bash
romano@development:/hyperplane/open-source/docker-update$  go get github.com/docker/docker/client
go: github.com/docker/docker/client@upgrade (v0.1.0-beta.0) requires github.com/docker/docker/client@v0.1.0-beta.0: parsing go.mod:
        module declares its path as: github.com/moby/moby/client
                but was required as: github.com/docker/docker/client
````

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review