### PR TITLE
Add case-sensitivity note for Docker ID

### DIFF
--- a/content/manuals/admin/organization/setup/convert-account.md
+++ b/content/manuals/admin/organization/setup/convert-account.md
@@ -75,6 +75,7 @@ an organization:
    account.
 1. Enter a **Username of new owner** to set an organization owner. The new
    Docker ID you specify becomes the organization’s owner. You cannot use the
-   same Docker ID as the account you are trying to convert.
+   same Docker ID as the account you are trying to convert. The Docker ID is
+   case-sensitive.
 1. Select **Confirm**. The new owner receives a notification email. Use that
    owner account to sign in and manage the new organization.


### PR DESCRIPTION
Clarify that the Docker ID is case-sensitive when setting a new organization owner.

## Description

Added explicit instruction the Docker ID is case sensitive.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review