### PR TITLE
docs: update Azure Pipelines link to learn.microsoft.com

### DIFF
--- a/content/manuals/docker-hub/usage/pulls.md
+++ b/content/manuals/docker-hub/usage/pulls.md
@@ -17,7 +17,7 @@ The following pull usage and limits apply based on your subscription, subject to
 fair use:
 
 | User type                | Pull rate limit per 6 hours             |
-|--------------------------|-----------------------------------------|
+| ------------------------ | --------------------------------------- |
 | Business (authenticated) | Unlimited                               |
 | Team (authenticated)     | Unlimited                               |
 | Pro (authenticated)      | Unlimited                               |
@@ -28,15 +28,15 @@ fair use:
 
 A pull is defined as the following:
 
- - A Docker pull includes both a version check and any download that
-   occurs as a result of the pull. Depending on the client, a `docker pull` can
-   verify the existence of an image or tag without downloading it by performing
-   a version check.
- - Version checks do not count towards usage pricing.
- - A pull for a normal image makes one pull for a [single
-   manifest](https://github.com/opencontainers/image-spec/blob/main/manifest.md).
- - A pull for a multi-arch image will count as one pull for each
-   different architecture.
+- A Docker pull includes both a version check and any download that
+  occurs as a result of the pull. Depending on the client, a `docker pull` can
+  verify the existence of an image or tag without downloading it by performing
+  a version check.
+- Version checks do not count towards usage pricing.
+- A pull for a normal image makes one pull for a [single
+  manifest](https://github.com/opencontainers/image-spec/blob/main/manifest.md).
+- A pull for a multi-arch image will count as one pull for each
+  different architecture.
 
 ## Pull attribution
 
@@ -53,16 +53,15 @@ Attribution is based on the following:
   verified domain, the attribution is set to be the owner of that
   [domain](/manuals/enterprise/security/single-sign-on/faqs/domain-faqs.md).
 - Single organization membership:
-   - If the owner of the verified domain is a company and the user is part of
-     only one organization within that
-     [company](../../admin/faqs/company-faqs.md#what-features-are-supported-at-the-company-level),
-     the pull is attributed to that specific organization.
-   - If the user is part of only one organization, the pull is attributed to
-     that specific organization.
+  - If the owner of the verified domain is a company and the user is part of
+    only one organization within that
+    [company](../../admin/faqs/company-faqs.md#what-features-are-supported-at-the-company-level),
+    the pull is attributed to that specific organization.
+  - If the user is part of only one organization, the pull is attributed to
+    that specific organization.
 - Multiple organization memberships: If the user is part of multiple
   organizations under the company, the pull is attributed to the user's personal
   namespace.
-
 
 ### Authentication
 
@@ -120,7 +119,7 @@ If you're using any third-party platforms, follow your provider’s instructions
 - [Artifactory](https://www.jfrog.com/confluence/display/JFROG/Advanced+Settings#AdvancedSettings-RemoteCredentials)
 - [AWS CodeBuild](https://aws.amazon.com/blogs/devops/how-to-use-docker-images-from-a-private-registry-in-aws-codebuild-for-your-build-environment/)
 - [AWS ECS/Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html)
-- [Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#sep-docreg)
+- [Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml)
 - [Chipper CI](https://docs.chipperci.com/builds/docker/#rate-limit-auth)
 - [CircleCI](https://circleci.com/docs/2.0/private-images/)
 - [Codefresh](https://codefresh.io/docs/docs/docker-registries/external-docker-registries/docker-hub/)
@@ -137,7 +136,7 @@ On that page, you can also send a report to your email that contains a comma
 separated file with the following detailed information.
 
 | CSV column           | Definition                                                                                                                                                                                                         | Usage guidance                                                                                                                                                                      |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `datehour`           | The date and hour (`yyyy/mm/dd/hh`) of the pull that resulted in the data transfer.                                                                                                                                | This helps in identifying peak usage times and patterns.                                                                                                                            |
 | `user_name`          | The Docker ID of the user that pulled the image                                                                                                                                                                    | This lets organization owners track data consumption per user and manage resources effectively.                                                                                     |
 | `repository`         | The name of the repository of the image that was pulled.                                                                                                                                                           | This lets you identify which repositories are most frequently accessed and consume most of the data transfer.                                                                       |
@@ -147,7 +146,7 @@ separated file with the following detailed information.
 | `tag`                | The tag for the image. The tag is only available if the pull included a tag.                                                                                                                                       | This helps in identifying the image. Tags are often used to identify specific versions or variants of an image.                                                                     |
 | `digest`             | The unique image digest for the image.                                                                                                                                                                             | This helps in identifying the image.                                                                                                                                                |
 | `version_checks`     | The number of version checks accumulated for the date and hour of each image repository. Depending on the client, a pull can do a version check to verify the existence of an image or tag without downloading it. | This helps identify the frequency of version checks, which you can use to analyze usage trends and potential unexpected behaviors.                                                  |
-| `pulls`              | The number of pulls accumulated for the date and hour of each image repository.                                                                                                                                            | This helps identify the frequency of repository pulls, which you can use to analyze usage trends and potential unexpected behaviors.                                                |
+| `pulls`              | The number of pulls accumulated for the date and hour of each image repository.                                                                                                                                    | This helps identify the frequency of repository pulls, which you can use to analyze usage trends and potential unexpected behaviors.                                                |
 
 ## View pull rate and limit
 
@@ -172,24 +171,22 @@ To view your current pull rate and limit:
 > To check your limits, you need `curl`, `grep`, and `jq` installed.
 
 1. Get a token.
-
    - To get a token anonymously, if you are pulling anonymously:
 
-      ```console
-      $ TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-      ```
+     ```console
+     $ TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+     ```
 
    - To get a token with a user account, if you are authenticated, insert your
      username and password in the following command:
 
-      ```console
-      $ TOKEN=$(curl --user 'username:password' "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-      ```
+     ```console
+     $ TOKEN=$(curl --user 'username:password' "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+     ```
 
 2. Get the headers that contain your limits. These headers are returned on both
    GET and HEAD requests. Using GET emulates a real pull and counts towards the
    limit. Using HEAD won't.
-
 
    ```console
    $ curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
@@ -211,4 +208,3 @@ To view your current pull rate and limit:
    organization. It could also mean that the user you are pulling as is part of a
    paid Docker subscription. Pulling that image won't count toward pull rate limits if you
    don't see these headers.
-


### PR DESCRIPTION
## Summary

- Updates the Azure Pipelines link in the "Third-party platforms" section of `content/manuals/docker-hub/usage/pulls.md`
- Replaces the deprecated `docs.microsoft.com` domain with `learn.microsoft.com` (Microsoft's current documentation domain)
- Removes the stale `#sep-docreg` anchor, which no longer exists on the current page and causes users to land at the wrong location

Closes #24437

🤖 Generated with [Claude Code](https://claude.com/claude-code)