### PR TITLE
engine: add bind-create-src mount option

### DIFF
--- a/content/get-started/docker-concepts/running-containers/sharing-local-files.md
+++ b/content/get-started/docker-concepts/running-containers/sharing-local-files.md
@@ -38,7 +38,7 @@ Here's a way to use `docker run` to start a container using a bind mount and map
 $ docker run -v /HOST/PATH:/CONTAINER/PATH -it nginx
 ```
 
-The `--mount` flag offers more advanced features and granular control, making it suitable for complex mount scenarios or production deployments. If you use `--mount` to bind-mount a file or directory that doesn't yet exist on the Docker host, the `docker run` command doesn't automatically create it for you but generates an error.
+The `--mount` flag offers more advanced features and granular control, making it suitable for complex mount scenarios or production deployments. By default, if you use `--mount` to bind-mount a file or directory that doesn't yet exist on the Docker host, the `docker run` command doesn't automatically create it for you but generates an error.
 
 ```console
 $ docker run --mount type=bind,source=/HOST/PATH,target=/CONTAINER/PATH,readonly nginx

--- a/content/manuals/engine/storage/bind-mounts.md
+++ b/content/manuals/engine/storage/bind-mounts.md
@@ -87,12 +87,19 @@ If you use `--volume` to bind-mount a file or directory that does not yet
 exist on the Docker host, Docker automatically creates the directory on the
 host for you. It's always created as a directory.
 
-`--mount` does not automatically create a directory if the specified mount
+By default, `--mount` does not automatically create a directory if the specified mount
 path does not exist on the host. Instead, it produces an error:
 
 ```console
 $ docker run --mount type=bind,src=/dev/noexist,dst=/mnt/foo alpine
 docker: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /dev/noexist.
+```
+
+You can use the `bind-create-src` option to automatically create the source directory
+on the host if it doesn't exist:
+
+```console
+$ docker run --mount type=bind,src=/home/user/mydir,dst=/mnt/foo,bind-create-src alpine
 ```
 
 ### Options for --mount
@@ -107,12 +114,13 @@ $ docker run --mount type=bind,src=<host-path>,dst=<container-path>[,<key>=<valu
 
 Valid options for `--mount type=bind` include:
 
-| Option                         | Description                                                                                                     |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `source`, `src`                | The location of the file or directory on the host. This can be an absolute or relative path.                    |
-| `destination`, `dst`, `target` | The path where the file or directory is mounted in the container. Must be an absolute path.                     |
-| `readonly`, `ro`               | If present, causes the bind mount to be [mounted into the container as read-only](#use-a-read-only-bind-mount). |
-| `bind-propagation`             | If present, changes the [bind propagation](#configure-bind-propagation).                                        |
+| Option                         | Description                                                                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`, `src`                | The location of the file or directory on the host. This can be an absolute or relative path.                                                                        |
+| `destination`, `dst`, `target` | The path where the file or directory is mounted in the container. Must be an absolute path.                                                                         |
+| `readonly`, `ro`               | If present, causes the bind mount to be [mounted into the container as read-only](#use-a-read-only-bind-mount).                                                     |
+| `bind-propagation`             | If present, changes the [bind propagation](#configure-bind-propagation).                                                                                            |
+| `bind-create-src`              | Automatically creates the source directory on the host if it doesn't exist. By default, `--mount` produces an error if the source path doesn't exist on the daemon. |
 
 ```console {title="Example"}
 $ docker run --mount type=bind,src=.,dst=/project,ro,bind-propagation=rshared


### PR DESCRIPTION
## Description

Adds a new option for `--mount type=bind`

## Related issues or tickets

- docker/cli#6792
