### PR TITLE
Revise Kubernetes images for Docker Desktop

### DIFF
--- a/content/manuals/desktop/use-desktop/kubernetes.md
+++ b/content/manuals/desktop/use-desktop/kubernetes.md
@@ -154,7 +154,7 @@ factors, including the version of Kubernetes being used. The tags vary for each 
 > [!NOTE]
 >
 > In Docker Desktop versions 4.44 or later you can run `docker desktop kubernetes images list` to list Kubernetes images used by the currently installed version of Docker Desktop.
-> See the [docker desktop](/reference/cli/docker/desktop/kubernetes/images) CLI reference for more details.
+> For more information, see the [Docker Desktop CLI](/reference/cli/docker/desktop/kubernetes/images).
 
 To accommodate scenarios where access to Docker Hub is not allowed, admins can
 configure Docker Desktop to pull the above listed images from a different registry (e.g., a mirror)
@@ -182,7 +182,7 @@ The recommended approach to set this up is the following:
 
 1. Start Kubernetes using the desired cluster provisioning method: `kubeadm` or `kind`.
 2. After Kubernetes has started, use either:
-   - (Docker Desktop v4.44 or later) `docker desktop kubernetes images list` to list the image tags that will be pulled by the current Docker Desktop installation
+   - (Docker Desktop version 4.44 or later) `docker desktop kubernetes images list` to list the image tags that will be pulled by the current Docker Desktop installation
    - `docker ps` to view the container images used by Docker Desktop for the Kubernetes control plane
 3. Clone or mirror those images (with matching tags) to your custom registry.
 4. Stop the Kubernetes cluster.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Update the list of Kuberenetes images pulled for a kubeadm installation. Also add references to the new-ish CLI list images command.

<!-- Tell us what you did and why -->
The original listed images are not entirely correct:
- the `docker.io/registry.k8s.io` registry prefix is redundant, it should just be `registry.k8s.io/*`
- the `registry.k8s.io` images are what kubeadm requires for installation, however Docker Desktop will pull mirrored copies from Docker registry + repository (`docker.io/docker`) and internally re-tag the images back to the original images required by kubeadm

The `desktop kubernetes images list` CLI command can be used to print out the images and their tags required by the current Docker Desktop installation. Of particular interest might be the programmatic output `desktop kubernetes images list --format=json` which can be used for automation purposes. The tags in the image list output are tied to the Docker Desktop version in which the commands are run, that is to say, it is not possible to find out all possible Kubernetes image tags (past or future? :laughing:) from one Docker Desktop version (the Release Notes would be a better place to check image tag changes).

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review