### PR TITLE
docs: fix GitHub authentication heading in OCI artifact guide

### DIFF
--- a/content/manuals/compose/how-tos/oci-artifact.md
+++ b/content/manuals/compose/how-tos/oci-artifact.md
@@ -56,7 +56,7 @@ AWS Client ID
 "services.serviceA.environment.AWS_ACCESS_KEY_ID": xxxxxxxxxx
 AWS Secret Key
 "services.serviceA.environment.AWS_SECRET_ACCESS_KEY": aws"xxxx/xxxx+xxxx+"
-Github authentication
+GitHub authentication
 "GITHUB_TOKEN": ghp_xxxxxxxxxx
 JSON Web Token
 "": xxxxxxx.xxxxxxxx.xxxxxxxx


### PR DESCRIPTION
## Description
- Fix GitHub capitalization in the OCI artifact guide's sample heading.

## Related issues or tickets
- N/A; trivial docs wording fix.

## Reviews
- Docs-only wording fix.
- [ ] Technical review
- [x] Editorial review
- [ ] Product review