### PR TITLE
gordon: clarify Business tier activation via Settings Management

### DIFF
--- a/content/manuals/ai/gordon/_index.md
+++ b/content/manuals/ai/gordon/_index.md
@@ -66,11 +66,11 @@ Before you begin:
 >
 > 1. Contact Docker Support to activate Gordon for your organization. Docker
 >    will confirm when activation is complete.
-> 2. Once confirmed, an organization administrator must set **Enable Gordon** to
->    **Enabled** or **Always enabled** in the
->    [Admin Console](/manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console.md).
->    Do not leave the setting at its default value, as this will not activate
->    Gordon organization-wide.
+> 2. Once confirmed, an organization administrator must enable Gordon via
+>    [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/).
+>    Set **Enable Gordon** to **Enabled** or **Always enabled**. Ensure all
+>    Settings Management prerequisites are met, otherwise the setting will not
+>    take effect on Docker Desktop clients.
 
 ### Quick start
 

--- a/content/manuals/ai/gordon/_index.md
+++ b/content/manuals/ai/gordon/_index.md
@@ -66,11 +66,11 @@ Before you begin:
 >
 > 1. Contact Docker Support to activate Gordon for your organization. Docker
 >    will confirm when activation is complete.
-> 2. Once confirmed, an organization administrator must enable Gordon via
->    [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/).
+> 2. Once confirmed, an organization administrator must turn on Gordon via
+>    [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md).
 >    Set **Enable Gordon** to **Enabled** or **Always enabled**. Ensure all
->    Settings Management prerequisites are met, otherwise the setting will not
->    take effect on Docker Desktop clients.
+>    Settings Management prerequisites are met for the setting to take effect
+>    on Docker Desktop clients.
 
 ### Quick start
 


### PR DESCRIPTION
## Summary

The Business tier activation note in the Gordon prerequisites linked directly to the Admin Console configuration page but didn't signal that Settings Management as a whole needs to be properly set up for the policy to reach Docker Desktop clients. Updated step 2 to link to the top-level Settings Management page and note that its prerequisites must be met — deferring to that page as the canonical source rather than duplicating the details here.

Generated by Claude Code