### PR TITLE
offload: remove redundant Early Access sidebar badge

### DIFF
--- a/content/manuals/offload/_index.md
+++ b/content/manuals/offload/_index.md
@@ -6,57 +6,53 @@ keywords: build, cloud, cloud build, remote builder
 params:
   sidebar:
     group: Products
-    badge:
-      color: blue
-      text: Beta
 
 grid:
+  - title: Quickstart
+    description: Get up and running with Docker Offload in just a few steps.
+    icon: rocket_launch
+    link: /offload/quickstart/
 
-- title: Quickstart
-  description: Get up and running with Docker Offload in just a few steps.
-  icon: rocket_launch
-  link: /offload/quickstart/
+  - title: About
+    description: Learn about Docker Offload and how it works.
+    icon: info
+    link: /offload/about/
 
-- title: About
-  description: Learn about Docker Offload and how it works.
-  icon: info
-  link: /offload/about/
+  - title: Configure
+    description: Set up and customize your cloud build environments.
+    icon: tune
+    link: /offload/configuration/
 
-- title: Configure
-  description: Set up and customize your cloud build environments.
-  icon: tune
-  link: /offload/configuration/
+  - title: Usage and billing
+    description: Learn about Docker Offload usage and billing, and how to monitor your cloud resources.
+    icon: monitor_heart
+    link: /offload/usage/
 
-- title: Usage
-  description: Learn about Docker Offload usage and how to monitor your cloud resources.
-  icon: monitor_heart
-  link: /offload/usage/
+  - title: Optimize
+    description: Improve performance and cost efficiency in Docker Offload.
+    icon: speed
+    link: /offload/optimize/
 
-- title: Optimize
-  description: Improve performance, caching, and cost efficiency in Docker Offload.
-  icon: speed
-  link: /offload/optimize/
+  - title: Troubleshoot
+    description: Learn how to troubleshoot issues with Docker Offload.
+    icon: bug_report
+    link: /offload/troubleshoot/
 
-- title: Troubleshoot
-  description: Learn how to troubleshoot issues with Docker Offload.
-  icon: bug_report
-  link: /offload/troubleshoot/
-
-- title: Feedback
-  description: Provide feedback on Docker Offload.
-  icon: feedback
-  link: /offload/feedback/
+  - title: Feedback
+    description: Provide feedback on Docker Offload.
+    icon: feedback
+    link: /offload/feedback/
 
 aliases:
-- /harmonia/
+  - /harmonia/
 ---
 
 {{< summary-bar feature_name="Docker Offload" >}}
 
 Docker Offload is a fully managed service that lets you offload building and
 running containers to the cloud using the Docker tools you already know. It
-provides cloud infrastructure for fast, consistent builds and compute-heavy
-workloads like running LLMs or machine learning pipelines.
+enables developers to work efficiently in virtual desktop infrastructure (VDI)
+environments or systems that don't support nested virtualization.
 
 In the following topics, learn about Docker Offload, how to set it up, use it
 for your workflows, and troubleshoot common issues.


### PR DESCRIPTION
## Summary

- Remove the "Early Access" sidebar badge from the Docker Offload landing page
- The availability status is already displayed by the `summary-bar` shortcode, which reads from `data/summary.yaml` (the canonical source of truth)
- Removing the redundant badge means one fewer place to update when the product status changes

Closes #24409

🤖 Generated with [Claude Code](https://claude.com/claude-code)