### PR TITLE
Add missing --ipv6 flag to IPvlan L3 dual-stack example

### DIFF
--- a/content/manuals/engine/network/drivers/ipvlan.md
+++ b/content/manuals/engine/network/drivers/ipvlan.md
@@ -534,7 +534,7 @@ in order to forward broadcast and multicast packets.
 $ docker network create -d ipvlan \
     --subnet=192.168.110.0/24 \
     --subnet=192.168.112.0/24 \
-    --subnet=2001:db8:abc6::/64 \
+    --ipv6 --subnet=2001:db8:abc6::/64 \
     -o parent=eth0 \
     -o ipvlan_mode=l3 ipnet110
 


### PR DESCRIPTION
## Summary

- Adds the missing `--ipv6` flag to the dual-stack IPv4/IPv6 IPvlan L3 mode network creation example
- Without this flag, the IPv6 subnet in the `docker network create` command is silently ignored

Fixes #19337

## Test plan

- [ ] Verify the corrected command creates a dual-stack network with both IPv4 and IPv6 subnets
- [ ] Confirm the example is consistent with other dual-stack examples in the same page (e.g., the L2 mode example which already includes `--ipv6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)