### PR TITLE
offload: remove Beta label and fix trial expiration note

### DIFF
--- a/content/manuals/offload/usage.md
+++ b/content/manuals/offload/usage.md
@@ -10,9 +10,9 @@ keywords: cloud, usage, cloud minutes, shared cache, top repositories, cloud bui
 
 > [!NOTE]
 >
-> All free trial usage granted for the Docker Offload Beta expire after 90 days from the time they are granted. To
-> continue using Docker Offload Beta after your usage expires, you can enable on-demand usage at [Docker Home
-> Billing](https://app.docker.com/billing).
+> Free trial usage for Docker Offload expires after 90 days. To continue using
+> Docker Offload after your trial expires, you can enable on-demand usage at
+> [Docker Home Billing](https://app.docker.com/billing).
 
 ## Understand usage and billing models
 


### PR DESCRIPTION
## Summary

- Remove "Docker Offload Beta" label from the trial expiration note — the product is "Early Access", not "Beta", per `data/summary.yaml`
- Simplify the redundant phrase "from the time they are granted"

Closes #24410
Closes #24411

🤖 Generated with [Claude Code](https://claude.com/claude-code)