### PR TITLE
Mark Autobuilds feature as deprecated

### DIFF
--- a/content/manuals/docker-hub/release-notes.md
+++ b/content/manuals/docker-hub/release-notes.md
@@ -14,6 +14,15 @@ tags: [Release notes]
 Here you can learn about the latest changes, new features, bug fixes, and
 known issues for each Docker Hub release.
 
+## 2026-05-06
+
+### Deprecation notice
+
+- [Docker Hub Automated Builds](https://docs.docker.com/docker-hub/repos/manage/builds/) 
+  is being deprecated. Existing accounts will have access until April 1st 2027. 
+  See [migration options](https://docs.docker.com/docker-hub/repos/manage/builds/migrate/)
+  for guides on migrating to GitHub Actions or Bitbucket Pipelines.
+
 ## 2026-02-13
 
 ### New

--- a/content/manuals/docker-hub/release-notes.md
+++ b/content/manuals/docker-hub/release-notes.md
@@ -18,9 +18,9 @@ known issues for each Docker Hub release.
 
 ### Deprecation notice
 
-- [Docker Hub Automated Builds](https://docs.docker.com/docker-hub/repos/manage/builds/) 
-  is being deprecated. Existing accounts will have access until April 1st 2027. 
-  See [migration options](https://docs.docker.com/docker-hub/repos/manage/builds/migrate/)
+- [Docker Hub Automated Builds](./repos/manage/builds/) 
+  is being deprecated. Existing accounts will have access until April 1, 2027. 
+  See [migration options](./repos/manage/builds/migrate/)
   for guides on migrating to GitHub Actions or Bitbucket Pipelines.
 
 ## 2026-02-13

--- a/content/manuals/docker-hub/repos/manage/builds/_index.md
+++ b/content/manuals/docker-hub/repos/manage/builds/_index.md
@@ -16,7 +16,7 @@ aliases:
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 Docker Hub can automatically build images from source code in an external
 repository and automatically push the built image to your Docker repositories.

--- a/content/manuals/docker-hub/repos/manage/builds/_index.md
+++ b/content/manuals/docker-hub/repos/manage/builds/_index.md
@@ -3,11 +3,21 @@ description: how automated builds work
 keywords: docker hub, automated builds
 title: Automated builds
 weight: 90
+params:
+  sidebar:
+    group: Products
+    badge:
+      color: gray
+      text: Deprecated
 aliases:
 - /docker-hub/builds/how-builds-work/
 ---
 
 {{< summary-bar feature_name="Automated builds" >}}
+
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
 
 Docker Hub can automatically build images from source code in an external
 repository and automatically push the built image to your Docker repositories.

--- a/content/manuals/docker-hub/repos/manage/builds/_index.md
+++ b/content/manuals/docker-hub/repos/manage/builds/_index.md
@@ -5,7 +5,6 @@ title: Automated builds
 weight: 90
 params:
   sidebar:
-    group: Products
     badge:
       color: gray
       text: Deprecated

--- a/content/manuals/docker-hub/repos/manage/builds/advanced.md
+++ b/content/manuals/docker-hub/repos/manage/builds/advanced.md
@@ -11,7 +11,7 @@ aliases:
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/advanced.md
+++ b/content/manuals/docker-hub/repos/manage/builds/advanced.md
@@ -8,6 +8,11 @@ aliases:
 - /docker-hub/builds/advanced/
 ---
 
+
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
+
 > [!NOTE]
 >
 > Automated builds require a

--- a/content/manuals/docker-hub/repos/manage/builds/automated-testing.md
+++ b/content/manuals/docker-hub/repos/manage/builds/automated-testing.md
@@ -7,6 +7,10 @@ aliases:
 - /docker-hub/builds/automated-testing/
 ---
 
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
+
 > [!NOTE]
 >
 > Automated builds require a

--- a/content/manuals/docker-hub/repos/manage/builds/automated-testing.md
+++ b/content/manuals/docker-hub/repos/manage/builds/automated-testing.md
@@ -9,7 +9,7 @@ aliases:
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/link-source.md
+++ b/content/manuals/docker-hub/repos/manage/builds/link-source.md
@@ -11,6 +11,10 @@ aliases:
 - /docker-hub/builds/link-source/
 ---
 
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
+
 > [!NOTE]
 >
 > Automated builds require a Docker Pro, Team, or Business subscription.

--- a/content/manuals/docker-hub/repos/manage/builds/link-source.md
+++ b/content/manuals/docker-hub/repos/manage/builds/link-source.md
@@ -13,7 +13,7 @@ aliases:
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/manage-builds.md
+++ b/content/manuals/docker-hub/repos/manage/builds/manage-builds.md
@@ -6,6 +6,10 @@ aliases:
 - /docker-hub/builds/manage-builds/
 ---
 
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
+
 > [!NOTE]
 >
 > Automated builds require a Docker Pro, Team, or Business subscription.

--- a/content/manuals/docker-hub/repos/manage/builds/manage-builds.md
+++ b/content/manuals/docker-hub/repos/manage/builds/manage-builds.md
@@ -8,7 +8,7 @@ aliases:
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/migrate.md
+++ b/content/manuals/docker-hub/repos/manage/builds/migrate.md
@@ -6,6 +6,10 @@ linkTitle: Migrate
 weight: 80
 ---
 
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
+
 This guide explains how to migrate your Docker Hub Autobuilds setup to
 Continuous Integration (CI) workflows, focusing on GitHub Actions and Bitbucket
 Pipelines as these are the built-in CI services for the two version control

--- a/content/manuals/docker-hub/repos/manage/builds/migrate.md
+++ b/content/manuals/docker-hub/repos/manage/builds/migrate.md
@@ -8,7 +8,7 @@ weight: 80
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 This guide explains how to migrate your Docker Hub Autobuilds setup to
 Continuous Integration (CI) workflows, focusing on GitHub Actions and Bitbucket

--- a/content/manuals/docker-hub/repos/manage/builds/setup.md
+++ b/content/manuals/docker-hub/repos/manage/builds/setup.md
@@ -10,6 +10,10 @@ aliases:
 - /docker-hub/builds/
 ---
 
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
+
 > [!NOTE]
 >
 > Automated builds require a

--- a/content/manuals/docker-hub/repos/manage/builds/setup.md
+++ b/content/manuals/docker-hub/repos/manage/builds/setup.md
@@ -12,7 +12,7 @@ aliases:
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/troubleshoot.md
+++ b/content/manuals/docker-hub/repos/manage/builds/troubleshoot.md
@@ -10,7 +10,7 @@ aliases:
 
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
-> It will be fully retired on April 1st 2027.
+> It will be fully retired on April 1, 2027.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/troubleshoot.md
+++ b/content/manuals/docker-hub/repos/manage/builds/troubleshoot.md
@@ -8,6 +8,10 @@ aliases:
 - /docker-hub/builds/troubleshoot/
 ---
 
+> [!WARNING]
+> Docker Hub Automated Builds is a deprecated feature.
+> It will be fully retired on April 1st 2027.
+
 > [!NOTE]
 >
 > Automated builds require a

--- a/content/manuals/retired.md
+++ b/content/manuals/retired.md
@@ -181,6 +181,14 @@ expiration, and better security auditing. OATs are included with Docker Team
 and Business subscriptions and offer similar functionality without requiring
 separate add-on purchases.
 
+### Docker Hub Automated Builds
+
+Docker Hub Automated Builds was a feature of Docker Hub that allowed building of 
+Docker images from source code in an external repository and automatically pushed
+the built image to your Docker repositories. This feature has been deprecated and
+will be removed on April 1st 2027
+
+
 ## Open source projects
 
 Several open-source projects originally maintained by Docker have been

--- a/content/manuals/retired.md
+++ b/content/manuals/retired.md
@@ -183,10 +183,10 @@ separate add-on purchases.
 
 ### Docker Hub Automated Builds
 
-Docker Hub Automated Builds was a feature of Docker Hub that allowed building of 
-Docker images from source code in an external repository and automatically pushed
+Docker Hub Automated Builds was a feature of Docker Hub that allowed building
+Docker images from source code in an external repository and automatically pushing
 the built image to your Docker repositories. This feature has been deprecated and
-will be removed on April 1st 2027
+will be removed on April 1, 2027.
 
 
 ## Open source projects

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -21,6 +21,7 @@ Gordon DHI migration:
   availability: Experimental
   requires: Docker Desktop [4.38.0](/manuals/desktop/release-notes.md#4380) or later
 Automated builds:
+  availability: Retired
   subscription: [Pro, Team, Business]
 Azure blob:
   availability: Experimental

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -21,7 +21,7 @@ Gordon DHI migration:
   availability: Experimental
   requires: Docker Desktop [4.38.0](/manuals/desktop/release-notes.md#4380) or later
 Automated builds:
-  availability: Retired
+  availability: Deprecated
   subscription: [Pro, Team, Business]
 Azure blob:
   availability: Experimental


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

Marks Docker Hub Automated Builds (Autobuilds) as a deprecated feature to be retired on Apr 1st 2027

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review