### PR TITLE
fix: improve contrast in code blocks where language is unrecognized

### DIFF
--- a/assets/css/utilities.css
+++ b/assets/css/utilities.css
@@ -172,6 +172,12 @@
   /* code blocks with unrecognized languages*/
   pre:not(.chroma) {
     @apply overflow-x-auto p-3;
+    background: var(--tw-prose-code-bg);
+    color: var(--color-gray-700);
+    .dark & {
+      background: var(--tw-prose-code-bg-dark);
+      color: var(--color-gray-200);
+    }
   }
 
   .highlight {


### PR DESCRIPTION
Before:

<img width="764" height="172" alt="image" src="https://github.com/user-attachments/assets/4fcd1c4e-f4c0-4192-90cf-2249dcac2b86" />

After:

<img width="764" height="179" alt="image" src="https://github.com/user-attachments/assets/1697f88b-17fe-4dfb-970b-24b43c149c10" />
