### PR TITLE
Add documentation for `HTTP_AUTH_TOKEN_`/`HTTP_AUTH_HEADER_`.

### DIFF
--- a/content/manuals/build/building/secrets.md
+++ b/content/manuals/build/building/secrets.md
@@ -264,3 +264,13 @@ $ docker build \
   --secret id=GIT_AUTH_HEADER.gitlab.com,env=GITLAB_AUTH_HEADER \
   https://github.com/example/todo-app.git
 ```
+
+## HTTP authentication for `COPY` and `ADD`
+
+To use secrets in `COPY` or `ADD` commands, you can create
+`HTTP_AUTH_TOKEN_<host>` or `HTTP_AUTH_HEADER_<host>` secrets for use when
+accessing the specified host. For example `HTTP_AUTH_TOKEN_127.0.0.1=token` will
+make requests to `127.0.0.1` add a header `Authorization: Bearer token`.
+
+These variables follow the same convention as the [Git HTTP authentication
+scheme](#http-authentication-scheme) handling.


### PR DESCRIPTION
## Description

Add documentation for the special `HTTP_AUTH_TOKEN_<host>` and `HTTP_AUTH_HEADER_<host>` secrets that are supported by Buildkit.

I couldn't find any documentation of this feature anywhere, but stumbled across https://github.com/moby/buildkit/pull/6023 when trying to use secrets in a Dockerfile `COPY`, and found it solved our issue.

Absolutely no worries if this needs a tweak or anything, but I felt like it was worth documenting (as I was very surprised when I couldn't find this feature anywhere) :-)

Thanks :-) 