### PR TITLE
hub: update repo export

### DIFF
--- a/content/manuals/docker-hub/repos/manage/export.md
+++ b/content/manuals/docker-hub/repos/manage/export.md
@@ -25,7 +25,7 @@ Before you begin, ensure you have:
 
 ## Create a personal access token
 
-[Create a personal access token](/security/for-developers/access-tokens/) from
+[Create a personal access token](/security/access-tokens/) from
 a user account that has access to the organization's repositories. When creating
 the token, select at minimum **Read-only** access permissions to list
 repositories.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Internal feedback reported that the deprecated auth endpoint does not support OATs.
Updated to new auth endpoint.

Upon testing the rest of the flow, the repositories endpoint has the following error, `token issued from organization access token is not allowed`.

The current flow does not appear to work with OATs. Updated to PAT and tested that it worked.

https://deploy-preview-24396--docsdocker.netlify.app/docker-hub/repos/manage/export/

## Related issues or tickets

https://docker.slack.com/archives/C04300R4G5U/p1773779041999559

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
