### PR TITLE
Remove time-relative language from CLI OpenTelemetry docs

### DIFF
--- a/content/manuals/engine/cli/otel.md
+++ b/content/manuals/engine/cli/otel.md
@@ -155,7 +155,7 @@ With these files in place:
 
 ## Available metrics
 
-Docker CLI currently exports a single metric, `command.time`, which measures
+Docker CLI exports a single metric, `command.time`, which measures
 the execution duration of a command in milliseconds. This metric has the
 following attributes:
 


### PR DESCRIPTION
Fixes #24564

Remove "currently" from the Available metrics section, as prohibited by STYLE.md.