### PR TITLE
Fix typo in Docker IP forwarding documentation

### DIFF
--- a/content/manuals/engine/network/packet-filtering-firewalls.md
+++ b/content/manuals/engine/network/packet-filtering-firewalls.md
@@ -39,7 +39,7 @@ iptables or nftables is used. See
 
 On Linux, Docker needs "IP Forwarding" enabled on the host. So, it enables
 the `sysctl` settings `net.ipv4.ip_forward` and `net.ipv6.conf.all.forwarding`
-it they are not already enabled when it starts. When it does that, it also
+if they are not already enabled when it starts. When it does that, it also
 configures the firewall to drop forwarded packets unless they are explicitly
 accepted.
 


### PR DESCRIPTION
## Description

Corrected a typo in the Docker section regarding IP forwarding settings.

## Related issues or tickets

Added on https://github.com/docker/docs/commit/2090e5bcbbdf38fa1004caa0488e555497ae8a39

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review