### PR TITLE
engine/release-notes: add missing patch release entries

### DIFF
--- a/content/manuals/engine/release-notes/20.10.md
+++ b/content/manuals/engine/release-notes/20.10.md
@@ -11,6 +11,76 @@ toc_max: 2
 This document describes the latest changes, additions, known issues, and fixes
 for Docker Engine version 20.10.
 
+## 20.10.27
+
+{{< release-date date="2023-12-01" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 20.10.27 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A20.10.27)
+- [moby/moby, 20.10.27 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A20.10.27)
+
+### Security
+
+- Deny containers access to `/sys/devices/virtual/powercap` by default. This change hardens against [CVE-2020-8694](https://scout.docker.com/v/CVE-2020-8694), [CVE-2020-8695](https://scout.docker.com/v/CVE-2020-8695), and [CVE-2020-12912](https://scout.docker.com/v/CVE-2020-12912), and an attack known as [the PLATYPUS attack](https://platypusattack.com/). For more details, see [advisory](https://github.com/moby/moby/security/advisories/GHSA-jq35-85cj-fj4p).
+
+### Bug fixes and enhancements
+
+- Fix `dockerd-rootless-setuptools.sh` when user name contains a backslash. [moby/moby#46424](https://github.com/moby/moby/pull/46424)
+- Add `IP_NF_MANGLE` to the "generally required" list in `check-config.sh` because it is required by Swarm. [moby/moby#46674](https://github.com/moby/moby/pull/46674)
+- Fix a deadlock in libnetwork which could prevent containers from starting. [moby/moby#46693](https://github.com/moby/moby/pull/46693)
+- Write overlay2 layer metadata atomically. [moby/moby#46705](https://github.com/moby/moby/pull/46705)
+- Support building with Go 1.20. [moby/moby#46694](https://github.com/moby/moby/pull/46694), [moby/moby#46695](https://github.com/moby/moby/pull/46695), [moby/moby#46696](https://github.com/moby/moby/pull/46696)
+
+### Packaging updates
+
+- Update Go to 1.20.10 and `golang.org/x/net` to v0.17.0. [moby/moby#46692](https://github.com/moby/moby/pull/46692)
+
+## 20.10.26
+
+{{< release-date date="2023-09-27" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 20.10.26 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A20.10.26)
+- [moby/moby, 20.10.26 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A20.10.26)
+
+### Bug fixes and enhancements
+
+- Support filesystems which do not support extended file attributes with the VFS graph driver. [moby/moby#45466](https://github.com/moby/moby/pull/45466)
+- Fix AppArmor profile `docker-default` `/proc/sys` rule. [moby/moby#45716](https://github.com/moby/moby/pull/45716)
+- seccomp: always allow `name_to_handle_at(2)`. [moby/moby#45835](https://github.com/moby/moby/pull/45835)
+- Fix an issue which prevented volumes mounted to a live-restored container from being removed. [moby/moby#45840](https://github.com/moby/moby/pull/45840)
+- client: resolve an incompatibility with Go 1.20.6, Go 1.20.7, Go 1.19.11 and Go 1.19.12. [moby/moby#45972](https://github.com/moby/moby/pull/45972)
+- windows: fix `--register-service` when executed from within binary directory. [moby/moby#46217](https://github.com/moby/moby/pull/46217)
+
+### Packaging updates
+
+- Update Go to 1.19.12. [moby/moby#46142](https://github.com/moby/moby/pull/46142)
+- Update containerd to [v1.6.22](https://github.com/containerd/containerd/releases/tag/v1.6.22). [moby/moby#46105](https://github.com/moby/moby/pull/46105)
+- Update runc to [v1.1.8](https://github.com/opencontainers/runc/releases/tag/v1.1.8). [moby/moby#46031](https://github.com/moby/moby/pull/46031)
+- Delete Upstart init scripts and clean up sysvinit. [moby/moby#46047](https://github.com/moby/moby/pull/46047)
+
+## 20.10.25
+
+{{< release-date date="2023-05-15" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 20.10.25 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A20.10.25)
+- [moby/moby, 20.10.25 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A20.10.25)
+
+### Bug fixes and enhancements
+
+- Fix log loss with the `awslogs` log driver. [moby/moby#45349](https://github.com/moby/moby/pull/45349)
+- Upgrade `github.com/docker/libnetwork` to fix a panic in libnetwork during daemon start ([moby/libnetwork#2677](https://github.com/moby/libnetwork/pull/2677)) and a deadlock which can occur when attaching and detaching containers from a network ([moby/libnetwork#2674](https://github.com/moby/libnetwork/pull/2674)). [moby/moby#45398](https://github.com/moby/moby/pull/45398)
+
+### Packaging updates
+
+- Update Go runtime to [1.19.9](https://go.dev/doc/devel/release#go1.19.minor).
+- Update containerd to [v1.6.20](https://github.com/containerd/containerd/releases/tag/v1.6.20).
+- Update runc to [v1.1.5](https://github.com/opencontainers/runc/releases/tag/v1.1.5).
+
 ## 20.10.24
 {{< release-date date="2023-04-04" >}}
 

--- a/content/manuals/engine/release-notes/23.0.md
+++ b/content/manuals/engine/release-notes/23.0.md
@@ -37,6 +37,119 @@ Changing the version format is a stepping-stone towards Go module compatibility,
 but the repository doesn't yet use Go modules, and still requires using a "+incompatible" version.
 Work continues towards Go module compatibility in a future release.
 
+## 23.0.13
+
+{{< release-date date="2024-06-20" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestone:
+
+- [moby/moby, 23.0.13 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A23.0.13)
+
+There is no corresponding docker/cli release for this version.
+
+
+## 23.0.12
+
+{{< release-date date="2024-05-29" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestone:
+
+- [moby/moby, 23.0.12 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A23.0.12)
+
+There is no corresponding docker/cli release for this version.
+
+
+## 23.0.11
+
+{{< release-date date="2024-05-06" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestone:
+
+- [moby/moby, 23.0.11 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A23.0.11)
+
+There is no corresponding docker/cli release for this version.
+
+
+## 23.0.10
+
+{{< release-date date="2024-03-21" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 23.0.10 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A23.0.10)
+- [moby/moby, 23.0.10 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A23.0.10)
+
+
+## 23.0.9
+
+{{< release-date date="2024-01-31" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 23.0.9 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A23.0.9)
+- [moby/moby, 23.0.9 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A23.0.9)
+
+
+## 23.0.8
+
+{{< release-date date="2023-12-01" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 23.0.8 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A23.0.8)
+- [moby/moby, 23.0.8 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A23.0.8)
+
+### Security
+
+- Deny containers access to `/sys/devices/virtual/powercap` by default. This change hardens against [CVE-2020-8694](https://scout.docker.com/v/CVE-2020-8694), [CVE-2020-8695](https://scout.docker.com/v/CVE-2020-8695), and [CVE-2020-12912](https://scout.docker.com/v/CVE-2020-12912), and an attack known as [the PLATYPUS attack](https://platypusattack.com/). For more details, see [advisory](https://github.com/moby/moby/security/advisories/GHSA-jq35-85cj-fj4p), [commit](https://github.com/moby/moby/commit/48ebe353e49a9def5e6679f6e386b0efb1c95f0e).
+
+### Bug fixes and enhancements
+
+- Make one-shot stats faster. [moby/moby#46617](https://github.com/moby/moby/pull/46617)
+- Fix "Rootful-in-Rootless" Docker-in-Docker on systemd >= 250. [moby/moby#46627](https://github.com/moby/moby/pull/46627)
+- Add `IP_NF_MANGLE` to the "generally required" list in check-config.sh because it is required by Swarm. [moby/moby#46675](https://github.com/moby/moby/pull/46675)
+- Write overlay2 layer metadata atomically. [moby/moby#46704](https://github.com/moby/moby/pull/46704)
+- Update github.com/klauspost/compress to v1.17.2 to fix data corruption with zstd output in "best". [moby/moby#46710](https://github.com/moby/moby/pull/46710)
+
+### Packaging Updates
+
+- Update Go to `1.20.10`. [moby/moby#46625](https://github.com/moby/moby/pull/46625)
+- Update `golang.org/x/net` to `v0.17.0`. [moby/moby#46691](https://github.com/moby/moby/pull/46691)
+
+
+## 23.0.7
+
+{{< release-date date="2023-09-27" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 23.0.7 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A23.0.7)
+- [moby/moby, 23.0.7 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A23.0.7)
+
+### Bug fixes and enhancements
+
+- Fix reloading the `insecure-registries` daemon configuration. [moby/moby#45572](https://github.com/moby/moby/pull/45572)
+- Allow empty body for `POST /commit` again. [moby/moby#45569](https://github.com/moby/moby/pull/45569)
+- Fix an issue which prevented encrypted overlay networks from functioning when the Swarm data path port is not set to 4789. [moby/moby#45638](https://github.com/moby/moby/pull/45638)
+- Fix an issue with graceful container shutdown. [moby/moby#45775](https://github.com/moby/moby/pull/45775)
+- Fix host-gateway support in `docker build`. [moby/moby#45791](https://github.com/moby/moby/pull/45791)
+- Fix missing Topology in Swarm cluster volume `NodeCSIInfo`. [moby/moby#45809](https://github.com/moby/moby/pull/45809)
+- seccomp: always allow `name_to_handle_at(2)`. [moby/moby#45834](https://github.com/moby/moby/pull/45834)
+- Fix an issue which prevented volumes mounted to a live-restored container from being removed. [moby/moby#45825](https://github.com/moby/moby/pull/45825)
+- client: resolve an incompatibility with Go 1.20.6, Go 1.20.7, Go 1.19.11 and Go 1.19.12. [moby/moby#45971](https://github.com/moby/moby/pull/45971)
+- Fix an issue which prevented process capabilities from being retained when starting a container as a non-root user with `--security-opt=no-new-privileges`. [moby/moby#46222](https://github.com/moby/moby/pull/46222)
+- Fix a bug which caused named volumes that set custom `device` or `type` volume option to be unmounted when restarting the daemon and not live-restoring it properly. [moby/moby#46367](https://github.com/moby/moby/pull/46367)
+- windows: fix `--register-service` when executed from within binary directory. [moby/moby#46216](https://github.com/moby/moby/pull/46216)
+- Fix `dockerd-rootless-setuptools.sh` when user name contains a backslash. [moby/moby#46408](https://github.com/moby/moby/pull/46408)
+
+### Packaging Updates
+
+- Update Go to `1.20.7`. [moby/moby#46141](https://github.com/moby/moby/pull/46141)
+- Update `containerd` to [v1.6.22](https://github.com/containerd/containerd/releases/tag/v1.6.22). [moby/moby#46104](https://github.com/moby/moby/pull/46104)
+- Update `runc` to [v1.1.9](https://github.com/opencontainers/runc/releases/tag/v1.1.9). [moby/moby#46229](https://github.com/moby/moby/pull/46229)
+- Delete Upstart init scripts and clean up sysvinit. [moby/moby#46046](https://github.com/moby/moby/pull/46046)
+
+
 ## 23.0.6
 
 {{< release-date date="2023-05-08" >}}

--- a/content/manuals/engine/release-notes/25.0.md
+++ b/content/manuals/engine/release-notes/25.0.md
@@ -25,7 +25,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 ### Security
 
-This release contains a fix for [CVE-2024-41110] / [GHSA-v23v-6jw2-98fq](https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq) that impacted setups using [authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/) for access control.
+This release contains a fix for [CVE-2024-41110] / [GHSA-v23v-6jw2-98fq] that impacted setups using [authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/) for access control.
 
 ### Bug fixes and enhancements
 
@@ -43,6 +43,7 @@ This release contains a fix for [CVE-2024-41110] / [GHSA-v23v-6jw2-98fq](https:/
 - Update containerd (static binaries only) to [v1.7.20](https://github.com/containerd/containerd/releases/tag/v1.7.20). [moby/moby#48199](https://github.com/moby/moby/pull/48199)
 
   [CVE-2024-41110]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110
+  [GHSA-v23v-6jw2-98fq]: https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq
 
 ## 25.0.5
 

--- a/content/manuals/engine/release-notes/25.0.md
+++ b/content/manuals/engine/release-notes/25.0.md
@@ -14,6 +14,36 @@ For more information about:
 - Deprecated and removed features, see [Deprecated Engine Features](../deprecated.md).
 - Changes to the Engine API, see [Engine API version history](/reference/api/engine/version-history/).
 
+## 25.0.6
+
+{{< release-date date="2024-07-25" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 25.0.6 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A25.0.6)
+- [moby/moby, 25.0.6 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A25.0.6)
+
+### Security
+
+This release contains a fix for [CVE-2024-41110] / [GHSA-v23v-6jw2-98fq](https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq) that impacted setups using [authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/) for access control.
+
+### Bug fixes and enhancements
+
+- Remove erroneous `platform` from image `config` OCI descriptor in `docker save` output. [moby/moby#47695](https://github.com/moby/moby/pull/47695)
+- Fix a nil dereference when getting image history for images having layers without the `Created` value set. [moby/moby#47759](https://github.com/moby/moby/pull/47759)
+- apparmor: Allow confined runc to kill containers. [moby/moby#47830](https://github.com/moby/moby/pull/47830)
+- Fix an issue where rapidly promoting a Swarm node after another node was demoted could cause the promoted node to fail its promotion. [moby/moby#47869](https://github.com/moby/moby/pull/47869)
+- Don't depend on containerd `platform.Parse` to return a typed error. [moby/moby#47890](https://github.com/moby/moby/pull/47890)
+- builder/mobyexporter: Add missing nil check. [moby/moby#47987](https://github.com/moby/moby/pull/47987)
+
+### Packaging updates
+
+- Update AWS SDK Go v2 to v1.24.1 for AWS CloudWatch logging driver. [moby/moby#47724](https://github.com/moby/moby/pull/47724)
+- Update Go runtime to 1.21.12, which contains security fixes for [CVE-2024-24791](https://github.com/advisories/GHSA-hw49-2p59-3mhj). [moby/moby#48146](https://github.com/moby/moby/pull/48146)
+- Update containerd (static binaries only) to [v1.7.20](https://github.com/containerd/containerd/releases/tag/v1.7.20). [moby/moby#48199](https://github.com/moby/moby/pull/48199)
+
+  [CVE-2024-41110]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110
+
 ## 25.0.5
 
 {{< release-date date="2024-03-19" >}}

--- a/content/manuals/engine/release-notes/26.1.md
+++ b/content/manuals/engine/release-notes/26.1.md
@@ -14,6 +14,21 @@ For more information about:
 - Deprecated and removed features, see [Deprecated Engine Features](../deprecated.md).
 - Changes to the Engine API, see [Engine API version history](/reference/api/engine/version-history/).
 
+## 26.1.5
+
+{{< release-date date="2024-07-24" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 26.1.5 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A26.1.5)
+- [moby/moby, 26.1.5 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A26.1.5)
+- Deprecated and removed features, see [Deprecated Features](https://github.com/docker/cli/blob/v26.1.5/docs/deprecated.md).
+- Changes to the Engine API, see [API version history](https://github.com/moby/moby/blob/v26.1.5/docs/api/version-history.md).
+
+### Security
+
+This release contains a fix for [CVE-2024-41110](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110) / [GHSA-v23v-6jw2-98fq](https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq) that impacted setups using [authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/) for access control. No other changes are included in this release, and this release is otherwise identical for users not using AuthZ plugins.
+
 ## 26.1.4
 
 {{< release-date date="2024-06-05" >}}

--- a/content/manuals/engine/release-notes/26.1.md
+++ b/content/manuals/engine/release-notes/26.1.md
@@ -27,7 +27,10 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 ### Security
 
-This release contains a fix for [CVE-2024-41110](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110) / [GHSA-v23v-6jw2-98fq](https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq) that impacted setups using [authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/) for access control. No other changes are included in this release, and this release is otherwise identical for users not using AuthZ plugins.
+This release contains a fix for [CVE-2024-41110] / [GHSA-v23v-6jw2-98fq] that impacted setups using [authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/) for access control. No other changes are included in this release, and this release is otherwise identical for users not using AuthZ plugins.
+
+[CVE-2024-41110]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110
+[GHSA-v23v-6jw2-98fq]: https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq
 
 ## 26.1.4
 


### PR DESCRIPTION
Fills the gaps flagged in #20505 for Docker Engine patch releases:

- 20.10.25, 20.10.26, 20.10.27
- 23.0.7 through 23.0.13
- 25.0.6
- 26.1.5

Each entry is drawn from the corresponding `moby/moby` release body, reformatted to match the surrounding style of its file (bullet marker, section casing, CVE reference style). 23.0.11/12/13 have no docker/cli counterpart upstream and are noted as such.

Note: 18.06.3 mentioned in the issue is already documented as 18.06.3-ce in `18.06.md`, so no change needed there. Later patches (23.0.14+, 25.0.7+) are out of scope for this PR and can be handled separately.

Closes #20505