### PR TITLE
fix: correct HEALTHCHECK interval documentation

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -2865,8 +2865,9 @@ The options that can appear before `CMD` are:
 - `--start-interval=DURATION` (default: `5s`)
 - `--retries=N` (default: `3`)
 
-The health check will first run **interval** seconds after the container is
-started, and then again **interval** seconds after each previous check completes.
+The health check will first run **start-interval** seconds after the container is
+started (during the start period), and then **interval** seconds after each
+previous check completes once the container is considered started.
 
 If a single run of the check takes longer than **timeout** seconds then the check
 is considered to have failed. The process performing the check is abruptly stopped


### PR DESCRIPTION
## Description

The HEALTHCHECK documentation stated that the health check first runs after **interval** seconds. In practice, the initial checks use **start-interval** (default 5s) during the start period, and then **interval** seconds after each previous check completes once the container is considered started.

Fixes #24096