### PR TITLE
feat: documentation for docker-pass CLI plugin

### DIFF
--- a/content/reference/cli/docker/pass/_index.md
+++ b/content/reference/cli/docker/pass/_index.md
@@ -1,0 +1,8 @@
+---
+datafolder: secrets-engine
+datafile: docker_pass
+title: docker pass
+layout: cli
+---
+
+{{< summary-bar feature_name="Docker Pass" >}}

--- a/content/reference/cli/docker/pass/get.md
+++ b/content/reference/cli/docker/pass/get.md
@@ -1,0 +1,8 @@
+---
+datafolder: secrets-engine
+datafile: docker_pass_get
+title: docker pass get
+layout: cli
+---
+
+{{< summary-bar feature_name="Docker Pass" >}}

--- a/content/reference/cli/docker/pass/ls.md
+++ b/content/reference/cli/docker/pass/ls.md
@@ -1,0 +1,8 @@
+---
+datafolder: secrets-engine
+datafile: docker_pass_ls
+title: docker pass ls
+layout: cli
+---
+
+{{< summary-bar feature_name="Docker Pass" >}}

--- a/content/reference/cli/docker/pass/rm.md
+++ b/content/reference/cli/docker/pass/rm.md
@@ -1,0 +1,8 @@
+---
+datafolder: secrets-engine
+datafile: docker_pass_rm
+title: docker pass rm
+layout: cli
+---
+
+{{< summary-bar feature_name="Docker Pass" >}}

--- a/content/reference/cli/docker/pass/set.md
+++ b/content/reference/cli/docker/pass/set.md
@@ -1,0 +1,8 @@
+---
+datafolder: secrets-engine
+datafile: docker_pass_set
+title: docker pass set
+layout: cli
+---
+
+{{< summary-bar feature_name="Docker Pass" >}}

--- a/data/secrets-engine/docker_pass.yaml
+++ b/data/secrets-engine/docker_pass.yaml
@@ -1,0 +1,64 @@
+command: docker pass
+short: Manage your local OS keychain secrets.
+long: |-
+  Docker Pass is a helper that allows you to store secrets securely in your
+  local OS keychain and inject them into containers later.
+
+  On Windows: Uses the Windows Credential Manager API.
+
+  On macOS: Uses macOS Keychain services API.
+
+  On Linux: `org.freedesktop.secrets` API (requires DBus and `gnome-keyring` or
+  `kdewallet` to be installed).
+usage: docker pass set|get|ls|rm
+pname: docker
+plink: docker.yaml
+cname:
+  - docker pass set
+  - docker pass get
+  - docker pass ls
+  - docker pass rm
+clink:
+  - docker_pass_set.yaml
+  - docker_pass_get.yaml
+  - docker_pass_ls.yaml
+  - docker_pass_rm.yaml
+deprecated: false
+experimental: true
+experimentalcli: true
+kubernetes: false
+swarm: false
+examples: |-
+  ### Using keychain secrets in containers
+
+  Create a secret:
+
+  ```console
+  $ docker pass set GH_TOKEN=123456789
+  ```
+
+  Creating a secret from STDIN:
+
+  ```console
+  echo 123456789 > token.txt
+  cat token.txt | docker pass set GH_TOKEN
+  ```
+
+  Run a container that uses the secret:
+
+  ```console
+  $ docker run -e GH_TOKEN= -dt --name demo busybox
+  ```
+
+  Inspect your secret from inside the container
+
+  ```console
+  $ docker exec demo sh -c 'echo $GH_TOKEN'
+  123456789
+  ```
+
+  Explicitly assigning a secret to another environment variable:
+
+  ```console
+  $ docker run -e GITHUB_TOKEN=se://GH_TOKEN -dt --name demo busybox
+  ```

--- a/data/secrets-engine/docker_pass_get.yaml
+++ b/data/secrets-engine/docker_pass_get.yaml
@@ -1,0 +1,11 @@
+command: docker pass get
+short: Get a secret
+usage: docker pass get NAME
+pname: docker pass
+plink: docker_pass.yaml
+deprecated: false
+hidden: false
+experimental: true
+experimentalcli: true
+kubernetes: false
+swarm: false

--- a/data/secrets-engine/docker_pass_ls.yaml
+++ b/data/secrets-engine/docker_pass_ls.yaml
@@ -1,0 +1,11 @@
+command: docker pass ls
+short: List secrets
+usage: docker pass ls
+pname: docker pass
+plink: docker_pass.yaml
+deprecated: false
+hidden: false
+experimental: true
+experimentalcli: true
+kubernetes: false
+swarm: false

--- a/data/secrets-engine/docker_pass_rm.yaml
+++ b/data/secrets-engine/docker_pass_rm.yaml
@@ -1,0 +1,11 @@
+command: docker pass rm
+short: Remove a secret
+usage: docker pass rm NAME
+pname: docker pass
+plink: docker_pass.yaml
+deprecated: false
+hidden: false
+experimental: true
+experimentalcli: true
+kubernetes: false
+swarm: false

--- a/data/secrets-engine/docker_pass_set.yaml
+++ b/data/secrets-engine/docker_pass_set.yaml
@@ -1,0 +1,17 @@
+command: docker pass set
+short: Set a secret
+usage: docker pass set NAME=VALUE
+long: |-
+  Secrets can also be created from STDIN:
+
+  ```console
+  <some command> | docker pass set <name>
+  ```
+pname: docker pass
+plink: docker_pass.yaml
+deprecated: false
+hidden: false
+experimental: true
+experimentalcli: true
+kubernetes: false
+swarm: false

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -182,6 +182,9 @@ Docker MCP Catalog:
   availability: Beta
 Docker MCP Toolkit:
   availability: Beta
+Docker Pass:
+  requires: Docker Desktop 4.54 and later
+  availability: Beta
 Docker Projects:
   availability: Beta
 Docker Sandboxes:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Adds new documentation for `docker pass` which is shipped as of Docker Desktop 4.54.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [x] Editorial review
- [x] Product review