### PR TITLE
chore: change mount path to work with postgres:18

### DIFF
--- a/content/get-started/docker-concepts/running-containers/overriding-container-defaults.md
+++ b/content/get-started/docker-concepts/running-containers/overriding-container-defaults.md
@@ -152,7 +152,7 @@ Sometimes, you might need to override the default commands (`CMD`) or entry poin
     ```yaml
     services:
       postgres:
-        image: postgres
+        image: postgres:18
         entrypoint: ["docker-entrypoint.sh", "postgres"]
         command: ["-h", "localhost", "-p", "5432"]
         environment:

--- a/content/get-started/docker-concepts/running-containers/persisting-container-data.md
+++ b/content/get-started/docker-concepts/running-containers/persisting-container-data.md
@@ -53,7 +53,7 @@ Volumes have their own lifecycle beyond that of containers and can grow quite la
 
 ## Try it out
 
-In this guide, you’ll practice creating and using volumes to persist data created by a Postgres container. When the database runs, it stores files into the `/var/lib/postgresql/data` directory. By attaching the volume here, you will be able to restart the container multiple times while keeping the data.
+In this guide, you'll practice creating and using volumes to persist data created by a Postgres container. When the database runs, it stores files into the `/var/lib/postgresql` directory. By attaching the volume here, you will be able to restart the container multiple times while keeping the data.
 
 ### Use volumes
 
@@ -62,7 +62,7 @@ In this guide, you’ll practice creating and using volumes to persist data crea
 2. Start a container using the [Postgres image](https://hub.docker.com/_/postgres) with the following command:
 
     ```console
-    $ docker run --name=db -e POSTGRES_PASSWORD=secret -d -v postgres_data:/var/lib/postgresql/data postgres
+    $ docker run --name=db -e POSTGRES_PASSWORD=secret -d -v postgres_data:/var/lib/postgresql postgres:18
     ```
 
     This will start the database in the background, configure it with a password, and attach a volume to the directory PostgreSQL will persist the database files.
@@ -115,7 +115,7 @@ In this guide, you’ll practice creating and using volumes to persist data crea
 8. Start a new container by running the following command, attaching the same volume with the persisted data:
 
     ```console
