### PR TITLE
engine/install: document iptables alternative on Fedora

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -152,13 +152,13 @@ $ sudo dnf config-manager addrepo --from-repofile {{% param "download-url-base" 
 
    > [!NOTE]
    >
-   > If the Docker service fails to start with `failed to find iptables`
-   > in the logs, set the `iptables` alternative to `iptables-nft` and
-   > start Docker again:
+   > If the Docker service fails to start and `journalctl -u docker`
+   > shows `failed to find iptables`, point the `iptables` command to
+   > `iptables-nft` using `alternatives` and restart the service:
    >
    > ```console
-   > $ sudo alternatives --set iptables /usr/sbin/iptables-nft
-   > $ sudo systemctl enable --now docker
+   > $ sudo alternatives --set iptables /usr/bin/iptables-nft
+   > $ sudo systemctl restart docker
    > ```
 
 3. Verify that the installation is successful by running the `hello-world` image:

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -150,6 +150,17 @@ $ sudo dnf config-manager addrepo --from-repofile {{% param "download-url-base" 
    boot your system. If you don't want Docker to start automatically, use `sudo
    systemctl start docker` instead.
 
+   > [!NOTE]
+   >
+   > If the Docker service fails to start with `failed to find iptables`
+   > in the logs, set the `iptables` alternative to `iptables-nft` and
+   > start Docker again:
+   >
+   > ```console
+   > $ sudo alternatives --set iptables /usr/sbin/iptables-nft
+   > $ sudo systemctl enable --now docker
+   > ```
+
 3. Verify that the installation is successful by running the `hello-world` image:
 
    ```console

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -210,6 +210,17 @@ download a new file each time you want to upgrade Docker Engine.
    boot your system. If you don't want Docker to start automatically, use `sudo
    systemctl start docker` instead.
 
+   > [!NOTE]
+   >
+   > If the Docker service fails to start and `journalctl -u docker`
+   > shows `failed to find iptables`, point the `iptables` command to
+   > `iptables-nft` using `alternatives` and restart the service:
+   >
+   > ```console
+   > $ sudo alternatives --set iptables /usr/bin/iptables-nft
+   > $ sudo systemctl restart docker
+   > ```
+
 4. Verify that the installation is successful by running the `hello-world` image:
 
    ```console


### PR DESCRIPTION
Adds a troubleshooting note on the Fedora install page for the case where the Docker service fails to start with `failed to find iptables` in the logs, pointing users to set the `iptables` alternative to `iptables-nft`.

Closes #23186