### PR TITLE
Correct terminology from 'annotations' to 'attestations'

### DIFF
--- a/content/manuals/build/metadata/attestations/_index.md
+++ b/content/manuals/build/metadata/attestations/_index.md
@@ -20,7 +20,7 @@ you to make informed decisions about how an image impacts the supply chain secur
 of your application. It also enables the use of policy engines for validating
 images based on policy rules you've defined.
 
-Two types of build annotations are available:
+Two types of build attestations are available:
 
 - Software Bill of Material (SBOM): list of software artifacts that an image
   contains, or that were used to build the image.


### PR DESCRIPTION
## Description

I might be wrong, but considering the docs page is about attestations, not annotations (there's a separate page for those), I feel like SBOMs and Provenance are in fact **attestations**.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review