### PR TITLE
docs: fix MD019 double space in Grafana MCP guide heading

### DIFF
--- a/content/guides/grafana-mcp-server-gemini.md
+++ b/content/guides/grafana-mcp-server-gemini.md
@@ -68,7 +68,7 @@ A successful connection will show `MCP_DOCKER` as **Ready**, exposing dozens too
 
 ## Use Cases
 
-###  Data source Discovery
+### Data source Discovery
 
 _List all Prometheus and Loki data sources._
 


### PR DESCRIPTION
The "Data source Discovery" heading in `content/guides/grafana-mcp-server-gemini.md` has two spaces after the `###`, which trips markdownlint (MD019). Since the lint job runs over the whole `content/**/*.md` tree, this currently fails CI on every open PR. This removes the extra space.