### PR TITLE
build: don't specify the buildx install/uninstall commands

### DIFF
--- a/content/manuals/build/builders/_index.md
+++ b/content/manuals/build/builders/_index.md
@@ -78,26 +78,20 @@ older versions of the Docker CLI. The `docker buildx build` command, on the
 other hand, checks whether you've set a different builder as the default
 builder before it sends your build to BuildKit.
 
-To use the `docker build` command with a non-default builder, you must either:
+To use the `docker build` command with a non-default builder, you must either
+specify the builder explicitly:
 
-- Specify the builder explicitly, using the `--builder` flag or the `BUILDX_BUILDER` environment variable:
+- Using the `--builder` flag:
 
   ```console
-  $ BUILDX_BUILDER=my_builder docker build .
   $ docker build --builder my_builder .
   ```
 
-- Configure Buildx as the default client by running the following command:
+- Or the `BUILDX_BUILDER` environment variable:
 
   ```console
-  $ docker buildx install
+  $ BUILDX_BUILDER=my_builder docker build .
   ```
-
-  This updates your [Docker CLI configuration file](/reference/cli/docker/_index.md#configuration-files)
-  to ensure all of your build-related commands are routed via Buildx.
-
-  > [!TIP]
-  > To undo this change, run `docker buildx uninstall`.
 
 <!-- vale Docker.We = NO -->
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

`install` and `uninstall` commands are hidden for quite some time now and are deprecated since https://github.com/docker/buildx/pull/3472

## Related issues or tickets

* https://github.com/docker/buildx/pull/3472

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review