### PR TITLE
dhi: update badges

### DIFF
--- a/content/manuals/dhi/explore/available.md
+++ b/content/manuals/dhi/explore/available.md
@@ -79,7 +79,7 @@ For example, you might find tags like the following in a DHI repository:
 - `3.9.23-debian12`: runtime image for Python 3.9.23
 - `3.9.23-debian12-dev`: development image for Python 3.9.23
 
-## FIPs and STIG variants {tier="DHI Select & Enterprise"}
+## FIPs and STIG variants
 
 {{< summary-bar feature_name="Docker Hardened Images" >}}
 

--- a/content/manuals/dhi/explore/build-process.md
+++ b/content/manuals/dhi/explore/build-process.md
@@ -72,7 +72,7 @@ dependencies. When a package update is detected (for example, a security patch
 for a library), Docker automatically identifies and rebuilds all images within
 the support window that use that package.
 
-### Customization changes {tier="DHI Select and Enterprise"}
+### Customization changes
 
 {{< summary-bar feature_name="Docker Hardened Images" >}}
 
@@ -151,7 +151,7 @@ The following diagram shows the base image build flow:
 '-------------------'      '-------------------'      '-------------------'      '-------------------'
 ```
 
-### Customized image pipeline {tier="DHI Select and Enterprise"}
+### Customized image pipeline
 
 {{< summary-bar feature_name="Docker Hardened Images" >}}
 

--- a/content/manuals/dhi/features.md
+++ b/content/manuals/dhi/features.md
@@ -116,7 +116,7 @@ advanced security needs.
 For a detailed comparison, see [Docker Hardened Images subscription
 comparison](https://www.docker.com/products/hardened-images/#compare).
 
-### SLA-backed security {tier="DHI Select & DHI Enterprise"}
+### SLA-backed security {tier="DHI Select or DHI Enterprise"}
 
 - CVE remediation SLA: 7-day SLA for critical and high severity vulnerabilities
 - Continuous patching: Regular security updates backed by SLA commitments
@@ -124,12 +124,12 @@ comparison](https://www.docker.com/products/hardened-images/#compare).
 
 For complete details, see the [Support Service Level Agreement](https://docs.docker.com/go/dhi-sla/).
 
-### Compliance variants {tier="DHI Select & DHI Enterprise"}
+### Compliance variants {tier="DHI Select or DHI Enterprise"}
 
 - FIPS-enabled images: For regulated industries and government systems
 - STIG-ready images: Meet DoD Security Technical Implementation Guide requirements
 
-### Customization and control {tier="DHI Select & DHI Enterprise"}
+### Customization and control {tier="DHI Select or DHI Enterprise"}
 
 - Build custom images: Add your own packages, tools, certificates, and configurations
   - DHI Select: Up to 5 customizations

--- a/content/manuals/dhi/how-to/cli.md
+++ b/content/manuals/dhi/how-to/cli.md
@@ -62,7 +62,9 @@ Get details of a specific image, including available tags and CVE counts:
 docker dhi catalog get <image-name>
 ```
 
-### Mirror DHI images {tier="DHI Select & DHI Enterprise"}
+### Mirror DHI images
+
+{{< summary-bar feature_name="Docker Hardened Images" >}}
 
 Start mirroring one or more DHI images to your Docker Hub organization:
 
@@ -107,7 +109,9 @@ docker dhi mirror stop dhi-golang --org my-org --delete
 docker dhi mirror stop dhi-golang --org my-org --delete --force
 ```
 
-### Customize DHI images {tier="DHI Select & DHI Enterprise"}
+### Customize DHI images
+
+{{< summary-bar feature_name="Docker Hardened Images" >}}
 
 The CLI can be used to create and manage DHI image customizations. For detailed
 instructions on creating customizations using the GUI, see [Customize a Docker
@@ -150,7 +154,9 @@ docker dhi customization delete my-org/dhi-golang "golang with git" --org my-org
 docker dhi customization delete my-org/dhi-golang "golang with git" --org my-org --yes
 ```
 
-### Enterprise package authentication {tier="DHI Enterprise"}
+### Enterprise package authentication
+
+{{< summary-bar feature_name="Docker Hardened Images Enterprise" >}}
 
 Generate authentication credentials for accessing the enterprise hardened
 package repository. This is used when configuring your package manager to
@@ -162,7 +168,9 @@ repository](./hardened-packages.md#enterprise-repository).
 docker dhi auth apk
 ```
 
-### Monitor customization builds {tier="DHI Select & DHI Enterprise"}
+### Monitor customization builds
+
+{{< summary-bar feature_name="Docker Hardened Images" >}}
 
 List builds for a customization:
 

--- a/content/manuals/dhi/how-to/hardened-packages.md
+++ b/content/manuals/dhi/how-to/hardened-packages.md
@@ -34,7 +34,9 @@ the same security standards as the base images themselves.
 
 You can add hardened packages to your own images in the following two ways.
 
-### Add packages through image customization {tier="DHI Select & DHI Enterprise"}
+### Add packages through image customization
+
+{{< summary-bar feature_name="Docker Hardened Images" >}}
 
 When customizing Docker Hardened Images with DHI Select or DHI Enterprise, you
 can add hardened packages for Alpine-based images through the customization
@@ -97,7 +99,9 @@ This ensures all packages are installed from Docker's hardened repository.
 All packages installed from the Docker Hardened Images repository are built from
 source by Docker and include full provenance.
 
-#### Enterprise repository {tier="DHI Enterprise"}
+#### Enterprise repository
+
+{{< summary-bar feature_name="Docker Hardened Images Enterprise" >}}
 
 With DHI Enterprise, you have access to an additional package
 repository that includes hardened packages for compliance variants such as FIPS,

--- a/content/manuals/dhi/how-to/use.md
+++ b/content/manuals/dhi/how-to/use.md
@@ -204,7 +204,7 @@ migration examples:
 - [Python](../migration/examples/python.md)
 - [Node.js](../migration/examples/node.md)
 
-## Use compliance and ELS variants {tier="DHI Select & Enterprise"}
+## Use compliance and ELS variants
 
 {{< summary-bar feature_name="Docker Hardened Images" >}}
 

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -165,6 +165,8 @@ Desktop logs:
   requires: Docker Desktop [4.65](/manuals/desktop/release-notes.md#4650) or later
 Docker Hardened Images:
   subscription: [Docker Hardened Images Select or Enterprise]
+Docker Hardened Images Enterprise:
+  subscription: [Docker Hardened Images Enterprise]
 Docker Init:
   requires: Docker Desktop [4.27](/manuals/desktop/release-notes.md#4270) and later
 Docker Model Runner:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- Remove tier badges from all DHI topics except `/dhi/features/` since the summary bar already conveys subscription tier info
- Update tier badges in `/dhi/features/` from `&` to `or` to match the prose and clarify that either DHI Select or Enterprise provides the feature
- Add summary bars to sections in `cli.md` and `hardened-packages.md` that previously only had badges
- Add new `Docker Hardened Images Enterprise` summary bar variant for Enterprise-only sections

## Related issues or tickets

Closes #24732

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
