### PR TITLE
Corrected 2 instances of 'all-user' to 'per-user' in the terminal tro…

### DIFF
--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
@@ -97,7 +97,7 @@ Docker Desktop cannot start.
    # For all-user installations
    $ C:\Program Files\Docker\Docker\resources\com.docker.diagnose.exe
 
-   # For all-user installations
+   # For per-user installations
    $ %LOCALAPPDATA%\Programs\DockerDesktop\resources\com.docker.diagnose.exe
    ```
 
@@ -107,7 +107,7 @@ Docker Desktop cannot start.
    # For all-user installations
    $ & "C:\Program Files\Docker\Docker\resources\com.docker.diagnose.exe" gather -upload
 
-   # For all-user installations
+   # For per-user installations
    $ & %LOCALAPPDATA%\Programs\DockerDesktop\resources\com.docker.diagnose.exe" gather -upload
    ```
 


### PR DESCRIPTION
Troubleshooting page, Diagnose from terminal section



## Description

 - In the Diagnose from the terminal section there are two code blocks that each give two commands based on how their Docker Desktop was installed it should be "all-user" and "per-user" but all of the methods were labeled as "all-user", corrected the appropriate methods to be tagged as "per-user"

## Related issues or tickets

None, noticed this while reviewing the documentation to provide instructions for diagnostic bundles

## Reviews

No structural changes were made to the page, just the two instances of "all-user" that were corrected to "per-user"

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review