### PR TITLE
[automated] Remove time-relative "now" from Scout Dashboard intro

### DIFF
--- a/content/manuals/scout/explore/dashboard.md
+++ b/content/manuals/scout/explore/dashboard.md
@@ -1,16 +1,17 @@
 ---
 description: The Docker Scout Dashboard helps review and share the analysis of images.
-keywords: scout, scanning, analysis, vulnerabilities, Hub, supply chain, security, report,
+keywords:
+  scout, scanning, analysis, vulnerabilities, Hub, supply chain, security, report,
   reports, dashboard
 title: Dashboard
 aliases:
-- /scout/reports/
-- /scout/web-app/
-- /scout/dashboard/
+  - /scout/reports/
+  - /scout/web-app/
+  - /scout/dashboard/
 ---
 
 The [Docker Scout Dashboard](https://scout.docker.com/) helps you share the
-analysis of images in an organization with your team. Developers can now see an
+analysis of images in an organization with your team. Developers can see an
 overview of their security status across all their images from Docker Hub, and
 get remediation advice at their fingertips. It helps team members in roles such
 as security, compliance, and operations to know what vulnerabilities and issues
@@ -138,7 +139,7 @@ vulnerability exposure or policy compliance as a result of pushing a new image.
 
 > [!NOTE]
 >
-> Notifications are only triggered for the *last pushed* image tags for each
+> Notifications are only triggered for the _last pushed_ image tags for each
 > repository. "Last pushed" refers to the image tag that was most recently
 > pushed to the registry and analyzed by Docker Scout. If the last pushed image
 > is not affected by a newly disclosed CVE, then no notification will be
@@ -152,7 +153,6 @@ The available notification settings are:
   repositories, or only for specific repositories. These settings apply to the
   currently selected organization, and can be changed for each organization you
   are a member of.
-
   - **All repositories**: select this option to receive notifications for all
     repositories that you have access to.
   - **Specific repositories**: select this option to receive notifications for
@@ -163,13 +163,12 @@ The available notification settings are:
 
   These settings control how you receive notifications from Docker Scout. They
   apply to all organizations that you're a member of.
-
   - **Notification pop-ups**: select this check-box to receive notification
     pop-up messages in the Docker Scout Dashboard.
   - **OS notifications**: select this check-box to receive OS-level notifications
     from your browser if you have the Docker Scout Dashboard open in a browser
     tab.
-  
+
   To enable OS notifications, Docker Scout needs permissions to send
   notifications using the browser API.
 


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

- Removes the word "now" from the Scout Dashboard introductory paragraph
- "now" is time-relative language prohibited by STYLE.md and Vale rules

Closes #24489