### PR TITLE
docs: fix Docker Daemon spelling in settings reference

### DIFF
--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
@@ -437,7 +437,7 @@ Overrides the Docker daemon configuration used in containers, without modifying 
 | Accepted values | JSON object |
 | Format | Stringified JSON |
 | JSON key | `linuxVM.dockerDaemonOptions` |
-| Admin Console | **Docker Deamon options** in the LinuxVM dropdown |
+| Admin Console | **Docker Daemon options** in the LinuxVM dropdown |
 
 ### VPNKit CIDR {{< badge color=blue text="Mac only" >}}
 


### PR DESCRIPTION
## Description
Fixes a typo in the Hardened Docker Desktop settings reference:
- "Docker Deamon options" -> "Docker Daemon options"

## Related issues or tickets
N/A (trivial docs typo fix)

## Reviews
Small docs wording correction with no behavioral impact.

- [ ] Technical review
- [x] Editorial review
- [ ] Product review