-    $ docker run --name=new-db -d -v postgres_data:/var/lib/postgresql/data postgres 
+    $ docker run --name=new-db -d -v postgres_data:/var/lib/postgresql postgres:18
     ```
 
     You might have noticed that the `POSTGRES_PASSWORD` environment variable has been omitted. That’s because that variable is only used when bootstrapping a new database.

--- a/content/guides/dotnet/deploy.md
+++ b/content/guides/dotnet/deploy.md
@@ -96,7 +96,7 @@ spec:
               value: example
             - name: POSTGRES_PASSWORD
               value: example
-          image: postgres
+          image: postgres:18
           name: db
           ports:
             - containerPort: 5432

--- a/content/guides/dotnet/develop.md
+++ b/content/guides/dotnet/develop.md
@@ -97,13 +97,13 @@ services:
       db:
         condition: service_healthy
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
@@ -250,13 +250,13 @@ services:
         - action: rebuild
           path: .
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
@@ -355,13 +355,13 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password

--- a/content/guides/frameworks/laravel/development-setup.md
+++ b/content/guides/frameworks/laravel/development-setup.md
@@ -285,7 +285,7 @@ services:
       - laravel-development
 
   postgres:
-    image: postgres:16
+    image: postgres:18
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     environment:
@@ -293,7 +293,7 @@ services:
       - POSTGRES_USER=laravel
       - POSTGRES_PASSWORD=secret
     volumes:
-      - postgres-data-development:/var/lib/postgresql/data
+      - postgres-data-development:/var/lib/postgresql
     networks:
       - laravel-development
 

--- a/content/guides/frameworks/laravel/production-setup.md
+++ b/content/guides/frameworks/laravel/production-setup.md
@@ -371,7 +371,7 @@ services:
       - laravel
 
   postgres:
-    image: postgres:16
+    image: postgres:18
     restart: unless-stopped
     user: postgres
     ports:
@@ -381,7 +381,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USERNAME}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
-      - postgres-data-production:/var/lib/postgresql/data
+      - postgres-data-production:/var/lib/postgresql
     networks:
       - laravel-production
     # Health check for PostgreSQL

--- a/content/guides/genai-claude-code-mcp/claude-code-mcp-guide.md
+++ b/content/guides/genai-claude-code-mcp/claude-code-mcp-guide.md
@@ -227,13 +227,13 @@ services:
       - app-net
 
   db:
-    image: postgres:<tag>
+    image: postgres:18
     environment:
       POSTGRES_USER: example
       POSTGRES_PASSWORD: example
       POSTGRES_DB: appdb
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     ports:
       - "5432:5432"
     networks:

--- a/content/guides/golang/deploy.md
+++ b/content/guides/golang/deploy.md
@@ -109,7 +109,7 @@ spec:
               value: whatever
             - name: POSTGRES_USER
               value: postgres
-          image: postgres
+          image: postgres:18
           name: db
           ports:
             - containerPort: 5432

--- a/content/guides/java/containerize.md
+++ b/content/guides/java/containerize.md
@@ -209,13 +209,13 @@ services:
 #       db:
 #         condition: service_healthy
 #   db:
-#     image: postgres
+#     image: postgres:18
 #     restart: always
 #     user: postgres
 #     secrets:
 #       - db-password
 #     volumes:
-#       - db-data:/var/lib/postgresql/data
+#       - db-data:/var/lib/postgresql
 #     environment:
 #       - POSTGRES_DB=example
 #       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password

--- a/content/guides/java/develop.md
+++ b/content/guides/java/develop.md
@@ -62,10 +62,10 @@ services:
     environment:
       - POSTGRES_URL=jdbc:postgresql://db:5432/petclinic
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=petclinic
       - POSTGRES_USER=petclinic
@@ -193,10 +193,10 @@ services:
     environment:
       - POSTGRES_URL=jdbc:postgresql://db:5432/petclinic
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=petclinic
       - POSTGRES_USER=petclinic
@@ -345,10 +345,10 @@ services:
         - action: rebuild
           path: .
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=petclinic
       - POSTGRES_USER=petclinic

--- a/content/guides/nodejs/configure-github-actions.md
+++ b/content/guides/nodejs/configure-github-actions.md
@@ -160,7 +160,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_DB: todoapp_test
           POSTGRES_USER: postgres

--- a/content/guides/nodejs/containerize.md
+++ b/content/guides/nodejs/containerize.md
@@ -210,14 +210,14 @@ services:
   # PostgreSQL Database Service
   # ========================================
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: todoapp-db
     environment:
       POSTGRES_DB: '${POSTGRES_DB:-todoapp}'
       POSTGRES_USER: '${POSTGRES_USER:-todoapp}'
       POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:-todoapp_password}'
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - '${DB_PORT:-5432}:5432'
     restart: unless-stopped

--- a/content/guides/nodejs/deploy.md
+++ b/content/guides/nodejs/deploy.md
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:16-alpine
+          image: postgres:18-alpine
           ports:
             - containerPort: 5432
               name: postgres
@@ -134,7 +134,7 @@ spec:
                   key: postgres-password
           volumeMounts:
             - name: postgres-storage
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
           livenessProbe:
             exec:
               command:

--- a/content/guides/nodejs/develop.md
+++ b/content/guides/nodejs/develop.md
@@ -38,14 +38,14 @@ services:
   # PostgreSQL Database Service
   # ========================================
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: todoapp-db
     environment:
       POSTGRES_DB: '${POSTGRES_DB:-todoapp}'
       POSTGRES_USER: '${POSTGRES_USER:-todoapp}'
       POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:-todoapp_password}'
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - '${DB_PORT:-5432}:5432'
     restart: unless-stopped
@@ -133,14 +133,14 @@ services:
       - todoapp-network
 
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: todoapp-db
     environment:
       POSTGRES_DB: '${POSTGRES_DB:-todoapp}'
       POSTGRES_USER: '${POSTGRES_USER:-todoapp}'
       POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:-todoapp_password}'
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - '${DB_PORT:-5432}:5432'
     restart: unless-stopped

--- a/content/guides/pgadmin.md
+++ b/content/guides/pgadmin.md
@@ -30,7 +30,7 @@ In this guide you will learn how to:
     ```yaml
     services:
       postgres:
