### PR TITLE
gordon: add Ultra plan tier (10x Base)

### DIFF
--- a/content/manuals/ai/gordon/usage-limits.md
+++ b/content/manuals/ai/gordon/usage-limits.md
@@ -3,7 +3,7 @@ title: Gordon usage limits and tiers
 linkTitle: Usage limits
 description: Gordon subscription tiers and usage limits for Docker Desktop and the CLI
 weight: 50
-keywords: [gordon, usage, limits, tiers, base, plus, max, subscription]
+keywords: [gordon, usage, limits, tiers, base, plus, max, ultra, subscription]
 ---
 
 {{< summary-bar feature_name="Gordon" >}}
@@ -13,11 +13,12 @@ plans unlock higher usage limits.
 
 ## Tiers
 
-| Tier | Usage allocation                 |
-| ---- | -------------------------------- |
-| Base | Included with any Docker account |
-| Plus | 2× Base                          |
-| Max  | 5× Base                          |
+| Tier  | Usage allocation                 |
+| ----- | -------------------------------- |
+| Base  | Included with any Docker account |
+| Plus  | 2× Base                          |
+| Max   | 5× Base                          |
+| Ultra | 10× Base                         |
 
 For more information about Gordon tiers and how to upgrade, go to
 [docker.com](https://www.docker.com/products/gordon).
@@ -28,11 +29,12 @@ Gordon usage is measured in questions. The number you can ask depends on
 complexity: questions that involve more context, files, or Docker operations
 count more toward your limit.
 
-| Tier | Per 4 hours | Per day | Per month |
-| ---- | ----------- | ------- | --------- |
-| Base | ~40         | ~100    | ~180      |
-| Plus | ~80         | ~200    | ~360      |
-| Max  | ~200        | ~500    | ~900      |
+| Tier  | Per 4 hours | Per day | Per month |
+| ----- | ----------- | ------- | --------- |
+| Base  | ~40         | ~100    | ~180      |
+| Plus  | ~80         | ~200    | ~360      |
+| Max   | ~200        | ~500    | ~900      |
+| Ultra | ~400        | ~1000   | ~1800     |
 
 These are estimates and vary based on question complexity.
 


### PR DESCRIPTION
## Summary

Adds the Ultra plan tier to the Gordon usage limits page. The tier hierarchy is now Base → Plus (2×) → Max (5×) → Ultra (10×), with corresponding usage limits of ~400/4hr, ~1000/day, ~1800/month.

Generated by Claude Code