### PR TITLE
ci: don't set public acl when uploading files to s3 bucket

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,6 @@ jobs:
         if: ${{ env.DOCS_S3_BUCKET != '' }}
         run: |
           aws --region ${{ env.DOCS_AWS_REGION }} s3 sync \
-            --acl public-read \
             --delete \
             --exclude "*" \
             --include "*.webp" \
@@ -109,7 +108,6 @@ jobs:
             --content-type="image/webp" \
             public s3://${{ env.DOCS_S3_BUCKET }}/
           aws --region ${{ env.DOCS_AWS_REGION }} s3 sync \
-            --acl public-read \
             --delete \
             --exclude "*.webp" \
             public s3://${{ env.DOCS_S3_BUCKET }}/


### PR DESCRIPTION
* follow-up https://github.com/docker/docs/pull/23530
* needs https://github.com/docker/docs/pull/23542

## Description

After #23542 is merged and deployed we can update our workflow to not set public acl when uploading files to s3 bucket.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review