-        image: postgres:17.4
+        image: postgres:18
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: secret

--- a/content/guides/pre-seeding.md
+++ b/content/guides/pre-seeding.md
@@ -179,7 +179,7 @@ $ docker container stop postgres
 
    ```plaintext
    # syntax=docker/dockerfile:1
-   FROM postgres:latest
+   FROM postgres:18
    COPY seed.sql /docker-entrypoint-initdb.d/
    ```
 
@@ -204,7 +204,7 @@ $ docker container stop postgres
        ports:
          - "5432:5432"
        volumes:
-         - data_sql:/var/lib/postgresql/data   # Persistent data storage
+         - data_sql:/var/lib/postgresql   # Persistent data storage
 
    volumes:
      data_sql:

--- a/content/guides/python/deploy.md
+++ b/content/guides/python/deploy.md
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres
+          image: postgres:18
           ports:
             - containerPort: 5432
           env:
@@ -56,7 +56,7 @@ spec:
                   key: POSTGRES_PASSWORD
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
       volumes:
         - name: postgres-data
           persistentVolumeClaim:

--- a/content/guides/python/develop.md
+++ b/content/guides/python/develop.md
@@ -205,13 +205,13 @@ You'll need to clone a new repository to get a sample application that includes 
    #       db:
    #         condition: service_healthy
    #   db:
-   #     image: postgres
+   #     image: postgres:18
    #     restart: always
    #     user: postgres
    #     secrets:
    #       - db-password
    #     volumes:
-   #       - db-data:/var/lib/postgresql/data
+   #       - db-data:/var/lib/postgresql
    #     environment:
    #       - POSTGRES_DB=example
    #       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
@@ -358,13 +358,13 @@ services:
     secrets:
       - db-password
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
@@ -501,13 +501,13 @@ services:
         - action: rebuild
           path: .
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password

--- a/content/guides/r/develop.md
+++ b/content/guides/r/develop.md
@@ -65,13 +65,13 @@ services:
     secrets:
       - db-password
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
@@ -172,13 +172,13 @@ services:
         - action: rebuild
           path: .
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password

--- a/content/guides/ruby/develop.md
+++ b/content/guides/ruby/develop.md
@@ -41,13 +41,13 @@ services:
       - RAILS_ENV=test
     env_file: "webapp.env"
   db:
-    image: postgres:latest
+    image: postgres:18
     secrets:
       - db-password
     environment:
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
 volumes:
   postgres_data:
@@ -153,13 +153,13 @@ services:
         - action: rebuild
           path: .
   db:
-    image: postgres:latest
+    image: postgres:18
     secrets:
       - db-password
     environment:
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
 volumes:
   postgres_data:

--- a/content/guides/rust/deploy.md
+++ b/content/guides/rust/deploy.md
@@ -106,7 +106,7 @@ spec:
               value: mysecretpassword
             - name: POSTGRES_USER
               value: postgres
-          image: postgres
+          image: postgres:18
           name: db
           ports:
             - containerPort: 5432

--- a/content/guides/rust/develop.md
+++ b/content/guides/rust/develop.md
@@ -44,13 +44,13 @@ In the following command, option `--mount` is for starting the container with a 
 
 ```console
 $ docker run --rm -d --mount \
-  "type=volume,src=db-data,target=/var/lib/postgresql/data" \
+  "type=volume,src=db-data,target=/var/lib/postgresql" \
   -p 5432:5432 \
   --network postgresnet \
   --name db \
   -e POSTGRES_PASSWORD=mysecretpassword \
   -e POSTGRES_DB=example \
-  postgres
+  postgres:18
 ```
 
 Now, make sure that your PostgreSQL database is running and that you can connect to it. Connect to the running PostgreSQL database inside the container.
