### PR TITLE
vendor: github.com/docker/model-runner v1.1.25

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -3,4 +3,4 @@
 # github.com/docker/buildx v0.32.1
 # github.com/docker/cli v29.3.0+incompatible
 # github.com/docker/compose/v5 v5.0.2
-# github.com/docker/model-runner v1.1.24
+# github.com/docker/model-runner v1.1.25

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,62 @@ require (
 	github.com/docker/buildx v0.32.1
 	github.com/docker/cli v29.3.0+incompatible
 	github.com/docker/compose/v5 v5.0.2
-	github.com/docker/model-runner v1.1.24
+	github.com/docker/model-runner v1.1.25
 	github.com/moby/buildkit v0.28.0
 	github.com/moby/moby/api v1.54.0
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/containerd/containerd/v2 v2.2.2 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/log v0.1.0 // indirect
+	github.com/containerd/platforms v1.0.0-rc.3 // indirect
+	github.com/containerd/typeurl/v2 v2.2.3 // indirect
+	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker-credential-helpers v0.9.5 // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/gpustack/gguf-parser-go v0.24.0 // indirect
+	github.com/henvic/httpretty v0.1.4 // indirect
+	github.com/jaypipes/ghw v0.23.0 // indirect
+	github.com/jaypipes/pcidb v1.1.1 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.4 // indirect
+	github.com/kolesnikovae/go-winjob v1.0.0 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/moby/locker v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.67.5 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/smallnest/ringbuffer v0.0.0-20241116012123-461381446e3d // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
+	golang.org/x/mod v0.33.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/tools v0.41.0 // indirect
+	gonum.org/v1/gonum v0.16.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	howett.net/plist v1.0.2-0.20250314012144-ee69052608d9 // indirect
 )
 
 tool (

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v1.0.0-rc.2 h1:0SPgaNZPVWGEi4grZdV8VRYQn78y+nm6acgLGv/QzE4=
 github.com/containerd/platforms v1.0.0-rc.2/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLVRzJGXfNuWCZCllLA4=
+github.com/containerd/platforms v1.0.0-rc.3 h1:YdvwaHtrN6wHcGJ2mYRYP3Nso8OcysuqFe9Hxm1X/tI=
+github.com/containerd/platforms v1.0.0-rc.3/go.mod h1:gw0R+alP3nFQPh1L4K9bv13fRWeeyokLGLu2fKuqI10=
 github.com/containerd/stargz-snapshotter v0.17.0 h1:djNS4KU8ztFhLdEDZ1bsfzOiYuVHT6TgSU5qwRk+cNc=
 github.com/containerd/stargz-snapshotter v0.18.2 h1:Ev/sxfQUjwzJQ9eqy3XzttcQ3osMIqkQgMYlcET+10M=
 github.com/containerd/stargz-snapshotter/estargz v0.17.0 h1:+TyQIsR/zSFI1Rm31EQBwpAA1ovYgIKHy7kctL3sLcE=
@@ -106,6 +108,8 @@ github.com/docker/model-runner v1.1.9-0.20260303081710-59280ed7abd5 h1:oY1RUGY7s
 github.com/docker/model-runner v1.1.9-0.20260303081710-59280ed7abd5/go.mod h1:S1ttvsnofZx35unrXuzhcbZ7fWOpNhLPawhNrRMHp+c=
 github.com/docker/model-runner v1.1.24 h1:SmlaZOlXJ5YC5ouxgwBj1qkfFSdgIw4BSFqnA3N86m8=
 github.com/docker/model-runner v1.1.24/go.mod h1:Sz8p8xoQiRW4Kbx8u7zAGynPESSJc/EZrPjHi+Ghtoo=
+github.com/docker/model-runner v1.1.25 h1:vwVtdqIos0ffxnaxakRjmpshqzBx1Sa4M6HJTXPVcsE=
+github.com/docker/model-runner v1.1.25/go.mod h1:AVBP5brJ8TkQD94cLKMVTn5jkrV1o8/b20hkeL8WTsE=
 github.com/docker/model-runner/cmd/cli v1.0.3 h1:oycm6fHwhFBNM47Y2Ka7nUSsrbSG3FL7NMShjTRuxak=
 github.com/docker/model-runner/cmd/cli v1.0.3/go.mod h1:86LCLsk93vuevYRDKoBxwGusyGlW+UnKCnbXJ7m6Zjo=
 github.com/docker/model-runner/pkg/go-containerregistry v0.0.0-20251121150728-6951a2a36575 h1:N2yLWYSZFTVLkLTh8ux1Z0Nug/F78pXsl2KDtbWhe+Y=
@@ -118,6 +122,7 @@ github.com/emirpasic/gods/v2 v2.0.0-alpha h1:dwFlh8pBg1VMOXWGipNMRt8v96dKAIvBeht
 github.com/emirpasic/gods/v2 v2.0.0-alpha/go.mod h1:W0y4M2dtBB9U5z3YlghmpuUhiaZT2h6yoeE+C1sCp6A=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
## Description

Update Model Runner CLI docs.
See changes in https://github.com/docker/model-runner/compare/v1.1.24...v1.1.25.

```
VENDOR_MODULE=github.com/docker/model-runner@v1.1.25 make vendor
```

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review