### PR TITLE
engine/install: remove Ubuntu 25.04 ("plucky"), which is EOL

### DIFF
--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -52,7 +52,6 @@ To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
 - Ubuntu Questing 25.10
-- Ubuntu Plucky 25.04
 - Ubuntu Noble 24.04 (LTS)
 - Ubuntu Jammy 22.04 (LTS)
 


### PR DESCRIPTION
Ubuntu 25.04 ("plucky") reached EOL on January 15, 2026; https://documentation.ubuntu.com/project/release-team/list-of-releases/#end-of-life

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review