### PR TITLE
docs: clarify DHI build auth requirement context

### DIFF
--- a/content/manuals/dhi/how-to/build.md
+++ b/content/manuals/dhi/how-to/build.md
@@ -19,9 +19,10 @@ paths, and dev variants.
 
 > [!IMPORTANT]
 >
-> You must authenticate to the Docker Hardened Images registry (`dhi.io`) to
-> pull base images and build tools. Use your Docker ID credentials (the same
-> username and password you use for Docker Hub) when signing in.
+> The DHI build system pulls base images and build tools from `dhi.io`, so you
+> must authenticate to that registry before building a definition file. Use your
+> Docker ID credentials (the same username and password you use for Docker Hub)
+> when signing in.
 >
 > Run `docker login dhi.io` to authenticate.
 


### PR DESCRIPTION
Fixes #24818.

The `[!IMPORTANT]` callout at the top of `content/manuals/dhi/how-to/build.md` read:

> You must authenticate to the Docker Hardened Images registry (`dhi.io`) to pull base images and build tools. [...]

Phrased that way it reads as if any Dockerfile using a DHI base image (e.g. `FROM dhi.io/python:3.13`) needs a special authentication step specific to the build page. The real reason is scoped: the DHI build frontend itself pulls from `dhi.io` when processing a YAML definition file.

Rewritten to tie the requirement explicitly to the DHI build system and to the act of building a definition file, so readers don't extrapolate the requirement to unrelated Dockerfile usage. Wording around the Docker ID credentials is preserved.