### PR TITLE
Update s3 cache options

### DIFF
--- a/content/manuals/build/cache/backends/s3.md
+++ b/content/manuals/build/cache/backends/s3.md
@@ -58,7 +58,7 @@ Alternatively, you can use the `access_key_id`, `secret_access_key`, and
 Refer to [AWS Go SDK, Specifying Credentials][3] for details about
 authentication using environment variables and credentials file.
 
-[3]: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+[3]: https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials
 
 ## Further reading
 


### PR DESCRIPTION
## Description

Add missing S3 `prefix` option, and update existing options which lacked current defaults.

A link regarding authentication pointed to an old, EOL API which was also updated; an equivalent link should be fixed in buildkit docs as well (https://github.com/moby/buildkit/pull/6379).

The description I added for `prefix` is a little vague.  The buildkit docs for that option in particular is also vague, but makes sense in the context of the documentation for other options.  I opted to stay consistent with the language and brevity of the surrounding docs, leaving it to buildkit docs  to clarify how it works.

## Reviews


<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review