### PR TITLE
docs: remove incorrect statement about user-defined function references in Bake

### DIFF
--- a/content/manuals/build/bake/funcs.md
+++ b/content/manuals/build/bake/funcs.md
@@ -109,8 +109,6 @@ $ docker buildx bake --print webapp
 You can make references to [variables](./variables) and standard library
 functions inside your functions.
 
-You can't reference user-defined functions from other functions.
-
 The following example uses a global variable (`REPO`) in a custom function.
 
 ```hcl {title=docker-bake.hcl}


### PR DESCRIPTION
## Summary

- Removes the incorrect statement "You can't reference user-defined functions from other functions" from the Bake functions documentation
- This claim contradicts actual behavior — user-defined HCL functions can reference other user-defined functions in Docker Bake


Fixes #23826