### PR TITLE
guides (python, deno, bun): update to dhi-only and remove external repo

### DIFF
--- a/content/guides/bun/containerize.md
+++ b/content/guides/bun/containerize.md
@@ -92,7 +92,6 @@ Create a file named `compose.yml` with the following contents:
 ```yaml {title="compose.yml"}
 services:
   server:
-    image: bun-server
     build:
       context: .
       dockerfile: Dockerfile

--- a/content/guides/bun/containerize.md
+++ b/content/guides/bun/containerize.md
@@ -10,7 +10,7 @@ aliases:
 
 ## Prerequisites
 
-* You have a [Git client](https://git-scm.com/downloads). The examples in this section use a command-line based Git client, but you can use any client.
+- You have installed the latest version of [Docker Desktop](/get-started/get-docker.md).
 
 ## Overview
 
@@ -29,52 +29,48 @@ dependencies. Also, as it's fairly a new runtime, getting a consistent
 development environment for Bun can be challenging. Docker can help you set up
 a consistent development environment for Bun.
 
-## Get the sample application
+## Create the application
 
-Clone the sample application to use with this guide. Open a terminal, change
-directory to a directory that you want to work in, and run the following
-command to clone the repository:
+Create a new directory for your project and navigate into it:
 
 ```console
-$ git clone https://github.com/dockersamples/bun-docker.git && cd bun-docker
+$ mkdir bun-docker && cd bun-docker
 ```
 
-You should now have the following contents in your `bun-docker` directory.
+Create a file named `server.js` with the following contents:
 
-```text
-├── bun-docker/
-│ ├── compose.yml
-│ ├── Dockerfile
-│ ├── LICENSE
-│ ├── server.js
-│ └── README.md
+```js {title="server.js"}
+import { serve } from "bun";
+
+serve({
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/") {
+      return new Response(JSON.stringify({ Status: "OK" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("Not found", { status: 404 });
+  },
+  port: 3000,
+});
+
+console.log("Server is running.");
 ```
 
-## Create a Dockerfile
+## Create Docker assets
 
