### PR TITLE
Remove roadmap language from security FAQ

### DIFF
--- a/content/manuals/security/faqs/general.md
+++ b/content/manuals/security/faqs/general.md
@@ -62,7 +62,7 @@ For information about metadata stored by Docker Scout, see [Data handling](/manu
 
 ## How are Marketplace extensions vetted for security?
 
-Security vetting for extensions is on the roadmap but isn't currently implemented. Extensions aren't covered as part of Docker's Third-Party Risk Management Program.
+Security vetting for extensions isn't implemented. Extensions aren't covered as part of Docker's Third-Party Risk Management Program.
 
 ## Can I prevent users from pushing images to Docker Hub private repositories?
 


### PR DESCRIPTION
## Description

The security FAQ states extension vetting "is on the roadmap but isn't currently implemented", which uses both roadmap language and "currently" (prohibited by STYLE.md). This type of statement becomes silently outdated.

Simplified to a timeless factual statement: "Security vetting for extensions isn't implemented."

Fixes #24490