### PR TITLE
Fix: missing stage name in php-fpm Dockerfile

### DIFF
--- a/content/guides/frameworks/laravel/production-setup.md
+++ b/content/guides/frameworks/laravel/production-setup.md
@@ -98,7 +98,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
     && composer install --no-dev --optimize-autoloader --no-interaction --no-progress --prefer-dist
 
 # Stage 2: Production environment
-FROM php:8.4-fpm
+FROM php:8.4-fpm AS production
 
 # Install only runtime libraries needed in production
 # libfcgi-bin and procps are required for the php-fpm-healthcheck script


### PR DESCRIPTION
I simply added the stage name that the compose.prod.yml references for service php-fpm since it was not building when I tried using those fiels.

<!--Delete sections as needed -->

## Description

I added the stage name to php-fpm Dockerfile as it was referenced in compose.prod.yml.
When I tried to build php-fpm service with that compose file it failed because it had a target referencing a non-existent stage.

<!-- Tell us what you did and why -->