### PR TITLE
update OAT authentication support for dhi.io

### DIFF
--- a/content/manuals/dhi/how-to/use.md
+++ b/content/manuals/dhi/how-to/use.md
@@ -17,9 +17,15 @@ package manager, and may run as a nonroot user by default.
 > [!IMPORTANT]
 >
 > You must authenticate to the Docker Hardened Images registry (`dhi.io`) to
-> pull images. Use your Docker ID credentials (the same username and password
-> you use for Docker Hub) when signing in. If you don't have a Docker account,
-> [create one](../../accounts/create-account.md) for free.
+> pull images. You can authenticate using either of the following:
+>
+> - **Docker ID (personal credentials):** Use the same username and password
+>   you use for Docker Hub. If you don't have a Docker account,
+>   [create one](../../accounts/create-account.md) for free.
+> - **Organization access token (OAT):** Use your organization name as the
+>   username and an OAT as the password. OATs are recommended for CI/CD
+>   pipelines and automated workflows. See
+>   [Organization access tokens](../../enterprise/security/access-tokens.md).
 >
 > Run `docker login dhi.io` to authenticate.
 


### PR DESCRIPTION
The dhi.io registry proxy now supports organization access tokens (OATs), including pulling attestations served dynamically from Scout.

Change:
- use.md: expand the authentication callout to document both Docker ID and OAT as supported methods for authenticating to dhi.io

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review