### PR TITLE
Link sandbox prerequisites from overview

### DIFF
--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -25,6 +25,9 @@ developer's machine. Available on a separate paid subscription.
 
 ## Get started
 
+For complete system requirements, see the
+[get started prerequisites](get-started.md#prerequisites).
+
 Install the `sbx` CLI and sign in:
 
 {{< tabs >}}


### PR DESCRIPTION
## Summary

The Sandboxes overview showed quick install commands without pointing to the full platform prerequisites. Add a prerequisite link before the quick install tabs so it applies to all installation methods.

Closes #25056

Generated by Codex