### PR TITLE
fix: remove named volume from volume prune example

### DIFF
--- a/data/engine-cli/docker_volume_prune.yaml
+++ b/data/engine-cli/docker_volume_prune.yaml
@@ -60,7 +60,6 @@ examples: |-
     Are you sure you want to continue? [y/N] y
     Deleted Volumes:
     07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e
-    my-named-vol
 
     Total reclaimed space: 36 B
     ```


### PR DESCRIPTION
## Description

The `docker volume prune` documentation states that by default it only removes anonymous volumes. However, the example output included `my-named-vol`, which is a named volume. Removed it from the example to match the documented behavior.

Fixes #24007