### PR TITLE
agents: scope git hygiene hook to `git add` commands

### DIFF
--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -16,6 +16,7 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git add *)",
             "command": "bash .agents/hooks/enforce-git-hygiene.sh"
           }
         ],


### PR DESCRIPTION
The `PreToolUse:Bash` hook in `.agents/settings.json` invokes `.agents/hooks/enforce-git-hygiene.sh` on every Bash tool call, but the script's only job is to block `git add . / -A / --all`. Scope the hook with `"if": "Bash(git add *)"` so the script only runs when the command contains `git add`. This removes per-tool-call overhead and noise — especially when an AI agent works across multiple projects in one session (e.g. via Claude Code's `/add-dir`), where this repo's hook isn't relevant to commands operating on the added directory.

Verified empirically that `Bash(git add *)` matches `git add` as a substring (covers compound forms like `cd subdir && git add .`), so the script's blocking coverage is unchanged.
