### PR TITLE
scout: remove experimental callout for watch

### DIFF
--- a/content/manuals/scout/integrations/registry/artifactory.md
+++ b/content/manuals/scout/integrations/registry/artifactory.md
@@ -146,23 +146,22 @@ Scout.
 8. Continuously watch for new or updated images.
 
    Run `docker scout watch` with the `--refresh-registry` option to watch for
-   new images to index. The following is an example command:
+   new images to index.
+
+   The `docker scout watch` command is a long-running process that must
+   continue running indefinitely in the background to receive webhooks and
+   watch for new images. If you run it directly in a terminal and close the
+   session, the process will stop.
+
+   The following is an example command. You can run the process as a system
+   service, for example using `systemd` or `nohup`, to ensure it continues
+   running in the background.
 
    ```console
    $ docker scout watch --registry \
    "type=artifactory,registry=example.jfrog.io,api=https://example.jfrog.io/artifactory,include=*/frontend*,exclude=*/dta/*,repository=docker-local,port=9000,subdomain-mode=true" \
    --refresh-registry
    ```
-
-   > [!IMPORTANT]
-   >
-   > The `docker scout watch` command is a long-running process that must
-   > continue running indefinitely in the background to receive webhooks and
-   > watch for new images. If you run it directly in a terminal and close the
-   > session, the process will stop.
-   >
-   > You can run the process as a system service, for example using
-   > `systemd` or `nohup`, to ensure it continues running in the background.
 
 9. Optional. Set up Scout integration for real-time notifications from popular
    collaboration platforms. For details, see [Integrate Docker Scout with


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Scout watch is no longer experimental as of v1.19.0. Removed callout.

Scout watch must continue running. Added the info to the step with a hint of some commands to run it as a system process.

https://deploy-preview-24181--docsdocker.netlify.app/scout/integrations/registry/artifactory/

## Related issues or tickets

https://docker.slack.com/archives/C04C69EM70C/p1771418602873829?thread_ts=1754573643.278429&cid=C04C69EM70C

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
