### PR TITLE
Document how to pass CLI options to OpenCode agent

### DIFF
--- a/content/manuals/ai/sandboxes/agents/opencode.md
+++ b/content/manuals/ai/sandboxes/agents/opencode.md
@@ -64,6 +64,20 @@ OpenCode uses a TUI interface and doesn't require extensive configuration
 files. The agent prompts you to select a provider when it starts, and you can
 switch providers during a session.
 
+### Pass options at runtime
+
+Pass OpenCode CLI options after `--`:
+
+```console
+$ sbx run opencode --name <sandbox-name> -- <opencode-options>
+```
+
+For example, to resume an existing session in a named sandbox:
+
+```console
+$ sbx run <sandbox-name> -- -s <session-id>
+```
+
 ### TUI mode
 
 OpenCode launches in TUI mode by default. The interface shows:


### PR DESCRIPTION
## Summary

The OpenCode sandbox agent page was missing the "Pass options at runtime"
section that other agent pages include. Adds the `--` pass-through syntax
and a concrete example for resuming a session by ID.

Generated by [Claude Code](https://claude.com/claude-code)

- relates to https://github.com/docker/docs/issues/23966#issuecomment-4201262704