### PR TITLE
build: clarify GitHub Actions build secret inputs

### DIFF
--- a/content/manuals/build/ci/github-actions/secrets.md
+++ b/content/manuals/build/ci/github-actions/secrets.md
@@ -64,16 +64,86 @@ jobs:
 > or the `target` option to customize the mount path.
 > For details on secret mounts, see [Build secrets](/manuals/build/building/secrets.md).
 
+### Secret sources
+
+The `docker/build-push-action` inputs for secret mounts define where the secret
+value comes from. The Dockerfile `RUN --mount=type=secret` options define how
+the build step consumes the secret.
+
+| Action input                           | Source                             | Equivalent Buildx option                 |
+| -------------------------------------- | ---------------------------------- | ---------------------------------------- |
+| `secrets: MY_SECRET=value`             | Inline value from the workflow     | `--secret id=MY_SECRET,src=<temp-file>`  |
+| `secret-envs: MY_SECRET=MY_ENV_VAR`    | Environment variable on the runner | `--secret id=MY_SECRET,env=MY_ENV_VAR`   |
+| `secret-files: MY_SECRET=./secret.txt` | File on the runner                 | `--secret id=MY_SECRET,src=./secret.txt` |
+
+For example, `RUN --mount=type=secret,id=MY_SECRET` mounts the secret as a file
+at `/run/secrets/MY_SECRET`. To expose the same secret as an environment
+variable for a `RUN` instruction, use the `env` option in the Dockerfile:
+`RUN --mount=type=secret,id=MY_SECRET,env=MY_SECRET`.
+
+### Using environment variables as secret sources
+
+The `secret-envs` input reads secrets from environment variables on the GitHub
+Actions runner. Use it when a previous workflow step sets an environment
+variable, or when you want to map a runner environment variable to a different
+secret ID for the build.
+
+```yaml
+name: ci
+
+on:
+  push:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@{{% param "checkout_action_version" %}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@{{% param "setup_buildx_action_version" %}}
+
+      - name: Build
+        uses: docker/build-push-action@{{% param "build_push_action_version" %}}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          context: .
+          secret-envs: |
+            sentry_token=SENTRY_AUTH_TOKEN
+          tags: user/app:latest
+```
+
+In your Dockerfile, mount the secret and expose it as an environment variable
+for the command that needs it:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+RUN --mount=type=secret,id=sentry_token,env=SENTRY_AUTH_TOKEN \
+    npm run build
+```
+
 ### Using secret files
 
 The `secret-files` input lets you mount existing files as secrets in your build.
 This is useful when you need to use credential files that are generated during your workflow,
 or when you need to mount configuration files like `.npmrc` or `.pypirc` that are already in the expected format.
 
-The key difference between `secrets` and `secret-files`:
+The key difference between `secrets`, `secret-envs`, and `secret-files`:
 
-- `secrets`: Pass secret values as strings (from environment variables or GitHub secrets)
-- `secret-files`: Mount existing files from the runner's filesystem
+- `secrets`: Pass secret values as strings from the workflow.
+- `secret-envs`: Read secret values from environment variables on the runner.
+- `secret-files`: Mount existing files from the runner's filesystem.
 
 #### Example: Using .npmrc for private npm packages
 
@@ -125,6 +195,14 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc \
 COPY . .
 
 RUN npm run build
+```
+
+If a `RUN` instruction uses a non-root user, set `uid`, `gid`, or `mode` on the
+secret mount so the user can read the mounted file:
+
+```dockerfile
+RUN --mount=type=secret,id=npmrc,target=/home/node/.npmrc,uid=1000,gid=1000 \
+    npm ci
 ```
 
 #### Example: Using dynamically generated credentials


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This updates the GitHub Actions build secrets documentation to explain how `docker/build-push-action` secret inputs map to Buildx secret source semantics.

The page now separates action input behavior from Dockerfile secret mount behavior, adds a table for `secrets`, `secret-envs`, and `secret-files`, and includes an example for using `secret-envs` with a Dockerfile `env` mount.

Users were conflating where a secret value comes from with how a Dockerfile consumes that secret during a `RUN` instruction, especially around `secret-envs`.

## Related issues or tickets

* fixes https://github.com/docker/build-push-action/issues/1329
* closes https://github.com/docker/build-push-action/pull/560

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review