### PR TITLE
Fix broken AI governance link on manage-licenses page

### DIFF
--- a/content/manuals/admin/organization/manage/manage-licenses.md
+++ b/content/manuals/admin/organization/manage/manage-licenses.md
@@ -44,5 +44,5 @@ See these docs to explore Docker Core add-ons, or products that need licenses:
 
 - [Scale your subscription](/manuals/subscription/scale.md) to learn about different add-ons
 - [Manage seats](/manuals/admin/organization/manage/manage-seats.md) to add more seats to your Docker Core subscription
-- [AI Governance](/manuals/ai/sandboxes/security/governance.md) to set up organization policies for your organization members
+- [AI Governance](/manuals/ai/sandboxes/governance/org.md) to set up organization policies for your organization members
 - [Docker Offload](/manuals/offload/about.md) to let your developers offload building and running containers to the cloud


### PR DESCRIPTION
The AI governance docs moved from /ai/sandboxes/security/governance/ to /ai/sandboxes/governance/. Update the reference on the manage-licenses page to point at the new org policy page.
