### PR TITLE
chore: update Debian distribution notes in installation guide

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -130,7 +130,7 @@ Docker from the repository.
 
    > [!NOTE]
    >
-   > If you use a derivative distribution, such as Kali Linux,
+   > If you use a debian testing or derivative distribution, such as Kali Linux,
    > you may need to substitute the part of this command that's expected to
    > print the version codename:
    >
@@ -139,7 +139,7 @@ Docker from the repository.
    > ```
    >
    > Replace this part with the codename of the corresponding Debian release,
-   > such as `bookworm`.
+   > such as `trixie`.
 
 2. Install the Docker packages.
 

--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -130,7 +130,7 @@ Docker from the repository.
 
    > [!NOTE]
    >
-   > If you use a debian testing or derivative distribution, such as Kali Linux,
+   > If you use Debian testing or a derivative distribution such as Kali Linux,
    > you may need to substitute the part of this command that's expected to
    > print the version codename:
    >


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This PR update notes on the debian installation guide.

Now also mention debian testing (atm codename is forky, but not available yet on https://download.docker.com/linux/debian/dists/). And the current kali-linux (2026.01) is now based on forky as well. the closest stable is now trixie. updated bookworm -> trixie in the given example.

Feel free to ammend/accept/drop this PR as needed, thank you for your time.

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review