### PR TITLE
dhi: xref guides from manuals

### DIFF
--- a/content/guides/bun/_index.md
+++ b/content/guides/bun/_index.md
@@ -6,7 +6,7 @@ summary: |
   Learn how to containerize JavaScript applications with the Bun runtime.
 linkTitle: Bun
 languages: [js]
-tags: []
+tags: [dhi]
 params:
   time: 10 minutes
 ---

--- a/content/guides/deno/_index.md
+++ b/content/guides/deno/_index.md
@@ -6,7 +6,7 @@ summary: |
   Learn how to containerize JavaScript applications with the Deno runtime using Docker.
 linkTitle: Deno
 languages: [js]
-tags: []
+tags: [dhi]
 params:
   time: 10 minutes
 ---

--- a/content/guides/nodejs/_index.md
+++ b/content/guides/nodejs/_index.md
@@ -11,7 +11,7 @@ aliases:
   - /language/nodejs/
   - /guides/language/nodejs/
 languages: [js]
-tags: []
+tags: [dhi]
 params:
   time: 20 minutes
 ---

--- a/content/guides/python/_index.md
+++ b/content/guides/python/_index.md
@@ -11,7 +11,7 @@ aliases:
   - /language/python/
   - /guides/language/python/
 languages: [python]
-tags: []
+tags: [dhi]
 params:
   time: 20 minutes
 ---

--- a/content/guides/rust/_index.md
+++ b/content/guides/rust/_index.md
@@ -11,6 +11,7 @@ aliases:
   - /language/rust/
   - /guides/language/rust/
 languages: [rust]
+tags: [dhi]
 params:
   time: 20 minutes
 ---

--- a/content/guides/traefik.md
+++ b/content/guides/traefik.md
@@ -4,7 +4,7 @@ description: &desc Use Traefik to easily route traffic between multiple containe
 keywords: traefik, container-supported development
 linktitle: HTTP routing with Traefik
 summary: *desc
-tags: [networking]
+tags: [networking, dhi]
 params:
   time: 20 minutes
 ---

--- a/content/guides/vuejs/_index.md
+++ b/content/guides/vuejs/_index.md
@@ -8,7 +8,7 @@ summary: |
 toc_min: 1
 toc_max: 2
 languages: [js]
-tags: [frameworks]
+tags: [frameworks, dhi]
 aliases:
   - /frameworks/vue/
 params:

--- a/content/manuals/dhi/_index.md
+++ b/content/manuals/dhi/_index.md
@@ -34,7 +34,7 @@ params:
       icon: help_center
       link: /dhi/troubleshoot/
     - title: Additional resources
-      description: Links to blog posts, Docker Hub catalog, GitHub repositories, and more.
+      description: Guides, blog posts, Docker Hub catalog, GitHub repositories, and more.
       icon: link
       link: /dhi/resources/
 ---

--- a/content/manuals/dhi/resources.md
+++ b/content/manuals/dhi/resources.md
@@ -6,7 +6,7 @@ weight: 999
 ---
 
 This page provides links to additional resources related to Docker Hardened
-Images (DHI), including blog posts, Docker Hub resources, and GitHub
+Images (DHI), including blog posts, guides, Docker Hub resources, and GitHub
 repositories.
 
 For product information and feature comparison, visit the [Docker Hardened
@@ -30,6 +30,11 @@ features, and announcements:
 | August 6, 2025 | [The Next Evolution of Docker Hardened Images: Customizable, FedRAMP Ready, AI Migration Agent, and Deeper Integrations](https://www.docker.com/blog/the-next-evolution-of-docker-hardened-images/) |
 | August 6, 2025 | [Accelerating FedRAMP Compliance with Docker Hardened Images](https://www.docker.com/blog/fedramp-compliance-with-hardened-images/) |
 | May 19, 2025 | [Introducing Docker Hardened Images: Secure, Minimal, and Ready for Production](https://www.docker.com/blog/introducing-docker-hardened-images/) |
+
+## Guides
+
+For guides that demonstrate how to use Docker Hardened Images in various
+scenarios, see the [guides section filtered by DHI](/guides/?tags=dhi).
 
 ## Docker Hub
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added awareness for DHI guides in the manual via the landing page and additional resources page.
Tagged guides that use a dhi with the dhi tag.

- https://deploy-preview-24506--docsdocker.netlify.app/dhi/
- https://deploy-preview-24506--docsdocker.netlify.app/dhi/resources/#guides
- https://deploy-preview-24506--docsdocker.netlify.app/guides/?tags=dhi

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
