### PR TITLE
docs: explain two-step process for Business subscribers to enable Gordon

### DIFF
--- a/content/manuals/ai/gordon/_index.md
+++ b/content/manuals/ai/gordon/_index.md
@@ -43,8 +43,16 @@ Before you begin:
 
 > [!NOTE]
 > Gordon is enabled by default for Personal, Pro, and Team subscriptions. For
-> Business subscriptions, an administrator must enable Gordon for the
-> organization before users can access it.
+> Business subscriptions, two steps are required before users can access Gordon:
+>
+> 1. Contact Docker support or your Docker account representative to request
+>    Gordon activation for your organization. Docker must enable it on their end
+>    first.
+> 2. After activation, an organization admin sets the Gordon setting to
+>    **Enabled** or **Always Enabled** (not **User Defined**) in the Admin
+>    Console. See the
+>    [settings reference](/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference/)
+>    for details.
 
 ### Quick start
 


### PR DESCRIPTION
## Summary
- Expands the Business subscriber note on the Gordon overview page
- Explains that Docker support must first activate Gordon for the org, then an admin enables it in the Admin Console
- Links to the settings reference for the admin step

## Related
Addresses user-reported issue: Gordon docs don't explain how Business subscribers enable Gordon.

## Test plan
- [ ] Verify note renders correctly on the Gordon overview page
- [ ] Verify settings reference link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)