### PR TITLE
docs: clarify OCI artifact ordering in DHI customize Docker Hub flow

### DIFF
--- a/content/manuals/dhi/how-to/customize.md
+++ b/content/manuals/dhi/how-to/customize.md
@@ -66,16 +66,18 @@ You can create customizations using either the DHI CLI or the Docker Hub web int
 
       The OCI artifacts are images that you have previously
       built and pushed to a repository in the same namespace as the mirrored
-      DHI. For example, you can add a custom root CA certificate or a another
+      DHI. For example, you can add a custom root CA certificate or another
       image that contains a tool you need, like adding Python to a Node.js
       image. For more details on how to create an OCI artifact image, see
       [Create an OCI artifact image](#create-an-oci-artifact-image-for-image-customization).
 
-      When combining images that contain directories and files with the same
-      path, images later in the list will overwrite files from earlier images.
-      To manage this, you must select paths to include and optionally exclude
-      from each OCI artifact image. This allows you to control which files are
-      included in the final customized image.
+      You can add multiple OCI artifact images to a single customization. When
+      you add more than one, they're applied in the order you add them in the
+      **OCI artifacts** drop-down. If multiple images contain directories or
+      files with the same path, images added later overwrite files from images
+      added earlier. To manage this, you must select paths to include and
+      optionally exclude from each OCI artifact image. This allows you to
+      control which files are included in the final customized image.
 
       By default, no files are included from the OCI artifact image. You must
       explicitly include the paths you want. After including a path, you can


### PR DESCRIPTION
Fixes #24819.

In `content/manuals/dhi/how-to/customize.md` the Docker Hub tab jumped from "select the repository / select the tag" straight to "images later in the list will overwrite files from earlier images" without first establishing that multiple OCI artifacts can be added or how their ordering is determined in the UI. Readers understood the consequence but not the mechanism.

Adds one short paragraph before the overwrite rule to anchor the reader:

- multiple OCI artifacts can be added to a single customization,
- they're applied in the order they're added in the **OCI artifacts** drop-down.

The overwrite rule is rephrased to:

- refer to "images added later / images added earlier" for consistency with the new paragraph,
- use "If multiple images contain directories or files with the same path" (the rule applies to any N≥2, not just two),
- use "directories or files" instead of the existing "directories and files", which could be read as requiring both types in the same artifact for the rule to apply.

No change to the subsequent paragraphs about include/exclude paths.