### PR TITLE
feat: Docker Debug no longer requires a subscription

### DIFF
--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -153,8 +153,7 @@ Docker Offload:
 docker compose alpha:
   availability: Experimental
 Docker Debug:
-  subscription: [Pro, Team, Business]
-  requires: Docker Desktop [4.33.0](/manuals/desktop/release-notes.md#4330) and later
+  requires: Docker Desktop 4.48 and later. For Docker Desktop versions 4.47.0 and earlier, you must have a Pro, Team, or Business subscription
 Docker Desktop Archlinux:
   availability: Experimental
 Docker Desktop CLI:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

We have removed the paywall on docker debug. It's shipped in DD 4.48.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review