### PR TITLE
docs: mention external networks in engine networking overview

### DIFF
--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -73,6 +73,22 @@ $ docker network create -d bridge my-net
 $ docker run --network=my-net -it busybox
 ```
 
+### External networks
+
+A Docker network persists until you remove it with `docker network rm`. Any container,
+Compose project, or Swarm service can attach to a pre-existing network without
+creating it. A network whose lifecycle is managed outside the application that uses
+it is often called an *external network*. Compose references one using the
+[`external: true`](/reference/compose-file/networks.md#external) flag.
+
+```console
+$ docker network create shared-net
+$ docker run --network=shared-net -d nginx
+```
+
+Any other container, Compose project, or Swarm service on the same host can then
+attach to `shared-net` without re-creating it.
+
 ### Drivers
 
 Docker Engine has a number of network drivers, as well as the default "bridge".


### PR DESCRIPTION
The engine networking overview did not mention external networks, so readers coming from Compose (where `external: true` is a common pattern) had no entry point to the concept on the Engine side.

Add a short subsection under user-defined networks that defines the term, shows that a pre-existing network can be shared between containers, Compose projects, and Swarm services, and links to the Compose reference.

Fixes #22498