### PR TITLE
Note that nftables support was added in moby29

### DIFF
--- a/content/manuals/engine/network/firewall-nftables.md
+++ b/content/manuals/engine/network/firewall-nftables.md
@@ -7,8 +7,8 @@ keywords: network, nftables, firewall
 
 > [!WARNING]
 >
-> Support for nftables is experimental, configuration options, behavior and
-> implementation may all change in future releases.
+> Support for nftables introduced in moby 29.0.0 is experimental, configuration
+> options, behavior and implementation may all change in future releases.
 > The rules for overlay networks have not yet been migrated from iptables.
 > So, nftables cannot be enabled when the daemon has Swarm enabled.
 


### PR DESCRIPTION
## Description

Added a note that nftables support was added in moby 29.0.0.

Moby 29.0 release candidates are now available, looking for feedback, so we should publish these changes.

## Related issues or tickets

- https://github.com/moby/moby/issues/49644

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review