### PR TITLE
Add note about application startup delay in Docker Compose tutorial

### DIFF
--- a/content/get-started/docker-concepts/the-basics/what-is-docker-compose.md
+++ b/content/get-started/docker-concepts/the-basics/what-is-docker-compose.md
@@ -81,7 +81,7 @@ Follow the instructions to run the to-do list app on your system.
 
     If this feels overwhelming, don't worry! You'll get there!
 
-5. With everything now up and running, you can open [http://localhost:3000](http://localhost:3000) in your browser to see the site. Feel free to add items to the list, check them off, and remove them.
+5. With everything now up and running, you can open [http://localhost:3000](http://localhost:3000) in your browser to see the site. Note that the application may take 10-15 seconds to fully start. If the page doesn't load right away, wait a moment and refresh. Feel free to add items to the list, check them off, and remove them.
 
     ![A screenshot of a webpage showing the todo-list application running on port 3000](images/todo-list-app.webp?border=true&w=950&h=400)
 


### PR DESCRIPTION
## Summary

Adds a note to the Docker Compose tutorial clarifying that the application may take 10-15 seconds to fully start after running `docker compose up -d --build`.

## Changes

Updated step 5 in the "Start the application" section to inform users that the application may not be immediately accessible at `localhost:3000` and that they should wait a moment and refresh if the page doesn't load right away.

## Why this change is needed

When users run `docker compose up`, Docker reports containers as "Started" once they're running, but the applications inside (Node.js app and MySQL database) still need time to initialize and connect. This causes confusion for beginners who expect immediate accessibility after seeing "Container started" in the CLI output or within the GUI. 

## Related Issue

Fixes #23500