### PR TITLE
Swap server names to use valid names in the MCP Catalog

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/cli.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/cli.md
@@ -324,8 +324,8 @@ Create a catalog and specify which servers to include:
 ```console
 $ docker mcp catalog create registry.example.com/mcp/data-tools:latest \
   --title "Data Analysis Tools" \
-  --server catalog://mcp/docker-mcp-catalog/postgres \
-  --server catalog://mcp/docker-mcp-catalog/brave-search \
+  --server catalog://mcp/docker-mcp-catalog/sequentialthinking \
+  --server catalog://mcp/docker-mcp-catalog/brave \
   --server docker://registry.example.com/mcp/analytics:latest
 ```
 


### PR DESCRIPTION
## Description

One of the sample commands to create a custom catalog attempts to use items in the Docker MCP Catalog. Unfortunately, two of the examples don't exist. This PR adjusts the command to use server names that exist in the catalog.