### PR TITLE
document yaml-ish .env file syntax and spacing rules

### DIFF
--- a/content/manuals/compose/how-tos/environment-variables/variable-interpolation.md
+++ b/content/manuals/compose/how-tos/environment-variables/variable-interpolation.md
@@ -136,7 +136,7 @@ The following syntax rules apply to environment files:
   - `VAR="VAL"` -> `VAL`
   - `VAR='VAL'` -> `VAL`
   - `VAR: VAL` -> `VAL`
-  - `VAR = VAL  ` -> `VAL`
+  - `VAR = VAL  ` -> `VAL` <!-- markdownlint-disable-line no-space-in-code -->
 - Inline comments for unquoted values must be preceded with a space.
   - `VAR=VAL # comment` -> `VAL`
   - `VAR=VAL# not a comment` -> `VAL# not a comment`

--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -694,7 +694,7 @@ Each line in an `.env` file must be in `VAR[=[VAL]]` format. The following synta
   - `VAR="VAL"` -> `VAL`
   - `VAR='VAL'` -> `VAL`
   - `VAR: VAL` -> `VAL`
-  - `VAR = VAL  ` -> `VAL`
+  - `VAR = VAL  ` -> `VAL` <!-- markdownlint-disable-line no-space-in-code -->
 - Inline comments for unquoted values must be preceded with a space.
   - `VAR=VAL # comment` -> `VAL`
   - `VAR=VAL# not a comment` -> `VAL# not a comment`


### PR DESCRIPTION
## Description

This patch documents syntax rules for spacing and delimiters in .env files.

Today while reviewing [some code](https://github.com/apache/fineract/pull/5131) I discovered Docker .env files may use colons as delimiters. This appears to be [intentional](https://github.com/compose-spec/compose-go/blob/75fb1aba98ff8a944ebc5ea54f1054f1329e999c/dotenv/parser.go#L117) but I don't see it documented anywhere.

## Related issues or tickets

None

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review