### PR TITLE
Volumes: Fix a wrong statement about named volume

### DIFF
--- a/content/manuals/engine/storage/volumes.md
+++ b/content/manuals/engine/storage/volumes.md
@@ -775,8 +775,8 @@ testing using your preferred tools.
 A Docker data volume persists after you delete a container. There are two types
 of volumes to consider:
 
-- Named volumes have a specific source from outside the container, for example, `awesome:/bar`.
-- Anonymous volumes have no specific source. Therefore, when the container is deleted, you can instruct the Docker Engine daemon to remove them.
+- Named volumes have a specific name, for example, `awesome:/bar`, where `awesome` is the name.
+- Anonymous volumes have no specific name. Therefore, when the container is deleted, you can instruct the Docker Engine daemon to remove them.
 
 ### Remove anonymous volumes
 


### PR DESCRIPTION

## Description

[Neither named nor anonymous](https://docs.docker.com/engine/storage/volumes/#when-to-use-volumes)  volumes use outside sources, those are for bind mounts. 

Additionally, referring to a volume's name as a "source" here can be confusing (even though [correct](https://docs.docker.com/engine/storage/volumes/#options-for---mount)), as the term has a [different](https://docs.docker.com/engine/storage/bind-mounts/#options-for---mount) definition for bind mounts. Calling it "name" is clear and straightforward.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review