### PR TITLE
dhi: add regctl attestation example

### DIFF
--- a/content/manuals/dhi/how-to/verify.md
+++ b/content/manuals/dhi/how-to/verify.md
@@ -148,7 +148,7 @@ $ regctl artifact get registry.scout.docker.com/${DOCKER_ORG}/dhi-node@sha256:6c
 
 ### Validate the attestation
 
-{{< tabs group="tool" >}}
+{{< tabs >}}
 {{< tab name="Docker Scout" >}}
 
 To validate the attestation using Docker Scout, you can use the `--verify` flag:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Currently, we only show how to use Scout to get attestations.

Added how to retrieve using regctl. Used tabs to show scout/regctl and scout/cosign.
Removed "Why use Docker Scout?" and put a more concise recommendation in the intro.

https://deploy-preview-24130--docsdocker.netlify.app/dhi/how-to/verify/

## Related issues or tickets

ENGDOCS-3115

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review