### PR TITLE
Deprecate Docker Desktop sandboxes

### DIFF
--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -1,13 +1,14 @@
 ---
 title: Docker Sandboxes
 description: Run AI coding agents in isolated environments
+keywords: docker sandboxes, sbx, ai agents, sandboxed agents, microVM
 weight: 20
 params:
   sidebar:
     group: AI
     badge:
-      color: violet
-      text: Experimental
+      color: blue
+      text: Early Access
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
@@ -76,13 +77,6 @@ the [usage guide](usage.md) for common patterns.
 
 ## Feedback
 
-Docker Sandboxes is experimental and under active development. Your feedback
-shapes what gets built next. If you run into a bug, hit a missing feature, or
-have a suggestion, open an issue at
+Your feedback shapes what gets built next. If you run into a bug, hit a
+missing feature, or have a suggestion, open an issue at
 [github.com/docker/sbx-releases/issues](https://github.com/docker/sbx-releases/issues).
-
-## Docker Desktop integration
-
-Docker Desktop also includes a [built-in sandbox command](docker-desktop.md)
-(`docker sandbox`) with a subset of features. The `sbx` CLI is recommended for
-most use cases.

--- a/content/manuals/ai/sandboxes/agents/_index.md
+++ b/content/manuals/ai/sandboxes/agents/_index.md
@@ -3,6 +3,7 @@ title: Supported agents
 linkTitle: Agents
 weight: 30
 description: AI coding agents supported by Docker Sandboxes.
+keywords: docker sandboxes, ai agents, claude code, codex, gemini
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/claude-code.md
+++ b/content/manuals/ai/sandboxes/agents/claude-code.md
@@ -4,6 +4,7 @@ weight: 10
 description: |
   Use Claude Code in Docker Sandboxes with authentication, configuration, and
   YOLO mode for AI-assisted development.
+keywords: docker sandboxes, claude code, anthropic, ai agent, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/codex.md
+++ b/content/manuals/ai/sandboxes/agents/codex.md
@@ -4,6 +4,7 @@ weight: 20
 description: |
   Use OpenAI Codex in Docker Sandboxes with API key authentication and YOLO
   mode configuration.
+keywords: docker sandboxes, codex, openai, ai agent, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/copilot.md
+++ b/content/manuals/ai/sandboxes/agents/copilot.md
@@ -4,6 +4,7 @@ weight: 30
 description: |
   Use GitHub Copilot in Docker Sandboxes with GitHub token authentication and
   trusted folder configuration.
+keywords: docker sandboxes, github copilot, ai agent, github token, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/custom-environments.md
+++ b/content/manuals/ai/sandboxes/agents/custom-environments.md
@@ -2,6 +2,7 @@
 title: Custom environments
 weight: 80
 description: Customize agent sandbox environments or use the shell sandbox for manual setup.
+keywords: docker sandboxes, custom environments, templates, shell, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
@@ -104,7 +105,7 @@ environment variable to a size string before starting the sandbox:
 $ DOCKER_SANDBOXES_DOCKER_SIZE=10g sbx run claude
 ```
 
-Use the non-docker variant if you don't need to build or run containers
+Use the non-Docker variant if you don't need to build or run containers
 inside the sandbox and want a lighter, non-privileged environment. Specify
 it explicitly with `--template`:
 

--- a/content/manuals/ai/sandboxes/agents/docker-agent.md
+++ b/content/manuals/ai/sandboxes/agents/docker-agent.md
@@ -4,6 +4,7 @@ weight: 70
 description: |
   Use Docker Agent in Docker Sandboxes with multi-provider authentication
   supporting OpenAI, Anthropic, and more.
+keywords: docker sandboxes, docker agent, openai, anthropic, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/droid.md
+++ b/content/manuals/ai/sandboxes/agents/droid.md
@@ -3,6 +3,7 @@ title: Droid
 weight: 35
 description: |
   Use Droid in Docker Sandboxes with API key or OAuth authentication.
+keywords: docker sandboxes, droid, factory, ai agent, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/gemini.md
+++ b/content/manuals/ai/sandboxes/agents/gemini.md
@@ -4,6 +4,7 @@ weight: 40
 description: |
   Use Google Gemini in Docker Sandboxes with proxy-managed authentication and
   API key configuration.
+keywords: docker sandboxes, gemini, google, ai agent, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/kiro.md
+++ b/content/manuals/ai/sandboxes/agents/kiro.md
@@ -4,6 +4,7 @@ weight: 50
 description: |
   Use Kiro in Docker Sandboxes with device flow authentication for interactive
   AI-assisted development.
+keywords: docker sandboxes, kiro, ai agent, authentication, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/agents/opencode.md
+++ b/content/manuals/ai/sandboxes/agents/opencode.md
@@ -4,6 +4,7 @@ weight: 60
 description: |
   Use OpenCode in Docker Sandboxes with multi-provider authentication and TUI
   interface for AI development.
+keywords: docker sandboxes, opencode, ai agent, authentication, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -2,6 +2,7 @@
 title: Architecture
 weight: 40
 description: Technical architecture of Docker Sandboxes; workspace mounting, storage, networking, and sandbox lifecycle.
+keywords: docker sandboxes, architecture, microVM, workspace mounting, sandbox lifecycle
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/docker-desktop.md
+++ b/content/manuals/ai/sandboxes/docker-desktop.md
@@ -1,21 +1,27 @@
 ---
-title: Docker Desktop sandboxes
+title: Docker Desktop sandboxes (deprecated)
 linkTitle: Docker Desktop
 description: Run sandboxed AI coding agents using Docker Desktop and the docker sandbox CLI.
+keywords: docker desktop, docker sandbox, ai agents, sandboxes, deprecated
 weight: 80
+sitemap: false
+notoc: true
 ---
 
-{{< summary-bar feature_name="Docker Sandboxes" >}}
+> [!WARNING]
+>
+> The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+> replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md). This
+> deprecation applies only to the Docker Desktop integration, not to Docker
+> Sandboxes.
 
-Docker Desktop includes a built-in sandbox feature for running AI coding
-agents in isolated microVMs using the `docker sandbox` command. This is a
-convenience integration. For full functionality, use the standalone `sbx`
-CLI instead.
+This page covers the Docker Desktop-integrated `docker sandbox` command for
+running AI coding agents in isolated microVMs. This integration is superseded
+by the standalone `sbx` CLI, which provides the full Docker Sandboxes workflow
+and doesn't require Docker Desktop.
 
 > [!NOTE]
-> The standalone `sbx` CLI provides more features, more flexibility, and doesn't
-> require Docker Desktop. If you're setting up sandboxed agents for the first
-> time, consider using the standalone CLI instead.
+> Use the standalone `sbx` CLI for sandboxed AI agent workflows.
 
 ## Prerequisites
 
@@ -58,8 +64,7 @@ Replace `claude` with a different [agent](#supported-agents) if needed.
 | OpenCode                          | `opencode`     |                                      |
 | Custom shell                      | `shell`        | Minimal environment for manual setup |
 
-All agents are experimental. The agent type is specified when creating a
-sandbox and can't be changed later.
+The agent type is specified when creating a sandbox and can't be changed later.
 
 ## Authentication
 

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -2,6 +2,7 @@
 title: FAQ
 weight: 70
 description: Frequently asked questions about Docker Sandboxes.
+keywords: docker sandboxes, sbx, faq, sign in, telemetry
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
@@ -26,7 +27,7 @@ Your Docker account email is only used for authentication, not marketing.
 
 The `sbx` CLI collects basic usage data about CLI invocations:
 
-- Which subcommand you ran
+- Which command you ran
 - Whether it succeeded or failed
 - How long it took
 - If you're signed in, your Docker username is included

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -181,7 +181,7 @@ The dashboard shows your sandboxes with live status, lets you attach to
 agents, open shells, and manage network rules from one place. See
 [Interactive mode](usage.md#interactive-mode) for details.
 
-![The sbx interactive dashboard showing sandbox status, resource usage, and network governance controls.](images/sbx-dashboard.png)
+![The interactive dashboard showing sandbox status, resource usage, and network governance controls.](images/sbx-dashboard.png)
 
 ## Use branch mode
 

--- a/content/manuals/ai/sandboxes/security/_index.md
+++ b/content/manuals/ai/sandboxes/security/_index.md
@@ -3,6 +3,7 @@ title: Security model
 linkTitle: Security model
 weight: 50
 description: Trust boundaries, isolation layers, and security properties of Docker Sandboxes.
+keywords: docker sandboxes, security model, isolation, trust boundaries, microVM
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
@@ -38,7 +39,7 @@ Everything else is blocked. The agent cannot access your host filesystem
 localhost, other sandboxes, or any domain not in the allow list. Raw TCP, UDP,
 and ICMP are blocked at the network layer.
 
-![Sandbox security model showing the hypervisor boundary between the sandbox VM and the host system. The workspace directory is shared read-write. The agent process, Docker engine, packages, and VM filesystem are inside the VM. Host filesystem, processes, Docker engine, and network are outside the VM and not accessible. A proxy enforces allow/deny policies and injects credentials into outbound requests.](../images/sbx-security.png)
+![Sandbox security model showing the hypervisor boundary between the sandbox VM and the host system. The workspace directory is shared read-write. The agent process, Docker Engine, packages, and VM filesystem are inside the VM. Host filesystem, processes, Docker Engine, and network are outside the VM and not accessible. A proxy enforces allow/deny policies and injects credentials into outbound requests.](../images/sbx-security.png)
 
 ## Isolation layers
 

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -2,6 +2,7 @@
 title: Credentials
 weight: 20
 description: How Docker Sandboxes handle API keys and authentication credentials for sandboxed agents.
+keywords: docker sandboxes, credentials, api keys, authentication, proxy
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/security/defaults.md
+++ b/content/manuals/ai/sandboxes/security/defaults.md
@@ -3,6 +3,7 @@ title: Default security posture
 linkTitle: Defaults
 weight: 15
 description: What a sandbox permits and blocks before you change any settings.
+keywords: docker sandboxes, security defaults, network policy, credentials, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -2,6 +2,7 @@
 title: Isolation layers
 weight: 10
 description: How Docker Sandboxes isolate AI agents using hypervisor, network, Docker Engine, and credential boundaries.
+keywords: docker sandboxes, isolation, hypervisor, network, credentials
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/security/policy.md
+++ b/content/manuals/ai/sandboxes/security/policy.md
@@ -2,6 +2,7 @@
 title: Policies
 weight: 30
 description: Configure network access rules for sandboxes.
+keywords: docker sandboxes, policies, network access, allow rules, deny rules
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/security/workspace.md
+++ b/content/manuals/ai/sandboxes/security/workspace.md
@@ -4,6 +4,7 @@ weight: 40
 description: |
   How sandboxed agents interact with your workspace files and what to review
   after an agent session.
+keywords: docker sandboxes, workspace trust, file access, review, sbx
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -2,6 +2,7 @@
 title: Troubleshooting
 weight: 60
 description: Resolve common issues when using Docker Sandboxes.
+keywords: docker sandboxes, sbx, troubleshooting, diagnostics, reset
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
@@ -78,7 +79,7 @@ $ git clone https://github.com/owner/repo.git
 ## Can't reach a service running on the host
 
 If a request to `127.0.0.1` or a local network IP returns "connection refused"
-from inside a sandbox, the address is not routable from within the sandbox VM.
+from inside a sandbox, the address is not reachable from within the sandbox VM.
 See [Accessing host services from a sandbox](usage.md#accessing-host-services-from-a-sandbox).
 
 ## Docker authentication failure
@@ -106,7 +107,7 @@ configured to use the forward proxy. See
 [Monitoring network activity](security/policy.md#monitoring)
 for details.
 
-## Docker build export fails with "lchown: operation not permitted"
+## Docker build export fails with an ownership error
 
 Running `docker build` with the local exporter (`--output=type=local` or `-o
 <path>`) inside a sandbox fails because the exporter tries to `lchown` output
@@ -218,8 +219,8 @@ If you have set custom `XDG_STATE_HOME`, `XDG_CACHE_HOME`, or
 If you've exhausted the steps above and the problem persists, file a GitHub
 issue at [github.com/docker/sbx-releases/issues](https://github.com/docker/sbx-releases/issues).
 
-To help the Docker team investigate, generate a diagnostics bundle and share
-it when reporting the issue:
+To help Docker investigate, generate a diagnostics bundle and share it when
+reporting the issue:
 
 ```console
 $ sbx diagnose --upload

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -2,6 +2,7 @@
 title: Usage
 weight: 20
 description: Common patterns for working with sandboxes.
+keywords: docker sandboxes, sbx, usage, run, policy, secrets
 ---
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
@@ -303,7 +304,7 @@ A few things to keep in mind:
 Services running on your host are reachable from inside a sandbox using the
 hostname `host.docker.internal`.
 Use this instead of `127.0.0.1` or your machine's local network IP address,
-which are not routable from inside the sandbox.
+which are not reachable from inside the sandbox.
 
 The sandbox proxy translates `host.docker.internal` to `localhost` before
 forwarding the request, so you must add the `localhost` address with the

--- a/content/manuals/retired.md
+++ b/content/manuals/retired.md
@@ -4,6 +4,7 @@ linkTitle: Deprecated products and features
 description: |
   Explore deprecated and retired Docker features, products, and open source
   projects, including details on transitioned tools and archived initiatives.
+keywords: deprecated, retired, docker products, docker features, legacy
 params:
   sidebar:
     group: Products
@@ -146,6 +147,16 @@ Dev Environments was a feature introduced in Docker Desktop that allowed
 developers to spin up development environments quickly. It was deprecated and removed from Docker Desktop version 4.42 and later. Similar workflows can be achieved through
 Docker Compose or by creating custom configurations tailored to specific
 project requirements.
+
+### Docker Desktop sandboxes
+
+Docker Desktop sandboxes let users run AI coding agents in isolated microVMs
+through the `docker sandbox` command. The Docker Desktop integration is
+deprecated. Use the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md)
+instead.
+
+You can still view the
+[Docker Desktop sandboxes documentation](/manuals/ai/sandboxes/docker-desktop.md).
 
 ### GitHub Copilot extension
 

