### PR TITLE
Fix typo: 'being' -> 'begin' in group-mapping prerequisites

### DIFF
--- a/content/manuals/enterprise/security/provisioning/scim/group-mapping.md
+++ b/content/manuals/enterprise/security/provisioning/scim/group-mapping.md
@@ -24,7 +24,7 @@ This page explains how group mapping works, and how to set up group mapping.
 
 ## Prerequisites
 
-Before you being, you must have:
+Before you begin, you must have:
 
 - SSO configured for your organization
 - Administrator access to Docker Home and your identity provider


### PR DESCRIPTION
## Description

Fixing a small typo in the docs

## Related issues or tickets

N/A

## Reviews

Tested locally:

<img width="776" height="369" alt="image" src="https://github.com/user-attachments/assets/60b93a2a-0c1b-4f3a-85fb-fdd4a1f49ecd" />
