### PR TITLE
Add use-case guidance for semantic-embeddings RAG strategy

### DIFF
--- a/content/manuals/ai/docker-agent/reference/config.md
+++ b/content/manuals/ai/docker-agent/reference/config.md
@@ -367,7 +367,7 @@ synonyms, and paraphrasing.
 #### Semantic-embeddings
 
 LLM-enhanced semantic search. Uses a language model to generate rich semantic
-summaries of each chunk before embedding, capturing deeper meaning.
+summaries of each chunk before embedding, capturing deeper meaning. Best for complex documents where context and relationships between concepts matter.
 
 | Field                              | Type    | Default |
 | ---------------------------------- | ------- | ------- |


### PR DESCRIPTION
## Description

The semantic-embeddings RAG strategy description is missing a "Best for..." statement, unlike the chunked-embeddings and BM25 strategies. This makes it harder for readers to compare strategies and choose the right one.

Added: "Best for complex documents where context and relationships between concepts matter."

Fixes #24571