### PR TITLE
Fix: add doc of DNS fallback

### DIFF
--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -190,6 +190,11 @@ You can configure DNS resolution on a per-container basis, using flags for the
 The following table describes the available `docker run` flags related to DNS
 configuration.
 
+> [!NOTE]
+>
+> In case no non-localhost DNS is defined in the `/etc/resolve.conf`,
+> Docker Engine automatically adds a fallback DNS configuration using public Google DNS servers (8.8.8.8 and 8.8.4.4).
+
 | Flag           | Description                                                                                                                                                                                                                                           |
 | -------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--dns`        | The IP address of a DNS server. To specify multiple DNS servers, use multiple `--dns` flags. DNS requests will be forwarded from the container's network namespace so, for example, `--dns=127.0.0.1` refers to the container's own loopback address. |


### PR DESCRIPTION
## Description

Add a note explaining that Docker Engine falls back to Google Public DNS servers (8.8.8.8 and 8.8.4.4) when /etc/resolv.conf contains only localhost or no valid DNS entries. 

## Related issues or tickets

#22945 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review