### PR TITLE
docs: complete the 'Create a team' steps

### DIFF
--- a/content/manuals/admin/organization/manage/manage-a-team.md
+++ b/content/manuals/admin/organization/manage/manage-a-team.md
@@ -54,7 +54,7 @@ For more information on roles, see
    organization.
 1. Select **Teams**.
 1. Select **Create team**.
-1. Provide a team name and an optional description, then select **Create**.
+1. Provide the team's information, then select **Create**.
 
 ## Set team repository permissions
 

--- a/content/manuals/admin/organization/manage/manage-a-team.md
+++ b/content/manuals/admin/organization/manage/manage-a-team.md
@@ -53,6 +53,8 @@ For more information on roles, see
 1. Sign in to [Docker Home](https://app.docker.com) and select your
    organization.
 1. Select **Teams**.
+1. Select **Create team**.
+1. Provide a team name and an optional description, then select **Create**.
 
 ## Set team repository permissions
 


### PR DESCRIPTION
The 'Create a team' section stopped after navigating to Teams, leaving readers without the actual creation steps. The cross-reference from 'Set team repository permissions' on the same page links back here, so the loop made the page unhelpful.

Adding the two missing steps based on the typical Docker Home flow (and the older Docker Hub version of this section in git history). The exact button labels (\`Create team\`, \`Create\`) should be confirmed against the current Docker Home UI by a maintainer with access; happy to adjust if the wording differs.

Closes #24915