### PR TITLE
engine/29.4.2: Add known issues and workarounds

### DIFF
--- a/content/manuals/engine/release-notes/29.md
+++ b/content/manuals/engine/release-notes/29.md
@@ -37,6 +37,48 @@ This release includes hardening for **CVE-2026-31431**.
 
 - Block `AF_ALG` sockets and the `socketcall(2)` multiplexer in the default seccomp profile to prevent in-container privilege escalation via the kernel crypto API ("Copy Fail"). [moby/moby#52501](https://github.com/moby/moby/pull/52501)
 
+### Known issues
+
+The hardening can break 32-bit programs and i386 images, including SteamCMD and some Wine-based workloads. [moby/moby#52506](https://github.com/moby/moby/issues/52506)
+
+#### Workaround
+
+> [!WARNING]
+> Don't use `--security-opt seccomp=unconfined` to work around this issue.  
+> Don't use the `seccomp/v0.2.0` profile.
+
+If you need a workaround, use the `seccomp/v0.2.1` profile from `moby/profiles`.
+Make sure you use a kernel that includes the fix for CVE-2026-31431.
+
+This profile unblocks `socketcall` while keeping `AF_ALG` blocked for `socket`.
+
+> [!IMPORTANT]
+> Use this workaround only for containers that require it.  
+> Containers that use this profile can still exploit CVE-2026-31431 through the `socketcall` syscall.
+
+Download the `seccomp/v0.2.1` profile:
+
+```console
+$ curl -fsSL https://raw.githubusercontent.com/moby/profiles/refs/tags/seccomp/v0.2.1/seccomp/default.json \
+  -o /etc/docker/seccomp-profile-v0.2.1.json
+```
+
+Use one of these options. You don't need both.
+
+1. To use the profile for a specific container when you control the `docker run` command, use `--security-opt`:
+
+  ```console
+  $ docker run --security-opt seccomp=<path> ...
+  ```
+
+2. To use the profile as the default for containers created by the daemon, add `seccomp-profile` to your `daemon.json`:
+
+  ```json
+  {
+    "seccomp-profile": "/etc/docker/seccomp-profile-v0.2.1.json"
+  }
+  ```
+
 ## 29.4.1
 
 {{< release-date date="2026-04-20" >}}


### PR DESCRIPTION
### engine/29.4.2: Add known issues and workarounds

  The seccomp hardening in Docker 29.4.2 that blocks AF_ALG sockets and socketcall can break 32-bit programs and i386 images, including SteamCMD and Wine workloads.