### PR TITLE
mcp catalog policy

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/_index.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/_index.md
@@ -27,6 +27,10 @@ grid:
     description: Learn about the underlying technology that powers the MCP Toolkit
     icon: developer_board
     link: /ai/mcp-catalog-and-toolkit/mcp-gateway/
+  - title: Governance and policy controls
+    description: Control which MCP servers and tools users can access
+    icon: security
+    link: /ai/mcp-catalog-and-toolkit/governance/
   - title: Dynamic MCP
     description: Discover and add MCP servers on-demand using natural language
     icon: search

--- a/content/manuals/ai/mcp-catalog-and-toolkit/_index.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/_index.md
@@ -11,30 +11,38 @@ weight: 10
 description: Learn about Docker's MCP catalog on Docker Hub
 keywords: Docker, ai, mcp servers, ai agents, extension, docker desktop, llm, docker hub
 grid:
- - title: Get started with MCP Toolkit
-   description: Learn how to quickly install and use the MCP Toolkit to set up servers and clients.
-   icon: explore
-   link: /ai/mcp-catalog-and-toolkit/get-started/
- - title: MCP Catalog
-   description: Learn about the benefits of the MCP Catalog, how you can use it, and how you can contribute
-   icon: hub
-   link: /ai/mcp-catalog-and-toolkit/catalog/
- - title: MCP Toolkit
-   description: Learn about the MCP Toolkit to manage MCP servers and clients
-   icon: /icons/toolkit.svg
-   link: /ai/mcp-catalog-and-toolkit/toolkit/
- - title: Dynamic MCP
-   description: Discover and add MCP servers on-demand using natural language
-   icon: search
-   link: /ai/mcp-catalog-and-toolkit/dynamic-mcp/
- - title: MCP Gateway
-   description: Learn about the underlying technology that powers the MCP Toolkit
-   icon: developer_board
-   link: /ai/mcp-catalog-and-toolkit/mcp-gateway/
- - title: Docker Hub MCP server
-   description: Explore about the Docker Hub server for searching images, managing repositories, and more
-   icon: device_hub
-   link: /ai/mcp-catalog-and-toolkit/hub-mcp/
+  - title: Get started with MCP Toolkit
+    description: Learn how to quickly install and use the MCP Toolkit to set up servers and clients.
+    icon: explore
+    link: /ai/mcp-catalog-and-toolkit/get-started/
+  - title: MCP Catalog
+    description: Browse Docker's curated collection of verified MCP servers
+    icon: hub
+    link: /ai/mcp-catalog-and-toolkit/catalog/
+  - title: MCP Toolkit
+    description: Learn about the MCP Toolkit to manage MCP servers and clients
+    icon: /icons/toolkit.svg
+    link: /ai/mcp-catalog-and-toolkit/toolkit/
+  - title: MCP Gateway
+    description: Learn about the underlying technology that powers the MCP Toolkit
+    icon: developer_board
+    link: /ai/mcp-catalog-and-toolkit/mcp-gateway/
+  - title: Dynamic MCP
+    description: Discover and add MCP servers on-demand using natural language
+    icon: search
+    link: /ai/mcp-catalog-and-toolkit/dynamic-mcp/
+  - title: Docker Hub MCP server
+    description: Use the Docker Hub MCP server to search images and manage repositories
+    icon: device_hub
+    link: /ai/mcp-catalog-and-toolkit/hub-mcp/
+  - title: Security FAQs
+    description: Common questions about MCP security, credentials, and server verification
+    icon: security
+    link: /ai/mcp-catalog-and-toolkit/faqs/
+  - title: E2B sandboxes
+    description: Cloud sandboxes for AI agents with built-in MCP Catalog access
+    icon: cloud
+    link: /ai/mcp-catalog-and-toolkit/e2b-sandboxes/
 ---
 
 {{< summary-bar feature_name="Docker MCP Catalog and Toolkit" >}}
@@ -45,47 +53,39 @@ and data sources. By connecting LLMs to local development tools, databases,
 APIs, and other resources, MCP extends their capabilities beyond their base
 training.
 
