### PR TITLE
Clarifying %L behavior for awslogs driver

### DIFF
--- a/content/manuals/engine/logging/drivers/awslogs.md
+++ b/content/manuals/engine/logging/drivers/awslogs.md
@@ -232,10 +232,9 @@ The following `strftime` codes are supported:
 
 In addition, the following non-`strftime` codes are supported:
 
-| Code | Meaning                                                          | Example  |
-| :--- | :--------------------------------------------------------------- | :------- |
-| `%L` | Milliseconds as a zero-padded decimal number preceded with a     | .123     |
-|      | period.                                                          |          |
+| Code | Meaning                                                              | Example  |
+| :--- | :------------------------------------------------------------------- | :------- |
+| `%L` | Milliseconds as a zero-padded decimal number preceded with a period. | .123     |
 
 ### awslogs-multiline-pattern
 


### PR DESCRIPTION
https://github.com/moby/moby/issues/36796

<!--Delete sections as needed -->

## Description

Moved the %L documentation out from under strftime options into it's own section( and clarified hardcoded period requirement), since it's custom behavior that's improperly documented

## Related issues or tickets

https://github.com/moby/moby/issues/36796

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review