### PR TITLE
build(deps): pin docker/cagent-action back to v1.5.1

### DIFF
--- a/.github/workflows/nightly-docs-scan.yml
+++ b/.github/workflows/nightly-docs-scan.yml
@@ -66,7 +66,7 @@ jobs:
           echo "GITHUB_APP_TOKEN=$PAT" >> "$GITHUB_ENV"
 
       - name: Run documentation scan
-        uses: docker/cagent-action@2a43a3882401f45e3114df7f6d66eca184993a90 # latest
+        uses: docker/cagent-action@0498757af1c50b084f763d626f571918cf317509 # v1.5.1
         env:
           GH_TOKEN: ${{ env.GITHUB_APP_TOKEN || github.token }}
         with:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@2a43a3882401f45e3114df7f6d66eca184993a90 # v1.5.2
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@0498757af1c50b084f763d626f571918cf317509 # v1.5.1
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary

- Reverts `docker/cagent-action` from `v1.5.2` back to `v1.5.1` in both `pr-review.yml` and `nightly-docs-scan.yml`.
- `v1.5.2`'s `review-pr/action.yml` fails to parse with a YAML error at line 822:1 (`While parsing a block mapping, did not find expected key`), which breaks the PR review workflow.
- Root cause is an unindented multi-line `TIMEOUT_NOTE` bash assignment that prematurely terminates the `run: |` block scalar. Tracked upstream in docker/cagent-action#205.
- Reverts the dependabot bump from #25027 / #25028.

Once a fixed `v1.5.3` is released, dependabot will re-bump.

## Test plan

- [ ] PR review workflow can be triggered with `/review` on this PR without the YAML parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)