### PR TITLE
engine: safer creation of rootlesskit apparmor profile

### DIFF
--- a/content/manuals/engine/security/rootless/troubleshoot.md
+++ b/content/manuals/engine/security/rootless/troubleshoot.md
@@ -25,8 +25,8 @@ weight: 30
   1. Create and install the currently logged-in user's AppArmor profile:
 
      ```console
-     $ filename=$(echo $HOME/bin/rootlesskit | sed -e s@^/@@ -e s@/@.@g)
-     $ cat <<EOF > ~/${filename}
+     $ filename=$(echo $HOME/bin/rootlesskit | sed -e 's@^/@@' -e 's@/@.@g')
+     $ [ ! -z "${filename}" ] && sudo cat <<EOF > /etc/apparmor.d/${filename}
      abi <abi/4.0>,
      include <tunables/global>
 
@@ -36,7 +36,6 @@ weight: 30
        include if exists <local/${filename}>
      }
      EOF
-     $ sudo mv ~/${filename} /etc/apparmor.d/${filename}
      ```
   2. Restart AppArmor.
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--Delete sections as needed -->

## Description

The current instruction is technically incorrect since we are not exporting the
`filename` variable and the instruction suggests that users should run this
discretely. This PR adds an `export` statement as well as a quick check to make
sure the file exists before attempting to move it into the apparmor directory
(to prevent users from accidentally `sudo mv`ing their home directory there in
case `$filename` is unset)

## Related issues or tickets

- Closes #23559
