### PR TITLE
docs: align DHI Python migration example auth note with Go and Node

### DIFF
--- a/content/manuals/dhi/migration/examples/python.md
+++ b/content/manuals/dhi/migration/examples/python.md
@@ -22,6 +22,10 @@ Hardened Images. Each example includes five variations:
 > supported for simplicity, but come with tradeoffs in size and security.
 >
 > You must authenticate to `dhi.io` before you can pull Docker Hardened Images.
+> Use your Docker ID credentials (the same username and password you use for
+> Docker Hub). If you don't have a Docker account, [create
+> one](../../../accounts/create-account.md) for free.
+>
 > Run `docker login dhi.io` to authenticate.
 
 {{< tabs >}}


### PR DESCRIPTION
Fixes #24743.

The authentication note at the top of `content/manuals/dhi/migration/examples/python.md` was the stripped-down version, missing:

- the indication that `docker login dhi.io` expects Docker ID credentials
- the detail that those are the same credentials as Docker Hub
- the link to the account creation page

The equivalent notes in `go.md` (lines 24-29) and `node.md` (lines 24-29) carry all three. This PR copies the full paragraph into `python.md` so Python readers get the same onboarding guidance.

No other content changed.