### PR TITLE
Remove warning issue references to docker/for-mac#7527

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -30,10 +30,6 @@ Docker Desktop versions older than 6 months from the latest release are not avai
 
 For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoot-and-support/faqs/releases.md).
 
-> [!WARNING]
->
-> If you're experiencing malware detection issues on Mac, follow the steps documented in [docker/for-mac#7527](https://github.com/docker/for-mac/issues/7527).
-
 ## 4.47.0
 
 {{< release-date date="2025-09-25" >}}

--- a/content/manuals/desktop/setup/install/mac-install.md
+++ b/content/manuals/desktop/setup/install/mac-install.md
@@ -32,10 +32,6 @@ This page provides download links, system requirements, and step-by-step install
 
 *For checksums, see [Release notes](/manuals/desktop/release-notes.md).*
 
-> [!WARNING]
->
-> If you're experiencing malware detection issues, follow the steps documented in [docker/for-mac#7527](https://github.com/docker/for-mac/issues/7527).
-
 ## System requirements
 
 {{< tabs >}}

--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
@@ -22,10 +22,6 @@ weight: 10
 
 This page contains information on how to diagnose and troubleshoot Docker Desktop, and how to check the logs.
 
-> [!WARNING]
->
-> If you're experiencing malware detection issues on Mac, follow the steps documented in [docker/for-mac#7527](https://github.com/docker/for-mac/issues/7527).
-
 ## Troubleshoot menu
 
 To navigate to **Troubleshoot** either:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Removing the warning references to the malware detection issue from last January docker/for-mac#7527. The affected versions are no longer supported and the volume of users reporting the issue is minimal.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review