### PR TITLE
docs/engine: Remove Fedora 41 from supported versions

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -28,7 +28,6 @@ Fedora versions:
 
 - Fedora 43
 - Fedora 42
-- Fedora 41
 
 ### Uninstall old versions
 


### PR DESCRIPTION
Fedora 41 reached its end of life on December 15, 2025.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review