### PR TITLE
docs: complete incomplete verification step in push.md

### DIFF
--- a/content/manuals/docker-hub/repos/manage/hub-images/push.md
+++ b/content/manuals/docker-hub/repos/manage/hub-images/push.md
@@ -42,3 +42,7 @@ images with others or use them in different environments.
    This command pushes the image tagged `v1.0` to the `my-namespace/my-repo` repository.
 
 3. Verify the image on Docker Hub.
+
+   Sign in to [Docker Hub](https://hub.docker.com) and navigate to your
+   repository (`my-namespace/my-repo` in this example). Select the **Tags**
+   tab to confirm that your tag (`v1.0` in this example) appears in the list.


### PR DESCRIPTION
## Description

Step 3 of the push guide listed "Verify the image on Docker Hub" with no instructions, leaving the workflow incomplete. Added a short prose explanation directing users to navigate to their repository's **Tags** tab on Docker Hub to confirm the push succeeded.

## Related issues or tickets

Closes #25004

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review