### PR TITLE
enterprise: dd settings reference AI

### DIFF
--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
@@ -869,7 +869,8 @@ third-party or unvetted plugins from being installed.
 
 | Default value | Accepted values | Format   |
 |---------------|-----------------|----------|
-| `false`       | `true`, `false` | Boolean  |
+| `false`       | Individual users: `true`, `false`<br>Business tier: `"Disabled"`, `"Enabled"`, `"Always Enabled"` | Boolean for individuals<br>Toggle in Admin Console |
+
 
 - **Description:** Docker AI features including "Ask Gordon" functionality.
 - **OS:** {{< badge color=blue text="All" >}}
@@ -878,6 +879,13 @@ third-party or unvetted plugins from being installed.
     - **Beta** settings in [Docker Desktop GUI](/manuals/desktop/settings-and-maintenance/settings.md)
     - Settings Management: `enableDockerAI` setting in the [`admin-settings.json` file](/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md)
     - Settings Management: **Enable Docker AI** setting in the [Admin Console](/manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console.md)
+
+> [!IMPORTANT]
+>
+> Docker Business customers must set this to `"Enabled"` or `"Always Enabled"`
+in the Admin Console. Setting to `"User Defined"` alone will not activate
+Docker AI features. This secure-by-default approach prevents unintended
+deployment of AI features in security-conscious organizations.
 
 ### Enable Docker MCP Toolkit
 


### PR DESCRIPTION
## Description
- Improve DD settings reference to include a callout about enabling the setting in Admin Console for Docker Business customers
- There is a safeguard in place that allows Business orgs to control this setting from the AC only, the prevent unauthorized use of Docker AI features

## Related issues or tickets
https://docker.atlassian.net/browse/ENGDOCS-3044?atlOrigin=eyJpIjoiOGUwZTUxMWJkOTkyNGNiNDg3ZGViNGZhOTM5N2I4YmIiLCJwIjoiaiJ9