### PR TITLE
docker agent: drop experimental label

### DIFF
--- a/content/manuals/ai/docker-agent/_index.md
+++ b/content/manuals/ai/docker-agent/_index.md
@@ -8,13 +8,8 @@ aliases:
 params:
   sidebar:
     group: AI and agents
-    badge:
-      color: violet
-      text: Experimental
 keywords: [ai, agent, docker agent, cagent]
 ---
-
-{{< summary-bar feature_name="Docker Agent" >}}
 
 [Docker Agent](https://github.com/docker/docker-agent) is an open-source framework
 for building teams of specialized AI agents. Instead of prompting one

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -70,8 +70,6 @@ Buildx no default:
   requires: Docker Buildx [0.10.4](https://github.com/docker/buildx/releases/tag/v0.10.4) and later
 Cache backend API:
   availability: Experimental
-Docker Agent:
-  availability: Experimental
 Company:
   subscription: [Business]
   for: Administrators


### PR DESCRIPTION
## Summary

Docker Agent is no longer experimental. Removes the sidebar "Experimental" badge and the `summary-bar` shortcode call from the Docker Agent landing page.