### PR TITLE
add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -193,7 +193,9 @@ jobs:
             
             If the updates are still relevant, please review our [contribution guidelines](https://docs.docker.com/contribute/overview/) and **create a new PR** against the latest version of our docs.
           
-          # Timing configuration
+          # Timing configuration NOTE: If you change days-before-issue-close or
+          # days-before-pr-close, also update the hardcoded values in the
+          # stale-issue-message and stale-pr-message above to match.
           days-before-issue-stale: 180  # 6 months
           days-before-pr-stale: 180     # 6 months
           days-before-issue-close: 14   # 2 weeks after stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,9 @@
 # It also handles lifecycle slash commands for managing stale labels.
 # For more information, see: https://github.com/actions/stale
 #
+# Security: Actions are pinned to full commit SHA to prevent supply chain attacks.
+# To update, check releases and update both the SHA and version comment.
+#
 # Debug mode:
 # - Lifecycle commands: Set DEBUG_ONLY to 'true' in the lifecycle-commands job env
 # - Stale action: Set debug-only to true in the stale job configuration
@@ -23,7 +26,7 @@ jobs:
     
     steps:
       - name: Handle lifecycle commands
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           # Set to 'true' to test without making actual changes
           DEBUG_ONLY: 'true'
@@ -153,9 +156,8 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: false
           operations-per-run: 30
           

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,14 +1,153 @@
 # This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+# It also handles lifecycle slash commands for managing stale labels.
 # For more information, see: https://github.com/actions/stale
+#
+# Debug mode:
+# - Lifecycle commands: Set DEBUG_ONLY to 'true' in the lifecycle-commands job env
+# - Stale action: Set debug-only to true in the stale job configuration
 name: Mark stale issues and pull requests
 
 on:
   schedule:
     - cron: '30 1 * * *'  # Daily at 1:30 AM UTC
+  issue_comment:
+    types: [created]
 
 jobs:
+  lifecycle-commands:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment'
+    permissions:
+      issues: write
+      pull-requests: write
+    
+    steps:
+      - name: Handle lifecycle commands
+        uses: actions/github-script@v7
+        env:
+          # Set to 'true' to test without making actual changes
+          DEBUG_ONLY: 'true'
+        with:
+          script: |
+            const comment = context.payload.comment.body.toLowerCase().trim();
+            const debugOnly = process.env.DEBUG_ONLY === 'true';
+            
+            if (debugOnly) {
+              console.log('🔍 DEBUG MODE: No changes will be made');
+            }
+            
+            // Define commands and their required permissions
+            const commands = {
+              '/lifecycle frozen': { label: 'lifecycle/frozen', requiresWrite: true },
+              '/lifecycle stale': { label: 'lifecycle/stale', requiresWrite: true },
+              '/lifecycle active': { action: 'remove-stale', requiresWrite: false },
+              '/remove-lifecycle frozen': { action: 'remove-frozen', requiresWrite: true },
+              '/remove-lifecycle stale': { action: 'remove-stale', requiresWrite: false }
+            };
+            
+            // Check if comment contains a lifecycle command
+            const commandKey = Object.keys(commands).find(cmd => 
+              comment === cmd || comment.startsWith(cmd + ' ')
+            );
+            
+            if (!commandKey) {
+              console.log('No lifecycle command found in comment');
+              return;
+            }
+            
+            const commandConfig = commands[commandKey];
+            const issue_number = context.issue.number;
+            
+            // Check user permissions for restricted commands
+            if (commandConfig.requiresWrite) {
+              if (debugOnly) {
+                console.log(`Would check permissions for user ${context.payload.comment.user.login} for ${commandKey}`);
+              } else {
+                try {
+                  const { data: userPermission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    username: context.payload.comment.user.login
+                  });
+                  
+                  const hasWriteAccess = ['admin', 'write', 'maintain'].includes(userPermission.permission);
+                  
+                  if (!hasWriteAccess) {
+                    console.log(`User ${context.payload.comment.user.login} does not have permission for ${commandKey}`);
+                    await github.rest.reactions.createForIssueComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: context.payload.comment.id,
+                      content: '-1'
+                    });
+                    return;
+                  }
+                  console.log(`User ${context.payload.comment.user.login} has ${userPermission.permission} access`);
+                } catch (error) {
+                  console.log('Error checking permissions:', error.message);
+                  return;
+                }
+              }
+            }
+            
+            // Handle remove commands
+            if (commandConfig.action && commandConfig.action.startsWith('remove-')) {
+              const labelToRemove = commandConfig.action === 'remove-stale' ? 'lifecycle/stale' : 'lifecycle/frozen';
+              
+              if (debugOnly) {
+                console.log(`Would remove ${labelToRemove} label from issue #${issue_number}`);
+                console.log('Would react with 👍 to comment');
+              } else {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue_number,
+                    name: labelToRemove
+                  });
+                  console.log(`Removed ${labelToRemove} label`);
+                  
+                  await github.rest.reactions.createForIssueComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: context.payload.comment.id,
+                    content: '+1'
+                  });
+                } catch (error) {
+                  console.log(`Label ${labelToRemove} not found or already removed`);
+                }
+              }
+            }
+            // Handle add label commands
+            else if (commandConfig.label) {
+              if (debugOnly) {
+                console.log(`Would add ${commandConfig.label} label to issue #${issue_number}`);
+                console.log('Would react with 👍 to comment');
+              } else {
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue_number,
+                    labels: [commandConfig.label]
+                  });
+                  console.log(`Added ${commandConfig.label} label`);
+                  
+                  await github.rest.reactions.createForIssueComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: context.payload.comment.id,
+                    content: '+1'
+                  });
+                } catch (error) {
+                  console.log(`Error adding label: ${error.message}`);
+                }
+              }
+            }
+
   stale:
     runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
     permissions:
       issues: write
       pull-requests: write
