### PR TITLE
docs: replace "re-use" with "reuse" in links guide

### DIFF
--- a/content/manuals/engine/network/links.md
+++ b/content/manuals/engine/network/links.md
@@ -170,7 +170,7 @@ You can also use `docker inspect` to return the container's name.
 > [!NOTE]
 >
 > Container names must be unique. That means you can only call
-> one container `web`. If you want to re-use a container name you must delete
+> one container `web`. If you want to reuse a container name you must delete
 > the old container (with `docker container rm`) before you can create a new
 > container with the same name. As an alternative you can use the `--rm`
 > flag with the `docker run` command. This deletes the container


### PR DESCRIPTION
## Description
- Update wording in `content/manuals/engine/network/links.md` from `re-use` to `reuse`.

## Related issues or tickets
- N/A (trivial docs typo/style fix)

## Reviews
- [ ] Technical review
- [x] Editorial review
- [ ] Product review

## Validation
- Not run; docs-only wording change.