### PR TITLE
Angular: Change the default Nginx paths to /tmp in Docker Container

### DIFF
--- a/content/guides/angular/containerize.md
+++ b/content/guides/angular/containerize.md
@@ -280,6 +280,12 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
     # Logging
     access_log off;
     error_log  /dev/stderr warn;


### PR DESCRIPTION
## Description

In your Angular + Nginx Docker example you are running a non-root user, but by default Nginx will try to write to directories like `/var/cache/nginx/`. Which will cause errors like:

```
mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

This PR fixes that, and simply changing the default temp path directories (like you did for the pid file as well) to the `/tmp` directory. Which will work when using the `nginx` user in Docker. Mainly `client_body_temp_path` change was needed here, but I would set more just to be sure.

## Reviews

- [x] Technical review
- [x] Editorial review
- [ ] Product review