### PR TITLE
Document `extends` lack of support in Docker Stack

### DIFF
--- a/content/manuals/compose/how-tos/multiple-compose-files/extends.md
+++ b/content/manuals/compose/how-tos/multiple-compose-files/extends.md
@@ -21,6 +21,10 @@ application, with the ability to override some attributes for your own needs.
 
 > [!IMPORTANT]
 >
+> `extends` in not supported in `docker stack`, only in `docker compose`, for obscure reasons. Running `docker stack config` on a compose file that uses it will result in the following useless message: “Configuration contains forbidden properties”.
+
+> [!IMPORTANT]
+>
 > When you use multiple Compose files, you must make sure all paths in the files
 are relative to the base Compose file (i.e. the Compose file in your main-project folder). This is required because extend files
 need not be valid Compose files. Extend files can contain small fragments of

--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -793,6 +793,8 @@ Compose does not automatically import these referenced resources into the extend
 
 Circular references with `extends` are not supported, Compose returns an error when one is detected.
 
+`extends` in not supported in `docker stack`, only in `docker compose`, for obscure reasons.
+
 #### Finding referenced service
 
 `file` value can be:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Mention that the `extends` property of services in compose files is not supported in `docker stack`, as it’s documented nowhere.

## Reviews

I’m open to suggestions for better wording, but I’d rather that this PR is rejected because it’s been made obsolete (by just implementing the missing feature.)

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review