@@ -258,13 +258,13 @@ services:
       db:
         condition: service_healthy
   db:
-    image: postgres
+    image: postgres:18
     restart: always
     user: postgres
     secrets:
       - db-password
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password

--- a/content/manuals/compose/how-tos/multiple-compose-files/merge.md
+++ b/content/manuals/compose/how-tos/multiple-compose-files/merge.md
@@ -252,8 +252,8 @@ For more merging rules, see [Merge and override](/reference/compose-file/merge.m
 
    ```console
    $ docker compose -f ~/sandbox/rails/compose.yaml pull db
-   Pulling db (postgres:latest)...
-   latest: Pulling from library/postgres
+   Pulling db (postgres:18)...
+   18: Pulling from library/postgres
    ef0380f84d05: Pull complete
    50cf91dc1db8: Pull complete
    d3add4cd115c: Pull complete
@@ -268,7 +268,7 @@ For more merging rules, see [Merge and override](/reference/compose-file/merge.m
    dcca70822752: Pull complete
    cecf11b8ccf3: Pull complete
    Digest: sha256:1364924c753d5ff7e2260cd34dc4ba05ebd40ee8193391220be0f9901d4e1651
-   Status: Downloaded newer image for postgres:latest
+   Status: Downloaded newer image for postgres:18
    ```
 
 ## Example
@@ -292,7 +292,7 @@ services:
       - cache
 
   db:
-    image: postgres:latest
+    image: postgres:18
 
   cache:
     image: redis:latest

--- a/content/manuals/compose/how-tos/networking.md
+++ b/content/manuals/compose/how-tos/networking.md
@@ -31,7 +31,7 @@ services:
     ports:
       - "8000:8000"
   db:
-    image: postgres
+    image: postgres:18
     ports:
       - "8001:5432"
 ```
@@ -80,7 +80,7 @@ services:
     links:
       - "db:database"
   db:
-    image: postgres
+    image: postgres:18
 ```
 
 See the [links reference](/reference/compose-file/services.md#links) for more information.
@@ -116,7 +116,7 @@ services:
       - frontend
       - backend
   db:
-    image: postgres
+    image: postgres:18
     networks:
       - backend
 
@@ -155,7 +155,7 @@ services:
     ports:
       - "8000:8000"
   db:
-    image: postgres
+    image: postgres:18
 
 networks:
   default:

--- a/content/manuals/compose/how-tos/startup-order.md
+++ b/content/manuals/compose/how-tos/startup-order.md
@@ -40,7 +40,7 @@ services:
   redis:
     image: redis
   db:
-    image: postgres
+    image: postgres:18
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s

--- a/content/reference/compose-file/networks.md
+++ b/content/reference/compose-file/networks.md
@@ -46,7 +46,7 @@ services:
       - frontend
       - backend
   db:
-    image: postgres
+    image: postgres:18
     networks:
       - backend
 

--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -38,7 +38,7 @@ services:
       - "8080:80"
 
   db:
-    image: postgres:13
+    image: postgres:18
     environment:
       POSTGRES_USER: example
       POSTGRES_DB: exampledb
@@ -433,7 +433,7 @@ services:
   redis:
     image: redis
   db:
-    image: postgres
+    image: postgres:18
 ```
 
 Compose guarantees dependency services have been started before
@@ -485,7 +485,7 @@ services:
   redis:
     image: redis
   db:
-    image: postgres
+    image: postgres:18
 ```
 
 Compose guarantees dependency services are started before


### PR DESCRIPTION
## Description

Changes the mount path for postgres examples to work with `postgres:18`

## Related issues or tickets

- https://github.com/docker-library/postgres/pull/1259
- closes #23789
- closes #23791
