### PR TITLE
build/buildkit: remove time-relative language

### DIFF
--- a/content/manuals/build/buildkit/_index.md
+++ b/content/manuals/build/buildkit/_index.md
@@ -11,7 +11,7 @@ keywords: build, buildkit
 is an improved backend to replace the legacy builder. BuildKit is the default builder
 for users on Docker Desktop, and Docker Engine as of version 23.0.
 
-BuildKit provides new functionality and improves your builds' performance.
+BuildKit provides improved functionality and improves your builds' performance.
 It also introduces support for handling more complex scenarios:
 
 - Detect and skip executing unused build stages
@@ -21,14 +21,13 @@ It also introduces support for handling more complex scenarios:
 - Detect and skip transferring unused files in your
   [build context](../concepts/context.md)
 - Use [Dockerfile frontend](frontend.md) implementations with many
-  new features
+  additional features
 - Avoid side effects with rest of the API (intermediate images and containers)
 - Prioritize your build cache for automatic pruning
 
-Apart from many new features, the main areas BuildKit improves on the current
-experience are performance, storage management, and extensibility. From the
-performance side, a significant update is a new fully concurrent build graph
-solver. It can run build steps in parallel when possible and optimize out
+The main areas BuildKit improves on the legacy builder are performance, storage
+management, and extensibility. From the performance side, a significant update
+is a fully concurrent build graph solver. It can run build steps in parallel when possible and optimize out
 commands that don't have an impact on the final result.
 The access to the local source files has also been optimized. By tracking
 only the updates made to these
@@ -180,11 +179,13 @@ see [GitHub issues](https://github.com/moby/buildkit/issues?q=is%3Aissue%20state
    $Env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + `
        [System.Environment]::GetEnvironmentVariable("Path","User")
    ```
+
 6. Start the BuildKit daemon.
 
    ```console
    > buildkitd.exe
    ```
+
    > [!NOTE]
    > If you are running a _dockerd-managed_ `containerd` process, use that instead, by supplying the address:
    > `buildkitd.exe --containerd-worker-addr "npipe:////./pipe/docker-containerd"`


### PR DESCRIPTION
## Summary

Three uses of the time-relative word "new" in the BuildKit overview page were replaced with neutral alternatives: "improved functionality", "additional features", and a rephrased paragraph that also replaces the vague "current experience" with the more precise "legacy builder".

Closes #24605

Generated by [Claude Code](https://claude.com/claude-code)