### PR TITLE
docs: update Docker Hub official image link for mongo (library -> _)

### DIFF
--- a/content/manuals/engine/security/trust/_index.md
+++ b/content/manuals/engine/security/trust/_index.md
@@ -63,7 +63,7 @@ have discretion on which tags they sign.
 
 An image repository can contain an image with one tag that is signed and another
 tag that is not. For example, consider [the Mongo image
-repository](https://hub.docker.com/r/library/mongo/tags/). The `latest`
+repository](https://hub.docker.com/_/mongo/tags/). The `latest`
 tag could be unsigned while the `3.1.6` tag could be signed. It is the
 responsibility of the image publisher to decide if an image tag is signed or
 not. In this representation, some image tags are signed, others are not:


### PR DESCRIPTION
### What changed
Replaced outdated Docker Hub link for the official `mongo` image:
- `https://hub.docker.com/r/library/mongo/...` → `https://hub.docker.com/_/mongo/...`

### Why
Official images are served under the `/_/` namespace on Docker Hub. Updating these links avoids redirects and potential 404s.

### Files changed
- content/manuals/engine/security/trust/_index.md

### How tested
- Verified the replacement with `git grep`.
- Manually opened the updated link in a browser to confirm it points to the mongo image tags page.

Closes: #23622
