### PR TITLE
Fix typo in What's next page description

### DIFF
--- a/content/get-started/introduction/whats-next.md
+++ b/content/get-started/introduction/whats-next.md
@@ -1,7 +1,7 @@
 ---
 title: What's next 
 keywords: concepts, build, images, container, docker desktop
-description: Explore step-by-step guides to hep you understand core Docker concepts, building images, and running containers.
+description: Explore step-by-step guides to help you understand core Docker concepts, building images, and running containers.
 aliases:
  - /guides/getting-started/whats-next/
 summary: |


### PR DESCRIPTION
## Description

Fixes a typo in the What's next page description by changing "hep" to "help".

## Related issues or tickets

N/A

## Reviews

Docs-only, single-file change aligned with CONTRIBUTING.md general guidelines.
Validation/testing: not run locally; no behavior change.

- [ ] Technical review
- [x] Editorial review
- [ ] Product review