### PR TITLE
engine/logging: fix json-file compress default value

### DIFF
--- a/content/manuals/engine/logging/drivers/json-file.md
+++ b/content/manuals/engine/logging/drivers/json-file.md
@@ -80,7 +80,7 @@ The `json-file` logging driver supports the following logging options:
 | `labels-regex` | Similar to and compatible with `labels`. A regular expression to match logging-related labels. Used for advanced [log tag options](log_tags.md).                                                              | `--log-opt labels-regex=^(production_status\|geo)` |
 | `env`          | Applies when starting the Docker daemon. A comma-separated list of logging-related environment variables this daemon accepts. Used for advanced [log tag options](log_tags.md).                               | `--log-opt env=os,customer`                        |
 | `env-regex`    | Similar to and compatible with `env`. A regular expression to match logging-related environment variables. Used for advanced [log tag options](log_tags.md).                                                  | `--log-opt env-regex=^(os\|customer)`              |
-| `compress`     | Toggles compression for rotated logs. Default is `disabled`.                                                                                                                                                  | `--log-opt compress=true`                          |
+| `compress`     | Toggles compression for rotated logs. Defaults to `false`.                                                                                                                                                    | `--log-opt compress=true`                          |
 
 ### Examples
 

--- a/content/manuals/engine/logging/drivers/json-file.md
+++ b/content/manuals/engine/logging/drivers/json-file.md
@@ -80,7 +80,7 @@ The `json-file` logging driver supports the following logging options:
 | `labels-regex` | Similar to and compatible with `labels`. A regular expression to match logging-related labels. Used for advanced [log tag options](log_tags.md).                                                              | `--log-opt labels-regex=^(production_status\|geo)` |
 | `env`          | Applies when starting the Docker daemon. A comma-separated list of logging-related environment variables this daemon accepts. Used for advanced [log tag options](log_tags.md).                               | `--log-opt env=os,customer`                        |
 | `env-regex`    | Similar to and compatible with `env`. A regular expression to match logging-related environment variables. Used for advanced [log tag options](log_tags.md).                                                  | `--log-opt env-regex=^(os\|customer)`              |
-| `compress`     | Toggles compression for rotated logs. Defaults to `false`.                                                                                                                                                    | `--log-opt compress=true`                          |
+| `compress`     | Toggles compression for rotated logs. Defaults to `false` (no compression).                                                                                                                                   | `--log-opt compress=true`                          |
 
 ### Examples
 


### PR DESCRIPTION
The `compress` option is parsed as a boolean via `strconv.ParseBool` in `moby/moby daemon/logger/jsonfilelog/jsonfilelog.go`. The previous wording claimed the default was `disabled`, which isn't a value the parser accepts (users copy-pasting it would hit an error). Aligns with the in-file convention already used by `max-size` and `max-file`.

Closes #21898