### PR TITLE
fix: update misleading Image Management description in hub-images index

### DIFF
--- a/content/manuals/docker-hub/repos/manage/hub-images/_index.md
+++ b/content/manuals/docker-hub/repos/manage/hub-images/_index.md
@@ -16,8 +16,8 @@ repositories, and supported software artifacts.
 - [Tags](./tags.md): Tags help you version and organize different iterations of
   your images within a single repository. This topic explains tagging and
   provides guidance on how to create, view, and delete tags in Docker Hub.
-- [Image Management](./manage.md): Manage your images and image indexes to
-  optimize your repository storage.
+- [Image Management](./manage.md): View, filter, and delete images and image
+  indexes in your repository.
 - [Software artifacts](./oci-artifacts.md): Docker Hub supports OCI (Open
   Container Initiative) artifacts, allowing you to store, manage, and distribute
   a range of content beyond standard Docker images, including Helm charts,


### PR DESCRIPTION
## Problem
The `_index.md` description for the Image Management link said:
> "Manage your images and image indexes to optimize your repository storage."

This is misleading — the actual page (`manage.md`) is about **viewing,
filtering, searching, and deleting** images and image indexes. Storage
optimization is not mentioned anywhere on that page.

## Fix
Updated the description to accurately reflect what the page does.

Fixes #25005