### PR TITLE
Rephrase version prerequisite in private marketplace docs

### DIFF
--- a/content/manuals/extensions/private-marketplace.md
+++ b/content/manuals/extensions/private-marketplace.md
@@ -17,7 +17,7 @@ Docker Extensions' private marketplace is designed specifically for organization
 
 ## Prerequisites
 
-- [Download and install Docker Desktop](https://docs.docker.com/desktop/release-notes/). Private marketplace support was introduced in Docker Desktop 4.26.0.
+- [Download and install Docker Desktop](https://docs.docker.com/desktop/release-notes/).
 - You must be an administrator for your organization.
 - You have the ability to push the `extension-marketplace` folder and `admin-settings.json` file to the locations specified below through device management software such as [Jamf](https://www.jamf.com/).
 


### PR DESCRIPTION
## Description

The prerequisites section states "Docker Desktop 4.26.0 or later" as a download requirement, which becomes stale as new versions are released.

This rephrases the version reference as a historical fact ("Private marketplace support was introduced in Docker Desktop 4.26.0") rather than a prerequisite, making it resistant to staleness.

Fixes #24547