### PR TITLE
Remove time-relative language from E2B sandboxes docs

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/e2b-sandboxes.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/e2b-sandboxes.md
@@ -6,7 +6,7 @@ aliases:
   - /ai/mcp-catalog-and-toolkit/sandboxes/
 ---
 
-Docker has partnered with [E2B](https://e2b.dev/), a provider of secure cloud sandboxes for AI agents. Through this partnership, every E2B sandbox includes direct access to Docker's [MCP Catalog](https://hub.docker.com/mcp), a collection of 200+ tools from publishers including GitHub, Notion, and Stripe.
+Docker has partnered with [E2B](https://e2b.dev/), a provider of secure cloud sandboxes for AI agents. E2B sandboxes include direct access to Docker's [MCP Catalog](https://hub.docker.com/mcp), a collection of 200+ tools from publishers including GitHub, Notion, and Stripe.
 
 When you create a sandbox, you specify which MCP tools it should access. E2B launches these tools and provides access through the Docker MCP Gateway.
 
@@ -22,7 +22,7 @@ Before you begin, make sure you have the following:
 - Anthropic API key for Claude
 
   > [!NOTE]
-  > This example uses Claude Code which comes pre-installed in E2B sandboxes.
+  > This example uses Claude Code, which is pre-installed in E2B sandboxes.
   > However, you can adapt the example to work with other AI assistants of your
   > choice. See [E2B's MCP documentation](https://e2b.dev/docs/mcp/quickstart)
   > for alternative connection methods.


### PR DESCRIPTION
## Summary

- Replaces "Through this partnership, every E2B sandbox" with direct statement "E2B sandboxes include"
- Changes "which comes pre-installed" to "which is pre-installed" (removes recency implication)
- Per STYLE.md, documentation should avoid time-relative framing and describe the product as-is

Closes #24266

🤖 Generated with [Claude Code](https://claude.com/claude-code)