### PR TITLE
docs: fix trust delegation typo

### DIFF
--- a/content/manuals/engine/security/trust/trust_delegation.md
+++ b/content/manuals/engine/security/trust/trust_delegation.md
@@ -360,7 +360,7 @@ Successfully removed ben from registry.example.com/admin/demo
    ```
 
 2) If you have added additional delegations already and are seeing an error 
-   message that there are no valid signatures in `targest/releases`, you will need
+   message that there are no valid signatures in `targets/releases`, you will need
    to resign the `targets/releases` delegation file with the Notary CLI.
 
    ```text


### PR DESCRIPTION
## Description

- Fixes a typo in the Docker Content Trust troubleshooting section by changing `targest/releases` to `targets/releases`.

## Related issues or tickets

- N/A (minor documentation typo fix)

## Reviews

- Technical review: requested
- Editorial review: requested
- Product review: not required for this typo-only docs change

- [x] Technical review
- [x] Editorial review
- [ ] Product review

## Guideline alignment

- https://github.com/docker/docs/blob/main/CONTRIBUTING.md

## Validation

- `git diff --check`
- No local site build was run; documentation-only change.
