### PR TITLE
Add sudo -E flag to curl command for proxy support

### DIFF
--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -129,7 +129,7 @@ Docker from the repository.
    sudo apt-get update
    sudo apt-get install ca-certificates curl
    sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
+   sudo -E curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc
 
    # Add the repository to Apt sources:


### PR DESCRIPTION
## Description

The curl command needs the `-E` flag with sudo to preserve environment variables, particularly `HTTP_PROXY` and `HTTPS_PROXY` settings. Without this flag, users behind corporate proxies cannot download Docker's GPG key.
