### PR TITLE
engine: update ubuntu installation instructions to use deb822, apt

### DIFF
--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -301,7 +301,7 @@ To upgrade Docker Engine, download the newer package files and repeat the
 3. Remove source list and keyrings
 
    ```console
-   $ sudo rm /etc/apt/sources.list.d/docker.list
+   $ sudo rm /etc/apt/sources.list.d/docker.sources
    $ sudo rm /etc/apt/keyrings/docker.asc
    ```
 


### PR DESCRIPTION
## Description

- **engine: use deb822 apt source format in ubuntu install**
- **engine: change apt-get to apt in ubuntu install**

## Related issues or tickets

Follow-ups to:

- #23249
- #23679
