### PR TITLE
mcp: gateway go link

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -295,7 +295,7 @@
 "/ai/mcp-catalog-and-toolkit/catalog/":
   - /go/mcp-catalog-and-toolkit-catalog/
 "/ai/mcp-catalog-and-toolkit/mcp-gateway/":
-  - /go/mcp-catalog-and-toolkit-gateway/
+  - /go/mcp-gateway/
 "/ai/mcp-catalog-and-toolkit/toolkit/#install-an-mcp-server":
   - /go/mcp-toolkit-install-mcp-server/
 "/ai/mcp-catalog-and-toolkit/toolkit/#install-an-mcp-client":


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Add a go link for the mcp gateway (https://docs.docker.com/ai/mcp-catalog-and-toolkit/mcp-gateway/) for use in our frontend products