### PR TITLE
gha/sync-cli-docs: Ignore explicitly closed versions

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -108,14 +108,22 @@ jobs:
             > **Reviewer:** Please close and reopen this PR to trigger CI checks.
             > See: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
         run: |
-          # Check for existing PR from this branch
-          EXISTING_PR=$(gh pr list --state open --head "$BRANCH_NAME" --json url --jq ".[0].url")
+          # Check for existing open PR from this branch
+          EXISTING_PR=$(gh pr list --state open --head "$BRANCH_NAME" --json url --jq ".[0].url // empty")
 
           if [ -n "$EXISTING_PR" ]; then
             echo "Updating existing PR: $EXISTING_PR" >> "$GITHUB_STEP_SUMMARY"
             git push -u origin "$BRANCH_NAME" --force
             gh pr edit "$EXISTING_PR" --title "$PR_TITLE" --body "$PR_BODY"
           else
+            # Check if a closed PR with the same title already exists
+            CLOSED_PR=$(gh pr list --state closed --search "$PR_TITLE in:title" --json url --jq ".[0].url // empty")
+            if [ -n "$CLOSED_PR" ]; then
+              echo "A closed PR already exists for this version: $CLOSED_PR" >> "$GITHUB_STEP_SUMMARY"
+              echo "Skipping PR creation."
+              exit 0
+            fi
+
             echo "Creating new PR" >> "$GITHUB_STEP_SUMMARY"
             git push -u origin "$BRANCH_NAME"
             gh pr create \


### PR DESCRIPTION
Avoid repeatedly opening new PRs for the same CLI version when a previous one was intentionally closed.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review