### PR TITLE
docs: fix freshness prompt spelling

### DIFF
--- a/.github/prompts/freshness-tier2.prompt.md
+++ b/.github/prompts/freshness-tier2.prompt.md
@@ -17,7 +17,7 @@ how fresh and up to date it is. Apply the following:
 4. If appropriate, follow the document from start to finish to see if steps make sense in sequence
 5. Try to add some helpful next steps to the end of the document, but only if there are no *Next steps* or *Related pages* section, already.
 6. Try to clarify, shorten or improve the efficiency of some sentences.
-7. Check for LLM readibility.
+7. Check for LLM readability.
 8. Ensure each line is limited to 80 characters.
 
 Do your best and don't be lazy.


### PR DESCRIPTION
## Description
- fix the "readability" spelling in the freshness tier 2 prompt

## Related issues or tickets
- N/A (trivial docs typo fix)

## Reviews
- N/A
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

## Validation
- Ran `git diff --check`
