### PR TITLE
fix: correct CMD form recommendation with exec ENTRYPOINT

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -2071,7 +2071,7 @@ Only the last `ENTRYPOINT` instruction in the Dockerfile will have an effect.
 ### Exec form ENTRYPOINT example
 
 You can use the exec form of `ENTRYPOINT` to set fairly stable default commands
-and arguments and then use either form of `CMD` to set additional defaults that
+and arguments and then use the exec form of `CMD` to set additional defaults that
 are more likely to be changed.
 
 ```dockerfile


### PR DESCRIPTION
## Description

The Dockerfile reference under "Exec form ENTRYPOINT example" stated that you can use "either form of CMD" with an exec form ENTRYPOINT. However, earlier in the same document it states that both CMD and ENTRYPOINT should use the exec form when CMD provides default arguments to ENTRYPOINT.

Changed "either form" to "the exec form" for consistency.

## Related issues or tickets

Fixes #23122

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review