### PR TITLE
Fix typo in Docker Desktop release notes

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -44,7 +44,7 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 
 ### Bug fixes and enhancements
 
-#### For all platforma
+#### For all platforms
 
 - Docker Sandboxes:
    - Added automated image caching to prevent re-downloading images unnecessarily.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This PR fixes a trivial typo in Docker Desktop release notes.
