### PR TITLE
docs(sandboxes): document non-interactive sbx login with PAT

### DIFF
--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -123,20 +123,6 @@ option.
 > See the [FAQ](faq.md) for details on why sign-in is required and what
 > happens with your data.
 
-### Non-interactive login
-
-For CI environments and scripts where a browser is not available, use a
-Docker Personal Access Token (PAT) with `--username` and `--password-stdin`:
-
-```console
-$ echo "$DOCKER_PAT" | sbx login --username <your-docker-id> --password-stdin
-```
-
-`--password-stdin` reads the token from standard input to keep it out of
-your shell history. Generate a PAT from your
-[Docker account settings](https://app.docker.com/settings/personal-access-tokens)
-with at least **Read** scope.
-
 ## Authenticate your agent
 
 Agents need credentials for their model provider. How you provide them depends

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -123,6 +123,20 @@ option.
 > See the [FAQ](faq.md) for details on why sign-in is required and what
 > happens with your data.
 
+### Non-interactive login
+
+For CI environments and scripts where a browser is not available, use a
+Docker Personal Access Token (PAT) with `--username` and `--password-stdin`:
+
+```console
+$ echo "$DOCKER_PAT" | sbx login --username <your-docker-id> --password-stdin
+```
+
+`--password-stdin` reads the token from standard input to keep it out of
+your shell history. Generate a PAT from your
+[Docker account settings](https://app.docker.com/settings/personal-access-tokens)
+with at least **Read** scope.
+
 ## Authenticate your agent
 
 Agents need credentials for their model provider. How you provide them depends

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -35,6 +35,20 @@ $ sbx rm my-sandbox
 $ sbx run claude
 ```
 
+## Non-interactive login
+
+For CI environments and scripts where a browser is not available, use a
+Docker Personal Access Token (PAT) with `--username` and `--password-stdin`:
+
+```console
+$ echo "$DOCKER_PAT" | sbx login --username <your-docker-id> --password-stdin
+```
+
+`--password-stdin` reads the token from standard input to keep it out of
+your shell history. Generate a PAT from your
+[Docker account settings](https://app.docker.com/settings/personal-access-tokens)
+with at least **Read** scope.
+
 ## Interactive mode
 
 Running `sbx` with no subcommands opens an interactive terminal dashboard:


### PR DESCRIPTION
## Summary

Documents the non-interactive `sbx login` flow using `--username` and `--password-stdin` with a Docker Personal Access Token, intended for CI environments and scripts where a browser is unavailable. ~Also vendors the updated `sbx_login.yaml` CLI reference that adds these two flags.~ Moved vendoring to separate PR.

Generated by Claude Code