### PR TITLE
sandboxes/get-started: replace branch mode with clone mode

### DIFF
--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -157,7 +157,7 @@ Pick a project directory and launch an agent with
 
 ```console
 $ cd ~/my-project
-$ sbx run claude
+$ sbx run --name my-sandbox claude
 ```
 
 Replace `claude` with the agent you want to use — see [Agents](agents/) for the
@@ -170,8 +170,8 @@ You can check what's running at any time:
 
 ```console
 $ sbx ls
-SANDBOX              AGENT    STATUS    PORTS   WORKSPACE
-claude-my-project    claude   running           ~/my-project
+SANDBOX       AGENT    STATUS    PORTS   WORKSPACE
+my-sandbox    claude   running           ~/my-project
 ```
 
 You can also run `sbx` with no arguments to open an interactive dashboard.
@@ -188,8 +188,8 @@ isolated copy of your repository, use `--clone`. Because `--clone` is a
 create-time flag, remove the existing sandbox first:
 
 ```console
-$ sbx rm claude-my-project
-$ sbx run --clone claude
+$ sbx rm my-sandbox
+$ sbx run --clone --name my-sandbox claude
 ```
 
 In clone mode, the sandbox keeps a private Git clone inside the microVM and
@@ -198,15 +198,15 @@ mounts your host repository read-only. The sandbox exposes its clone as a
 commits the same way you'd fetch from any other remote:
 
 ```console
-$ git fetch sandbox-claude-my-project
-$ git log sandbox-claude-my-project/main
-$ git diff main..sandbox-claude-my-project/main
+$ git fetch sandbox-my-sandbox
+$ git log sandbox-my-sandbox/main
+$ git diff main..sandbox-my-sandbox/main
 ```
 
 When you're ready to create a pull request:
 
 ```console
-$ git checkout -b my-feature sandbox-claude-my-project/main
+$ git checkout -b my-feature sandbox-my-sandbox/main
 $ git push -u origin my-feature
 $ gh pr create
 ```
@@ -216,7 +216,7 @@ For Claude Code, pair `--clone` with the
 subagents that each work on their own branch inside the same sandbox:
 
 ```console
-$ sbx run --clone claude -- --dangerously-skip-permissions agents
+$ sbx run --clone --name my-sandbox claude -- agents
 ```
 
 Clone mode is especially useful when running multiple agents on the same
@@ -252,19 +252,15 @@ set and how to customize it.
 Sandboxes persist after the agent exits. To stop a sandbox without deleting it:
 
 ```console
-$ sbx stop claude-my-project
+$ sbx stop my-sandbox
 ```
-
-The sandbox name comes from the agent and workspace directory — see
-[Reconnecting and naming](usage.md#reconnecting-and-naming) for details, or run
-`sbx ls` to see the names of your existing sandboxes.
 
 Installed packages, Docker images, and configuration changes are preserved
 across restarts. When you're done with a sandbox, remove it to reclaim disk
 space:
 
 ```console
-$ sbx rm claude-my-project
+$ sbx rm my-sandbox
 ```
 
 Removing a sandbox deletes everything inside it — installed packages, Docker

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -3,7 +3,7 @@ title: Get started with Docker Sandboxes
 linkTitle: Get started
 weight: 10
 description: Install the sbx CLI, configure credentials, and work through your first sandbox session.
-keywords: sandbox, sbx, get started, install, credentials, branch mode, network policy
+keywords: sandbox, sbx, get started, install, credentials, clone mode, network policy
 ---
 
 Docker Sandboxes run AI coding agents in isolated microVM sandboxes. Each
@@ -12,8 +12,8 @@ build containers, install packages, and modify files without touching your host
 system.
 
 This page walks through a typical first session: installing the CLI,
-authenticating your agent, running a sandbox, working with branches, and
-cleaning up.
+authenticating your agent, running a sandbox, isolating the agent's workspace,
+and cleaning up.
 
 ## Prerequisites
 
@@ -181,38 +181,49 @@ agents, open shells, and manage network rules from one place. See
 
 ![The interactive dashboard showing sandbox status, resource usage, and network governance controls.](images/sbx-dashboard.png)
 
-## Use branch mode
+## Use clone mode
 
-By default, the agent edits your working tree directly. To give it its own
-Git branch, use `--branch`:
+By default, the agent edits your working tree directly. To give the agent an
+isolated copy of your repository, use `--clone`. Because `--clone` is a
+create-time flag, remove the existing sandbox first:
 
 ```console
-$ sbx run claude --branch my-feature
+$ sbx rm claude-my-project
+$ sbx run --clone claude
 ```
 
-This creates a [Git worktree](https://git-scm.com/docs/git-worktree) under
-`.sbx/` in your repository root. The agent works on its own branch and
-directory without touching your main working tree.
-
-When the session ends, review what the agent did from the worktree:
+In clone mode, the sandbox keeps a private Git clone inside the microVM and
+mounts your host repository read-only. The sandbox exposes its clone as a
+`sandbox-<sandbox-name>` remote on your host, so you review the agent's
+commits the same way you'd fetch from any other remote:
 
 ```console
-$ cd .sbx/claude-my-project-worktrees/my-feature
-$ git log
-$ git diff main
+$ git fetch sandbox-claude-my-project
+$ git log sandbox-claude-my-project/main
+$ git diff main..sandbox-claude-my-project/main
 ```
 
-If you're satisfied, push the branch and open a pull request:
+When you're ready to create a pull request:
 
 ```console
+$ git checkout -b my-feature sandbox-claude-my-project/main
 $ git push -u origin my-feature
 $ gh pr create
 ```
 
-Branch mode is especially useful when running multiple agents on the same
-repository — each gets its own branch and can't overwrite the other's changes.
-See [Branch mode](usage.md#branch-mode) for more options, including
-`--branch auto` and multiple branches per sandbox.
+For Claude Code, pair `--clone` with the
+[agents view](agents/claude-code.md#agents-view) to dispatch tasks to
+subagents that each work on their own branch inside the same sandbox:
+
+```console
+$ sbx run --clone claude -- --dangerously-skip-permissions agents
+```
+
+Clone mode is especially useful when running multiple agents on the same
+repository in parallel — each works in its own isolated clone without
+touching your host working tree. See [Clone mode](usage.md#clone-mode) for
+the full workflow, including how to have the agent commit to a dedicated
+branch.
 
 ## Manage network access
 
@@ -257,8 +268,8 @@ $ sbx rm claude-my-project
 ```
 
 Removing a sandbox deletes everything inside it — installed packages, Docker
-images, and any branch mode worktrees under `.sbx/`. Files in your main
-working tree are unaffected.
+images, and the in-sandbox Git clone if you used clone mode. Files in your
+host working tree are unaffected.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

The get-started guide documented the deprecated `--branch` flag for workspace isolation. This replaces the "Use branch mode" section with a "Use clone mode" section covering `--clone` (introduced in sbx v0.31.0), including the `sbx rm` prerequisite (since `--clone` is create-time only), the `git fetch`/`git diff`/`git checkout -b`/`gh pr create` review workflow, and a tip for Claude Code users pairing `--clone` with the agents view.

Generated by Claude Code