### PR TITLE
Fix formatting of cache command in registry.md

### DIFF
--- a/content/manuals/build/cache/backends/registry.md
+++ b/content/manuals/build/cache/backends/registry.md
@@ -29,8 +29,8 @@ configuration parameters:
 
 ```console
 $ docker buildx build --push -t <registry>/<image> \
-  --cache-to type=registry,ref=<registry>/<cache-image>[,parameters...] \
-  --cache-from type=registry,ref=<registry>/<cache-image> .
+  --cache-to=type=registry,ref=<registry>/<cache-image>[,parameters...] \
+  --cache-from=type=registry,ref=<registry>/<cache-image> .
 ```
 
 The following table describes the available CSV parameters that you can pass to


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
There is an error in the example commands, which makes the correct usage unclear.

## Related issues or tickets
None

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review