### PR TITLE
docs: fix extension SDK wording

### DIFF
--- a/content/manuals/extensions/extensions-sdk/design/_index.md
+++ b/content/manuals/extensions/extensions-sdk/design/_index.md
@@ -20,7 +20,7 @@ To get started on your UI, follow the steps below.
 
 ### Recommended: React+MUI, using our theme
 
-Docker Desktop's UI is written in React and [MUI](https://mui.com/) (using Material UI to specific). This is the only officially supported framework for building extensions, and the one that our `init` command automatically configures for you. Using it brings significant benefits to authors:
+Docker Desktop's UI is written in React and [MUI](https://mui.com/) (using Material UI to be specific). This is the only officially supported framework for building extensions, and the one that our `init` command automatically configures for you. Using it brings significant benefits to authors:
 
 - You can use our [Material UI theme](https://www.npmjs.com/package/@docker/docker-mui-theme) to automatically replicate Docker Desktop's look and feel.
 - In future, we'll release utilities and components specifically targeting this combination (e.g. custom MUI components, or React hooks for interacting with Docker).

--- a/content/manuals/extensions/extensions-sdk/design/_index.md
+++ b/content/manuals/extensions/extensions-sdk/design/_index.md
@@ -20,7 +20,7 @@ To get started on your UI, follow the steps below.
 
 ### Recommended: React+MUI, using our theme
 
-Docker Desktop's UI is written in React and [MUI](https://mui.com/) (using Material UI to be specific). This is the only officially supported framework for building extensions, and the one that our `init` command automatically configures for you. Using it brings significant benefits to authors:
+Docker Desktop's UI is written in React and [MUI](https://mui.com/) (using Material UI specifically). This is the only officially supported framework for building extensions, and the one that our `init` command automatically configures for you. Using it brings significant benefits to authors:
 
 - You can use our [Material UI theme](https://www.npmjs.com/package/@docker/docker-mui-theme) to automatically replicate Docker Desktop's look and feel.
 - In future, we'll release utilities and components specifically targeting this combination (e.g. custom MUI components, or React hooks for interacting with Docker).

--- a/content/manuals/extensions/extensions-sdk/design/_index.md
+++ b/content/manuals/extensions/extensions-sdk/design/_index.md
@@ -20,7 +20,7 @@ To get started on your UI, follow the steps below.
 
 ### Recommended: React+MUI, using our theme
 
-Docker Desktop's UI is written in React and [MUI](https://mui.com/) (using Material UI specifically). This is the only officially supported framework for building extensions, and the one that our `init` command automatically configures for you. Using it brings significant benefits to authors:
+Docker Desktop's UI is written in React and [MUI](https://mui.com/) (using Material UI specifically). This is the only officially supported framework for building extensions, and the one that the `init` command automatically configures for you. Using it brings significant benefits to authors:
 
 - You can use our [Material UI theme](https://www.npmjs.com/package/@docker/docker-mui-theme) to automatically replicate Docker Desktop's look and feel.
 - In future, we'll release utilities and components specifically targeting this combination (e.g. custom MUI components, or React hooks for interacting with Docker).


### PR DESCRIPTION
## Description
- fix the extension SDK wording from `to specific` to `to be specific`
- keep the change limited to one docs file

## Related issues or tickets
- N/A (minor docs wording fix)

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review