### PR TITLE
Clarify sandbox networking, env sourcing, and approval defaults

### DIFF
--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -83,6 +83,26 @@ $ sbx exec -it <sandbox-name> bash
 $ echo $BRAVE_API_KEY
 ```
 
+## Why do agents run without approval prompts?
+
+The sandbox itself is the safety boundary. Because agents run inside an
+isolated microVM with [network policies](security/policy.md),
+[credential isolation](security/credentials.md), and no access to your host
+system outside the workspace, the usual reasons for approval prompts (preventing
+destructive commands, network access, file modifications) are handled by the
+sandbox isolation layers instead.
+
+If you prefer to re-enable approval prompts for a specific agent, pass the
+agent's own CLI flags after the `--` separator. For example, to run Claude
+Code with its default permission checks instead of auto-approve:
+
+```console
+$ sbx run claude --name my-sandbox -- --permission-mode default
+```
+
+The flags vary by agent. Refer to each agent's own documentation for the
+available permission or approval options.
+
 ## How do I know if my agent is running in a sandbox?
 
 Ask the agent. The agent can see whether or not it's running inside a sandbox.

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -92,16 +92,15 @@ system outside the workspace, the usual reasons for approval prompts (preventing
 destructive commands, network access, file modifications) are handled by the
 sandbox isolation layers instead.
 
-If you prefer to re-enable approval prompts for a specific agent, pass the
-agent's own CLI flags after the `--` separator. For example, to run Claude
-Code with its default permission checks instead of auto-approve:
+If you prefer to re-enable approval prompts, you have two options:
 
-```console
-$ sbx run claude --name my-sandbox -- --permission-mode default
-```
-
-The flags vary by agent. Refer to each agent's own documentation for the
-available permission or approval options.
+- **Change the permission mode inside the session.** Most agents let you
+  switch permission modes after startup. In Claude Code, use the
+  `/permissions` command to change the mode interactively.
+- **Build a custom template.** Create a
+  [custom environment](agents/custom-environments.md) that launches the
+  agent with different default flags. This is useful if your team wants a
+  consistent permission policy across sandboxes.
 
 ## How do I know if my agent is running in a sandbox?
 

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -92,15 +92,10 @@ system outside the workspace, the usual reasons for approval prompts (preventing
 destructive commands, network access, file modifications) are handled by the
 sandbox isolation layers instead.
 
-If you prefer to re-enable approval prompts, you have two options:
-
-- **Change the permission mode inside the session.** Most agents let you
-  switch permission modes after startup. In Claude Code, use the
-  `/permissions` command to change the mode interactively.
-- **Build a custom template.** Create a
-  [custom environment](agents/custom-environments.md) that launches the
-  agent with different default flags. This is useful if your team wants a
-  consistent permission policy across sandboxes.
+If you prefer to re-enable approval prompts, change the permission mode
+inside the session. Most agents let you switch permission modes after
+startup. In Claude Code, use the `/permissions` command to change the mode
+interactively.
 
 ## How do I know if my agent is running in a sandbox?
 

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -65,6 +65,17 @@ sandbox instead of on your host.
 > the sandbox. The agent process can read it directly. Only use this for
 > credentials where proxy-based injection isn't available.
 
+Variables in `/etc/sandbox-persistent.sh` are sourced automatically during
+interactive shell sessions (for example, `sbx exec -it <name> bash`) and by
+agents started with `sbx run`. If you run a command directly with
+`sbx exec <name> <command>`, the persistent environment file is not sourced
+because no login shell is started. To run a command with the persistent
+environment loaded, wrap it in a login shell:
+
+```console
+$ sbx exec -it <sandbox-name> bash -lc "your-command"
+```
+
 To verify the variable is set, open a shell in the sandbox:
 
 ```console

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -65,15 +65,15 @@ sandbox instead of on your host.
 > the sandbox. The agent process can read it directly. Only use this for
 > credentials where proxy-based injection isn't available.
 
-Variables in `/etc/sandbox-persistent.sh` are sourced automatically during
-interactive shell sessions (for example, `sbx exec -it <name> bash`) and by
-agents started with `sbx run`. If you run a command directly with
-`sbx exec <name> <command>`, the persistent environment file is not sourced
-because no login shell is started. To run a command with the persistent
-environment loaded, wrap it in a login shell:
+Variables in `/etc/sandbox-persistent.sh` are sourced automatically when
+bash runs inside the sandbox, including interactive sessions and agents
+started with `sbx run`. If you run a command directly with
+`sbx exec <name> <command>`, the command runs without a shell, so the
+persistent environment file is not sourced. Wrap the command in `bash -c`
+to load the environment:
 
 ```console
-$ sbx exec -it <sandbox-name> bash -lc "your-command"
+$ sbx exec <sandbox-name> bash -c "your-command"
 ```
 
 To verify the variable is set, open a shell in the sandbox:

--- a/content/manuals/ai/sandboxes/security/policy.md
+++ b/content/manuals/ai/sandboxes/security/policy.md
@@ -15,9 +15,12 @@ to all sandboxes on the machine.
 ## Network policies
 
 The only way traffic can leave a sandbox is through an HTTP/HTTPS proxy on
-your host, which enforces access rules on every outbound request. Non-HTTP
-protocols such as SSH, raw TCP, UDP, and ICMP are blocked at the network
-layer and can't be unblocked with policy rules.
+your host, which enforces access rules on every outbound request.
+
+Non-HTTP TCP traffic, including SSH, can be allowed by adding a policy rule
+for the destination IP address and port (for example,
+`sbx policy allow network "10.1.2.3:22"`). UDP and ICMP traffic is blocked
+at the network layer and can't be unblocked with policy rules.
 
 ### Initial policy selection
 
