### PR TITLE
Add network_mode: bridge to Compose file reference

### DIFF
--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -1334,6 +1334,7 @@ If either is omitted, Compose automatically generates the environment variable n
 
 `network_mode` sets a service container's network mode.
 
+- `bridge`: Connects the container to the host's default bridge network instead of creating a project-specific network.
 - `none`: Turns off all container networking.
 - `host`: Gives the container raw access to the host's network interface.
 - `service:{name}`: Gives the container access to the specified container by referring to its service name.
@@ -1342,6 +1343,7 @@ If either is omitted, Compose automatically generates the environment variable n
 For more information container networks, see the [Docker Engine documentation](/manuals/engine/network/_index.md#container-networks).
 
 ```yml
+    network_mode: "bridge"
     network_mode: "host"
     network_mode: "none"
     network_mode: "service:[service name]"

--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -1334,7 +1334,9 @@ If either is omitted, Compose automatically generates the environment variable n
 
 `network_mode` sets a service container's network mode.
 
-- `bridge`: Connects the container to the host's default bridge network instead of creating a project-specific network.
+- `bridge`: Connects the container to Docker's default bridge network instead of
+  a project-specific network. Containers on the default bridge network cannot
+  resolve each other by service name . Instead, use a user-defined network for DNS resolution.
 - `none`: Turns off all container networking.
 - `host`: Gives the container raw access to the host's network interface.
 - `service:{name}`: Gives the container access to the specified container by referring to its service name.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Adds documentation for `network_mode: bridge` in the Compose file reference.

While `bridge` is a valid and functional network_mode option that connects
containers to the host's default bridge network, it was not documented
alongside the other options (none, host, service, container).

Fixes #24742.

- #24742

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review