### PR TITLE
DKP-2613 Remove support for Windows 10 and 11 22H2

### DIFF
--- a/content/manuals/desktop/setup/install/windows-install.md
+++ b/content/manuals/desktop/setup/install/windows-install.md
@@ -48,8 +48,7 @@ _For checksums, see [Release notes](/manuals/desktop/release-notes.md)_
 {{< tab name="WSL 2 backend, x86_64" >}}
 
 - WSL version 2.1.5 or later.
-- Windows 11 64-bit: Home or Pro version 22H2 or higher, or Enterprise or Education version 22H2 or higher.
-- Windows 10 64-bit: Minimum required is Home or Pro 22H2 (build 19045) or higher, or Enterprise or Education 22H2 (build 19045) or higher. 
+- Windows 11 64-bit: Enterprise, Pro, or Education version 23H2 or higher.
 - Turn on the WSL 2 feature on Windows. For detailed instructions, refer to the
   [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 - The following hardware prerequisites are required to successfully run
@@ -73,8 +72,7 @@ For more information on setting up WSL 2 with Docker Desktop, see [WSL](/manuals
 {{< /tab >}}
 {{< tab name="Hyper-V backend, x86_64" >}}
 
-- Windows 11 64-bit: Enterprise, Pro, or Education version 22H2 or higher.
-- Windows 10 64-bit: Enterprise, Pro, or Education version 22H2 (build 19045) or higher.
+- Windows 11 64-bit: Enterprise, Pro, or Education version 23H2 or higher.
 - Turn on Hyper-V and Containers Windows features.
 - The following hardware prerequisites are required to successfully run Client
   Hyper-V on Windows 10:
@@ -98,8 +96,7 @@ For more information on setting up WSL 2 with Docker Desktop, see [WSL](/manuals
 {{< tab name="WSL 2 backend, Arm (Early Access)" >}}
 
 - WSL version 2.1.5 or later.
-- Windows 11 64-bit: Home or Pro version 22H2 or higher, or Enterprise or Education version 22H2 or higher.
-- Windows 10 64-bit: Minimum required is Home or Pro 22H2 (build 19045) or higher, or Enterprise or Education 22H2 (build 19045) or higher.
+- Windows 11 64-bit: Enterprise, Pro, or Education version 23H2 or higher.
 - Turn on the WSL 2 feature on Windows. For detailed instructions, refer to the
   [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 - The following hardware prerequisites are required to successfully run


### PR DESCRIPTION
## Description

Increased the minimum version of Windows supported for Docker Desktop to Windows 11 23H2.
We typically follow [Microsoft end of servicing dates for Windows](https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information#windows-11-current-versions-by-servicing-option).

## Related issues or tickets

https://docker.atlassian.net/browse/DKP-2513

## Reviews

- [ ] Editorial review
