### PR TITLE
nftables doc: rename moby 29.0.0 -> Docker 29.0.0

### DIFF
--- a/content/manuals/engine/network/firewall-nftables.md
+++ b/content/manuals/engine/network/firewall-nftables.md
@@ -7,7 +7,7 @@ keywords: network, nftables, firewall
 
 > [!WARNING]
 >
-> Support for nftables introduced in moby 29.0.0 is experimental, configuration
+> Support for nftables introduced in Docker 29.0.0 is experimental, configuration
 > options, behavior and implementation may all change in future releases.
 > The rules for overlay networks have not yet been migrated from iptables.
 > So, nftables cannot be enabled when the daemon has Swarm enabled.


### PR DESCRIPTION
## Description

- Related to https://github.com/docker/docs/pull/23560#discussion_r2431762035

nftables doc: renamed moby 29.0.0 -> Docker 29.0.0

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review