### PR TITLE
Fix capitalization of 'the' in export.md

### DIFF
--- a/content/manuals/build/building/export.md
+++ b/content/manuals/build/building/export.md
@@ -18,7 +18,7 @@ from that image, or push it to a registry. Under the hood, this uses the default
 exporter, called the `docker` exporter.
 
 To export your build results as files instead, you can use the `--output` flag,
-or `-o` for short. the `--output` flag lets you change the output format of
+or `-o` for short. The `--output` flag lets you change the output format of
 your build.
 
 ## Export binaries from a build


### PR DESCRIPTION
This pull request makes a minor change to the documentation for build exporting. It corrects the capitalization at the start of a sentence for clarity and consistency. 

* Changed "the `--output` flag" to "The `--output` flag" at the start of a sentence in `content/manuals/build/building/export.md` for improved readability.