-Through a client-server architecture, applications such as Claude, ChatGPT, and
-[Gordon](/manuals/ai/gordon/_index.md) act as clients that send requests to MCP
-servers, which then process these requests and deliver the necessary context to
-AI models.
-
-MCP servers extend the utility of AI applications, but running servers locally
-also presents several operational challenges. Typically, servers must be
-installed directly on your machine and configured individually for each
-application. Running untrusted code locally requires careful vetting, and the
-responsibility of keeping servers up-to-date and resolving environment
-conflicts falls on the user.
+The challenge is that running MCP servers locally creates operational friction.
+Each server requires separate installation and configuration for every
+application you use. You run untrusted code directly on your machine, manage
+updates manually, and troubleshoot dependency conflicts yourself. Configure a
+GitHub server for Claude, then configure it again for Cursor, and so on. Each
+time you manage credentials, permissions, and environment setup.
 
 ## Docker MCP features
 
-Docker provides three integrated components that address the challenges of
-running local MCP servers:
+Docker solves these challenges by packaging MCP servers as containers and
+providing tools to manage them centrally. Docker provides three integrated
+components: the [MCP Catalog](/ai/mcp-catalog-and-toolkit/catalog/) for
+discovering servers, the [MCP Gateway](/ai/mcp-catalog-and-toolkit/mcp-gateway/)
+for running them, and the [MCP Toolkit](/ai/mcp-catalog-and-toolkit/toolkit/)
+for managing everything through Docker Desktop.
 
