### PR TITLE
docs: document Docker Desktop VM-level backup for general use

### DIFF
--- a/content/manuals/desktop/settings-and-maintenance/backup-and-restore.md
+++ b/content/manuals/desktop/settings-and-maintenance/backup-and-restore.md
@@ -62,54 +62,71 @@ and [install a different version](/manuals/desktop/release-notes.md) or reset Do
 
 To restore volume data, refer to [backup, restore, or migrate data volumes](/manuals/engine/storage/volumes.md#back-up-restore-or-migrate-data-volumes). 
 
-## If Docker Desktop fails to start 
+## Back up the Docker Desktop VM
 
-If Docker Desktop cannot launch and must be reinstalled, you can back up its VM disk and image data directly from disk. Docker Desktop must be fully stopped before backing up these files.
+You can also back up Docker Desktop's disk image directly from disk. This is
+useful to:
+
+- Include Docker Desktop's data in a system-level backup (such as Time Machine
+  on macOS).
+- Migrate your whole Docker Desktop environment, including images, containers,
+  and volumes, to a new computer in one step.
+- Recover when Docker Desktop fails to start and must be reinstalled.
+
+> [!IMPORTANT]
+>
+> Docker Desktop must be fully stopped before backing up these files. Copying
+> them while Docker Desktop is running may produce a corrupted backup.
 
 {{< tabs >}}
 {{< tab name="Windows" >}}
 
-1. Back up Docker containers/images.
+1. Back up the Docker Desktop disk image.
 
-   Backup the following file:
+   Back up the following file:
 
    ```console
    %LOCALAPPDATA%\Docker\wsl\data\docker_data.vhdx
    ```
 
-   Copy it to a safe location. 
+   Copy it to a safe location.
 
 1. Back up WSL distributions.
 
-   If you're running any WSL Linux distributions (Ubuntu, Alpine, etc.), back them up using [Microsoft's guide](https://learn.microsoft.com/en-us/windows/wsl/faq#how-can-i-back-up-my-wsl-distributions-).
+   If you're running any WSL Linux distributions (Ubuntu, Alpine, etc.), back
+   them up using [Microsoft's guide](https://learn.microsoft.com/en-us/windows/wsl/faq#how-can-i-back-up-my-wsl-distributions-).
 
-1. Restore. 
+1. Restore.
 
-   After reinstalling Docker Desktop, restore the `docker_data.vhdx` to the same location and re-import your WSL distributions if needed.
+   After reinstalling Docker Desktop, restore the `docker_data.vhdx` to the
+   same location and re-import your WSL distributions if needed.
 
 {{< /tab >}}
 {{< tab name="Mac" >}}
 
-1. Back up Docker containers/images.
+1. Back up the Docker Desktop disk image.
 
-   Backup the following file:
+   Back up the following file:
 
    ```console
    ~/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw
    ```
 
-   Copy it to a safe location. 
+   Copy it to a safe location. You can also include the parent directory
+   (`~/Library/Containers/com.docker.docker`) in your Time Machine backup to
+   capture it automatically.
 
-1. Restore. 
+1. Restore.
 
-   After reinstalling Docker Desktop, restore the `Docker.raw` to the same location.
+   After reinstalling Docker Desktop, restore the `Docker.raw` to the same
+   location.
 
 {{< /tab >}}
 {{< tab name="Linux" >}}
 
-1. Back up Docker containers/images:
+1. Back up the Docker Desktop disk image.
 
-   Backup the following file:
+   Back up the following file:
 
    ```console
    ~/.docker/desktop/vms/0/data/Docker.raw
@@ -117,9 +134,10 @@ If Docker Desktop cannot launch and must be reinstalled, you can back up its VM 
 
    Copy it to a safe location.
 
-1. Restore. 
+1. Restore.
 
-   After reinstalling Docker Desktop, restore the `Docker.raw` to the same location.
+   After reinstalling Docker Desktop, restore the `Docker.raw` to the same
+   location.
 
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
Fixes #22743.

The `If Docker Desktop fails to start` section of `content/manuals/desktop/settings-and-maintenance/backup-and-restore.md` already documented the VM disk paths per platform (Windows `docker_data.vhdx`, Mac and Linux `Docker.raw`) and the WSL distributions backup procedure, but it was gated behind a failure-recovery framing, so users looking for a generic way to back up the whole Docker Desktop environment (for migration or system-level backup like Time Machine) wouldn't find it.

Changes:

- Renamed the section to `Back up the Docker Desktop VM` to reflect that VM-level backup is useful beyond failure recovery.
- Added an intro that lists the three real use cases: inclusion in a system-level backup (Time Machine), whole-environment migration to another machine, recovery after a failed installation.
- Promoted the "Docker Desktop must be fully stopped" warning from an inline sentence to an `[!IMPORTANT]` callout, so readers who skim the section don't miss it.
- Renamed each tab's first subheader from `Back up Docker containers/images` to `Back up the Docker Desktop disk image`, which is accurate (the VM disk contains images, containers, volumes, and runtime state).
- Added a note in the Mac tab pointing out that the parent directory `~/Library/Containers/com.docker.docker` can be included in a Time Machine backup to capture the disk image automatically.

No change to the `If Docker Desktop is functioning normally` section (image-level `docker commit` / `docker push` / `docker image save`), which remains the recommended default path.