### PR TITLE
v1 billing refresh

### DIFF
--- a/content/manuals/billing/3d-secure.md
+++ b/content/manuals/billing/3d-secure.md
@@ -3,7 +3,7 @@ title: Use 3D Secure authentication for Docker billing
 linkTitle: 3D Secure authentication
 description: Docker billing supports 3D Secure (3DS) for secure payment authentication. Learn how 3DS works with Docker subscriptions.
 keywords: billing, renewal, payments, subscriptions, 3DS, credit card verification, secure payments, Docker billing security
-weight: 40
+weight: 30
 ---
 
 Docker supports 3D Secure (3DS), an extra layer of authentication required
@@ -28,7 +28,7 @@ You may be asked to verify your identity when performing any of the following
 actions:
 
 - Starting a [paid subscription](../subscription/setup.md)
-- Changing your [billing cycle](/manuals/billing/cycle.md) from monthly to annual
+- Changing your [billing cycle](cycles-info/cycle.md) from monthly to annual
 - [Upgrading your subscription](../subscription/change.md)
 - [Adding seats](../subscription/manage-seats.md) to an existing subscription
 

--- a/content/manuals/billing/_index.md
+++ b/content/manuals/billing/_index.md
@@ -14,11 +14,11 @@ grid_core:
   icon: credit_score
 - title: Update billing information
   description: Discover how to update the billing information for your personal account or organization.
-  link: /billing/details/
+  link: /billing/cycles-info/details/
   icon: contract_edit
 - title: View billing history
   description: Learn how to view billing history and download past invoices.
-  link: /billing/history/
+  link: /billing/cycles-info/history/
   icon: payments
 - title: Billing FAQs
   description: Find the answers you need and explore common questions.

--- a/content/manuals/billing/cycles-info/_index.md
+++ b/content/manuals/billing/cycles-info/_index.md
@@ -1,0 +1,6 @@
+---
+build:
+  render: never
+title: Manage
+weight: 20
+---

--- a/content/manuals/billing/cycles-info/cycle.md
+++ b/content/manuals/billing/cycles-info/cycle.md
@@ -1,8 +1,12 @@
 ---
-title: Change your billing cycle
-weight: 50
+title: Change billing cycle
+linkTitle: Billing cycle
+weight: 20
 description: Learn to change your billing cycle for your Docker subscription
 keywords: billing, cycle, payments, subscription
+aliases:
+  - /billing/cycle/
+  - /billing/method-cycles/cycle/
 ---
 
 You can choose between a monthly or annual billing cycle when purchasing a
@@ -37,7 +41,7 @@ To change your billing cycle:
 1. On the plans and usage page, select **Switch to annual billing**.
 1. Verify your billing information.
 1. Select **Continue to payment**.
