### PR TITLE
Document log file location for json-file driver

### DIFF
--- a/content/manuals/engine/logging/drivers/json-file.md
+++ b/content/manuals/engine/logging/drivers/json-file.md
@@ -28,6 +28,28 @@ only one container.
 > with external tools may interfere with Docker's logging system and result in
 > unexpected behavior, and should be avoided.
 
+## Log file location
+
+By default, Docker stores log files in the Docker data directory
+(`/var/lib/docker` on Linux). The log file for a container is located at:
+
+```text
+/var/lib/docker/containers/<container-id>/<container-id>-json.log
+```
+
+If you configured the daemon to use a different
+[data root directory](/manuals/engine/daemon/_index.md#configure-the-data-directory-location),
+the log files are stored under that directory instead.
+
+On Docker Desktop, log files are stored inside the Docker Desktop VM and
+aren't directly accessible from the host filesystem.
+
+To find the log file path for a specific container, run:
+
+```console
+$ docker inspect --format='{{.LogPath}}' <container>
+```
+
 ## Usage
 
 To use the `json-file` driver as the default logging driver, set the `log-driver`


### PR DESCRIPTION
## Summary

The json-file logging driver page described the log format and configuration
options but never stated where the log files are stored on disk. Added a
"Log file location" section documenting the default path
(`/var/lib/docker/containers/<id>/<id>-json.log`), its dependency on the
daemon data root directory, Docker Desktop behavior, and the
`docker inspect --format='{{.LogPath}}'` command.

Closes #22851

Generated by [Claude Code](https://claude.com/claude-code)