### PR TITLE
[automated] Remove hardcoded Scout subscription limit from analysis docs

### DIFF
--- a/content/manuals/scout/explore/analysis.md
+++ b/content/manuals/scout/explore/analysis.md
@@ -29,11 +29,8 @@ see [Integrating Docker Scout with other systems](/manuals/scout/integrations/_i
 
 ## Activate Docker Scout on a repository
 
-Docker Personal comes with 1 Scout-enabled repository. You can upgrade your
-Docker subscription if you need additional repositories.
 See [Subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsScoutAnalysis)
-to learn how many Scout-enabled
-repositories come with each subscription tier.
+to learn how many Scout-enabled repositories come with each subscription tier.
 
 Before you can activate image analysis on a repository in a third-party registry,
 the registry must be integrated with Docker Scout for your Docker organization.
@@ -233,4 +230,3 @@ To analyze images larger than that:
 
 - Attach an [SBOM attestation](/manuals/build/metadata/attestations/sbom.md) at build-time. When an image includes an SBOM attestation, Docker Scout uses it instead of generating one, so the 10 GB limit doesn’t apply.
 - Alternatively, you can use the [CLI](#cli) to analyze the image locally. The 10 GB limit doesn’t apply when using the CLI. If the image includes an SBOM attestation, the CLI uses it to complete the analysis faster.
-


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

- Removes the hardcoded "Docker Personal comes with 1 Scout-enabled repository" statement
- Replaces it with a direct link to the pricing page, which is the source of truth for subscription limits
- Reduces maintenance burden by avoiding inline duplication of subscription tier details

Closes #24491