### PR TITLE
Fix image paths in Claude Code MCP guide

### DIFF
--- a/content/guides/genai-claude-code-mcp/claude-code-mcp-guide.md
+++ b/content/guides/genai-claude-code-mcp/claude-code-mcp-guide.md
@@ -73,11 +73,11 @@ Make sure you have:
 1. [Create a read-only personal access token](/security/access-tokens/#create-a-personal-access-token) and enter your access token under **Secrets**
 1. Save the configuration
 
-![Docker Hub](./images/catalog_docker_hub.avif "Docker Hub")
+![Docker Hub](./Images/catalog_docker_hub.avif "Docker Hub")
 
 Public images work without credentials. For private repositories, you can add your Docker Hub username and token later.
 
-![Docker Hub Secrets](./images/dockerhub_secrets.avif "Docker Hub Secrets")
+![Docker Hub Secrets](./Images/dockerhub_secrets.avif "Docker Hub Secrets")
 
 
 ---
@@ -93,7 +93,7 @@ You can connect from Docker Desktop or using the CLI.
 1. Locate **Claude Code**  
 1. Select **Connect**
 
-![Docker Connection](./images/docker-connect-claude.avif)
+![Docker Connection](./Images/docker-connect-claude.avif)
 
 ### Option B. Connect using the CLI
 
@@ -128,7 +128,7 @@ You should now see:
 - The MCP gateway (for example `MCP_DOCKER`)
 - Tools provided by the Docker Hub MCP server
 
-![mcp-docker](./images/mcp-servers.avif)
+![mcp-docker](./Images/mcp-servers.avif)
 
 If not, restart Claude Code or check Docker Desktop to confirm the connection.
 
@@ -268,7 +268,7 @@ Open your browser:
 ```console
 http://localhost:3000
 ```
-![Local Host](./images/Localhost.avif)
+![Local Host](./Images/Localhost.avif)
 
 Your Node.js app should now be running.
 


### PR DESCRIPTION



## Description

This update fixes the incorrect image paths in the **Claude Code MCP guide** located under
`content/guides/genai-claude-code-mcp/`.

The previous paths did not match the referenced images path directory. This patch standardizes all image references to the correct relative paths so the guide renders properly in the Docker Docs build pipeline (Netlify/Hugo).

No content changes were made — only image path corrections to ensure the guide displays as intended.

---

## Related issues or tickets

N/A — build fix for newly added guide content.

---

## Reviews

Notes for reviewers:

* All image URLs now point to valid files inside the `Images/` directory.
* Fix resolves Netlify build errors related to missing/invalid image paths.
* No content or structural changes — only asset path corrections.
* Safe to merge once documentation preview renders cleanly.

Checklist:

* [ ] Technical review
* [ ] Editorial review
* [ ] Product review

---

If you want, I can help rewrite the entire PR description into a more “Docker Docs style” version too.
