### PR TITLE
[automated] docs: update Engine API version to v1.54, docker CE to v29.3.0

### DIFF
--- a/content/reference/api/engine/version/v1.53.md
+++ b/content/reference/api/engine/version/v1.53.md
@@ -1,7 +1,4 @@
 ---
 linkTitle: v1.53
 title: Docker Engine API v1.53 reference
-aliases:
-  - /engine/api/latest/
-  - /reference/api/engine/latest/
 ---

--- a/content/reference/api/engine/version/v1.54.md
+++ b/content/reference/api/engine/version/v1.54.md
@@ -1,0 +1,7 @@
+---
+linkTitle: v1.54
+title: Docker Engine API v1.54 reference
+aliases:
+  - /engine/api/latest/
+  - /reference/api/engine/latest/
+---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -139,12 +139,12 @@ params:
   # Use `grep` to figure out how they might be used.
 
   # Latest version of the Docker Engine API
-  latest_engine_api_version: "1.53"
+  latest_engine_api_version: "1.54"
   # Latest version of Docker Engine
-  docker_ce_version: "29.2.1"
+  docker_ce_version: "29.3.0"
   # Previous version of the Docker Engine
   # (Used to show e.g., "latest" and "latest"-1 in engine install examples
-  docker_ce_version_prev: "29.2.0"
+  docker_ce_version_prev: "29.2.1"
   # Latest Docker Compose version
   compose_version: "v5.0.1"
   # Latest BuildKit version
@@ -171,18 +171,18 @@ params:
 menus:
   # Site header menu
   main:
-  - name: Get started
-    pageRef: /get-started/
-    weight: 1
-  - name: Guides
-    pageRef: /guides/
-    weight: 2
-  - name: Manuals
-    pageRef: /manuals/
-    weight: 3
-  - name: Reference
-    pageRef: /reference/
-    weight: 4
+    - name: Get started
+      pageRef: /get-started/
+      weight: 1
+    - name: Guides
+      pageRef: /guides/
+      weight: 2
+    - name: Manuals
+      pageRef: /manuals/
+      weight: 3
+    - name: Reference
+      pageRef: /reference/
+      weight: 4
 
   # Footer links
   footer:
@@ -308,7 +308,6 @@ module:
       target: assets/css/highlight-github-dark.css
 
   imports:
-
     # Docker Engine API
     - path: github.com/moby/moby/api
       mounts:


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

- Update `latest_engine_api_version` from `1.53` to `1.54` in `hugo.yaml`
- Update `docker_ce_version` from `29.2.1` to `29.3.0` in `hugo.yaml`
- Update `docker_ce_version_prev` from `29.2.0` to `29.2.1` in `hugo.yaml`
- Add new `content/reference/api/engine/version/v1.54.md` stub with `/latest/` aliases
- Remove `/latest/` aliases from `v1.53.md` (now superseded by v1.54)

Closes #24473