### PR TITLE
Remove hedge word from Bake wildcard pattern note

### DIFF
--- a/content/manuals/build/bake/targets.md
+++ b/content/manuals/build/bake/targets.md
@@ -122,7 +122,7 @@ Supported patterns:
 > [!NOTE]
 >
 > Always wrap wildcard patterns in quotes. Without quotes, your shell will expand the
-> wildcard to match files in the current directory, which usually causes errors.
+> wildcard to match files in the current directory, causing errors.
 
 Examples:
 


### PR DESCRIPTION
## Description

The note about quoting wildcard patterns uses the hedge word "usually" ("which usually causes errors"), which per STYLE.md should be avoided as it overstates or understates behavior.

Simplified to "causing errors" for clearer, more direct guidance.

Fixes #24516