### PR TITLE
Fix wording in Compose extends docs

### DIFF
--- a/content/manuals/compose/how-tos/multiple-compose-files/extends.md
+++ b/content/manuals/compose/how-tos/multiple-compose-files/extends.md
@@ -42,7 +42,7 @@ services:
       service: webapp
 ```
 
-This instructs Compose to re-use only the properties of the `webapp` service
+This instructs Compose to reuse only the properties of the `webapp` service
 defined in the `common-services.yml` file. The `webapp` service itself is not part of the final project.
 
 If `common-services.yml`


### PR DESCRIPTION
## Summary
Fix wording in the Compose extends documentation by changing `re-use` to `reuse`.

## Related issue
N/A

## Guideline alignment
Single-file documentation wording fix with no behavior change.

## Validation
Not run locally; documentation-only change.
