### PR TITLE
Update base image version in multi-stage Dockerfile build

### DIFF
--- a/content/get-started/docker-concepts/building-images/multi-stage-builds.md
+++ b/content/get-started/docker-concepts/building-images/multi-stage-builds.md
@@ -287,7 +287,7 @@ Now that you have the project, you’re ready to create the `Dockerfile`.
 
     - The first stage remains the same as the previous Dockerfile, providing a Java Development Kit (JDK) environment for building the application. This stage is given the name of builder.
 
-    - The second stage is a new stage named `final`. It uses a slimmer `eclipse-temurin:21.0.2_13-jre-jammy` image, containing just the Java Runtime Environment (JRE) needed to run the application. This image provides a Java Runtime Environment (JRE) which is enough for running the compiled application (JAR file). 
+    - The second stage is a new stage named `final`. It uses a slimmer `eclipse-temurin:21.0.8_9-jre-jammy` image, containing just the Java Runtime Environment (JRE) needed to run the application. This image provides a Java Runtime Environment (JRE) which is enough for running the compiled application (JAR file). 
 
     
    > For production use, it's highly recommended that you produce a custom JRE-like runtime using jlink. JRE images are available for all versions of Eclipse Temurin, but `jlink` allows you to create a minimal runtime containing only the necessary Java modules for your application. This can significantly reduce the size and improve the security of your final image. [Refer to this page](https://hub.docker.com/_/eclipse-temurin) for more information.
@@ -333,4 +333,3 @@ Now that you have the project, you’re ready to create the `Dockerfile`.
 * [Dockerfile best practices](/develop/develop-images/dockerfile_best-practices/)
 * [Base images](/build/building/base-images/)
 * [Spring Boot Docker](https://spring.io/guides/topicals/spring-boot-docker)
-


### PR DESCRIPTION
## Description

the example's original Dockerfile did not reflect the docs content:

>The second stage is a new stage named final. It uses a slimmer `eclipse-temurin:21.0.2_13-jre-jammy` image

I also verified that using this image indeed works properly with the provided example