### PR TITLE
component: adjust grid resizing

### DIFF
--- a/layouts/shortcodes/grid.html
+++ b/layouts/shortcodes/grid.html
@@ -1,6 +1,6 @@
 {{ $cols := .Get "cols" | default 3 }}
 <div
-  class="not-prose md:grid-cols-{{ math.Max 2 (sub $cols 1) }} lg:grid-cols-{{ $cols }} grid grid-cols-1 gap-4 mb-6"
+  class="not-prose md:grid-cols-{{ math.Max 2 (sub $cols 1) }} xl:grid-cols-{{ $cols }} grid grid-cols-1 gap-4 mb-6"
 >
   {{ $items := index .Page.Params (.Get "items" | default "grid") }}
   {{ range $items }}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Large titles, like `Troubleshoot`, leak over the card when resizing. Adjusted the breakpoint.

https://deploy-preview-23880--docsdocker.netlify.app/dhi/

<img width="950" height="822" alt="image" src="https://github.com/user-attachments/assets/04a35129-5d4c-4685-8d52-f165f61640cf" />

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
