### PR TITLE
add missing 'direct path' to provider 'type' attribute definition

### DIFF
--- a/content/manuals/compose/how-tos/provider-services.md
+++ b/content/manuals/compose/how-tos/provider-services.md
@@ -81,7 +81,7 @@ The `type` field in a provider service references the name of either:
 
 1. A Docker CLI plugin (e.g., `docker-model`)
 2. A binary available in the user's PATH
-3. Path to the binary or script to execute
+3. A path to the binary or script to execute
 
 When Compose encounters a provider service, it looks for a plugin or binary with the specified name to handle the provisioning of the requested capability.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Add the 3rd option allowing to pass a direct path to configure `provider.type` attribute

## Related issues or tickets
N/A

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review