### PR TITLE
engine: add some extra keywords for finding the debug section

### DIFF
--- a/content/manuals/engine/daemon/logs.md
+++ b/content/manuals/engine/daemon/logs.md
@@ -1,7 +1,7 @@
 ---
 title: Read the daemon logs
-description: How to read the event logs for the Docker daemon
-keywords: docker, daemon, configuration, troubleshooting, logging
+description: How to read Docker daemon logs and force a stack trace using SIGUSR1 for debugging
+keywords: docker, daemon, configuration, troubleshooting, logging, debug, stack trace, SIGUSR1, signal, goroutine dump, crash diagnostics
 aliases:
   - /config/daemon/logs/
 ---


### PR DESCRIPTION
I forgot where we documented this, and ChatGPT wasn't able to provide the link, so I asked it to suggest improvements for it to discover the page :)

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review