### PR TITLE
Remove stale 'New' badge from Dynamic MCP page

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/dynamic-mcp.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/dynamic-mcp.md
@@ -4,11 +4,6 @@ linkTitle: Dynamic discovery
 description: Discover and add MCP servers on-demand using natural language with Dynamic MCP servers
 keywords: dynamic mcps, mcp discovery, mcp-find, mcp-add, code-mode, ai agents, model context protocol
 weight: 40
-params:
-  sidebar:
-    badge:
-      color: green
-      text: New
 ---
 
 Dynamic MCP enables AI agents to discover and add MCP servers on-demand during


### PR DESCRIPTION
## Summary

- Removes the time-sensitive "New" sidebar badge from the Dynamic MCP page front matter
- Per STYLE.md, time-relative language like "new" goes stale silently and should be avoided
- The experimental status is already communicated through content callouts on the page

Closes #24265

🤖 Generated with [Claude Code](https://claude.com/claude-code)