### PR TITLE
docs: fix repositories wording in go.mod comment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/docker/docs
 go 1.26.0
 
 // This go.mod file is used by hugo to vendor documentation from upstream
-// reposities. Use the "require" section to specify the version of the
+// repositories. Use the "require" section to specify the version of the
 // upstream repository.
 //
 // Make sure to add an entry in the "tools" section when adding a new repository.


### PR DESCRIPTION
## Description

- Fix `reposities` -> `repositories` in the root `go.mod` comment.

## Related issues or tickets

- N/A (trivial comment fix)

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
