### PR TITLE
docs: fix Kubernetes provisioning typo

### DIFF
--- a/content/manuals/desktop/use-desktop/kubernetes.md
+++ b/content/manuals/desktop/use-desktop/kubernetes.md
@@ -24,7 +24,7 @@ With Docker Desktop version 4.51 and later, you can manage Kubernetes directly f
 3. Choose your cluster type:
    - **Kubeadm** creates a single-node cluster and the version is set by Docker Desktop.
    - **kind** creates a multi-node cluster and you can set the version and number of nodes.
-   For more detailed information on each cluster type, see [Cluster provisioining method](#cluster-provisioning-method).
+   For more detailed information on each cluster type, see [Cluster provisioning method](#cluster-provisioning-method).
 4. Optional: Select **Show system containers (advanced)** to view internal containers when using Docker commands.
 5. Select **Create**. 
 


### PR DESCRIPTION
## Description

- change "provisioining" to "provisioning" in the Kubernetes desktop docs

## Related issues or tickets

- N/A (trivial docs typo fix)

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
