### PR TITLE
Fix typo: --excludes → --exclude

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -2062,7 +2062,7 @@ COPY --exclude=*.txt hom* /mydir/
 ```
 
 You can specify the `--exclude` option multiple times for a `COPY` instruction.
-Multiple `--excludes` are files matching its patterns not to be copied,
+Multiple `--exclude` are files matching its patterns not to be copied,
 even if the files paths match the pattern specified in `<src>`.
 To add all files starting with "hom", excluding files with either `.txt` or `.md` extensions:
 


### PR DESCRIPTION
## Description
Fixed typo in Dockerfile reference (COPY --exclude), where "--excludes" should be "--exclude".

## Related issues or tickets

#24993 
