### PR TITLE
compose: clarify standalone install warning with recommended alternatives

### DIFF
--- a/content/manuals/compose/install/standalone.md
+++ b/content/manuals/compose/install/standalone.md
@@ -10,13 +10,16 @@ weight: 20
 > [!WARNING]
 >
 > This install scenario is not recommended and is only supported for backward compatibility purposes.
+> Use [Docker Desktop](/manuals/desktop/_index.md) or the
+> [Docker Compose plugin](/manuals/compose/install/linux.md) instead.
+> Use the standalone binary only if you cannot use either of these options.
 
 This page contains instructions on how to install Docker Compose standalone on Linux or Windows Server, from the command line.
 
 > [!WARNING]
 >
 > The Docker Compose standalone uses the `-compose` syntax instead of the current standard syntax `compose`.  
-> For example, you must type `docker-compose up` when using Docker Compose standalone, instead of `docker compose up`. 
+> For example, you must type `docker-compose up` when using Docker Compose standalone, instead of `docker compose up`.
 > Use it only for backward compatibility.
 
 ## On Linux
@@ -40,6 +43,7 @@ This page contains instructions on how to install Docker Compose standalone on L
 > If the command `docker-compose` fails after installation, check your path.
 > You can also create a symbolic link to `/usr/bin` or any other directory in your path.
 > For example:
+>
 > ```console
 > $ sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 > ```
@@ -52,14 +56,14 @@ on Microsoft Windows Server](/manuals/engine/install/binaries.md#install-server-
 1.  Run PowerShell as an administrator.
     In order to proceed with the installation, select **Yes** when asked if you want this app to make changes to your device.
 
-2.  Optional. Ensure TLS1.2 is enabled. 
+2.  Optional. Ensure TLS1.2 is enabled.
     GitHub requires TLS1.2 for secure connections. If you’re using an older version of Windows Server, for example 2016, or suspect that TLS1.2 is not enabled, run the following command in PowerShell:
 
     ```powershell
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     ```
 
-3. Download the latest release of Docker Compose ({{% param "compose_version" %}}). Run the following command:
+3.  Download the latest release of Docker Compose ({{% param "compose_version" %}}). Run the following command:
 
     ```powershell
      Start-BitsTransfer -Source "https://github.com/docker/compose/releases/download/{{% param "compose_version" %}}/docker-compose-windows-x86_64.exe" -Destination $Env:ProgramFiles\Docker\docker-compose.exe
@@ -70,8 +74,8 @@ on Microsoft Windows Server](/manuals/engine/install/binaries.md#install-server-
     > [!NOTE]
     >
     > On Windows Server 2019 you can add the Compose executable to `$Env:ProgramFiles\Docker`.
-     Because this directory is registered in the system `PATH`, you can run the `docker-compose --version` 
-     command on the subsequent step with no additional configuration.
+    > Because this directory is registered in the system `PATH`, you can run the `docker-compose --version`
+    > command on the subsequent step with no additional configuration.
 
 4.  Test the installation.
 


### PR DESCRIPTION
## Summary

- Expand the "not recommended" warning on the Compose standalone install page to explain what users should use instead: Docker Desktop or the Compose plugin
- Add a clear condition for when standalone is appropriate: only when neither alternative is available
- Removes user confusion about whether to follow the instructions at all

Closes #24387

🤖 Generated with [Claude Code](https://claude.com/claude-code)