### PR TITLE
Style cleanup: add missing keywords and remove bold-for-emphasis

### DIFF
--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -53,6 +53,7 @@ Crowdstrike
 datacenter
 datasource
 Datadog
+DBeaver
 Ddosify
 Debootstrap
 denylist

--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -42,6 +42,7 @@ classpath
 cli
 CLI
 CloudFront
+composable
 Codefresh
 Codespaces
 config

--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -2,6 +2,7 @@
 title: Docker guides
 linkTitle: Guides
 description: Explore the Docker guides
+keywords: docker, guides, tutorials, learning paths, getting started
 params:
   icon: book-open
 layout: landing

--- a/content/guides/admin-set-up/_index.md
+++ b/content/guides/admin-set-up/_index.md
@@ -3,6 +3,7 @@ title: Set up your company for success with Docker
 linkTitle: Admin set up
 summary: Get the most out of Docker by streamlining workflows, standardizing development environments, and ensuring smooth deployments across your company.
 description: Learn how to onboard your company and take advantage of all of the Docker products and features.
+keywords: admin, onboarding, deployment, organization setup, docker business, rollout
 tags: [admin]
 params:
   time: 20 minutes

--- a/content/guides/admin-set-up/comms-and-info-gathering.md
+++ b/content/guides/admin-set-up/comms-and-info-gathering.md
@@ -1,6 +1,7 @@
 ---
 title: Communication and information gathering
 description: Gather your company's requirements from key stakeholders and communicate to your developers.
+keywords: admin, onboarding, stakeholders, communication, mdm, requirements
 weight: 10
 ---
 

--- a/content/guides/admin-set-up/deploy.md
+++ b/content/guides/admin-set-up/deploy.md
@@ -1,6 +1,7 @@
 ---
 title: Deploy your Docker setup
 description: Deploy your Docker setup across your company.
+keywords: admin, onboarding, deployment, sso, rollout, organization
 weight: 40
 ---
 

--- a/content/guides/admin-set-up/finalize-plans-and-setup.md
+++ b/content/guides/admin-set-up/finalize-plans-and-setup.md
@@ -1,6 +1,7 @@
 ---
 title: Finalize plans and begin setup
 description: Collaborate with your MDM team to distribute configurations and set up SSO and Docker product trials.
+keywords: admin, onboarding, mdm, settings management, sso, configuration
 weight: 20
 ---
 

--- a/content/guides/admin-set-up/testing.md
+++ b/content/guides/admin-set-up/testing.md
@@ -1,6 +1,7 @@
 ---
 title: Testing
 description: Test your Docker setup.
+keywords: admin, onboarding, testing, sso, scim, verification
 weight: 30
 ---
 

--- a/content/guides/admin-user-management/_index.md
+++ b/content/guides/admin-user-management/_index.md
@@ -2,6 +2,7 @@
 title: Mastering user and access management
 summary: Simplify user access while ensuring security and efficiency in Docker.
 description: A guide for managing roles, provisioning users, and optimizing Docker access with tools like SSO and activity logs.
+keywords: admin, user management, roles, permissions, sso, provisioning, access control
 tags: [admin]
 params:
   featured: false

--- a/content/guides/angular/configure-github-actions.md
+++ b/content/guides/angular/configure-github-actions.md
@@ -31,7 +31,7 @@ In this section, you'll set up a CI/CD pipeline using [GitHub Actions](https://d
 
 To enable GitHub Actions to build and push Docker images, you’ll securely store your Docker Hub credentials in your new GitHub repository.
 
