### PR TITLE
Fix typo "--excludes" in COPY --exclude documentation

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -2062,7 +2062,7 @@ COPY --exclude=*.txt hom* /mydir/
 ```
 
 You can specify the `--exclude` option multiple times for a `COPY` instruction.
-Multiple `--excludes` are files matching its patterns not to be copied,
+Multiple `--exclude` are files matching its patterns not to be copied,
 even if the files paths match the pattern specified in `<src>`.
 To add all files starting with "hom", excluding files with either `.txt` or `.md` extensions:
 


### PR DESCRIPTION
Closes #24993

## Summary

Fixes a typo in the Dockerfile reference documentation.

Changed incorrect flag reference:

* `--excludes`

- `--exclude`

to match the actual supported Dockerfile option syntax.
