### PR TITLE
docs: fix misleading title on company members page

### DIFF
--- a/content/manuals/admin/company/manage/users.md
+++ b/content/manuals/admin/company/manage/users.md
@@ -1,7 +1,7 @@
 ---
-title: Manage company members
+title: Manage organization members
 linkTitle: Users
-description: Learn how to manage company members in the Docker Admin Console.
+description: Learn how to manage members in your company's organizations using the Docker Admin Console.
 keywords: company, company members, members, admin, Admin Console, member management, organization management, company management, bulk invite, resend invites
 aliases:
   - /admin/company/users/


### PR DESCRIPTION
## Description

The page at `content/manuals/admin/company/manage/users.md` had a misleading title and description that implied a "company member" concept exists in Docker's architecture. In reality, users are members of **organizations** — companies only contain organizations.

Changes:
- `title`: `Manage company members` → `Manage organization members`
- `description`: updated to clarify this page covers managing members in the company's organizations

## Related issues or tickets

Closes #24893

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review