### PR TITLE
explicit arch line

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -121,6 +121,7 @@ Docker from the repository.
    URIs: {{% param "download-url-base" %}}
    Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
    Components: stable
+   Architectures: $(dpkg --print-architecture)
    Signed-By: /etc/apt/keyrings/docker.asc
    EOF
 

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -137,6 +137,7 @@ Docker from the repository.
    URIs: {{% param "download-url-base" %}}
    Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
    Components: stable
+   Architectures: $(dpkg --print-architecture)
    Signed-By: /etc/apt/keyrings/docker.asc
    EOF
 


### PR DESCRIPTION
- **engine: add explicit Architecture to ubuntu/debian install instructions**

Closes #24549