### PR TITLE
Fix: update compose intro doc

### DIFF
--- a/content/manuals/compose/intro/compose-application-model.md
+++ b/content/manuals/compose/intro/compose-application-model.md
@@ -47,7 +47,7 @@ You can use [fragments](/reference/compose-file/fragments.md) and [extensions](/
 
 Multiple Compose files can be [merged](/reference/compose-file/merge.md) together to define the application model. The combination of YAML files is implemented by appending or overriding YAML elements based on the Compose file order you set. 
 Simple attributes and maps get overridden by the highest order Compose file, lists get merged by appending. Relative
-paths are resolved based on the first Compose file's parent folder, whenever complimentary files being
+paths are resolved based on the first Compose file's parent folder, whenever complementary files being
 merged are hosted in other folders. As some Compose file elements can both be expressed as single strings or complex objects, merges apply to
 the expanded form. For more information, see [Working with multiple Compose files](/manuals/compose/how-tos/multiple-compose-files/_index.md).
 


### PR DESCRIPTION
## Description
Corrected a minor typo in the Compose documentation.
The word “complimentary” was replaced with “complementary” to accurately describe “complementary files”.

## Related issues or tickets

#23466 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review