### PR TITLE
fix: update links to docker hub trusted content categories

### DIFF
--- a/content/get-started/docker-concepts/the-basics/what-is-an-image.md
+++ b/content/get-started/docker-concepts/the-basics/what-is-an-image.md
@@ -32,9 +32,9 @@ These two principles let you to extend or add to existing images. For example, i
 
 Docker Hub provides a variety of Docker-supported and endorsed images known as Docker Trusted Content. These provide fully managed services or great starters for your own images. These include:
 
-- [Docker Official Images](https://hub.docker.com/search?q=&type=image&image_filter=official) - a curated set of Docker repositories, serve as the starting point for the majority of users, and are some of the most secure on Docker Hub
-- [Docker Verified Publishers](https://hub.docker.com/search?q=&image_filter=store) - high-quality images from commercial publishers verified by Docker
-- [Docker-Sponsored Open Source](https://hub.docker.com/search?q=&image_filter=open_source) - images published and maintained by open-source projects sponsored by Docker through Docker's open source program
+- [Docker Official Images](https://hub.docker.com/search?badges=official) - a curated set of Docker repositories, serve as the starting point for the majority of users, and are some of the most secure on Docker Hub
+- [Docker Verified Publishers](https://hub.docker.com/search?badges=verified_publisher) - high-quality images from commercial publishers verified by Docker
+- [Docker-Sponsored Open Source](https://hub.docker.com/search?badges=open_source) - images published and maintained by open-source projects sponsored by Docker through Docker's open source program
 
 For example, [Redis](https://hub.docker.com/_/redis) and [Memcached](https://hub.docker.com/_/memcached) are a few popular ready-to-go Docker Official Images. You can download these images and have these services up and running in a matter of seconds. There are also base images, like the [Node.js](https://hub.docker.com/_/node) Docker image, that you can use as a starting point and add your own files and configurations.
 

--- a/content/get-started/introduction/build-and-push-first-image.md
+++ b/content/get-started/introduction/build-and-push-first-image.md
@@ -40,7 +40,7 @@ In [Develop with containers](develop-with-containers.md), you used the following
 - [phpmyadmin](https://hub.docker.com/_/phpmyadmin) - provides phpMyAdmin, a web-based interface to the MySQL database
 - [traefik](https://hub.docker.com/_/traefik) - provides Traefik, a modern HTTP reverse proxy and load balancer that routes requests to the appropriate container based on routing rules
 
-Explore the full catalog of [Docker Official Images](https://hub.docker.com/search?image_filter=official&q=), [Docker Verified Publishers](https://hub.docker.com/search?q=&image_filter=store), and [Docker Sponsored Open Source Software](https://hub.docker.com/search?q=&image_filter=open_source) images to see more of what there is to run and build on.
+Explore the full catalog of [Docker Official Images](https://hub.docker.com/search?badges=official), [Docker Verified Publishers](https://hub.docker.com/search?badges=verified_publisher), and [Docker Sponsored Open Source Software](https://hub.docker.com/search?badges=open_source) images to see more of what there is to run and build on.
 
 ## Try it out
 

--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -45,17 +45,17 @@ The first step towards achieving a secure image is to choose the right base
 image. When choosing an image, ensure it's built from a trusted source and keep
 it small.
 
-- [Docker Official Images](https://hub.docker.com/search?image_filter=official)
+- [Docker Official Images](https://hub.docker.com/search?badges=official)
   are a curated collection that have clear documentation, promote best
   practices, and are regularly updated. They provide a trusted starting point
   for many applications.
 
-- [Verified Publisher](https://hub.docker.com/search?image_filter=store) images
+- [Verified Publisher](https://hub.docker.com/search?badges=verified_publisher) images
   are high-quality images published and maintained by the organizations
   partnering with Docker, with Docker verifying the authenticity of the content
   in their repositories.
 
-- [Docker-Sponsored Open Source](https://hub.docker.com/search?image_filter=open_source)
+- [Docker-Sponsored Open Source](https://hub.docker.com/search?badges=open_source)
   are published and maintained by open source projects sponsored by Docker
   through an [open source program](../../docker-hub/image-library/trusted-content.md#docker-sponsored-open-source-software-images).
 

--- a/content/manuals/build/concepts/dockerfile.md
+++ b/content/manuals/build/concepts/dockerfile.md
@@ -148,7 +148,7 @@ use this notation to name your images. There are many public images you can
 leverage in your projects, by importing them into your build steps using the
 Dockerfile `FROM` instruction.
 
-[Docker Hub](https://hub.docker.com/search?image_filter=official&q=&type=image)
+[Docker Hub](https://hub.docker.com/search?badges=official)
 contains a large set of official images that you can use for this purpose.
 
 ### Environment setup

--- a/content/manuals/docker-hub/repos/manage/trusted-content/dsos-program.md
+++ b/content/manuals/docker-hub/repos/manage/trusted-content/dsos-program.md
@@ -7,7 +7,7 @@ aliases:
   - /trusted-content/dsos-program/
 ---
 
-[Docker-Sponsored Open Source images](https://hub.docker.com/search?q=&image_filter=open_source) are published and maintained by open-source projects sponsored by Docker through the program.
+[Docker-Sponsored Open Source images](https://hub.docker.com/search?badges=open_source) are published and maintained by open-source projects sponsored by Docker through the program.
 
 Images that are part of this program have a special badge on Docker Hub making it easier for users to identify projects that Docker has verified as trusted, secure, and active open-source projects.
 

--- a/content/manuals/docker-hub/repos/manage/trusted-content/dvp-program.md
+++ b/content/manuals/docker-hub/repos/manage/trusted-content/dvp-program.md
@@ -18,7 +18,7 @@ toc_max: 2
 ---
 
 [The Docker Verified Publisher
-Program](https://hub.docker.com/search?q=&image_filter=store) provides
+Program](https://hub.docker.com/search?badges=verified_publisher) provides
 high-quality images from commercial publishers verified by Docker.
 
 These images help development teams build secure software supply chains,


### PR DESCRIPTION
## Description

Docker Hub has changed the URL parameter to filter for content based on category (dsos, dvp, doi).
Updated all external links to use the new `?badges` url param:

- https://hub.docker.com/search?badges=official
- https://hub.docker.com/search?badges=verified_publisher
- https://hub.docker.com/search?badges=open_source

## Related issues or tickets

- Closes #23622
