### PR TITLE
engine: document DNS fallback to Google public servers

### DIFF
--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -267,6 +267,11 @@ The embedded DNS server address is `127.0.0.11`.
 There is no IPv6 equivalent; the IPv4 address works even in IPv6-only containers.
 If an application requires an explicit DNS server address, use `127.0.0.11`.
 
+If the host's `/etc/resolv.conf` contains no non-localhost nameservers, the
+Docker daemon falls back to using Google's public DNS servers (`8.8.8.8` and
+`8.8.4.4`) for external name resolution. This fallback also applies when
+using the embedded DNS server.
+
 You can configure DNS resolution on a per-container basis, using flags for the
 `docker run` or `docker create` command used to start the container.
 The following table describes the available `docker run` flags related to DNS


### PR DESCRIPTION
## What

Documents Docker's fallback behavior when the host's `/etc/resolv.conf` has no
non-localhost nameservers: the daemon uses Google's public DNS servers
(`8.8.8.8` and `8.8.4.4`) as a fallback for external name resolution.

## Why

This behavior was entirely undocumented, causing confusion for users in
offline or restricted-network environments who expected DNS lookups to fail
immediately. Users discovered it only by reading `dockerd` log output:

```
No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4]
```

See also: https://github.com/moby/moby/issues/23910

Fixes #22945