### PR TITLE
Fix typo in Docker Agent config reference

### DIFF
--- a/content/manuals/ai/docker-agent/reference/config.md
+++ b/content/manuals/ai/docker-agent/reference/config.md
@@ -6,7 +6,7 @@ keywords: [ai, agent, cagent, configuration, yaml]
 weight: 10
 ---
 
-This reference documents the YAML configuration file format for agents suing Docker Agent.
+This reference documents the YAML configuration file format for agents using Docker Agent.
 It covers file structure, agent parameters, model configuration, toolset setup,
 and RAG sources.
 


### PR DESCRIPTION
## Description

Simple typo fix: "suing" → "using" in the introductory sentence of the Docker Agent configuration reference.

Fixes #24570