### PR TITLE
docs: rename compose.yaml to docker-compose.yaml for dex guide

### DIFF
--- a/content/guides/dex.md
+++ b/content/guides/dex.md
@@ -40,7 +40,7 @@ Organize your project with the following structure:
 ```bash
 dex-mock-server/
 ├── config.yaml
-└── compose.yaml
+└── docker-compose.yaml
 ```
 
 Create the Dex Configuration File:


### PR DESCRIPTION
Updated the filename from 'compose.yaml' to 'docker-compose.yaml' in the directory structure.

<!--Delete sections as needed -->

## Description
The docker docs for [mocking OAuth services](https://docs.docker.com/guides/dex/) incorrectly shows `compoe.yaml` instead of `docker-compose.yaml`. This PR corrects that.
<!-- Tell us what you did and why -->
