### PR TITLE
docs: explain two-step process for Business subscribers to enable Gordon

### DIFF
--- a/content/manuals/ai/gordon/_index.md
+++ b/content/manuals/ai/gordon/_index.md
@@ -45,10 +45,10 @@ Before you begin:
 > Gordon is enabled by default for Personal, Pro, and Team subscriptions.
 > Business subscribers must complete two steps before users can access Gordon:
 >
-> 1. Contact Docker support to activate Gordon for your organization. Docker
+> 1. Contact Docker Support to activate Gordon for your organization. Docker
 >    will confirm when activation is complete.
 > 2. Once confirmed, an organization administrator must set **Enable Gordon** to
->    **Enabled** or **Always Enabled** in the
+>    **Enabled** or **Always enabled** in the
 >    [Admin Console](/manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console.md).
 >    Do not leave the setting at its default value, as this will not activate
 >    Gordon organization-wide.


### PR DESCRIPTION
## Summary
- Expands the Business subscriber note on the Gordon overview page
- Explains that Docker support must first activate Gordon for the org (and will confirm when done), then an admin enables it in the Admin Console
- Links to the settings reference for the admin step


🤖 Generated with [Claude Code](https://claude.com/claude-code)