### PR TITLE
fix: remove duplicate YAML keys

### DIFF
--- a/content/manuals/dhi/how-to/debug.md
+++ b/content/manuals/dhi/how-to/debug.md
@@ -2,9 +2,8 @@
 title: Debug a Docker Hardened Image container
 linkTitle: Debug a container
 weight: 60
-keywords: debug, hardened images, DHI, troubleshooting, ephemeral container, docker debug
+keywords: debug, hardened images, DHI, troubleshooting, ephemeral container, docker debug, non-root containers, hardened container image, debug secure container
 description: Learn how to use Docker Debug to troubleshoot Docker Hardened Images (DHI) locally or in production.
-keywords: docker debug, ephemeral container, non-root containers, hardened container image, debug secure container
 ---
 
 {{< summary-bar feature_name="Docker Hardened Images" >}}

--- a/data/desktop-cli/docker_desktop_kubernetes.yaml
+++ b/data/desktop-cli/docker_desktop_kubernetes.yaml
@@ -3,9 +3,6 @@ short: Manage Kubernetes settings
 usage: docker desktop kubernetes
 pname: docker desktop
 plink: docker_desktop.yaml
-usage: docker desktop kubernetes
-pname: docker desktop
-plink: docker_desktop.yaml
 cname:
     - docker desktop kubernetes images
 clink:


### PR DESCRIPTION
fix: remove duplicate front matter and YAML keys

- Removed duplicate `keywords` in `content/manuals/dhi/how-to/debug.md`
- Removed duplicate `usage` in `data/desktop-cli/docker_desktop_kubernetes.yaml`
