### PR TITLE
Fix docs for docker agent share push/pull

### DIFF
--- a/content/manuals/ai/docker-agent/_index.md
+++ b/content/manuals/ai/docker-agent/_index.md
@@ -148,8 +148,8 @@ Agent configurations are packaged as OCI artifacts. Push and pull them like
 container images:
 
 ```console
-$ docker agent push ./debugger.yaml myusername/debugger
-$ docker agent pull myusername/debugger
+$ docker agent share push ./debugger.yaml myusername/debugger
+$ docker agent share pull myusername/debugger
 ```
 
 Use Docker Hub or any OCI-compatible registry. Pushing creates the repository if

--- a/content/manuals/ai/docker-agent/reference/cli.md
+++ b/content/manuals/ai/docker-agent/reference/cli.md
@@ -344,7 +344,7 @@ Opens interactive TUI to configure and generate agent YAML.
 Pull agent from OCI registry.
 
 ```console
-$ docker agent pull registry-ref
+$ docker agent share pull registry-ref
 ```
 
 Arguments:
@@ -360,7 +360,7 @@ Flags:
 Example:
 
 ```console
-$ docker agent pull docker.io/user/agent:latest
+$ docker agent share pull docker.io/user/agent:latest
 ```
 
 Saves to local YAML file.
@@ -370,7 +370,7 @@ Saves to local YAML file.
 Push agent to OCI registry.
 
 ```console
-$ docker agent push agent-file registry-ref
+$ docker agent share push agent-file registry-ref
 ```
 
 Arguments:
@@ -381,7 +381,7 @@ Arguments:
 Example:
 
 ```console
-$ docker agent push ./agent.yaml docker.io/myuser/myagent:latest
+$ docker agent share push ./agent.yaml docker.io/myuser/myagent:latest
 ```
 
 ### run

--- a/content/manuals/ai/docker-agent/sharing-agents.md
+++ b/content/manuals/ai/docker-agent/sharing-agents.md
@@ -27,7 +27,7 @@ For other registries, use their authentication method.
 Push your agent configuration to a registry:
 
 ```console
-$ docker agent push ./agent.yml myusername/agent-name
+$ docker agent share push ./agent.yml myusername/agent-name
 ```
 
 Push creates the repository if it doesn't exist yet. Use Docker Hub or
@@ -36,8 +36,8 @@ any OCI-compatible registry.
 Tag specific versions:
 
 ```console
-$ docker agent push ./agent.yml myusername/agent-name:v1.0.0
-$ docker agent push ./agent.yml myusername/agent-name:latest
+$ docker agent share push ./agent.yml myusername/agent-name:v1.0.0
+$ docker agent share push ./agent.yml myusername/agent-name:latest
 ```
 
 ## Using published agents
@@ -45,7 +45,7 @@ $ docker agent push ./agent.yml myusername/agent-name:latest
 Pull an agent to inspect it locally:
 
 ```console
-$ docker agent pull agentcatalog/pirate
+$ docker agent share pull agentcatalog/pirate
 ```
 
 This saves the configuration as a local YAML file.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Fix docs for docker agent push/pull commands moved under "share"
