### PR TITLE
build: deprecate install input for setup-buildx-action

### DIFF
--- a/content/manuals/build-cloud/ci.md
+++ b/content/manuals/build-cloud/ci.md
@@ -100,7 +100,6 @@ jobs:
         with:
           driver: cloud
           endpoint: "${{ vars.DOCKER_ACCOUNT }}/${{ vars.CLOUD_BUILDER_NAME }}" # for example, "acme/default"
-          install: true
       
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -110,6 +109,31 @@ jobs:
           # Otherwise, push to a registry.
           outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || 'type=registry' }}
 ```
+
+The example above uses `docker/build-push-action`, which automatically uses the
+builder set up by `setup-buildx-action`. If you need to use the `docker build`
+command directly instead, you have two options:
+
+- Use `docker buildx build` instead of `docker build`
+- Set the `BUILDX_BUILDER` environment variable to use the cloud builder:
+
+  ```yaml
+  - name: Set up Docker Buildx
+    id: builder
+    uses: docker/setup-buildx-action@v3
+    with:
+      driver: cloud
+      endpoint: "${{ vars.DOCKER_ACCOUNT }}/${{ vars.CLOUD_BUILDER_NAME }}"
+
+  - name: Build
+    run: |
+      docker build .
+    env:
+      BUILDX_BUILDER: ${{ steps.builder.outputs.name }}
+  ```
+
+For more information about the `BUILDX_BUILDER` environment variable, see
+[Build variables](/manuals/build/building/variables.md#buildx_builder).
 
 ### GitLab
 

--- a/content/manuals/build-cloud/usage.md
+++ b/content/manuals/build-cloud/usage.md
@@ -45,11 +45,11 @@ Changing your default builder with `docker buildx use` only changes the default
 builder for the `docker buildx build` command. The `docker build` command still
 uses the `default` builder, unless you specify the `--builder` flag explicitly.
 
-If you use build scripts, such as `make`, we recommend that you update your
-build commands from `docker build` to `docker buildx build`, to avoid any
-confusion with regards to builder selection. Alternatively, you can run `docker
-buildx install` to make the default `docker build` command behave like `docker
-buildx build`, without discrepancies.
+If you use build scripts, such as `make`, that use the `docker build` command,
+we recommend updating your build commands to `docker buildx build`. Alternatively,
+you can set the [`BUILDX_BUILDER` environment
+variable](/manuals/build/building/variables.md#buildx_builder) to specify which
+builder `docker build` should use.
 
 ## Use with Docker Compose
 


### PR DESCRIPTION
## Description

Remove 'install' inputs from setup-buildx-action examples,
and mention BUILDX_BUILDER env var as a fallback.

## Related issues or tickets

- docker/setup-buildx-action#455
