### PR TITLE
Update local-models.md

### DIFF
--- a/content/manuals/ai/cagent/local-models.md
+++ b/content/manuals/ai/cagent/local-models.md
@@ -45,10 +45,10 @@ Docker Model Runner can run any compatible model. Models can come from:
 - HuggingFace models directly (`hf.co/org/model-name`)
 - The Docker Model catalog in Docker Desktop
 
-To see models available through the Docker catalog, run:
+To see models available to the local Docker catalog, run:
 
 ```console
-$ docker model list --available
+$ docker model list --openai
 ```
 
 To use a model, reference it in your configuration. DMR automatically pulls


### PR DESCRIPTION
Models available to the local Docker catalog are only option for list


## Description

Updated documentation to reflect true state of local docker catalog flags. The `--available` option does not exist and the 'list' or 'ls' command is only supported for local viewing of installed models. Documentation currently suggests a user can [1] use the --available flag, and [2] a user can use 'ls' to query an online catalog. 

## Related issues or tickets


## Reviews


- [ ] Technical review
- [x] Editorial review
- [ ] Product review