### PR TITLE
Remove time-relative language from A2A experimental notice

### DIFF
--- a/content/manuals/ai/docker-agent/reference/cli.md
+++ b/content/manuals/ai/docker-agent/reference/cli.md
@@ -57,9 +57,9 @@ $ docker agent serve a2a agent-file|registry-ref
 ```
 
 > [!NOTE]
-> A2A support is currently experimental and needs further work. Tool calls are
+> A2A support is experimental. Tool calls are
 > handled internally and not exposed as separate ADK events. Some ADK features
-> are not yet integrated.
+> are not integrated.
 
 Arguments:
 


### PR DESCRIPTION
## Description

The A2A support note uses "currently experimental and needs further work" and "not yet integrated", which are time-relative phrases prohibited by STYLE.md.

Simplified to factual statements: "experimental" and "not integrated".

Fixes #24568