### PR TITLE
Fix Slack notification for release notes PRs from forks

### DIFF
--- a/.github/workflows/notify-release-notes-pr.yml
+++ b/.github/workflows/notify-release-notes-pr.yml
@@ -1,16 +1,29 @@
 name: Notify Slack on Desktop Release Notes PR
 
 on:
-  pull_request:
-    types: [opened]
-    paths:
-      - content/manuals/desktop/release-notes.md
+  workflow_run:
+    workflows: ["Release Notes PR Trigger"]
+    types: [completed]
 
 jobs:
   notify:
     runs-on: ubuntu-24.04
-    if: github.repository_owner == 'docker'
+    if: github.repository_owner == 'docker' && github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Download PR details
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pr-details
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR details
+        id: pr
+        run: |
+          echo "url=$(jq -r .url pr-details.json)" >> "$GITHUB_OUTPUT"
+          echo "title=$(jq -r .title pr-details.json)" >> "$GITHUB_OUTPUT"
+          echo "author=$(jq -r .author pr-details.json)" >> "$GITHUB_OUTPUT"
+
       - name: Notify Slack
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
@@ -25,7 +38,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":memo: *Desktop release notes*:\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}> by <https://github.com/${{ github.event.pull_request.user.login }}|${{ github.event.pull_request.user.login }}>"
+                    "text": ":memo: *Desktop release notes*:\n<${{ steps.pr.outputs.url }}|${{ steps.pr.outputs.title }}> by <https://github.com/${{ steps.pr.outputs.author }}|${{ steps.pr.outputs.author }}>"
                   }
                 }
               ]

--- a/.github/workflows/release-notes-pr-trigger.yml
+++ b/.github/workflows/release-notes-pr-trigger.yml
@@ -1,0 +1,28 @@
+name: Release Notes PR Trigger
+
+on:
+  pull_request:
+    types: [opened]
+    paths:
+      - content/manuals/desktop/release-notes.md
+
+jobs:
+  trigger:
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'docker'
+    steps:
+      - name: Save PR details
+        run: |
+          cat <<'EOF' > pr-details.json
+          {
+            "url": "${{ github.event.pull_request.html_url }}",
+            "title": "${{ github.event.pull_request.title }}",
+            "author": "${{ github.event.pull_request.user.login }}"
+          }
+          EOF
+
+      - name: Upload PR details
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: pr-details
+          path: pr-details.json


### PR DESCRIPTION
## Description

The Slack notification workflow for Desktop release notes PRs fails when
the PR is opened from a fork because GitHub doesn't expose repository
secrets to `pull_request` events from forks.

This PR splits the workflow into two:

1. **Release Notes PR Trigger** — runs on `pull_request`, saves PR
   details (URL, title, author) as an artifact. No secrets needed.
2. **Notify Slack on Desktop Release Notes PR** — runs on `workflow_run`
   after the trigger completes, downloads the artifact, and sends the
   Slack notification. Has access to secrets since `workflow_run` runs in
   the context of the base repository.

## Related issues or tickets

Fixes the `SlackError: Missing input! A token must be provided` error
in the notify-release-notes-pr workflow.

## Reviews

- [x] Technical review