### PR TITLE
docs: fix wording in trust automation guide

### DIFF
--- a/content/manuals/engine/security/trust/trust_automation.md
+++ b/content/manuals/engine/security/trust/trust_automation.md
@@ -16,8 +16,8 @@ When working directly with the Notary client, it uses its [own set of environmen
 ## Add a delegation private key
 
 To automate importing a delegation private key to the local Docker trust store, we 
-need to pass a passphrase for the new key. This passphrase will be required 
-everytime that delegation signs a tag. 
+need to pass a passphrase for the new key. This passphrase will be required
+every time that delegation signs a tag.
 
 ```console
 $ export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE="mypassphrase123"


### PR DESCRIPTION
## Description

- fix "everytime" to "every time" in the trust automation guide
- guideline alignment: follows [CONTRIBUTING.md](https://github.com/docker/docs/blob/main/CONTRIBUTING.md) as a single-file docs-only change
- validation: not run (documentation-only change)

## Related issues or tickets

- N/A (trivial docs wording fix)

## Reviews

- [ ] Technical review
- [x] Editorial review
- [ ] Product review
