### PR TITLE
Clarify admin-settings.json workaround version scope

### DIFF
--- a/content/manuals/extensions/private-marketplace.md
+++ b/content/manuals/extensions/private-marketplace.md
@@ -184,7 +184,7 @@ It's recommended that you try the private marketplace on your Docker Desktop ins
 
 > [!IMPORTANT]
 >
-> > If your org is managing settings via the [Admin Console](manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console/_index.md), with Docker Desktop version 4.59 and earlier you need to manually delete the `admin-settings.json` file that has been created in the target folder by the `apply` command before step 2. 
+> > If your org is managing settings via the [Admin Console](manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console/_index.md), in Docker Desktop 4.59 and earlier, you must manually delete the `admin-settings.json` file created in the target folder by the `apply` command before step 2. In Docker Desktop 4.60 and later, this step is no longer necessary. 
 
 When you select the **Extensions** tab, you should see the private marketplace listing only the extensions you have allowed in `extensions.txt`.
 


### PR DESCRIPTION
## Description

The note about manually deleting the `admin-settings.json` file uses time-relative language ("with Docker Desktop version 4.59 and earlier") without explaining what changed in later versions.

This rephrases the note to clearly state:
- In Docker Desktop 4.59 and earlier: manual deletion is required
- In Docker Desktop 4.60 and later: this step is no longer necessary

Fixes #24545