### PR TITLE
gha/sync-cli-docs: Detect existing PR

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: ""
   pull_request:
+    paths:
+      - '.github/workflows/sync-cli-docs.yml'
+      - 'hack/sync-cli-docs.sh'
 
 permissions:
   contents: write


### PR DESCRIPTION
Add deduplication logic to prevent multiple PRs for the same CLI version and enhance PR management.

When an existing PR is found, the workflow adds a bump comment instead of creating a duplicate.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review