### PR TITLE
Update Dockerfile code snippet for "Using the official Docker image" tab

### DIFF
--- a/content/guides/python/containerize.md
+++ b/content/guides/python/containerize.md
@@ -146,8 +146,7 @@ Create a file named `Dockerfile` with the following contents.
 
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
-# This Dockerfile uses Docker Hardened Images (DHI) for enhanced security.
-# For more information, see https://docs.docker.com/dhi/
+# This Dockerfile uses Python Docker Official Image
 ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim
 


### PR DESCRIPTION
The code snippet for Dockerfile under the "Using the official Docker images" contains a comment which says that this Docker file uses DHI image, which is incorrect.

<!--Delete sections as needed -->

Updated the code snippet to match the tab contents 

<!-- Tell us what you did and why -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review