### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -3,6 +3,8 @@ MinAlertLevel = suggestion
 IgnoredScopes = text.frontmatter, code, tt, b, strong, i, a
 Vocab = Docker
 
+Packages = https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
+
 # Disable rules for genered content
 [content/reference/**/**.md]
 Vale.Spelling = NO
@@ -34,7 +36,7 @@ Docker.Capitalization = NO
 Docker.Exclamation = NO
 
 [*.md]
-BasedOnStyles = Vale, Docker
+BasedOnStyles = Vale, Docker, NoAnimalViolence
 # Exclude `{{< ... >}}`, `{{% ... %}}`, [Who]({{< ... >}})
 TokenIgnores = ({{[%<] .* [%>]}}.*?{{[%<] ?/.* [%>]}}), \
 (\[.+\]\({{< .+ >}}\)), \


### PR DESCRIPTION
Adds the [no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the docs Vale configuration.

The package flags phrases that normalize violence toward animals and suggests clearer, more professional alternatives. Several are especially common in container and infrastructure documentation:

| Phrase | Suggested alternative |
|--------|----------------------|
| "cattle vs. pets" | "ephemeral vs. persistent" |
| "canary deployment" | "progressive rollout" |
| "kill two birds with one stone" | "accomplish two things at once" |
| "guinea pig" | "test subject" |
| "monkey patch" | "runtime patch" |
| "dead cat bounce" | "temporary rebound" |

The alternatives are more precise and clearer for non-native English readers.

**Package**: https://github.com/Open-Paws/vale-no-animal-violence (MIT)

**Change**: `.vale.ini` — add `NoAnimalViolence` to `Packages` (full URL) and `BasedOnStyles`