### PR TITLE
Fix admin-settings.json macOS path formatting

### DIFF
--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
@@ -34,7 +34,7 @@ You can create the `admin-settings.json` file in two ways:
   - [Mac](/manuals/desktop/setup/install/mac-install.md#install-from-the-command-line) installation guide
   - [Windows](/manuals/desktop/setup/install/windows-install.md#install-from-the-command-line) installation guide
 - Create it manually (UTF-8 without BOM) and place it in the following locations:
-  - Mac: `/Library/Application\ Support/com.docker.docker/admin-settings.json`
+  - Mac: `/Library/Application Support/com.docker.docker/admin-settings.json`
   - Windows: `C:\ProgramData\DockerDesktop\admin-settings.json`
   - Linux: `/usr/share/docker-desktop/admin-settings.json`
 


### PR DESCRIPTION
## Summary

The admin-settings.json macOS location used shell escaping in a filesystem path list. This removes the backslash so the path matches the actual directory name.

Closes #24968

Generated by Codex