### PR TITLE
sandboxes/policy: document blocked values for user-defined rules

### DIFF
--- a/content/manuals/ai/sandboxes/security/policy.md
+++ b/content/manuals/ai/sandboxes/security/policy.md
@@ -60,6 +60,17 @@ and denies `*.corp.internal`:
 - `sbx policy allow network build.corp.internal` — no effect, because the
   organization denies `*.corp.internal`
 
+#### Blocked values in user-defined rules
+
+To prevent overly broad rules from undermining the organization's policy,
+certain catch-all values are blocked in user-defined rules:
+
+- Domain patterns: `*`, `**`, `*.com`, `**.com`, `*.*`, `**.**`
+- CIDR ranges: `0.0.0.0/0`, `::/0`
+
+Scoped wildcards like `*.example.com` are still allowed. If you attempt to
+use a blocked value, `sbx policy` returns an error immediately.
+
 ## Network policies
 
 The only way traffic can leave a sandbox is through an HTTP/HTTPS proxy on


### PR DESCRIPTION
## Summary

Documents the catch-all values that are blocked in user-defined rules when the **User defined** delegation setting is enabled in organization governance. Adds a new subsection listing blocked domain patterns and CIDR ranges, and notes that scoped wildcards like `*.example.com` remain allowed.

Generated by [Claude Code](https://claude.com/claude-code)