### PR TITLE
fix: clarify STOPSIGNAL applies to docker stop, not Ctrl+C

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -2832,10 +2832,15 @@ STOPSIGNAL signal
 ```
 
 The `STOPSIGNAL` instruction sets the system call signal that will be sent to the
-container to exit. This signal can be a signal name in the format `SIG<NAME>`,
-for instance `SIGKILL`, or an unsigned number that matches a position in the
-kernel's syscall table, for instance `9`. The default is `SIGTERM` if not
-defined.
+container to exit when running `docker stop` or `docker container stop`. This
+signal can be a signal name in the format `SIG<NAME>`, for instance `SIGKILL`,
+or an unsigned number that matches a position in the kernel's syscall table,
+for instance `9`. The default is `SIGTERM` if not defined.
+
+> **Note**
+>
+> Stopping a foreground container with `Ctrl+C` sends `SIGINT` to the
+> container process, not the signal specified by `STOPSIGNAL`.
 
 The image's default stopsignal can be overridden per container, using the
 `--stop-signal` flag on `docker run` and `docker create`.


### PR DESCRIPTION
## Description

Clarified that the `STOPSIGNAL` instruction applies specifically when stopping a container via `docker stop` or `docker container stop`. Added a note explaining that `Ctrl+C` on a foreground container sends `SIGINT`, not the signal specified by `STOPSIGNAL`.

## Related issues or tickets

Fixes #23140

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review