### PR TITLE
fix(desktop): only show mac release

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -31,7 +31,7 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 
 {{< release-date date="2026-01-29" >}}
 
-{{< desktop-install-v2 all=true win_arm_release="Early Access" version="4.58.1" build_path="/217134/" >}}
+{{< desktop-install-v2 mac=true version="4.58.1" build_path="/217134/" >}}
 
 ### Bug fixes and enhancements
 


### PR DESCRIPTION
- fixes https://github.com/docker/docs/issues/24048

<!--Delete sections as needed -->

## Description

4.58.1 was a mac only release

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review