### PR TITLE
Improve agent/LLM discoverability of the docs site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,15 @@ jobs:
             --include "*.pf_meta" \
             --include "*.pf_fragment"
       -
+        name: Set markdown Content-Type on llms.txt
+        if: ${{ env.DOCS_S3_BUCKET != '' }}
+        run: |
+          aws --region ${{ env.DOCS_AWS_REGION }} s3 cp \
+            s3://${{ env.DOCS_S3_BUCKET }}/llms.txt \
+            s3://${{ env.DOCS_S3_BUCKET }}/llms.txt \
+            --content-type="text/markdown" \
+            --metadata-directive="REPLACE"
+      -
         name: Update Cloudfront config
         if: ${{ env.DOCS_CLOUDFRONT_ID != '' }}
         uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7

--- a/hack/releaser/cloudfront-lambda-redirects.js
+++ b/hack/releaser/cloudfront-lambda-redirects.js
@@ -68,8 +68,11 @@ exports.handler = (event, context, callback) => {
     // If it's not a file, treat it as a directory
     if (!hasFileExtension) {
         if (wantsMarkdown) {
-            // Markdown files are flattened: /path/to/page.md not /path/to/page/index.md
-            uri = uri.replace(/\/$/, '') + '.md';
+            // Markdown files are flattened: /path/to/page.md not /path/to/page/index.md.
+            // Homepage has no flattened equivalent, so serve llms.txt as the
+            // agent-oriented markdown index of the site.
+            const stripped = uri.replace(/\/$/, '');
+            uri = stripped === '' ? '/llms.txt' : stripped + '.md';
         } else {
             // HTML uses directory structure with index.html
             if (!uri.endsWith("/")) {
@@ -79,8 +82,9 @@ exports.handler = (event, context, callback) => {
         }
         request.uri = uri;
     } else if (wantsMarkdown && uri.endsWith('/index.html')) {
-        // If requesting index.html but wants markdown, use the flattened .md file
-        uri = uri.replace(/\/index\.html$/, '.md');
+        // If requesting index.html but wants markdown, use the flattened .md file.
+        // Root index.html has no flattened equivalent, so serve llms.txt instead.
+        uri = uri === '/index.html' ? '/llms.txt' : uri.replace(/\/index\.html$/, '.md');
         request.uri = uri;
     }
 

--- a/layouts/home.llms.txt
+++ b/layouts/home.llms.txt
@@ -3,6 +3,8 @@
 {{- $grouped := $sorted.GroupBy "Section" -}}
 
 # Docker Documentation
+
+> MCP endpoint for structured agent access: https://mcp-docs.docker.com/mcp
 {{- range $grouped }}
 
 ## {{ humanize .Key }}

--- a/layouts/home.robots.txt
+++ b/layouts/home.robots.txt
@@ -7,6 +7,7 @@
 {{- if hugo.IsProduction -}}
 User-agent: *
 Disallow: /unassociated-machines/
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 
 Sitemap: {{ "sitemap.xml" | absURL }}

--- a/static/.well-known/mcp/server-card.json
+++ b/static/.well-known/mcp/server-card.json
@@ -1,0 +1,23 @@
+{
+  "serverInfo": {
+    "name": "llms-txt",
+    "version": "1.26.0",
+    "description": "Official Docker documentation MCP server. Exposes a fetch_docker_docs tool that returns the docs.docker.com content index."
+  },
+  "transport": {
+    "type": "http",
+    "url": "https://mcp-docs.docker.com/mcp"
+  },
+  "capabilities": {
+    "prompts": {
+      "listChanged": false
+    },
+    "resources": {
+      "subscribe": false,
+      "listChanged": false
+    },
+    "tools": {
+      "listChanged": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Address legitimate findings from an agent-readiness audit of docs.docker.com:

- **Fix homepage markdown content negotiation.** The CloudFront Lambda rewrote `/` with `Accept: text/markdown` to an invalid `.md` URI, returning a 502. It now routes to `/llms.txt`, and the deploy workflow sets `Content-Type: text/markdown` on that file so the response media type matches the request.
- **Declare AI content usage preferences.** Adds `Content-Signal: ai-train=yes, search=yes, ai-input=yes` to `robots.txt`. Docker's official docs benefit from being trained on and used as RAG input.
- **Advertise the Docker docs MCP server.** Publishes an MCP Server Card at `/.well-known/mcp/server-card.json` pointing at `https://mcp-docs.docker.com/mcp`, and adds a pointer in `llms.txt`.

## Out of scope

Several audit findings don't apply to a docs site (OAuth/OIDC discovery, OAuth Protected Resource Metadata, WebMCP — we have no protected APIs or site "tools" to expose) or are too early-stage to invest in (Agent Skills index).

**Link headers (RFC 8288)** deserves a specific note: the audit flags their absence as a pattern, but docs.docker.com is a multi-product site without a single canonical API to advertise via `rel="service-doc"` / `rel="service-desc"`. Agents that follow the `llms.txt` convention already find `/llms.txt` without a hint, and MCP clients now find the server via the `.well-known/mcp/server-card.json` added here. Adding Link headers would also require a new viewer-response Lambda trigger — real infrastructure cost for no marginal discovery value. Skipped intentionally.

Generated by [Claude Code](https://claude.com/claude-code)