### PR TITLE
docs: fix proxy settings wording

### DIFF
--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
@@ -314,7 +314,7 @@ The following tables describe all available settings in the `admin-settings.json
 
 |Parameter|OS|Description|Version|
 |:-------------------------------|---|:-------------------------------|---|
-|`proxy`|   |If `mode` is set to `system` instead of `manual`, Docker Desktop gets the proxy values from the system and ignores and values set for `http`, `https` and `exclude`. Change `mode` to `manual` to manually configure proxy servers. If the proxy port is custom, specify it in the `http` or `https` property, for example `"https": "http://myotherproxy.com:4321"`. The `exclude` property specifies a comma-separated list of hosts and domains to bypass the proxy. |  |
+|`proxy`|   |If `mode` is set to `system` instead of `manual`, Docker Desktop gets the proxy values from the system and ignores any values set for `http`, `https` and `exclude`. Change `mode` to `manual` to manually configure proxy servers. If the proxy port is custom, specify it in the `http` or `https` property, for example `"https": "http://myotherproxy.com:4321"`. The `exclude` property specifies a comma-separated list of hosts and domains to bypass the proxy. |  |
 | `windowsDockerdPort`| Windows only | Exposes Docker Desktop's internal proxy locally on this port for the Windows Docker daemon to connect to. If it is set to 0, a random free port is chosen. If the value is greater than 0, use that exact value for the port. The default value is -1 which disables the option. |  |
 |`enableKerberosNtlm`|  |When set to `true`, Kerberos and NTLM authentication is enabled. Default is `false`. For more information, see the settings documentation. | Docker Desktop version 4.32 and later. |
 | `pac` | | Specifies a PAC file URL. For example, `"pac": "http://proxy/proxy.pac"`. | |


### PR DESCRIPTION
## Description

Fix the proxy settings description so it says Docker Desktop ignores any manual proxy values when `mode` is set to `system`.

## Related issues or tickets

- N/A

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

## Guideline alignment

- Minimal docs-only change following the repo contribution guidance: https://github.com/docker/docs/blob/main/CONTRIBUTING.md

## Validation/testing

- Not run locally; docs-only change
