### PR TITLE
build: deprecate `docker buildx install`

### DIFF
--- a/content/manuals/build/builders/_index.md
+++ b/content/manuals/build/builders/_index.md
@@ -99,6 +99,9 @@ To use the `docker build` command with a non-default builder, you must either:
   > [!TIP]
   > To undo this change, run `docker buildx uninstall`.
 
+  > [!WARNING]
+  > The `docker buildx install` and `docker buildx uninstall` commands are deprecated.
+
 <!-- vale Docker.We = NO -->
 
 In general, we recommend that you use the `docker buildx build` command when

--- a/data/buildx/docker_buildx_install.yaml
+++ b/data/buildx/docker_buildx_install.yaml
@@ -25,7 +25,7 @@ inherited_options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-deprecated: false
+deprecated: true
 hidden: true
 experimental: false
 experimentalcli: false

--- a/data/buildx/docker_buildx_uninstall.yaml
+++ b/data/buildx/docker_buildx_uninstall.yaml
@@ -25,7 +25,7 @@ inherited_options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-deprecated: false
+deprecated: true
 hidden: true
 experimental: false
 experimentalcli: false


### PR DESCRIPTION

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

Deprecate `docker buildx install` and `docker buildx uninstall`

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

- docker/buildx#3472

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [X] Technical review
- [ ] Editorial review
- [ ] Product review