### PR TITLE
vendor: github.com/docker/model-runner v1.1.28

### DIFF
--- a/_vendor/github.com/docker/model-runner/cmd/cli/docs/reference/docker_model_run.yaml
+++ b/_vendor/github.com/docker/model-runner/cmd/cli/docs/reference/docker_model_run.yaml
@@ -50,6 +50,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: websearch
+      value_type: bool
+      default_value: "false"
+      description: Enable web search tool during chat
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 examples: |-
     ### One-time prompt
 

--- a/_vendor/github.com/docker/model-runner/cmd/cli/docs/reference/model_run.md
+++ b/_vendor/github.com/docker/model-runner/cmd/cli/docs/reference/model_run.md
@@ -11,6 +11,7 @@ Run a model and interact with it using a submitted prompt or chat mode
 | `--debug`        | `bool`   |         | Enable debug logging                                 |
 | `-d`, `--detach` | `bool`   |         | Load the model in the background without interaction |
 | `--openaiurl`    | `string` |         | OpenAI-compatible API endpoint URL to chat with      |
+| `--websearch`    | `bool`   |         | Enable web search tool during chat                   |
 
 
 <!---MARKER_GEN_END-->

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -3,4 +3,4 @@
 # github.com/docker/buildx v0.32.1
 # github.com/docker/cli v29.3.0+incompatible
 # github.com/docker/compose/v5 v5.0.2
-# github.com/docker/model-runner v1.1.24
+# github.com/docker/model-runner v1.1.28

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/buildx v0.32.1
 	github.com/docker/cli v29.3.0+incompatible
 	github.com/docker/compose/v5 v5.0.2
-	github.com/docker/model-runner v1.1.24
+	github.com/docker/model-runner v1.1.28
 	github.com/moby/buildkit v0.28.0
 	github.com/moby/moby/api v1.54.0
 )

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v1.0.0-rc.2 h1:0SPgaNZPVWGEi4grZdV8VRYQn78y+nm6acgLGv/QzE4=
 github.com/containerd/platforms v1.0.0-rc.2/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLVRzJGXfNuWCZCllLA4=
+github.com/containerd/platforms v1.0.0-rc.3 h1:YdvwaHtrN6wHcGJ2mYRYP3Nso8OcysuqFe9Hxm1X/tI=
+github.com/containerd/platforms v1.0.0-rc.3/go.mod h1:gw0R+alP3nFQPh1L4K9bv13fRWeeyokLGLu2fKuqI10=
 github.com/containerd/stargz-snapshotter v0.17.0 h1:djNS4KU8ztFhLdEDZ1bsfzOiYuVHT6TgSU5qwRk+cNc=
 github.com/containerd/stargz-snapshotter v0.18.2 h1:Ev/sxfQUjwzJQ9eqy3XzttcQ3osMIqkQgMYlcET+10M=
 github.com/containerd/stargz-snapshotter/estargz v0.17.0 h1:+TyQIsR/zSFI1Rm31EQBwpAA1ovYgIKHy7kctL3sLcE=
@@ -106,6 +108,8 @@ github.com/docker/model-runner v1.1.9-0.20260303081710-59280ed7abd5 h1:oY1RUGY7s
 github.com/docker/model-runner v1.1.9-0.20260303081710-59280ed7abd5/go.mod h1:S1ttvsnofZx35unrXuzhcbZ7fWOpNhLPawhNrRMHp+c=
 github.com/docker/model-runner v1.1.24 h1:SmlaZOlXJ5YC5ouxgwBj1qkfFSdgIw4BSFqnA3N86m8=
 github.com/docker/model-runner v1.1.24/go.mod h1:Sz8p8xoQiRW4Kbx8u7zAGynPESSJc/EZrPjHi+Ghtoo=
+github.com/docker/model-runner v1.1.28 h1:SrGTSP8X0v3z5m1jEzZu5n3OnOJbDZom6UMmrSZ3iQE=
+github.com/docker/model-runner v1.1.28/go.mod h1:AVBP5brJ8TkQD94cLKMVTn5jkrV1o8/b20hkeL8WTsE=
 github.com/docker/model-runner/cmd/cli v1.0.3 h1:oycm6fHwhFBNM47Y2Ka7nUSsrbSG3FL7NMShjTRuxak=
 github.com/docker/model-runner/cmd/cli v1.0.3/go.mod h1:86LCLsk93vuevYRDKoBxwGusyGlW+UnKCnbXJ7m6Zjo=
 github.com/docker/model-runner/pkg/go-containerregistry v0.0.0-20251121150728-6951a2a36575 h1:N2yLWYSZFTVLkLTh8ux1Z0Nug/F78pXsl2KDtbWhe+Y=
@@ -118,6 +122,7 @@ github.com/emirpasic/gods/v2 v2.0.0-alpha h1:dwFlh8pBg1VMOXWGipNMRt8v96dKAIvBeht
 github.com/emirpasic/gods/v2 v2.0.0-alpha/go.mod h1:W0y4M2dtBB9U5z3YlghmpuUhiaZT2h6yoeE+C1sCp6A=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
## Description

Update Model Runner CLI docs.
See changes in https://github.com/docker/model-runner/compare/v1.1.27...v1.1.28.

```
VENDOR_MODULE=github.com/docker/model-runner@v1.1.28 make vendor
```

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review