### PR TITLE
dhi: enterprise get-started wording fix

### DIFF
--- a/content/manuals/dhi/how-to/select-enterprise.md
+++ b/content/manuals/dhi/how-to/select-enterprise.md
@@ -14,14 +14,15 @@ customize images, and get SLA-backed updates.
 
 ## Prerequisites
 
-To use this workflow, you need organization owner access in your Docker Hub
-namespace, and one of the following:
+To use this workflow, you need:
 
-- A DHI Select or Enterprise subscription. [Contact Docker
-  sales](https://www.docker.com/products/hardened-images/#compare) to purchase
-  or learn more about these subscriptions.
-- An active DHI trial. [Start a free DHI
-  trial](https://hub.docker.com/hardened-images/start-free-trial).
+- Organization owner access in your Docker Hub namespace.
+- One of the following:
+  - A DHI Select or Enterprise subscription. [Contact Docker
+    sales](https://www.docker.com/products/hardened-images/#compare) to purchase
+    or learn more about these subscriptions.
+  - An active DHI trial. [Start a free DHI
+    trial](https://hub.docker.com/hardened-images/start-free-trial).
 - [Docker Desktop](../../desktop/release-notes.md) 4.65 or later to use the
   `docker dhi` CLI.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Clarified the prerequisites structure in the DHI Enterprise guide. The previous wording incorrectly listed Docker Desktop 4.65+ as part of "one of the following" options, making it appear optional or mutually exclusive with the subscription/trial requirement.

Changed:

- Restructured prerequisites to show Docker Desktop 4.65+ is always required (not optional) for CLI 
Clarified that "one of the following" applies only to the subscription/trial choice
- Made it clear there are 3 distinct prerequisites:
  - Organization owner access (required)
  - DHI Select/Enterprise subscription OR trial (required - pick one)
  - Docker Desktop 4.65+ (required for cli)

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