--- a/data/cli/sandbox/docker_sandbox.yaml
+++ b/data/cli/sandbox/docker_sandbox.yaml
@@ -1,6 +1,13 @@
 command: docker sandbox
 short: Docker Sandbox
-long: Local sandbox environments for AI agents, using Docker.
+long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
+    Local sandbox environments for AI agents, using Docker.
 usage: docker sandbox
 pname: docker
 plink: docker.yaml

--- a/data/cli/sandbox/docker_sandbox_create.yaml
+++ b/data/cli/sandbox/docker_sandbox_create.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create
 short: Create a sandbox for an agent
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for an agent.
 
     Available agents are provided as subcommands. Use "create AGENT --help" for agent-specific options.

--- a/data/cli/sandbox/docker_sandbox_create_cagent.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_cagent.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create cagent
 short: Create a sandbox for cagent
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for cagent.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_create_claude.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_claude.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create claude
 short: Create a sandbox for claude
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for claude.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_create_codex.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_codex.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create codex
 short: Create a sandbox for codex
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for codex.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_create_copilot.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_copilot.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create copilot
 short: Create a sandbox for copilot
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for copilot.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_create_gemini.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_gemini.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create gemini
 short: Create a sandbox for gemini
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for gemini.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_create_kiro.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_kiro.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create kiro
 short: Create a sandbox for kiro
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for kiro.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_create_opencode.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_opencode.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create opencode
 short: Create a sandbox for opencode
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for opencode.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_create_shell.yaml
+++ b/data/cli/sandbox/docker_sandbox_create_shell.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox create shell
 short: Create a sandbox for shell
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Create a sandbox with access to a host workspace for shell.
 
     The workspace path is required and will be exposed inside the sandbox at the same path as on the host.

