### PR TITLE
docs(github-actions): add missing "checkout" step before docker build

### DIFF
--- a/content/manuals/build/ci/github-actions/multi-platform.md
+++ b/content/manuals/build/ci/github-actions/multi-platform.md
@@ -37,6 +37,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - uses: actions/checkout@v5
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -89,6 +91,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
+      - uses: actions/checkout@v5
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -153,6 +157,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - uses: actions/checkout@v5
 
       - name: Build and push by digest
         id: build
@@ -281,7 +287,7 @@ jobs:
       matrix: ${{ steps.platforms.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create matrix
         id: platforms


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Fixing documentation for GitHub Actions section: adding missing [`actions/checkout`](https://github.com/actions/checkout) step, before building docker images.

To build images we need the Dockerfile to be checked-out. If we don't call the checkout step first, build is failling as it does not find any file: `ERROR: failed to build: resolve : lstat tests: no such file or directory`

## Related issues or tickets

N/A

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review