### PR TITLE
Fix script injection in release notes PR trigger workflow

### DIFF
--- a/.github/workflows/release-notes-pr-trigger.yml
+++ b/.github/workflows/release-notes-pr-trigger.yml
@@ -12,14 +12,16 @@ jobs:
     if: github.repository_owner == 'docker'
     steps:
       - name: Save PR details
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          cat <<'EOF' > pr-details.json
-          {
-            "url": "${{ github.event.pull_request.html_url }}",
-            "title": "${{ github.event.pull_request.title }}",
-            "author": "${{ github.event.pull_request.user.login }}"
-          }
-          EOF
+          jq -n \
+            --arg url "$PR_URL" \
+            --arg title "$PR_TITLE" \
+            --arg author "$PR_AUTHOR" \
+            '{url: $url, title: $title, author: $author}' > pr-details.json
 
       - name: Upload PR details
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7


### PR DESCRIPTION
## Description

The `release-notes-pr-trigger` workflow was interpolating PR context values
(`html_url`, `title`, `user.login`) directly into a shell heredoc. A
specially crafted PR title or author name could break out of the JSON string
and execute arbitrary commands.

This change moves the GitHub context values into environment variables and
uses `jq` to safely construct the JSON artifact, eliminating the injection
vector.

## Related issues or tickets

None

## Reviews

- [x] Technical review