@@ -21,16 +160,36 @@ jobs:
           operations-per-run: 30
           
           # Exempt labels - issues/PRs with these labels will never be marked stale
-          exempt-issue-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis'
-          exempt-pr-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis'
+          exempt-issue-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis,lifecycle/frozen'
+          exempt-pr-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis,lifecycle/frozen'
+          
+          # Use lifecycle/stale label to match existing convention
+          stale-issue-label: 'lifecycle/stale'
+          stale-pr-label: 'lifecycle/stale'
           
           # Stale messages
-          stale-issue-message: "There hasn't been any activity on this issue for a long time. If the problem is still relevant, add a comment on this issue. If not, this issue will be closed in 14 days."
-          stale-pr-message: "Thanks for the PR. We'd like to make our product docs better, but haven't been able to review all the suggestions. As our docs change often and quickly diverge, we do not have the bandwidth to review and rebase old PRs. If the updates are still relevant, review our [contribution guidelines](https://docs.docker.com/contribute/overview/) and rebase your PR against the latest version of the docs. This helps our maintainers focus on the active issues. If there's no activity, this PR will be closed in 30 days."
+          stale-issue-message: |
+            There hasn't been any activity on this issue for a long time. If the problem is still relevant, **add a comment** to keep it open. Otherwise, this issue will be automatically closed in 14 days.
+            
+            **To remove the stale label:** Comment `/lifecycle active`
+            **To freeze (requires write access):** Comment `/lifecycle frozen`
+          stale-pr-message: |
+            Thanks for the PR. We'd like to make our product docs better, but haven't been able to review all the suggestions. As our docs change often and quickly diverge, we do not have the bandwidth to review and rebase old PRs.
+            
+            If the updates are still relevant, please **add a comment** and review our [contribution guidelines](https://docs.docker.com/contribute/overview/) to rebase your PR against the latest version of the docs. This helps our maintainers focus on active contributions. If there's no activity, this PR will be closed in 30 days.
+            
+            **To remove the stale label:** Comment `/lifecycle active`
+            **To freeze (requires write access):** Comment `/lifecycle frozen`
           
           # Close messages
-          close-issue-message: "Closing this issue as there hasn't been any activity on this issue for a long time. If the problem is still relevant, open a new issue and complete the issue template so we can capture the details required to investigate the issue further. This also helps our maintainers focus on the active issues."
-          close-pr-message: "Closing this PR as there hasn't been any activity on this PR for a long time. If the updates are still relevant, review our [contribution guidelines](https://docs.docker.com/contribute/overview/) and create a new PR against the latest version of our docs."
+          close-issue-message: |
+            Closing this issue as there hasn't been any activity for a long time. 
+            
+            If the problem is still relevant, please **open a new issue** and complete the issue template so we can capture the details required to investigate further. This helps our maintainers focus on active issues.
+          close-pr-message: |
+            Closing this PR as there hasn't been any activity for a long time. 
+            
+            If the updates are still relevant, please review our [contribution guidelines](https://docs.docker.com/contribute/overview/) and **create a new PR** against the latest version of our docs.
           
           # Timing configuration
           days-before-issue-stale: 180  # 6 months

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+# For more information, see: https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '30 1 * * *'  # Daily at 1:30 AM UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ascending: false
+          operations-per-run: 30
+          
+          # Exempt labels - issues/PRs with these labels will never be marked stale
+          exempt-issue-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis'
+          exempt-pr-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis'
+          
+          # Stale messages
+          stale-issue-message: "There hasn't been any activity on this issue for a long time. If the problem is still relevant, add a comment on this issue. If not, this issue will be closed in 14 days."
+          stale-pr-message: "Thanks for the PR. We'd like to make our product docs better, but haven't been able to review all the suggestions. As our docs change often and quickly diverge, we do not have the bandwidth to review and rebase old PRs. If the updates are still relevant, review our [contribution guidelines](https://docs.docker.com/contribute/overview/) and rebase your PR against the latest version of the docs. This helps our maintainers focus on the active issues. If there's no activity, this PR will be closed in 30 days."
+          
+          # Close messages
+          close-issue-message: "Closing this issue as there hasn't been any activity on this issue for a long time. If the problem is still relevant, open a new issue and complete the issue template so we can capture the details required to investigate the issue further. This also helps our maintainers focus on the active issues."
+          close-pr-message: "Closing this PR as there hasn't been any activity on this PR for a long time. If the updates are still relevant, review our [contribution guidelines](https://docs.docker.com/contribute/overview/) and create a new PR against the latest version of our docs."
+          
+          # Timing configuration
+          days-before-issue-stale: 180  # 6 months
+          days-before-pr-stale: 180     # 6 months
+          days-before-issue-close: 14   # 2 weeks after stale
+          days-before-pr-close: 30      # 1 month after stale
+          
+          # Debug mode - set to false when ready for production
+          # When true, no actual changes will be made (dry-run for testing)
+          debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -162,8 +162,8 @@ jobs:
           operations-per-run: 30
           
           # Exempt labels - issues/PRs with these labels will never be marked stale
-          exempt-issue-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis,lifecycle/frozen'
-          exempt-pr-labels: 'kind/help wanted,status/need-more-info,status/needs-analysis,lifecycle/frozen'
+          exempt-issue-labels: 'kind/help-wanted,status/need-more-info,status/needs-analysis,lifecycle/frozen'
+          exempt-pr-labels: 'kind/help-wanted,status/need-more-info,status/needs-analysis,lifecycle/frozen'
           
           # Use lifecycle/stale label to match existing convention
           stale-issue-label: 'lifecycle/stale'


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This PR adds a GitHub Actions workflow to automatically mark and close stale issues and PRs, helping maintainers focus on active items. The old app/bot stopped working around mid 2025 and was disabled. This reimplements it using a GitHub Action with additional slash command functionality.

### Timeframes

- **Mark as stale**: After **180 days** (6 months) of inactivity
- **Close stale issues**: After **14 additional days** of no activity
- **Close stale PRs**: After **30 additional days** of no activity

### Exempt Labels

Issues and PRs with any of these labels will never be marked as stale:
- `kind/help-wanted`
- `status/need-more-info`
- `status/needs-analysis`
- `lifecycle/frozen`

### How to Keep Issues/PRs Active

To prevent an issue or PR from being marked as stale or closed:

**Anyone can:**
1. **Add a comment** - any comment resets the inactivity timer
2. **Use `/lifecycle active`** - removes the stale label via slash command

**Maintainers can also:**
3. **Use `/lifecycle frozen`** - prevents the issue/PR from ever being marked stale
4. **Add exempt labels** - manually apply one of the labels listed above
5. **Make any update** - editing the description, adding labels, or any activity resets the timer

### Slash Commands

The workflow supports these lifecycle commands (comment them on any issue/PR):

| Command | Access | Description |
|---------|--------|-------------|
| `/lifecycle active` | Anyone | Removes the stale label |
| `/lifecycle frozen` | Write access required | Prevents stale marking |
| `/lifecycle stale` | Write access required | Manually marks as stale |
| `/remove-lifecycle frozen` | Write access required | Removes frozen label |
| `/remove-lifecycle stale` | Anyone | Removes stale label |

Commands respond with a 👍 reaction when successful, 👎 when permission is denied.

### Messages

When marked as stale, issues and PRs receive a friendly comment explaining:
- The situation and timeline for closure (14-30 days)
- How to remove the stale label using `/lifecycle active`
- How maintainers can freeze with `/lifecycle frozen`

### Debug Mode

The workflow is currently set to **debug mode** for both components:

**Stale action** (`debug-only: true`):
- ✅ Runs and logs what actions it would take
- ❌ No actual changes will be made (no labels, comments, or closures)

**Lifecycle commands** (`DEBUG_ONLY: 'true'`):
- ✅ Logs what would happen when slash commands are used
- ❌ No labels added, removed, or permission checks enforced

## Related issues

- #19050