### PR TITLE
docs: explain named bind mounts in Compose volumes

### DIFF
--- a/content/includes/compose/volumes.md
+++ b/content/includes/compose/volumes.md
@@ -1,1 +1,15 @@
-Volumes are persistent data stores implemented by the container engine. Compose offers a neutral way for services to mount volumes, and configuration parameters to allocate them to infrastructure. The top-level `volumes` declaration lets you configure named volumes that can be reused across multiple services. 
+Volumes are persistent data stores implemented by the container engine. Compose offers a neutral way for services to mount volumes, and configuration parameters to allocate them to infrastructure. The top-level `volumes` declaration lets you configure named volumes that can be reused across multiple services.
+
+If you want a named bind mount, use the `local` driver with `driver_opts`. This pattern gives a Compose volume a stable name while mapping it to a specific host path:
+
+```yaml
+volumes:
+  app-data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /srv/app-data
+```
+
+The `type`, `o`, and `device` keys are passed through to the local driver. For a one-off host-path mount on a single service, see [bind mounts](/manuals/engine/storage/bind-mounts.md).


### PR DESCRIPTION
The Compose volumes docs mention `driver_opts`, but they do not show how to use the local driver to create a named bind mount.

This adds a short explanation and example in the shared Compose volumes include so the reference page shows the `type: none`, `o: bind`, `device: ...` pattern directly.

The fix is intentionally small and stays scoped to one docs include file.