### PR TITLE
Docker Engine Networking updates for style, clarity

### DIFF
--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -31,15 +31,9 @@ and the concepts around container networking.
 
 ## Default network
 
-When Docker Engine starts for the first time, it uses a single
-built-in network called the default bridge network. This means that when 
-you start container without specifying `--network` option, the container 
-defaults to the `bridge` value. When your Docker host (the virtual or physical 
-machine running Docker) has Internet access, no additional configuration is 
-needed for the container to have Internet access.
-
-The Docker bridge network is an isolated network for containers to communicate 
-with each other. 
+When Docker Engine starts for the first time, the default bridge network is created and containers attach to it automatically. The Docker bridge network is an isolated network for containers to communicate 
+with each other. Containers 
+default to the `bridge` value if no other `network_mode` option is specified.  
 
 * By default, the bridge network gives your containers 
 access to external networks through masquerading, or borrowing your Docker 
@@ -51,15 +45,15 @@ going to your containers with your Docker host's IP address.
 If you want to test the bridge network, you can send a ping request 
 from an active container and wait for the reply. For example:
 
-    ```console
-    $ docker run --rm -ti busybox ping -c1 docker.com
-    PING docker.com (23.185.0.4): 56 data bytes
-    64 bytes from 23.185.0.4: seq=0 ttl=62 time=6.564 ms
+  ```console
+  $ docker run --rm -ti busybox ping -c1 docker.com
+  PING docker.com (23.185.0.4): 56 data bytes
+  64 bytes from 23.185.0.4: seq=0 ttl=62 time=6.564 ms
 
-    --- docker.com ping statistics ---
-    1 packets transmitted, 1 packets received, 0% packet loss
-    round-trip min/avg/max = 6.564/6.564/6.564 ms
-    ```
+  --- docker.com ping statistics ---
+  1 packets transmitted, 1 packets received, 0% packet loss
+  round-trip min/avg/max = 6.564/6.564/6.564 ms
+  ```
 
 ## User-defined networks
 

--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -5,16 +5,16 @@ weight: 30
 description: Learn how networking works from the container's point of view
 keywords: networking, container, standalone, IP address, DNS resolution
 aliases:
-- /articles/networking/
-- /config/containers/container-networking/
-- /engine/tutorials/networkingcontainers/
-- /engine/userguide/networking/
-- /engine/userguide/networking/configure-dns/
-- /engine/userguide/networking/default_network/binding/
-- /engine/userguide/networking/default_network/configure-dns/
-- /engine/userguide/networking/default_network/container-communication/
-- /engine/userguide/networking/dockernetworks/
-- /network/
+  - /articles/networking/
+  - /config/containers/container-networking/
+  - /engine/tutorials/networkingcontainers/
+  - /engine/userguide/networking/
+  - /engine/userguide/networking/configure-dns/
+  - /engine/userguide/networking/default_network/binding/
+  - /engine/userguide/networking/default_network/configure-dns/
+  - /engine/userguide/networking/default_network/container-communication/
+  - /engine/userguide/networking/dockernetworks/
+  - /network/
 ---
 
 Container networking refers to the ability for containers to connect to and
@@ -31,29 +31,26 @@ and the concepts around container networking.
 
 ## Default network
 
-When Docker Engine starts for the first time, the default bridge network is created and containers attach to it automatically. The Docker bridge network is an isolated network for containers to communicate 
-with each other. Containers 
-default to the `bridge` value if no other `network_mode` option is specified.  
+When Docker Engine starts, it creates the default bridge network. New containers
+attach to it unless you choose another network. Traffic between containers on the
+same bridge stays on the bridge.
 
-* By default, the bridge network gives your containers 
-access to external networks through masquerading, or borrowing your Docker 
-host's public IP address to make requests to and receive replies from the Internet.
-* While your containers communicate with each other on the bridge network, devices 
-with access to your external network only see communication coming from and 
-going to your containers with your Docker host's IP address. 
+- By default, outbound traffic from the bridge is masqueraded. The Docker host
+  replaces the container's source address with its own before forwarding to
+  external networks.
+- Return traffic is mapped back to the correct container.
 
-If you want to test the bridge network, you can send a ping request 
-from an active container and wait for the reply. For example:
+To verify connectivity from a container:
 
