### PR TITLE
docs: include registry key structure in Group Policy deployment step

### DIFF
--- a/content/manuals/enterprise/security/enforce-sign-in/methods.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/methods.md
@@ -52,9 +52,9 @@ To configure the registry key method manually:
 Deploy the registry key across your organization using Group Policy:
 
 1. Create a registry script with the following structure:
-   - Key: `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Docker\Docker Desktop`
+   - Path: `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Docker\Docker Desktop`
    - Value name: `allowedOrgs` (multi-string)
-   - Value data: Your organization names, one per line, in lowercase only.
+   - Value data: Your organization names, one per line, in lowercase only
 1. In Group Policy Management, create or edit a GPO.
 1. Navigate to **Computer Configuration** > **Preferences** > **Windows Settings** > **Registry**.
 1. Right-click **Registry** > **New** > **Registry Item**.

--- a/content/manuals/enterprise/security/enforce-sign-in/methods.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/methods.md
@@ -51,7 +51,10 @@ To configure the registry key method manually:
 
 Deploy the registry key across your organization using Group Policy:
 
-1. Create a registry script with the required key structure.
+1. Create a registry script with the following structure:
+   - Key: `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Docker\Docker Desktop`
+   - Value name: `allowedOrgs` (multi-string)
+   - Value data: Your organization names, one per line, in lowercase only.
 1. In Group Policy Management, create or edit a GPO.
 1. Navigate to **Computer Configuration** > **Preferences** > **Windows Settings** > **Registry**.
 1. Right-click **Registry** > **New** > **Registry Item**.


### PR DESCRIPTION
The Group Policy deployment tab in `enforce-sign-in/methods.md` told admins to "Create a registry script with the required key structure" without documenting that structure, forcing them to switch to the Manual setup tab. Inlining the key, value name and value data so the Group Policy procedure is self-contained.

Closes #24946