### PR TITLE
engine/release-notes: fix header inconsistency in 28.2.1 section

### DIFF
--- a/content/manuals/engine/release-notes/28.md
+++ b/content/manuals/engine/release-notes/28.md
@@ -320,7 +320,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 {{< release-date date="2025-05-29" >}}
 
-## Packaging updates
+### Packaging updates
 
 - Fix packaging regression in [v28.2.0](https://github.com/moby/moby/releases/tag/v28.2.0) which broke creating the `docker` group/user on fresh installations. [docker-ce-packaging#1209](https://github.com/docker/docker-ce-packaging/issues/1209)
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This fixes the TOC
<img width="419" height="460" alt="image" src="https://github.com/user-attachments/assets/fb51921d-8650-422d-82bb-6eb69f375345" />


<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review