### PR TITLE
Fix issue #24010: warn about containerd separate storage path

### DIFF
--- a/content/manuals/engine/storage/containerd.md
+++ b/content/manuals/engine/storage/containerd.md
@@ -62,6 +62,16 @@ uncompressed layers are still de-duplicated through snapshotters. The
 compressed storage adds overhead proportional to the number of images using
 those layers.
 
+> [!IMPORTANT]
+> containerd uses a separate storage path from the Docker data directory.
+> If you previously configured a custom data directory for Docker (for example,
+> to use a different partition), containerd's storage is not automatically
+> moved to that location. You need to configure containerd's data directory
+> separately to avoid filling your root partition.
+>
+> To configure containerd's data directory, see
+> [Configure the data directory location](../daemon/_index.md#configure-the-data-directory-location).
+
 If disk space is constrained, consider the following:
 
 - Regularly prune unused images with `docker image prune`


### PR DESCRIPTION
Adds warning about containerd using a separate storage path from the Docker data directory.

Changes:
- Added IMPORTANT callout in "Disk space usage" section explaining that containerd uses separate storage
- Warns users with custom data directories that they need to configure containerd separately
- Links to containerd configuration documentation for data directory setup

This prevents users from unexpectedly filling their root partition when they assumed their custom data directory configuration would apply to containerd.

Fixes #24010