--- a/data/cli/sandbox/docker_sandbox_exec.yaml
+++ b/data/cli/sandbox/docker_sandbox_exec.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox exec
 short: Execute a command inside a sandbox
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Execute a command in a sandbox that was previously created with 'docker sandbox create'.
 
     The command and any additional arguments are executed inside the sandbox container.

--- a/data/cli/sandbox/docker_sandbox_inspect.yaml
+++ b/data/cli/sandbox/docker_sandbox_inspect.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox inspect
 short: Display detailed information on one or more sandboxes
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Display detailed information on one or more sandboxes.
 
     This command retrieves and displays detailed information about the specified

--- a/data/cli/sandbox/docker_sandbox_ls.yaml
+++ b/data/cli/sandbox/docker_sandbox_ls.yaml
@@ -1,7 +1,14 @@
 command: docker sandbox ls
 aliases: docker sandbox ls, docker sandbox list
 short: List VMs
-long: List all VMs managed by sandboxd with their sandboxes
+long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
+    List all VMs managed by sandboxd with their sandboxes
 usage: docker sandbox ls [OPTIONS]
 pname: docker sandbox
 plink: docker_sandbox.yaml

--- a/data/cli/sandbox/docker_sandbox_network.yaml
+++ b/data/cli/sandbox/docker_sandbox_network.yaml
@@ -1,6 +1,13 @@
 command: docker sandbox network
 short: Manage sandbox networking
