### PR TITLE
docs: fix GitHub Actions wording in extension CI guide

### DIFF
--- a/content/manuals/extensions/extensions-sdk/dev/continuous-integration.md
+++ b/content/manuals/extensions/extensions-sdk/dev/continuous-integration.md
@@ -26,7 +26,7 @@ steps:
 
 > [!NOTE]
 >
-> This action supports only Github Action macOS runners at the moment. You need to specify `runs-on: macOS-latest` for your end to end tests.
+> This action supports only GitHub Actions macOS runners at the moment. You need to specify `runs-on: macOS-latest` for your end to end tests.
 
 Once the step has executed, the next steps use Docker Desktop and the Docker CLI to install and test the extension.
 


### PR DESCRIPTION
## Description
- Fix GitHub capitalization in the extension CI guide for Docker Extensions.

## Related issues or tickets
- N/A; trivial docs wording fix.

## Reviews
- Docs-only wording fix.
- [ ] Technical review
- [x] Editorial review
- [ ] Product review