### PR TITLE
Update 4.57 release notes with mention of CVE-2025-14740

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -138,6 +138,10 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 
 {{< desktop-install-v2 all=true win_arm_release="Early Access" version="4.57.0" build_path="/215387/" >}}
 
+### Security
+
+- Fixed [CVE-2025-14740](https://www.cve.org/cverecord?id=CVE-2025-14740) where the Docker Desktop for Windows installer contained multiple incorrect permission assignment vulnerabilities in the handling of the `C:\ProgramData\DockerDesktop` directory.
+
 ### New
 
 - Docker Desktop now has a new issue tracker for all platforms at https://github.com/docker/desktop-feedback. Relevant, actively discussed issues from the previous platform-specific trackers will be migrated.


### PR DESCRIPTION
## Description

Added mention of CVE-2025-14740 to the release notes of 4.57, as we had fixed it in that version but we didn’t publish the CVE back then.

## Related issues or tickets

https://docker.atlassian.net/browse/DKP-2556

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review