### PR TITLE
docs: clarify that team membership is managed at the organization level

### DIFF
--- a/content/manuals/admin/company/manage/users.md
+++ b/content/manuals/admin/company/manage/users.md
@@ -143,5 +143,10 @@ see the [Bulk create invites](https://docs.docker.com/reference/api/hub/latest/#
 
 ## Manage members on a team
 
-Use Docker Hub to add a member to a team or remove a member from a team. For
-more details, see [Manage members](../../organization/manage/members.md#manage-members-on-a-team).
+After you invite members to an organization, you can manage team membership
+within that organization in Docker Hub. Team membership isn't managed at the
+company level in the Admin Console.
+
+To add or remove members from teams, switch to the organization in Docker Hub.
+For more details, see
+[Manage members](../../organization/manage/members.md#manage-members-on-a-team).


### PR DESCRIPTION
## Description

- explain why the page switches from company-level member invitations to organization-level team management
- clarify that team membership is managed in Docker Hub at the organization level

## Related issues or tickets

- Addresses #24894

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review
