### PR TITLE
fix desc about cli api version 1.44

### DIFF
--- a/content/manuals/engine/release-notes/29.md
+++ b/content/manuals/engine/release-notes/29.md
@@ -515,7 +515,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 - Hide the `--kernel-memory` option on `docker run` and `docker create`, and produce a warning when used as it's no longer supported by the daemon and kernel. [docker/cli#6455](https://github.com/docker/cli/pull/6455)
 - Remove `VirtualSize` field from `docker image ls` output when using JSON format. [docker/cli#6524](https://github.com/docker/cli/pull/6524)
 - Remove `VirtualSize` formatting options and output. [docker/cli#6524](https://github.com/docker/cli/pull/6524)
-- Remove API version compatibility for API version v1.44 and earlier (Docker v24.0 and older). [docker/cli#6551](https://github.com/docker/cli/pull/6551)
+- Remove API version compatibility for API version < v1.44 (Docker v24.0 and older). [docker/cli#6551](https://github.com/docker/cli/pull/6551)
 - Remove deprecated `bind-nonrecursive` option for `--mount`. [docker/cli#6241](https://github.com/docker/cli/pull/6241)
 - Remove deprecated packages (`pkg/archive`, `pkg/chrootarchive`, `pkg/atomicwriter`, `pkg/reexec`, `pkg/platform`, `pkg/parsers`), `pkg/system.MkdirAll`. For replacements, see `github.com/moby/go-archive`, `github.com/moby/sys` and the standard library. [moby/moby#50208](https://github.com/moby/moby/pull/50208)
 - Remove special handling for quoted values for the `--tlscacert`, `--tlscert`, and `--tlskey` command-line flags. [docker/cli#6306](https://github.com/docker/cli/pull/6306)


### PR DESCRIPTION
## Description

the api version 1.44 is still supported from https://github.com/docker/cli/pull/6551

## Reviews
https://github.com/docker/cli/pull/6551
