### PR TITLE
hub: modify dct deprecation notice

### DIFF
--- a/content/manuals/docker-hub/image-library/trusted-content.md
+++ b/content/manuals/docker-hub/image-library/trusted-content.md
@@ -18,22 +18,6 @@ Source Software images.
 
 ## Docker Official Images
 
-> [!NOTE]
->
-> Docker is retiring Docker Content Trust (DCT) for Docker Official Images
-> (DOI). Starting on August 8th, 2025, the oldest of DOI DCT signing
-> certificates will begin to expire. You may have already started seeing expiry
-> warnings if you use the `docker trust` commands with DOI. These certificates,
-> once cached by the Docker client, are not subsequently refreshed, making
-> certificate rotation impractical. If you have set the `DOCKER_CONTENT_TRUST`
-> environment variable to true (`DOCKER_CONTENT_TRUST=1`), DOI pulls will start to
-> fail. The workaround is to unset the `DOCKER_CONTENT_TRUST` environment
-> variable. The use of  `docker trust inspect` will also start to fail and should
-> no longer be used for DOI.
->
-> For more details, see
-> https://www.docker.com/blog/retiring-docker-content-trust/.
-
 The Docker Official Images are a curated set of Docker repositories hosted on
 Docker Hub.
 
@@ -171,6 +155,15 @@ tag variants are explained in the Docker Official Images repository
 documentation. Reading through the "How to use this image" and
 "Image Variants" sections will help you to understand how to use these
 variants.
+
+### Troubleshooting failed pulls
+
+If you're experiencing failed pulls of Docker Official Images, check whether
+the `DOCKER_CONTENT_TRUST` environment variable is set to `1`. Starting in
+August 2025, Docker Content Trust signing certificates for Docker Official
+Images began expiring. To resolve pull failures, unset the `DOCKER_CONTENT_TRUST`
+environment variable. For more details, see the
+[DCT retirement blog post](https://www.docker.com/blog/retiring-docker-content-trust/).
 
 ## Verified Publisher images
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This PR moves the DCT retirement notice from a callout at the top of the DOI section to a "Troubleshooting failed pulls" subsection at the end.

From a user's perspective:
- Many users don't have `DOCKER_CONTENT_TRUST=1` set and won't experience any issues. A callout at the top of the page adds unnecessary friction for users just trying to learn about DOI.
- Users trying to implement DCT will see notices in DCT docs
- Users experiencing pull failures will naturally look for troubleshooting information. Placing this at the end of the section as a dedicated troubleshooting subsection makes it easier to find when they actually need it.
- The new structure follows a logical IA flow of learn about DOI → understand how to use them → troubleshoot issues if they occur.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
