### PR TITLE
dhi: add get trivy vex repo

### DIFF
--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -211,7 +211,6 @@ undeterminable
 Unix
 unmanaged
 Visual Studio Code
-VEXhub
 VMware
 vpnkit
 vSphere

--- a/content/manuals/dhi/how-to/scan.md
+++ b/content/manuals/dhi/how-to/scan.md
@@ -193,14 +193,14 @@ $ trivy image --scanners vuln dhi.io/<image>:<tag>
 ```
 
 To filter vulnerabilities using VEX statements, Trivy supports multiple
-approaches. Docker recommeneds using VEXhub, which provides a seamless workflow
+approaches. Docker recommends using VEX Hub, which provides a seamless workflow
 for automatically downloading and applying VEX statements from configured
 repositories.
 
-#### Using VEXhub (recommended)
+#### Using VEX Hub (recommended)
 
 Configure Trivy to download the Docker Hardened Images advisories repository
-from VEXhub. Run the following commands to set up the VEX repository:
+from VEX Hub. Run the following commands to set up the VEX repository:
 
 ```console
 $ trivy vex repo init
@@ -220,7 +220,7 @@ $ trivy vex repo list
 $ trivy vex repo download
 ```
 
-After setting up VEXhub, you can scan a Docker Hardened Image with VEX filtering:
+After setting up VEX Hub, you can scan a Docker Hardened Image with VEX filtering:
 
 ```console
 $ docker pull dhi.io/<image>:<tag>
@@ -255,7 +255,7 @@ which filters out known non-exploitable CVEs.
 
 #### Using local VEX files
 
-In addition to VEXhub, Trivy also supports the use of local VEX files for
+In addition to VEX Hub, Trivy also supports the use of local VEX files for
 vulnerability filtering. You can download the VEX attestation that Docker
 Hardened Images provide and use it directly with Trivy.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

When using vexhub with Trivy, it needs to be setup before it works.

https://deploy-preview-23854--docsdocker.netlify.app/dhi/how-to/scan/#trivy

## Related issues or tickets

https://docker.slack.com/archives/C0A3X908ASG/p1765983906348749

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review