### PR TITLE
Warn about reserved IPv6 addresses in examples

### DIFF
--- a/content/manuals/engine/daemon/ipv6.md
+++ b/content/manuals/engine/daemon/ipv6.md
@@ -35,6 +35,13 @@ IPv6 is only supported on Docker daemons running on Linux hosts.
            - subnet: 2001:db8::/64
   ```
 
+> [!NOTE]
+>
+> The address `2001:db8::/64` in these examples is
+> [reserved for use in documentation][wikipedia-ipv6-reserved].
+> Replace it with a valid IPv6 network, for example a
+> [Unique Local Address (ULA)][wikipedia-ipv6-ula] subnet from `fd00::/8`.
+
 You can now run containers that attach to the `ip6net` network.
 
 ```console
@@ -73,6 +80,13 @@ The following steps show you how to use IPv6 on the default bridge network.
      "fixed-cidr-v6": "2001:db8:1::/64"
    }
    ```
+
+   > [!NOTE]
+   >
+   > The address `2001:db8:1::/64` in this example is
+   > [reserved for use in documentation][wikipedia-ipv6-reserved].
+   > Replace it with a valid IPv6 network, for example a
+   > [Unique Local Address (ULA)][wikipedia-ipv6-ula] subnet from `fd00::/8`.
 
    - `ipv6` enables IPv6 networking on the default network.
    - `fixed-cidr-v6` assigns a subnet to the default bridge network,


### PR DESCRIPTION
## Summary

The "Create an IPv6 network" and "Use IPv6 for the default bridge network"
sections used RFC 3849 documentation-reserved addresses (`2001:db8::/64`)
without warning, causing users to copy unusable configuration. Added notes
to both sections — matching the existing style in "Dynamic IPv6 subnet
allocation" — warning about the reserved range and suggesting ULA subnets
from `fd00::/8` as a replacement.

Closes #13552

Generated by [Claude Code](https://claude.com/claude-code)