### PR TITLE
fix(cli): render experimental callout without markdownify round-trip

### DIFF
--- a/layouts/cli.html
+++ b/layouts/cli.html
@@ -53,17 +53,18 @@
       }}
     {{ end }}
     {{ if or $data.experimental $data.experimentalcli }}
-      {{ markdownify `
-{{% experimental %}}
-
-**This command is experimental.**
-
-Experimental features are intended for testing and feedback as their
-functionality or design may change between releases without warning or
-can be removed entirely in a future release.
-
-{{% /experimental %}}`
-      }}
+      <div class="px-4 border-l-2 border-l-magenta-light dark:border-l-magenta-dark">
+        <p class="not-prose flex gap-2 items-center text-magenta-light dark:text-magenta-dark">
+          <span class="icon-svg pb-1">{{ partialCached "icon" "beaker" "beaker" }}</span>
+          <strong>{{ i18n "experimental" }}</strong>
+        </p>
+        <p><strong>This command is experimental.</strong></p>
+        <p>
+          Experimental features are intended for testing and feedback as their
+          functionality or design may change between releases without warning or
+          can be removed entirely in a future release.
+        </p>
+      </div>
     {{ end }}
     {{ with $data.kubernetes }}
       <p>


### PR DESCRIPTION
Fixes #25215.

## Summary

CLI reference pages with `experimental: true` or `experimentalcli: true` (e.g. [`docker pass`](https://docs.docker.com/reference/cli/docker/pass/)) render an HTML fragment as a literal code block instead of the styled experimental notice:

```
</span>
<strong>Experimental</strong>
```

## Root cause

`layouts/cli.html` produces the experimental notice by feeding a string containing the `{{% experimental %}}` shortcode through `markdownify`. The shortcode template embeds the icon partial. After the recent migration to multi-line Heroicons SVGs (commit ee71c80562), the inner `<path>` line and the trailing `</span>` / `<strong>Experimental</strong>` lines end up at ≥4-space indent inside the expanded HTML — at which point `markdownify` re-parses them as a Markdown indented code block.

The Material Symbols icons in use before that migration were single-line SVGs, so the same template produced single-line indented HTML and the bug stayed dormant.

## Fix

Replace the `markdownify`+shortcode round-trip with the rendered HTML inline, matching the styling of the `experimental` shortcode but with no Markdown re-parse. No new content, just template rendering.

## Affected pages (27)

All pages where the data file sets `experimental: true` or `experimentalcli: true`: `docker pass` and subcommands, `docker scout` policy/environment/compare/stream/vex/attestation, `docker checkpoint`, `docker manifest`, `docker buildx debug`.

## Verification

Built the site locally with `docker compose up` and confirmed the broken `<pre><code></span>...` block on `/reference/cli/docker/pass/` is replaced by the proper styled callout with the beaker icon, **Experimental** heading, and explanatory paragraphs.

The Markdown export path (`cli.markdown.md`, used by *View Markdown* / *Copy Markdown*) was already correct and is untouched.

<img width="1800" height="671" alt="Screenshot 2026-05-30 at 19 23 22" src="https://github.com/user-attachments/assets/7b2d5d6d-cfd2-42a9-840b-9c9bed059df8" />
