### PR TITLE
engine/29.5.0 followups

### DIFF
--- a/_vendor/github.com/docker/cli/docs/extend/plugins_authorization.md
+++ b/_vendor/github.com/docker/cli/docs/extend/plugins_authorization.md
@@ -86,6 +86,31 @@ passed to the authorization plugins. For commands that return chunked HTTP
 response, such as `logs` and `events`, only the HTTP request is sent to the
 authorization plugins.
 
+### Response body size and partial buffering
+
+The internal buffer that holds the response body between the daemon's HTTP
+handler and the plugin's response authorization callback (`responseModifier`,
+defined in [`pkg/authorization/response.go`](https://github.com/moby/moby/blob/master/pkg/authorization/response.go))
+has a fixed capacity of 64 KiB (`maxBufferSize`).
+
+For most non-streaming endpoints the full response is buffered for plugin
+inspection regardless of total size, because Go's `encoding/json` encoder
+serializes the complete payload into a single underlying write. The
+streaming-response exclusion noted above (for example, `logs` and `events`)
+is the practical effect of this 64 KiB threshold combined with the
+`io.WriteFlusher` write pattern used by streaming handlers, where each write
+is immediately drained to the client and is therefore no longer available
+for plugin inspection by the time the handler returns.
+
+> [!NOTE]
+> Plugins that depend on `ResponseBody` inspection for redaction or
+> content-filtering should restrict their policies to endpoints whose
+> response is produced as a single write (typical of REST-style API
+> responses). For commands whose responses are streamed or are likely to
+> exceed the buffer through multiple writes, do not rely on `ResponseBody`
+> for security-relevant decisions; perform the filtering in a separate
+> layer in front of the daemon.
+
 During request/response processing, some authorization flows might
 need to do additional queries to the Docker daemon. To complete such flows,
 plugins can call the daemon API similar to a regular user. To enable these

--- a/_vendor/github.com/docker/cli/docs/reference/dockerd.md
+++ b/_vendor/github.com/docker/cli/docs/reference/dockerd.md
@@ -958,8 +958,6 @@ the `--cgroup-parent` option on the daemon.
 #### Daemon metrics
 
 The `--metrics-addr` option takes a TCP address to serve the metrics API.
-This feature is still experimental, therefore, the daemon must be running in experimental
-mode for this feature to work.
 
 To serve the metrics API on `localhost:9323` you would specify `--metrics-addr 127.0.0.1:9323`,
 allowing you to make requests on the API at `127.0.0.1:9323/metrics` to receive metrics in the

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby/api v1.54.2
 # github.com/moby/buildkit v0.30.0
 # github.com/docker/buildx v0.34.0
-# github.com/docker/cli v29.4.3+incompatible
+# github.com/docker/cli v29.5.0+incompatible
 # github.com/docker/compose/v5 v5.1.2
 # github.com/docker/model-runner v1.1.36

--- a/content/reference/api/engine/_index.md
+++ b/content/reference/api/engine/_index.md
@@ -148,6 +148,7 @@ to provide full compatibility, some functionality may not be available.
 
 | Docker version | Maximum API version                          | Minimum API version                          | Change log                                                         |
 |:---------------|:---------------------------------------------|:---------------------------------------------|:-------------------------------------------------------------------|
+| 29.5           | [1.54](/reference/api/engine/version/v1.54/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v154-api-changes) |
 | 29.4           | [1.54](/reference/api/engine/version/v1.54/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v154-api-changes) |
 | 29.3           | [1.54](/reference/api/engine/version/v1.54/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v154-api-changes) |
 | 29.2           | [1.53](/reference/api/engine/version/v1.53/) | [1.44](/reference/api/engine/version/v1.44/) | [changes](/reference/api/engine/version-history/#v153-api-changes) |

--- a/content/reference/api/engine/_index.md
+++ b/content/reference/api/engine/_index.md
@@ -73,21 +73,21 @@ support, use `docker version`:
 ```console
 $ docker version
 Client: Docker Engine - Community
- Version:           29.4.0
+ Version:           29.5.0
  API version:       1.54
- Go version:        go1.26.1
- Git commit:        9d7ad9f
- Built:             Tue Apr  7 08:34:32 2026
+ Go version:        go1.26.3
+ Git commit:        98f1464
+ Built:             Thu May 14 14:41:41 2026
  OS/Arch:           darwin/arm64
  Context:           desktop-linux
 
 Server: Docker Engine - Community
  Engine:
-  Version:          29.4.0
+  Version:          29.5.0
   API version:      1.54 (minimum version 1.40)
-  Go version:       go1.26.1
-  Git commit:       daa0cb7
-  Built:            Tue Apr  7 08:36:25 2026
+  Go version:       go1.26.3
+  Git commit:       ff8d90a
+  Built:            Thu May 14 14:41:41 2026
   OS/Arch:          linux/arm64
   ...
 ```

--- a/content/reference/api/engine/_index.md
+++ b/content/reference/api/engine/_index.md
@@ -178,11 +178,7 @@ to provide full compatibility, some functionality may not be available.
 
 API versions before v1.40 are deprecated and no longer supported by current
 versions of the Docker Engine and CLI. You can find archived documentation
-for deprecated versions of the API in the code repository on GitHub:
-
-- [Documentation for API versions 1.24–1.43](https://github.com/moby/moby/tree/28.x/docs/api).
-- [Documentation for API versions 1.18–1.23](https://github.com/moby/moby/tree/v25.0.0/docs/api).
-- [Documentation for API versions 1.17 and before](https://github.com/moby/moby/tree/v1.9.1/docs/reference/api).
+for deprecated versions [on GitHub](https://github.com/moby/moby/tree/master/api/docs).
 
 | Docker version | Maximum API version | Minimum API version | Change log                                                         |
 |:---------------|:--------------------|:--------------------|:-------------------------------------------------------------------|

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ go 1.26.0
 // Make sure to add an entry in the "tools" section when adding a new repository.
 require (
 	github.com/docker/buildx v0.34.0
-	github.com/docker/cli v29.4.3+incompatible
+	github.com/docker/cli v29.5.0+incompatible
 	github.com/docker/compose/v5 v5.1.2
 	github.com/docker/model-runner v1.1.36
 	github.com/moby/buildkit v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/docker/cli v29.4.0+incompatible h1:+IjXULMetlvWJiuSI0Nbor36lcJ5BTcVpU
 github.com/docker/cli v29.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v29.4.3+incompatible h1:u+UliYm2J/rYrIh2FqHQg32neRG8GjbvNuwQRTzGspU=
 github.com/docker/cli v29.4.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v29.5.0+incompatible h1:FPUvKJoKpeP4Njz8NrQdeUN8o247P7ndTiILtaP5/l4=
+github.com/docker/cli v29.5.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose/v5 v5.0.0 h1:J2uMCzJ/5xLcoIVVXvMmPe6HBzVQpmJThKa7Qk7Xldc=
 github.com/docker/compose/v5 v5.0.0/go.mod h1:BurapGv8zmYnsbSmlpCz5EU2Pi3YFV/PjeUnoFpcw64=
 github.com/docker/compose/v5 v5.0.1 h1:5yCjDJbwUqcuI+6WNFHNWz2/3vyBDsNnfe8LlFjyxEc=


### PR DESCRIPTION
- **vendor: github.com/docker/cli v29.5.0**
- **engine: add v29.5 to supported api versions matrix**
- **engine: update docker version example to v29.5.0**
- **engine: update documentation link for deprecated API versions**
