### PR TITLE
docs: models-and-compose: move deprecated provider service type section to end of page

### DIFF
--- a/content/manuals/ai/compose/models-and-compose.md
+++ b/content/manuals/ai/compose/models-and-compose.md
@@ -83,33 +83,6 @@ Common configuration options include:
 > [!TIP]
 > See more example in the [Common runtime configurations](#common-runtime-configurations) section.
 
-### Alternative configuration with provider services
-
-> [!IMPORTANT]
->
-> This approach is deprecated. Use the [`models` top-level element](#basic-model-definition) instead.
-
-You can also use the `provider` service type, which allows you to declare platform capabilities required by your application.
-For AI models, you can use the `model` type to declare model dependencies.
-
-To define a model provider:
-
-```yaml
-services:
-  chat:
-    image: my-chat-app
-    depends_on:
-      - ai_runner
-
-  ai_runner:
-    provider:
-      type: model
-      options:
-        model: ai/smollm2
-        context-size: 1024
-        runtime-flags: "--no-prefill-assistant"
-```
-
 ## Service model binding
 
 Services can reference models in two ways: short syntax and long syntax.
@@ -358,6 +331,33 @@ models:
       - "0.1"
       - "--top-p"               # Top-p sampling
       - "0.9"
+```
+
+## Alternative configuration with provider services
+
+> [!IMPORTANT]
+>
+> This approach is deprecated. Use the [`models` top-level element](#basic-model-definition) instead.
+
+You can also use the `provider` service type, which allows you to declare platform capabilities required by your application.
+For AI models, you can use the `model` type to declare model dependencies.
+
+To define a model provider:
+
+```yaml
+services:
+  chat:
+    image: my-chat-app
+    depends_on:
+      - ai_runner
+
+  ai_runner:
+    provider:
+      type: model
+      options:
+        model: ai/smollm2
+        context-size: 1024
+        runtime-flags: "--no-prefill-assistant"
 ```
 
 ## Reference


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

Move deprecated `provider` service type section to end of page to not interrupt the reading flow of the preferred definition.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review