### PR TITLE
engine-cli: fix `docker volume prune` output without `--all`

### DIFF
--- a/data/engine-cli/docker_volume_prune.yaml
+++ b/data/engine-cli/docker_volume_prune.yaml
@@ -60,7 +60,7 @@ examples: |-
     Are you sure you want to continue? [y/N] y
     Deleted Volumes:
     07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e
-    my-named-vol
+    2b9af34974f8a2340a35400a1aa2345252837914391192f88d852b85385ffcaa
 
     Total reclaimed space: 36 B
     ```


### PR DESCRIPTION

## Description

`docker volume prune`, without the `--all` flag, only deletes anonymous volumes. The example in the documentation would not delete the `my-named-vol` volume because it is not run with `--all`. This changes the deleted `my-named-vol` to an anonymous volume in the example.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review