### PR TITLE
a11y: Add accessible names to footer social media links

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,27 +2,27 @@
   class="ml-auto hidden grid-cols-3 gap-6 border-t border-gray-200 bg-gray-100 px-4 pt-6 pb-2 text-gray-600 md:grid dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 [&_a:hover]:underline [&_a:hover]:underline-offset-4"
 >
   <div class="flex min-w-20 flex-wrap items-center gap-1">
-    <a href="https://www.linkedin.com/company/docker">
+    <a href="https://www.linkedin.com/company/docker" aria-label="LinkedIn">
       <span class="icon-svg">
         {{ partial "utils/svg" "icons/linkedin.svg" }}
       </span>
     </a>
-    <a href="https://x.com/docker/">
+    <a href="https://x.com/docker/" aria-label="Twitter">
       <span class="icon-svg">
         {{ partial "utils/svg" "icons/twitter.svg" }}
       </span>
     </a>
-    <a href="https://www.facebook.com/docker.run">
+    <a href="https://www.facebook.com/docker.run" aria-label="Facebook">
       <span class="icon-svg">
         {{ partial "utils/svg" "icons/facebook.svg" }}
       </span>
     </a>
-    <a href="http://www.youtube.com/user/dockerrun">
+    <a href="http://www.youtube.com/user/dockerrun" aria-label="YouTube">
       <span class="icon-svg">
         {{ partial "utils/svg" "icons/youtube.svg" }}
       </span>
     </a>
-    <a href="https://www.instagram.com/dockerinc/">
+    <a href="https://www.instagram.com/dockerinc/" aria-label="Instagram">
       <span class="icon-svg">
         {{ partial "utils/svg" "icons/instagram.svg" }}
       </span>


### PR DESCRIPTION

## Description

This PR addresses 5 accessibility violations identified in the site footer of [homepage](https://docs.docker.com/). Currently, the social media links (LinkedIn, X/Twitter, Facebook, YouTube, and Instagram) contain only SVG icons without any descriptive text.

According to WCAG guidelines, hyperlinks must have an accessible name so that screen reader users can understand the destination of the link.

## Related issues or tickets
5 Accessibility violations reported by IBM Equal Access Accessibility Checker: 
`Hyperlinks must have an accessible name for their purpose`

<img width="2560" height="922" alt="image" src="https://github.com/user-attachments/assets/fb0a51e4-b545-413c-9e06-1fb97a7e1a6f" />

**Why is this important?**
When the purpose of a link is clear users can easily navigate links on the page without having to see the surrounding information for context.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review