-long: Manage sandbox networking
+long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
+    Manage sandbox networking
 usage: docker sandbox network
 pname: docker sandbox
 plink: docker_sandbox.yaml

--- a/data/cli/sandbox/docker_sandbox_network_log.yaml
+++ b/data/cli/sandbox/docker_sandbox_network_log.yaml
@@ -1,6 +1,13 @@
 command: docker sandbox network log
 short: Show network logs
-long: Show network logs
+long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
+    Show network logs
 usage: docker sandbox network log
 pname: docker sandbox network
 plink: docker_sandbox_network.yaml

--- a/data/cli/sandbox/docker_sandbox_network_proxy.yaml
+++ b/data/cli/sandbox/docker_sandbox_network_proxy.yaml
@@ -1,6 +1,13 @@
 command: docker sandbox network proxy
 short: Manage proxy configuration for a sandbox
-long: Manage proxy configuration for a sandbox
+long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
+    Manage proxy configuration for a sandbox
 usage: docker sandbox network proxy <sandbox> [OPTIONS]
 pname: docker sandbox network
 plink: docker_sandbox_network.yaml

--- a/data/cli/sandbox/docker_sandbox_reset.yaml
+++ b/data/cli/sandbox/docker_sandbox_reset.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox reset
 short: Reset all VM sandboxes and clean up state
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Reset all VM sandboxes and permanently delete all VM data.
 
     This command will:

