### PR TITLE
feat(gha): add Slack notification workflow for Desktop release notes PRs

### DIFF
--- a/.github/workflows/notify-release-notes-pr.yml
+++ b/.github/workflows/notify-release-notes-pr.yml
@@ -1,0 +1,32 @@
+name: Notify Slack on Desktop Release Notes PR
+
+on:
+  pull_request:
+    types: [opened]
+    paths:
+      - content/manuals/desktop/release-notes.md
+
+jobs:
+  notify:
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'docker'
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
+              "text": "Desktop release notes",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":memo: *Desktop release notes*:\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}> by <https://github.com/${{ github.event.pull_request.user.login }}|${{ github.event.pull_request.user.login }}>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Adds a GitHub Actions workflow that posts a Slack notification when a pull request is opened that modifies the Desktop release notes page (content/manuals/desktop/release-notes.md).                                          

The workflow uses slackapi/slack-github-action v3.0.1 and sends a message with a link to the PR and the author's GitHub profile to the configured Slack channel.

Will need to add the secrets. 

## Related issues or tickets

n/a

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review