### PR TITLE
Update control startup example

### DIFF
--- a/content/manuals/compose/how-tos/startup-order.md
+++ b/content/manuals/compose/how-tos/startup-order.md
@@ -42,7 +42,7 @@ services:
   db:
     image: postgres
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s
       retries: 5
       start_period: 30s


### PR DESCRIPTION
## Description

This PR updates control startup example to prevent Compose from interpolating values intended as shell command arguments.

Current example yields the following warnings:

```bash
WARN[0000] The "POSTGRES_USER" variable is not set. Defaulting to a blank string. 
WARN[0000] The "POSTGRES_DB" variable is not set. Defaulting to a blank string. 
```

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review