### PR TITLE
remove usage of CAGENT_* org secrets in docs repo

### DIFF
--- a/.github/workflows/nightly-docs-scan.yml
+++ b/.github/workflows/nightly-docs-scan.yml
@@ -23,8 +23,10 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      HAS_APP_SECRETS: ${{ secrets.CAGENT_REVIEWER_APP_ID != '' }}
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -45,24 +47,33 @@ jobs:
           restore-keys: |
             docs-scanner-state-${{ github.repository }}-
 
-      - name: Generate GitHub App token
-        if: env.HAS_APP_SECRETS == 'true'
-        id: app-token
+      - name: Configure AWS credentials
+        id: aws-credentials
         continue-on-error: true
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
-          app_id: ${{ secrets.CAGENT_REVIEWER_APP_ID }}
-          private_key: ${{ secrets.CAGENT_REVIEWER_APP_PRIVATE_KEY }}
+          role-to-assume: arn:aws:iam::710015040892:role/docker-agent-action-20260409141318957000000001
+          aws-region: us-east-1
+
+      - name: Fetch bot PAT
+        if: steps.aws-credentials.outcome == 'success'
+        run: |
+          PAT=$(aws secretsmanager get-secret-value \
+            --secret-id docker-agent-action/github-app \
+            --query SecretString \
+            --output text | jq -r '.pat')
+          echo "::add-mask::$PAT"
+          echo "GITHUB_APP_TOKEN=$PAT" >> "$GITHUB_ENV"
 
       - name: Run documentation scan
         uses: docker/cagent-action@3a12dbd0c6cd7dda3d4e05f24f0143c9701456de # latest
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ env.GITHUB_APP_TOKEN || github.token }}
         with:
           agent: ${{ github.workspace }}/.github/agents/docs-scanner.yaml
-          prompt: "${{ inputs['dry-run'] && 'DRY RUN MODE: Do not create any GitHub issues. Report what you would create but skip the gh issue create commands.' || 'Run the nightly documentation scan as described in your instructions.' }}"
+          prompt: "${{ inputs.dry-run == true && 'DRY RUN MODE: Do not create any GitHub issues. Report what you would create but skip the gh issue create commands.' || 'Run the nightly documentation scan as described in your instructions.' }}"
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github-token: ${{ steps.app-token.outputs.token || github.token }}
+          github-token: ${{ env.GITHUB_APP_TOKEN || github.token }}
           timeout: 1200
 
       - name: Save scanner state

--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,0 +1,33 @@
+name: PR Review - Trigger
+on:
+  pull_request:
+    types: [ready_for_review, opened, review_requested]
+  pull_request_review_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  save-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save event context
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_JSON: ${{ toJSON(github.event.comment) }}
+        run: |
+          mkdir -p context
+          printf '%s' "${{ github.event_name }}" > context/event_name.txt
+          printf '%s' "$PR_NUMBER" > context/pr_number.txt
+          printf '%s' "$PR_HEAD_SHA" > context/pr_head_sha.txt
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            printf '%s' "$COMMENT_JSON" > context/comment.json
+          fi
+
+      - name: Upload context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-review-context
+          path: context/
+          retention-days: 1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,34 +1,30 @@
-# Thin wrapper around docker/cagent-action's reusable review workflow.
-# Fork detection, org-membership gating, and review posting are all handled
-# by the reusable workflow, so no additional guards are needed here.
-#
-# Triggers:
-#   issue_comment               — `/review` slash command (works for fork contributors).
-#   pull_request_review_comment — captures feedback for agent learning.
 name: PR Review
-
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request:
-    types: [ready_for_review, opened]
+  workflow_run:
+    workflows: ["PR Review - Trigger"]
+    types: [completed]
 
 permissions:
-  contents: read
+  contents: read # Required at top-level to give `issue_comment` events access to the secrets below.
 
 jobs:
   review:
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@d98096f432f2aea5091c811852c4da804e60623a # v1.4.1
+    if: |
+      github.event_name == 'issue_comment' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@c22076b8856ee12d9b4c4685bb49cf26eb974079 # v1.5.0
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs
-      pull-requests: write # Post review comments and approve/request changes
-      issues: write # Create security incident issues if secrets are detected in output
-      checks: write # (Optional) Show review progress as a check run on the PR
+      pull-requests: write # Post review comments
+      issues: write # Create security incident issues if secrets detected
+      checks: write # (Optional) Show review progress as a check run
       id-token: write # Required for OIDC authentication to AWS Secrets Manager
+      actions: read # Download artifacts from trigger workflow
     with:
+      trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}', github.event.workflow_run.id) || '' }}
       add-prompt-files: STYLE.md,COMPONENTS.md
       additional-prompt: |
         ## Documentation Review Focus


### PR DESCRIPTION
## Description

Removes usage of `CAGENT_*` organization secrets from the nightly docs scan workflow and replaces them with AWS-based credential management. The workflow now uses AWS IAM role assumption to fetch a GitHub PAT from AWS Secrets Manager instead of relying on GitHub App secrets.

## Changes

- Replace GitHub App token generation with AWS credentials configuration and AWS Secrets Manager lookup
- Update `GH_TOKEN` and `github-token` to use the fetched PAT from environment variable
- Add explicit workflow permissions (`id-token: write`, `contents: read`, `issues: write`)
- Fix prompt condition syntax from `inputs['dry-run']` to `inputs.dry-run == true`

## Related issues or tickets

Closes: https://github.com/docker/gordon/issues/537

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review