### PR TITLE
Docker Desktop 4.55 release notes - add missing fix for DDB-363

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -48,6 +48,7 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 - Fixed an issue that caused Docker Desktop to get stuck during startup.
 - Improved the error message when the `daemon.json` is invalid.
 - Fixed performance issues on every keystroke within a long Ask Gordon session.
+- Fixed an issue that prevented Kubernetes in kubeadm mode from starting up when an organization has configured Registry Access Management to block Docker Hub.
 
 > [!IMPORTANT]
 >


### PR DESCRIPTION
## Description

Added an item to the Docker Desktop 4.55 release notes to indicate it fixed a bug with kubeadm + Registry Access Management.

## Related issues or tickets

DDB-363

## Reviews

<!-- Notes for reviewers here -->

<!-- List applicable reviews (optionally @tag reviewers) -->

- [X] Technical review
- [ ] Editorial review
- [ ] Product review