-MCP Catalog
-: A curated collection of verified MCP servers, packaged and distributed as
-container images via Docker Hub. All servers are versioned, come with full
-provenance and SBOM metadata, and are continuously maintained and updated with
-security patches.
+The [MCP Catalog](/ai/mcp-catalog-and-toolkit/catalog/) is where you find
+servers. Docker maintains 300+ verified servers, packaged as container images
+with versioning, provenance, and security updates. Servers run isolated in
+containers rather than directly on your machine. Organizations can create
+[custom catalogs](/ai/mcp-catalog-and-toolkit/catalog/#custom-catalogs) with
+approved servers for their teams.
 
-MCP Toolkit
-: A graphical interface in Docker Desktop for discovering, configuring, and
-managing MCP servers. The Toolkit provides a unified way to search for servers,
-handle authentication, and connect them to AI applications.
+The [MCP Gateway](/ai/mcp-catalog-and-toolkit/mcp-gateway/) runs your servers
+and routes requests from AI applications to the right server. It handles
+containerized servers, remote servers, authentication, and lifecycle
+management. Every AI application connects to the Gateway, which means you
+configure credentials and permissions once instead of per-application.
 
-MCP Gateway
-: The core open source component that powers the MCP Toolkit. The MCP Gateway
-manages MCP containers provides a unified endpoint that exposes your enabled
-servers to all AI applications you use.
-
-This integrated approach ensures:
-
-- Simplified discovery and setup of trusted MCP servers from a curated catalog
-  of tools
-- Centralized configuration and authentication from within Docker Desktop
-- A secure, consistent execution environment by default
-- Improved performance since applications can share a single server runtime,
-  compared to having to spin up duplicate servers for each application.
+The [MCP Toolkit](/ai/mcp-catalog-and-toolkit/toolkit/) provides a graphical
+interface in Docker Desktop for browsing catalogs, enabling servers, and
+connecting clients. You can also use the `docker mcp` CLI to manage everything
+from the terminal.
 
 ![MCP overview](./images/mcp-overview.svg)
 

--- a/content/manuals/ai/mcp-catalog-and-toolkit/catalog.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/catalog.md
@@ -26,7 +26,7 @@ environments.
 
 The Docker MCP Catalog includes:
 
-- Verified servers: All servers are versioned with full provenance and SBOM
+- Verified servers: All local servers are versioned with full provenance and SBOM
   metadata
 - Partner tools: Servers from New Relic, Stripe, Grafana, and other trusted
   partners

--- a/content/manuals/ai/mcp-catalog-and-toolkit/catalog.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/catalog.md
@@ -1,6 +1,6 @@
 ---
 title: Docker MCP Catalog
-linkTitle: MCP Catalog
+linkTitle: Catalog
 description: Learn about the benefits of the MCP Catalog, how you can use it, and how you can contribute
 keywords: docker hub, mcp, mcp servers, ai agents, catalog, docker
 weight: 20
@@ -8,79 +8,64 @@ weight: 20
 
 {{< summary-bar feature_name="Docker MCP Catalog" >}}
 
-The [Docker MCP Catalog](https://hub.docker.com/mcp) is a centralized, trusted
-registry for discovering, sharing, and running MCP-compatible tools. Integrated
-with Docker Hub, it offers verified, versioned, and curated MCP servers
-packaged as Docker images. The catalog is also available in Docker Desktop.
+The [Docker MCP Catalog](https://hub.docker.com/mcp) is a curated collection of
+verified MCP servers, packaged as Docker images and distributed through Docker
+Hub. It solves common challenges with running MCP servers locally: environment
+conflicts, setup complexity, and security concerns.
 
-The catalog solves common MCP server challenges:
-
-- Environment conflicts. Tools often need specific runtimes that might clash
-  with existing setups.
-- Lack of isolation. Traditional setups risk exposing the host system.
-- Setup complexity. Manual installation and configuration slow adoption.
-- Inconsistency across platforms. Tools might behave unpredictably on different
-  operating systems.
-
-With Docker, each MCP server runs as a self-contained container. This makes it
-portable, isolated, and consistent. You can launch tools instantly using the
-Docker CLI or Docker Desktop, without worrying about dependencies or
-compatibility.
-
-## Key features
-
-- Extensive collection of verified MCP servers in one place.
-- Publisher verification and versioned releases.
-- Pull-based distribution using Docker infrastructure.
-- Tools provided by partners such as New Relic, Stripe, Grafana, and more.
+The catalog serves as the source of available MCP servers. Each server runs as
+an isolated container, making it portable and consistent across different
+environments.
 
 > [!NOTE]
 > E2B sandboxes now include direct access to the Docker MCP Catalog, giving developers
 > access to over 200 tools and services to seamlessly build and run AI agents. For
 > more information, see [E2B Sandboxes](sandboxes.md).
 
-## How it works
+## What's in the catalog
 
-Each tool in the MCP Catalog is packaged as a Docker image with metadata.
+The Docker MCP Catalog includes:
 
-- Discover tools on Docker Hub under the `mcp/` namespace.
-- Connect tools to your preferred agents with simple configuration through the
-  [MCP Toolkit](toolkit.md).
-- Pull and run tools using Docker Desktop or the CLI.
+- Verified servers: All servers are versioned with full provenance and SBOM
+  metadata
+- Partner tools: Servers from New Relic, Stripe, Grafana, and other trusted
+  partners
+- Docker-built servers: Locally-running servers built and digitally signed by
+  Docker for enhanced security
+- Remote services: Cloud-hosted servers that connect to external services like
+  GitHub, Notion, and Linear
 
-Each catalog entry displays:
+You can browse the catalog at [hub.docker.com/mcp](https://hub.docker.com/mcp)
+or through the **Catalog** tab in Docker Desktop's MCP Toolkit.
 
-- Tool description and metadata.
-- Version history.
-- List of tools provided by the MCP server.
-- Example configuration for agent integration.
+### Local versus remote servers
 
-## Server deployment types
+The catalog contains two types of servers based on where they run:
 
-The Docker MCP Catalog supports both local and remote server deployments, each optimized for different use cases and requirements.
+Local servers run as containers on your machine. They work offline once
+downloaded and offer predictable performance and complete data privacy. Docker
+builds and signs all local servers in the catalog.
 
-### Local MCP servers
+Remote servers run on the provider's infrastructure and connect to external
+services. Many remote servers use OAuth authentication, which the MCP Toolkit
+handles automatically through your browser.
 
-Local MCP servers are containerized applications that run directly on your machine. All local servers are built and digitally signed by Docker, providing enhanced security through verified provenance and integrity. These servers run as containers on your local environment and function without internet connectivity once downloaded. Local servers display a Docker icon {{< inline-image src="../../desktop/images/whale-x.svg" alt="docker whale icon" >}} to indicate they are built by Docker.
+## Using servers from the catalog
 
-Local servers offer predictable performance, complete data privacy, and independence from external service availability. They work well for development workflows, sensitive data processing, and scenarios requiring offline functionality.
+To start using MCP servers from the catalog:
 
-### Remote MCP servers
+1. Browse servers in the [MCP Catalog](https://hub.docker.com/mcp) or in Docker
+   Desktop
+2. Enable servers through the MCP Toolkit
+3. Configure any required authentication (OAuth is handled automatically)
+4. Connect your AI applications to use the servers
 
-Remote MCP servers are hosted services that run on the provider's
-infrastructure and connect to external services like GitHub, Notion, and
-Linear. Many remote servers use OAuth authentication. When a remote server
-requires OAuth, the MCP Toolkit handles authentication automatically - you
-authorize access through your browser, and the Toolkit manages credentials
-securely. You don't need to manually create API tokens or configure
-authentication.
+For detailed step-by-step instructions, see:
 
-Remote servers display a cloud icon in the catalog. For setup instructions, see
-[MCP Toolkit](toolkit.md#oauth-authentication).
-
-## Use an MCP server from the catalog
-
-To use an MCP server from the catalog, see [MCP Toolkit](toolkit.md).
+- [Get started with MCP Toolkit](/ai/mcp-catalog-and-toolkit/get-started/) -
+  Quick start guide
+- [MCP Toolkit](/ai/mcp-catalog-and-toolkit/toolkit/) - Detailed usage
+  instructions
 
 ## Contribute an MCP server to the catalog
 
@@ -95,3 +80,119 @@ within 24 hours on:
 - The [Docker MCP Catalog](https://hub.docker.com/mcp).
 - The [Docker Hub](https://hub.docker.com/u/mcp) `mcp` namespace (for MCP
   servers built by Docker).
+
+## Custom catalogs
+
+Custom catalogs let you curate focused collections of recommended servers. You
+can package custom server implementations alongside public servers, distribute
+curated lists to your team, and define what agents can discover when using
+Dynamic MCP.
+
+Common use cases:
+
+- Curate a subset of servers from the Docker MCP Catalog that your organization
+  approves
+- Include community registry servers that aren't in the Docker catalog
+- Add your organization's private MCP servers
+- Control which versions of servers your team uses
+
+### Custom catalogs with Dynamic MCP
+
+Custom catalogs work particularly well with
+[Dynamic MCP](/ai/mcp-catalog-and-toolkit/dynamic-mcp/), where agents
+discover and add MCP servers on-demand during conversations. When you specify a
+custom catalog with the gateway, the `mcp-find` tool searches only within your
+curated catalog. If your catalog contains 20 servers instead of 300+, agents
+work within that focused set and can dynamically add servers as needed without
+manual configuration each time.
+
+This gives agents the autonomy to discover and use tools while keeping their
+options within boundaries your team defines.
+
+### Create and curate a catalog
+
+The most practical way to create a custom catalog is to fork the Docker catalog
+and then curate which servers to keep:
+
+```console
+$ docker mcp catalog fork docker-mcp my-catalog
+```
+
+This creates a copy of the Docker catalog with all available servers. Export it
+to a file where you can edit which servers to include:
+
+```console
+$ docker mcp catalog export my-catalog ./my-catalog.yaml
+```
+
+Edit `my-catalog.yaml` to remove servers you don't want, keeping only the ones
+your team needs. Each server is listed in the `registry` section. Import the
+edited catalog back:
+
+```console
+$ docker mcp catalog import ./my-catalog.yaml
+```
+
+View your curated catalog:
+
+```console
+$ docker mcp catalog show my-catalog
+```
+
+#### Alternative: Build incrementally
+
+You can also build a catalog from scratch. Start with an empty catalog or a
+template:
+
+```console
+$ docker mcp catalog create my-catalog
+```
+
+Or create a starter template with example servers:
+
+```console
+$ docker mcp catalog bootstrap ./starter-catalog.yaml
+```
+
+Add servers from other catalog files:
+
+```console
+$ docker mcp catalog add my-catalog notion ./other-catalog.yaml
+```
+
+### Use a custom catalog
+
+Use your custom catalog when running the MCP gateway. For static server
+configuration, specify which servers to enable:
+
+```console
+$ docker mcp gateway run --catalog my-catalog.yaml --servers notion,brave
+```
+
+For Dynamic MCP, where agents discover and add servers during conversations,
+specify just the catalog:
+
+```console
+$ docker mcp gateway run --catalog my-catalog.yaml
+```
+
+Agents can then use `mcp-find` to search for servers within your catalog and
+`mcp-add` to enable them dynamically.
+
+The `--catalog` flag points to a catalog file in `~/.docker/mcp/catalogs/`.
+
+### Share your catalog
+
+Share your catalog with your team by distributing the YAML file or hosting it
+at a URL:
+
+```console
+$ docker mcp catalog export my-catalog ./team-catalog.yaml
+```
+
+Team members can import it:
+
+```console
+$ docker mcp catalog import ./team-catalog.yaml
+$ docker mcp catalog import https://example.com/team-catalog.yaml
+```

--- a/content/manuals/ai/mcp-catalog-and-toolkit/governance.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/governance.md
@@ -1,0 +1,389 @@
+---
+title: MCP governance and policy controls
+linkTitle: Governance and policy
+description: Control which MCP servers and tools users can access
+keywords: mcp, governance, policy, security, access control, settings management
+weight: 35
+---
+
+Organizations can define rules to control which MCP servers and tools
+users can load and invoke. This lets administrators enforce security
+policies and compliance requirements by allowing or denying specific
+servers based on criteria like server type, source, or transport
+mechanism.
+
+Policies are configured through Settings Management using either the Admin
+Console or the `admin-settings.json` file. Rules can apply globally to the
+entire organization or target specific users. See
+[Configuration](#configuration) for setup instructions.
+
+## Policy structure
+
+The policy is a JSON format evaluated by Open Policy Agent
+([Rego](https://www.openpolicyagent.org/docs/policy-language)) under the hood.
+A policy contains a set of rules that define conditions and actions. When an
+MCP server attempts to load or a tool attempts to execute, the policy engine
+evaluates each rule in order until it finds a match (first match wins). If a
+rule matches the current context, the engine applies the rule's decision (allow
+or deny). If no rules match, the default behavior applies.
+
+Here's a basic policy that blocks a specific server:
+
+```json
+{
+  "version": 1,
+  "default": "allow",
+  "rules": [
+    {
+      "action": "load",
+      "server": "untrusted-server",
+      "allow": false,
+      "reason": "This server is not approved for organizational use"
+    }
+  ]
+}
+```
+
+This policy allows all servers except `untrusted-server`. Rules override
+the default behavior when they match.
+
+### Policy schema
+
+Policies consist of:
+
+- `version` (optional): Policy schema version (currently `1`)
+- `default`: Default action when no rules match ("allow" or "deny")
+- `rules`: Array of rule objects that define specific conditions
+
+Each rule can specify:
+
+- `action`: Operation to control ("load", "invoke", "prompt")
+- `server`: Specific server name to match
+- `serverType`: Type of server ("registry", "image", "remote")
+- `serverSource`: Source identifier for the server
+  - For `registry` and `image` servers this is the image reference (for example `docker.io/mcp/github:1.2.3` or `ghcr.io/org/server:latest`)
+  - For `remote` servers this is the endpoint URL (for example `https://mcp.example.com`)
+- `transport`: Communication method ("stdio", "sse", "streamable")
+- `tools`: Array of tool names to match
+- `allow`: Whether to allow (`true`) or deny (`false`) the action. Can also use `deny: true` as an alternative to `allow: false`
+- `reason`: Human-readable explanation for the rule
+
+### Rule evaluation
+
+The policy engine evaluates rules sequentially:
+
+1. Check if a rule matches the current action and context
+2. If a rule matches, apply its `allow` or `deny` decision
+3. If no rules match, apply the `default` behavior
+
+Order matters. Place more specific rules before general rules to ensure
+they evaluate first. For example, a rule blocking a specific tool should
+come before a rule allowing all tools on a server
+
+## Policy examples
+
+The following examples demonstrate common policy patterns. Each example
+builds on the previous concepts, starting with basic server blocking and
+progressing to comprehensive production policies.
+
+### Block a specific server
+
+Use default allow with explicit deny rules to block specific servers.
+This approach requires minimal configuration while preventing access to
+known problematic servers:
+
+```json
+{
+  "version": 1,
+  "default": "allow",
+  "rules": [
+    {
+      "action": "load",
+      "server": "untrusted-server",
+      "allow": false,
+      "reason": "This server is not approved for organizational use"
+    }
+  ]
+}
+```
+
+### Default deny with allowlist
+
+For security-sensitive environments, use default deny with an explicit
+allowlist. This approach ensures users can only load pre-approved servers,
+preventing unauthorized or untested servers from executing:
+
+```json
+{
+  "version": 1,
+  "default": "deny",
+  "rules": [
+    {
+      "action": "load",
+      "serverType": "registry",
+      "serverSource": "docker.io/mcp/*",
+      "allow": true,
+      "reason": "Allow official Docker MCP servers from registry"
+    },
+    {
+      "action": "load",
+      "server": "github-official",
+      "allow": true,
+      "reason": "Allow GitHub official server"
+    },
+    {
+      "action": "load",
+      "server": "filesystem",
+      "allow": true,
+      "reason": "Allow filesystem access server"
+    }
+  ]
+}
+```
+
+This policy:
+
+- Blocks all servers by default
+- Allows official Docker MCP servers from the registry
+- Allows specific named servers that have been approved
+
+### Block specific tools
+
+Allow servers to load but restrict individual tools within them. This
+provides granular control, permitting read-only operations while blocking
+destructive actions:
+
+```json
+{
+  "version": 1,
+  "default": "allow",
+  "rules": [
+    {
+      "action": "invoke",
+      "server": "github-official",
+      "tools": ["create_repository", "delete_repository"],
+      "allow": false,
+      "reason": "Block destructive GitHub operations"
+    },
+    {
+      "action": "invoke",
+      "server": "filesystem",
+      "tools": ["write_file", "delete_file"],
+      "allow": false,
+      "reason": "Prevent file modifications"
+    }
+  ]
+}
+```
+
+This policy allows servers to load but restricts specific tools that
+could modify or delete data. Always specify a `server` field for tool rules
+to avoid unintended matches when multiple servers have tools with the same name.
+
+### Block servers from specific registries
+
+Organizations using [custom catalogs](catalog.md#custom-catalogs) can
+include servers from multiple OCI registries beyond Docker Hub (such as
+GHCR, private registries, or community registries). Use policies to control
+which registries users can load servers from:
+
+- **`serverType: "registry"`** - Servers loaded from OCI registries (GHCR,
+  private registries, etc.)
+- **`serverType: "image"`** - Servers loaded from local Docker images
+- **`serverSource`** - Matches the server image reference for `registry` and
+  `image` servers, or the endpoint URL of `remote` servers. Supports wildcards.
+
+This example blocks servers from GitHub Container Registry while allowing
+other sources:
+
+```json
+{
+  "version": 1,
+  "default": "allow",
+  "rules": [
+    {
+      "action": "load",
+      "serverType": "registry",
+      "serverSource": "ghcr.io/*",
+      "allow": false,
+      "reason": "Block servers from GitHub Container Registry"
+    },
+    {
+      "action": "load",
+      "serverType": "image",
+      "allow": false,
+      "reason": "Block all local image-based servers"
+    }
+  ]
+}
+```
+
+This policy:
+
+- Blocks servers from specific OCI registries (like GitHub Container Registry)
+- Blocks all local image-based servers
+- Allows servers from other sources (like Docker Hub)
+
+### Filter by transport mechanism
+
+Restrict communication protocols based on security requirements. Block
+remote servers or specific transports to limit network exposure:
+
+```json
+{
+  "version": 1,
+  "default": "allow",
+  "rules": [
+    {
+      "action": "load",
+      "transport": "sse",
+      "allow": false,
+      "reason": "Block server-sent events transport for security"
+    },
+    {
+      "action": "load",
+      "serverType": "remote",
+      "allow": false,
+      "reason": "Block all remote servers"
+    }
+  ]
+}
+```
+
+This policy restricts transport mechanisms and prevents remote server
+connections.
+
+### Combined policy for production
+
+A comprehensive policy for production environments:
+
+```json
+{
+  "version": 1,
+  "default": "deny",
+  "rules": [
+    {
+      "action": "load",
+      "serverType": "registry",
+      "serverSource": "docker.io/mcp/*",
+      "allow": true,
+      "reason": "Allow official Docker MCP servers"
+    },
+    {
+      "action": "load",
+      "serverType": "registry",
+      "serverSource": "internal-registry.company.com/mcp/*",
+      "allow": true,
+      "reason": "Allow company-approved internal servers"
+    },
+    {
+      "action": "invoke",
+      "tools": ["delete_*", "remove_*", "destroy_*"],
+      "allow": false,
+      "reason": "Block destructive operations across all servers"
+    },
+    {
+      "action": "load",
+      "serverType": "remote",
+      "allow": false,
+      "reason": "Block remote servers for security"
+    }
+  ]
+}
+```
+
+This production policy:
+
+- Denies all servers by default
+- Allows only official Docker and internal company servers
+- Blocks tools with destructive names
+- Prevents remote server connections
+
+## Configuration
+
+Configure MCP policies using either the Admin Console or the `admin-settings.json` file.
+
+### Admin Console
+
+To apply a policy through the Admin Console:
+
+1. Open the [Admin Console](https://app.docker.com) and navigate to Settings
+   Management.
+2. Select the policy that you want to update.
+3. Find the **AI > MCP Policy** option.
+4. Enter your policy JSON into the configuration field.
+5. Save and distribute the policy.
+
+For detailed instructions, see [Configure with Admin Console](/manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console.md).
+
+### admin-settings.json file
+
+For automated deployments or scripted installations, use the
+[`admin-settings.json` file](/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md)
+placed on end-user machines.
+
+To configure an MCP policy in `admin-settings.json`, add the policy as a
+JSON-escaped string in the `mcpPolicy` field:
+
+```json
+{
+  "configurationFileVersion": 2,
+  "mcpPolicy": {
+    "locked": true,
+    "value": "{\"version\":1,\"default\":\"deny\",\"rules\":[{\"action\":\"load\",\"server\":\"approved-server\",\"allow\":true,\"reason\":\"Approved for use\"}]}"
+  }
+}
+```
+
+> [!NOTE]
+> The policy JSON must be escaped as a string value. Admin Console policies
+> take precedence over `admin-settings.json` policies.
+
+### Policy propagation
+
+Policy updates may take a moment to propagate to Docker Desktop. If a policy
+change doesn't take effect immediately, restart Docker Desktop to apply the
+updated policy.
+
+## Policy strategies
+
+Choose a policy approach based on your security requirements:
+
+**Default deny**: Use `"default": "deny"` for hardened environments.
+Explicitly allow only approved servers and tools. This prevents unauthorized
+servers from loading.
+
+With default deny, you must create rules for both `"action": "load"` and
+`"action": "invoke"` to enable tools. For example:
+
+```json
+{
+  "version": 1,
+  "default": "deny",
+  "rules": [
+    {
+      "action": "load",
+      "server": "github-official",
+      "allow": true,
+      "reason": "Allow GitHub server to load"
+    },
+    {
+      "action": "invoke",
+      "server": "github-official",
+      "allow": true,
+      "reason": "Allow invoking GitHub tools"
+    }
+  ]
+}
+```
+
+Without both rules, the server loads but its tools remain blocked.
+
+**Default allow**: Use `"default": "allow"` for development environments.
+Block specific problematic servers while permitting experimentation with new
+tools.
+
+Use wildcards (`*`) in `serverSource` to match multiple servers from the
+same registry or organization. Combine action types (load and invoke) for
+layered security - allow a server to load but block specific destructive
+tools within it.

--- a/content/manuals/ai/mcp-catalog-and-toolkit/toolkit.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/toolkit.md
@@ -80,6 +80,23 @@ are invoked, enforced through resource and access limitations.
 - Interception of tool requests: Requests to and from tools that contain sensitive
   information such as secrets are blocked.
 
+### Governance and policy controls
+
+Organizations can define rules to control which MCP servers and tools
+users can load and invoke. This lets administrators enforce security
+policies and compliance requirements.
+
+The policy system supports:
+
+- Allow or deny rules for loading MCP servers
+- Control over tool invocation within allowed servers
+- Filtering by server type, source, or transport mechanism
+- Default allow or deny behavior with explicit exceptions
+
+Policies are configured through Settings Management in the Admin Console.
+For detailed policy documentation, examples, and best practices, see
+[MCP governance and policy controls](/manuals/ai/mcp-catalog-and-toolkit/governance.md).
+
 ### OAuth authentication
 
 Some MCP servers require authentication to access external services like

--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
@@ -687,6 +687,26 @@ Builders settings lets you manage Buildx builder instances for advanced image-bu
     - Settings Management: `enableInferenceGPUVariant` setting in the [`admin-settings.json` file](/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md)
     - Settings Management: **Enable GPU-backed inference** setting in the [Admin Console](/manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console.md)
 
+### MCP Policy
+
+| Default value     | Accepted values                  | Format      |
+| ----------------- | -------------------------------- | ----------- |
+| Empty (allow all) | JSON object following policy DSL | JSON object |
+
+- **Description:** Define allow/deny rules for MCP servers and tools.
+  Control which MCP servers users can load and which tools they can
+  invoke based on server type, source, transport, and other criteria.
+- **OS:** {{< badge color=blue text="All" >}}
+- **Use case:** Enforce organizational security policies by restricting
+  access to approved MCP servers, blocking untrusted sources, or limiting
+  tool invocation capabilities.
+- **Configure this setting with:**
+  - Settings Management: **MCP Policy** setting in the [Admin Console](/manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console.md)
+  - [`admin-settings.json` file](/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md): `mcpPolicy` field
+
+For complete policy documentation including structure, examples, and best
+practices, see [MCP governance and policy controls](/manuals/ai/mcp-catalog-and-toolkit/governance.md).
+
 ## Kubernetes settings
 
 ### Enable Kubernetes

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -326,6 +326,10 @@
   - /go/mcp-toolkit-install-mcp-client/
 "/ai/mcp-catalog-and-toolkit/toolkit/#example-use-claude-desktop-as-a-client":
   - /go/mcp-toolkit-use-client-examples/
+"/ai/mcp-catalog-and-toolkit/get-started/#verify-connections":
+  - /go/mcp-client-verify/
+"/ai/mcp-catalog-and-toolkit/catalog/#custom-catalogs":
+  - /go/mcp-custom-catalogs/
 
  # Desktop DMR
 "/ai/model-runner/":
@@ -394,9 +398,6 @@
 
 "/dhi/how-to/customize/#create-an-oci-artifact-image":
   - /go/dhi-customization-artifacts/
-
-"/ai/mcp-catalog-and-toolkit/get-started/#verify-connections":
-  - /go/mcp-client-verify/
 
 # Copilot extension (deprecated)
 "https://github.com/marketplace/docker-for-github-copilot":


### PR DESCRIPTION
- add docs for custom MCP catalogs (pre-profiles)
- add mcp governance/policy controls

Preview: https://deploy-preview-24118--docsdocker.netlify.app/ai/mcp-catalog-and-toolkit/governance/