### PR TITLE
docs: note that not every Debian version and architecture has packages

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -46,7 +46,10 @@ To install Docker Engine, you need one of these Debian versions:
 - Debian Bullseye 11 (oldoldstable)
 
 Docker Engine for Debian is compatible with x86_64 (or amd64), armhf (arm/v7),
-arm64, and ppc64le (ppc64el) architectures.
+arm64, and ppc64le (ppc64el) architectures. Not every combination of Debian
+version and architecture is available as a pre-built package. To confirm which
+packages exist for your release and CPU, browse the
+[Docker Debian package repository](https://download.docker.com/linux/debian/dists/).
 
 ### Uninstall old versions
 


### PR DESCRIPTION
The Debian install page lists three supported Debian versions and four supported architectures, which reads as if the full cartesian product is available. In practice, the repository doesn't ship every combination (for example, Raspbian Trixie armhf isn't built), so users following the convenience script on those combinations hit a cryptic apt 'no Release file' error.

Add a sentence pointing readers at the actual `dists/` listing so they can confirm the combination they need before trying to install.

Fixes #24824