### PR TITLE
mcp: dcr oauth support

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/catalog.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/catalog.md
@@ -67,9 +67,16 @@ Local servers offer predictable performance, complete data privacy, and independ
 
 ### Remote MCP servers
 
-Remote MCP servers are hosted services that you connect to through the internet. Service providers maintain and update these servers, ensuring access to current features and live data without requiring local updates or maintenance. Remote servers display a cloud icon {{< inline-image src="../../offload/images/cloud-mode.png" alt="cloud icon" >}} to indicate their hosted nature and external connectivity requirements.
+Remote MCP servers are hosted services that run on the provider's
+infrastructure and connect to external services like GitHub, Notion, and
+Linear. Many remote servers use OAuth authentication. When a remote server
+requires OAuth, the MCP Toolkit handles authentication automatically - you
+authorize access through your browser, and the Toolkit manages credentials
+securely. You don't need to manually create API tokens or configure
+authentication.
 
-Remote servers excel when you need always-current data, want to minimize local resource usage, or require capabilities that benefit from provider-managed infrastructure and scaling.
+Remote servers display a cloud icon in the catalog. For setup instructions, see
+[MCP Toolkit](toolkit.md#oauth-authentication).
 
 ## Use an MCP server from the catalog
 

--- a/content/manuals/ai/mcp-catalog-and-toolkit/faqs.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/faqs.md
@@ -54,6 +54,20 @@ In the upcoming versions of Docker Desktop, Docker plans to support pluggable st
 
 No. MCP servers are not technically uninstalled since they exist as Docker containers pulled to your local Docker Desktop. Removing an MCP server stops the container but leaves the image on your system. Even if the container is deleted, credentials remain stored until you remove them manually.
 
+### Why don't I see remote MCP servers in the catalog?
+
+If remote MCP servers aren't visible in the Docker Desktop catalog, your local
+catalog may be out of date. Remote servers are indicated by a cloud icon and
+include services like GitHub, Notion, and Linear.
+
+Update your catalog by running:
+
+```console
+$ docker mcp catalog update
+```
+
+After the update completes, refresh the **Catalog** tab in Docker Desktop.
+
 ## Related pages
 
 - [Get started with MCP Toolkit](/manuals/ai/mcp-catalog-and-toolkit/get-started.md)

--- a/content/manuals/ai/mcp-catalog-and-toolkit/toolkit.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/toolkit.md
@@ -82,15 +82,60 @@ are invoked, enforced through resource and access limitations.
 
 ### OAuth authentication
 
-Some MCP servers require authentication to access external services. The MCP
-Toolkit handles OAuth flows for supported services, currently limited to
-GitHub. When you authorize the MCP Toolkit to access your GitHub account, any
-installed MCP server that needs GitHub access can use those credentials without
-requiring separate authentication.
+Some MCP servers require authentication to access external services like
+GitHub, Notion, and Linear. The MCP Toolkit handles OAuth authentication
+automatically. You authorize access through your browser, and the Toolkit
+manages credentials securely. You don't need to manually create API tokens or
+configure authentication for each service.
 
-To set up OAuth for a service, use the **OAuth** tab in the MCP Toolkit section
-in Docker Desktop. Once authorized, the credentials are available to any MCP
-server that needs them. You can revoke access at any time from the same tab.
+#### Authorize a server with OAuth
+
+{{< tabs >}}
+{{< tab name="Docker Desktop">}}
+
+1. In Docker Desktop, go to **MCP Toolkit** and select the **Catalog** tab.
+2. Find and add an MCP server that requires OAuth.
+3. In the server's **Configuration** tab, select the **OAuth** authentication
+   method. Follow the link to begin the OAuth authorization.
+4. Your browser opens the authorization page for the service. Follow the
+   on-screen instructions to complete authentication.
+5. Return to Docker Desktop when authentication is complete.
+
+View all authorized services in the **OAuth** tab. To revoke access, select
+**Revoke** next to the service you want to disconnect.
+
+{{< /tab >}}
+{{< tab name="CLI">}}
+
+Enable an MCP server:
+
+```console
+$ docker mcp server enable github-official
+```
+
+If the server requires OAuth, authorize the connection:
+
+```console
+$ docker mcp oauth authorize github
+```
+
+Your browser opens the authorization page. Complete the authentication process,
+then return to your terminal.
+
+View authorized services:
+
+```console
+$ docker mcp oauth ls
+```
+
+Revoke access to a service:
+
+```console
+$ docker mcp oauth revoke github
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Usage examples
 
@@ -102,7 +147,7 @@ interact with your GitHub account:
 
 1. From the **MCP Toolkit** menu in Docker Desktop, select the **Catalog** tab
    and find the **GitHub Official** server and add it.
-2. In the server's **Config** tab, authenticate via OAuth.
+2. In the server's **Configuration** tab, authenticate via OAuth.
 3. In the **Clients** tab, ensure Gordon is connected.
 4. From the **Ask Gordon** menu, you can now send requests related to your
    GitHub account, in accordance to the tools provided by the GitHub Official


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Description

Updates MCP documentation to reflect that DCR Oauth is supported for remote
servers.

## Related issues or tickets

Closes https://docker.atlassian.net/browse/ENGDOCS-3103
