### PR TITLE
Add Docker Desktop note for daemon.json in logging drivers

### DIFF
--- a/content/includes/daemon-cfg-desktop.md
+++ b/content/includes/daemon-cfg-desktop.md
@@ -1,0 +1,6 @@
+> [!NOTE]
+>
+> If you're using Docker Desktop, edit the daemon configuration through the
+> Docker Desktop Dashboard. Open **Settings** and select **Docker Engine**.
+> For details, see
+> [Docker Engine settings](/manuals/desktop/settings-and-maintenance/settings.md#docker-engine).

--- a/content/manuals/engine/logging/drivers/awslogs.md
+++ b/content/manuals/engine/logging/drivers/awslogs.md
@@ -17,11 +17,12 @@ and Command Line Tools](https://docs.aws.amazon.com/cli/latest/reference/logs/in
 ## Usage
 
 To use the `awslogs` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
+and `log-opt` keys to appropriate values in the `daemon.json` file. For more
+about configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
+
 The following example sets the log driver to `awslogs` and sets the
 `awslogs-region` option.
 

--- a/content/manuals/engine/logging/drivers/fluentd.md
+++ b/content/manuals/engine/logging/drivers/fluentd.md
@@ -33,10 +33,11 @@ Some options are supported by specifying `--log-opt` as many times as needed:
 - `tag`: specify a tag for Fluentd messages. Supports some Go template markup, ex `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`.
 
 To use the `fluentd` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+and `log-opt` keys to appropriate values in the `daemon.json` file. For more
+about configuring Docker using `daemon.json`, see
+[daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 The following example sets the log driver to `fluentd` and sets the
 `fluentd-address` option.

--- a/content/manuals/engine/logging/drivers/gcplogs.md
+++ b/content/manuals/engine/logging/drivers/gcplogs.md
@@ -14,11 +14,11 @@ Logging.
 ## Usage
 
 To use the `gcplogs` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
+and `log-opt` keys to appropriate values in the `daemon.json` file. For more
+about configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 The following example sets the log driver to `gcplogs` and sets the
 `gcp-meta-name` option.

--- a/content/manuals/engine/logging/drivers/gelf.md
+++ b/content/manuals/engine/logging/drivers/gelf.md
@@ -23,10 +23,11 @@ In GELF, every log message is a dict with the following fields:
 ## Usage
 
 To use the `gelf` driver as the default logging driver, set the `log-driver` and
-`log-opt` keys to appropriate values in the `daemon.json` file, which is located
-in `/etc/docker/` on Linux hosts or `C:\ProgramData\docker\config\daemon.json`
-on Windows Server. For more about configuring Docker using `daemon.json`, see
+`log-opt` keys to appropriate values in the `daemon.json` file. For more about
+configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 The following example sets the log driver to `gelf` and sets the `gelf-address`
 option.

--- a/content/manuals/engine/logging/drivers/journald.md
+++ b/content/manuals/engine/logging/drivers/journald.md
@@ -28,11 +28,11 @@ stores the following metadata in the journal with each message:
 ## Usage
 
 To use the `journald` driver as the default logging driver, set the `log-driver`
-and `log-opts` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
+and `log-opts` keys to appropriate values in the `daemon.json` file. For more
+about configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 The following example sets the log driver to `journald`:
 

--- a/content/manuals/engine/logging/drivers/json-file.md
+++ b/content/manuals/engine/logging/drivers/json-file.md
@@ -31,11 +31,11 @@ only one container.
 ## Usage
 
 To use the `json-file` driver as the default logging driver, set the `log-driver`
-and `log-opts` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\` on Windows Server. If the file does not exist, create it first. For more information about
-configuring Docker using `daemon.json`, see
+and `log-opts` keys to appropriate values in the `daemon.json` file. For more
+information about configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 The following example sets the log driver to `json-file` and sets the `max-size`
 and `max-file` options to enable automatic log-rotation.

--- a/content/manuals/engine/logging/drivers/local.md
+++ b/content/manuals/engine/logging/drivers/local.md
@@ -26,11 +26,11 @@ for each file and a default count of 5 for the number of such files (to account 
 ## Usage
 
 To use the `local` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
+and `log-opt` keys to appropriate values in the `daemon.json` file. For more
+about configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 The following example sets the log driver to `local` and sets the `max-size`
 option.

--- a/content/manuals/engine/logging/drivers/splunk.md
+++ b/content/manuals/engine/logging/drivers/splunk.md
@@ -32,10 +32,10 @@ configuration file and restart Docker. For example:
 }
 ```
 
-The daemon.json file is located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
+For more about configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 > [!NOTE]
 >

--- a/content/manuals/engine/logging/drivers/syslog.md
+++ b/content/manuals/engine/logging/drivers/syslog.md
@@ -35,11 +35,11 @@ The format is defined in [RFC 5424](https://tools.ietf.org/html/rfc5424) and Doc
 ## Usage
 
 To use the `syslog` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
+and `log-opt` keys to appropriate values in the `daemon.json` file. For more
+about configuring Docker using `daemon.json`, see
 [daemon.json](/reference/cli/dockerd.md#daemon-configuration-file).
+
+{{% include "daemon-cfg-desktop.md" %}}
 
 The following example sets the log driver to `syslog` and sets the
 `syslog-address` option. The `syslog-address` options supports both UDP and TCP;


### PR DESCRIPTION
## Summary

Logging driver pages referenced OS-specific `daemon.json` file paths
(`/etc/docker/` and `C:\ProgramData\`) without mentioning Docker Desktop,
where daemon config should be edited through Settings > Docker Engine.
Replaced the path references across 9 logging driver pages with a reusable
include that directs Docker Desktop users to the Dashboard settings.

Closes #15106

Generated by [Claude Code](https://claude.com/claude-code)