### PR TITLE
Clarify version-specific note about AI settings location

### DIFF
--- a/content/manuals/ai/model-runner/get-started.md
+++ b/content/manuals/ai/model-runner/get-started.md
@@ -27,11 +27,6 @@ You can enable DMR using Docker Desktop or Docker Engine. Follow the instruction
 You can now use the `docker model` command in the CLI and view and interact
 with your local models in the **Models** tab in the Docker Desktop Dashboard.
 
-> [!NOTE]
->
-> In Docker Desktop 4.45 and earlier, this setting is located under the
-> **Beta features** tab. In version 4.46 and later, it is under the **AI** tab.
-
 ### Docker Engine
 
 1. Ensure you have installed [Docker Engine](/engine/install/).


### PR DESCRIPTION
## Description

The note about the Docker Model Runner setting location used time-relative language ("versions 4.45 and earlier... was under") that becomes confusing as newer versions are released.

This rewrites the note to clearly state both locations:
- Docker Desktop 4.45 and earlier: **Beta features** tab
- Version 4.46 and later: **AI** tab

Also downgrades the callout from `IMPORTANT` to `NOTE` since this is informational context, not a critical warning.

Fixes #24531