-  ```console
-  $ docker run --rm -ti busybox ping -c1 docker.com
-  PING docker.com (23.185.0.4): 56 data bytes
-  64 bytes from 23.185.0.4: seq=0 ttl=62 time=6.564 ms
+```console
+$ docker run --rm -ti busybox ping -c1 docker.com
+PING docker.com (23.185.0.4): 56 data bytes
+64 bytes from 23.185.0.4: seq=0 ttl=62 time=6.564 ms
 
-  --- docker.com ping statistics ---
-  1 packets transmitted, 1 packets received, 0% packet loss
-  round-trip min/avg/max = 6.564/6.564/6.564 ms
-  ```
+--- docker.com ping statistics ---
+1 packets transmitted, 1 packets received, 0% packet loss
+round-trip min/avg/max = 6.564/6.564/6.564 ms
+```
 
 ## User-defined networks
 
@@ -82,7 +79,7 @@ Docker Engine has a number of network drivers, as well as the default "bridge".
 On Linux, the following built-in network drivers are available:
 
 | Driver                          | Description                                                         |
-|:--------------------------------|:--------------------------------------------------------------------|
+| :------------------------------ | :------------------------------------------------------------------ |
 | [bridge](./drivers/bridge.md)   | The default network driver.                                         |
 | [host](./drivers/host.md)       | Remove network isolation between the container and the Docker host. |
 | [none](./drivers/none.md)       | Completely isolate a container from the host and other containers.  |
