### PR TITLE
gordon: introduce max tier

### DIFF
--- a/content/manuals/ai/gordon/usage-limits.md
+++ b/content/manuals/ai/gordon/usage-limits.md
@@ -3,7 +3,7 @@ title: Gordon usage limits and tiers
 linkTitle: Usage limits
 description: Gordon subscription tiers and usage limits for Docker Desktop and the CLI
 weight: 50
-keywords: [gordon, usage, limits, tiers, base, plus, subscription]
+keywords: [gordon, usage, limits, tiers, base, plus, max, subscription]
 ---
 
 {{< summary-bar feature_name="Gordon" >}}
@@ -13,10 +13,11 @@ plans unlock higher usage limits.
 
 ## Tiers
 
-| Tier  | Usage allocation                 |
-| ----- | -------------------------------- |
-| Base  | Included with any Docker account |
-| Plus  | 2× Base                          |
+| Tier | Usage allocation                 |
+| ---- | -------------------------------- |
+| Base | Included with any Docker account |
+| Plus | 2× Base                          |
+| Max  | 5× Base                          |
 
 For more information about Gordon tiers and how to upgrade, go to
 [docker.com](https://www.docker.com/products/gordon).
@@ -27,10 +28,11 @@ Gordon usage is measured in questions. The number you can ask depends on
 complexity: questions that involve more context, files, or Docker operations
 count more toward your limit.
 
-| Tier  | Per 4 hours | Per day | Per month |
-| ----- | ----------- | ------- | --------- |
-| Base  | ~40         | ~100    | ~180      |
-| Plus  | ~80         | ~200    | ~360      |
+| Tier | Per 4 hours | Per day | Per month |
+| ---- | ----------- | ------- | --------- |
+| Base | ~40         | ~100    | ~180      |
+| Plus | ~80         | ~200    | ~360      |
+| Max  | ~200        | ~500    | ~900      |
 
 These are estimates and vary based on question complexity.
 


### PR DESCRIPTION
## Summary
Introduces the Max tier (5× Base) in Gordon usage limits and tiers.

Generated by Claude Code