### PR TITLE
RFC: standardize upstream CLI reference syncing

### DIFF
--- a/.github/workflows/sync-upstream-cli.yml
+++ b/.github/workflows/sync-upstream-cli.yml
@@ -1,0 +1,143 @@
+# Reusable workflow for syncing CLI reference YAML from upstream repositories.
+#
+# Upstream repos call this after generating their CLI reference YAML files.
+# The workflow copies the YAML to data/cli/<tool>/ and opens a PR.
+#
+# Example caller (in upstream repo):
+#
+#   jobs:
+#     generate:
+#       runs-on: ubuntu-latest
+#       steps:
+#         - uses: actions/checkout@v5
+#         - run: make generate-yaml-docs
+#         - uses: actions/upload-artifact@v4
+#           with:
+#             name: cli-yaml
+#             path: docs/yaml/*.yaml
+#
+#     sync:
+#       needs: generate
+#       uses: docker/docs/.github/workflows/sync-upstream-cli.yml@main
+#       with:
+#         tool: buildx
+#         version: ${{ github.ref_name }}
+#         data-files-id: cli-yaml
+#       secrets:
+#         token: ${{ secrets.DOCS_GITHUB_TOKEN }}
+
+name: sync-upstream-cli
+
+on:
+  workflow_call:
+    inputs:
+      tool:
+        description: "CLI tool name — subfolder under data/cli/ (e.g., buildx, compose, model)"
+        required: true
+        type: string
+      version:
+        description: "Version string for commit message and PR title (e.g., v0.33.0)"
+        required: true
+        type: string
+      data-files-id:
+        description: "Name of the uploaded artifact containing YAML reference files"
+        required: true
+        type: string
+    secrets:
+      token:
+        description: "GitHub token with contents:write and pull-requests:write on docker/docs"
+        required: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    env:
+      BRANCH: "bot/sync-${{ inputs.tool }}-cli"
+    steps:
+      - name: Checkout docker/docs
+        uses: actions/checkout@v5
+        with:
+          repository: docker/docs
+          token: ${{ secrets.token }}
+          fetch-depth: 0
+
+      - name: Download data files
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.data-files-id }}
+          path: /tmp/cli-data
+
+      - name: Copy data files
+        run: |
+          mkdir -p "data/cli/${{ inputs.tool }}"
+          rm -f "data/cli/${{ inputs.tool }}"/*.yaml
+          cp /tmp/cli-data/*.yaml "data/cli/${{ inputs.tool }}/"
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git add "data/cli/${{ inputs.tool }}/"
+          if git diff --cached --quiet; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes detected" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            git diff --cached --stat >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -m "cli(${{ inputs.tool }}): sync docs ${{ inputs.version }}"
+          git push -u origin "$BRANCH" --force
+
+      - name: Create or update PR
+        if: steps.diff.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+        run: |
+          TITLE="cli(${{ inputs.tool }}): sync docs ${{ inputs.version }}"
+
+          EXISTING=$(gh pr list --repo docker/docs --state open \
+            --head "$BRANCH" --json url --jq '.[0].url // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing PR: $EXISTING" >> "$GITHUB_STEP_SUMMARY"
+            gh pr edit "$EXISTING" --repo docker/docs \
+              --title "$TITLE" \
+              --body "$(cat <<EOF
+          ## Summary
+
+          Automated sync of CLI reference docs.
+
+          | | |
+          |---|---|
+          | **Tool** | \`${{ inputs.tool }}\` |
+          | **Version** | \`${{ inputs.version }}\` |
+          | **Source** | ${{ github.repository }}@\`$(echo ${{ github.sha }} | head -c 12)\` |
+          EOF
+          )"
+          else
+            echo "Creating new PR" >> "$GITHUB_STEP_SUMMARY"
+            gh pr create --repo docker/docs \
+              --title "$TITLE" \
+              --base main \
+              --head "$BRANCH" \
+              --body "$(cat <<EOF
+          ## Summary
+
+          Automated sync of CLI reference docs.
+
+          | | |
+          |---|---|
+          | **Tool** | \`${{ inputs.tool }}\` |
+          | **Version** | \`${{ inputs.version }}\` |
+          | **Source** | ${{ github.repository }}@\`$(echo ${{ github.sha }} | head -c 12)\` |
+          EOF
+          )"
+          fi

--- a/.github/workflows/sync-upstream-cli.yml
+++ b/.github/workflows/sync-upstream-cli.yml
@@ -4,10 +4,16 @@
 # The workflow copies the YAML to data/cli/<folder>/ and opens a PR.
 #
 # Uses the same input names as validate-upstream.yml so upstream repos
-# can share the generate step and swap validate/sync based on trigger:
+# can share the generate step and swap validate/sync based on trigger.
+#
+# Auth: uses a GitHub App (docker-docs-sync) installed on docker/docs.
+# The calling workflow mints a short-lived token and passes it as a secret.
+# App credentials are stored as org secrets (DOCS_SYNC_APP_ID, DOCS_SYNC_APP_PRIVATE_KEY).
+#
+# Example caller (e.g., in docker/buildx .github/workflows/docs-release.yml):
 #
 #   jobs:
-#     generate:
+#     docs-yaml:
 #       runs-on: ubuntu-latest
 #       steps:
 #         - uses: actions/checkout@v5
@@ -17,9 +23,23 @@
 #             name: cli-yaml
 #             path: docs/yaml/*.yaml
 #
+#     # Mint a short-lived token from the GitHub App
+#     token:
+#       runs-on: ubuntu-latest
+#       outputs:
+#         token: ${{ steps.app.outputs.token }}
+#       steps:
+#         - uses: actions/create-github-app-token@v2
+#           id: app
+#           with:
+#             app-id: ${{ vars.DOCS_SYNC_APP_ID }}
+#             private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
+#             owner: docker
+#             repositories: docs
+#
 #     # On PR — validate that docs still build
 #     validate:
-#       needs: generate
+#       needs: docs-yaml
 #       uses: docker/docs/.github/workflows/validate-upstream.yml@main
 #       with:
 #         module-name: docker/buildx
@@ -28,14 +48,14 @@
 #
 #     # On release — sync to docker/docs
 #     sync:
-#       needs: generate
+#       needs: [docs-yaml, token]
 #       uses: docker/docs/.github/workflows/sync-upstream-cli.yml@main
 #       with:
 #         data-files-id: cli-yaml
 #         data-files-folder: buildx
 #         version: ${{ github.ref_name }}
 #       secrets:
-#         token: ${{ secrets.DOCS_GITHUB_TOKEN }}
+#         token: ${{ needs.token.outputs.token }}
 
 name: sync-upstream-cli
 

--- a/.github/workflows/sync-upstream-cli.yml
+++ b/.github/workflows/sync-upstream-cli.yml
@@ -1,9 +1,10 @@
 # Reusable workflow for syncing CLI reference YAML from upstream repositories.
 #
 # Upstream repos call this after generating their CLI reference YAML files.
-# The workflow copies the YAML to data/cli/<tool>/ and opens a PR.
+# The workflow copies the YAML to data/cli/<folder>/ and opens a PR.
 #
-# Example caller (in upstream repo):
+# Uses the same input names as validate-upstream.yml so upstream repos
+# can share the generate step and swap validate/sync based on trigger:
 #
 #   jobs:
 #     generate:
@@ -16,13 +17,23 @@
 #             name: cli-yaml
 #             path: docs/yaml/*.yaml
 #
+#     # On PR — validate that docs still build
+#     validate:
+#       needs: generate
+#       uses: docker/docs/.github/workflows/validate-upstream.yml@main
+#       with:
+#         module-name: docker/buildx
+#         data-files-id: cli-yaml
+#         data-files-folder: buildx
+#
+#     # On release — sync to docker/docs
 #     sync:
 #       needs: generate
 #       uses: docker/docs/.github/workflows/sync-upstream-cli.yml@main
 #       with:
-#         tool: buildx
-#         version: ${{ github.ref_name }}
 #         data-files-id: cli-yaml
+#         data-files-folder: buildx
+#         version: ${{ github.ref_name }}
 #       secrets:
 #         token: ${{ secrets.DOCS_GITHUB_TOKEN }}
 
@@ -31,16 +42,16 @@ name: sync-upstream-cli
 on:
   workflow_call:
     inputs:
-      tool:
-        description: "CLI tool name — subfolder under data/cli/ (e.g., buildx, compose, model)"
+      data-files-folder:
+        description: "Subfolder under data/cli/ (e.g., buildx, compose, model). Same as validate-upstream."
+        required: true
+        type: string
+      data-files-id:
+        description: "Name of the uploaded artifact containing YAML reference files. Same as validate-upstream."
         required: true
         type: string
       version:
         description: "Version string for commit message and PR title (e.g., v0.33.0)"
-        required: true
-        type: string
-      data-files-id:
-        description: "Name of the uploaded artifact containing YAML reference files"
         required: true
         type: string
     secrets:
@@ -52,7 +63,7 @@ jobs:
   sync:
     runs-on: ubuntu-24.04
     env:
-      BRANCH: "bot/sync-${{ inputs.tool }}-cli"
+      BRANCH: "bot/sync-${{ inputs.data-files-folder }}-cli"
     steps:
       - name: Checkout docker/docs
         uses: actions/checkout@v5
@@ -69,14 +80,14 @@ jobs:
 
       - name: Copy data files
         run: |
-          mkdir -p "data/cli/${{ inputs.tool }}"
-          rm -f "data/cli/${{ inputs.tool }}"/*.yaml
-          cp /tmp/cli-data/*.yaml "data/cli/${{ inputs.tool }}/"
+          mkdir -p "data/cli/${{ inputs.data-files-folder }}"
+          rm -f "data/cli/${{ inputs.data-files-folder }}"/*.yaml
+          cp /tmp/cli-data/*.yaml "data/cli/${{ inputs.data-files-folder }}/"
 
       - name: Check for changes
         id: diff
         run: |
-          git add "data/cli/${{ inputs.tool }}/"
+          git add "data/cli/${{ inputs.data-files-folder }}/"
           if git diff --cached --quiet; then
             echo "changes=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected" >> "$GITHUB_STEP_SUMMARY"
@@ -93,7 +104,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git commit -m "cli(${{ inputs.tool }}): sync docs ${{ inputs.version }}"
+          git commit -m "cli(${{ inputs.data-files-folder }}): sync docs ${{ inputs.version }}"
           git push -u origin "$BRANCH" --force
 
       - name: Create or update PR
@@ -101,7 +112,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.token }}
         run: |
-          TITLE="cli(${{ inputs.tool }}): sync docs ${{ inputs.version }}"
+          TITLE="cli(${{ inputs.data-files-folder }}): sync docs ${{ inputs.version }}"
 
           EXISTING=$(gh pr list --repo docker/docs --state open \
             --head "$BRANCH" --json url --jq '.[0].url // empty')
@@ -117,7 +128,7 @@ jobs:
 
           | | |
           |---|---|
-          | **Tool** | \`${{ inputs.tool }}\` |
+          | **Tool** | \`${{ inputs.data-files-folder }}\` |
           | **Version** | \`${{ inputs.version }}\` |
           | **Source** | ${{ github.repository }}@\`$(echo ${{ github.sha }} | head -c 12)\` |
           EOF
@@ -135,7 +146,7 @@ jobs:
 
           | | |
           |---|---|
-          | **Tool** | \`${{ inputs.tool }}\` |
+          | **Tool** | \`${{ inputs.data-files-folder }}\` |
           | **Version** | \`${{ inputs.version }}\` |
           | **Source** | ${{ github.repository }}@\`$(echo ${{ github.sha }} | head -c 12)\` |
           EOF


### PR DESCRIPTION
## RFC: standardize how upstream repos sync CLI reference docs

This PR proposes a generic reusable workflow that upstream repos can call to push CLI reference YAML to `data/cli/<folder>/` and open a PR. The goal is to replace the current patchwork of import mechanisms with a single, consistent pattern.

### Problem

We currently have **4 different mechanisms** for getting CLI reference YAML into `data/cli/`:

| Mechanism | Used by |
|---|---|
| Hugo module mounts via `_vendor/` | compose, model-runner |
| Daily cron job (`sync-cli-docs.sh`) that clones + builds docker/cli | engine |
| Semi-manual commits alongside Hugo vendor | buildx |
| Fully manual commits, no automation | scout, mcp, desktop, dhi, sandbox, offload, secrets, debug, init |

### Proposed solution

One reusable workflow (`sync-upstream-cli.yml`) that shares input names with the existing `validate-upstream.yml`, so upstream repos get a consistent interface.

**Auth:** A dedicated GitHub App (`docker-docs-sync`) installed on docker/docs with `contents:write` + `pull-requests:write`. App credentials stored as org secrets, accessible to upstream repos. The calling workflow mints a short-lived token and passes it as a plain secret — the reusable workflow just receives a token string.

Example caller (e.g., `docs-release.yml` in an upstream repo):

```yaml
jobs:
  # Generate YAML reference files (same step used for validate-upstream)
  docs-yaml:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v5
      - run: make generate-yaml-docs
      - uses: actions/upload-artifact@v4
        with:
          name: cli-yaml
          path: docs/yaml/*.yaml

  # Mint a short-lived token from the GitHub App
  token:
    runs-on: ubuntu-latest
    outputs:
      token: ${{ steps.app.outputs.token }}
    steps:
      - uses: actions/create-github-app-token@v2
        id: app
        with:
          app-id: ${{ vars.DOCS_SYNC_APP_ID }}
          private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
          owner: docker
          repositories: docs

  # On PR — validate that docs still build (existing workflow, unchanged)
  validate:
    needs: docs-yaml
    uses: docker/docs/.github/workflows/validate-upstream.yml@main
    with:
      module-name: docker/buildx
      data-files-id: cli-yaml
      data-files-folder: buildx

  # On release — sync to docker/docs (new workflow)
  sync:
    needs: [docs-yaml, token]
    uses: docker/docs/.github/workflows/sync-upstream-cli.yml@main
    with:
      data-files-id: cli-yaml
      data-files-folder: buildx
      version: ${{ github.ref_name }}
    secrets:
      token: ${{ needs.token.outputs.token }}
```

The `data-files-id` and `data-files-folder` inputs are shared between both workflows. The only differences:

- **validate** adds `module-name` (for Hugo module replacement of markdown content)
- **sync** adds `version` + `token` (for commit metadata and write access)

The sync workflow:
1. Downloads the YAML artifact
2. Replaces `data/cli/<folder>/*.yaml` (clear + copy, so deletions are reflected)
3. Opens/updates a PR in docker/docs

### Migration plan

Adoption is incremental — each upstream migrates when ready:

| Repo | Current mechanism | Migration |
|---|---|---|
| docker/buildx | Semi-manual alongside vendor | Add sync call to existing `docs-release.yml` |
| docker/compose | Hugo module mount | Add `docs-release.yml` with sync call, remove mount from `hugo.yaml` |
| docker/model-runner | Hugo module mount | Same |
| docker/cli | Daily cron (`sync-cli-docs.sh`) | Add `docs-release.yml` triggered on tag push, retire cron + script |
| scout, mcp, desktop, etc. | Manual commits | Add workflow when ready; manual still works in the meantime |

### What this does NOT change

- **Hugo module imports for markdown content** (buildkit Dockerfile ref, bake docs, deprecated.md, etc.) stay as-is. Those are a separate concern.
- **`validate-upstream.yml`** stays — it validates upstream PRs before merge. This new workflow syncs after release. They're complementary.
- **The `_content.gotmpl` content adapter** stays — it already generates CLI pages from whatever YAML is in `data/cli/`.

### Cleanup opportunities

- `validate-upstream.yml` still has a `create-placeholder-stubs` input that is no longer needed since the content adapter generates pages dynamically. Can be removed in a follow-up.
- Once all CLI tools use the sync workflow, `sync-cli-docs.yml` and `hack/sync-cli-docs.sh` can be retired.

### Setup

1. Create a GitHub App (`docker-docs-sync`) in the Docker org with `contents:write` + `pull-requests:write`
2. Install it on `docker/docs`
3. Store App ID as org variable (`DOCS_SYNC_APP_ID`) and private key as org secret (`DOCS_SYNC_APP_PRIVATE_KEY`), accessible to upstream repos

---

This is an RFC — feedback welcome before we start migrating upstream repos.