@@ -173,11 +176,11 @@ my-sandbox   network  registry.npmjs.org     transparent  policykit  10:15:20 29
 
 The **PROXY** column shows how the request left the sandbox:
 
-| Value         | Description                                                                                         |
-| ------------- | --------------------------------------------------------------------------------------------------- |
-| `forward`     | Routed through the forward proxy. Supports [credential injection](credentials.md).                  |
-| `transparent` | Intercepted by the transparent proxy. Policy is enforced but credential injection is not available. |
-| `network`     | Non-HTTP traffic (raw TCP, UDP, ICMP). Always blocked.                                              |
+| Value         | Description                                                                                                    |
+| ------------- | -------------------------------------------------------------------------------------------------------------- |
+| `forward`     | Routed through the forward proxy. Supports [credential injection](credentials.md).                             |
+| `transparent` | Intercepted by the transparent proxy. Policy is enforced but credential injection is not available.            |
+| `network`     | Non-HTTP traffic (raw TCP, UDP, ICMP). TCP can be allowed with a policy rule; UDP and ICMP are always blocked. |
 
 Filter by sandbox name by passing it as an argument:
 

--- a/content/manuals/ai/sandboxes/security/policy.md
+++ b/content/manuals/ai/sandboxes/security/policy.md
@@ -15,7 +15,9 @@ to all sandboxes on the machine.
 ## Network policies
 
 The only way traffic can leave a sandbox is through an HTTP/HTTPS proxy on
-your host, which enforces access rules on every outbound request.
+your host, which enforces access rules on every outbound request. Non-HTTP
+protocols such as SSH, raw TCP, UDP, and ICMP are blocked at the network
+layer and can't be unblocked with policy rules.
 
 ### Initial policy selection
 

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -36,12 +36,23 @@ $ sbx policy allow network "**"
 
 ## SSH and other non-HTTP connections fail
 
-Sandbox network isolation only proxies HTTP and HTTPS traffic. Non-HTTP
-protocols, including SSH, raw TCP, UDP, and ICMP, are blocked at the network
-layer. Adding an allow rule with `sbx policy allow` does not unblock these
-protocols because policy rules only apply to HTTP/HTTPS requests.
+Non-HTTP TCP connections like SSH can be allowed by adding a policy rule for
+the destination IP address and port. For example, to allow SSH to a specific
+host:
 
-For Git operations over SSH, use HTTPS URLs instead:
+```console
+$ sbx policy allow network "10.1.2.3:22"
+```
+
+Hostname-based rules (for example, `myhost:22`) don't work for non-HTTP
+connections because the proxy can't resolve the hostname to an IP address in
+this context. Use the IP address directly.
+
+UDP and ICMP traffic is blocked at the network layer and can't be unblocked
+with policy rules.
+
+For Git operations over SSH, you can either add an allow rule for the Git
+server's IP address or use HTTPS URLs instead:
 
 ```console
 $ git clone https://github.com/owner/repo.git

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -34,6 +34,23 @@ To allow all outbound traffic instead:
 $ sbx policy allow network "**"
 ```
 
+## SSH and other non-HTTP connections fail
+
+Sandbox network isolation only proxies HTTP and HTTPS traffic. Non-HTTP
+protocols, including SSH, raw TCP, UDP, and ICMP, are blocked at the network
+layer. Adding an allow rule with `sbx policy allow` does not unblock these
+protocols because the allow list only applies to HTTP/HTTPS requests routed
+through the proxy.
+
+If `sbx policy log` shows entries with a **PROXY** value of `network`, the
+traffic is non-HTTP and is blocked regardless of your allow rules.
+
+For Git operations over SSH, use HTTPS URLs instead:
+
+```console
+$ git clone https://github.com/owner/repo.git
+```
+
 ## Can't reach a service running on the host
 
 If a request to `127.0.0.1` or a local network IP returns "connection refused"

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -39,11 +39,7 @@ $ sbx policy allow network "**"
 Sandbox network isolation only proxies HTTP and HTTPS traffic. Non-HTTP
 protocols, including SSH, raw TCP, UDP, and ICMP, are blocked at the network
 layer. Adding an allow rule with `sbx policy allow` does not unblock these
-protocols because the allow list only applies to HTTP/HTTPS requests routed
-through the proxy.
-
-If `sbx policy log` shows entries with a **PROXY** value of `network`, the
-traffic is non-HTTP and is blocked regardless of your allow rules.
+protocols because policy rules only apply to HTTP/HTTPS requests.
 
 For Git operations over SSH, use HTTPS URLs instead:
 


### PR DESCRIPTION
## Summary

- Clarify that `/etc/sandbox-persistent.sh` is sourced when bash runs inside
  the sandbox, but not when `sbx exec <name> <command>` runs a command
  directly without a shell. Add a `bash -c` workaround.
  (Related: docker/sbx-releases#53)
- Add FAQ entry explaining why agents run without approval prompts (the
  sandbox is the safety boundary) and how to re-enable them: change the
  permission mode inside the session, or build a custom template.
  (Related: docker/sbx-releases#47)
- Add a note to the network policy page and a troubleshooting entry making
  it explicit that SSH and other non-HTTP protocols are always blocked,
  regardless of allow rules. (Related: docker/sbx-releases#46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)