### PR TITLE
docs: state lowercase-only requirement upfront for all methods

### DIFF
--- a/content/manuals/enterprise/security/enforce-sign-in/methods.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/methods.md
@@ -21,6 +21,10 @@ You can enforce sign-in for Docker Desktop using several methods. Choose the met
 | `plist` file | Mac only |
 | `registry.json` | All platforms |
 
+> [!NOTE]
+>
+> Whichever method you choose, organization names must use lowercase letters only.
+
 > [!TIP]
 >
 > For Mac, configuration profiles offer the highest security because they're


### PR DESCRIPTION
The lowercase-letters requirement for organization names was only documented inside the Windows registry key tab (and in the troubleshooting list), not in the Mac or registry.json methods. Surfacing it as a note right under the method table so administrators see it before picking a method, regardless of which one they pick.

Closes #24942