### PR TITLE
engine: document LimitNOFILE change in engine v29 / containerd v2.1.5

### DIFF
--- a/content/manuals/engine/release-notes/25.0.md
+++ b/content/manuals/engine/release-notes/25.0.md
@@ -217,9 +217,9 @@ For a full list of pull requests and changes in this release, refer to the relev
   `LimitNOFILE=1048576`.
 
   This change currently only affects build containers created with `docker
-  build` when using BuildKit with the `docker` driver. Future versions of
-  containerd will also use this limit, which will cause this behavior to affect
-  all containers, not only build containers.
+  build` when using BuildKit with the `docker` driver. Starting with Docker
+  Engine v29.0 (containerd v2.1.5), this limit applies to all containers, not
+  only build containers.
 
   If you're experiencing issues with the higher ulimit in systemd v240 or later,
   consider adding a system `drop-in` or `override` file to configure the ulimit

--- a/content/manuals/engine/release-notes/29.md
+++ b/content/manuals/engine/release-notes/29.md
@@ -98,6 +98,32 @@ For a full list of pull requests and changes in this release, refer to the relev
 - The Windows overlay network driver now supports option `--dns`. [moby/moby#51229](https://github.com/moby/moby/pull/51229)
 - Update BuildKit to [v0.25.2](https://github.com/moby/buildkit/releases/tag/v0.25.2). [moby/moby#51397](https://github.com/moby/moby/pull/51397)
 - Update containerd to [v2.1.5](https://github.com/containerd/containerd/releases/tag/v2.1.5). [moby/moby#51409](https://github.com/moby/moby/pull/51409)
+
+  containerd v2.1.5 now uses systemd's default `LimitNOFILE` for containers,
+  changing the open file descriptor limit (`ulimit -n`) from `1048576` to
+  `1024`. This extends a change introduced in Docker Engine v25.0 for build
+  containers to all containers.
+
+  This prevents programs that adjust behavior based on ulimits from consuming
+  excessive memory when the limit is set to `infinity`. Containers now behave
+  the same way as programs running on the host.
+
+  If your workload needs a higher limit, use `--ulimit` with `docker run`, or
+  set defaults in `/etc/docker/daemon.json`:
+
+  ```json
+  {
+    "default-ulimits": {
+      "nofile": {
+        "Name": "nofile",
+        "Soft": 1048576,
+        "Hard": 1048576
+      }
+    }
+  }
+  ```
+
+  For more information, see [moby#51485](https://github.com/moby/moby/issues/51485).
 - Update Go runtime to [1.25.4](https://go.dev/doc/devel/release#go1.25.4). [moby/moby#51418](https://github.com/moby/moby/pull/51418), [docker/cli#6632](https://github.com/docker/cli/pull/6632)
 - Users can request a specific prefix size for networks allocated from the default pools by using the unspecified address, for example `--subnet 0.0.0.0/24 --subnet ::/96`. [moby/moby#50114](https://github.com/moby/moby/pull/50114)
 


### PR DESCRIPTION
## Description

Adds a callout to the v29 release note to explain the new ulimit setting.

## Related issues or tickets

- closes moby/moby#51485
