### PR TITLE
docs: clarify both PayloadUUID values must be replaced with unique UUIDs

### DIFF
--- a/content/manuals/enterprise/security/enforce-sign-in/methods.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/methods.md
@@ -134,7 +134,7 @@ Overriding at least one of the proxy settings via Configuration profiles will au
 1. Replace placeholders:
    - Change `com.yourcompany.docker.config` to your company identifier
    - Replace `Your Company Name` with your organization name
-   - Replace `PayloadUUID` with a randomly generated UUID
+   - Replace both `PayloadUUID` values with randomly generated UUIDs (each value must be unique)
    - Update the `allowedOrgs` value with your organization names (separated by semicolons)
    - Replace `company.proxy:port` with http/https proxy server host(or IP address) and port
 1. Deploy the profile using your MDM solution.


### PR DESCRIPTION
The Mac configuration profile example contains two `PayloadUUID` fields (inner payload and outer configuration) with different values, but the replacement instruction was singular and ambiguous about whether one or both should be replaced. Updating to make explicit that both must be replaced with distinct UUIDs.

Closes #24944