### PR TITLE
Show sign-in enforcement Group Policy registry structure

### DIFF
--- a/content/manuals/enterprise/security/enforce-sign-in/methods.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/methods.md
@@ -51,7 +51,11 @@ To configure the registry key method manually:
 
 Deploy the registry key across your organization using Group Policy:
 
-1. Create a registry script with the required key structure.
+1. Create a registry script with the required key structure:
+   - Key: `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Docker\Docker Desktop`
+   - Value name: `allowedOrgs`
+   - Value type: Multi-string
+   - Value data: Your organization names, one per line
 1. In Group Policy Management, create or edit a GPO.
 1. Navigate to **Computer Configuration** > **Preferences** > **Windows Settings** > **Registry**.
 1. Right-click **Registry** > **New** > **Registry Item**.


### PR DESCRIPTION
## Summary

The Group Policy deployment steps referenced a required registry key structure without showing it. This adds the key, value name, type, and organization-name format to the tab.

Closes #24946

Generated by Codex