### PR TITLE
Update Docker login command syntax

### DIFF
--- a/content/get-started/workshop/04_sharing_app.md
+++ b/content/get-started/workshop/04_sharing_app.md
@@ -64,7 +64,7 @@ Let's try to push the image to Docker Hub.
    docker image ls
    ```
 
-2. To fix this, first sign in to Docker Hub using your Docker ID: `docker login YOUR-USER-NAME`.
+2. To fix this, first sign in to Docker Hub using your Docker ID: `docker login -u YOUR-USER-NAME`.
 3. Use the `docker tag` command to give the `getting-started` image a new name. Replace `YOUR-USER-NAME` with your Docker ID.
 
    ```console


### PR DESCRIPTION
There was -u missing in the login command syntax, which would prompt to provide username and password, but never succeed the login attempt.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why --> I added -u in the login command syntax, which was missing from the instruction and creating confusion because it was not complete.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review