### PR TITLE
Align with more common way to install softwares on Debian

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -110,18 +110,20 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt update
-   sudo apt install ca-certificates curl
+   sudo apt install ca-certificates
    sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
-   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   wget -qO- {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
-   # Add the repository to Apt sources:
+   # Add the repository to Apt sources. This command uses Bash syntax.
+   # If you are using different shell, please run `bash` to switch to Bash
+   # before running the following command.
    sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
    Types: deb
    URIs: {{% param "download-url-base" %}}
    Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
    Components: stable
-   Signed-By: /etc/apt/keyrings/docker.asc
+   Signed-By: /etc/apt/keyrings/docker.gpg
    EOF
 
    sudo apt update

--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -110,7 +110,6 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt update
-   sudo apt install ca-certificates
    sudo install -m 0755 -d /etc/apt/keyrings
    wget -qO- {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
    sudo chmod a+r /etc/apt/keyrings/docker.gpg

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -127,18 +127,20 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt update
-   sudo apt install ca-certificates curl
+   sudo apt install ca-certificates
    sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
-   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   wget -qO- {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
-   # Add the repository to Apt sources:
+   # Add the repository to Apt sources. This command uses Bash syntax.
+   # If you are using different shell, please run `bash` to switch to Bash
+   # before running the following command.
    sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
    Types: deb
    URIs: {{% param "download-url-base" %}}
    Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
    Components: stable
-   Signed-By: /etc/apt/keyrings/docker.asc
+   Signed-By: /etc/apt/keyrings/docker.gpg
    EOF
 
    sudo apt update

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -127,7 +127,6 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt update
-   sudo apt install ca-certificates
    sudo install -m 0755 -d /etc/apt/keyrings
    wget -qO- {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
    sudo chmod a+r /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Update install guide for Debian / Ubuntu to align with common practice on these platforms.

- Replace `curl` with `wget`, because `wget` is pre-included in Debian / Ubuntu, whereas `curl` needs to be installed by users.
- Use `gpg` to "dearmor` the GPG key (base64 -> binary). Though `APT` supports "armored" key, it still recommends to use non-armored one.
- Add note for non-Bash users.