### PR TITLE
analytics: fix Marlin endpoint URL double-encoding

### DIFF
--- a/assets/js/src/marlin.js
+++ b/assets/js/src/marlin.js
@@ -3,15 +3,14 @@ import { Marlin, Environment } from "@docker/marlin-sdk-web-public";
 const config = window.__marlinConfig;
 
 if (config && config.apiKey && config.endpoint) {
+  const environment =
+    config.environment === "staging" ? Environment.STAGING : Environment.PROD;
   try {
     window.marlin = new Marlin({
       endpoint: config.endpoint,
       apiKey: config.apiKey,
       site: "docs",
-      environment:
-        config.environment === "staging"
-          ? Environment.STAGING
-          : Environment.PROD,
+      environment,
     });
   } catch (err) {
     console.warn("Marlin SDK init failed:", err);

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -82,11 +82,7 @@
   {{- end -}}
   {{- if and $apiKey $endpoint -}}
     <script>
-      window.__marlinConfig = {
-        apiKey: {{ $apiKey | jsonify }},
-        endpoint: {{ $endpoint | jsonify }},
-        environment: {{ $env | jsonify }}
-      };
+      window.__marlinConfig = {{ dict "apiKey" $apiKey "endpoint" $endpoint "environment" $env | jsonify | safeJS }};
     </script>
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Summary

Hugo's `html/template` is JS-context-aware: inside `<script>` blocks it automatically escapes string values. The previous code called `jsonify` per field, which produced quoted strings like `"https://..."` — html/template then re-escaped those quotes, embedding literal `"` characters in the endpoint value. The Marlin SDK received `"https://marlin-2.docker.com"` (with embedded quotes) and rejected it as an invalid URL.

Fix by jsonifying the whole config dict at once and piping through `safeJS`, which tells html/template to treat the output as already-safe JavaScript and skip the second escaping pass.

## Learnings

- Hugo's `html/template` applies context-aware escaping inside `<script>` tags. Calling `jsonify` on individual string fields and then embedding them raw causes double-encoding. The correct pattern is `dict ... | jsonify | safeJS` so the template engine does not re-escape the already-encoded JSON.

Generated by Claude Code