### PR TITLE
sandboxes: add sbx-releases links for manual install and feedback

### DIFF
--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -63,6 +63,13 @@ the [usage guide](usage.md) for common patterns.
 - [Troubleshooting](troubleshooting.md) — common issues and fixes
 - [FAQ](faq.md) — login requirements, telemetry, etc
 
+## Feedback
+
+Docker Sandboxes is experimental and under active development. Your feedback
+shapes what gets built next. If you run into a bug, hit a missing feature, or
+have a suggestion, open an issue at
+[github.com/docker/sbx-releases/issues](https://github.com/docker/sbx-releases/issues).
+
 ## Docker Desktop integration
 
 Docker Desktop also includes a [built-in sandbox command](docker-desktop.md)

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -49,6 +49,9 @@ $ sbx login
 {{< /tab >}}
 {{< /tabs >}}
 
+If you need to install `sbx` manually, download a binary directly from the
+[sbx-releases](https://github.com/docker/sbx-releases/releases) repository.
+
 `sbx login` opens a browser for Docker OAuth. On first login (and after `sbx
 policy reset`), the CLI prompts you to choose a default network policy for your
 sandboxes:

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -136,3 +136,8 @@ Windows:
 ```powershell
 > Remove-Item -Recurse -Force "$env:LOCALAPPDATA\DockerSandboxes"
 ```
+
+## Report an issue
+
+If you've exhausted the steps above and the problem persists, file a GitHub
+issue at [github.com/docker/sbx-releases/issues](https://github.com/docker/sbx-releases/issues).


### PR DESCRIPTION
## Summary

Adds links to the `docker/sbx-releases` GitHub repository across the sandboxes docs: a manual binary download note in the get-started guide, a "Report an issue" section at the bottom of troubleshooting, and a "Feedback" section on the overview page calling out the experimental status and inviting community feedback.

Generated by [Claude Code](https://claude.com/claude-code)