### PR TITLE
docs: update dnf repo installation commands

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -83,12 +83,8 @@ Docker from the repository.
 
 #### Set up the repository
 
-Install the `dnf-plugins-core` package (which provides the commands to manage
-your DNF repositories) and set up the repository.
-
 ```console
-$ sudo dnf -y install dnf-plugins-core
-$ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
+$ sudo dnf config-manager addrepo --from-repofile {{% param "download-url-base" %}}/docker-ce.repo
 ```
 
 #### Install Docker Engine


### PR DESCRIPTION
## Description

dnf5 is used by default since Fedora 41:
https://fedoraproject.org/wiki/Releases/41/ChangeSet#Switch_to_dnf5

It comes with `config-manager` by default, albeit with slightly different CLI arguments.

I've tested it on Fedora 43.

## Related issues

- Follow-up to #21037
- Closes #22371
- Closes #21543