### PR TITLE
Fix spelling errors across documentation and config files

### DIFF
--- a/_vale/Docker/Units.yml
+++ b/_vale/Docker/Units.yml
@@ -7,4 +7,4 @@ swap:
   gigabytes?: GB
   megabytes?: MB
   petabytes?: PB
-  terrabytes?: TB
+  terabytes?: TB

--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -61,7 +61,7 @@ Django
 DMR
 Docker Build Cloud
 Docker Business
-Docker Dasboard
+Docker Dashboard
 Docker Desktop
 Docker Engine
 Docker Extension

--- a/content/guides/opentelemetry.md
+++ b/content/guides/opentelemetry.md
@@ -25,7 +25,7 @@ In this guide, you'll learn how to:
 
 ## Using OpenTelemetry with Docker
 
-The [Docker Official Image for OpenTelemetry](https://hub.docker.com/r/otel/opentelemetry-collector-contrib) provides a convenient way to deploy and manage Dex instances. OpenTelemetry is available for various CPU architectures, including amd64, armv7, and arm64, ensuring compatibility with different devices and platforms. Same for the [Jaeger docekr image](https://hub.docker.com/r/jaegertracing/jaeger).
+The [Docker Official Image for OpenTelemetry](https://hub.docker.com/r/otel/opentelemetry-collector-contrib) provides a convenient way to deploy and manage Dex instances. OpenTelemetry is available for various CPU architectures, including amd64, armv7, and arm64, ensuring compatibility with different devices and platforms. Same for the [Jaeger Docker image](https://hub.docker.com/r/jaegertracing/jaeger).
 
 ## Prerequisites
 

--- a/content/guides/tensorflowjs.md
+++ b/content/guides/tensorflowjs.md
@@ -293,10 +293,10 @@ gui
   .add(state, "backend", ["wasm", "webgl", "cpu"])
   .onChange(async (backend) => {
     await tf.setBackend(backend);
-    addFlagLables();
+    addFlagLabels();
   });
 
-async function addFlagLables() {
+async function addFlagLabels() {
   if (!document.querySelector("#simd_supported")) {
     const simdSupportLabel = document.createElement("div");
     simdSupportLabel.id = "simd_supported";
@@ -385,7 +385,7 @@ const renderPrediction = async () => {
 
 const setupPage = async () => {
   await tf.setBackend(state.backend);
-  addFlagLables();
+  addFlagLabels();
   await setupCamera();
   video.play();
 

--- a/content/manuals/accounts/manage-account.md
+++ b/content/manuals/accounts/manage-account.md
@@ -7,7 +7,7 @@ keywords: accounts, docker ID, account settings, account management, docker home
 ---
 
 You can centrally manage your Docker account using Docker Home, including
-adminstrative and security settings.
+administrative and security settings.
 
 > [!TIP]
 >

--- a/content/manuals/engine/release-notes/17.07.md
+++ b/content/manuals/engine/release-notes/17.07.md
@@ -61,7 +61,7 @@ toc_max: 2
 
 ### Swarm mode
 
-* Initial support for plugable secret backends [moby/moby#34157](https://github.com/moby/moby/pull/34157) [moby/moby#34123](https://github.com/moby/moby/pull/34123)
+* Initial support for pluggable secret backends [moby/moby#34157](https://github.com/moby/moby/pull/34157) [moby/moby#34123](https://github.com/moby/moby/pull/34123)
 * Sort swarm stacks and nodes using natural sorting [docker/cli#315](https://github.com/docker/cli/pull/315)
 * Make engine support cluster config event [moby/moby#34032](https://github.com/moby/moby/pull/34032)
 * Only pass a join address when in the process of joining a cluster [moby/moby#33361](https://github.com/moby/moby/pull/33361)

--- a/content/manuals/engine/release-notes/prior-releases.md
+++ b/content/manuals/engine/release-notes/prior-releases.md
@@ -1041,7 +1041,7 @@ additional binaries; `dockerd`, and `docker-proxy`. If you have scripts for inst
 * Support for AAAA Records (aka IPv6 Service Discovery) in embedded DNS Server ([#21396](https://github.com/docker/docker/pull/21396))
 - Fix to not forward docker domain IPv6 queries to external servers ([#21396](https://github.com/docker/docker/pull/21396))
 * Multiple A/AAAA records from embedded DNS Server for DNS Round robin ([#21019](https://github.com/docker/docker/pull/21019))
-- Fix endpoint count inconsistency after an ungraceful dameon restart ([#21261](https://github.com/docker/docker/pull/21261))
+- Fix endpoint count inconsistency after an ungraceful daemon restart ([#21261](https://github.com/docker/docker/pull/21261))
 - Move the ownership of exposed ports and port-mapping options from Endpoint to Sandbox ([#21019](https://github.com/docker/docker/pull/21019))
 - Fixed a bug which prevents docker reload when host is configured with ipv6.disable=1 ([#21019](https://github.com/docker/docker/pull/21019))
 - Added inbuilt nil IPAM driver ([#21019](https://github.com/docker/docker/pull/21019))

--- a/content/reference/api/hub/latest.yaml
+++ b/content/reference/api/hub/latest.yaml
@@ -139,7 +139,7 @@ tags:
     description: |
       The groups endpoints allow you to manage your organization's teams and their members.
 
-      For more information, seee [Create and manage a team](https://docs.docker.com/admin/organization/manage-a-team/).
+      For more information, see [Create and manage a team](https://docs.docker.com/admin/organization/manage-a-team/).
   - name: invites
     x-displayName: Invites
     x-audience: public

--- a/data/buildx/docker_buildx_history_inspect_attachment.yaml
+++ b/data/buildx/docker_buildx_history_inspect_attachment.yaml
@@ -206,7 +206,7 @@ examples: |-
 
     ### Inspect an attachment by digest
 
-    You can inspect an attachment directly using its digset, which you can get from
+    You can inspect an attachment directly using its digest, which you can get from
     the `inspect` output:
 
     ```console

--- a/data/engine-cli/docker_image_rm.yaml
+++ b/data/engine-cli/docker_image_rm.yaml
@@ -161,8 +161,8 @@ examples: |-
     The following uses of this option are equivalent;
 
     ```console
-    $ docker image rm --plaform linux/amd64 --platform linux/ppc64le myimage
-    $ docker image rm --plaform linux/amd64,linux/ppc64le myimage
+    $ docker image rm --platform linux/amd64 --platform linux/ppc64le myimage
+    $ docker image rm --platform linux/amd64,linux/ppc64le myimage
     ```
 
     The following example removes the `linux/amd64` and `linux/ppc64le` variants

--- a/data/engine-cli/docker_service_create.yaml
+++ b/data/engine-cli/docker_service_create.yaml
@@ -1162,7 +1162,7 @@ examples: |-
             Read-only mounts are made recursively read-only if kernel is v5.12 or later.
             Otherwise the Engine raises an error.</li>
           </ul>
-          When the option is not specified, the default behavior correponds to setting <tt>enabled</tt>.
+          When the option is not specified, the default behavior corresponds to setting <tt>enabled</tt>.
         </td>
       </tr>
     </table>


### PR DESCRIPTION
## Summary

Fixes #24098

- Fix 14 spelling errors across 11 documentation and configuration files
- Found using automated spell checking (typos-cli)

## Changes

| File | Typo | Correction |
|------|------|------------|
| `content/reference/api/hub/latest.yaml` | seee | see |
| `content/manuals/engine/release-notes/prior-releases.md` | dameon | daemon |
| `content/manuals/engine/release-notes/17.07.md` | plugable | pluggable |
| `content/manuals/accounts/manage-account.md` | adminstrative | administrative |
| `content/guides/opentelemetry.md` | docekr | Docker |
| `content/guides/tensorflowjs.md` | addFlagLables | addFlagLabels (×3) |
| `_vale/Docker/Units.yml` | terrabytes | terabytes |
| `_vale/config/vocabularies/Docker/accept.txt` | Dasboard | Dashboard |
| `data/engine-cli/docker_image_rm.yaml` | plaform | platform (×2) |
| `data/engine-cli/docker_service_create.yaml` | correponds | corresponds |
| `data/buildx/docker_buildx_history_inspect_attachment.yaml` | digset | digest |

## Test plan

- [x] Verified each correction is accurate
- [x] No functional changes, documentation only