### PR TITLE
sandboxes: warn against mounting network drives

### DIFF
--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -21,6 +21,12 @@ absolute paths means error messages, configuration files, and build outputs all
 reference paths you can find on your host. The agent sees exactly the directory
 structure you see, which reduces confusion when debugging or reviewing changes.
 
+> [!WARNING]
+> Avoid mounting network-attached or remote storage (network drives, SMB/NFS
+> shares, or cloud-synced folders) as a workspace. The sandbox accesses
+> workspaces through a filesystem passthrough, so every file read and write
+> goes over the network. This adds latency and slows agent performance.
+
 ## Storage and persistence
 
 When you create a sandbox, everything inside it persists until you remove it:


### PR DESCRIPTION
## Summary

Adds a warning to the workspace mounting section of the architecture page advising users not to mount network-attached or remote storage as a workspace, since the filesystem passthrough means all I/O goes over the network, adding latency and degrading agent performance.

Generated by Claude Code