### PR TITLE
Add security release notes for CVE-2026-5817 and CVE-2026-5843

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -181,6 +181,10 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 - Fixed a bug where Kubernetes could fail to start on WSL 2 when `HTTP_PROXY` environment variables are set in WSL 2 itself.
 - Fixed a bug in Enhanced Container Isolation (ECI) that was causing loss of container `rootfs` persistence across Docker Desktop restarts, when using WSL.
 
+### Security
+
+- Addressed [CVE-2026-5843](https://www.cve.org/cverecord?id=CVE-2026-5843), container-to-host code execution in the Docker Model Runner MLX inference backend via MLX-LM `model_file` importlib loading.
+
 ## 4.70.0
 
 {{< release-date date="2026-04-20" >}}
@@ -301,6 +305,10 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 - Fixed an issue where the installer extraction did not update the progress bar and could take around 5 minutes, depending on the machine. Extraction is now ~60% faster and includes proper progress updates.
 - Fixed a race condition where container ports would sometimes not be published correctly after container start, affecting ephemeral ports, `--publish-all`, and gateway IP bindings.
 - Fixed an issue where a failed WSL distro move could leave the distro unregistered.
+
+### Security
+
+- Addressed [CVE-2026-5817](https://www.cve.org/cverecord?id=CVE-2026-5817), container-to-host code execution in the Docker Model Runner vllm-metal inference backend via unsandboxed `trust_remote_code` tokenizer loading.
 
 ## 4.67.0
 

--- a/content/manuals/security/security-announcements.md
+++ b/content/manuals/security/security-announcements.md
@@ -16,13 +16,13 @@ toc_max: 2
 
 A vulnerability in Docker Desktop was fixed on April 27 in the [4.71.0](/manuals/desktop/release-notes.md#4710) release:
 
-- Addressed [CVE-2026-5843](https://www.cve.org/cverecord?id=CVE-2026-5843), container-to-host code execution in the Docker Model Runner MLX inference backend via MLX-LM `model_file` importlib loading.
+- Addressed [CVE-2026-5843](https://www.cve.org/cverecord?id=CVE-2026-5843), container-to-host code execution in the Docker Model Runner MLX inference backend.
 
 ## Docker Desktop 4.68.0 security update: CVE-2026-5817
 
 A vulnerability in Docker Desktop was fixed on April 7 in the [4.68.0](/manuals/desktop/release-notes.md#4680) release:
 
-- Addressed [CVE-2026-5817](https://www.cve.org/cverecord?id=CVE-2026-5817), container-to-host code execution in the Docker Model Runner vllm-metal inference backend via unsandboxed `trust_remote_code` tokenizer loading.
+- Addressed [CVE-2026-5817](https://www.cve.org/cverecord?id=CVE-2026-5817), container-to-host code execution in the Docker Model Runner vllm-metal inference backend.
 
 ## Docker Desktop 4.67.0 security update: CVE-2026-33990
 

--- a/content/manuals/security/security-announcements.md
+++ b/content/manuals/security/security-announcements.md
@@ -12,6 +12,18 @@ toc_max: 2
 
 [Subscribe to security RSS feed](/security/security-announcements/index.xml)
 
+## Docker Desktop 4.71.0 security update: CVE-2026-5843
+
+A vulnerability in Docker Desktop was fixed on April 27 in the [4.71.0](/manuals/desktop/release-notes.md#4710) release:
+
+- Addressed [CVE-2026-5843](https://www.cve.org/cverecord?id=CVE-2026-5843), container-to-host code execution in the Docker Model Runner MLX inference backend via MLX-LM `model_file` importlib loading.
+
+## Docker Desktop 4.68.0 security update: CVE-2026-5817
+
+A vulnerability in Docker Desktop was fixed on April 7 in the [4.68.0](/manuals/desktop/release-notes.md#4680) release:
+
+- Addressed [CVE-2026-5817](https://www.cve.org/cverecord?id=CVE-2026-5817), container-to-host code execution in the Docker Model Runner vllm-metal inference backend via unsandboxed `trust_remote_code` tokenizer loading.
+
 ## Docker Desktop 4.67.0 security update: CVE-2026-33990
 
 A vulnerability in Docker Desktop was fixed on March 30 in the [4.67.0](/manuals/desktop/release-notes.md#4670) release:


### PR DESCRIPTION
## Summary

Adds Security subsections to Docker Desktop 4.68.0 and 4.71.0 release notes and corresponding entries in the security announcements page for two Docker Model Runner container-to-host code execution issues that have already shipped fixes.

- **CVE-2026-5817** — Docker Model Runner vllm-metal trust_remote_code RCE (fixed in DD 4.68.0, April 7)
- **CVE-2026-5843** — Docker Model Runner MLX-LM model_file importlib RCE (fixed in DD 4.71.0, April 27)

Mirrors the style of #24565 and #24207. Both fixed releases are already live, so this back-fills the Security sections required to reference from the corresponding CVE records.

## Test plan

- [ ] Verify Security subsection renders under DD 4.71.0 with link to CVE-2026-5843
- [ ] Verify Security subsection renders under DD 4.68.0 with link to CVE-2026-5817
- [ ] Verify two new entries appear at top of security-announcements.md
- [ ] Confirm CVE.org links resolve (currently will show RESERVED until CVE records are published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)