### PR TITLE
chore: prune irrelevant go.mod imports, update buildkit to v0.25.1

### DIFF
--- a/_vendor/github.com/moby/buildkit/docs/buildkitd.toml.md
+++ b/_vendor/github.com/moby/buildkit/docs/buildkitd.toml.md
@@ -21,6 +21,11 @@ trace = true
 root = "/var/lib/buildkit"
 # insecure-entitlements allows insecure entitlements, disabled by default.
 insecure-entitlements = [ "network.host", "security.insecure", "device" ]
+# provenanceEnvDir is the directory where extra config is loaded that is added
+# to the provenance of builds:
+# slsa v0.2: invocation.environment.*
+# slsa v1: buildDefinition.internalParameters.*
+provenanceEnvDir = "/etc/buildkit/provenance.d"
 
 [log]
   # log formatter: json or text

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,6 @@ replace (
 	github.com/docker/mcp-gateway => github.com/docker/mcp-gateway v0.22.0
 	github.com/docker/model-runner/cmd/cli => github.com/docker/model-runner/cmd/cli v0.1.44
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.18.4
-	github.com/moby/buildkit => github.com/moby/buildkit v0.25.0
+	github.com/moby/buildkit => github.com/moby/buildkit v0.25.1
 	github.com/moby/moby => github.com/moby/moby v28.5.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/docker/model-runner/cmd/cli v0.1.44 h1:A0LBBlH8Bzjxl8CAW5tTDiqePwkNi0
 github.com/docker/model-runner/cmd/cli v0.1.44/go.mod h1:Ue7MAkIgCE7sKVuaH61UOblYUBTKMpdjZaUowrXjM9s=
 github.com/docker/scout-cli v1.18.4 h1:Td+SSA55WlD7gmrNaBe0imgfVzzQjlfb/prwBn9GOSw=
 github.com/docker/scout-cli v1.18.4/go.mod h1:Eo1RyCJsx3ldz/YTY5yGxu9g9mwTYbRUutxQUkow3Fc=
-github.com/moby/buildkit v0.25.0/go.mod h1:phM8sdqnvgK2y1dPDnbwI6veUCXHOZ6KFSl6E164tkc=
+github.com/moby/buildkit v0.25.1 h1:j7IlVkeNbEo+ZLoxdudYCHpmTsbwKvhgc/6UJ/mY/o8=
+github.com/moby/buildkit v0.25.1/go.mod h1:phM8sdqnvgK2y1dPDnbwI6veUCXHOZ6KFSl6E164tkc=
 github.com/moby/moby v28.5.1+incompatible h1:JD8lBdCDBF2oiHWLqIRofPqI8qvkppRjMJ6EnwrhvX0=
 github.com/moby/moby v28.5.1+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review