### PR TITLE
feat: Add `expires_at` to PAT management

### DIFF
--- a/content/reference/api/hub/changelog.md
+++ b/content/reference/api/hub/changelog.md
@@ -15,6 +15,12 @@ issues for Docker Service APIs.
 
 ---
 
+## 2025-11-21
+
+### Updates
+
+- Add missing `expires_at` fields on [PAT management](/reference/api/hub/latest/#tag/access-tokens) endpoints.
+
 ## 2025-09-25
 
 ### Updates

--- a/content/reference/api/hub/latest.yaml
+++ b/content/reference/api/hub/latest.yaml
@@ -1106,7 +1106,7 @@ paths:
         Updates the immutable tags configuration for this repository.
         
         **Only users with administrative privileges for the repository can modify these settings.**
-      tags: 
+      tags:
         - repositories
       security:
         - bearerAuth: []
@@ -3213,6 +3213,10 @@ components:
             - repo:read
           items:
             type: string
+        expires_at:
+          type: string
+          format: date-time
+          example: "2021-10-28T18:30:19.520861Z"
     createAccessTokenRequest:
       type: object
       required:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- feat: Add expiry fields to PAT management API endpoints.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review