### PR TITLE
docs(scout): standardize CLI command to `docker scout` in CI guides

### DIFF
--- a/content/manuals/scout/integrations/ci/circle-ci.md
+++ b/content/manuals/scout/integrations/ci/circle-ci.md
@@ -55,7 +55,7 @@ steps:
   - run:
       name: Scan image for CVEs
       command: |
-        docker-scout cves $IMAGE_TAG --exit-code --only-severity critical,high
+        docker scout cves $IMAGE_TAG --exit-code --only-severity critical,high
 ```
 
 This checks out the repository files and then sets up a separate Docker

--- a/content/manuals/scout/integrations/ci/jenkins.md
+++ b/content/manuals/scout/integrations/ci/jenkins.md
@@ -31,7 +31,7 @@ pipeline {
                 sh 'echo $DOCKER_HUB_PSW | docker login -u $DOCKER_HUB_USR --password-stdin'
 
                 // Analyze and fail on critical or high vulnerabilities
-                sh 'docker-scout cves $IMAGE_TAG --exit-code --only-severity critical,high'
+                sh 'docker scout cves $IMAGE_TAG --exit-code --only-severity critical,high'
             }
         }
     }


### PR DESCRIPTION
## Summary
Standardize the Docker Scout CLI command on `docker scout` (with space) across the CircleCI and Jenkins integration guides so it matches the format used in `azure.md`, `gitlab.md`, and the rest of the Scout docs (`install.md`, `quickstart.md`, `gha.md`).

## Issue
Fixes #24843

## Changes
- `content/manuals/scout/integrations/ci/circle-ci.md`: change `docker-scout cves …` to `docker scout cves …`
- `content/manuals/scout/integrations/ci/jenkins.md`: change `docker-scout cves …` to `docker scout cves …`

Other references to `docker-scout` that are not CLI invocations (the binary filename in `install.md`, the GitHub Action step `id: docker-scout` in `gha.md`, external URLs, and Azure resource names) are intentionally left unchanged.

## Testing
- Docs-only change. Diff is two lines, no content rewrites.