### PR TITLE
docs: hyphenate Kubernetes boot-up wording

### DIFF
--- a/content/manuals/desktop/use-desktop/kubernetes.md
+++ b/content/manuals/desktop/use-desktop/kubernetes.md
@@ -38,7 +38,7 @@ The following actions are also triggered in the Docker Desktop backend and VM:
 
 - Generation of certificates and cluster configuration
 - Download and installation of Kubernetes internal components
-- Cluster bootup
+- Cluster boot-up
 - Installation of additional controllers for networking and storage
 
 When Kubernetes is enabled, its status is displayed in the Docker Desktop Dashboard footer and the Docker menu.


### PR DESCRIPTION
## Description

Hyphenate "boot-up" in the Docker Desktop Kubernetes docs for clearer wording.

## Related issues or tickets

N/A

## Reviews

Guideline alignment: https://github.com/docker/docs/blob/main/CONTRIBUTING.md

Validation: Not run; docs-only wording change.

- [ ] Technical review
- [x] Editorial review
- [ ] Product review
