### PR TITLE
docs: remove obsolete compose version field from Go and OpenTelemetry guides

### DIFF
--- a/content/guides/golang/develop.md
+++ b/content/guides/golang/develop.md
@@ -524,8 +524,6 @@ In this section, you'll create a Docker Compose file to start your `docker-gs-pi
 In your application's directory, create a new text file named `compose.yaml` with the following content.
 
 ```yaml
-version: "3.8"
-
 services:
   docker-gs-ping-roach:
     depends_on:

--- a/content/guides/opentelemetry.md
+++ b/content/guides/opentelemetry.md
@@ -133,8 +133,6 @@ service:
 Create the `docker-compose.yaml` file:
 
 ```yaml
-version: '3.9'
-
 services:
   app:
     build: ./app


### PR DESCRIPTION
The Compose files in the Go (`guides/golang/develop.md`) and OpenTelemetry (`guides/opentelemetry.md`) guides start with a top-level `version:` field. The Compose reference already documents this as obsolete ("Version top-level element (obsolete)" in `reference/compose-file/version-and-name.md`), and running `docker compose up` on these files prints a warning: `the attribute \`version\` is obsolete, it will be ignored, please remove it`.

This removes the `version:` line from both so the guides match the reference and don't emit a warning when followed. I verified `docker compose config` is clean on both files after the change. Left the swarm guide (`docker stack deploy`) untouched, since that still uses the versioned format.