### PR TITLE
engine: add more redirects for deprecated api versions

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -17,6 +17,26 @@
   - /engine/api/v1.21/
   - /engine/api/v1.22/
   - /engine/api/v1.23/
+  - /engine/api/v1.24/
+  - /engine/api/v1.25/
+  - /engine/api/v1.26/
+  - /engine/api/v1.27/
+  - /engine/api/v1.28/
+  - /engine/api/v1.29/
+  - /engine/api/v1.30/
+  - /engine/api/v1.31/
+  - /engine/api/v1.32/
+  - /engine/api/v1.33/
+  - /engine/api/v1.34/
+  - /engine/api/v1.35/
+  - /engine/api/v1.36/
+  - /engine/api/v1.37/
+  - /engine/api/v1.38/
+  - /engine/api/v1.39/
+  - /engine/api/v1.40/
+  - /engine/api/v1.41/
+  - /engine/api/v1.42/
+  - /engine/api/v1.43/
   - /engine/reference/api/docker_remote_api_v1.18/
   - /engine/reference/api/docker_remote_api_v1.19/
   - /engine/reference/api/docker_remote_api_v1.20/


### PR DESCRIPTION
## Description

Adds add'l redirects for engine API versions =< v1.43 that were recently deprecated

## Related issues or tickets

- Relates to #23933
