### PR TITLE
Fixes https://github.com/docker/docs/issues/23958

### DIFF
--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -1956,6 +1956,17 @@ secrets:
 
 `security_opt` overrides the default labeling scheme for each container.
 
+Options accept either `option=value` or `option:value` syntax. For boolean options
+such as `no-new-privileges`, the value may be omitted entirely, in which case the
+option is treated as enabled. The following syntaxes are all equivalent:
+
+```yml
+security_opt:
+  - no-new-privileges
+  - no-new-privileges=true
+  - no-new-privileges:true
+```
+
 ```yml
 security_opt:
   - label=user:USER


### PR DESCRIPTION
The `security_opt` field in the Compose services reference did not document 
the accepted syntax variants, which was confusing for users.

Added a note explaining that options accept `option=value`, `option:value`, 
or bare `option` syntax (for booleans). Added examples showing all three 
equivalent forms for `no-new-privileges`.