### PR TITLE
admin: clarify SSO condition for company owner seat occupancy

### DIFF
--- a/content/manuals/admin/company/owners.md
+++ b/content/manuals/admin/company/owners.md
@@ -3,7 +3,7 @@ title: Manage company owners
 description: Learn how to add and remove company owners.
 keywords: company, owners, add company owner, remove company owner, company manageemnt, company owner permissions
 aliases:
-- /docker-hub/company-owner/
+  - /docker-hub/company-owner/
 ---
 
 {{< summary-bar feature_name="Company" >}}
@@ -16,12 +16,13 @@ don’t need to be members of any individual organization.
 > [!IMPORTANT]
 >
 > Company owners do not occupy a seat unless they are added as a member of an
-organization under your company or SSO is enabled.
+> organization under your company, or SSO is enabled and the company owner signs
+> in via SSO (which automatically adds them as an organization member).
 
 ## Add a company owner
 
 1. Sign in to [Docker Home](https://app.docker.com) and select your company from
-the top-left account drop-down.
+   the top-left account drop-down.
 1. Select **Admin Console**, then **Company owners**.
 1. Select **Add owner**.
 1. Specify the user's Docker ID to search for the user.
@@ -30,7 +31,7 @@ the top-left account drop-down.
 ## Remove a company owner
 
 1. Sign in to [Docker Home](https://app.docker.com) and select your company from
-the top-left account drop-down.
+   the top-left account drop-down.
 1. Select **Admin Console**, then **Company owners**.
 1. Locate the company owner you want to remove and select the **Actions** menu.
 1. Select **Remove as company owner**.

--- a/content/manuals/admin/faqs/company-faqs.md
+++ b/content/manuals/admin/faqs/company-faqs.md
@@ -6,8 +6,8 @@ description: Company FAQs
 keywords: Docker, Docker Hub, SSO FAQs, single sign-on, company, administration, company management
 tags: [FAQ]
 aliases:
-- /docker-hub/company-faqs/
-- /faq/admin/company-faqs/
+  - /docker-hub/company-faqs/
+  - /faq/admin/company-faqs/
 ---
 
 ### Some of my organizations don’t have a Docker Business subscription. Can I still use a parent company?
@@ -27,7 +27,7 @@ outside of the company.
 Company owners do not occupy a seat unless one of the following is true:
 
 - They are added as a member of an organization under your company
-- SSO is enabled
+- SSO is enabled and the company owner signs in via SSO, which automatically adds them as an organization member
 
 Although company owners have the same access as organization owners across all
 organizations in the company, it's not necessary to add them to any


### PR DESCRIPTION
## Summary

- Expand "SSO is enabled" condition in both `company-faqs.md` and `company/owners.md` to explain that SSO causes seat occupancy because signing in via SSO automatically adds the company owner as an organization member
- Addresses user confusion about why SSO being enabled affects seat counts

Closes #24282

🤖 Generated with [Claude Code](https://claude.com/claude-code)