### PR TITLE
hack: Add script to sync Moby release notes from docs

### DIFF
--- a/hack/moby-sync-release.sh
+++ b/hack/moby-sync-release.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Update the Github release notes to match the release notes from the docs.
+set -euo pipefail
+
+version="${1:-}"
+
+if [ -z "$version" ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+moby="moby/moby"
+version="${version#v}" # remove the v prefix
+major_version="${version%%.*}" # get the major version (e.g. 29.0.3 -> 29)
+moby_tag="docker-v${version}"
+
+docs_notes=$(mktemp   -t new)
+github_notes=$(mktemp -t old)
+
+# Get the release notes from the docs.
+grep -A 10000 "## ${version}" "content/manuals/engine/release-notes/${major_version}.md" | \
+    grep -m 2 -A 0 -B 10000 '^## ' | \
+    sed '$d' | `# remove the last line` \
+    sed '/{{< release-date /{N;d;}' \
+    > "$docs_notes"
+
+# Get the release notes from the Github.
+curl -s "https://api.github.com/repos/$moby/releases/tags/${moby_tag}" | jq -r '.body' | sed 's/\r$//' > "$github_notes"
+
+docs_notes_diff=$(mktemp -t diff)
+# Copy docs_notes content and ensure it has exactly 2 blank lines at the end
+# Because Github for some reason adds an extra newline at the end of the release notes.
+sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$docs_notes" > "$docs_notes_diff"
+printf '\n\n' >> "$docs_notes_diff"
+
+# Compare the release notes.
+if diff -u --color=auto "$github_notes" "$docs_notes_diff"; then
+    printf '\033[0;32mThe release notes are already up to date.\033[0m\n'
+    exit 0
+fi
+
+echo '========================================'
+printf '\033[0;34mTo update the release notes run the following command:\033[0m\n\n'
+echo gh -R moby/moby release edit "$moby_tag" --notes-file "$docs_notes"


### PR DESCRIPTION
This script helps maintain consistency between documentation and GitHub release notes by making the docs the source of truth.

Previously, any djustments to release notes during review, needed to be manually propagated back to the corresponding Moby GitHub releases, creating a maintenance burden and potential for inconsistency.

The script extracts release notes for a given version from the engine documentation markdown files, compares them with the existing GitHub release notes, and provides a command to update the GitHub release if differences are found.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review