### PR TITLE
Modify launch lab shortcode to add tear down instructions

### DIFF
--- a/layouts/_shortcodes/labspace-launch.html
+++ b/layouts/_shortcodes/labspace-launch.html
@@ -2,7 +2,7 @@
 {{ $modelDownload := .Get "model-download" | default "false" }}
 {{ $browserUrl := .Get "browserUrl" | default "http://localhost:3030"}}
 
-{{ $step1 := printf "1. Start the labspace:\n\n   ```console\n   $ docker compose -f oci://%s up -d\n   ```" $image }}
+{{ $step1 := printf "1. Start the labspace:\n\n   ```console\n   $ docker compose -p labspace -f oci://%s up -d\n   ```" $image }}
 
 {{ if eq $modelDownload "true" }}
   {{ $step1 = printf "%s\n\n   > [!NOTE]\n   >\n   > The lab may take a few minutes to launch, as this lab requires an AI model that will need to be downloaded." $step1 }}
@@ -10,4 +10,6 @@
 
 {{ $step2 := printf "2. Open your browser to [%s](%s)." $browserUrl $browserUrl }}
 
-{{ printf "%s\n\n%s" $step1 $step2 | .Page.RenderString (dict "display" "block") }}
+{{ $step3 := "3. When you're done, tear down the labspace:\n\n   ```console\n   $ docker compose -p labspace down\n   ```" }}
+
+{{ printf "%s\n\n%s\n\n%s" $step1 $step2 $step3 | .Page.RenderString (dict "display" "block") }}


### PR DESCRIPTION
## Description

Modify the shortcode used to launch labs to add teardown instructions. 

In order for the teardown instructions to work reliably (since there's no guarantee the user will be in the same directory), the startup command also adds a flag to specify the project name (`-p labspace`).
