### PR TITLE
clarify OAT limitation is specific to registry.scout.docker.com

### DIFF
--- a/content/manuals/dhi/how-to/mirror.md
+++ b/content/manuals/dhi/how-to/mirror.md
@@ -200,7 +200,7 @@ which makes them better suited for CI/CD pipelines and automated workflows.
 >
 > When using an OAT, use your **organization name** as the username, not your
 > personal Docker ID. OATs are org-scoped and will return a `401 Unauthorized`
-> error if presented under an individual user's account name.
+> error if presented under an individual username.
 
 To authenticate using an OAT:
 
@@ -211,7 +211,7 @@ To authenticate using an OAT:
 5. Under **Repository access**, select **Read public repositories**.
 6. Select **Generate token**, then copy and save the token. You won't be able
    to retrieve it after closing the screen.
-7. Log in to `dhi.io` using your organization name as the username and the OAT
+7. Sign in to `dhi.io` using your organization name as the username and the OAT
    as the password:
 ```console
    $ oras login dhi.io -u <YOUR_ORGANIZATION_NAME>


### PR DESCRIPTION
Changes:
- mirror.md: update Step 1 of the regctl example to clarify that OATs work with docker.io but are not supported for registry.scout.docker.com
- Reword "organization namespace" to "organization name" to match the actual value used as the login username

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review