### PR TITLE
Fix missing --ipv6 flag in IPVLAN L3 dual-stack example

### DIFF
--- a/content/manuals/engine/network/drivers/ipvlan.md
+++ b/content/manuals/engine/network/drivers/ipvlan.md
@@ -534,7 +534,7 @@ in order to forward broadcast and multicast packets.
 $ docker network create -d ipvlan \
     --subnet=192.168.110.0/24 \
     --subnet=192.168.112.0/24 \
-    --subnet=2001:db8:abc6::/64 \
+    --ipv6 --subnet=2001:db8:abc6::/64 \
     -o parent=eth0 \
     -o ipvlan_mode=l3 ipnet110
 


### PR DESCRIPTION
## Summary

- Adds missing `--ipv6` flag to the IPVLAN L3 dual-stack network creation example
- Without this flag, Docker defaults to `EnableIPv6: false` even when an IPv6 subnet is specified
- The L2 dual-stack example already includes this flag; this makes the L3 example consistent

Fixes #19337

🤖 Generated with [Claude Code](https://claude.com/claude-code)