### PR TITLE
docs: note BuildKit ships QEMU emulators for multi-platform builds

### DIFF
--- a/content/manuals/build/building/multi-platform.md
+++ b/content/manuals/build/building/multi-platform.md
@@ -89,8 +89,11 @@ $ docker buildx create \
 > drivers](/manuals/build/builders/drivers/_index.md).
 
 If you're using Docker Engine standalone and you need to build multi-platform
-images using emulation, you also need to install QEMU, see [Install QEMU
-manually](#install-qemu-manually).
+images using emulation, official BuildKit releases bundle QEMU user-mode
+emulators, so in most cases you don't need to install QEMU manually. See
+[Install QEMU manually](#install-qemu-manually) if emulation fails, for
+example with a third-party BuildKit package that doesn't ship the bundled
+emulators.
 
 ## Build multi-platform images
 
@@ -131,10 +134,10 @@ QEMU that's bundled within the Docker Desktop VM.
 
 #### Install QEMU manually
 
-If you're using a builder outside of Docker Desktop, such as if you're using
-Docker Engine on Linux, or a custom remote builder, you need to install QEMU
-and register the executable types on the host OS. The prerequisites for
-installing QEMU are:
+If the QEMU emulators bundled with BuildKit don't work for your build, for
+example with a third-party BuildKit package that doesn't ship them, you can
+install QEMU and register the executable types on the host OS. The
+prerequisites for installing QEMU are:
 
 - Linux kernel version 4.8 or later
 - `binfmt-support` version 2.1.7 or later


### PR DESCRIPTION
Fixes #22899.

The Prerequisites paragraph on `docs.docker.com/build/building/multi-platform/` tells Docker Engine standalone users they "also need to install QEMU" to build multi-platform images with emulation, but official BuildKit releases already bundle QEMU user-mode emulators ([upstream doc](https://github.com/moby/buildkit/blob/master/docs/multi-platform.md#building-multi-platform-images) : "You do not need to set up QEMU manually in most cases").

Reword the Prerequisites pointer and the Install QEMU manually intro so the manual install is presented as a fallback (for example, with a third-party BuildKit package that doesn't ship the bundled emulators) rather than a default step.