### PR TITLE
docs: clarify Docker Desktop version requirement for starter lab

### DIFF
--- a/content/guides/lab-container-getting-started.md
+++ b/content/guides/lab-container-getting-started.md
@@ -26,6 +26,8 @@ image, and see container immutability and isolation in action.
 
 ## Launch the lab
 
+If you're using Docker Desktop, use version 4.43 or later before launching this lab.
+
 {{< labspace-launch image="dockersamples/labspace-container-getting-started" >}}
 
 ## What you'll learn


### PR DESCRIPTION
## Summary

Adds a missing Docker Desktop version prerequisite for the starter lab.

## Why

The lab uses `use_api_socket`, which requires a recent Docker Desktop version.

Without this clarification, users on older versions may encounter a launch error even when following the instructions correctly.

## What

- adds a single sentence indicating the required Docker Desktop version

## Scope

- documentation-only change
- no behavior changes
- no new concepts

## Related issues or tickets

Related to #24700

## Risks

- the exact version requirement may need adjustment if dependencies change

## Rollback

Remove the added sentence.