### PR TITLE
docs: clarify depends_on short syntax does not wait for healthy services

### DIFF
--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -438,7 +438,7 @@ services:
 
 Compose guarantees dependency services have been started before
 starting a dependent service.
-Compose waits for dependency services to be "ready" before
+With short syntax, Compose does not wait for dependency services to be "healthy" before
 starting a dependent service.
 
 #### Long syntax


### PR DESCRIPTION
## Description

Clarifies that the `depends_on` short syntax does not wait for services to become healthy, and waits only for them to be started (running).

This aligns with the long syntax section, which defines `service_started` as equivalent to the short syntax, and with the [Control startup and shutdown order](https://docs.docker.com/compose/how-tos/startup-order/#control-startup) manual:

> On startup, Compose does not wait until a container is "ready", only until it's running.

Confirmed locally that short syntax behaves equivalently to `condition: service_started`.

## Related issues or tickets

None

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [x] Editorial review
- [ ] Product review