### PR TITLE
fix: correct compose config reference link

### DIFF
--- a/content/manuals/engine/swarm/configs.md
+++ b/content/manuals/engine/swarm/configs.md
@@ -133,7 +133,7 @@ Docker configs.
 
 The `docker stack` command supports defining configs in a Compose file.
 However, the `configs` key is not supported for `docker compose`. See
-[the Compose file reference](/reference/compose-file/legacy-versions.md) for details.
+[the Compose file reference](/reference/compose-file/configs.md) for details.
 
 ### Simple example: Get started with configs
 


### PR DESCRIPTION
## Description

The link under the "Defining and using configs in compose files" section in the Swarm configs documentation pointed to `/reference/compose-file/legacy-versions/` instead of `/reference/compose-file/configs/`.

Fixes #24079