### PR TITLE
Remove time-relative language from swarm services documentation

### DIFF
--- a/content/manuals/engine/swarm/how-swarm-mode-works/services.md
+++ b/content/manuals/engine/swarm/how-swarm-mode-works/services.md
@@ -15,11 +15,11 @@ When you create a service, you specify which container image to use and which
 commands to execute inside running containers. You also define options for the
 service including:
 
-* The port where the swarm makes the service available outside the swarm
-* An overlay network for the service to connect to other services in the swarm
-* CPU and memory limits and reservations
-* A rolling update policy
-* The number of replicas of the image to run in the swarm
+- The port where the swarm makes the service available outside the swarm
+- An overlay network for the service to connect to other services in the swarm
+- CPU and memory limits and reservations
+- A rolling update policy
+- The number of replicas of the image to run in the swarm
 
 ## Services, tasks, and containers
 
@@ -61,8 +61,7 @@ The underlying logic of Docker's Swarm mode is a general purpose scheduler and
 orchestrator. The service and task abstractions themselves are unaware of the
 containers they implement. Hypothetically, you could implement other types of
 tasks such as virtual machine tasks or non-containerized process tasks. The
-scheduler and orchestrator are agnostic about the type of the task. However, the
-current version of Docker only supports container tasks.
+scheduler and orchestrator are agnostic about the type of the task. However, Docker only supports container tasks.
 
 The diagram below shows how Swarm mode accepts service create requests and
 schedules tasks to worker nodes.
@@ -121,5 +120,5 @@ in black.
 
 ## Learn more
 
-* Read about how Swarm mode [nodes](nodes.md) work.
-* Learn how [PKI](pki.md) works in Swarm mode.
+- Read about how Swarm mode [nodes](nodes.md) work.
+- Learn how [PKI](pki.md) works in Swarm mode.


### PR DESCRIPTION
Replace "the current version of Docker only supports container tasks" with
"Docker only supports container tasks". The phrase "current version" is a
temporal qualifier that goes stale silently, violating the style guide.

Fixes #24463

🤖 Generated with [Claude Code](https://claude.com/claude-code)