### PR TITLE
docs: document how to remove sign-in enforcement

### DIFF
--- a/content/manuals/enterprise/security/enforce-sign-in/methods.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/methods.md
@@ -299,10 +299,10 @@ When multiple configuration methods exist on the same system, Docker Desktop use
 
 To remove enforcement, undo the configuration for the method you used:
 
-- **Windows registry key**: Delete the `allowedOrgs` value, or remove the entire `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Docker\Docker Desktop` key. If the key was deployed with Group Policy, remove it from the GPO and run `gpupdate /force` on target machines.
+- **Windows registry key**: Delete the `allowedOrgs` value, or remove the entire `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Docker\Docker Desktop` key.
 - **Mac configuration profiles**: Remove the profile through your MDM solution, or from **System Settings** > **General** > **Device Management**.
 - **Mac plist file**: Delete `/Library/Application Support/com.docker.docker/desktop.plist`.
-- **registry.json**: Delete the `registry.json` file from the location used during setup:
+- **registry.json**: Delete the `registry.json` file at:
   - Windows: `/ProgramData/DockerDesktop/registry.json`
   - Mac: `/Library/Application Support/com.docker.docker/registry.json`
   - Linux: `/usr/share/docker-desktop/registry/registry.json`

--- a/content/manuals/enterprise/security/enforce-sign-in/methods.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/methods.md
@@ -295,6 +295,20 @@ When multiple configuration methods exist on the same system, Docker Desktop use
 1. plist file (Mac only)
 1. registry.json file
 
+## Remove sign-in enforcement
+
+To remove enforcement, undo the configuration for the method you used:
+
+- **Windows registry key**: Delete the `allowedOrgs` value, or remove the entire `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Docker\Docker Desktop` key. If the key was deployed with Group Policy, remove it from the GPO and run `gpupdate /force` on target machines.
+- **Mac configuration profiles**: Remove the profile through your MDM solution, or from **System Settings** > **General** > **Device Management**.
+- **Mac plist file**: Delete `/Library/Application Support/com.docker.docker/desktop.plist`.
+- **registry.json**: Delete the `registry.json` file from the location used during setup:
+  - Windows: `/ProgramData/DockerDesktop/registry.json`
+  - Mac: `/Library/Application Support/com.docker.docker/registry.json`
+  - Linux: `/usr/share/docker-desktop/registry/registry.json`
+
+Restart Docker Desktop after removing the configuration so the change takes effect.
+
 ## Troubleshoot sign-in enforcement
 
 If sign-in enforcement doesn't work:


### PR DESCRIPTION
The setup methods are well documented but the inverse procedure is not, so admins testing or troubleshooting deployment have to guess. Adding a 'Remove sign-in enforcement' section that lists the inverse step for each method (Windows registry key, Mac configuration profile, Mac plist, registry.json) using the same paths the setup section already documents.

Closes #24943