### PR TITLE
ci: Add automated CLI documentation sync workflow

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -1,0 +1,100 @@
+name: sync-cli-docs
+
+on:
+  schedule:
+    # Run daily at 02:00 UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "(optional) Docker CLI version - defaults to docker_ce_version in hugo.yaml"
+        required: false
+        default: ""
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-cli-docs:
+    runs-on: ubuntu-24.04
+    steps:
+      -
+        name: Checkout docs repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      -
+        name: Get version from hugo.yaml
+        id: get-version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=$(grep "docker_ce_version:" hugo.yaml | awk '{print $2}' | tr -d '"')
+          fi
+          # TODO(vvoland): Remove this after 29.2.0 is released
+          # VERSION=v${VERSION}
+          VERSION=60f06cb2df3df36ddfb531c1dae8c6fa96e5f9e7
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Docker CLI version: **$VERSION**" | tee -a "$GITHUB_STEP_SUMMARY"
+      -
+        name: Checkout docker/cli repo
+        uses: actions/checkout@v5
+        with:
+          repository: docker/cli
+          path: cli-source
+          ref: ${{ steps.get-version.outputs.version }}
+          fetch-depth: 0
+      -
+        name: Create update branch
+        id: create-branch
+        run: |
+          BRANCH_NAME="bot/sync-cli-docs-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      -
+        name: Run sync script
+        id: sync
+        run: |
+          set +e
+          ./hack/sync-cli-docs.sh HEAD cli-source
+          EXIT_CODE=$?
+          set -e
+          
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected - syncing CLI docs" >> "$GITHUB_STEP_SUMMARY"
+          elif [ $EXIT_CODE -eq 100 ]; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to sync - CLI docs are up to date" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Script failed with exit code $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
+
+      -
+        name: Show PR
+        if: steps.sync.outputs.changes == 'true'
+        run: |
+          git show "${{ steps.create-branch.outputs.branch_name }}"
+      -
+        name: Create Pull Request
+        if: steps.sync.outputs.changes == 'true' && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: |
+            ## Summary
+
+            Automated sync of CLI documentation from docker/cli repository.
+        run: |
+          git push -u origin "${{ steps.create-branch.outputs.branch_name }}"
+          gh pr create \
+            --title "cli: sync docs with docker/cli" \
+            --body "$PR_BODY" \
+            --base main \
+            --head "${{ steps.create-branch.outputs.branch_name }}"

--- a/hack/sync-cli-docs.sh
+++ b/hack/sync-cli-docs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+main() {
+    local branch_name="${1:-upstream/master}"
+    local cli_source="${2:-$HOME/src/cli}/.git"
+    local worktree_dir="./internal-update-cli-docs"
+
+    (
+        set -e
+        GIT_DIR="$cli_source"
+        GIT_DIR="$GIT_DIR" git fetch upstream
+        GIT_DIR="$GIT_DIR" git worktree add "$worktree_dir" "$branch_name"
+    ) || return $?
+    trap "GIT_DIR=\"$cli_source\" git worktree remove \"$worktree_dir\" --force 2>/dev/null || true" EXIT
+
+    (set -e; cd "$worktree_dir"; make -f docker.Makefile yamldocs || { printf "::error::Failed to generate YAML docs!\n"; exit 1; }) || return $?
+    cp "$worktree_dir"/docs/yaml/*.yaml ./data/engine-cli/
+
+    if git diff --quiet "./data/engine-cli/*.yaml"; then
+        printf "\e[32m✅ Already up to date\e[0m\n"
+        return 100
+    fi
+
+    echo -e "ℹ️ Changes detected:"
+    git diff --stat "./data/engine-cli/*.yaml" || true
+
+    NICE_GIT_REF=$(cd "$worktree_dir" && git describe --always --dirty) || return $?
+
+    git add "./data/engine-cli/*.yaml"
+
+    git commit -m "cli: sync docs with docker/cli $NICE_GIT_REF"
+    
+    printf "\e[32m✅ Committed changes\e[0m\n"
+    return 0
+}
+
+main "$@"


### PR DESCRIPTION
This adds a GitHub Actions workflow and supporting script to automatically sync CLI documentation from the docker/cli repository on a daily schedule.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review