### PR TITLE
ci: specify full cagent action version

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -31,7 +31,7 @@ jobs:
           git checkout -b agent/issue-${{ github.event.issue.number }}
 
       - name: Run agent
-        uses: docker/cagent-action@v1
+        uses: docker/cagent-action@v1.0.3
         with:
           agent: ./agent.yml
           yolo: true


### PR DESCRIPTION
docker/cagent-action was not available as `@v1` so pinning to patch

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
