### PR TITLE
Remove Segment endpoints from allow-list

### DIFF
--- a/content/manuals/desktop/setup/allow-list.md
+++ b/content/manuals/desktop/setup/allow-list.md
@@ -17,8 +17,6 @@ This page contains the domain URLs that you need to add to a firewall allowlist 
 
 | Domains                                                                              | Description                                  |
 | ------------------------------------------------------------------------------------ | -------------------------------------------- |
-| https://api.segment.io                                                               | Analytics                                    |
-| https://cdn.segment.com                                                              | Analytics                                    |
 | https://notify.bugsnag.com                                                           | Error reports                                |
 | https://sessions.bugsnag.com                                                         | Error reports                                |
 | https://auth.docker.io                                                               | Authentication                               |


### PR DESCRIPTION
## Description

We’ve removed Segment from Docker Desktop.

## Related issues or tickets

https://docker.atlassian.net/browse/DKP-2677

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review