### PR TITLE
Clarify that Bake YAML support means Compose files

### DIFF
--- a/content/manuals/build/bake/_index.md
+++ b/content/manuals/build/bake/_index.md
@@ -10,9 +10,9 @@ Bake is a feature of Docker Buildx that lets you define your build configuration
 using a declarative file, as opposed to specifying a complex CLI expression. It
 also lets you run multiple builds concurrently with a single invocation.
 
-A Bake file can be written in HCL, JSON, or YAML formats, where the YAML format
-is an extension of a Docker Compose file. Here's an example Bake file in HCL
-format:
+A Bake file can be written in HCL or JSON format. Bake can also build directly
+from a [Docker Compose file](./compose-file.md). Here's an example Bake file in
+HCL format:
 
 ```hcl {title=docker-bake.hcl}
 group "default" {

--- a/content/manuals/build/bake/introduction.md
+++ b/content/manuals/build/bake/introduction.md
@@ -51,10 +51,11 @@ building images in a consistent way, with the same configuration.
 
 ## The Bake file format
 
-You can write Bake files in HCL, YAML (Docker Compose files), or JSON. In
-general, HCL is the most expressive and flexible format, which is why you'll
-see it used in most of the examples in this documentation, and in projects that
-use Bake.
+You can write Bake files in HCL or JSON. Bake can also read
+[Docker Compose files](./compose-file.md) and translate each service to a build
+target. HCL is the most expressive and flexible format, which is why you'll see
+it used in most of the examples in this documentation, and in projects that use
+Bake.
 
 The properties that can be set for a target closely resemble the CLI flags for
 `docker build`. For instance, consider the following `docker build` command:


### PR DESCRIPTION
## Summary

The Bake overview and introduction pages described Bake as supporting "HCL, JSON, or YAML formats", implying a standalone YAML-based Bake file format exists. This confused users into trying to write YAML Bake files. Reworded both pages to clarify that HCL and JSON are native Bake file formats, while YAML support means Bake can build from a Compose file, with links to the existing Compose file documentation.

Closes #22759

Generated by [Claude Code](https://claude.com/claude-code)