-### Step 1: Generate Docker Hub Credentials and Set GitHub Secrets"
+### Step 1: Generate Docker Hub credentials and set GitHub secrets
 
 1. Create a Personal Access Token (PAT) from [Docker Hub](https://hub.docker.com)
    1. Go to your **Docker Hub account → Account Settings → Security**.

--- a/content/guides/angular/configure-github-actions.md
+++ b/content/guides/angular/configure-github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Automate your builds with GitHub Actions
-linkTitle: Automate your builds with GitHub Actions
+linkTitle: GitHub Actions CI
 weight: 60
 keywords: CI/CD, GitHub( Actions), Angular
 description: Learn how to configure CI/CD using GitHub Actions for your Angular application.

--- a/content/guides/angular/deploy.md
+++ b/content/guides/angular/deploy.md
@@ -118,7 +118,7 @@ If everything is configured properly, you’ll see confirmation that both the De
    
 This confirms that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
-### Step 2. Check the Deployment status
+### Step 2. Check the deployment status
 
 Run the following command to check the status of your deployment:
    
@@ -135,7 +135,7 @@ You should see output similar to the following:
 
 This confirms that your pod is up and running with one replica available.
 
-### Step 3. Verify the Service exposure
+### Step 3. Verify the service exposure
 
 Check if the NodePort service is exposing your app to your local machine:
 

--- a/content/guides/angular/develop.md
+++ b/content/guides/angular/develop.md
@@ -24,7 +24,7 @@ You’ll learn how to:
 
 ---
 
-## Automatically update services (Development Mode)
+## Automatically update services (development mode)
 
 Use Compose Watch to automatically sync source file changes into your containerized development environment. This provides a seamless, efficient development experience without restarting or rebuilding containers manually.
 

--- a/content/guides/azure-pipelines.md
+++ b/content/guides/azure-pipelines.md
@@ -3,6 +3,7 @@ title: Introduction to Azure Pipelines with Docker
 linkTitle: Azure Pipelines and Docker
 summary: |
   Learn how to automate Docker image build and push using Azure Pipelines.
+keywords: azure pipelines, azure devops, ci/cd, docker hub, build and push, automation
 params:
   tags: [devops]
   time: 10 minutes

--- a/content/guides/bake/index.md
+++ b/content/guides/bake/index.md
@@ -88,7 +88,7 @@ line. Here's a quick summary of the options for the `default` target:
 
 - `platforms`: Platform variants to build.
 
-To execute this build, simply run the following command in the root of the
+To execute this build, run the following command in the root of the
 repository:
 
 ```console
@@ -186,7 +186,7 @@ And in the Dockerfile, add the build stage. This stage will use the official
 > [!TIP]
 > Because this stage relies on executing an external dependency, it's generally
 > a good idea to define the version you want to use as a build argument. This
-> lets you more easily manage version upgrades in the future by collocating
+> lets you manage version upgrades in the future by collocating
 > dependency versions to the beginning of the Dockerfile.
 
 ```dockerfile {hl_lines=[2,"6-8"]}
@@ -267,7 +267,7 @@ matrix variable.
 ```
 
 You'll also want to change how the image tags are assigned to these builds.
-Currently, both matrix paths would generate the same image tag names, and
+As written, both matrix paths would generate the same image tag names, and
 overwrite each other. Update the `tags` attribute use a conditional operator to
 set the tag depending on the matrix variable value.
 
@@ -498,7 +498,7 @@ build/
 Docker Buildx Bake streamlines complex build workflows, enabling efficient
 multi-platform builds, testing, and artifact export. By integrating Buildx Bake
 into your projects, you can simplify your Docker builds, make your build
-configuration portable, and wrangle complex configurations more easily.
+configuration portable, and wrangle complex configurations.
 
 Experiment with different configurations and extend your Bake files to suit
 your project's needs. You might consider integrating Bake into your CI/CD

--- a/content/guides/bake/index.md
+++ b/content/guides/bake/index.md
@@ -5,6 +5,7 @@ description: >
   Learn how to manage simple and complex build configurations with Buildx Bake.
 summary: >
   Learn to automate Docker builds and testing with declarative configurations using Buildx Bake.
+keywords: bake, buildx, multi-platform, build configuration, hcl, automation
 tags: [devops]
 languages: [go]
 params:

--- a/content/guides/compose-bake/index.md
+++ b/content/guides/compose-bake/index.md
@@ -3,6 +3,7 @@ title: Building Compose projects with Bake
 description: Learn how to build Docker Compose projects with Docker Buildx Bake
 summary: |
   This guide demonstrates how you can use Bake to build production-grade images for Docker Compose projects.
+keywords: docker compose, bake, buildx, multi-service, production builds, build configuration
 languages: []
 tags: [devops]
 params:

--- a/content/guides/container-supported-development.md
+++ b/content/guides/container-supported-development.md
@@ -5,6 +5,7 @@ summary: |
   Containers don't have to be just for your app. Learn how to run your app's dependent services and other debugging tools to enhance your development environment.
 description: |
   Use containers in your local development loop to develop and test faster… even if your main app isn't running in containers.
+keywords: containers, local development, dependent services, testing, debugging, development environment
 tags: [app-dev]
 params:
   image: images/learning-paths/container-supported-development.png
@@ -31,7 +32,6 @@ And best of all, you can have these benefits regardless of whether the main app 
 - Teams that want to reduce the complexity and costs associated with using cloud services directly during development
 - Developers that want to make it easier to visualize what's going on in their databases, queues, etc.
 - Teams that want to reduce the complexity of setting up their development environment without impacting the development of the app itself
-
 
 ## Tools integration
 
@@ -69,7 +69,7 @@ This demo will demonstrate how using WireMock can make it easy to develop and te
 
 ### Demo: developing the cloud locally
 
-When developing apps, it's often easier to outsource aspects of the application to cloud services, such as Amazon S3. However, connecting to those services in local development introduces IAM policies, networking constraints, and provisioning complications. While these requirements are important in a production setting, they complicate development environments significantly. 
+When developing apps, it's often easier to outsource aspects of the application to cloud services, such as Amazon S3. However, connecting to those services in local development introduces IAM policies, networking constraints, and provisioning complications. While these requirements are important in a production setting, they complicate development environments significantly.
 
 With container-supported development, you can run local instances of these services during development and testing, removing the need for complex setups. In this demo, you'll see how LocalStack makes it easy to develop and test applications entirely from the developer's workstation.
 

--- a/content/guides/container-supported-development.md
+++ b/content/guides/container-supported-development.md
@@ -1,6 +1,6 @@
 ---
 title: "Faster development and testing with container-supported development"
-linkTitle: Container-supported development
+linkTitle: Container-supported dev
 summary: |
   Containers don't have to be just for your app. Learn how to run your app's dependent services and other debugging tools to enhance your development environment.
 description: |

--- a/content/guides/cpp/containerize.md
+++ b/content/guides/cpp/containerize.md
@@ -1,6 +1,6 @@
 ---
 title: Containerize a C++ application
-linkTitle: Build and run a C++ application using Docker Compose
+linkTitle: Containerize
 weight: 10
 keywords: C++, containerize, initialize
 description: Learn how to use Docker Compose to build and run a C++ application.

--- a/content/guides/cpp/multistage.md
+++ b/content/guides/cpp/multistage.md
@@ -1,6 +1,6 @@
 ---
 title: Create a multi-stage build for your C++ application
-linkTitle: Containerize your app using a multi-stage build
+linkTitle: Multi-stage build
 weight: 5
 keywords: C++, containerize, multi-stage
 description: Learn how to create a multi-stage build for a C++ application.

--- a/content/guides/databases.md
+++ b/content/guides/databases.md
@@ -236,7 +236,7 @@ To run a container using the GUI:
 
 6. Select `Run`.
 7. In the **Containers** view, verify that the port is mapped under the
-   **Port(s)** column. You should see **3307:3306** for the **my-mysql**
+   **Port(s)** column. You should see `3307:3306` for the `my-mysql`
    container.
 
 {{< /tab >}}

--- a/content/guides/dex.md
+++ b/content/guides/dex.md
@@ -27,7 +27,7 @@ The official [Docker image for Dex](https://hub.docker.com/r/dexidp/dex/) provid
 
 [Docker Compose](/compose/): Recommended for managing multi-container Docker applications.
 
-### Setting Up Dex with Docker
+### Setting up Dex with Docker
 
 Begin by creating a directory for your Dex project:
 

--- a/content/guides/dhi-from-doi.md
+++ b/content/guides/dhi-from-doi.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate to DHI from Docker Official Images
 summary: Step-by-step guide to migrate from Docker Official Images to Docker Hardened Images
+keywords: docker hardened images, dhi, docker official images, migration, secure images
 type: redirect
 target: /dhi/migration/migrate-from-doi/
 tags: [dhi]

--- a/content/guides/dhi-from-wolfi.md
+++ b/content/guides/dhi-from-wolfi.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate to DHI from Wolfi
 summary: Step-by-step guide to migrate from Wolfi to Docker Hardened Images
+keywords: docker hardened images, dhi, wolfi, migration, secure images, distroless
 type: redirect
 target: /dhi/migration/migrate-from-wolfi/
 tags: [dhi]

--- a/content/guides/dhi-go-example.md
+++ b/content/guides/dhi-go-example.md
@@ -2,6 +2,7 @@
 title: Migrate a Go app to DHI
 summary: |
   Example showing how to migrate a Go application to Docker Hardened Images
+keywords: docker hardened images, dhi, go, golang, migration, secure images
 type: redirect
 target: /dhi/migration/examples/go/
 tags: [dhi]

--- a/content/guides/dhi-nodejs-example.md
+++ b/content/guides/dhi-nodejs-example.md
@@ -3,6 +3,7 @@ title: Migrate a Node.js app to DHI
 summary: |
   Example showing how to migrate a Node.js application to Docker Hardened
   Images
+keywords: docker hardened images, dhi, node.js, nodejs, migration, secure images
 type: redirect
 target: /dhi/migration/examples/node/
 tags: [dhi]

--- a/content/guides/dhi-python-example.md
+++ b/content/guides/dhi-python-example.md
@@ -2,6 +2,7 @@
 title: Migrate a Python app to DHI
 summary: |
   Example showing how to migrate a Python application to Docker Hardened Images
+keywords: docker hardened images, dhi, python, migration, secure images
 type: redirect
 target: /dhi/migration/examples/python/
 tags: [dhi]

--- a/content/guides/docker-build-cloud/_index.md
+++ b/content/guides/docker-build-cloud/_index.md
@@ -7,6 +7,7 @@ description: |
 summary: |
   Build applications up to 39x faster using cloud-based resources, shared team
   cache, and native multi-architecture support.
+keywords: docker build cloud, cloud builds, multi-architecture, shared cache, ci/cd, build performance
 tags: [product-demo]
 aliases:
   - /learning-paths/docker-build-cloud/

--- a/content/guides/docker-build-cloud/ci.md
+++ b/content/guides/docker-build-cloud/ci.md
@@ -1,11 +1,12 @@
 ---
 title: "Demo: Using Docker Build Cloud in CI"
 description: Learn how to use Docker Build Cloud to build your app faster in CI.
+keywords: docker build cloud, ci/cd, github actions, cloud builds, build performance
 weight: 30
 ---
 
 Docker Build Cloud can significantly decrease the time it takes for your CI builds
-take to run, saving you time and money. 
+take to run, saving you time and money.
 
 Since the builds run remotely, your CI runner can still use the Docker tooling CLI
 without needing elevated permissions, making your builds more secure by default.

--- a/content/guides/docker-build-cloud/common-questions.md
+++ b/content/guides/docker-build-cloud/common-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Common challenges and questions
 description: Explore common challenges and questions related to Docker Build Cloud.
+keywords: docker build cloud, faq, troubleshooting, cloud builds, pricing
 weight: 40
 ---
 

--- a/content/guides/docker-build-cloud/dev.md
+++ b/content/guides/docker-build-cloud/dev.md
@@ -1,6 +1,7 @@
 ---
 title: "Demo: set up and use Docker Build Cloud in development"
 description: Learn how to use Docker Build Cloud for local builds.
+keywords: docker build cloud, local development, cloud builds, multi-platform, build performance
 weight: 20
 ---
 

--- a/content/guides/docker-build-cloud/why.md
+++ b/content/guides/docker-build-cloud/why.md
@@ -1,6 +1,7 @@
 ---
 title: Why Docker Build Cloud?
 description: Learn how Docker Build Cloud makes your builds faster.
+keywords: docker build cloud, cloud builds, shared cache, multi-architecture, build performance
 weight: 10
 ---
 

--- a/content/guides/docker-compose/_index.md
+++ b/content/guides/docker-compose/_index.md
@@ -5,6 +5,7 @@ summary: |
   Simplify the process of defining, configuring, and running multi-container
   Docker applications.
 description: Learn how to use Docker Compose to define and run multi-container Docker applications.
+keywords: docker compose, multi-container, compose file, services, orchestration, yaml
 tags: [product-demo]
 aliases:
   - /learning-paths/docker-compose/

--- a/content/guides/docker-compose/common-questions.md
+++ b/content/guides/docker-compose/common-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Common challenges and questions
 description: Explore common challenges and questions related to Docker Compose.
+keywords: docker compose, faq, troubleshooting, environments, multi-container
 weight: 30
 ---
 

--- a/content/guides/docker-compose/setup.md
+++ b/content/guides/docker-compose/setup.md
@@ -1,6 +1,7 @@
 ---
 title: "Demo: set up and use Docker Compose"
 description: Learn how to get started with Docker Compose.
+keywords: docker compose, getting started, multi-container, demo, orchestration
 weight: 20
 ---
 

--- a/content/guides/docker-compose/why.md
+++ b/content/guides/docker-compose/why.md
@@ -1,6 +1,7 @@
 ---
 title: Why Docker Compose?
 description: Learn how Docker Compose can help you simplify app development.
+keywords: docker compose, multi-container, yaml, services, orchestration, application
 weight: 10
 ---
 

--- a/content/guides/docker-scout/_index.md
+++ b/content/guides/docker-scout/_index.md
@@ -8,6 +8,7 @@ description: |
   Learn how to use Docker Scout to enhance container security by automating
   vulnerability detection and remediation, ensuring compliance, and protecting
   your development workflow.
+keywords: docker scout, container security, vulnerability scanning, sbom, supply chain, remediation
 tags: [product-demo]
 aliases:
   - /learning-paths/docker-scout/

--- a/content/guides/docker-scout/common-questions.md
+++ b/content/guides/docker-scout/common-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Common challenges and questions
 description: Explore common challenges and questions related to Docker Scout.
+keywords: docker scout, faq, container security, vulnerability scanning, troubleshooting
 ---
 
 <!-- vale Docker.HeadingLength = NO -->

--- a/content/guides/docker-scout/demo.md
+++ b/content/guides/docker-scout/demo.md
@@ -2,6 +2,7 @@
 title: Docker Scout demo
 linkTitle: Demo
 description: Learn about Docker Scout's powerful features for enhanced supply chain security.
+keywords: docker scout, demo, supply chain, vulnerability scanning, container security
 weight: 20
 ---
 

--- a/content/guides/docker-scout/why.md
+++ b/content/guides/docker-scout/why.md
@@ -1,6 +1,7 @@
 ---
 title: Why Docker Scout?
 description: Learn how Docker Scout can help you secure your supply chain.
+keywords: docker scout, supply chain security, vulnerability detection, sbom, container security
 weight: 10
 ---
 

--- a/content/guides/frameworks/laravel/_index.md
+++ b/content/guides/frameworks/laravel/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Develop and Deploy Laravel applications with Docker Compose
-linkTitle: Laravel applications with Docker Compose
+linkTitle: Laravel
 summary: Learn how to efficiently set up Laravel development and production environments using Docker Compose.
 description: A guide on using Docker Compose to manage Laravel applications for development and production, covering container configurations and service management.
 keywords: laravel, php, docker compose, web framework, development, production

--- a/content/guides/frameworks/laravel/_index.md
+++ b/content/guides/frameworks/laravel/_index.md
@@ -3,6 +3,7 @@ title: Develop and Deploy Laravel applications with Docker Compose
 linkTitle: Laravel applications with Docker Compose
 summary: Learn how to efficiently set up Laravel development and production environments using Docker Compose.
 description: A guide on using Docker Compose to manage Laravel applications for development and production, covering container configurations and service management.
+keywords: laravel, php, docker compose, web framework, development, production
 tags: [frameworks]
 languages: [php]
 aliases:

--- a/content/guides/frameworks/laravel/common-questions.md
+++ b/content/guides/frameworks/laravel/common-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Common Questions on Using Laravel with Docker
 description: Find answers to common questions about setting up and managing Laravel environments with Docker Compose, including troubleshooting and best practices.
+keywords: laravel, php, docker compose, faq, troubleshooting, best practices
 weight: 40
 ---
 

--- a/content/guides/frameworks/laravel/development-setup.md
+++ b/content/guides/frameworks/laravel/development-setup.md
@@ -1,6 +1,7 @@
 ---
 title: Laravel Development Setup with Docker Compose
 description: Set up a Laravel development environment using Docker Compose.
+keywords: laravel, php, docker compose, development, xdebug, php-fpm, nginx
 weight: 30
 ---
 

--- a/content/guides/frameworks/laravel/development-setup.md
+++ b/content/guides/frameworks/laravel/development-setup.md
@@ -210,7 +210,7 @@ CMD ["bash"]
 > [!NOTE]
 > If you prefer a **one-service-per-container** approach, simply omit the workspace container and run separate containers for each task. For example, you could use a dedicated `php-cli` container for your PHP scripts, and a `node` container to handle the asset building.
 
-## Create a Docker Compose Configuration for development
+## Create a Docker Compose configuration for development
 
 Here's the `compose.yaml` file to set up the development environment:
 

--- a/content/guides/frameworks/laravel/prerequisites.md
+++ b/content/guides/frameworks/laravel/prerequisites.md
@@ -1,6 +1,7 @@
 ---
 title: Prerequisites for Setting Up Laravel with Docker Compose
 description: Ensure you have the required tools and knowledge before setting up Laravel with Docker Compose.
+keywords: laravel, php, docker compose, prerequisites, requirements, setup
 weight: 10
 ---
 

--- a/content/guides/frameworks/laravel/production-setup.md
+++ b/content/guides/frameworks/laravel/production-setup.md
@@ -1,6 +1,7 @@
 ---
 title: Laravel Production Setup with Docker Compose
 description: Set up a production-ready environment for Laravel using Docker Compose.
+keywords: laravel, php, docker compose, production, deployment, php-fpm
 weight: 20
 ---
 

--- a/content/guides/genai-claude-code-mcp/claude-code-mcp-guide.md
+++ b/content/guides/genai-claude-code-mcp/claude-code-mcp-guide.md
@@ -30,13 +30,13 @@ In this guide, you’ll learn how to:
 ## Use Claude Code and Docker MCP Toolkit to generate a Docker Compose file from natural language
 
 
-- **Setup**: Enable MCP Toolkit → Add Docker Hub MCP server → Connect Claude Code  
-- **Use Claude**: Describe your stack in plain English  
-- **Automate**: Claude queries Docker Hub via MCP and builds a complete `docker-compose.yaml`  
-- **Deploy**: Run `docker compose up` → Node.js + PostgreSQL live on `localhost:3000`  
-- **Benefit**: Zero YAML authoring. Zero image searching. Describe once → Claude builds it.
+- Setup: Enable MCP Toolkit → Add Docker Hub MCP server → Connect Claude Code  
+- Use Claude: Describe your stack in plain English  
+- Automate: Claude queries Docker Hub via MCP and builds a complete `docker-compose.yaml`  
+- Deploy: Run `docker compose up` → Node.js + PostgreSQL live on `localhost:3000`  
+- Benefit: Zero YAML authoring. Zero image searching. Describe once → Claude builds it.
 
-**Estimated time**: ~15 minutes
+Estimated time: ~15 minutes
 
 ---
 
@@ -46,7 +46,7 @@ The goal is simple: use Claude Code together with the Docker MCP Toolkit to sear
 
 The Model Context Protocol (MCP) bridges Claude Code and Docker Desktop, giving Claude real-time access to Docker's tools. Instead of context-switching between Docker, terminal commands, and YAML editors, you describe your requirements once and Claude handles the infrastructure details.
 
-**Why this matters:** This pattern scales to complex multi-service setups, database migrations, networking, security policies — all through conversational prompts.
+Why this matters: This pattern scales to complex multi-service setups, database migrations, networking, security policies — all through conversational prompts.
 
 ---
 
@@ -63,7 +63,7 @@ Make sure you have:
 
 ## 3. Install the Docker Hub MCP server
 
-1. Open **Docker Desktop**  
+1. Open Docker Desktop  
 1. Select **MCP Toolkit**  
 1. Go to the **Catalog** tab  
 1. Search for **Docker Hub**  
@@ -90,7 +90,7 @@ You can connect from Docker Desktop or using the CLI.
 
 1. Open **MCP Toolkit**  
 1. Go to the **Clients** tab  
-1. Locate **Claude Code**  
+1. Locate Claude Code  
 1. Select **Connect**
 
 ![Docker Connection](./Images/docker-connect-claude.avif)
@@ -292,6 +292,6 @@ The future of development is not about switching between tools. It is about tool
 
 ## Learn more
 
-- **[Explore the MCP Catalog](https://hub.docker.com/mcp):** Discover containerized, security-hardened MCP servers  
-- **[Get started with MCP Toolkit in Docker Desktop](https://hub.docker.com/open-desktop?url=https://open.docker.com/dashboard/mcp):** Requires version 4.48 or newer to launch automatically  
-- **[Read the MCP Horror Stories series](https://www.docker.com/blog/mcp-horror-stories-the-supply-chain-attack/):** Learn about common MCP security pitfalls and how to avoid them  
+- [Explore the MCP Catalog](https://hub.docker.com/mcp): Discover containerized, security-hardened MCP servers  
+- [Get started with MCP Toolkit in Docker Desktop](https://hub.docker.com/open-desktop?url=https://open.docker.com/dashboard/mcp): Requires version 4.48 or newer to launch automatically  
+- [Read the MCP Horror Stories series](https://www.docker.com/blog/mcp-horror-stories-the-supply-chain-attack/): Learn about common MCP security pitfalls and how to avoid them  

--- a/content/guides/genai-leveraging-rag/index.md
+++ b/content/guides/genai-leveraging-rag/index.md
@@ -35,7 +35,7 @@ The system operates as follows:
 2. These patterns help find matching information in a database
 3. The LLM generates responses that blend the model's inherent knowledge with the this extra information.
 
-To hold this vector information in an efficient manner, we need a special type of database.
+To hold this vector information in an efficient manner, you need a special type of database.
 
 ## Introduction to Graph databases
 
@@ -110,7 +110,7 @@ The first startup may take some time because the system needs to download a larg
 
 ### Monitoring progress
 
-We can monitor the download and initialization progress by viewing the logs. Run the following command to view the logs:
+You can monitor the download and initialization progress by viewing the logs. Run the following command to view the logs:
 
 ```bash
 docker compose logs
@@ -128,9 +128,9 @@ Wait for specific lines in the logs indicating that the download is complete and
 
 You can now access the interface at [http://localhost:8501/](http://localhost:8501/) to ask questions. For example, you can try the sample question:
 
-When we see those lines in the logs, web apps are ready to be used.
+When those lines appear in the logs, the web apps are ready to use.
 
-Since our goal is to teach AI about things it does not yet know, we begin by asking it a simple question about Nifi at
+Since the goal is to teach AI about things it does not yet know, begin by asking it a simple question about Nifi at
 [http://localhost:8501/](http://localhost:8501/).
 ![alt text](image.png)
 
@@ -140,13 +140,13 @@ RAG: Disabled
 Hello! I'm here to help you with your question about Apache NiFi. Unfortunately, I don't know the answer to that question. I'm just an AI and my knowledge cutoff is December 2022, so I may not be familiar with the latest technologies or software. Can you please provide more context or details about Apache NiFi? Maybe there's something I can help you with related to it.
 ```
 
-As we can see, AI does not know anything about this subject because it did not exist during the time of its training, also known as the information cutoff point.
+As shown, the AI does not know anything about this subject because it did not exist during the time of its training, also known as the information cutoff point.
 
 Now it's time to teach the AI some new tricks. First, connect to [http://localhost:8502/](http://localhost:8502/). Instead of using the "neo4j" tag, change it to the "apache-nifi" tag, then select the **Import** button.
 
 ![alt text](image-1.png)
 
-After the import is successful, we can access Neo4j to verify the data.
+After the import is successful, you can access Neo4j to verify the data.
 
 After logging in to [http://localhost:7474/](http://localhost:7474/) using the credentials from the `.env` file, you can run queries on Neo4j. Using the Neo4j Cypher query language, you can check for the data stored in the database.
 
@@ -162,7 +162,7 @@ To execute this query, write in the box on the top and select the blue run butto
 
 ![alt text](image-2.png)
 
-Results will appear below. What we are seeing here is the information system downloaded from Stack Overflow and saved in the graph database. RAG will utilize this information to enhance its responses.
+Results will appear below. The information shown is downloaded from Stack Overflow and saved in the graph database. RAG will utilize this information to enhance its responses.
 
 You can also run the following query to visualize the data:
 
@@ -176,7 +176,7 @@ To check the relationships in the database, run the following query:
 CALL db.relationshipTypes()
 ```
 
-Now, we are ready to enable our LLM to use this information. Go back to [http://localhost:8501/](http://localhost:8501/), enable the **RAG** checkbox, and ask the same question again. The LLM will now provide a more detailed answer.
+You're ready to enable the LLM to use this information. Go back to [http://localhost:8501/](http://localhost:8501/), enable the **RAG** checkbox, and ask the same question again. The LLM will provide a more detailed answer.
 
 ![alt text](image-3.png)
 
@@ -209,7 +209,7 @@ For optimal results, choose a tag that the LLM is not familiar with.
 
 ### When to leverage RAG for optimal results
 
-Retrieval-Augmented Generation (RAG) is particularly effective in scenarios where standard Large Language Models (LLMs) fall short. The three key areas where RAG excels are knowledge limitations, business requirements, and cost efficiency. Below, we explore these aspects in more detail.
+Retrieval-Augmented Generation (RAG) is particularly effective in scenarios where standard Large Language Models (LLMs) fall short. The three key areas where RAG excels are knowledge limitations, business requirements, and cost efficiency. The following sections explore these aspects in more detail.
 
 #### Overcoming knowledge limitations
 

--- a/content/guides/genai-leveraging-rag/index.md
+++ b/content/guides/genai-leveraging-rag/index.md
@@ -130,7 +130,7 @@ You can now access the interface at [http://localhost:8501/](http://localhost:85
 
 When those lines appear in the logs, the web apps are ready to use.
 
-Since the goal is to teach AI about things it does not yet know, begin by asking it a simple question about Nifi at
+Since the goal is to teach AI about things it does not yet know, begin by asking it a simple question about NiFi at
 [http://localhost:8501/](http://localhost:8501/).
 ![alt text](image.png)
 

--- a/content/guides/gha.md
+++ b/content/guides/gha.md
@@ -3,6 +3,7 @@ title: Introduction to GitHub Actions with Docker
 linkTitle: GitHub Actions and Docker
 summary: |
   Learn how to automate image build and push with GitHub Actions.
+keywords: github actions, ci/cd, docker hub, build and push, automation, workflows
 params:
   tags: [devops]
   time: 10 minutes

--- a/content/guides/github-sonarqube-sandbox/_index.md
+++ b/content/guides/github-sonarqube-sandbox/_index.md
@@ -3,6 +3,7 @@ title: How to build an AI-powered code quality workflow with SonarQube and E2B
 linkTitle: Build an AI-powered code quality workflow
 summary: Build AI-powered code quality workflows using E2B sandboxes with Docker's MCP catalog to automate GitHub and SonarQube integration.
 description: Learn how to create E2B sandboxes with MCP servers, analyze code quality with SonarQube, and generate quality-gated pull requests using GitHub—all through natural language interactions with Claude.
+keywords: sonarqube, e2b, sandboxes, mcp, github, code quality, ai workflow, claude
 tags: [devops]
 params:
   time: 40 minutes

--- a/content/guides/github-sonarqube-sandbox/_index.md
+++ b/content/guides/github-sonarqube-sandbox/_index.md
@@ -1,6 +1,6 @@
 ---
 title: How to build an AI-powered code quality workflow with SonarQube and E2B
-linkTitle: Build an AI-powered code quality workflow
+linkTitle: AI-powered code quality
 summary: Build AI-powered code quality workflows using E2B sandboxes with Docker's MCP catalog to automate GitHub and SonarQube integration.
 description: Learn how to create E2B sandboxes with MCP servers, analyze code quality with SonarQube, and generate quality-gated pull requests using GitHub—all through natural language interactions with Claude.
 keywords: sonarqube, e2b, sandboxes, mcp, github, code quality, ai workflow, claude

--- a/content/guides/github-sonarqube-sandbox/customize.md
+++ b/content/guides/github-sonarqube-sandbox/customize.md
@@ -3,6 +3,7 @@ title: Customize a code quality check workflow
 linkTitle: Customize workflow
 summary: Adapt your GitHub and SonarQube workflow to focus on specific quality issues, integrate with CI/CD, and set custom thresholds.
 description: Learn how to customize prompts for specific quality issues, filter by file patterns, set quality thresholds, and integrate your workflow with GitHub Actions for automated code quality checks.
+keywords: sonarqube, e2b, mcp, github actions, code quality, customization, ci/cd
 weight: 20
 ---
 

--- a/content/guides/github-sonarqube-sandbox/troubleshoot.md
+++ b/content/guides/github-sonarqube-sandbox/troubleshoot.md
@@ -3,6 +3,7 @@ title: Troubleshoot code quality workflows
 linkTitle: Troubleshoot
 summary: Resolve common issues with E2B sandboxes, MCP server connections, and GitHub/SonarQube integration.
 description: Solutions for MCP tools not loading, authentication errors, permission issues, workflow timeouts, and other common problems when building code quality workflows with E2B.
+keywords: sonarqube, e2b, mcp, troubleshooting, debugging, authentication, code quality
 weight: 30
 ---
 
@@ -298,7 +299,6 @@ Solution:
 
    {{< /tab >}}
    {{< tab name="Python" >}}
-
    1. Ensure `dotenv` is loaded at the top of your file:
 
       ```python

--- a/content/guides/github-sonarqube-sandbox/workflow.md
+++ b/content/guides/github-sonarqube-sandbox/workflow.md
@@ -3,6 +3,7 @@ title: Build a code quality check workflow
 linkTitle: Build workflow
 summary: Learn to use GitHub and SonarQube MCP servers in E2B sandboxes through progressive examples.
 description: Create E2B sandboxes, discover MCP tools, test individual operations, and build complete quality-gated PR workflows.
+keywords: sonarqube, e2b, mcp, github, code quality, pull requests, workflow
 weight: 10
 ---
 

--- a/content/guides/go-prometheus-monitoring/_index.md
+++ b/content/guides/go-prometheus-monitoring/_index.md
@@ -4,7 +4,7 @@ keywords: golang, prometheus, grafana, monitoring, containerize
 title: Monitor a Golang application with Prometheus and Grafana
 summary: |
   Learn how to containerize a Golang application and monitor it with Prometheus and Grafana.
-linkTitle: Monitor with Prometheus and Grafana
+linkTitle: Prometheus and Grafana
 languages: [go]
 params:
   time: 45 minutes

--- a/content/guides/go-prometheus-monitoring/compose.md
+++ b/content/guides/go-prometheus-monitoring/compose.md
@@ -1,6 +1,6 @@
 ---
 title: Connecting services with Docker Compose
-linkTitle: Connecting services with Docker Compose
+linkTitle: Connect with Compose
 weight: 30 #
 keywords: go, golang, prometheus, grafana, containerize, monitor
 description: Learn how to connect services with Docker Compose to monitor a Golang application with Prometheus and Grafana.

--- a/content/guides/golang/build-images.md
+++ b/content/guides/golang/build-images.md
@@ -195,7 +195,7 @@ This should be familiar. The result of that command will be a static application
 binary named `docker-gs-ping` and located in the root of the filesystem of the
 image that you are building. You could have put the binary into any other place
 you desire inside that image, the root directory has no special meaning in this
-regard. It's just convenient to use it to keep the file paths short for improved
+regard. It's convenient to use it to keep the file paths short for improved
 readability.
 
 Now, all that is left to do is to tell Docker what command to run when your
@@ -275,7 +275,7 @@ $ docker build --tag docker-gs-ping .
 ```
 
 The build process will print some diagnostic messages as it goes through the build steps.
-The following is just an example of what these messages may look like.
+The following is an example of what these messages may look like.
 
 ```console
 [+] Building 2.2s (15/15) FINISHED
@@ -310,7 +310,7 @@ successfully built your image named `docker-gs-ping`.
 
 To see the list of images you have on your local machine, you have two options.
 One is to use the CLI and the other is to use [Docker
-Desktop](/manuals/desktop/_index.md). Since you're currently working in the
+Desktop](/manuals/desktop/_index.md). Since you're working in the
 terminal, take a look at listing images with the CLI.
 
 To list images, run the `docker image ls`command (or the `docker images` shorthand):
@@ -350,7 +350,7 @@ $ docker image tag docker-gs-ping:latest docker-gs-ping:v1.0
 ```
 
 The Docker `tag` command creates a new tag for the image. It doesn't create a
-new image. The tag points to the same image and is just another way to reference
+new image. The tag points to the same image and is another way to reference
 the image.
 
 Now run the `docker image ls` command again to see the updated list of local
@@ -459,7 +459,7 @@ ENTRYPOINT ["/docker-gs-ping"]
 Since you have two Dockerfiles now, you have to tell Docker what Dockerfile
 you'd like to use to build the image. Tag the new image with `multistage`. This
 tag (like any other, apart from `latest`) has no special meaning for Docker,
-it's just something you chose.
+it's something you chose.
 
 ```console
 $ docker build -t docker-gs-ping:multistage -f Dockerfile.multistage .

--- a/content/guides/golang/develop.md
+++ b/content/guides/golang/develop.md
@@ -582,7 +582,7 @@ The exact value doesn't really matter for this example, because you run Cockroac
 
 ### Merging Compose files
 
-The file name `compose.yaml` is the default file name which `docker compose` command recognizes if no `-f` flag is provided. This means you can have multiple Docker Compose files if your environment has such requirements. Furthermore, Docker Compose files are... composable (pun intended), so multiple files can be specified on the command line to merge parts of the configuration together. The following list is just a few examples of scenarios where such a feature would be very useful:
+The file name `compose.yaml` is the default file name which `docker compose` command recognizes if no `-f` flag is provided. This means you can have multiple Docker Compose files if your environment has such requirements. Furthermore, Docker Compose files are... composable (pun intended), so multiple files can be specified on the command line to merge parts of the configuration together. The following list shows a few examples of scenarios where such a feature would be very useful:
 
 - Using a bind mount for the source code for local development but not when running the CI tests;
 - Switching between using a pre-built image for the frontend for some API application vs creating a bind mount for source code;

--- a/content/guides/golang/develop.md
+++ b/content/guides/golang/develop.md
@@ -582,7 +582,7 @@ The exact value doesn't really matter for this example, because you run Cockroac
 
 ### Merging Compose files
 
-The file name `compose.yaml` is the default file name which `docker compose` command recognizes if no `-f` flag is provided. This means you can have multiple Docker Compose files if your environment has such requirements. Furthermore, Docker Compose files are... composable (pun intended), so multiple files can be specified on the command line to merge parts of the configuration together. The following list shows a few examples of scenarios where such a feature would be very useful:
+The filename `compose.yaml` is the default filename which `docker compose` command recognizes if no `-f` flag is provided. This means you can have multiple Docker Compose files if your environment has such requirements. Furthermore, Docker Compose files are composable, so multiple files can be specified on the command line to merge parts of the configuration together. The following list shows a few examples of scenarios where such a feature would be useful:
 
 - Using a bind mount for the source code for local development but not when running the CI tests;
 - Switching between using a pre-built image for the frontend for some API application vs creating a bind mount for source code;

--- a/content/guides/lab-attestation-basics.md
+++ b/content/guides/lab-attestation-basics.md
@@ -1,6 +1,6 @@
 ---
 title: "Lab: Container Image Attestations"
-linkTitle: "Lab: Container Image Attestations"
+linkTitle: "Lab: Image attestations"
 description: |
   Learn to attach SBOMs, build provenance, image signatures, and VEX
   statements to container images for a verifiable software supply chain.

--- a/content/guides/lab-container-getting-started.md
+++ b/content/guides/lab-container-getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: "Lab: Getting Started with Docker"
-linkTitle: "Lab: Getting Started with Docker"
+linkTitle: "Lab: Docker basics"
 description: |
   Learn Docker fundamentals by running containers, exploring the container
   lifecycle, and packaging a real Node.js app into your own custom image.

--- a/content/guides/lab-container-supported-development.md
+++ b/content/guides/lab-container-supported-development.md
@@ -1,6 +1,6 @@
 ---
 title: "Lab: Container-Supported Development"
-linkTitle: "Lab: Container-Supported Development"
+linkTitle: "Lab: Container-supported dev"
 description: |
   Learn to use containers for local development by running a PostgreSQL
   database, defining a Compose file, and adding a pgAdmin dev tool — no local

--- a/content/guides/lab-creating-ai-product-reviewer.md
+++ b/content/guides/lab-creating-ai-product-reviewer.md
@@ -1,6 +1,6 @@
 ---
 title: "Lab: Building an AI Product Reviewer"
-linkTitle: "Lab: Building an AI Product Reviewer"
+linkTitle: "Lab: AI product reviewer"
 description: |
   Build a complete AI-powered feedback analysis pipeline — sentiment analysis,
   semantic clustering with embeddings, and response generation — all running

--- a/content/guides/lab-docker-agent.md
+++ b/content/guides/lab-docker-agent.md
@@ -1,6 +1,6 @@
 ---
 title: "Lab: Getting Started with Docker Agent"
-linkTitle: "Lab: Getting Started with Docker Agent"
+linkTitle: "Lab: Docker Agent"
 description: |
   Build intelligent multi-agent teams with Docker Agent and Docker in this hands-on
   interactive lab.

--- a/content/guides/lab-docker-for-ai-redirect.md
+++ b/content/guides/lab-docker-for-ai-redirect.md
@@ -1,5 +1,6 @@
 ---
 title: Docker for AI Labs
+keywords: docker, ai, labs, machine learning, hands-on
 type: redirect
 target: /guides/?tags=labs
 aliases:

--- a/content/guides/nextjs/configure-github-actions.md
+++ b/content/guides/nextjs/configure-github-actions.md
@@ -19,7 +19,7 @@ You must also have:
 
 ## Overview
 
-In this section, you'll set up a **CI/CD pipeline** using [GitHub Actions](https://docs.github.com/en/actions) to automatically:
+In this section, you'll set up a CI/CD pipeline using [GitHub Actions](https://docs.github.com/en/actions) to automatically:
 
 - Build your Next.js application inside a Docker container.
 - Run tests in a consistent environment.
@@ -273,7 +273,7 @@ After you've added your workflow file, it's time to trigger and observe the CI/C
 2. Monitor the workflow execution
 
    1. Go to the Actions tab in your GitHub repository.
-   2. Click into the workflow run to follow each step: **build**, **test**, and (if successful) **push**.
+   2. Click into the workflow run to follow each step: `build`, `test`, and (if successful) `push`.
 
 3. Verify the Docker image on Docker Hub
 

--- a/content/guides/nextjs/configure-github-actions.md
+++ b/content/guides/nextjs/configure-github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Automate your builds with GitHub Actions
-linkTitle: Automate your builds with GitHub Actions
+linkTitle: GitHub Actions CI
 weight: 60
 keywords: CI/CD, GitHub Actions, Next.js
 description: Learn how to configure CI/CD using GitHub Actions for your Next.js application.

--- a/content/guides/nextjs/configure-github-actions.md
+++ b/content/guides/nextjs/configure-github-actions.md
@@ -273,7 +273,7 @@ After you've added your workflow file, it's time to trigger and observe the CI/C
 2. Monitor the workflow execution
 
    1. Go to the Actions tab in your GitHub repository.
-   2. Click into the workflow run to follow each step: `build`, `test`, and (if successful) `push`.
+   2. Select the workflow run to follow each step: `build`, `test`, and (if successful) `push`.
 
 3. Verify the Docker image on Docker Hub
 

--- a/content/guides/nextjs/containerize.md
+++ b/content/guides/nextjs/containerize.md
@@ -14,8 +14,8 @@ Before you begin, make sure the following tools are installed and available on y
 - You have installed the latest version of [Docker Desktop](/get-started/get-docker.md).
 - You have a [git client](https://git-scm.com/downloads). The examples in this section use a command-line based git client, but you can use any client.
 
-> **New to Docker?**  
-> Start with the [Docker basics](/get-started/docker-concepts/the-basics/what-is-a-container.md) guide to get familiar with key concepts like images, containers, and Dockerfiles.
+> [!NOTE]
+> New to Docker? Start with the [Docker basics](/get-started/docker-concepts/the-basics/what-is-a-container.md) guide to get familiar with key concepts like images, containers, and Dockerfiles.
 
 ---
 
@@ -49,7 +49,7 @@ $ git clone https://github.com/kristiyan-velkov/docker-nextjs-sample
 
 ## Build the Docker image
 
-Next.js has specific requirements for production deployments. This guide shows two approaches: **standalone** output (Node.js server) and **export** output (static files with Nginx).
+Next.js has specific requirements for production deployments. This guide shows two approaches: `standalone` output (Node.js server) and `export` output (static files with Nginx).
 
 > [!TIP]
 >
@@ -66,11 +66,11 @@ Before creating a Dockerfile, choose a base image: the [Node.js Official Image](
 
 #### 1.1 Next.js with standalone output
 
-**Standalone output** (`output: "standalone"`) makes Next.js build a self-contained output that includes only the files and dependencies needed to run the application. A single `node server.js` can serve the app, which is ideal for Docker and supports server-side rendering, API routes, and incremental static regeneration. For details, see the [Next.js output configuration documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/output) (including the "standalone" option).
+Standalone output (`output: "standalone"`) makes Next.js build a self-contained output that includes only the files and dependencies needed to run the application. A single `node server.js` can serve the app, which is ideal for Docker and supports server-side rendering, API routes, and incremental static regeneration. For details, see the [Next.js output configuration documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/output) (including the "standalone" option).
 
-The container runs the Next.js server with Node.js on **port 3000**.
+The container runs the Next.js server with Node.js on port 3000.
 
-**Configure Next.js** — Open or create `next.config.ts` in your project root:
+Configure Next.js — Open or create `next.config.ts` in your project root:
 
 ```ts
 import type { NextConfig } from "next";
@@ -332,7 +332,7 @@ Create a file named `Dockerfile` with the following contents (uses `node`):
 ```
 
 > [!NOTE]
-> This Dockerfile uses three stages: **dependencies**, **builder**, and **runner**. The final image runs `node server.js` and listens on port 3000.
+> This Dockerfile uses three stages: `dependencies`, `builder`, and `runner`. The final image runs `node server.js` and listens on port 3000.
 
 {{< /tab >}}
 {{< /tabs >}}
@@ -341,9 +341,9 @@ Create a file named `Dockerfile` with the following contents (uses `node`):
 
 #### 1.2 Next.js with export output
 
-**Output export** (`output: "export"`) makes Next.js build a fully static site at build time. It generates HTML, CSS, and JavaScript into an `out` directory that can be served by any static host or CDN—no Node.js server at runtime. Use this when you don't need server-side rendering or API routes. For details, see the [Next.js output configuration documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/output).
+Output export (`output: "export"`) makes Next.js build a fully static site at build time. It generates HTML, CSS, and JavaScript into an `out` directory that can be served by any static host or CDN—no Node.js server at runtime. Use this when you don't need server-side rendering or API routes. For details, see the [Next.js output configuration documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/output).
 
-**Configure Next.js** — Open  `next.config.ts` in your project root and add the following code:
+Configure Next.js — Open  `next.config.ts` in your project root and add the following code:
 
 ```ts
 import type { NextConfig } from "next";
@@ -584,7 +584,7 @@ CMD ["-g", "daemon off;"]
 {{< /tab >}}
 {{< /tabs >}}
 
-1. **Create `nginx.conf`** (required for export output only) — Create a file named `nginx.conf` in the root of your project:
+1. Create `nginx.conf` (required for export output only) — Create a file named `nginx.conf` in the root of your project:
 
     ```nginx
     # Minimal Nginx config for static Next.js app
@@ -654,7 +654,7 @@ CMD ["-g", "daemon off;"]
     ```
 
       > [!NOTE]
-      > Export uses **port 8080**. For more details, see the [Next.js output configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js/output) and [Nginx documentation](https://nginx.org/en/docs/).
+      > Export uses port 8080. For more details, see the [Next.js output configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js/output) and [Nginx documentation](https://nginx.org/en/docs/).
 
 ### Step 2: Create the compose.yaml file
 
@@ -848,11 +848,11 @@ nextjs-sample             latest            8c5fc80f098e   14 seconds ago   130M
 
 This output provides key details about your images:
 
-- **Repository** – The name assigned to the image.
-- **Tag** – A version label that helps identify different builds (e.g., latest).
-- **Image ID** – A unique identifier for the image.
-- **Created** – The timestamp indicating when the image was built.
-- **Size** – The total disk space used by the image.
+- Repository – The name assigned to the image.
+- Tag – A version label that helps identify different builds (e.g., latest).
+- Image ID – A unique identifier for the image.
+- Created – The timestamp indicating when the image was built.
+- Size – The total disk space used by the image.
 
 If the build was successful, you should see `nextjs-sample` image listed. 
 
@@ -862,19 +862,19 @@ If the build was successful, you should see `nextjs-sample` image listed.
 
 In the previous step, you created a Dockerfile for your Next.js application and built a Docker image using the docker build command. Now it's time to run that image in a container and verify that your application works as expected.
 
-Run the following command in a terminal. Use the port that matches your setup: **standalone** uses port 3000, **export** uses port 8080.
+Run the following command in a terminal. Use the port that matches your setup: standalone uses port 3000, export uses port 8080.
 
 ```console
 $ docker run -p 3000:3000 nextjs-sample
 ```
 
-For **export** output, use port 8080 instead:
+For export output, use port 8080 instead:
 
 ```console
 $ docker run -p 8080:8080 nextjs-sample
 ```
 
-Open a browser and view the application: [http://localhost:3000](http://localhost:3000) for **standalone** or [http://localhost:8080](http://localhost:8080) for **export**. You should see your Next.js web application.
+Open a browser and view the application: [http://localhost:3000](http://localhost:3000) for standalone or [http://localhost:8080](http://localhost:8080) for export. You should see your Next.js web application.
 
 Press `ctrl+c` in the terminal to stop your application.
 
@@ -886,13 +886,13 @@ You can run the application detached from the terminal by adding the `-d` option
 $ docker run -d -p 3000:3000 --name nextjs-app nextjs-sample
 ```
 
-For **export** output, use port 8080:
+For export output, use port 8080:
 
 ```console
 $ docker run -d -p 8080:8080 --name nextjs-app nextjs-sample
 ```
 
-Open a browser and view the application: [http://localhost:3000](http://localhost:3000) for **standalone** or [http://localhost:8080](http://localhost:8080) for **export**. You should see your web application.
+Open a browser and view the application: [http://localhost:3000](http://localhost:3000) for standalone or [http://localhost:8080](http://localhost:8080) for export. You should see your web application.
 
 To confirm that the container is running, use the `docker ps` command:
 

--- a/content/guides/nextjs/deploy.md
+++ b/content/guides/nextjs/deploy.md
@@ -116,7 +116,7 @@ If everything is configured properly, you'll see confirmation that both the Depl
    
 This output means that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
-### Step 2. Check the Deployment status
+### Step 2. Check the deployment status
 
 Run the following command to check the status of your deployment:
    
@@ -133,7 +133,7 @@ You should see an output similar to:
 
 This confirms that your pod is up and running with one replica available.
 
-### Step 3. Verify the Service exposure
+### Step 3. Verify the service exposure
 
 Check if the NodePort service is exposing your app to your local machine:
 

--- a/content/guides/nextjs/develop.md
+++ b/content/guides/nextjs/develop.md
@@ -24,7 +24,7 @@ You'll learn how to:
 
 ---
 
-## Automatically update services (Development Mode)
+## Automatically update services (development mode)
 
 Use Compose Watch to automatically sync source file changes into your
 containerized development environment. This automatically syncs file changes

--- a/content/guides/nodejs/configure-github-actions.md
+++ b/content/guides/nodejs/configure-github-actions.md
@@ -22,7 +22,7 @@ You must also have:
 
 ## Overview
 
-In this section, you'll set up a **CI/CD pipeline** using [GitHub Actions](https://docs.github.com/en/actions) to automatically:
+In this section, you'll set up a CI/CD pipeline using [GitHub Actions](https://docs.github.com/en/actions) to automatically:
 
 - Build your Node.js application inside a Docker container.
 - Run unit and integration tests, and make sure your application meets solid code quality standards.
@@ -285,7 +285,7 @@ After adding your workflow file, trigger the CI/CD process.
 
 2. Monitor the workflow execution
    1. From your GitHub repository, go to the **Actions** tab.
-   2. Select the workflow run to follow each step: **test**, **build**, **security**, and (if successful) **push** and **deploy**.
+   2. Select the workflow run to follow each step: `test`, `build`, `security`, and (if successful) `push` and `deploy`.
 
 3. Verify the Docker image on Docker Hub
    - After a successful workflow run, visit your [Docker Hub repositories](https://hub.docker.com/repositories).

--- a/content/guides/nodejs/configure-github-actions.md
+++ b/content/guides/nodejs/configure-github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Automate your builds with GitHub Actions
-linkTitle: Automate your builds with GitHub Actions
+linkTitle: GitHub Actions CI
 weight: 50
 keywords: CI/CD, GitHub Actions, Node.js, Docker
 description: Learn how to configure CI/CD using GitHub Actions for your Node.js application.

--- a/content/guides/nodejs/containerize.md
+++ b/content/guides/nodejs/containerize.md
@@ -19,8 +19,8 @@ Before you begin, make sure the following tools are installed and available on y
 - You have installed the latest version of [Docker Desktop](/get-started/get-docker.md).
 - You have a [git client](https://git-scm.com/downloads). The examples in this section use a command-line based git client, but you can use any client.
 
-> **New to Docker?**  
-> Start with the [Docker basics](/get-started/docker-concepts/the-basics/what-is-a-container.md) guide to get familiar with key concepts like images, containers, and Dockerfiles.
+> [!NOTE]
+> New to Docker? Start with the [Docker basics](/get-started/docker-concepts/the-basics/what-is-a-container.md) guide to get familiar with key concepts like images, containers, and Dockerfiles.
 
 ---
 
@@ -531,11 +531,11 @@ networks:
 
 This Docker Compose configuration includes:
 
-- **Development service** (`app-dev`): Full development environment with hot reload, debugging support, and bind mounts
-- **Production service** (`app-prod`): Optimized production deployment with resource limits and security hardening
-- **Database service** (`db`): PostgreSQL 18 with persistent storage and health checks
-- **Networking**: Isolated network for secure service communication
-- **Volumes**: Persistent storage for database data
+- Development service (`app-dev`): Full development environment with hot reload, debugging support, and bind mounts
+- Production service (`app-prod`): Optimized production deployment with resource limits and security hardening
+- Database service (`db`): PostgreSQL 18 with persistent storage and health checks
+- Networking: Isolated network for secure service communication
+- Volumes: Persistent storage for database data
 
 ### Step 3: Create environment configuration
 
@@ -683,11 +683,11 @@ docker-nodejs-sample     latest           423525528038   14 seconds ago  237.46M
 
 This output provides key details about your images:
 
-- **Repository** – The name assigned to the image.
-- **Tag** – A version label that helps identify different builds (e.g., latest).
-- **Image ID** – A unique identifier for the image.
-- **Created** – The timestamp indicating when the image was built.
-- **Size** – The total disk space used by the image.
+- Repository – The name assigned to the image.
+- Tag – A version label that helps identify different builds (e.g., latest).
+- Image ID – A unique identifier for the image.
+- Created – The timestamp indicating when the image was built.
+- Size – The total disk space used by the image.
 
 If the build was successful, you should see `docker-nodejs-sample` image listed.
 
@@ -705,9 +705,9 @@ $ docker compose up app-dev --build
 
 The development application will start with both servers:
 
-- **API Server**: [http://localhost:3000](http://localhost:3000) - Express.js backend with REST API
-- **Frontend**: [http://localhost:5173](http://localhost:5173) - Vite dev server with React frontend
-- **Health Check**: [http://localhost:3000/health](http://localhost:3000/health) - Application health status
+- API Server: [http://localhost:3000](http://localhost:3000) - Express.js backend with REST API
+- Frontend: [http://localhost:5173](http://localhost:5173) - Vite dev server with React frontend
+- Health Check: [http://localhost:3000/health](http://localhost:3000/health) - Application health status
 
 For production deployment, you can use:
 

--- a/content/guides/nodejs/deploy.md
+++ b/content/guides/nodejs/deploy.md
@@ -376,13 +376,13 @@ spec:
 
 Before deploying, you need to customize the deployment file for your environment:
 
-1. **Image reference**: Replace `your-username` with your GitHub username or Docker Hub username:
+1. Image reference: Replace `your-username` with your GitHub username or Docker Hub username:
 
    ```yaml
    image: ghcr.io/your-username/docker-nodejs-sample:latest
    ```
 
-2. **Domain name**: Replace `yourdomain.com` with your actual domain in two places:
+2. Domain name: Replace `yourdomain.com` with your actual domain in two places:
 
    ```yaml
    # In ConfigMap
@@ -392,7 +392,7 @@ Before deploying, you need to customize the deployment file for your environment
    - host: yourdomain.com
    ```
 
-3. **Database password** (optional): The default password is already base64 encoded. To change it:
+3. Database password (optional): The default password is already base64 encoded. To change it:
 
    ```console
    $ echo -n "your-new-password" | base64
@@ -405,7 +405,7 @@ Before deploying, you need to customize the deployment file for your environment
      postgres-password: <your-base64-encoded-password>
    ```
 
-4. **Storage class**: Adjust based on your cluster (current: `standard`)
+4. Storage class: Adjust based on your cluster (current: `standard`)
 
 ## Understanding the deployment
 
@@ -415,10 +415,10 @@ The deployment file creates a complete application stack with multiple component
 
 The deployment includes:
 
-- **Node.js application**: Runs 3 replicas of your containerized Todo app
-- **PostgreSQL database**: Single instance with 10Gi of persistent storage
-- **Services**: Kubernetes services handle load balancing across application replicas
-- **Ingress**: External access through an ingress controller with SSL/TLS support
+- Node.js application: Runs 3 replicas of your containerized Todo app
+- PostgreSQL database: Single instance with 10Gi of persistent storage
+- Services: Kubernetes services handle load balancing across application replicas
+- Ingress: External access through an ingress controller with SSL/TLS support
 
 ### Security
 
@@ -538,26 +538,26 @@ Open your browser and visit [http://localhost:8080](http://localhost:8080) to se
 
 Test that your application is working correctly:
 
-1. **Add some todos** through the web interface
-2. **Check application pods**:
+1. Add some todos through the web interface
+2. Check application pods:
 
    ```console
    $ kubectl get pods -n todoapp -l app=todoapp
    ```
 
-3. **View application logs**:
+3. View application logs:
 
    ```console
    $ kubectl logs -f deployment/todoapp-deployment -n todoapp
    ```
 
-4. **Check database connectivity**:
+4. Check database connectivity:
 
    ```console
    $ kubectl get pods -n todoapp -l app=todoapp-postgres
    ```
 
-5. **Monitor auto-scaling**:
+5. Monitor auto-scaling:
    ```console
    $ kubectl describe hpa todoapp-hpa -n todoapp
    ```

--- a/content/guides/nodejs/develop.md
+++ b/content/guides/nodejs/develop.md
@@ -320,12 +320,12 @@ services:
 
 Key features of the development configuration:
 
-- **Multi-port exposure**: API server (3000), Vite dev server (5173), and debugger (9229)
-- **Comprehensive bind mounts**: Source code, configuration files, and package files for hot reloading
-- **Environment variables**: Configurable through `.env` file or defaults
-- **PostgreSQL database**: Production-ready database with persistent storage
-- **Docker Compose watch**: Automatic file synchronization and container rebuilds
-- **Health checks**: Database health monitoring with automatic dependency management
+- Multi-port exposure: API server (3000), Vite dev server (5173), and debugger (9229)
+- Comprehensive bind mounts: Source code, configuration files, and package files for hot reloading
+- Environment variables: Configurable through `.env` file or defaults
+- PostgreSQL database: Production-ready database with persistent storage
+- Docker Compose watch: Automatic file synchronization and container rebuilds
+- Health checks: Database health monitoring with automatic dependency management
 
 ### Run your development container and debug your application
 
@@ -387,9 +387,9 @@ $ task logs             # View container logs
 
 The application will start with both the Express API server and Vite development server:
 
-- **API Server**: [http://localhost:3000](http://localhost:3000) - Express.js backend with REST API
-- **Frontend**: [http://localhost:5173](http://localhost:5173) - Vite dev server with hot module replacement
-- **Health Check**: [http://localhost:3000/health](http://localhost:3000/health) - Application health status
+- API Server: [http://localhost:3000](http://localhost:3000) - Express.js backend with REST API
+- Frontend: [http://localhost:5173](http://localhost:5173) - Vite dev server with hot module replacement
+- Health Check: [http://localhost:3000/health](http://localhost:3000/health) - Application health status
 
 Any changes to the application's source files on your local machine will now be immediately reflected in the running container thanks to the bind mounts.
 
@@ -409,7 +409,7 @@ Try making a change to test hot reloading:
 
 1. Save the file and the Vite dev server will automatically reload the page with your changes.
 
-**Debugging support:**
+Debugging support:
 
 You can connect a debugger to your application on port 9229. The Node.js inspector is enabled with `--inspect=0.0.0.0:9230` in the development script (`dev:server`).
 
@@ -473,9 +473,9 @@ You can also use Chrome DevTools for debugging:
 
 The debugger configuration:
 
-- **Container port**: 9230 (internal debugger port)
-- **Host port**: 9229 (mapped external port)
-- **Script**: `tsx watch --inspect=0.0.0.0:9230 src/server/index.ts`
+- Container port: 9230 (internal debugger port)
+- Host port: 9229 (mapped external port)
+- Script: `tsx watch --inspect=0.0.0.0:9230 src/server/index.ts`
 
 The debugger listens on all interfaces (`0.0.0.0`) inside the container on port 9230 and is accessible on port 9229 from your host machine.
 

--- a/content/guides/nodejs/develop.md
+++ b/content/guides/nodejs/develop.md
@@ -354,7 +354,7 @@ $ npm run db:start    # Start PostgreSQL container
 $ npm run dev         # Start both server and client
 ```
 
-### Using Task Runner (alternative)
+### Using Task runner (alternative)
 
 The project includes a Taskfile.yml for advanced workflows:
 

--- a/content/guides/nodejs/run-tests.md
+++ b/content/guides/nodejs/run-tests.md
@@ -63,10 +63,10 @@ services:
 
 This test service configuration:
 
-- **Builds from test stage**: Uses the `test` target from your multi-stage Dockerfile
-- **Isolated test database**: Uses a separate `todoapp_test` database for testing
-- **Profile-based**: Uses the `test` profile so it only runs when explicitly requested
-- **Health dependency**: Waits for the database to be healthy before starting tests
+- Builds from test stage: Uses the `test` target from your multi-stage Dockerfile
+- Isolated test database: Uses a separate `todoapp_test` database for testing
+- Profile-based: Uses the `test` profile so it only runs when explicitly requested
+- Health dependency: Waits for the database to be healthy before starting tests
 
 ### Run tests in a container
 
@@ -123,12 +123,12 @@ You should see output like the following:
 
 The test suite covers:
 
-- **Client Components** (`src/client/components/__tests__/`): React component testing with React Testing Library
-- **Custom Hooks** (`src/client/hooks/__tests__/`): React hooks testing with proper mocking
-- **Server Routes** (`src/server/__tests__/routes/`): API endpoint testing
-- **Database Layer** (`src/server/database/__tests__/`): PostgreSQL database operations testing
-- **Utility Functions** (`src/shared/utils/__tests__/`): Validation and helper function testing
-- **Integration Tests** (`src/client/__tests__/`): Full application integration testing
+- Client Components (`src/client/components/__tests__/`): React component testing with React Testing Library
+- Custom Hooks (`src/client/hooks/__tests__/`): React hooks testing with proper mocking
+- Server Routes (`src/server/__tests__/routes/`): API endpoint testing
+- Database Layer (`src/server/database/__tests__/`): PostgreSQL database operations testing
+- Utility Functions (`src/shared/utils/__tests__/`): Validation and helper function testing
+- Integration Tests (`src/client/__tests__/`): Full application integration testing
 
 ## Run tests when building
 
@@ -156,10 +156,10 @@ CMD ["npm", "run", "test:coverage"]
 
 This test stage:
 
-- **Test environment**: Sets `NODE_ENV=test` and `CI=true` for proper test execution
-- **Non-root user**: Runs tests as the `nodejs` user for security
-- **Flexible execution**: Uses `CMD` instead of `RUN` to allow running tests during build or as a separate container
-- **Coverage support**: Configured to run tests with coverage reporting
+- Test environment: Sets `NODE_ENV=test` and `CI=true` for proper test execution
+- Non-root user: Runs tests as the `nodejs` user for security
+- Flexible execution: Uses `CMD` instead of `RUN` to allow running tests during build or as a separate container
+- Coverage support: Configured to run tests with coverage reporting
 
 ### Build and run tests during image build
 

--- a/content/guides/opentelemetry.md
+++ b/content/guides/opentelemetry.md
@@ -33,7 +33,7 @@ The [Docker Official Image for OpenTelemetry](https://hub.docker.com/r/otel/open
 
 Basic knowledge of Node.js and Docker.
 
-## Project Structure
+## Project structure
 
 Create the project directory:
 ```bash
@@ -51,7 +51,7 @@ otel-js-app/
 │   └── tracer.js
 ```
 
-## Create a Simple Node.js App
+## Create a simple Node.js app
 
 Initialize a basic Node.js app:
 
@@ -82,7 +82,7 @@ app.listen(PORT, () => {
 });
 ```
 
-## Configure OpenTelemetry Tracing
+## Configure OpenTelemetry tracing
 
 Create the tracer configuration file:
 
@@ -128,7 +128,7 @@ service:
       exporters: [logging, jaeger]
 ```
 
-## Add Docker Compose Configuration
+## Add Docker Compose configuration
 
 Create the `docker-compose.yaml` file:
 
@@ -173,7 +173,7 @@ RUN npm install
 CMD ["node", "app.js"]
 ```
 
-## Start the Stack
+## Start the stack
 
 Start all services with Docker Compose:
 
@@ -187,7 +187,7 @@ Visit your app at [http://localhost:3000](http://localhost:3000)
 
 View traces at [http://localhost:16686](http://localhost:16686) in the Jaeger UI
 
-## Verify Traces in Jaeger
+## Verify traces in Jaeger
 
 After visiting your app's root endpoint, open Jaeger’s UI, search for the service (default is usually `unknown_service` unless explicitly named), and check the traces.
 

--- a/content/guides/postgresql/companions-for-postgresql.md
+++ b/content/guides/postgresql/companions-for-postgresql.md
@@ -10,7 +10,7 @@ weight: 40
 ---
 
 
-## PostgreSQL Ecosystem companions: pgAdmin, PgBouncer, and Performance Testing
+## PostgreSQL ecosystem companions: pgAdmin, PgBouncer, and performance testing
 
 Running a standalone PostgreSQL container is often just the beginning. What happens when thousands of connections arrive, or when you need a visual interface to manage your database?
 

--- a/content/guides/postgresql/networking-and-connectivity.md
+++ b/content/guides/postgresql/networking-and-connectivity.md
@@ -8,16 +8,17 @@ weight: 30
 
 This guide covers two common ways to connect to PostgreSQL running in Docker:
 
-- **Container-to-container**: Connect from your application container to PostgreSQL over a private Docker network. No ports need to be exposed to the host.
-- **Host-to-container**: Connect from your laptop or development machine using `localhost` and a published port.
+- Container-to-container: Connect from your application container to PostgreSQL over a private Docker network. No ports need to be exposed to the host.
+- Host-to-container: Connect from your laptop or development machine using `localhost` and a published port.
 
-**Prerequisite**: This guide assumes you have PostgreSQL running with persistent storage. If you don't, follow the [Immediate Setup & Data Persistence](/guides/postgresql/immediate-setup-and-data-persistence/) guide first.
+Prerequisite: This guide assumes you have PostgreSQL running with persistent storage. If you don't, follow the [Immediate Setup & Data Persistence](/guides/postgresql/immediate-setup-and-data-persistence/) guide first.
 
 ## Internal network access (container-to-container)
 
 When your application runs in another container, connecting to PostgreSQL through a user-defined bridge network is the recommended approach. This setup provides automatic DNS resolution, so your application can connect to PostgreSQL using the container name as the hostname, without needing to track IP addresses.
 
-> **Why not use the default bridge network?** While containers on the default bridge network can communicate, they can only do so by IP address. Since container IP addresses change when containers restart, this would require updating your PostgreSQL connection strings each time. User-defined bridge networks solve this by providing automatic DNS resolution, ensuring your PostgreSQL connection strings remain stable even if containers restart and receive new IP addresses.
+> [!NOTE]
+> Why not use the default bridge network? While containers on the default bridge network can communicate, they can only do so by IP address. Since container IP addresses change when containers restart, this would require updating your PostgreSQL connection strings each time. User-defined bridge networks solve this by providing automatic DNS resolution, ensuring your PostgreSQL connection strings remain stable even if containers restart and receive new IP addresses.
 
 Here's a quick comparison:
 
@@ -93,13 +94,13 @@ docker run --rm -it \
   psql -h postgres-dev -U postgres
 ```
 
-**Key point**: `-h postgres-dev` works because Docker DNS resolves the container name on a user-defined network. The container name acts as the hostname.
+Key point: `-h postgres-dev` works because Docker DNS resolves the container name on a user-defined network. The container name acts as the hostname.
 
 ### Connection string examples
 
 When connecting from your application container, use these PostgreSQL connection strings:
 
-- **PostgreSQL URI format**:
+- PostgreSQL URI format:
   This is the standard PostgreSQL connection URI format that combines all connection parameters into a single string, widely supported by PostgreSQL clients and libraries.
 
   ```bash
@@ -118,7 +119,7 @@ When connecting from your application container, use these PostgreSQL connection
   ```
 
 
-- **PostgreSQL connection parameters**:
+- PostgreSQL connection parameters:
   This format uses key-value pairs separated by spaces, which many PostgreSQL client libraries accept as an alternative to URI format.
   ```bash
   host=postgres-dev
@@ -139,7 +140,7 @@ When connecting from your application container, use these PostgreSQL connection
   )
   ```
 
-- **Connecting to a specific database**:
+- Connecting to a specific database:
   Replace the database name in the connection string to connect to a specific database instead of the default `postgres` database.
   If you created a custom database (e.g., `testdb`), use:
   ```bash
@@ -175,8 +176,8 @@ docker run -d --name postgres-dev \
 
 Now connect from your host:
 
-- **Host**: `localhost` or `127.0.0.1`
-- **Port**: `5432`
+- Host: `localhost` or `127.0.0.1`
+- Port: `5432`
 
 If you have `psql` installed on your host:
 ```bash
@@ -192,9 +193,9 @@ PGPASSWORD=mysecretpassword psql -h localhost -p 5432 -U postgres
 
 Popular PostgreSQL GUI tools can connect using these common connection details: Host: `localhost`, Port: `5432`, User: `postgres`, Database: `postgres` (or your database name).
 
-- **pgAdmin**: A web-based PostgreSQL administration and development platform
-- **DBeaver**: A universal database tool that supports PostgreSQL and many other databases. Select PostgreSQL as the connection type
-- **TablePlus**: A modern, native database management tool for macOS and Windows with a clean interface
+- pgAdmin: A web-based PostgreSQL administration and development platform
+- DBeaver: A universal database tool that supports PostgreSQL and many other databases. Select PostgreSQL as the connection type
+- TablePlus: A modern, native database management tool for macOS and Windows with a clean interface
 
 All tools will prompt for the password you set with `POSTGRES_PASSWORD`.
 
@@ -218,11 +219,11 @@ docker run -d --name postgres-dev \
 
 When exposing PostgreSQL to external access, follow these PostgreSQL-specific security practices:
 
-- **Avoid using the `postgres` superuser**: The default `postgres` user has full database privileges. Create dedicated users with only the permissions your application needs.
-- **Use strong passwords**: PostgreSQL passwords should be complex. Consider using environment variables or secrets management instead of `hardcoding` passwords.
-- **Limit network exposure**: Binding to `127.0.0.1` (localhost only) is safer than exposing to all interfaces (`0.0.0.0`).
-- **Consider SSL/TLS**: For production, configure PostgreSQL to require SSL connections. The [Advanced Configuration and Initialization](/guides/postgresql/advanced-configuration-and-initialization/) guide shows how to configure PostgreSQL settings.
-- **Create application-specific users**: Use initialization scripts to create users with limited privileges. For example, a read-only user for reporting or a user that can only access specific databases.
+- Avoid using the `postgres` superuser: The default `postgres` user has full database privileges. Create dedicated users with only the permissions your application needs.
+- Use strong passwords: PostgreSQL passwords should be complex. Consider using environment variables or secrets management instead of `hardcoding` passwords.
+- Limit network exposure: Binding to `127.0.0.1` (localhost only) is safer than exposing to all interfaces (`0.0.0.0`).
+- Consider SSL/TLS: For production, configure PostgreSQL to require SSL connections. The [Advanced Configuration and Initialization](/guides/postgresql/advanced-configuration-and-initialization/) guide shows how to configure PostgreSQL settings.
+- Create application-specific users: Use initialization scripts to create users with limited privileges. For example, a read-only user for reporting or a user that can only access specific databases.
 
 The [Advanced configuration and initialization](/guides/postgresql/advanced-configuration-and-initialization/) guide shows how to use initialization scripts to create users and roles automatically.
 
@@ -290,14 +291,14 @@ This section covers common PostgreSQL connection issues and their solutions when
 
 ### "Connection refused" or "could not connect to server"
 
-- **PostgreSQL may still be initializing**: PostgreSQL takes a few seconds to start and initialize the database cluster. Wait 5-10 seconds after container start and retry.
-- **Check if the PostgreSQL container is running**:
+- PostgreSQL may still be initializing: PostgreSQL takes a few seconds to start and initialize the database cluster. Wait 5-10 seconds after container start and retry.
+- Check if the PostgreSQL container is running:
 
   ```bash
   docker ps --filter name=postgres-dev
   ```
 
-- **Check PostgreSQL logs for initialization or connection errors**:
+- Check PostgreSQL logs for initialization or connection errors:
 
   ```bash
   docker logs postgres-dev
@@ -305,7 +306,7 @@ This section covers common PostgreSQL connection issues and their solutions when
 
   Look for messages like "database system is ready to accept connections" to confirm PostgreSQL is fully started.
 
-- **Verify the port mapping is correct**:
+- Verify the port mapping is correct:
 
   ```bash
   docker port postgres-dev
@@ -313,7 +314,7 @@ This section covers common PostgreSQL connection issues and their solutions when
 
   This should show `5432/tcp -> 127.0.0.1:5432` (or `0.0.0.0:5432` if bound to all interfaces).
 
-- **Test PostgreSQL connectivity from inside the container**:
+- Test PostgreSQL connectivity from inside the container:
 
   ```bash
   docker exec -it postgres-dev psql -U postgres -c "SELECT version();"
@@ -323,14 +324,14 @@ This section covers common PostgreSQL connection issues and their solutions when
 
 ### "Password authentication failed" or "FATAL: password authentication failed for user"
 
-- **Confirm the password**: Verify you're using the same password set in `POSTGRES_PASSWORD` when you started the container.
-- **Existing volume with old credentials**: If you reused an existing volume, the password from the original initialization is still in effect. The `POSTGRES_PASSWORD` environment variable only sets the password during the first database initialization. To reset:
+- Confirm the password: Verify you're using the same password set in `POSTGRES_PASSWORD` when you started the container.
+- Existing volume with old credentials: If you reused an existing volume, the password from the original initialization is still in effect. The `POSTGRES_PASSWORD` environment variable only sets the password during the first database initialization. To reset:
   - Remove the volume: `docker volume rm postgres_data`
   - Or connect with the old password
   - Or change the password after connecting: `ALTER USER postgres WITH PASSWORD 'newpassword';`
-- **Try connecting with password prompt**: `psql -h localhost -U postgres -W` (the `-W` flag forces a password prompt)
-- **Use PGPASSWORD environment variable**: `PGPASSWORD=mysecretpassword psql -h localhost -U postgres`
-- **Check PostgreSQL authentication configuration**: If you've customized `pg_hba.conf`, verify the authentication method allows password authentication
+- Try connecting with password prompt: `psql -h localhost -U postgres -W` (the `-W` flag forces a password prompt)
+- Use PGPASSWORD environment variable: `PGPASSWORD=mysecretpassword psql -h localhost -U postgres`
+- Check PostgreSQL authentication configuration: If you've customized `pg_hba.conf`, verify the authentication method allows password authentication
 
 ### "Network not found"
 

--- a/content/guides/postgresql/networking-and-connectivity.md
+++ b/content/guides/postgresql/networking-and-connectivity.md
@@ -158,7 +158,7 @@ When connecting from your application container, use these PostgreSQL connection
 > The default port `5432` is used in these examples. If you're connecting to a different PostgreSQL instance or have changed the port, update the connection string accordingly. The container name (`postgres-dev`) is resolved by Docker DNS to the container's IP address on the network.
 
 
-## Connecting from the Host (external access)
+## Connecting from the host (external access)
 
 To connect to PostgreSQL from your host machine using tools like `psql`, `pgAdmin`, `DBeaver`, or database management scripts, you need to publish PostgreSQL's port (`5432`) to the host. This allows external tools to reach the PostgreSQL container.
 

--- a/content/guides/python/configure-github-actions.md
+++ b/content/guides/python/configure-github-actions.md
@@ -102,11 +102,11 @@ jobs:
 
 Each GitHub Actions workflow includes one or several jobs. Each job consists of steps. Each step can either run a set of commands or use already [existing actions](https://github.com/marketplace?type=actions). The action above has three steps:
 
-1. [**Login to Docker Hub**](https://github.com/docker/login-action): Action logs in to Docker Hub using the Docker ID and Personal Access Token (PAT) you created earlier.
+1. [Login to Docker Hub](https://github.com/docker/login-action): Action logs in to Docker Hub using the Docker ID and Personal Access Token (PAT) you created earlier.
 
-2. [**Set up Docker Buildx**](https://github.com/docker/setup-buildx-action): Action sets up Docker [Buildx](https://github.com/docker/buildx), a CLI plugin that extends the capabilities of the Docker CLI.
+2. [Set up Docker Buildx](https://github.com/docker/setup-buildx-action): Action sets up Docker [Buildx](https://github.com/docker/buildx), a CLI plugin that extends the capabilities of the Docker CLI.
 
-3. [**Build and push**](https://github.com/docker/build-push-action): Action builds and pushes the Docker image to Docker Hub. The `tags` parameter specifies the image name and tag. The `latest` tag is used in this example.
+3. [Build and push](https://github.com/docker/build-push-action): Action builds and pushes the Docker image to Docker Hub. The `tags` parameter specifies the image name and tag. The `latest` tag is used in this example.
 
 ## 2. Run the workflow
 

--- a/content/guides/python/configure-github-actions.md
+++ b/content/guides/python/configure-github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Automate your builds with GitHub Actions
-linkTitle: Automate your builds with GitHub Actions
+linkTitle: GitHub Actions CI
 weight: 40
 keywords: ci/cd, github actions, python, flask
 description: Learn how to configure CI/CD using GitHub Actions for your Python application.

--- a/content/guides/reactjs/configure-github-actions.md
+++ b/content/guides/reactjs/configure-github-actions.md
@@ -19,7 +19,7 @@ You must also have:
 
 ## Overview
 
-In this section, you'll set up a **CI/CD pipeline** using [GitHub Actions](https://docs.github.com/en/actions) to automatically:
+In this section, you'll set up a CI/CD pipeline using [GitHub Actions](https://docs.github.com/en/actions) to automatically:
 
 - Build your React.js application inside a Docker container.
 - Run tests in a consistent environment.
@@ -262,7 +262,7 @@ After you've added your workflow file, it's time to trigger and observe the CI/C
 2. Monitor the workflow execution
 
    1. Go to the Actions tab in your GitHub repository.
-   2. Click into the workflow run to follow each step: **build**, **test**, and (if successful) **push**.
+   2. Click into the workflow run to follow each step: `build`, `test`, and (if successful) `push`.
 
 3. Verify the Docker image on Docker Hub
 

--- a/content/guides/reactjs/configure-github-actions.md
+++ b/content/guides/reactjs/configure-github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Automate your builds with GitHub Actions
-linkTitle: Automate your builds with GitHub Actions
+linkTitle: GitHub Actions CI
 weight: 60
 keywords: CI/CD, GitHub( Actions), React.js, Next.js
 description: Learn how to configure CI/CD using GitHub Actions for your React.js application.

--- a/content/guides/reactjs/configure-github-actions.md
+++ b/content/guides/reactjs/configure-github-actions.md
@@ -262,7 +262,7 @@ After you've added your workflow file, it's time to trigger and observe the CI/C
 2. Monitor the workflow execution
 
    1. Go to the Actions tab in your GitHub repository.
-   2. Click into the workflow run to follow each step: `build`, `test`, and (if successful) `push`.
+   2. Select the workflow run to follow each step: `build`, `test`, and (if successful) `push`.
 
 3. Verify the Docker image on Docker Hub
 

--- a/content/guides/reactjs/deploy.md
+++ b/content/guides/reactjs/deploy.md
@@ -111,7 +111,7 @@ If everything is configured properly, you’ll see confirmation that both the De
    
 This output means that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
-### Step 2. Check the Deployment status
+### Step 2. Check the deployment status
 
 Run the following command to check the status of your deployment:
    
@@ -128,7 +128,7 @@ You should see an output similar to:
 
 This confirms that your pod is up and running with one replica available.
 
-### Step 3. Verify the Service exposure
+### Step 3. Verify the service exposure
 
 Check if the NodePort service is exposing your app to your local machine:
 

--- a/content/guides/reactjs/develop.md
+++ b/content/guides/reactjs/develop.md
@@ -24,7 +24,7 @@ You’ll learn how to:
 
 ---
 
-## Automatically update services (Development Mode)
+## Automatically update services (development mode)
 
 Use Compose Watch to automatically sync source file changes into your containerized development environment. This provides a seamless, efficient development experience without needing to restart or rebuild containers manually.
 

--- a/content/guides/ros2/turtlesim-example.md
+++ b/content/guides/ros2/turtlesim-example.md
@@ -62,7 +62,7 @@ $ docker compose up -d
 $ docker compose exec ros2 /bin/bash
 ```
 
-## Install and Run Turtlesim
+## Install and run Turtlesim
 
 Inside the container, install the Turtlesim package:
 

--- a/content/guides/ruby/configure-github-actions.md
+++ b/content/guides/ruby/configure-github-actions.md
@@ -81,11 +81,11 @@ jobs:
 
 Each GitHub Actions workflow includes one or several jobs. Each job consists of steps. Each step can either run a set of commands or use already [existing actions](https://github.com/marketplace?type=actions). The action above has three steps:
 
-1. [**Login to Docker Hub**](https://github.com/docker/login-action): Action logs in to Docker Hub using the Docker ID and Personal Access Token (PAT) you created earlier.
+1. [Login to Docker Hub](https://github.com/docker/login-action): Action logs in to Docker Hub using the Docker ID and Personal Access Token (PAT) you created earlier.
 
-2. [**Set up Docker Buildx**](https://github.com/docker/setup-buildx-action): Action sets up Docker [Buildx](https://github.com/docker/buildx), a CLI plugin that extends the capabilities of the Docker CLI.
+2. [Set up Docker Buildx](https://github.com/docker/setup-buildx-action): Action sets up Docker [Buildx](https://github.com/docker/buildx), a CLI plugin that extends the capabilities of the Docker CLI.
 
-3. [**Build and push**](https://github.com/docker/build-push-action): Action builds and pushes the Docker image to Docker Hub. The `tags` parameter specifies the image name and tag. The `latest` tag is used in this example.
+3. [Build and push](https://github.com/docker/build-push-action): Action builds and pushes the Docker image to Docker Hub. The `tags` parameter specifies the image name and tag. The `latest` tag is used in this example.
 
 ## 2. Run the workflow
 

--- a/content/guides/ruby/configure-github-actions.md
+++ b/content/guides/ruby/configure-github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Automate your builds with GitHub Actions
-linkTitle: Automate your builds with GitHub Actions
+linkTitle: GitHub Actions CI
 weight: 20
 keywords: ci/cd, github actions, ruby, flask
 description: Learn how to configure CI/CD using GitHub Actions for your Ruby on Rails application.

--- a/content/guides/rust/run-containers.md
+++ b/content/guides/rust/run-containers.md
@@ -173,7 +173,7 @@ Run the `docker ps --all` command again to see that Docker removed all container
 
 Now, it's time to address the random naming issue. Standard practice is to name your containers for the simple reason that it's easier to identify what's running in the container and what application or service it's associated with.
 
-To name a container, you just need to pass the `--name` flag to the `docker run` command.
+To name a container, pass the `--name` flag to the `docker run` command.
 
 ```console
 $ docker run -d -p 3001:8000 --name docker-rust-container docker-rust-image-dhi
@@ -183,11 +183,11 @@ CONTAINER ID   IMAGE                   COMMAND                  CREATED         
 219b2e3c7c38   docker-rust-image-dhi   "/server"                6 seconds ago   Up 5 seconds   0.0.0.0:3001->8000/tcp, [::]:3001->8000/tcp   docker-rust-container
 ```
 
-That’s better! You can now easily identify your container based on the name.
+That’s better! You can now identify your container based on the name.
 
 ## Summary
 
-In this section, you took a look at running containers. You also took a look at managing containers by starting, stopping, and restarting them. And finally, you looked at naming your containers so they are more easily identifiable.
+In this section, you took a look at running containers. You also took a look at managing containers by starting, stopping, and restarting them. And finally, you looked at naming your containers so they are more identifiable.
 
 Related information:
 

--- a/content/guides/rust/run-containers.md
+++ b/content/guides/rust/run-containers.md
@@ -183,7 +183,7 @@ CONTAINER ID   IMAGE                   COMMAND                  CREATED         
 219b2e3c7c38   docker-rust-image-dhi   "/server"                6 seconds ago   Up 5 seconds   0.0.0.0:3001->8000/tcp, [::]:3001->8000/tcp   docker-rust-container
 ```
 
-That’s better! You can now identify your container based on the name.
+Now you can identify your container based on the name.
 
 ## Summary
 

--- a/content/guides/tensorflowjs.md
+++ b/content/guides/tensorflowjs.md
@@ -43,7 +43,7 @@ pre-trained models, facilitating a wide range of ML applications directly in web
 environments. TensorFlow.js offers efficient computation, making sophisticated
 ML tasks accessible to web developers without deep ML expertise.
 
-## Why Use TensorFlow.js and Docker together?
+## Why use TensorFlow.js and Docker together?
 
 - Environment consistency and simplified deployment: Docker packages
   TensorFlow.js applications and their dependencies into containers, ensuring

--- a/content/guides/testcontainers-cloud/_index.md
+++ b/content/guides/testcontainers-cloud/_index.md
@@ -6,6 +6,7 @@ summary: |
   Automate, scale, and optimize testing workflows with Testcontainers Cloud
 description: |
   Testcontainers Cloud by Docker streamlines integration testing by offloading container management to the cloud. It enables faster, consistent tests for containerized services like databases, improving performance and scalability in CI/CD pipelines without straining local or CI resources. Ideal for developers needing efficient, reliable testing environments.
+keywords: testcontainers cloud, integration testing, ci/cd, containerized tests, cloud testing, scalable testing
 tags: [product-demo]
 params:
   image: images/learning-paths/testcontainers-cloud-learning-path.png

--- a/content/guides/testcontainers-cloud/common-questions.md
+++ b/content/guides/testcontainers-cloud/common-questions.md
@@ -1,6 +1,7 @@
 ---
 title: Common challenges and questions
 description: Explore common challenges and questions related to Testcontainers Cloud by Docker.
+keywords: testcontainers cloud, faq, integration testing, troubleshooting, cloud testing
 weight: 40
 ---
 
@@ -36,7 +37,7 @@ Testcontainers Cloud supports any language that works with the open-source Testc
 
 ### How is container cleanup handled in Testcontainers Cloud?
 
-While Testcontainers library automatically handles container lifecycle management, Testcontainers Cloud manages the allocated cloud worker lifetime. This means that containers are spun up, monitored, and cleaned up after tests are completed by Testcontainers library, and the worker where these containers have being running will be removed automatically after the ~35 min idle period by Testcontainers Cloud. This approach frees developers from manually managing containers and associated cloud resources. 
+While Testcontainers library automatically handles container lifecycle management, Testcontainers Cloud manages the allocated cloud worker lifetime. This means that containers are spun up, monitored, and cleaned up after tests are completed by Testcontainers library, and the worker where these containers have being running will be removed automatically after the ~35 min idle period by Testcontainers Cloud. This approach frees developers from manually managing containers and associated cloud resources.
 
 ### Is there a free tier or pricing model for Testcontainers Cloud?
 

--- a/content/guides/testcontainers-cloud/demo-ci.md
+++ b/content/guides/testcontainers-cloud/demo-ci.md
@@ -1,6 +1,7 @@
 ---
 title: Configuring Testcontainers Cloud in the CI Pipeline
 description: Use Testcontainers Cloud with GitHub Workflows to automate testing in a CI pipeline.
+keywords: testcontainers cloud, ci/cd, github actions, integration testing, cloud testing
 weight: 30
 ---
 
@@ -18,6 +19,6 @@ orchestration to the cloud. This approach improves the scalability of your
 pipeline, ensures consistency across tests, and simplifies resource management,
 making it an ideal solution for modern, containerized development workflows.
 
-- Understand how to set up a GitHub Actions workflow to automate the build and testing of a project.   
+- Understand how to set up a GitHub Actions workflow to automate the build and testing of a project.
 - Learn how to configure Testcontainers Cloud within GitHub Actions to offload containerized testing to the cloud, improving efficiency and resource management.
 - Explore how Testcontainers Cloud integrates with GitHub workflows to run integration tests that require containerized services, such as databases and message brokers.

--- a/content/guides/testcontainers-cloud/demo-local.md
+++ b/content/guides/testcontainers-cloud/demo-local.md
@@ -1,6 +1,7 @@
 ---
 title: Setting up Testcontainers Cloud by Docker
 description: Set up Testcontainers Cloud by Docker in a local development environment.
+keywords: testcontainers cloud, local development, testcontainers desktop, integration testing, setup
 weight: 20
 ---
 

--- a/content/guides/testcontainers-cloud/why.md
+++ b/content/guides/testcontainers-cloud/why.md
@@ -1,6 +1,7 @@
 ---
 title: Why Testcontainers Cloud?
 description: Learn how Testcontainers Cloud by Docker can help you optimize integration testing.
+keywords: testcontainers cloud, integration testing, scalable testing, ci/cd, cloud testing
 weight: 10
 ---
 

--- a/content/guides/testcontainers-dotnet-aspnet-core/create-project.md
+++ b/content/guides/testcontainers-dotnet-aspnet-core/create-project.md
@@ -2,6 +2,7 @@
 title: Set up the project
 linkTitle: Create the project
 description: Set up an ASP.NET Core Razor Pages project with integration test dependencies.
+keywords: testcontainers, dotnet, asp.net core, getting started, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-dotnet-aspnet-core/run-tests.md
+++ b/content/guides/testcontainers-dotnet-aspnet-core/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run the Testcontainers-based integration tests and explore next steps.
+keywords: testcontainers, dotnet, asp.net core, integration testing, run tests
 weight: 30
 ---
 

--- a/content/guides/testcontainers-dotnet-aspnet-core/write-tests.md
+++ b/content/guides/testcontainers-dotnet-aspnet-core/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Replace SQLite with a real Microsoft SQL Server using Testcontainers for .NET.
+keywords: testcontainers, dotnet, asp.net core, sql server, integration testing, xunit
 weight: 20
 ---
 

--- a/content/guides/testcontainers-dotnet-getting-started/create-project.md
+++ b/content/guides/testcontainers-dotnet-getting-started/create-project.md
@@ -2,6 +2,7 @@
 title: Create the .NET project
 linkTitle: Create the project
 description: Set up a .NET solution with a PostgreSQL-backed customer service.
+keywords: testcontainers, dotnet, postgresql, getting started, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-dotnet-getting-started/run-tests.md
+++ b/content/guides/testcontainers-dotnet-getting-started/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based integration tests and explore next steps.
+keywords: testcontainers, dotnet, postgresql, integration testing, run tests
 weight: 30
 ---
 

--- a/content/guides/testcontainers-dotnet-getting-started/write-tests.md
+++ b/content/guides/testcontainers-dotnet-getting-started/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Write integration tests using Testcontainers for .NET and xUnit with a real PostgreSQL database.
+keywords: testcontainers, dotnet, postgresql, xunit, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-go-getting-started/create-project.md
+++ b/content/guides/testcontainers-go-getting-started/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Go project
 linkTitle: Create the project
 description: Set up a Go project with a PostgreSQL-backed repository.
+keywords: testcontainers, go, golang, postgresql, getting started, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-go-getting-started/run-tests.md
+++ b/content/guides/testcontainers-go-getting-started/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based integration tests and explore next steps.
+keywords: testcontainers, go, golang, integration testing, run tests
 weight: 40
 ---
 

--- a/content/guides/testcontainers-go-getting-started/test-suites.md
+++ b/content/guides/testcontainers-go-getting-started/test-suites.md
@@ -2,6 +2,7 @@
 title: Reuse containers with test suites
 linkTitle: Test suites
 description: Share a single Postgres container across multiple tests using testify suites.
+keywords: testcontainers, go, golang, testify, test suites, container reuse
 weight: 30
 ---
 

--- a/content/guides/testcontainers-go-getting-started/write-tests.md
+++ b/content/guides/testcontainers-go-getting-started/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Write your first integration test using testcontainers-go and PostgreSQL.
+keywords: testcontainers, go, golang, postgresql, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-aws-localstack/create-project.md
+++ b/content/guides/testcontainers-java-aws-localstack/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Spring Boot project
 linkTitle: Create the project
 description: Set up a Spring Boot project with Spring Cloud AWS, S3, and SQS.
+keywords: testcontainers, java, spring boot, aws, localstack, s3, sqs, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-aws-localstack/run-tests.md
+++ b/content/guides/testcontainers-java-aws-localstack/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based Spring Cloud AWS integration tests and explore next steps.
+keywords: testcontainers, java, spring boot, aws, localstack, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-aws-localstack/write-tests.md
+++ b/content/guides/testcontainers-java-aws-localstack/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Test Spring Cloud AWS S3 and SQS integration using Testcontainers and LocalStack.
+keywords: testcontainers, java, spring boot, aws, localstack, s3, sqs, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-getting-started/create-project.md
+++ b/content/guides/testcontainers-java-getting-started/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Java project
 linkTitle: Create the project
 description: Set up a Java project with Maven and implement a PostgreSQL-backed customer service.
+keywords: testcontainers, java, maven, postgresql, getting started, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-getting-started/run-tests.md
+++ b/content/guides/testcontainers-java-getting-started/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based integration tests and explore next steps.
+keywords: testcontainers, java, postgresql, integration testing, run tests
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-getting-started/write-tests.md
+++ b/content/guides/testcontainers-java-getting-started/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Write your first integration test using Testcontainers for Java and PostgreSQL.
+keywords: testcontainers, java, postgresql, junit, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-jooq-flyway/create-project.md
+++ b/content/guides/testcontainers-java-jooq-flyway/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Spring Boot project
 linkTitle: Create the project
 description: Set up a Spring Boot project with jOOQ, Flyway, PostgreSQL, and Testcontainers code generation.
+keywords: testcontainers, java, spring boot, jooq, flyway, postgresql, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-jooq-flyway/run-tests.md
+++ b/content/guides/testcontainers-java-jooq-flyway/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run the jOOQ and Flyway integration tests and explore next steps.
+keywords: testcontainers, java, spring boot, jooq, flyway, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-jooq-flyway/write-tests.md
+++ b/content/guides/testcontainers-java-jooq-flyway/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Test jOOQ repositories using Testcontainers with the @JooqTest slice and @SpringBootTest.
+keywords: testcontainers, java, spring boot, jooq, flyway, postgresql, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-keycloak-spring-boot/create-project.md
+++ b/content/guides/testcontainers-java-keycloak-spring-boot/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Spring Boot project
 linkTitle: Create the project
 description: Set up a Spring Boot OAuth 2.0 Resource Server with Keycloak, PostgreSQL, and Testcontainers.
+keywords: testcontainers, java, spring boot, keycloak, oauth2, postgresql, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-keycloak-spring-boot/create-project.md
+++ b/content/guides/testcontainers-java-keycloak-spring-boot/create-project.md
@@ -291,7 +291,7 @@ Then set up the realm:
 2. Under the `keycloaktcdemo` realm, create a client with the following
    settings:
    - **Client ID**: `product-service`
-   - **Client Authentication**: **On**
+   - **Client Authentication**: `On`
    - **Authentication flow**: select only **Service accounts roles**
 3. On the **Client details** screen, go to the **Credentials** tab and copy the
    **Client secret** value.

--- a/content/guides/testcontainers-java-keycloak-spring-boot/run-tests.md
+++ b/content/guides/testcontainers-java-keycloak-spring-boot/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based Spring Boot Keycloak integration tests and explore next steps.
+keywords: testcontainers, java, spring boot, keycloak, oauth2, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-keycloak-spring-boot/write-tests.md
+++ b/content/guides/testcontainers-java-keycloak-spring-boot/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Test the secured Spring Boot API endpoints using Testcontainers Keycloak and PostgreSQL modules.
+keywords: testcontainers, java, spring boot, keycloak, oauth2, postgresql, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-lifecycle/create-project.md
+++ b/content/guides/testcontainers-java-lifecycle/create-project.md
@@ -2,6 +2,7 @@
 title: Create the project and business logic
 linkTitle: Create the project
 description: Set up a Java project with a PostgreSQL-backed customer service for lifecycle testing.
+keywords: testcontainers, java, lifecycle, postgresql, junit, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-lifecycle/extension-annotations.md
+++ b/content/guides/testcontainers-java-lifecycle/extension-annotations.md
@@ -2,6 +2,7 @@
 title: JUnit 5 extension annotations
 linkTitle: Extension annotations
 description: Manage Testcontainers container lifecycle using @Testcontainers and @Container annotations.
+keywords: testcontainers, java, lifecycle, junit, annotations, container management
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-lifecycle/lifecycle-callbacks.md
+++ b/content/guides/testcontainers-java-lifecycle/lifecycle-callbacks.md
@@ -2,6 +2,7 @@
 title: JUnit 5 lifecycle callbacks
 linkTitle: Lifecycle callbacks
 description: Manage Testcontainers container lifecycle using JUnit 5 @BeforeAll and @AfterAll callbacks.
+keywords: testcontainers, java, lifecycle, junit, callbacks, beforeall, afterall
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-lifecycle/singleton-containers.md
+++ b/content/guides/testcontainers-java-lifecycle/singleton-containers.md
@@ -2,6 +2,7 @@
 title: Singleton containers pattern
 linkTitle: Singleton containers
 description: Share containers across multiple test classes using the singleton containers pattern.
+keywords: testcontainers, java, lifecycle, singleton, container reuse, junit
 weight: 40
 ---
 

--- a/content/guides/testcontainers-java-micronaut-kafka/create-project.md
+++ b/content/guides/testcontainers-java-micronaut-kafka/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Micronaut project
 linkTitle: Create the project
 description: Set up a Micronaut project with Kafka, Micronaut Data JPA, and MySQL.
+keywords: testcontainers, java, micronaut, kafka, mysql, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-micronaut-kafka/run-tests.md
+++ b/content/guides/testcontainers-java-micronaut-kafka/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based Micronaut Kafka integration tests and explore next steps.
+keywords: testcontainers, java, micronaut, kafka, mysql, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-micronaut-kafka/write-tests.md
+++ b/content/guides/testcontainers-java-micronaut-kafka/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Test the Micronaut Kafka listener using Testcontainers Kafka and MySQL modules with Awaitility.
+keywords: testcontainers, java, micronaut, kafka, mysql, awaitility, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-micronaut-wiremock/create-project.md
+++ b/content/guides/testcontainers-java-micronaut-wiremock/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Micronaut project
 linkTitle: Create the project
 description: Set up a Micronaut project with an external REST API integration using declarative HTTP clients.
+keywords: testcontainers, java, micronaut, wiremock, rest api, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-micronaut-wiremock/run-tests.md
+++ b/content/guides/testcontainers-java-micronaut-wiremock/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers WireMock integration tests and explore next steps.
+keywords: testcontainers, java, micronaut, wiremock, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-micronaut-wiremock/write-tests.md
+++ b/content/guides/testcontainers-java-micronaut-wiremock/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with WireMock and Testcontainers
 linkTitle: Write tests
 description: Test external REST API integrations using WireMock and the Testcontainers WireMock module.
+keywords: testcontainers, java, micronaut, wiremock, rest api, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-mockserver/create-project.md
+++ b/content/guides/testcontainers-java-mockserver/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Spring Boot project
 linkTitle: Create the project
 description: Set up a Spring Boot project with an external REST API integration using declarative HTTP clients.
+keywords: testcontainers, java, spring boot, mockserver, rest api, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-mockserver/run-tests.md
+++ b/content/guides/testcontainers-java-mockserver/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers MockServer integration tests and explore next steps.
+keywords: testcontainers, java, spring boot, mockserver, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-mockserver/write-tests.md
+++ b/content/guides/testcontainers-java-mockserver/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers MockServer
 linkTitle: Write tests
 description: Test external REST API integrations using the Testcontainers MockServer module and REST Assured.
+keywords: testcontainers, java, spring boot, mockserver, rest assured, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-quarkus/create-project.md
+++ b/content/guides/testcontainers-java-quarkus/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Quarkus project
 linkTitle: Create the project
 description: Set up a Quarkus project with Hibernate ORM with Panache, PostgreSQL, Flyway, and REST API endpoints.
+keywords: testcontainers, java, quarkus, postgresql, hibernate, flyway, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-quarkus/run-tests.md
+++ b/content/guides/testcontainers-java-quarkus/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based Quarkus integration tests and explore next steps.
+keywords: testcontainers, java, quarkus, postgresql, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-quarkus/write-tests.md
+++ b/content/guides/testcontainers-java-quarkus/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Test the Quarkus REST API using Dev Services with Testcontainers, and test with services not supported by Dev Services.
+keywords: testcontainers, java, quarkus, dev services, rest api, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-replace-h2/jdbc-url-approach.md
+++ b/content/guides/testcontainers-java-replace-h2/jdbc-url-approach.md
@@ -2,6 +2,7 @@
 title: Replace H2 with the Testcontainers JDBC URL
 linkTitle: JDBC URL approach
 description: Use the Testcontainers special JDBC URL to swap H2 for a real PostgreSQL database.
+keywords: testcontainers, java, h2, postgresql, jdbc, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-replace-h2/junit-extension-approach.md
+++ b/content/guides/testcontainers-java-replace-h2/junit-extension-approach.md
@@ -2,6 +2,7 @@
 title: Use the JUnit 5 extension for more control
 linkTitle: JUnit 5 extension
 description: Use the Testcontainers JUnit 5 extension for more control over the PostgreSQL container.
+keywords: testcontainers, java, h2, postgresql, junit, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-replace-h2/problem-with-h2.md
+++ b/content/guides/testcontainers-java-replace-h2/problem-with-h2.md
@@ -2,6 +2,7 @@
 title: The problem with H2 for testing
 linkTitle: The H2 problem
 description: Understand why using H2 in-memory databases for testing gives false confidence.
+keywords: testcontainers, java, h2, in-memory database, integration testing
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-service-configuration/copy-files.md
+++ b/content/guides/testcontainers-java-service-configuration/copy-files.md
@@ -2,6 +2,7 @@
 title: Copy files into containers
 linkTitle: Copy files
 description: Initialize containers by copying files into specific locations.
+keywords: testcontainers, java, service configuration, copy files, container initialization
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-service-configuration/exec-in-container.md
+++ b/content/guides/testcontainers-java-service-configuration/exec-in-container.md
@@ -2,6 +2,7 @@
 title: Execute commands inside containers
 linkTitle: Execute commands
 description: Run commands inside running containers to initialize services for testing.
+keywords: testcontainers, java, service configuration, exec, container initialization
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-spring-boot-kafka/create-project.md
+++ b/content/guides/testcontainers-java-spring-boot-kafka/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Spring Boot project
 linkTitle: Create the project
 description: Set up a Spring Boot project with Kafka, Spring Data JPA, and MySQL.
+keywords: testcontainers, java, spring boot, kafka, mysql, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-spring-boot-kafka/run-tests.md
+++ b/content/guides/testcontainers-java-spring-boot-kafka/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based Spring Boot Kafka integration tests and explore next steps.
+keywords: testcontainers, java, spring boot, kafka, mysql, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-spring-boot-kafka/write-tests.md
+++ b/content/guides/testcontainers-java-spring-boot-kafka/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Test the Spring Boot Kafka listener using Testcontainers Kafka and MySQL modules with Awaitility.
+keywords: testcontainers, java, spring boot, kafka, mysql, awaitility, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-spring-boot-rest-api/create-project.md
+++ b/content/guides/testcontainers-java-spring-boot-rest-api/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Spring Boot project
 linkTitle: Create the project
 description: Set up a Spring Boot project with Spring Data JPA, PostgreSQL, and a REST API.
+keywords: testcontainers, java, spring boot, rest api, postgresql, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-spring-boot-rest-api/run-tests.md
+++ b/content/guides/testcontainers-java-spring-boot-rest-api/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based Spring Boot integration tests and explore next steps.
+keywords: testcontainers, java, spring boot, rest api, postgresql, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-spring-boot-rest-api/write-tests.md
+++ b/content/guides/testcontainers-java-spring-boot-rest-api/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Test the Spring Boot REST API using Testcontainers and REST Assured.
+keywords: testcontainers, java, spring boot, rest api, rest assured, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-java-wiremock/create-project.md
+++ b/content/guides/testcontainers-java-wiremock/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Spring Boot project
 linkTitle: Create the project
 description: Set up a Spring Boot project with an external REST API integration using WireMock and Testcontainers.
+keywords: testcontainers, java, spring boot, wiremock, rest api, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-java-wiremock/run-tests.md
+++ b/content/guides/testcontainers-java-wiremock/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers WireMock integration tests and explore next steps.
+keywords: testcontainers, java, spring boot, wiremock, integration testing
 weight: 30
 ---
 

--- a/content/guides/testcontainers-java-wiremock/write-tests.md
+++ b/content/guides/testcontainers-java-wiremock/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with WireMock and Testcontainers
 linkTitle: Write tests
 description: Test external REST API integrations using WireMock with both the JUnit 5 extension and the Testcontainers WireMock module.
+keywords: testcontainers, java, spring boot, wiremock, junit, rest api, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-nodejs-getting-started/create-project.md
+++ b/content/guides/testcontainers-nodejs-getting-started/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Node.js project
 linkTitle: Create the project
 description: Set up a Node.js project with a PostgreSQL-backed customer repository.
+keywords: testcontainers, node.js, nodejs, postgresql, getting started, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-nodejs-getting-started/run-tests.md
+++ b/content/guides/testcontainers-nodejs-getting-started/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based integration tests and explore next steps.
+keywords: testcontainers, node.js, nodejs, postgresql, integration testing, run tests
 weight: 30
 ---
 

--- a/content/guides/testcontainers-nodejs-getting-started/write-tests.md
+++ b/content/guides/testcontainers-nodejs-getting-started/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Write integration tests using Testcontainers for Node.js and Jest with a real PostgreSQL database.
+keywords: testcontainers, node.js, nodejs, postgresql, jest, integration testing
 weight: 20
 ---
 

--- a/content/guides/testcontainers-python-getting-started/create-project.md
+++ b/content/guides/testcontainers-python-getting-started/create-project.md
@@ -2,6 +2,7 @@
 title: Create the Python project
 linkTitle: Create the project
 description: Set up a Python project with a PostgreSQL-backed customer service.
+keywords: testcontainers, python, postgresql, getting started, project setup
 weight: 10
 ---
 

--- a/content/guides/testcontainers-python-getting-started/run-tests.md
+++ b/content/guides/testcontainers-python-getting-started/run-tests.md
@@ -2,6 +2,7 @@
 title: Run tests and next steps
 linkTitle: Run tests
 description: Run your Testcontainers-based integration tests and explore next steps.
+keywords: testcontainers, python, postgresql, integration testing, run tests
 weight: 30
 ---
 

--- a/content/guides/testcontainers-python-getting-started/write-tests.md
+++ b/content/guides/testcontainers-python-getting-started/write-tests.md
@@ -2,6 +2,7 @@
 title: Write tests with Testcontainers
 linkTitle: Write tests
 description: Write integration tests using testcontainers-python and pytest with a real PostgreSQL database.
+keywords: testcontainers, python, postgresql, pytest, integration testing
 weight: 20
 ---
 

--- a/content/guides/vuejs/configure-github-actions.md
+++ b/content/guides/vuejs/configure-github-actions.md
@@ -31,7 +31,7 @@ In this section, you'll set up a CI/CD pipeline using [GitHub Actions](https://d
 
 To enable GitHub Actions to build and push Docker images, you’ll securely store your Docker Hub credentials in your new GitHub repository.
 
-### Step 1: Generate Docker Hub Credentials and Set GitHub Secrets"
+### Step 1: Generate Docker Hub credentials and set GitHub secrets
 
 1. Create a Personal Access Token (PAT) from [Docker Hub](https://hub.docker.com)
    1. Go to your **Docker Hub account → Account Settings → Security**.

--- a/content/guides/vuejs/configure-github-actions.md
+++ b/content/guides/vuejs/configure-github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Automate your builds with GitHub Actions
-linkTitle: Automate your builds with GitHub Actions
+linkTitle: GitHub Actions CI
 weight: 60
 keywords: CI/CD, GitHub( Actions), Vue.js
 description: Learn how to configure CI/CD using GitHub Actions for your Vue.js application.

--- a/content/guides/vuejs/deploy.md
+++ b/content/guides/vuejs/deploy.md
@@ -118,7 +118,7 @@ If everything is configured properly, you’ll see confirmation that both the De
    
 This confirms that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
-### Step 2. Check the Deployment status
+### Step 2. Check the deployment status
 
 Run the following command to check the status of your deployment:
    
@@ -135,7 +135,7 @@ You should see output similar to the following:
 
 This confirms that your pod is up and running with one replica available.
 
-### Step 3. Verify the Service exposure
+### Step 3. Verify the service exposure
 
 Check if the NodePort service is exposing your app to your local machine:
 

--- a/content/guides/vuejs/develop.md
+++ b/content/guides/vuejs/develop.md
@@ -24,7 +24,7 @@ You’ll learn how to:
 
 ---
 
-## Automatically update services (Development Mode)
+## Automatically update services (development mode)
 
 Leverage Compose Watch to enable real-time file synchronization between your local machine and the containerized Vue.js development environment. This powerful feature eliminates the need to manually rebuild or restart containers, providing a fast, seamless, and efficient development workflow.
 

--- a/content/guides/wiremock.md
+++ b/content/guides/wiremock.md
@@ -208,7 +208,7 @@ Follow the steps to setup a non-containerized Node application:
    > [!TIP]
    > Before you proceed to the next step, ensure that you stop the node application service.
 
-## Use a Live API in production to fetch real-time weather data from AccuWeather
+## Use a live API in production to fetch real-time weather data from AccuWeather
 
    To enhance your Node.js application with real-time weather data, you can seamlessly integrate the AccuWeather API. This section of the guide will walk you through the steps involved in setting up a non-containerized Node.js application and fetching weather information directly from the AccuWeather API.
 

--- a/content/guides/zscaler/index.md
+++ b/content/guides/zscaler/index.md
@@ -5,6 +5,7 @@ summary: |
   This guide explains how to embed Zscaler’s root certificate into Docker
   images, allowing containers to operate securely with Zscaler proxies and
   avoid SSL errors.
+keywords: zscaler, proxy, ssl certificates, corporate network, https, root certificate
 params:
   time: 10 minutes
 ---


### PR DESCRIPTION
Two related style-conformance fixes across `content/guides/`, motivated by a recent audit of guide-page style against STYLE.md, COMPONENTS.md, and AGENTS.md.

## What changed

### 1. Add missing `keywords:` frontmatter to 104 guide pages

`keywords` is documented as required (AGENTS.md, COMPONENTS.md) but was missing from 10 single-file guides, 8 `_index.md` landing pages, and 86 chapter pages. Each page now has a meaningful, page-specific comma-separated keyword list derived from its title, lead content, and sibling pages where applicable.

Examples of the convention applied:
- `content/guides/testcontainers-java-spring-boot-kafka/create-project.md` — `testcontainers, java, spring boot, kafka, mysql, project setup`
- `content/guides/docker-compose/why.md` — `docker compose, multi-container, yaml, services, orchestration, application`

Post-change verification confirms zero guide pages under `content/guides/` are missing the field.

### 2. Remove bold-for-emphasis from 14 guide pages

STYLE.md restricts bold to UI elements only — never for emphasis, product names, command names, or the `**Term**: description` subsection-label pattern. Cleaned up the top-15 offender files identified by raw bold-span count (code blocks excluded). One file (`jupyter.md`, 32 spans) was untouched because all spans were legitimate UI references.

Shape of the work across 14 files:
- ~60 `**Term**: description` list items de-bolded
- ~10 identifiers/values/commands converted to backticks (e.g. `**my-mysql**` → `` `my-mysql` ``)
- ~10 product/emphasis bolds removed
- 6 bolded link texts un-bolded
- 3 blockquote-style notes converted to `> [!NOTE]` callouts

Legitimate UI bolds (button names, menu items, field labels, tab names) were preserved throughout. `databases.md` kept 47 of 49 spans for this reason — only port-mapping value and container name were converted to backticks.

## Out of scope

The audit surfaced other items not addressed here:
- Series `params` block missing on all 48 `_index.md` landing pages — this is a "decide what's authoritative" question that warrants discussion before code changes.
- Vale prose violations (`just`, `easily`, `we`, etc.) — concentrated in ~5 files; can land separately.
- Heading numbering convention (`## Step N:` vs `## N.` vs plain) — undocumented; should be pinned down in STYLE.md or COMPONENTS.md before mechanical sweeps.

## Verification

- `markdownlint` (via `scripts/lint.sh`) clean on all changed files.
- Vale not installed locally; relying on CI to validate prose.
- `git diff --stat` confirms scope: 118 unique files, all under `content/guides/`. No vendored, layout, or generated-file changes.