### PR TITLE
Rephrase settings file rename as historical fact

### DIFF
--- a/content/manuals/extensions/settings-feedback.md
+++ b/content/manuals/extensions/settings-feedback.md
@@ -22,7 +22,7 @@ Docker Extensions is switched on by default. To change your settings:
 > [!NOTE]
 >
 > If you are an [organization owner](/manuals/admin/organization/manage-a-team.md#organization-owner), you can turn off extensions for your users. Open the `settings-store.json` file, and set `"extensionsEnabled"` to `false`.
-> The `settings-store.json` file (`settings.json` was renamed to `settings-store.json` in Docker Desktop 4.35) is located at:
+> The `settings-store.json` file is located at:
 >   - `~/Library/Group Containers/group.com.docker/settings-store.json` on Mac
 >   - `C:\Users\[USERNAME]\AppData\Roaming\Docker\settings-store.json` on Windows
 >


### PR DESCRIPTION
## Description

The documentation uses time-relative language ("for Docker Desktop versions 4.34 and earlier") when mentioning the old `settings.json` file name, which becomes increasingly stale over time.

This rephrases it as a historical fact: the file was renamed from `settings.json` to `settings-store.json` in Docker Desktop 4.35.

Fixes #24546