### PR TITLE
docs: remove contradictory auto-start note in install guides

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -178,14 +178,13 @@ Docker from the repository.
 
     > [!NOTE]
     >
-    > The Docker service starts automatically after installation. To verify that
-    > Docker is running, use:
-    > 
+    > After installation, verify that Docker is running:
+    >
     > ```console
     > $ sudo systemctl status docker
     > ```
     >
-    > Some systems may have this behavior disabled and will require a manual start:
+    > If Docker is not running, start it manually:
     >
     > ```console
     > $ sudo systemctl start docker
@@ -246,14 +245,13 @@ download a new file each time you want to upgrade Docker Engine.
 
     > [!NOTE]
     >
-    > The Docker service starts automatically after installation. To verify that
-    > Docker is running, use:
-    > 
+    > After installation, verify that Docker is running:
+    >
     > ```console
     > $ sudo systemctl status docker
     > ```
     >
-    > Some systems may have this behavior disabled and will require a manual start:
+    > If Docker is not running, start it manually:
     >
     > ```console
     > $ sudo systemctl start docker

--- a/content/manuals/engine/install/raspberry-pi-os.md
+++ b/content/manuals/engine/install/raspberry-pi-os.md
@@ -190,14 +190,13 @@ Docker from the repository.
 
     > [!NOTE]
     >
-    > The Docker service starts automatically after installation. To verify that
-    > Docker is running, use:
-    > 
+    > After installation, verify that Docker is running:
+    >
     > ```console
     > $ sudo systemctl status docker
     > ```
     >
-    > Some systems may have this behavior disabled and will require a manual start:
+    > If Docker is not running, start it manually:
     >
     > ```console
     > $ sudo systemctl start docker
@@ -258,14 +257,13 @@ download a new file each time you want to upgrade Docker Engine.
 
     > [!NOTE]
     >
-    > The Docker service starts automatically after installation. To verify that
-    > Docker is running, use:
-    > 
+    > After installation, verify that Docker is running:
+    >
     > ```console
     > $ sudo systemctl status docker
     > ```
     >
-    > Some systems may have this behavior disabled and will require a manual start:
+    > If Docker is not running, start it manually:
     >
     > ```console
     > $ sudo systemctl start docker

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -182,14 +182,13 @@ Docker from the repository.
 
     > [!NOTE]
     >
-    > The Docker service starts automatically after installation. To verify that
-    > Docker is running, use:
-    > 
+    > After installation, verify that Docker is running:
+    >
     > ```console
     > $ sudo systemctl status docker
     > ```
     >
-    > Some systems may have this behavior disabled and will require a manual start:
+    > If Docker is not running, start it manually:
     >
     > ```console
     > $ sudo systemctl start docker
@@ -250,14 +249,13 @@ download a new file each time you want to upgrade Docker Engine.
 
     > [!NOTE]
     >
-    > The Docker service starts automatically after installation. To verify that
-    > Docker is running, use:
-    > 
+    > After installation, verify that Docker is running:
+    >
     > ```console
     > $ sudo systemctl status docker
     > ```
     >
-    > Some systems may have this behavior disabled and will require a manual start:
+    > If Docker is not running, start it manually:
     >
     > ```console
     > $ sudo systemctl start docker


### PR DESCRIPTION
The `systemctl` note in `debian.md`, `ubuntu.md`, and `raspberry-pi-os.md` claimed the Docker service "starts automatically after installation" and then, in the same block, that "some systems may have this behavior disabled" without telling the reader how to tell which case applies.

Reword the note around a verification step and a recovery step so readers get an actionable check regardless of what the package manager did.

Fixes #24861