### PR TITLE
Fix restricted shortcode rendering on unassociated machines page

### DIFF
--- a/content/manuals/unassociated-machines/_index.md
+++ b/content/manuals/unassociated-machines/_index.md
@@ -10,10 +10,10 @@ params:
     group: Enterprise
 ---
 
-{{% restricted title="About unassociated machines" %}}
+{{< restricted title="About unassociated machines" >}}
 Unassociated machines is a private feature that may not be available to all
 accounts.
-{{% /restricted %}}
+{{< /restricted >}}
 
 Docker administrators can identify, view, and manage Docker Desktop machines
 that are likely associated with their organization but aren't currently linked


### PR DESCRIPTION
## Description

The restricted shortcode on the [unassociated machines page](https://docs.docker.com/unassociated-machines/) renders with a visible `</span>` tag due to using `{{% %}}` (markdown) delimiters instead of `{{< >}}` (HTML) delimiters.

The `{{% %}}` delimiter causes Hugo to process the shortcode's HTML output through the markdown renderer, which escapes the HTML tags from the icon partial.

## Fix

Switch from `{{% restricted %}}` to `{{< restricted >}}` delimiters.

This matches the pattern used by the similar `experimental` shortcode in other content files (e.g., `layouts/cli.html`).

## Testing

Before (Prod) | After (Preview)
--- | ---
<img width="1082" height="649" alt="image" src="https://github.com/user-attachments/assets/6713bf13-ebb0-46c2-8772-247b62afbc6a" /> | <img width="1075" height="500" alt="image" src="https://github.com/user-attachments/assets/250933a7-7701-4d3e-aae9-6b3732321edb" />


