### PR TITLE
docs(guide): Update CockroachDB setup commands with correct image tag

### DIFF
--- a/content/guides/golang/develop.md
+++ b/content/guides/golang/develop.md
@@ -89,13 +89,13 @@ $ docker run -d \
   -p 26257:26257 \
   -p 8080:8080 \
   -v roach:/cockroach/cockroach-data \
-  cockroachdb/cockroach:latest-v20.1 start-single-node \
+  cockroachdb/cockroach:latest-v25.4 start-single-node \
   --insecure
 
 # ... output omitted ...
 ```
 
-Notice a clever use of the tag `latest-v20.1` to make sure that you're pulling the latest patch version of 20.1. The diversity of available tags depend on the image maintainer. Here, your intent was to have the latest patched version of CockroachDB while not straying too far away from the known working version as the time goes by. To see the tags available for the CockroachDB image, you can go to the [CockroachDB page on Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach/tags).
+Notice a clever use of the tag `latest-v25.4` to make sure that you're pulling the latest patch version of 25.4. The diversity of available tags depend on the image maintainer. Here, your intent was to have the latest patched version of CockroachDB while not straying too far away from the known working version as the time goes by. To see the tags available for the CockroachDB image, you can go to the [CockroachDB page on Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach/tags).
 
 ### Configure the database engine
 
@@ -473,7 +473,7 @@ $ docker run -d \
   -p 26257:26257 \
   -p 8080:8080 \
   -v roach:/cockroach/cockroach-data \
-  cockroachdb/cockroach:latest-v20.1 start-single-node \
+  cockroachdb/cockroach:latest-v25.4 start-single-node \
   --insecure
 ```
 
@@ -548,7 +548,7 @@ services:
       restart_policy:
         condition: on-failure
   roach:
-    image: cockroachdb/cockroach:latest-v20.1
+    image: cockroachdb/cockroach:latest-v25.4
     container_name: roach
     hostname: db
     networks:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This PR fixes broken `docker` commands in the CockroachDB setup guide by updating the image tag to a currently supported version.

### Why is this change needed?

The existing command used the image tag `:latest-v20.1`, which is no longer available on Docker Hub (verified by the error: `docker.io/cockroachdb/cockroach:latest-v20.1: not found`). This caused the setup guide to fail for all new users.

## Reviews

@dvdksn


- [ ] Technical review
- [ ] Editorial review
- [ ] Product review