--- a/data/cli/sandbox/docker_sandbox_rm.yaml
+++ b/data/cli/sandbox/docker_sandbox_rm.yaml
@@ -2,6 +2,12 @@ command: docker sandbox rm
 aliases: docker sandbox rm, docker sandbox remove
 short: Remove one or more sandboxes
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Remove one or more sandboxes and all their associated resources.
 
     This command will:

--- a/data/cli/sandbox/docker_sandbox_run.yaml
+++ b/data/cli/sandbox/docker_sandbox_run.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox run
 short: Run an agent in a sandbox
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Run an agent in a sandbox. Create the sandbox if it does not exist.
 
     Pass agent arguments after the "--" separator.

--- a/data/cli/sandbox/docker_sandbox_save.yaml
+++ b/data/cli/sandbox/docker_sandbox_save.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox save
 short: Save a snapshot of the sandbox as a template
 long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Save a snapshot of the sandbox as a template.
 
     By default, the image is loaded into the host's Docker daemon (requires Docker to be running).

--- a/data/cli/sandbox/docker_sandbox_stop.yaml
+++ b/data/cli/sandbox/docker_sandbox_stop.yaml
@@ -1,6 +1,12 @@
 command: docker sandbox stop
 short: Stop one or more sandboxes without removing them
 long: |
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
     Stop one or more sandboxes without removing them. The sandboxes can be restarted later.
 usage: docker sandbox stop SANDBOX [SANDBOX...]
 pname: docker sandbox

--- a/data/cli/sandbox/docker_sandbox_version.yaml
+++ b/data/cli/sandbox/docker_sandbox_version.yaml
@@ -1,6 +1,13 @@
 command: docker sandbox version
 short: Show sandbox version information
-long: Show sandbox version information
+long: |-
+    > [!WARNING]
+    > The Docker Desktop-integrated `docker sandbox` commands are deprecated and
+    > replaced by the standalone [`sbx` CLI](/manuals/ai/sandboxes/_index.md).
+    > This deprecation applies only to the Docker Desktop integration, not to Docker
+    > Sandboxes.
+
+    Show sandbox version information
 usage: docker sandbox version
 pname: docker sandbox
 plink: docker_sandbox.yaml

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -187,7 +187,7 @@ Docker Pass:
 Docker Projects:
   availability: Beta
 Docker Sandboxes sbx:
-  availability: Experimental
+  availability: Early Access
 Docker Sandboxes:
   availability: Experimental
   requires: Docker Desktop [4.58](/manuals/desktop/release-notes.md#4580) or later


### PR DESCRIPTION
## Summary

Deprecates the Docker Desktop sandbox integration and hides its page from navigation and sitemap output. Removes sbx experimental callouts, adds the Docker Desktop sandbox docs to retired products, and marks docker sandbox CLI reference data as deprecated.

Generated by Codex