### PR TITLE
ci: declare permissions on release-notes-pr workflows

### DIFF
--- a/.github/workflows/notify-release-notes-pr.yml
+++ b/.github/workflows/notify-release-notes-pr.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["Release Notes PR Trigger"]
     types: [completed]
 
+permissions:
+  contents: read
+  actions: read # download-artifact across runs needs actions:read
+
 jobs:
   notify:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-notes-pr-trigger.yml
+++ b/.github/workflows/release-notes-pr-trigger.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - content/manuals/desktop/release-notes.md
 
+permissions: {}
+
 jobs:
   trigger:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The two release-notes-PR workflows chain across runs (`Release Notes PR Trigger` uploads an artifact, `Notify Slack on Desktop Release Notes PR` downloads it). Neither writes to the repo via the workflow `GITHUB_TOKEN`:

- `.github/workflows/release-notes-pr-trigger.yml` -- `permissions: {}`. The single job builds a `pr-details.json` from event payload fields and uploads it via `actions/upload-artifact@v7`. In v4+ the upload doesn't require any explicit permissions.
- `.github/workflows/notify-release-notes-pr.yml` -- `permissions: contents: read, actions: read`. The job runs on `workflow_run`, fetches the `pr-details` artifact via `actions/download-artifact@v8` with `run-id` + `github-token` (cross-run download requires `actions: read`), then posts to Slack via `SLACK_BOT_TOKEN`. No GitHub API write.

The shape matches `pr-review-trigger.yml`, which already declares `permissions: {}`, and the workflow-level blocks in `build.yml`, `deploy.yml`, and `sync-cli-docs.yml`.

Third-party action exposure that motivates pinning: `slackapi/slack-github-action`, `actions/download-artifact`, `actions/upload-artifact`. Explicit scope keeps a hypothetical compromise (cf. `tj-actions/changed-files` CVE-2025-30066) contained to read.

No behavioural change. The artifact chain and Slack post continue to work identically.