### PR TITLE
docs: fix Jenkins example comment and syntax in Scout environment guide

### DIFF
--- a/content/manuals/scout/integrations/environment/cli.md
+++ b/content/manuals/scout/integrations/environment/cli.md
@@ -113,7 +113,7 @@ stages:
 {{< tab name="Jenkins" >}}
 
 ```groovy
-stage('Analyze image') {
+stage('Record environment') {
     steps {
         // Install Docker Scout
         sh 'curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s -- -b /usr/local/bin'
@@ -121,8 +121,8 @@ stage('Analyze image') {
         // Log into Docker Hub
         sh 'echo $DOCKER_SCOUT_HUB_PASSWORD | docker login -u $DOCKER_SCOUT_HUB_USER --password-stdin'
 
-        // Analyze and fail on critical or high vulnerabilities
-        sh 'docker-scout environment --org "<MY_DOCKER_ORG>" "<ENVIRONMENT>" $IMAGE_TAG
+        // Record image to environment
+        sh 'docker-scout environment --org "<MY_DOCKER_ORG>" "<ENVIRONMENT>" $IMAGE_TAG'
     }
 }
 ```


### PR DESCRIPTION
## Description

Fixed an incorrect comment and a minor syntax error in the Jenkins example within the Docker Scout environment integration guide (`content/manuals/scout/integrations/environment/cli.md`). 

The comment stated that the command would "Analyze and fail on critical or high vulnerabilities," but the accompanying command was actually `docker-scout environment`, which records an image to an environment rather than analyzing it. 

**Changes made:**
- Updated the stage name to `Record environment`
- Corrected the comment to `// Record image to environment`
- Fixed a missing closing single quote (`'`) at the end of the `$IMAGE_TAG` string to prevent pipeline syntax errors.

## Related issues or tickets

Fixes #25083

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review