### PR TITLE
docs: fix broken link to service users section in link-source.md

### DIFF
--- a/content/manuals/docker-hub/repos/manage/builds/link-source.md
+++ b/content/manuals/docker-hub/repos/manage/builds/link-source.md
@@ -21,7 +21,7 @@ code service to Docker Hub so that it can access your source code
 repositories. You can configure this link for user accounts or
 organizations.
 
-If you are linking a source code provider to create autobuilds for a team, follow the instructions to [create a service account](index.md#service-users-for-team-autobuilds) for the team before linking the account as described below.
+If you are linking a source code provider to create autobuilds for a team, follow the instructions to [create a service account](setup.md#service-users-for-team-autobuilds) for the team before linking the account as described below.
 
 ## Link to a GitHub user account
 


### PR DESCRIPTION
## Description

The \"create a service account\" link in `content/manuals/docker-hub/repos/manage/builds/link-source.md` pointed to `index.md#service-users-for-team-autobuilds`, but the \"Service users for team autobuilds\" section actually lives in `setup.md` (line 250). Readers clicking the link landed on the overview page with no matching anchor.

Updated the link to `setup.md#service-users-for-team-autobuilds` so it resolves to the right section.

## Related issues or tickets

Fixes #24882

## Reviews

- [ ] Technical review
- [ ] Editorial review