### PR TITLE
build: clarify registry cache driver support

### DIFF
--- a/content/manuals/build/cache/backends/registry.md
+++ b/content/manuals/build/cache/backends/registry.md
@@ -18,8 +18,9 @@ everything that the inline cache can do, and more:
 - It works with other exporters for more flexibility, instead of only the
   `image` exporter.
 
-This cache storage backend is not supported with the default `docker` driver.
-To use this feature, create a new builder using a different driver. See
+This cache storage backend works with the default `docker` driver only when the
+[containerd image store](/manuals/desktop/features/containerd.md) is enabled. If
+the containerd image store isn't enabled, use a different driver. See
 [Build drivers](/manuals/build/builders/drivers/_index.md) for more information.
 
 ## Synopsis


### PR DESCRIPTION
## Summary

Clarify that the registry cache backend works with the default `docker` driver when the containerd image store is enabled, and direct users to another driver otherwise.

Closes #25019