### PR TITLE
fix: Clarify Compose standalone deprecation warning and link to recommended alternatives

### DIFF
--- a/content/manuals/compose/install/standalone.md
+++ b/content/manuals/compose/install/standalone.md
@@ -9,15 +9,11 @@ weight: 20
 
 > [!WARNING]
 >
-> This install scenario is not recommended and is only supported for backward compatibility purposes.
+> The Compose standalone binary uses the legacy `docker-compose` syntax instead of the standard `docker compose` CLI plugin syntax. It is only supported for backward compatibility. Docker recommends that you install [Docker Desktop](/manuals/desktop/_index.md) or the [Compose plugin](linux.md) instead.
+>
+> For more background on the transition from Compose v1 to v2, see [History and development of Docker Compose](/manuals/compose/intro/history.md).
 
 This page contains instructions on how to install Docker Compose standalone on Linux or Windows Server, from the command line.
-
-> [!WARNING]
->
-> The Docker Compose standalone uses the `-compose` syntax instead of the current standard syntax `compose`.  
-> For example, you must type `docker-compose up` when using Docker Compose standalone, instead of `docker compose up`. 
-> Use it only for backward compatibility.
 
 ## On Linux
 
@@ -40,6 +36,7 @@ This page contains instructions on how to install Docker Compose standalone on L
 > If the command `docker-compose` fails after installation, check your path.
 > You can also create a symbolic link to `/usr/bin` or any other directory in your path.
 > For example:
+>
 > ```console
 > $ sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 > ```
@@ -50,16 +47,16 @@ Follow these instructions if you are [running the Docker daemon directly
 on Microsoft Windows Server](/manuals/engine/install/binaries.md#install-server-and-client-binaries-on-windows) and want to install Docker Compose.
 
 1.  Run PowerShell as an administrator.
-    In order to proceed with the installation, select **Yes** when asked if you want this app to make changes to your device.
+    To proceed with the installation, select **Yes** when asked if you want this app to make changes to your device.
 
-2.  Optional. Ensure TLS1.2 is enabled. 
+2.  Optional. Ensure TLS1.2 is enabled.
     GitHub requires TLS1.2 for secure connections. If you’re using an older version of Windows Server, for example 2016, or suspect that TLS1.2 is not enabled, run the following command in PowerShell:
 
     ```powershell
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     ```
 
-3. Download the latest release of Docker Compose ({{% param "compose_version" %}}). Run the following command:
+3.  Download the latest release of Docker Compose ({{% param "compose_version" %}}). Run the following command:
 
     ```powershell
      Start-BitsTransfer -Source "https://github.com/docker/compose/releases/download/{{% param "compose_version" %}}/docker-compose-windows-x86_64.exe" -Destination $Env:ProgramFiles\Docker\docker-compose.exe
@@ -70,8 +67,8 @@ on Microsoft Windows Server](/manuals/engine/install/binaries.md#install-server-
     > [!NOTE]
     >
     > On Windows Server 2019 you can add the Compose executable to `$Env:ProgramFiles\Docker`.
-     Because this directory is registered in the system `PATH`, you can run the `docker-compose --version` 
-     command on the subsequent step with no additional configuration.
+    > Because this directory is registered in the system `PATH`, you can run the `docker-compose --version`
+    > command on the subsequent step with no additional configuration.
 
 4.  Test the installation.
 


### PR DESCRIPTION
## Description

The Compose standalone install page had two vague warnings saying "not recommended" without explaining why or what to use instead. Users landing here from search had no way to understand the difference between standalone and the modern Compose plugin, or where to go for the recommended approach.

Consolidated both warnings into a single callout that explains the legacy `docker-compose` vs `docker compose` syntax difference, links to Docker Desktop and the Compose plugin as alternatives, and points to the history page for context. Also fixed an "In order to" style violation.

## Related issues or tickets

Fixes #24387

## Reviews

- [ ] Editorial review
