### PR TITLE
Fix link to point to MCP Catalog for available servers instead of MCP Gateway

### DIFF
--- a/content/manuals/ai/docker-agent/integrations/mcp.md
+++ b/content/manuals/ai/docker-agent/integrations/mcp.md
@@ -55,8 +55,9 @@ agents:
 ```
 
 The `docker:` prefix tells Docker Agent to use the MCP Gateway for this server. See
-the [MCP Gateway documentation](/ai/mcp-catalog-and-toolkit/mcp-gateway/) for
-available servers and configuration options.
+the [MCP Catalog](/ai/mcp-catalog-and-toolkit/catalog/) for available servers and the
+[MCP Gateway documentation](/ai/mcp-catalog-and-toolkit/mcp-gateway/) for
+configuration options.
 
 You can also use the [MCP Toolkit](/ai/mcp-catalog-and-toolkit/) to explore and
 manage MCP servers interactively.
@@ -95,7 +96,7 @@ Example configuration:
     "myagent": {
       "command": "docker",
       "args": [
-        "agent", 
+        "agent",
         "serve",
         "mcp",
         "/path/to/agent.yml",


### PR DESCRIPTION
## Description

Fix incorrect cross-reference in the MCP integration page. The link for
"available servers" pointed to the MCP Gateway page, which explains gateway
architecture and configuration but doesn't list servers. Updated the link
to point to the MCP Catalog page, which is where available servers are
actually listed.

## Related issues or tickets

Fixes #24365

## Reviews

- [ ] Technical review
- [ ] Editorial review
