### PR TITLE
docs: fix output heading in PostgreSQL guide

### DIFF
--- a/content/guides/postgresql/networking-and-connectivity.md
+++ b/content/guides/postgresql/networking-and-connectivity.md
@@ -75,7 +75,7 @@ docker run -d --name postgres-dev \
   -v postgres_data:/var/lib/postgresql \
   postgres:18
 
-  # Outout
+  # Output
 CONTAINER ID  IMAGE        COMMAND                 CREATED         STATUS        PORTS     NAMES
 6d351ed89efc  postgres:18  "docker-entrypoint.s…"  9 seconds ago   Up 8 seconds  5432/tcp  postgres-dev
 


### PR DESCRIPTION
## Description

- Fix the `Outout` typo in the example output heading in the PostgreSQL networking guide.
- Validation: not run locally; docs-only change.

## Related issues or tickets

- N/A

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
