### PR TITLE
Clarify vLLM minimum version requirement

### DIFF
--- a/content/manuals/ai/model-runner/inference-engines.md
+++ b/content/manuals/ai/model-runner/inference-engines.md
@@ -145,7 +145,7 @@ vllm: running vllm version: 0.11.0
 #### Docker Desktop (Windows with WSL2)
 
 1. Ensure you have:
-   - Docker Desktop 4.54 or later
+   - Docker Desktop 4.54 or later (minimum version for vLLM support)
    - NVIDIA GPU with updated drivers
    - WSL2 enabled
 


### PR DESCRIPTION
## Description

The prerequisites for the vLLM setup on Windows (WSL2) mention "Docker Desktop 4.54 or later" without explaining why this specific version is required. This can become confusing as newer versions are released.

This adds a short parenthetical clarifying that 4.54 is the minimum version that introduced vLLM support.

Fixes #24532