### PR TITLE
Fix PR-review bot false positives (80-char rule, enable/disable)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -50,7 +50,6 @@ jobs:
 
         ### 3. Markdown Formatting
         - Poor markdown syntax (unclosed code blocks, broken lists, indentation issues, etc.)
-        - Line wrapping over 80 characters (except links, code blocks, tables)
 
         ### 4. AI-Generated Patterns (HIGH PRIORITY)
         Flag AI-isms from STYLE.md:

--- a/STYLE.md
+++ b/STYLE.md
@@ -464,6 +464,12 @@ _1. Optional. Enter a description for the job._
 | use                                   | utilize                |
 | help                                  | facilitate             |
 
+Use "turn on" and "turn off" for UI toggles, switches, and settings a user
+flips in the interface. In general prose, "enable" and "disable" are
+acceptable when describing a feature or capability becoming available — for
+example, "When you enable auto-log-out, your users are logged out." Don't
+treat every "enable" or "disable" as a violation.
+
 ### Version numbers
 
 - Use "earlier" not "lower": Docker Desktop 4.1 and earlier


### PR DESCRIPTION
## Summary

An audit of docker-agent review comments across recent merged PRs surfaced two
recurring false positives, both traced to their source:

- The bot's prompt (`.github/workflows/pr-review.yml`) instructed it to flag
  lines over 80 characters, but no such rule exists — markdownlint MD013 is
  disabled and STYLE.md never mentions it. The bot itself conceded this
  mid-review on a past PR. Removed the instruction.
- STYLE.md's word list banned "enable" yet used it in a ✅ example, so the bot
  flagged every "enable"/"disable" as a violation. Added a note clarifying that
  "turn on/off" is for UI toggles while "enable/disable" is fine in general
  prose.

## Learnings

- The docker-agent PR reviewer is driven by the `additional-prompt` block in
  `.github/workflows/pr-review.yml` (via `docker/cagent-action`), plus
  `STYLE.md` and `COMPONENTS.md` loaded as prompt files. That prompt — not just
  the style guides — is the source of truth for what the bot flags, so review
  noise can be tuned there directly.

Generated by Claude Code