### PR TITLE
add: build child images with provenance attestations

### DIFF
--- a/content/manuals/dhi/how-to/scan.md
+++ b/content/manuals/dhi/how-to/scan.md
@@ -62,6 +62,7 @@ the provenance chain. As a result, it reports CVEs that are already suppressed
 by VEX statements in the base image, producing false CVE positives in your
 scan results.
 
+> [!NOTE]
 > **Why provenance attestation is required**
 >
 > Docker Scout uses max-mode provenance attestations to identify the DHI base image


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This PR adds a new subsection under the Docker Scout section of the DHI scan page explaining that child images built from Docker Hardened Images must be built with `--provenance=mode=max` and `--sbom=true` for Docker Scout to correctly apply VEX statements from the DHI base image.

<!-- Tell us what you did and why -->

Without these flags, Docker Scout cannot walk the provenance chain back to the DHI base image. As a result, VEX statements that suppress known non-applicable CVEs are not applied, causing users to see false CVE positives when scanning their child images.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review