### PR TITLE
sbx: note that org policy overrides kit network rules

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -143,6 +143,13 @@ registries, install endpoints, or external APIs. Use `deniedDomains` for
 hosts the agent should not reach, such as telemetry endpoints. If a domain
 matches both an allow rule and a deny rule, the deny rule wins.
 
+> [!IMPORTANT]
+> Kit network rules don't apply when organization governance is active. In
+> that case, only organization rules are evaluated, so kit-defined allow and
+> deny rules are ignored — including any domains a kit allows for the agent
+> to reach. For details, see
+> [Policy precedence](../governance/concepts.md#precedence).
+
 For authenticated services, see
 [Authenticate to external services](#authenticate-to-external-services).
 

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -94,11 +94,12 @@ no effect.
 Local and organization policies don't combine. Which one applies depends on
 whether your organization has governance enabled:
 
-- **No organization governance**: local rules determine what sandboxes can
-  access.
+- **No organization governance**: local rules and any
+  [kit-defined network rules](../customize/kits.md#control-network-access)
+  determine what sandboxes can access.
 - **Organization governance active**: organization rules apply across all
-  developer machines, and local rules are not evaluated. Local rules still
-  appear in `sbx policy ls`, but with an `inactive` status.
+  developer machines, and local and kit-defined rules are not evaluated. They
+  still appear in `sbx policy ls`, but with an `inactive` status.
 
 Within the active policy, deny rules beat allow rules regardless of specificity
 or order.


### PR DESCRIPTION
## Description

Documents a gap in the Docker Sandboxes (`sbx`) docs: network rules defined in a kit (`allowedDomains` / `deniedDomains`) **don't apply when organization governance is active**. In that case only organization rules are evaluated, so kit-defined allows and denies are ignored — including domains a kit allows for the agent to reach. This precedence behavior wasn't documented anywhere.

Changes:

- **`customize/kits.md`** — Add an `[!IMPORTANT]` callout in the "Control network access" section (where a kit author defines network rules) explaining that org governance takes precedence, with a link to Policy precedence.
- **`governance/concepts.md`** — The "Precedence" section previously mentioned only *local* rules. Both bullets now account for kit-defined network rules: they apply alongside local rules when there's no org governance, and are not evaluated (shown `inactive` in `sbx policy ls`) when org governance is active.

## Related issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)