### PR TITLE
fix: set "production" as hugo environment in prod

### DIFF
--- a/hack/releaser/env.json
+++ b/hack/releaser/env.json
@@ -9,7 +9,7 @@
     "DOCS_LAMBDA_FUNCTION_REDIRECTS": "DockerDocsRedirectFunction-labs"
   },
   "refs/heads/main": {
-    "HUGO_ENV": "prod",
+    "HUGO_ENV": "production",
     "DOCS_URL": "https://docs.docker.com",
     "DOCS_AWS_IAM_ROLE": "arn:aws:iam::710015040892:role/prod-docs-docs.docker.com-20220818202218674300000001",
     "DOCS_AWS_REGION": "us-east-1",


### PR DESCRIPTION
## Description

Use `production` instead of `prod` as the hugo environment for main site builds.

Fixes missing feedback widget on docs site.

## Related issues or tickets

- follow-up to #23591

https://github.com/docker/docs/pull/23591/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L35

https://github.com/docker/docs/pull/23591/files#diff-74ab793ae9f46206c77edcc2244a7ec82f48cd72eb961c9b71d6afa6e48cfca2R12