### PR TITLE
dhi: update cli ref

### DIFF
--- a/data/cli/dhi/docker_dhi_auth.yaml
+++ b/data/cli/dhi/docker_dhi_auth.yaml
@@ -5,8 +5,10 @@ pname: docker dhi
 plink: docker_dhi.yaml
 cname:
     - docker dhi auth apk
+    - docker dhi auth deb
 clink:
     - docker_dhi_auth_apk.yaml
+    - docker_dhi_auth_deb.yaml
 deprecated: false
 hidden: false
 experimental: false

--- a/data/cli/dhi/docker_dhi_auth_deb.yaml
+++ b/data/cli/dhi/docker_dhi_auth_deb.yaml
@@ -1,0 +1,13 @@
+command: docker dhi auth deb
+short: Create authentication details for DHI DEB repositories
+long: Create authentication details for DHI DEB repositories
+usage: docker dhi auth deb
+pname: docker dhi auth
+plink: docker_dhi_auth.yaml
+deprecated: false
+hidden: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Updated DHI CLI to v0.0.4 that adds `docker dhi auth deb`.

https://github.com/docker-hardened-images/dhictl/releases/tag/v0.0.4

https://deploy-preview-25163--docsdocker.netlify.app/reference/cli/docker/dhi/auth/

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
