### PR TITLE
Remove time-relative language from Model Runner docs

### DIFF
--- a/content/manuals/ai/model-runner/_index.md
+++ b/content/manuals/ai/model-runner/_index.md
@@ -117,7 +117,7 @@ See [Configuration options](configuration.md) for details on context size and ot
 > Using Testcontainers or Docker Compose?
 > [Testcontainers for Java](https://java.testcontainers.org/modules/docker_model_runner/)
 > and [Go](https://golang.testcontainers.org/modules/dockermodelrunner/), and
-> [Docker Compose](/manuals/ai/compose/models-and-compose.md) now support Docker
+> [Docker Compose](/manuals/ai/compose/models-and-compose.md) support Docker
 > Model Runner.
 
 ## Known issues


### PR DESCRIPTION
Fixes #24530

Remove "now" from Testcontainers/Compose support statement.