### PR TITLE
compose-file: note that environment source isn't supported by stack deploy

### DIFF
--- a/content/reference/compose-file/configs.md
+++ b/content/reference/compose-file/configs.md
@@ -89,8 +89,9 @@ configs:
 
 > [!IMPORTANT]
 >
-> The `environment` source isn't supported by `docker stack deploy`:
-> the command fails to read the config. Use the `file` source, or an
-> `external` config created with `docker config create`.
+> The `environment` and `content` sources aren't supported by
+> `docker stack deploy`: the command fails to read the config. Use the
+> `file` source, or an [`external`](/manuals/engine/swarm/configs.md)
+> config created with `docker config create`.
 
 If `external` is set to `true`, all other attributes apart from `name` are irrelevant. If Compose detects any other attribute, it rejects the Compose file as invalid.

--- a/content/reference/compose-file/configs.md
+++ b/content/reference/compose-file/configs.md
@@ -87,4 +87,10 @@ configs:
     environment: "SIMPLE_CONFIG_VALUE"
 ```
 
+> [!IMPORTANT]
+>
+> The `environment` source isn't supported by `docker stack deploy`:
+> the command fails to read the config. Use the `file` source, or an
+> `external` config created with `docker config create`.
+
 If `external` is set to `true`, all other attributes apart from `name` are irrelevant. If Compose detects any other attribute, it rejects the Compose file as invalid.

--- a/content/reference/compose-file/secrets.md
+++ b/content/reference/compose-file/secrets.md
@@ -39,6 +39,13 @@ secrets:
     environment: "OAUTH_TOKEN"
 ```
 
+> [!IMPORTANT]
+>
+> The `environment` source isn't supported by `docker stack deploy`:
+> the command fails to read the secret. Use the `file` source, or an
+> [`external`](/manuals/engine/swarm/secrets.md) secret created with
+> `docker secret create`.
+
 ## Additional resources
 
 For more information, see [How to use secrets in Compose](/manuals/compose/how-tos/use-secrets.md).


### PR DESCRIPTION
Adds a callout on both `secrets.md` and `configs.md` reference pages explaining that the `environment` source is honored by `docker compose` but causes `docker stack deploy` to fail, with `file` or `external` as the workaround.

Verified against `docker/cli` `cli/compose/convert/compose.go` where `fileObjectConfig()` only reads `obj.File`. When only `environment:` is set, `os.ReadFile("")` surfaces an error and the stack deploy fails.

Closes #23678