### PR TITLE
engine/security/rootless/troubleshoot: fix "Historical limitations"

### DIFF
--- a/content/manuals/engine/security/rootless/troubleshoot.md
+++ b/content/manuals/engine/security/rootless/troubleshoot.md
@@ -77,15 +77,18 @@ weight: 30
   - Exposing SCTP ports
 - To use the `ping` command, see [Routing ping packets](./tips.md#routing-ping-packets).
 - To expose privileged TCP/UDP ports (< 1024), see [Exposing privileged ports](./tips.md#exposing-privileged-ports).
+- `IPAddress` shown in `docker inspect` is namespaced inside RootlessKit's network namespace.
+  This means the IP address is not reachable from the host without `nsenter`-ing into the network namespace.
+- Port forwarding with `docker run -p` does not propagate source IP addresses by default.
+  See [`docker run -p` does not propagate source IP addresses](#docker-run--p-does-not-propagate-source-ip-addresses) to enable source IP propagation.
 - NFS mounts as the docker "data-root" is not supported. This limitation is not specific to rootless mode.
 
 ### Historical limitations
 
 #### Until Docker Engine v29.5
 
-- `IPAddress` shown in `docker inspect` is namespaced inside RootlessKit's network namespace.
-  This means the IP address is not reachable from the host without `nsenter`-ing into the network namespace.
-- Host network (`docker run --net=host`) is also namespaced inside RootlessKit.
+- Host network (`docker run --net=host`) was namespaced inside RootlessKit.
+  This meant that ports listened by containers with `--net=host` were not reachable from the real host network namespace.
 
 ## Troubleshooting
 
@@ -280,8 +283,8 @@ For details, see [Routing ping packets](./tips.md#routing-ping-packets).
 
 #### `IPAddress` shown in `docker inspect` is unreachable
 
-This was an expected behavior until Docker Engine v29.5, as the daemon was namespaced inside RootlessKit's
-network namespace. Use `docker run -p` instead, or upgrade to Docker Engine v29.5 or later.
+This is an expected behavior, as the daemon is namespaced inside RootlessKit's
+network namespace. Use `docker run -p` instead.
 
 #### `--net=host` doesn't listen ports on the host network namespace
 


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description

Fixed "Historical limitations".

"`IPAddress` shown in `docker inspect` is unreachable" is not a historical limitation and still holds true in Docker Engine v29.5 and later.

When I wrote this section, I probably confused the topic with the source IP address propagation issue with `docker run -p` which is fixed in Docker Engine v29.5. 🤦

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
Follow-up to:
- #24645
- 
## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review