### PR TITLE
[ai/model-runner] Update runtime flag configuration command

### DIFF
--- a/content/manuals/ai/model-runner/configuration.md
+++ b/content/manuals/ai/model-runner/configuration.md
@@ -105,7 +105,7 @@ models:
 With the `docker model configure` command:
 
 ```console
-$ docker model configure --runtime-flag "--temp" --runtime-flag "0.7" --runtime-flag "--top-p" --runtime-flag "0.9" ai/qwen2.5-coder
+$ docker model configure ai/qwen2.5-coder -- --temp 0.7 --top-p 0.9
 ```
 
 ### Common llama.cpp parameters


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description
`--runtime-flag` is no longer a valid flag to pass runtime flags and is now unknown to `docker model configure`.
Update the document with the latest command as defined in the [source code](https://github.com/docker/model-runner/blob/7e4b3da129c896036b17f39768604c8961741630/cmd/cli/commands/configure.go#L14). It works in a test.



<!-- Tell us what you did and why -->

## Related issues or tickets
Not found.
<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review