### PR TITLE
Fix: Corrected /. to ./ in bind_mounts under the git bash tab in bind mounts docs

### DIFF
--- a/content/get-started/workshop/06_bind_mounts.md
+++ b/content/get-started/workshop/06_bind_mounts.md
@@ -79,7 +79,7 @@ filesystem you can share with containers. For details about accessing the settin
    {{< tab name="Git Bash" >}}
 
    ```console
-   $ docker run -it --mount type=bind,src="/.",target=/src ubuntu bash
+   $ docker run -it --mount type=bind,src="./",target=/src ubuntu bash
    ```
    
    {{< /tab >}}
@@ -318,7 +318,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
 
    ```console
    $ docker run -dp 127.0.0.1:3000:3000 \
-       -w //app --mount type=bind,src="/.",target=/app \
+       -w //app --mount type=bind,src="./",target=/app \
        node:24-alpine \
        sh -c "npm install && npm run dev"
    ```


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

I was practicing how to use bind mounts via git bash
I used the command as seen on the docs: docker run -it --mount type=bind,src="/.",target=/src ubuntu bash
It didn't work until I changed src="/." to src="./"

## Related issues or tickets



## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review