### PR TITLE
Update typescript examples for e2b quickstart

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/e2b-sandboxes.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/e2b-sandboxes.md
@@ -96,7 +96,7 @@ import { Sandbox } from "e2b";
 async function quickstart(): Promise<void> {
   console.log("Creating E2B sandbox with Notion and GitHub MCP servers...\n");
 
-  const sbx: Sandbox = await Sandbox.betaCreate({
+  const sbx: Sandbox = await Sandbox.create({
     envs: {
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY as string,
     },
@@ -111,8 +111,8 @@ async function quickstart(): Promise<void> {
     },
   });
 
-  const mcpUrl: string = sbx.betaGetMcpUrl();
-  const mcpToken: string = await sbx.betaGetMcpToken();
+  const mcpUrl = sbx.getMcpUrl();
+  const mcpToken = await sbx.getMcpToken();
 
   console.log("Sandbox created successfully!");
   console.log(`MCP Gateway URL: ${mcpUrl}\n`);
@@ -254,7 +254,7 @@ import { Sandbox } from "e2b";
 async function exampleWorkflow(): Promise<void> {
   console.log("Creating sandbox...\n");
 
-  const sbx: Sandbox = await Sandbox.betaCreate({
+  const sbx: Sandbox = await Sandbox.create({
     envs: {
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY as string,
     },
@@ -269,8 +269,8 @@ async function exampleWorkflow(): Promise<void> {
     },
   });
 
-  const mcpUrl: string = sbx.betaGetMcpUrl();
-  const mcpToken: string = await sbx.betaGetMcpToken();
+  const mcpUrl = sbx.getMcpUrl();
+  const mcpToken = await sbx.getMcpToken();
 
   console.log("Sandbox created successfully\n");
 


### PR DESCRIPTION
The commands for creating a sandbox as well as retreiving the sandbox URL and access token were no longer beta so they method names needed to be changed.

## Description

Some of the commands in the typescript examples were no longer in beta, so I updated the relevant function calls to drop the "beta" tag. 

Also, the functions could return string or undefined, and were typed a string which caused problems. 


## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review