### PR TITLE
docs: link to RootlessKit docs on master instead of v2.0.0

### DIFF
--- a/content/manuals/engine/security/rootless/troubleshoot.md
+++ b/content/manuals/engine/security/rootless/troubleshoot.md
@@ -286,7 +286,7 @@ If slirp4netns is not installed, Docker falls back to [VPNKit](https://github.co
 Installing slirp4netns may improve the network throughput.
 
 For more information about network drivers for RootlessKit, see
-[RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md).
+[RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/blob/v3.0.0/docs/network.md).
 
 Also, changing MTU value may improve the throughput.
 The MTU value can be specified by creating `~/.config/systemd/user/docker.service.d/override.conf` with the following content:
@@ -345,8 +345,8 @@ To change the RootlessKit networking configuration:
 
 For more information about networking options for RootlessKit, see:
 
-- [Network drivers](https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md)
-- [Port drivers](https://github.com/rootless-containers/rootlesskit/blob/master/docs/port.md)
+- [Network drivers](https://github.com/rootless-containers/rootlesskit/blob/v3.0.0/docs/network.md)
+- [Port drivers](https://github.com/rootless-containers/rootlesskit/blob/v3.0.0/docs/port.md)
 
 ### Tips for debugging
 

--- a/content/manuals/engine/security/rootless/troubleshoot.md
+++ b/content/manuals/engine/security/rootless/troubleshoot.md
@@ -286,7 +286,7 @@ If slirp4netns is not installed, Docker falls back to [VPNKit](https://github.co
 Installing slirp4netns may improve the network throughput.
 
 For more information about network drivers for RootlessKit, see
-[RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/blob/v2.0.0/docs/network.md).
+[RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md).
 
 Also, changing MTU value may improve the throughput.
 The MTU value can be specified by creating `~/.config/systemd/user/docker.service.d/override.conf` with the following content:
@@ -345,8 +345,8 @@ To change the RootlessKit networking configuration:
 
 For more information about networking options for RootlessKit, see:
 
-- [Network drivers](https://github.com/rootless-containers/rootlesskit/blob/v2.0.0/docs/network.md)
-- [Port drivers](https://github.com/rootless-containers/rootlesskit/blob/v2.0.0/docs/port.md)
+- [Network drivers](https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md)
+- [Port drivers](https://github.com/rootless-containers/rootlesskit/blob/master/docs/port.md)
 
 ### Tips for debugging
 


### PR DESCRIPTION
The RootlessKit network/port docs were linked at the \`v2.0.0\` tag, leaving readers unsure whether the content reflects current RootlessKit behavior. Switching to the \`master\` branch (default branch on rootless-containers/rootlesskit, verified that \`docs/network.md\` and \`docs/port.md\` exist there) so the references stay current.

- Closes #24941
- Relates to https://github.com/moby/moby/pull/52456
- Relates to #24645