### PR TITLE
Update release-notes.md about dhictl

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -36,7 +36,7 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 
 - Gordon hints now appear when `docker build`, `docker run`, or `docker compose` commands fail, offering contextual suggestions.
 - Community MCP servers now support OAuth authentication directly in the UI.
-- Added the `docker dhi` CLI plugin for managing Docker Hardened Images, learn more at https://github.com/docker-hardened-images/dhictl.
+- Added the [`docker dhi` CLI plugin](https://github.com/docker-hardened-images/dhictl) for managing Docker Hardened Images.
 
 ### Updates
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

The release note of 4.65 mention `dhictl` which seems confusing to users as the `dhictl` when bundled in DD is a cli-plugin available as `docker dhi`. 

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review