### PR TITLE
Fix typo in Compose Bridge documentation

### DIFF
--- a/content/manuals/compose/bridge/_index.md
+++ b/content/manuals/compose/bridge/_index.md
@@ -8,7 +8,7 @@ weight: 50
 
 {{< summary-bar feature_name="Compose bridge" >}}
 
-Compose Bridge converts your Docker Compose configuration into platform-specific deployment formats such as Kubernetes manifests. By default, it geneterates:
+Compose Bridge converts your Docker Compose configuration into platform-specific deployment formats such as Kubernetes manifests. By default, it generates:
 
 - Kubernetes manifests 
 - A Kustomize overlay


### PR DESCRIPTION

This pull request corrects a minor typo in the Compose Bridge documentation to improve clarity.

- Documentation:
  * Fixed a typo in the description of the Compose Bridge feature in `content/manuals/compose/bridge/_index.md` ("geneterates" → "generates").