### PR TITLE
Update Docker Engine 18.09 blog link to Wayback Machine archive

### DIFF
--- a/content/manuals/engine/release-notes/18.09.md
+++ b/content/manuals/engine/release-notes/18.09.md
@@ -186,7 +186,7 @@ toc_max: 2
 * Update `runc` to address a critical vulnerability that allows specially-crafted containers to gain administrative privileges on the host. [CVE-2019-5736](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736)
 * Ubuntu 14.04 customers using a 3.13 kernel will need to upgrade to a supported Ubuntu 4.x kernel
 
-For additional information, [refer to the Docker blog post](https://blog.docker.com/2019/02/docker-security-update-cve-2018-5736-and-container-security-best-practices/).
+For additional information, [refer to the Docker blog post](https://web.archive.org/web/20200227084534/https://www.docker.com/blog/docker-security-update-cve-2018-5736-and-container-security-best-practices/).
 
 ### Known Issues
 * There are important changes to the upgrade process that, if not correctly followed, can have impact on the availability of applications running on the Swarm during upgrades. These constraints impact any upgrades coming from any version before 18.09 to version 18.09 or greater.


### PR DESCRIPTION
## Summary

The supplementary blog post link in the Docker Engine 18.09.2 security
fixes section no longer resolves to the original article. Both the old
domain (`blog.docker.com/2019/02/...`) and the equivalent path on the
current blog (`www.docker.com/blog/...`) redirect to the blog index
rather than the article itself.

Per maintainer suggestion, this PR updates the link to the Internet
Archive snapshot of the article so the supplementary context remains
available to readers. If the post is restored upstream, the link can
be swapped back to a live URL in a follow-up.

## Test plan

- [x] Verified the Wayback URL returns `200` and contains the original
      CVE-2018-5736 article body
- [x] `docker buildx bake lint vale` — no new violations introduced on
      the edited line
- [x] `docker buildx bake test` — htmltest passes (3,170 documents, no
      broken internal links)