### PR TITLE
Document sbx cp

### DIFF
--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -233,6 +233,21 @@ $ sbx run claude ~/project-b
 $ sbx rm <sandbox-name>       # when finished
 ```
 
+## Copying files between host and sandbox
+
+Use [`sbx cp`](/reference/cli/sbx/cp/) to copy files or directories between
+your host and a sandbox. This is useful for one-off files that aren't part of a
+mounted workspace, such as generated output, logs, or setup files.
+
+```console
+$ sbx cp ./config.json my-sandbox:/home/user/
+$ sbx cp my-sandbox:/home/user/output.log ./
+$ sbx cp ./src/ my-sandbox:/home/user/src
+```
+
+One side of the copy must use `SANDBOX:PATH`. Copying directly between two
+sandboxes isn't supported.
+
 ## Installing dependencies and using Docker
 
 Ask the agent to install what's needed — it has sudo access, and installed

--- a/data/sbx_cli/sbx.yaml
+++ b/data/sbx_cli/sbx.yaml
@@ -16,6 +16,7 @@ options:
       usage: help for sbx
 see_also:
     - sbx completion - Generate the autocompletion script for the specified shell
+    - sbx cp - Copy files or directories between a sandbox and the host
     - sbx create - Create a sandbox for an agent
     - sbx diagnose - Diagnose common issues with your sbx installation
     - sbx exec - Execute a command inside a sandbox

--- a/data/sbx_cli/sbx_cp.yaml
+++ b/data/sbx_cli/sbx_cp.yaml
@@ -1,0 +1,36 @@
+name: sbx cp
+synopsis: Copy files or directories between a sandbox and the host
+description: |-
+    Either SRC or DST must be a sandbox path, written as SANDBOX:PATH.
+    The other must be a local path. Copying between two sandboxes is not supported.
+
+    When copying a directory, the directory itself is placed at the destination.
+    If the destination path does not exist it is created; if it already exists
+    as a directory, the source is placed inside it.
+usage: sbx cp [flags] SRC DST
+options:
+    - name: follow-link
+      shorthand: L
+      default_value: "false"
+      usage: |
+        Follow symbolic links in the source path when copying from host to sandbox
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for cp
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+example: |4-
+      # Copy a file from host to sandbox
+      sbx cp ./config.json my-sandbox:/home/user/
+
+      # Copy a file from sandbox to host
+      sbx cp my-sandbox:/home/user/output.log ./
+
+      # Copy a directory
+      sbx cp ./src/ my-sandbox:/home/user/src
+see_also:
+    - sbx - Manage AI coding agent sandboxes.


### PR DESCRIPTION
## Summary

Add generated CLI reference data for `sbx cp` and mention the command in the Docker Sandboxes usage guide for one-off file copies between host and sandbox.

Generated by Codex