### PR TITLE
docs: clarify sandbox kits status

### DIFF
--- a/content/manuals/ai/sandboxes/customize/_index.md
+++ b/content/manuals/ai/sandboxes/customize/_index.md
@@ -20,6 +20,11 @@ defaults:
   tools, credentials, network rules, and files at runtime, or define a new
   agent from scratch.
 
+Kits are experimental. The kit file format, CLI commands, and experience for
+creating, loading, and managing kits are subject to change as the feature
+evolves. Share feedback and bug reports in the
+[docker/sbx-releases](https://github.com/docker/sbx-releases) repository.
+
 ## When to use which
 
 | Goal                                                      | Option                                                        |

--- a/content/manuals/ai/sandboxes/customize/build-an-agent.md
+++ b/content/manuals/ai/sandboxes/customize/build-an-agent.md
@@ -21,10 +21,6 @@ behind a part of the spec, so you can apply the same reasoning to other agents.
 For reference on every field, see the [Kits](kits.md) page. This tutorial
 focuses on the journey.
 
-The finished kit is also published as a runnable sample at
-[docker/sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib/tree/main/amp) —
-useful as a reference while you follow along.
-
 ## Choose a base image
 
 An agent kit needs a container image that satisfies the
@@ -263,13 +259,6 @@ agent argument:
 
 ```console
 $ sbx run --kit ./amp/ amp
-```
-
-The published copy of this kit also runs directly from the contrib
-repo:
-
-```console
-$ sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=amp" amp
 ```
 
 ## Iterate

--- a/content/manuals/ai/sandboxes/customize/build-an-agent.md
+++ b/content/manuals/ai/sandboxes/customize/build-an-agent.md
@@ -8,6 +8,12 @@ weight: 30
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
 
+> [!NOTE]
+> Kits are experimental. The kit file format, CLI commands, and experience
+> for creating, loading, and managing kits are subject to change as the
+> feature evolves. Share feedback and bug reports in the
+> [docker/sbx-releases](https://github.com/docker/sbx-releases) repository.
+
 This tutorial walks through building an agent kit for the
 [Amp](https://ampcode.com/) coding agent. Each step explains the decision
 behind a part of the spec, so you can apply the same reasoning to other agents.

--- a/content/manuals/ai/sandboxes/customize/kit-examples.md
+++ b/content/manuals/ai/sandboxes/customize/kit-examples.md
@@ -8,6 +8,12 @@ weight: 25
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
 
+> [!NOTE]
+> Kits are experimental. The kit file format, CLI commands, and experience
+> for creating, loading, and managing kits are subject to change as the
+> feature evolves. Share feedback and bug reports in the
+> [docker/sbx-releases](https://github.com/docker/sbx-releases) repository.
+
 Each section below shows one `spec.yaml` snippet that demonstrates a
 single kit pattern. These aren't complete, distributable kits — they're
 small, focused examples you can lift into your own kit. For the full

--- a/content/manuals/ai/sandboxes/customize/kit-examples.md
+++ b/content/manuals/ai/sandboxes/customize/kit-examples.md
@@ -129,12 +129,6 @@ command can invoke it directly.
 Use `initFiles` instead of a static file whenever the content depends
 on a runtime value. Use a static file otherwise.
 
-> [!TIP]
-> This snippet is lifted from the
-> [code-server kit](https://github.com/docker/sbx-kits-contrib/tree/main/code-server)
-> in the contrib repo, which is also a runnable sample that demonstrates
-> the full pattern.
-
 ## Ship a Claude Code skill
 
 Claude Code reads project-scoped skills from
@@ -229,14 +223,3 @@ $ sbx run claude-safe --kit ./claude-safe
 
 For a step-by-step walkthrough of building a new agent kit from
 scratch, see [Build an agent](build-an-agent.md).
-
-## More examples
-
-These patterns are all drawn from working kits in the
-[sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib)
-repository, which contains each example as a complete, loadable kit.
-Use it to study the full shape of a kit, or load one directly:
-
-```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=<kit>"
-```

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -309,7 +309,7 @@ removed from a running sandbox — remove and recreate it to start clean.
 ### Git repository
 
 ```console
-$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#ref=v0.1.0&dir=code-server"
+$ sbx run claude --kit "git+https://github.com/<owner>/<repo>.git#ref=v0.1.0&dir=code-server"
 ```
 
 - `#ref=<branch|tag|commit>` pins to a specific revision. Defaults to the

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -7,6 +7,12 @@ weight: 20
 
 {{< summary-bar feature_name="Docker Sandboxes sbx" >}}
 
+> [!NOTE]
+> Kits are experimental. The kit file format, CLI commands, and experience
+> for creating, loading, and managing kits are subject to change as the
+> feature evolves. Share feedback and bug reports in the
+> [docker/sbx-releases](https://github.com/docker/sbx-releases) repository.
+
 A kit packages a set of capabilities a sandbox can use, such as:
 
 - Tools to install

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -573,22 +573,22 @@ only inside the sandbox — nothing is written to the host.
 
 ## Debugging
 
-When a kit doesn't behave as expected, two commands cover most cases:
+When a kit doesn't behave as expected, start with the network policy log
+and direct inspection inside the sandbox:
 
 - `sbx policy log` shows every outbound request the sandbox proxy saw,
   the rule it matched, and how it was forwarded (`forward-bypass`,
-  `forward`, `block`). It's the primary tool for diagnosing
-  install-time download failures, blocked domains, or unintended TLS
-  interception. It was the diagnostic that surfaced the
-  `serviceDomains`-too-wide install corruption documented in
-  [Build your own agent kit](build-an-agent.md).
+  `forward`, `block`). Use it to diagnose install-time download failures,
+  blocked domains, and unexpected TLS interception. If downloads fail or
+  arrive corrupted after you add `serviceDomains`, check whether the
+  service mapping is too broad. Map only the hosts that need credential
+  injection.
 - `sbx exec <sandbox> -- <cmd>` runs an arbitrary command inside an
   existing sandbox. Useful for inspecting post-install state without
   recreating: `which mytool`, `ls /home/agent/.local/bin/`,
   `cat /home/agent/.config/...`, and so on.
 
-Install and startup command output isn't currently retained after
-sandbox creation — it scrolls past in the `sbx run` / `sbx create`
-output and isn't captured anywhere accessible afterward. For now, the
-two commands listed plus a clean recreate
-(`sbx rm <sandbox> && sbx run …`) are the practical loop.
+Install and startup command output is only emitted during `sbx run` or
+`sbx create`; `sbx` doesn't retain it for later inspection. To repeat
+setup with fresh output, remove and recreate the sandbox:
+`sbx rm <sandbox> && sbx run ...`.


### PR DESCRIPTION
## Summary

Clarify that Docker Sandboxes kits are experimental and that the kit format, commands, and management workflow may change. Remove internal sbx-kits-contrib references and polish the kit debugging guidance.

Generated by Codex