### PR TITLE
docs: fix broken cross-references to regexes section in setup.md

### DIFF
--- a/content/manuals/docker-hub/repos/manage/builds/setup.md
+++ b/content/manuals/docker-hub/repos/manage/builds/setup.md
@@ -170,7 +170,7 @@ You can configure your automated builds so that pushes to specific branches or t
     > [!NOTE]
     >
     > You can enter a name, or use a regex to match which source branch or tag
-    > names to build. To learn more, see [regexes](index.md#regexes-and-automated-builds).
+    > names to build. To learn more, see [regexes](#regexes-and-automated-builds).
 
 4. Enter the tag to apply to Docker images built from this source.
 
@@ -178,7 +178,7 @@ You can configure your automated builds so that pushes to specific branches or t
    >
    > If you configured a regex to select the source, you can reference the
    > capture groups and use its result as part of the tag. To learn more, see
-   > [regexes](index.md#regexes-and-automated-builds).
+   > [regexes](#regexes-and-automated-builds).
 
 5. Repeat steps 2 through 4 for each new build rule you set up.
 


### PR DESCRIPTION
## Description

Two links in `content/manuals/docker-hub/repos/manage/builds/setup.md` pointed to `index.md#regexes-and-automated-builds`, but the "Regexes and automated builds" section lives in `setup.md` itself (line 206). Following the links landed readers on the overview page without the anchor they were looking for.

Switched both references to same-file anchors (`#regexes-and-automated-builds`) to match the two existing correct usages on lines 106 and 112.

## Related issues or tickets

Fixes #24881

## Reviews

- [ ] Technical review
- [ ] Editorial review