### PR TITLE
[scripts] Added basic safety to the repository installation Bash script

### DIFF
--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -126,14 +126,15 @@ Docker from the repository.
 
    ```bash
    # Add Docker's official GPG key:
-   sudo apt update
-   sudo apt install ca-certificates curl
-   sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
-   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   sudo apt update &&
+   sudo apt install ca-certificates curl &&
+   sudo install -m 0755 -d /etc/apt/keyrings &&
+   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc &&
+   sudo chmod a+r /etc/apt/keyrings/docker.asc &&
 
-   # Add the repository to Apt sources:
-   sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
+   {
+     # Add the repository to Apt sources:
+     sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
    Types: deb
    URIs: {{% param "download-url-base" %}}
    Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
@@ -141,8 +142,9 @@ Docker from the repository.
    Architectures: $(dpkg --print-architecture)
    Signed-By: /etc/apt/keyrings/docker.asc
    EOF
-
-   sudo apt update
+   } &&
+   
+   sudo apt update;
    ```
 
 2. Install the Docker packages.


### PR DESCRIPTION
Dear Developers and Artists,

Thank you for the marvel, art you do!

## Description

The main issue is that it's not the first time the publicly proposed script does not complete successfully somewhere in the middle, and since no checks happen, the commands just get executed regardless. A person may not even notice some command failed above if the output from the next commands fills up the screen, too.

I am not sure the initial reason the script had no execution checks, but just in case, what do you think about the command group, due to the here-doc?

Or would it look better with the previous command core check?:

<details>
  <summary>Check the exit status code of the previous command</summary>

```diff
# ...
EOF

+ (( ! $? )) &&
sudo apt update
```

</details>

There's a [less recommended](<https://mywiki.wooledge.org/BashFAQ/105>) alternative:

<details>
  <summary>Set the bash-opt to stop execution on any command fail</summary>

```diff
+ # Create a sub-shell to not affect the current shell.
+ (
+ # Set the bash-opt to stop execution on any command fail.
+ set -e;
+ 
# Add Docker's official GPG key:
sudo apt update
sudo apt install ca-certificates curl
sudo install -m 0755 -d /etc/apt/keyrings
sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
sudo chmod a+r /etc/apt/keyrings/docker.asc

# Add the repository to Apt sources:
sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
Types: deb
URIs: https://download.docker.com/linux/ubuntu
Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
Components: stable
Architectures: $(dpkg --print-architecture)
Signed-By: /etc/apt/keyrings/docker.asc
EOF

sudo apt update
+ )
```

</details>

May I ask, why don't you use `;` to separate the commands?

## Reviews

- [ ] Technical review
- [X] Editorial review
- [X] Product review