-1. Verify payment information and select **Upgrade subscription**. If you choose to pay using a US bank account, you must verify the account. For more information, see [Verify a bank account](/manuals/billing/payment-method.md#verify-a-bank-account).
+1. Verify payment information and select **Upgrade subscription**. If you choose to pay using a US bank account, you must verify the account. For more information, see [Verify a bank account](../payment-method.md#verify-a-bank-account).
 
 The billing plans and usage page will now reflect your new annual plan details.
 
@@ -56,4 +60,4 @@ organization's Docker subscription:
 1. On the plans and usage page, select **Switch to annual billing**.
 1. Verify your billing information.
 1. Select **Continue to payment**.
-1. Verify payment information and select **Upgrade subscription**. If you choose to pay using a US bank account, you must verify the account. For more information, see [Verify a bank account](/manuals/billing/payment-method.md#verify-a-bank-account).
+1. Verify payment information and select **Upgrade subscription**. If you choose to pay using a US bank account, you must verify the account. For more information, see [Verify a bank account](../payment-method.md#verify-a-bank-account).

--- a/content/manuals/billing/cycles-info/details.md
+++ b/content/manuals/billing/cycles-info/details.md
@@ -1,8 +1,12 @@
 ---
-title: Manage your billing information
+title: Manage billing details
+linkTitle: Billing details
 weight: 30
 description: Learn how to update your billing information in Docker Hub
 keywords: payments, billing, subscription, invoices, update billing email, change billing address, VAT ID, Docker billing account
+aliases:
+  - /billing/details/
+  - /billing/method-cycles/details/
 ---
 
 You can update the billing information for your personal account or for an

--- a/content/manuals/billing/cycles-info/history.md
+++ b/content/manuals/billing/cycles-info/history.md
@@ -1,10 +1,13 @@
 ---
-title: Invoices and billing history
+title: View and manage invoices and billing history
+linkTitle: Invoices and history
 weight: 40
 description: Learn how to view invoices and your billing history
 keywords: payments, billing, subscription, invoices, renewals, invoice management, billing administration, pay invoice
 aliases:
   - /billing/core-billing/history/
+  - /billing/history/
+  - /billing/method-cycles/history/
 ---
 
 Learn how to view and pay invoices, view your billing history, and verify
@@ -51,7 +54,7 @@ For more information, see [Update billing information](details.md).
 > [!NOTE]
 >
 > Pay by invoice is only available for subscribers on an annual billing cycle.
-> To change your billing cycle, see [Change your billing cycle](/manuals/billing/cycle.md).
+> To change your billing cycle, see [Change your billing cycle](cycle.md).
 
 If you've selected pay by invoice for your subscription, you'll receive email
 reminders to pay your invoice at 10 days before the due date, on the due date,
@@ -69,7 +72,7 @@ When your payment has processed, the invoice's **Status** column will update to
 **Paid** and you will receive a confirmation email.
 
 If you choose to pay using a US bank account, you must verify the account. For
-more information, see [Verify a bank account](/manuals/billing/payment-method.md#verify-a-bank-account).
+more information, see [Verify a bank account](../payment-method.md#verify-a-bank-account).
 
 ### View renewal date
 

--- a/content/manuals/billing/faqs.md
+++ b/content/manuals/billing/faqs.md
@@ -4,7 +4,7 @@ linkTitle: FAQs
 description: Frequently asked questions related to billing
 keywords: billing, renewal, payments, faq
 tags: [FAQ]
-weight: 60
+weight: 50
 ---
 
 ### What happens if my subscription payment fails?
@@ -31,7 +31,7 @@ No. Docker retries failed payments on a [retry schedule](/manuals/billing/faqs.m
 
 To ensure a retired payment is successful, verify your default payment is
 updated. If you need to update your default payment method, see
-[Manage payment method](/manuals/billing/payment-method.md#manage-payment-method).
+[Manage payment method](payment-method.md#manage-payment-method).
 
 ### Does Docker collect sales tax and/or VAT?
 
@@ -43,7 +43,7 @@ Docker collects sales tax and/or VAT from the following:
 
 To ensure that tax assessments are correct, make sure that your billing
 information and VAT/Tax ID, if applicable, are updated. See
-[Update the billing information](/manuals/billing/details.md).
+[Update the billing information](cycles-info/details.md).
 
 If you're exempt from sales tax, see
 [Register a tax certificate](/manuals/billing/tax-certificate.md).
@@ -60,4 +60,4 @@ purchasing upgrades or additional seats. You must use card payment or US bank
 accounts for these changes.
 
 For a list of supported payment methods, see
-[Add or update a payment method](/manuals/billing/payment-method.md).
+[Add or update a payment method](payment-method.md).

--- a/content/manuals/billing/payment-method.md
+++ b/content/manuals/billing/payment-method.md
@@ -1,10 +1,12 @@
 ---
-title: Add or update a payment method
-weight: 20
+title: Add or update payment method
+linkTitle: Payment methods
+weight: 10
 description: Learn how to add or update a payment method in Docker Hub
 keywords: payments, billing, subscription, supported payment methods, failed payments, add credit card, bank transfer, Stripe Link, payment failure
 aliases:
   - /billing/core-billing/payment-method/
+  - /billing/method-cycles/payment-method/
 ---
 
 Docker supports different payment methods for your paid personal
@@ -25,8 +27,8 @@ at any time. All charges are in United States dollars (USD). The following payme
 
 Certain payment methods require additional steps before selecting them as a payment method:
 
-- You must [verify a bank account](/manuals/billing/payment-method.md#verify-a-bank-account) before choosing a bank account.
-- You must have a Docker Business or Docker Team plan to [pay by invoice](/manuals/billing/payment-method.md#enable-and-disable-pay-by-invoice).
+- You must [verify a bank account](#verify-a-bank-account) before choosing a bank account.
+- You must have a Docker Business or Docker Team plan to [pay by invoice](#enable-and-disable-pay-by-invoice).
 - You must be an existing Stripe Link customer, or fill out the card information form to use Link payments.
 
 ## Manage payment method

--- a/content/manuals/billing/tax-certificate.md
+++ b/content/manuals/billing/tax-certificate.md
@@ -2,14 +2,14 @@
 title: Submit a tax exemption certificate
 description: Learn how to submit a tax exemption or VAT certificate for Docker billing.
 keywords: billing, renewal, payments, tax, exemption, VAT, billing support, Docker billing
-weight: 50
+weight: 40
 ---
 
 If you're a customer in the United States and are exempt from sales tax, you
 can submit a valid tax exemption certificate to Docker Support.
 
 If you're a global customer subject to VAT, make sure to include your
-[VAT number](/manuals/billing/history.md#include-your-vat-number-on-your-invoice)
+[VAT number](cycles-info/history.md#include-your-vat-number-on-your-invoice)
 along with your country prefix when you update your billing profile.
 
 ## Prerequisites


### PR DESCRIPTION
Billing category v1 changes

* Experimenting with billing subcategory
* The invoices/history/cycles are all post-payment actions that are similar in ~kind. I thought grouping them together might add some organization/order to the billing category
* I'm doubtful this is necessary, however.

Created PR to experiment and get some tech writer feedback. See billing category v2 prototype. 

Related to https://github.com/docker/docs/pull/24859