### PR TITLE
docs: fix wording in Go guide

### DIFF
--- a/content/guides/golang/develop.md
+++ b/content/guides/golang/develop.md
@@ -24,7 +24,7 @@ The database engine you are going to use is called [CockroachDB](https://www.coc
 
 Instead of compiling CockroachDB from the source code or using the operating system's native package manager to install CockroachDB, you are going to use the [Docker image for CockroachDB](https://hub.docker.com/r/cockroachdb/cockroach) and run it in a container.
 
-CockroachDB is compatible with PostgreSQL to a significant extent, and shares many conventions with the latter, particularly the default names for the environment variables. So, if you are familiar with Postgres, don't be surprised if you see some familiar environment variables names. The Go modules that work with Postgres, such as [pgx](https://pkg.go.dev/github.com/jackc/pgx), [pq](https://pkg.go.dev/github.com/lib/pq), [GORM](https://gorm.io/index.html), and [upper/db](https://upper.io/v4/) also work with CockroachDB.
+CockroachDB is compatible with PostgreSQL to a significant extent, and shares many conventions with the latter, particularly the default names for the environment variables. So, if you are familiar with Postgres, don't be surprised if you see some familiar environment variable names. The Go modules that work with Postgres, such as [pgx](https://pkg.go.dev/github.com/jackc/pgx), [pq](https://pkg.go.dev/github.com/lib/pq), [GORM](https://gorm.io/index.html), and [upper/db](https://upper.io/v4/) also work with CockroachDB.
 
 For more information on the relation between Go and CockroachDB, refer to the [CockroachDB documentation](https://www.cockroachlabs.com/docs/v20.2/build-a-go-app-with-cockroachdb.html), although this isn't necessary to continue with the present guide.
 


### PR DESCRIPTION
## Summary

Fix a wording issue in the Go development guide by changing "environment variables names" to "environment variable names".

## Related issue

N/A. This is a trivial docs-only wording fix.

## Guideline alignment

- Followed the repository contributing guide: https://github.com/docker/docs/blob/main/CONTRIBUTING.md
- The change is limited to one Markdown file under `content/`.

## Validation/testing

Not run. This is a one-line documentation change.
