### PR TITLE
hub: add webhook callback note

### DIFF
--- a/content/manuals/docker-hub/repos/manage/webhooks.md
+++ b/content/manuals/docker-hub/repos/manage/webhooks.md
@@ -57,3 +57,7 @@ Webhook payloads have the following JSON format:
   }
 }
 ```
+
+> [!NOTE]
+>
+> The `callback_url` field is a legacy field and is no longer supported.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added note that callback is legacy and is no longer supported.

## Related issues or tickets

Closes #23955
https://docker.slack.com/archives/C01043ZHY6L/p1768249016247099

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
- [X] Technical review