@@ -116,7 +113,7 @@ Containers can also share networking stacks, see [Container networks](#container
 
 When sending packets, if the destination is an address in a directly connected
 network, packets are sent to that network. Otherwise, packets are sent to
-a default gateway for routing to their destination. In the example above,
+a default gateway for routing to their destination. In the previous example,
 the `ipvlan` network's gateway must be the default gateway.
 
 The default gateway is selected by Docker, and may change whenever a
@@ -162,7 +159,7 @@ $ docker network create --ipv6 --ipv4=false v6net
 
 By default, the container gets an IP address for every Docker network it attaches to.
 A container receives an IP address out of the IP subnet of the network.
-The Docker daemon performs dynamic subnetting and IP address allocation for containers.
+The Docker daemon allocates subnets and IP addresses for containers.
 Each network also has a default subnet mask and gateway.
 
 You can connect a running container to multiple networks,
@@ -195,13 +192,13 @@ These pools can be configured in `/etc/docker/daemon.json`. Docker's built-in de
 ```json
 {
   "default-address-pools": [
-    {"base":"172.17.0.0/16","size":16},
-    {"base":"172.18.0.0/16","size":16},
-    {"base":"172.19.0.0/16","size":16},
-    {"base":"172.20.0.0/14","size":16},
-    {"base":"172.24.0.0/14","size":16},
-    {"base":"172.28.0.0/14","size":16},
-    {"base":"192.168.0.0/16","size":20}
+    { "base": "172.17.0.0/16", "size": 16 },
+    { "base": "172.18.0.0/16", "size": 16 },
+    { "base": "172.19.0.0/16", "size": 16 },
+    { "base": "172.20.0.0/14", "size": 16 },
+    { "base": "172.24.0.0/14", "size": 16 },
+    { "base": "172.28.0.0/14", "size": 16 },
+    { "base": "192.168.0.0/16", "size": 20 }
   ]
 }
 ```
@@ -209,7 +206,7 @@ These pools can be configured in `/etc/docker/daemon.json`. Docker's built-in de
 - `base`: The subnet that can be allocated from.
 - `size`: The prefix length used for each allocated subnet.
 
-When an IPv6 subnet is required and there are no IPv6 addresses in  `default-address-pools`, Docker allocates
+When an IPv6 subnet is required and there are no IPv6 addresses in `default-address-pools`, Docker allocates
 subnets from a Unique Local Address (ULA) prefix. To use specific IPv6 subnets instead, add them to your
 `default-address-pools`. See [Dynamic IPv6 subnet allocation](../daemon/ipv6.md#dynamic-ipv6-subnet-allocation)
 for more information.
@@ -225,9 +222,7 @@ Docker will allocate subnets `172.17.0.0/24`, `172.17.1.0/24`, and so on, up to 
 
 ```json
 {
-  "default-address-pools": [
-    {"base": "172.17.0.0/16", "size": 24}
-  ]
+  "default-address-pools": [{ "base": "172.17.0.0/16", "size": 24 }]
 }
 ```
 
@@ -275,7 +270,7 @@ The following table describes the available `docker run` flags related to DNS
 configuration.
 
 | Flag           | Description                                                                                                                                                                                                                                           |
-| -------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--dns`        | The IP address of a DNS server. To specify multiple DNS servers, use multiple `--dns` flags. DNS requests will be forwarded from the container's network namespace so, for example, `--dns=127.0.0.1` refers to the container's own loopback address. |
 | `--dns-search` | A DNS search domain to search non-fully qualified hostnames. To specify multiple DNS search prefixes, use multiple `--dns-search` flags.                                                                                                              |
 | `--dns-opt`    | A key-value pair representing a DNS option and its value. See your operating system's documentation for `resolv.conf` for valid options.                                                                                                              |

--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -29,7 +29,7 @@ routing table, DNS services, and other networking details.
 This page describes networking from the point of view of the container,
 and the concepts around container networking.
 
-## Bridge network
+## Default network
 
 When Docker Engine starts for the first time, it uses a single
 built-in network called the default bridge network. This means that when 
@@ -43,8 +43,8 @@ with each other.
 
 * By default, the bridge network gives your containers 
 access to external networks through masquerading, or borrowing your Docker 
-host's public IP address to make and receive requests from the Internet.
-* While your containers communicate on the bridge network, devices 
+host's public IP address to make requests to and receive replies from the Internet.
+* While your containers communicate with each other on the bridge network, devices 
 with access to your external network only see communication coming from and 
 going to your containers with your Docker host's IP address. 
 

--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Networking overview
+title: Networking
 linkTitle: Networking
 weight: 30
 description: Learn how networking works from the container's point of view
@@ -29,28 +29,37 @@ routing table, DNS services, and other networking details.
 This page describes networking from the point of view of the container,
 and the concepts around container networking.
 
-When Docker Engine on Linux starts for the first time, it has a single
-built-in network called the "default bridge" network. When you run a
-container without the `--network` option, it is connected to the default
-bridge.
+## Bridge network
 
-Containers attached to the default bridge have access to network services
-outside the Docker host. They use "masquerading" which means, if the
-Docker host has Internet access, no additional configuration is needed
-for the container to have Internet access.
+When Docker Engine starts for the first time, it uses a single
+built-in network called the default bridge network. This means that when 
+you start container without specifying `--network` option, the container 
+defaults to the `bridge` value. When your Docker host (the virtual or physical 
+machine running Docker) has Internet access, no additional configuration is 
+needed for the container to have Internet access.
 
-For example, to run a container on the default bridge network, and have
-it ping an Internet host:
+The Docker bridge network is an isolated network for containers to communicate 
+with each other. 
 
-```console
-$ docker run --rm -ti busybox ping -c1 docker.com
-PING docker.com (23.185.0.4): 56 data bytes
-64 bytes from 23.185.0.4: seq=0 ttl=62 time=6.564 ms
+* By default, the bridge network gives your containers 
+access to external networks through masquerading, or borrowing your Docker 
+host's public IP address to make and receive requests from the Internet.
+* While your containers communicate on the bridge network, devices 
+with access to your external network only see communication coming from and 
+going to your containers with your Docker host's IP address. 
 
---- docker.com ping statistics ---
-1 packets transmitted, 1 packets received, 0% packet loss
-round-trip min/avg/max = 6.564/6.564/6.564 ms
-```
+If you want to test the bridge network, you can send a ping request 
+from an active container and wait for the reply. For example:
+
+    ```console
+    $ docker run --rm -ti busybox ping -c1 docker.com
+    PING docker.com (23.185.0.4): 56 data bytes
+    64 bytes from 23.185.0.4: seq=0 ttl=62 time=6.564 ms
+
+    --- docker.com ping statistics ---
+    1 packets transmitted, 1 packets received, 0% packet loss
+    round-trip min/avg/max = 6.564/6.564/6.564 ms
+    ```
 
 ## User-defined networks
 


### PR DESCRIPTION
This PR:

- Separates an overburdened introductory section by segmenting out Bridge network concepts
- This creates internal parallels between user-defined network and Bridge networks (both being options for container networking)
- I updated the doc title to match the left nav title, which helps with breadcrumbing