### PR TITLE
subscription: link to pricing page

### DIFF
--- a/content/manuals/subscription/details.md
+++ b/content/manuals/subscription/details.md
@@ -3,6 +3,5 @@ title: Subscriptions and features
 weight: 10
 params:
   sidebar:
-    group: Platform
     goto: "https://www.docker.com/pricing/"
 ---


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

As discussed with Usha and Sarah (before she left) we agreed we'd have the subscription page link to the official pricing page to have a single source of truth. Simplifies maintenance and the pricing page already does a good job of communicating everything. 


## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review