### PR TITLE
dhi: complete authentication note in Python migration example

### DIFF
--- a/content/manuals/dhi/migration/examples/python.md
+++ b/content/manuals/dhi/migration/examples/python.md
@@ -22,6 +22,10 @@ Hardened Images. Each example includes five variations:
 > supported for simplicity, but come with tradeoffs in size and security.
 >
 > You must authenticate to `dhi.io` before you can pull Docker Hardened Images.
+> Use your Docker ID credentials (the same username and password you use for
+> Docker Hub). If you don't have a Docker account, [create
+> one](../../../accounts/create-account.md) for free.
+>
 > Run `docker login dhi.io` to authenticate.
 
 {{< tabs >}}


### PR DESCRIPTION
## Description

The Python migration example was missing credential details included in the Go and Node.js examples. Users following the Python guide had no guidance on which credentials to use for `docker login dhi.io` or how to create an account if they don't have one.

This adds the missing two sentences to match the Go and Node.js examples exactly.

Fixes #24743

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review