### PR TITLE
Update environment variable instructions in manual (removed reference to ai gateway)

### DIFF
--- a/content/manuals/ai/cagent/_index.md
+++ b/content/manuals/ai/cagent/_index.md
@@ -45,14 +45,6 @@ they don't share knowledge.
 1. Set the following environment variables:
 
    ```bash
-   # If using the Docker AI Gateway, set this environment variable or use
-   # the `--models-gateway <url_to_docker_ai_gateway>` CLI flag
-
-   export CAGENT_MODELS_GATEWAY=<url_to_docker_ai_gateway>
-
-   # Alternatively, set keys for remote inference services.
-   # These are not needed if you are using Docker AI Gateway.
-
    export OPENAI_API_KEY=<your_api_key_here>    # For OpenAI models
    export ANTHROPIC_API_KEY=<your_api_key_here> # For Anthropic models
    export GOOGLE_API_KEY=<your_api_key_here>    # For Gemini models


### PR DESCRIPTION
Removed instructions for Docker AI Gateway environment variable.

<!--Delete sections as needed -->

## Description

Update environment variable instructions in manual (removed reference to ai gateway) as AI Gateway is not public yet. 



## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review