### PR TITLE
Clarify legacy builder note for Windows container builds

### DIFF
--- a/content/manuals/desktop/use-desktop/builds.md
+++ b/content/manuals/desktop/use-desktop/builds.md
@@ -16,9 +16,7 @@ connected to the same cloud builder.
 
 > [!NOTE]
 >
-> When building Windows container images, the `docker build` command uses a legacy builder that does not populate the **Builds** view. To use BuildKit and see builds in this view, you can either:
-> - Set `DOCKER_BUILDKIT=1` in the build command, such as `DOCKER_BUILDKIT=1 docker build .` or
-> - Use the `docker buildx build` command
+> Windows container image builds use the legacy builder and do not appear in the **Builds** view. Only BuildKit-powered builds are shown here.
 
 ## Show build list
 


### PR DESCRIPTION
## Description

The note about Windows container builds uses passive voice ("the legacy builder is used") which makes the behavior unclear. Readers can't tell if this is expected behavior or a temporary limitation.

Rewritten in active voice to make the cause and workaround clear: the `docker build` command uses a legacy builder, and here is how to switch to BuildKit to see builds in the Builds view.

Fixes #24453