-Before creating a Dockerfile, you need to choose a base image. You can either use the [Bun Docker Official Image](https://hub.docker.com/r/oven/bun) or a Docker Hardened Image (DHI) from the [Hardened Image catalog](https://hub.docker.com/hardened-images/catalog).
+This guide uses [Docker Hardened Images (DHI)](/dhi/) as the base image. Docker Hardened Images are minimal, secure, and production-ready base images maintained by Docker.
 
-Choosing DHI offers the advantage of a production-ready image that is lightweight and secure. For more information, see [Docker Hardened Images](https://docs.docker.com/dhi/).
+Docker Hardened Images (DHIs) are available for Bun in the [Docker Hardened Images catalog](https://hub.docker.com/hardened-images/catalog/dhi/bun). Sign in to the DHI registry before pulling:
 
-{{< tabs >}}
-{{< tab name="Using Docker Hardened Images" >}}
+```console
+$ docker login dhi.io
+```
 
-Docker Hardened Images (DHIs) are available for Bun in the [Docker Hardened Images catalog](https://hub.docker.com/hardened-images/catalog/dhi/bun). You can pull DHIs directly from the `dhi.io` registry.
+Create a file named `Dockerfile` with the following contents:
 
-1. Sign in to the DHI registry:
-   ```console
-   $ docker login dhi.io
-   ```
-
-2. Pull the Bun DHI as `dhi.io/bun:1`. The tag (`1`) in this example refers to the version to the latest 1.x version of Bun.
-
-   ```console
-   $ docker pull dhi.io/bun:1
-   ```
-
-For other available versions, refer to the [catalog](https://hub.docker.com/hardened-images/catalog/dhi/bun).
-
-```dockerfile
+```dockerfile {title="Dockerfile"}
 # Use the DHI Bun image as the base image
 FROM dhi.io/bun:1
 
@@ -91,39 +87,27 @@ EXPOSE 3000
 CMD ["bun", "server.js"]
 ```
 
-{{< /tab >}}
-{{< tab name="Using the official image" >}}
+Create a file named `compose.yml` with the following contents:
 
-Using the Docker Official Image is straightforward. In the following Dockerfile, you'll notice that the `FROM` instruction uses `oven/bun` as the base image.
-
-You can find the image on [Docker Hub](https://hub.docker.com/r/oven/bun). This is the Docker Official Image for Bun created by Oven, the company behind Bun, and it's available on Docker Hub.
-
-```dockerfile
-# Use the official Bun image
-FROM oven/bun:latest
-
-# Set the working directory in the container
-WORKDIR /app
-
-# Copy the current directory contents into the container at /app
-COPY . .
-
-# Expose the port on which the API will listen
-EXPOSE 3000
-
-# Run the server when the container launches
-CMD ["bun", "server.js"]
+```yaml {title="compose.yml"}
+services:
+  server:
+    image: bun-server
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
 ```
 
-{{< /tab >}}
-{{< /tabs >}}
+You should now have the following files in your `bun-docker` directory:
 
-In addition to specifying the base image, the Dockerfile also:
-
-- Sets the working directory in the container to `/app`.
-- Copies the content of the current directory to the `/app` directory in the container.
-- Exposes port 3000, where the API is listening for requests.
-- And finally, starts the server when the container launches with the command `bun server.js`.
+```text
+├── bun-docker/
+│   ├── compose.yml
+│   ├── Dockerfile
+│   └── server.js
+```
 
 ## Run the application
 

--- a/content/guides/bun/develop.md
+++ b/content/guides/bun/develop.md
@@ -18,14 +18,6 @@ In this section, you'll learn how to set up a development environment for your c
 
 - Configuring Compose to automatically update your running Compose services as you edit and save your code
 
-## Get the sample application
-
-Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
-
-```console
-$ git clone https://github.com/dockersamples/bun-docker.git && cd bun-docker
-```
-
 ## Automatically update services
 
 Use Compose Watch to automatically update your running Compose services as you

--- a/content/guides/deno/containerize.md
+++ b/content/guides/deno/containerize.md
@@ -10,7 +10,7 @@ aliases:
 
 ## Prerequisites
 
-* You have a [Git client](https://git-scm.com/downloads). The examples in this section use a command-line based Git client, but you can use any client.
+- You have installed the latest version of [Docker Desktop](/get-started/get-docker.md).
 
 ## Overview
 
@@ -18,39 +18,22 @@ For a long time, Node.js has been the go-to runtime for server-side JavaScript a
 
 Why develop Deno applications with Docker? Having a choice of runtimes is exciting, but managing multiple runtimes and their dependencies consistently across environments can be tricky. This is where Docker proves invaluable. Using containers to create and destroy environments on demand simplifies runtime management and ensures consistency. Additionally, as Deno continues to grow and evolve, Docker helps establish a reliable and reproducible development environment, minimizing setup challenges and streamlining the workflow.
 
-## Get the sample application
+## Create the application
 
-Clone the sample application to use with this guide. Open a terminal, change
-directory to a directory that you want to work in, and run the following
-command to clone the repository:
+Create a new directory for your project and navigate into it:
 
 ```console
-$ git clone https://github.com/dockersamples/docker-deno.git && cd docker-deno
+$ mkdir deno-docker && cd deno-docker
 ```
 
-You should now have the following contents in your `deno-docker` directory.
+Create a file named `server.ts` with the following contents:
 
-```text
-├── deno-docker/
-│ ├── compose.yml
-│ ├── Dockerfile
-│ ├── LICENSE
-│ ├── server.ts
-│ └── README.md
-```
-
-## Understand the sample application
-
-The sample application is a simple Deno application that uses the Oak framework to create a simple API that returns a JSON response. The application listens on port 8000 and returns a message `{"Status" : "OK"}` when you access the application in a browser.
-
-```typescript
-// server.ts
+```typescript {title="server.ts"}
 import { Application, Router } from "https://deno.land/x/oak@v12.0.0/mod.ts";
 
 const app = new Application();
 const router = new Router();
 
-// Define a route that returns JSON
 router.get("/", (context) => {
   context.response.body = { Status: "OK" };
   context.response.type = "application/json";
@@ -63,32 +46,19 @@ console.log("Server running on http://localhost:8000");
 await app.listen({ port: 8000 });
 ```
 
-## Create a Dockerfile
+## Create Docker assets
 
-Before creating a Dockerfile, you need to choose a base image. You can either use the [Deno Docker Official Image](https://hub.docker.com/r/denoland/deno) or a Docker Hardened Image (DHI) from the [Hardened Image catalog](https://hub.docker.com/hardened-images/catalog).
+This guide uses [Docker Hardened Images (DHI)](/dhi/) as the base image. Docker Hardened Images are minimal, secure, and production-ready base images maintained by Docker.
 
-Choosing DHI offers the advantage of a production-ready image that is lightweight and secure. For more information, see [Docker Hardened Images](https://docs.docker.com/dhi/).
+Docker Hardened Images (DHIs) are available for Deno in the [Docker Hardened Images catalog](https://hub.docker.com/hardened-images/catalog/dhi/deno). Sign in to the DHI registry before pulling:
 
-{{< tabs >}}
-{{< tab name="Using Docker Hardened Images" >}}
+```console
+$ docker login dhi.io
+```
 
-Docker Hardened Images (DHIs) are available for Deno in the [Docker Hardened Images catalog](https://hub.docker.com/hardened-images/catalog/dhi/deno). You can pull DHIs directly from the `dhi.io` registry.
+Create a file named `Dockerfile` with the following contents:
 
-1. Sign in to the DHI registry:
-
-   ```console
-   $ docker login dhi.io
-   ```
-
-2. Pull the Deno DHI as `dhi.io/deno:2`. The tag (`2`) in this example refers to the version to the latest 2.x version of Deno.
-
-   ```console
-   $ docker pull dhi.io/deno:2
-   ```
-
-For other available versions, refer to the [catalog](https://hub.docker.com/hardened-images/catalog/dhi/deno).
-
-```dockerfile
+```dockerfile {title="Dockerfile"}
 # Use the DHI Deno image as the base image
 FROM dhi.io/deno:2
 
@@ -108,48 +78,31 @@ EXPOSE 8000
 CMD ["run", "--allow-net", "server.ts"]
 ```
 
-{{< /tab >}}
-{{< tab name="Using the official image" >}}
+Create a file named `compose.yml` with the following contents:
 
-Using the Docker Official Image is straightforward. In the following Dockerfile, you'll notice that the `FROM` instruction uses `denoland/deno:latest` as the base image.
-
-This is the official image for Deno. This image is [available on the Docker Hub](https://hub.docker.com/r/denoland/deno).
-
-```dockerfile
-# Use the official Deno image
-FROM denoland/deno:latest
-
-# Set the working directory
-WORKDIR /app
-
-# Copy server code into the container
-COPY server.ts .
-
-# Set permissions (optional but recommended for security)
-USER deno
-
-# Expose port 8000
-EXPOSE 8000
-
-# Run the Deno server
-CMD ["run", "--allow-net", "server.ts"]
+```yaml {title="compose.yml"}
+services:
+  server:
+    image: deno-server
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
 ```
 
-{{< /tab >}}
-{{< /tabs >}}
+You should now have the following files in your `deno-docker` directory:
 
-In addition to specifying the base image, the Dockerfile also:
-
-- Sets the working directory in the container to `/app`.
-- Copies `server.ts` into the container.
-- Sets the user to `deno` to run the application as a non-root user.
-- Exposes port 8000 to allow traffic to the application.
-- Runs the Deno server using the `CMD` instruction.
-- Uses the `--allow-net` flag to allow network access to the application. The `server.ts` file uses the Oak framework to create a simple API that listens on port 8000.
+```text
+├── deno-docker/
+│   ├── compose.yml
+│   ├── Dockerfile
+│   └── server.ts
+```
 
 ## Run the application
 
-Make sure you are in the `deno-docker` directory. Run the following command in a terminal to build and run the application.
+From the `deno-docker` directory, run the following command in a terminal.
 
 ```console
 $ docker compose up --build
@@ -170,7 +123,6 @@ $ docker compose up --build -d
 ```
 
 Open a browser and view the application at [http://localhost:8000](http://localhost:8000).
-
 
 In the terminal, run the following command to stop the application.
 

--- a/content/guides/deno/containerize.md
+++ b/content/guides/deno/containerize.md
@@ -83,7 +83,6 @@ Create a file named `compose.yml` with the following contents:
 ```yaml {title="compose.yml"}
 services:
   server:
-    image: deno-server
     build:
       context: .
       dockerfile: Dockerfile

--- a/content/guides/deno/develop.md
+++ b/content/guides/deno/develop.md
@@ -18,14 +18,6 @@ In this section, you'll learn how to set up a development environment for your c
 
 - Configuring Compose to automatically update your running Compose services as you edit and save your code
 
-## Get the sample application
-
-Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
-
-```console
-$ git clone https://github.com/dockersamples/docker-deno.git && cd docker-deno
-```
-
 ## Automatically update services
 
 Use Compose Watch to automatically update your running Compose services as you

--- a/content/guides/python/containerize.md
+++ b/content/guides/python/containerize.md
@@ -241,12 +241,12 @@ directory.
 
 ```text
 ├── python-docker-example/
-│ ├── app.py
-│ ├── requirements.txt
-│ ├── .dockerignore
-│ ├── .gitignore
-│ ├── compose.yaml
-│ └── Dockerfile
+│   ├── app.py
+│   ├── requirements.txt
+│   ├── .dockerignore
+│   ├── .gitignore
+│   ├── compose.yaml
+│   └── Dockerfile
 ```
 
 To learn more about the files, see the following:

--- a/content/guides/python/containerize.md
+++ b/content/guides/python/containerize.md
@@ -14,20 +14,38 @@ aliases:
 ## Prerequisites
 
 - You have installed the latest version of [Docker Desktop](/get-started/get-docker.md).
-- You have a [Git client](https://git-scm.com/downloads). The examples in this section use a command-line based Git client, but you can use any client.
 
 ## Overview
 
 This section walks you through containerizing and running a Python application.
 
-## Get the sample application
+## Create the application
 
 The sample application uses the popular [FastAPI](https://fastapi.tiangolo.com) framework.
 
-Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
+Create a new directory for your project and navigate into it:
 
 ```console
-$ git clone https://github.com/estebanx64/python-docker-example && cd python-docker-example
+$ mkdir python-docker-example && cd python-docker-example
+```
+
+Create a file named `app.py` with the following contents:
+
+```python {title="app.py"}
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+```
+
+Create a file named `requirements.txt` with the following contents:
+
+```text {title="requirements.txt"}
+fastapi==0.111.0
 ```
 
 ## Create Docker assets
@@ -37,208 +55,22 @@ containerize your application.
 
 > [!TIP]
 >
-> [Gordon](/ai/gordon/), Docker's AI assistant, can generate Docker assets for your project. Ask Gordon to create a Dockerfile, Compose file, and `.dockerignore` tailored to your application.
+> [Gordon](/ai/gordon/), Docker's AI assistant, can generate Docker assets for
+> your project. Ask Gordon to create a Dockerfile, Compose file, and
+> `.dockerignore` tailored to your application.
 
-Before creating your Dockerfile, you need to choose a base image. You can use the [Python Docker Official Image](https://hub.docker.com/_/python),
-or a [Docker Hardened Image (DHI)](https://hub.docker.com/hardened-images/catalog/dhi/python).
+This guide uses [Docker Hardened Images (DHI)](/dhi/) as the base image. Docker
+Hardened Images are minimal, secure, and production-ready base images maintained
+by Docker. They help reduce vulnerabilities and simplify compliance. For more
+details, see [Docker Hardened Images](/dhi/).
 
-Docker Hardened Images (DHIs) are minimal, secure, and production-ready base images maintained by Docker.
-They help reduce vulnerabilities and simplify compliance. For more details, see [Docker Hardened Images](/dhi/).
+Docker Hardened Images (DHIs) are available for Python in the [Docker Hardened
+Images catalog](https://hub.docker.com/hardened-images/catalog/dhi/python). Sign
+in to the DHI registry so Docker can pull the base images during the build:
 
-{{< tabs >}}
-{{< tab name="Using the official Docker image" >}}
-
-Create the following files in your project directory.
-
-Create a file named `Dockerfile` with the following contents.
-
-```dockerfile {collapse=true,title=Dockerfile}
-# syntax=docker/dockerfile:1
-
-# Comments are provided throughout this file to help you get started.
-# If you need more help, visit the Dockerfile reference guide at
-# https://docs.docker.com/go/dockerfile-reference/
-
-# This Dockerfile uses Python Docker Official Image
-ARG PYTHON_VERSION=3.12
-FROM python:${PYTHON_VERSION}-slim
-
-# Prevents Python from writing pyc files.
-ENV PYTHONDONTWRITEBYTECODE=1
-
-# Keeps Python from buffering stdout and stderr to avoid situations where
-# the application crashes without emitting any logs due to buffering.
-ENV PYTHONUNBUFFERED=1
-
-WORKDIR /app
-
-# Create a non-privileged user that the app will run under.
-# See https://docs.docker.com/go/dockerfile-user-best-practices/
-ARG UID=10001
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    appuser
-
-# Download dependencies as a separate step to take advantage of Docker's caching.
-# Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
-# Leverage a bind mount to requirements.txt to avoid having to copy them into
-# into this layer.
-RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,source=requirements.txt,target=requirements.txt \
-    python -m pip install -r requirements.txt
-
-# Switch to the non-privileged user to run the application.
-USER appuser
-
-# Copy the source code into the container.
-COPY . .
-
-# Expose the port that the application listens on.
-EXPOSE 8000
-
-# Run the application.
-CMD ["python3", "-m", "uvicorn", "app:app", "--host=0.0.0.0", "--port=8000"]
+```console
+$ docker login dhi.io
 ```
-
-Create a file named `compose.yaml` with the following contents.
-
-```yaml {collapse=true,title=compose.yaml}
-# Comments are provided throughout this file to help you get started.
-# If you need more help, visit the Docker Compose reference guide at
-# https://docs.docker.com/go/compose-spec-reference/
-
-# Here the instructions define your application as a service called "server".
-# This service is built from the Dockerfile in the current directory.
-# You can add other services your application may depend on here, such as a
-# database or a cache. For examples, see the Awesome Compose repository:
-# https://github.com/docker/awesome-compose
-services:
-  server:
-    build:
-      context: .
-    ports:
-      - 8000:8000
-```
-
-Create a file named `.dockerignore` with the following contents.
-
-```text {collapse=true,title=".dockerignore"}
-# Include any files or directories that you don't want to be copied to your
-# container here (e.g., local build artifacts, temporary files, etc.).
-#
-# For more help, visit the .dockerignore file reference guide at
-# https://docs.docker.com/go/build-context-dockerignore/
-
-**/.DS_Store
-**/__pycache__
-**/.venv
-**/.classpath
-**/.dockerignore
-**/.env
-**/.git
-**/.gitignore
-**/.project
-**/.settings
-**/.toolstarget
-**/.vs
-**/.vscode
-**/*.*proj.user
-**/*.dbmdl
-**/*.jfm
-**/bin
-**/charts
-**/docker-compose*
-**/compose.y*ml
-**/Dockerfile*
-**/node_modules
-**/npm-debug.log
-**/obj
-**/secrets.dev.yaml
-**/values.dev.yaml
-LICENSE
-README.md
-```
-
-Create a file named `.gitignore` with the following contents.
-
-```text {collapse=true,title=".gitignore"}
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-cover/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-```
-
-{{< /tab >}}
-{{< tab name="Using Docker Hardened Image" >}}
-
-Docker Hardened Images (DHIs) are available for Python in the [Docker Hardened Images catalog](https://hub.docker.com/hardened-images/catalog/dhi/python). Docker Hardened Images are freely available to everyone with no subscription required. You can pull and use them like any other Docker image after signing in to the DHI registry. For more information, see the [DHI quickstart](/dhi/get-started/) guide.
-
-1. Sign in to the DHI registry:
-
-   ```console
-   $ docker login dhi.io
-   ```
-
-2. Pull the Python DHI (check the catalog for available versions):
-
-   ```console
-   $ docker pull dhi.io/python:3.12.12-debian13-fips-dev
-   ```
 
 Create a file named `Dockerfile` with the following contents.
 
@@ -251,32 +83,14 @@ Create a file named `Dockerfile` with the following contents.
 
 # This Dockerfile uses Docker Hardened Images (DHI) for enhanced security.
 # For more information, see https://docs.docker.com/dhi/
-ARG PYTHON_VERSION=3.12.12-debian13-fips-dev
-FROM dhi.io/python:${PYTHON_VERSION}
 
-# Prevents Python from writing pyc files.
-ENV PYTHONDONTWRITEBYTECODE=1
-
-# Keeps Python from buffering stdout and stderr to avoid situations where
-# the application crashes without emitting any logs due to buffering.
-ENV PYTHONUNBUFFERED=1
-
-#Add dependencies for adduser
-RUN apt update -y && apt install adduser -y
+# Use the dev image to build and install dependencies.
+FROM dhi.io/python:3.12-dev AS builder
 
 WORKDIR /app
 
-# Create a non-privileged user that the app will run under.
-# See https://docs.docker.com/go/dockerfile-user-best-practices/
-ARG UID=10001
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    appuser
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
@@ -284,10 +98,15 @@ RUN adduser \
 # into this layer.
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=requirements.txt \
-    python -m pip install -r requirements.txt
+    pip install -r requirements.txt
 
-# Switch to the non-privileged user to run the application.
-USER appuser
+# Use the minimal runtime image. It runs as nonroot by default.
+FROM dhi.io/python:3.12
+
+WORKDIR /app
+
+COPY --from=builder /venv /venv
+ENV PATH="/venv/bin:$PATH"
 
 # Copy the source code into the container.
 COPY . .
@@ -296,7 +115,7 @@ COPY . .
 EXPOSE 8000
 
 # Run the application.
-CMD ["python3", "-m", "uvicorn", "app:app", "--host=0.0.0.0", "--port=8000"]
+CMD ["/venv/bin/python3", "-m", "uvicorn", "app:app", "--host=0.0.0.0", "--port=8000"]
 ```
 
 Create a file named `compose.yaml` with the following contents.
@@ -417,9 +236,6 @@ env.bak/
 venv.bak/
 ```
 
-{{< /tab >}}
-{{< /tabs >}}
-
 You should now have the following contents in your `python-docker-example`
 directory.
 
@@ -430,8 +246,7 @@ directory.
 │ ├── .dockerignore
 │ ├── .gitignore
 │ ├── compose.yaml
-│ ├── Dockerfile
-│ └── README.md
+│ └── Dockerfile
 ```
 
 To learn more about the files, see the following:

--- a/content/guides/python/deploy.md
+++ b/content/guides/python/deploy.md
@@ -18,9 +18,21 @@ aliases:
 
 In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This allows you to test and debug your workloads on Kubernetes locally before deploying.
 
+## Registry authentication
+
+The Docker Hardened Images used in this guide are hosted on `dhi.io`. Docker
+Desktop's Kubernetes shares credentials with Docker Desktop, so the `docker login dhi.io`
+you completed earlier is all that's needed. No additional image pull secret is required.
+
+> [!NOTE]
+>
+> If you're deploying to a Kubernetes cluster outside of Docker Desktop, you'll
+> need to create an image pull secret and reference it in your pod specs. See
+> [Use a Docker Hardened Image](/dhi/how-to/use/#use-with-kubernetes) for instructions.
+
 ## Create a Kubernetes YAML file
 
-In your `python-docker-dev-example` directory, create a file named `docker-postgres-kubernetes.yaml`. Open the file in an IDE or text editor and add
+In your `python-docker-example` directory, create a file named `docker-postgres-kubernetes.yaml`. Open the file in an IDE or text editor and add
 the following contents.
 
 ```yaml
@@ -41,7 +53,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:18
+          image: dhi.io/postgres:18
           ports:
             - containerPort: 5432
           env:
@@ -95,7 +107,7 @@ data:
   POSTGRES_PASSWORD: cG9zdGdyZXNfcGFzc3dvcmQ= # Base64 encoded password (e.g., 'postgres_password')
 ```
 
-In your `python-docker-dev-example` directory, create a file named
+In your `python-docker-example` directory, create a file named
 `docker-python-kubernetes.yaml`. Replace `DOCKER_USERNAME/REPO_NAME` with your
 Docker username and the repository name that you created in [Configure CI/CD for
 your Python application](./configure-github-actions.md).
@@ -135,7 +147,7 @@ spec:
             - name: POSTGRES_PORT
               value: "5432"
           ports:
-            - containerPort: 8001
+            - containerPort: 8000
 ---
 apiVersion: v1
 kind: Service
@@ -147,8 +159,8 @@ spec:
   selector:
     service: fastapi
   ports:
-    - port: 8001
-      targetPort: 8001
+    - port: 8000
+      targetPort: 8000
       nodePort: 30001
 ```
 
@@ -163,7 +175,7 @@ In these Kubernetes YAML file, there are various objects, separated by the `---`
 - A PersistentVolumeClaim, to define a storage that will be persistent through restarts for the database.
 - A Secret, Keeping the database password as an example using secret kubernetes resource.
 - A NodePort service, which will route traffic from port 30001 on your host to
-  port 8001 inside the pods it routes to, allowing you to reach your app
+  port 8000 inside the pods it routes to, allowing you to reach your app
   from the network.
 
 To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
@@ -174,7 +186,7 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
 
 ## Deploy and check your application
 
-1. In a terminal, navigate to `python-docker-dev-example` and deploy your database to
+1. In a terminal, navigate to `python-docker-example` and deploy your database to
    Kubernetes.
 
    ```console
@@ -193,7 +205,7 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
    Now, deploy your python application.
 
    ```console
-   kubectl apply -f docker-python-kubernetes.yaml
+   $ kubectl apply -f docker-python-kubernetes.yaml
    ```
 
    You should see output that looks like the following, indicating your Kubernetes objects were created successfully.
@@ -229,17 +241,17 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
    NAME                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    kubernetes           ClusterIP   10.43.0.1      <none>        443/TCP          13h
    postgres             ClusterIP   10.43.209.25   <none>        5432/TCP         3m10s
-   service-entrypoint   NodePort    10.43.67.120   <none>        8001:30001/TCP   79s
+   service-entrypoint   NodePort    10.43.67.120   <none>        8000:30001/TCP   79s
    ```
 
    In addition to the default `kubernetes` service, you can see your `service-entrypoint` service, accepting traffic on port 30001/TCP and the internal `ClusterIP` `postgres` with the port `5432` open to accept connections from you python app.
 
-3. In a terminal, curl the service. Note that a database was not deployed in
-   this example.
+3. In a terminal, curl the service. This hits the root endpoint, which doesn't
+   interact with the database.
 
    ```console
    $ curl http://localhost:30001/
-   Hello, Docker!!!
+   Hello, Docker!
    ```
 
 4. Run the following commands to tear down your application.

--- a/content/guides/python/deploy.md
+++ b/content/guides/python/deploy.md
@@ -175,7 +175,7 @@ In these Kubernetes YAML file, there are various objects, separated by the `---`
 - A PersistentVolumeClaim, to define a storage that will be persistent through restarts for the database.
 - A Secret, Keeping the database password as an example using secret kubernetes resource.
 - A NodePort service, which will route traffic from port 30001 on your host to
-  port 8000 inside the pods it routes to, allowing you to reach your app
+  port 8000 inside the pods it routes to, so you can reach your app
   from the network.
 
 To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).

--- a/content/guides/python/develop.md
+++ b/content/guides/python/develop.md
@@ -310,15 +310,15 @@ directory.
 
 ```text
 ├── python-docker-example/
-│ ├── db/
-│ │ └── password.txt
-│ ├── app.py
-│ ├── config.py
-│ ├── requirements.txt
-│ ├── .dockerignore
-│ ├── .gitignore
-│ ├── compose.yaml
-│ └── Dockerfile
+│   ├── db/
+│   │   └── password.txt
+│   ├── app.py
+│   ├── config.py
+│   ├── requirements.txt
+│   ├── .dockerignore
+│   ├── .gitignore
+│   ├── compose.yaml
+│   └── Dockerfile
 ```
 
 Now, run the following `docker compose up` command to start your application.
@@ -358,7 +358,7 @@ You should receive the following response:
 Let's make a get request with the next curl command:
 
 ```console
-curl -X 'GET' \
+$ curl -X 'GET' \
   'http://localhost:8000/heroes/' \
   -H 'accept: application/json'
 ```

--- a/content/guides/python/develop.md
+++ b/content/guides/python/develop.md
@@ -20,241 +20,241 @@ In this section, you'll learn how to set up a development environment for your c
 - Adding a local database and persisting data
 - Configuring Compose to automatically update your running Compose services as you edit and save your code
 
-## Get the sample application
+## Update the application
 
-You'll need to clone a new repository to get a sample application that includes logic to connect to the database.
+You'll update your application to connect to a PostgreSQL database. Continue
+working in your `python-docker-example` directory.
 
-1. Change to a directory where you want to clone the repository and run the following command.
+Replace the contents of `app.py` with the following:
 
-   ```console
-   $ git clone https://github.com/estebanx64/python-docker-dev-example
-   ```
+```python {title="app.py"}
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 
-2. In the cloned repository's directory, create the necessary Docker assets.
+from fastapi import FastAPI
+from sqlmodel import Field, Session, SQLModel, create_engine, select
 
-   Create the following files in your project directory.
+from config import settings
 
-   Create a file named `Dockerfile` with the following contents.
 
-   ```dockerfile {collapse=true,title=Dockerfile}
-   # syntax=docker/dockerfile:1
+class Hero(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    secret_name: str
+    age: int | None = Field(default=None, index=True)
 
-   # Comments are provided throughout this file to help you get started.
-   # If you need more help, visit the Dockerfile reference guide at
-   # https://docs.docker.com/go/dockerfile-reference/
 
-   ARG PYTHON_VERSION=3.12
-   FROM python:${PYTHON_VERSION}-slim
+engine = create_engine(str(settings.SQLALCHEMY_DATABASE_URI))
 
-   # Prevents Python from writing pyc files.
-   ENV PYTHONDONTWRITEBYTECODE=1
 
-   # Keeps Python from buffering stdout and stderr to avoid situations where
-   # the application crashes without emitting any logs due to buffering.
-   ENV PYTHONUNBUFFERED=1
+def create_db_and_tables() -> None:
+    SQLModel.metadata.create_all(engine)
 
-   WORKDIR /app
 
-   # Create a non-privileged user that the app will run under.
-   # See https://docs.docker.com/go/dockerfile-user-best-practices/
-   ARG UID=10001
-   RUN adduser \
-       --disabled-password \
-       --gecos "" \
-       --home "/nonexistent" \
-       --shell "/sbin/nologin" \
-       --no-create-home \
-       --uid "${UID}" \
-       appuser
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    create_db_and_tables()
+    yield
 
-   # Download dependencies as a separate step to take advantage of Docker's    caching.
-   # Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
-   # Leverage a bind mount to requirements.txt to avoid having to copy them into
-   # into this layer.
-   RUN --mount=type=cache,target=/root/.cache/pip \
-       --mount=type=bind,source=requirements.txt,target=requirements.txt \
-       python -m pip install -r requirements.txt
 
-   # Switch to the non-privileged user to run the application.
-   USER appuser
+app = FastAPI(lifespan=lifespan)
 
-   # Copy the source code into the container.
-   COPY . .
 
-   # Expose the port that the application listens on.
-   EXPOSE 8001
+@app.get("/")
+def hello() -> str:
+    return "Hello, Docker!"
 
-   # Run the application.
-   CMD ["python3", "-m", "uvicorn", "app:app", "--host=0.0.0.0", "--port=8001"]
-   ```
 
-   Create a file named `compose.yaml` with the following contents.
+@app.post("/heroes/")
+def create_hero(hero: Hero) -> Hero:
+    with Session(engine) as session:
+        session.add(hero)
+        session.commit()
+        session.refresh(hero)
+        return hero
 
-   ```yaml {collapse=true,title=compose.yaml}
-   # Comments are provided throughout this file to help you get started.
-   # If you need more help, visit the Docker Compose reference guide at
-   # https://docs.docker.com/go/compose-spec-reference/
 
-   # Here the instructions define your application as a service called "server".
-   # This service is built from the Dockerfile in the current directory.
-   # You can add other services your application may depend on here, such as a
-   # database or a cache. For examples, see the Awesome Compose repository:
-   # https://github.com/docker/awesome-compose
-   services:
-     server:
-       build:
-         context: .
-       ports:
-         - 8001:8001
-   # The commented out section below is an example of how to define a PostgreSQL
-   # database that your application can use. `depends_on` tells Docker Compose to
-   # start the database before your application. The `db-data` volume persists the
-   # database data between container restarts. The `db-password` secret is used
-   # to set the database password. You must create `db/password.txt` and add
-   # a password of your choosing to it before running `docker compose up`.
-   #     depends_on:
-   #       db:
-   #         condition: service_healthy
-   #   db:
-   #     image: postgres:18
-   #     restart: always
-   #     user: postgres
-   #     secrets:
-   #       - db-password
-   #     volumes:
-   #       - db-data:/var/lib/postgresql
-   #     environment:
-   #       - POSTGRES_DB=example
-   #       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
-   #     expose:
-   #       - 5432
-   #     healthcheck:
-   #       test: [ "CMD", "pg_isready" ]
-   #       interval: 10s
-   #       timeout: 5s
-   #       retries: 5
-   # volumes:
-   #   db-data:
-   # secrets:
-   #   db-password:
-   #     file: db/password.txt
-   ```
+@app.get("/heroes/")
+def read_heroes() -> Sequence[Hero]:
+    with Session(engine) as session:
+        heroes = session.exec(select(Hero)).all()
+        return heroes
+```
 
-   Create a file named `.dockerignore` with the following contents.
+Create a new file named `config.py` with the following contents:
 
-   ```text {collapse=true,title=".dockerignore"}
-   # Include any files or directories that you don't want to be copied to your
-   # container here (e.g., local build artifacts, temporary files, etc.).
-   #
-   # For more help, visit the .dockerignore file reference guide at
-   # https://docs.docker.com/go/build-context-dockerignore/
+```python {title="config.py"}
+import os
+from typing import Any
 
-   **/.DS_Store
-   **/__pycache__
-   **/.venv
-   **/.classpath
-   **/.dockerignore
-   **/.env
-   **/.git
-   **/.gitignore
-   **/.project
-   **/.settings
-   **/.toolstarget
-   **/.vs
-   **/.vscode
-   **/*.*proj.user
-   **/*.dbmdl
-   **/*.jfm
-   **/bin
-   **/charts
-   **/docker-compose*
-   **/compose.y*ml
-   **/Dockerfile*
-   **/node_modules
-   **/npm-debug.log
-   **/obj
-   **/secrets.dev.yaml
-   **/values.dev.yaml
-   LICENSE
-   README.md
-   ```
+from pydantic import (
+    PostgresDsn,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+from pydantic_core import MultiHostUrl
+from pydantic_settings import BaseSettings
 
-   Create a file named `.gitignore` with the following contents.
 
-   ```text {collapse=true,title=".gitignore"}
-   # Byte-compiled / optimized / DLL files
-   __pycache__/
-   *.py[cod]
-   *$py.class
+class Settings(BaseSettings):
+    POSTGRES_SERVER: str
+    POSTGRES_PORT: int = 5432
+    POSTGRES_USER: str
+    POSTGRES_PASSWORD: str | None = None
+    POSTGRES_PASSWORD_FILE: str | None = None
+    POSTGRES_DB: str
 
-   # C extensions
-   *.so
+    @model_validator(mode="before")
+    @classmethod
+    def check_postgres_password(cls, data: Any) -> Any:
+        """Validate that either POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE is set."""
+        if isinstance(data, dict):
+            password_file: str | None = data.get("POSTGRES_PASSWORD_FILE")  # type: ignore
+            password: str | None = data.get("POSTGRES_PASSWORD")  # type: ignore
+            if password_file is None and password is None:
+                raise ValueError(
+                    "At least one of POSTGRES_PASSWORD_FILE and POSTGRES_PASSWORD must be set."
+                )
+        return data  # type: ignore
 
-   # Distribution / packaging
-   .Python
-   build/
-   develop-eggs/
-   dist/
-   downloads/
-   eggs/
-   .eggs/
-   lib/
-   lib64/
-   parts/
-   sdist/
-   var/
-   wheels/
-   share/python-wheels/
-   *.egg-info/
-   .installed.cfg
-   *.egg
-   MANIFEST
+    @field_validator("POSTGRES_PASSWORD_FILE", mode="before")
+    @classmethod
+    def read_password_from_file(cls, v: str | None) -> str | None:
+        if v is not None:
+            file_path = v
+            if os.path.exists(file_path):
+                with open(file_path) as file:
+                    return file.read().strip()
+            raise ValueError(f"Password file {file_path} does not exist.")
+        return v
 
-   # Unit test / coverage reports
-   htmlcov/
-   .tox/
-   .nox/
-   .coverage
-   .coverage.*
-   .cache
-   nosetests.xml
-   coverage.xml
-   *.cover
-   *.py,cover
-   .hypothesis/
-   .pytest_cache/
-   cover/
+    @computed_field
+    @property
+    def SQLALCHEMY_DATABASE_URI(self) -> PostgresDsn:
+        url = MultiHostUrl.build(
+            scheme="postgresql+psycopg",
+            username=self.POSTGRES_USER,
+            password=self.POSTGRES_PASSWORD
+            if self.POSTGRES_PASSWORD
+            else self.POSTGRES_PASSWORD_FILE,
+            host=self.POSTGRES_SERVER,
+            port=self.POSTGRES_PORT,
+            path=self.POSTGRES_DB,
+        )
+        return PostgresDsn(url)
 
-   # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-   __pypackages__/
 
-   # Environments
-   .env
-   .venv
-   env/
-   venv/
-   ENV/
-   env.bak/
-   venv.bak/
-   ```
+settings = Settings()  # type: ignore
+```
 
-## Add a local database and persist data
+Replace the contents of `requirements.txt` with the following:
 
-You can use containers to set up local services, like a database. In this section, you'll update the `compose.yaml` file to define a database service and a volume to persist data.
+```text {title="requirements.txt"}
+fastapi==0.115.12
+sqlmodel==0.0.24
+psycopg[binary]==3.2.9
+pydantic-settings==2.9.1
+uvicorn==0.34.3
+```
 
-In the cloned repository's directory, open the `compose.yaml` file in an IDE or text editor and update it for your unique application.
+## Update Docker assets
 
-In the `compose.yaml` file, you need to uncomment all of the database instructions. In addition, you need to add the database password file as an environment variable to the server service and specify the secret file to use .
+Replace the contents of `Dockerfile` with the following. This version adds
+`COPY` and `CMD` to the builder stage so that Compose can target it directly
+during development.
 
-The following is the updated `compose.yaml` file.
+```dockerfile {collapse=true,title=Dockerfile}
+# syntax=docker/dockerfile:1
 
-```yaml {hl_lines="7-43"}
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# This Dockerfile uses Docker Hardened Images (DHI) for enhanced security.
+# For more information, see https://docs.docker.com/dhi/
+
+# Use the dev image to build and install dependencies.
+# The builder stage is also used directly in development (see compose.yaml).
+FROM dhi.io/python:3.12-dev AS builder
+
+WORKDIR /app
+
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
+# Leverage a bind mount to requirements.txt to avoid having to copy them into
+# into this layer.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements.txt,target=requirements.txt \
+    pip install -r requirements.txt
+
+# Copy the source code into the container.
+COPY . .
+
+# Expose the port that the application listens on.
+EXPOSE 8000
+
+# Run the application.
+CMD ["/venv/bin/python3", "-m", "uvicorn", "app:app", "--host=0.0.0.0", "--port=8000"]
+
+
+# Use the minimal runtime image for production. It runs as nonroot by default.
+FROM dhi.io/python:3.12
+
+WORKDIR /app
+
+COPY --from=builder /venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+COPY --from=builder /app .
+
+EXPOSE 8000
+
+CMD ["/venv/bin/python3", "-m", "uvicorn", "app:app", "--host=0.0.0.0", "--port=8000"]
+```
+
+Update `compose.yaml` to add `target: builder` so that Compose uses the dev
+image during development.
+
+```yaml {collapse=true,title=compose.yaml}
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker Compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
 services:
   server:
     build:
       context: .
+      target: builder
     ports:
-      - 8001:8001
+      - 8000:8000
+```
+
+## Add a local database and persist data
+
+You can use containers to set up local services, like a database. In this
+section, you'll update the `compose.yaml` file to define a database service
+and a volume to persist data.
+
+In the `python-docker-example` directory, open the `compose.yaml` file in an
+IDE or text editor and update it with the following.
+
+```yaml {hl_lines="8-40"}
+services:
+  server:
+    build:
+      context: .
+      target: builder
+    ports:
+      - 8000:8000
     environment:
       - POSTGRES_SERVER=db
       - POSTGRES_USER=postgres
@@ -266,7 +266,7 @@ services:
     secrets:
       - db-password
   db:
-    image: postgres:18
+    image: dhi.io/postgres:18
     restart: always
     user: postgres
     secrets:
@@ -297,7 +297,7 @@ secrets:
 
 Before you run the application using Compose, notice that this Compose file specifies a `password.txt` file to hold the database's password. You must create this file as it's not included in the source repository.
 
-In the cloned repository's directory, create a new directory named `db` and inside that directory create a file named `password.txt` that contains the password for the database. Using your favorite IDE or text editor, add the following contents to the `password.txt` file.
+In the `python-docker-example` directory, create a new directory named `db` and inside that directory create a file named `password.txt` that contains the password for the database. Using your favorite IDE or text editor, add the following contents to the `password.txt` file.
 
 ```text
 mysecretpassword
@@ -305,11 +305,11 @@ mysecretpassword
 
 Save and close the `password.txt` file.
 
-You should now have the following contents in your `python-docker-dev-example`
+You should now have the following contents in your `python-docker-example`
 directory.
 
 ```text
-├── python-docker-dev-example/
+├── python-docker-example/
 │ ├── db/
 │ │ └── password.txt
 │ ├── app.py
@@ -318,8 +318,7 @@ directory.
 │ ├── .dockerignore
 │ ├── .gitignore
 │ ├── compose.yaml
-│ ├── Dockerfile
-│ └── README.md
+│ └── Dockerfile
 ```
 
 Now, run the following `docker compose up` command to start your application.
@@ -334,7 +333,7 @@ Let's create an object with a post method
 
 ```console
 $ curl -X 'POST' \
-  'http://localhost:8001/heroes/' \
+  'http://localhost:8000/heroes/' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -360,7 +359,7 @@ Let's make a get request with the next curl command:
 
 ```console
 curl -X 'GET' \
-  'http://localhost:8001/heroes/' \
+  'http://localhost:8000/heroes/' \
   -H 'accept: application/json'
 ```
 
@@ -386,13 +385,14 @@ Watch](/manuals/compose/how-tos/file-watch.md).
 Open your `compose.yaml` file in an IDE or text editor and then add the Compose
 Watch instructions. The following is the updated `compose.yaml` file.
 
-```yaml {hl_lines="17-20"}
+```yaml {hl_lines="18-21"}
 services:
   server:
     build:
       context: .
+      target: builder
     ports:
-      - 8001:8001
+      - 8000:8000
     environment:
       - POSTGRES_SERVER=db
       - POSTGRES_USER=postgres
@@ -408,7 +408,7 @@ services:
         - action: rebuild
           path: .
   db:
-    image: postgres:18
+    image: dhi.io/postgres:18
     restart: always
     user: postgres
     secrets:
@@ -441,13 +441,13 @@ $ docker compose watch
 In a terminal, curl the application to get a response.
 
 ```console
-$ curl http://localhost:8001
+$ curl http://localhost:8000
 Hello, Docker!
 ```
 
 Any changes to the application's source files on your local machine will now be immediately reflected in the running container.
 
-Open `python-docker-dev-example/app.py` in an IDE or text editor and update the `Hello, Docker!` string by adding a few more exclamation marks.
+Open `python-docker-example/app.py` in an IDE or text editor and update the `Hello, Docker!` string by adding a few more exclamation marks.
 
 ```diff
 -    return 'Hello, Docker!'
@@ -457,7 +457,7 @@ Open `python-docker-dev-example/app.py` in an IDE or text editor and update the 
 Save the changes to `app.py` and then wait a few seconds for the application to rebuild. Curl the application again and verify that the updated text appears.
 
 ```console
-$ curl http://localhost:8001
+$ curl http://localhost:8000
 Hello, Docker!!!
 ```
 

--- a/content/guides/python/develop.md
+++ b/content/guides/python/develop.md
@@ -185,7 +185,7 @@ ENV PATH="/venv/bin:$PATH"
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
-# Leverage a bind mount to requirements.txt to avoid having to copy them into
+# Leverage a bind mount to requirements.txt to avoid having to copy them
 # into this layer.
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=requirements.txt \

--- a/content/guides/python/lint-format-typing.md
+++ b/content/guides/python/lint-format-typing.md
@@ -156,12 +156,13 @@ Pre-commit hooks run checks automatically before each commit on your local
 machine. The following `.pre-commit-config.yaml` snippet sets up Ruff:
 
 ```yaml
-  https: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.2.2
-  hooks:
-    - id: ruff
-      args: [--fix]
-    - id: ruff-format
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.2.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
 ```
 
 To install and use:

--- a/content/guides/python/lint-format-typing.md
+++ b/content/guides/python/lint-format-typing.md
@@ -20,21 +20,16 @@ In this section, you'll learn how to set up code quality tools for your Python a
 - Static type checking with Pyright
 - Automating checks with pre-commit hooks
 
+You can run these tools locally, or inside a Docker Hardened Image container
+using a bind mount — no local Python installation required.
+
 ## Linting and formatting with Ruff
 
 Ruff is an extremely fast Python linter and formatter written in Rust. It replaces multiple tools like flake8, isort, and black with a single unified tool.
 
-Before using Ruff, install it in your Python environment:
+Create a `pyproject.toml` file in your `python-docker-example` directory:
 
-```bash
-pip install ruff
-```
-
-If you're using a virtual environment, make sure it is activated so the `ruff` command is available when you run the commands below.
-
-Create a `pyproject.toml` file:
-
-```toml
+```toml {title="pyproject.toml"}
 [tool.ruff]
 target-version = "py312"
 
@@ -59,6 +54,18 @@ ignore = [
 
 ### Using Ruff
 
+{{< tabs >}}
+{{< tab name="Local" >}}
+
+Install Ruff:
+
+```bash
+pip install ruff
+```
+
+If you're using a virtual environment, make sure it is activated so the `ruff`
+command is available.
+
 Run these commands to check and format your code:
 
 ```bash
@@ -72,11 +79,38 @@ ruff check --fix .
 ruff format .
 ```
 
+{{< /tab >}}
+{{< tab name="Container (DHI)" >}}
+
+Run Ruff inside the DHI dev image with your project directory mounted in:
+
+```console
+# Check for errors
+$ docker run --rm -v $PWD:/app -w /app dhi.io/python:3.12-dev \
+  sh -c "pip install --quiet ruff && ruff check ."
+
+# Automatically fix fixable errors
+$ docker run --rm -v $PWD:/app -w /app dhi.io/python:3.12-dev \
+  sh -c "pip install --quiet ruff && ruff check --fix ."
+
+# Format code
+$ docker run --rm -v $PWD:/app -w /app dhi.io/python:3.12-dev \
+  sh -c "pip install --quiet ruff && ruff format ."
+```
+
+> [!NOTE]
+>
+> On Windows, replace `$PWD` with `${PWD}` in PowerShell or `%cd%` in
+> Command Prompt.
+
+{{< /tab >}}
+{{< /tabs >}}
+
 ## Type checking with Pyright
 
 Pyright is a fast static type checker for Python that works well with modern Python features.
 
-Add `Pyright` configuration in `pyproject.toml`:
+Add `Pyright` configuration to your `pyproject.toml`:
 
 ```toml
 [tool.pyright]
@@ -87,15 +121,39 @@ exclude = [".venv"]
 
 ### Running Pyright
 
-To check your code for type errors:
+{{< tabs >}}
+{{< tab name="Local" >}}
+
+Install Pyright and run it:
 
 ```bash
+pip install pyright
 pyright
 ```
 
+{{< /tab >}}
+{{< tab name="Container (DHI)" >}}
+
+Run Pyright inside the DHI dev image. The command also installs your project's
+dependencies so Pyright can fully resolve all imports:
+
+```console
+$ docker run --rm -v $PWD:/app -w /app dhi.io/python:3.12-dev \
+  sh -c "pip install --quiet -r requirements.txt pyright && pyright"
+```
+
+> [!NOTE]
+>
+> On Windows, replace `$PWD` with `${PWD}` in PowerShell or `%cd%` in
+> Command Prompt.
+
+{{< /tab >}}
+{{< /tabs >}}
+
 ## Setting up pre-commit hooks
 
-Pre-commit hooks automatically run checks before each commit. The following `.pre-commit-config.yaml` snippet sets up Ruff:
+Pre-commit hooks run checks automatically before each commit on your local
+machine. The following `.pre-commit-config.yaml` snippet sets up Ruff:
 
 ```yaml
   https: https://github.com/charliermarsh/ruff-pre-commit
@@ -109,6 +167,7 @@ Pre-commit hooks automatically run checks before each commit. The following `.pr
 To install and use:
 
 ```bash
+pip install pre-commit
 pre-commit install
 git commit -m "Test commit"  # Automatically runs checks
 ```


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Doing a couple of easy guides plus the popular Python guide to get some feedback and agent-priming before tackling the other guides.

- Updated guides to DHI-only. DHI Community is now free.
- Updated guides away from git clone. Maintaining and updating separate repos is a burden. It's a bit more copy-paste for users, so will monitor feedback closely. Pondering a faux file browser & copy-paste-to-create-all-files component to make the UX slicker for scaffolding samples.
- Updated the Python linting and typing topic to offer a container-based alternative to installing tools locally.

Previews:
- https://deploy-preview-25184--docsdocker.netlify.app/guides/python/
- https://deploy-preview-25184--docsdocker.netlify.app/guides/deno/
- https://deploy-preview-25184--docsdocker.netlify.app/guides/bun/

## Related issues or tickets

ENGDOCS-3308

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
