### PR TITLE
docs: fix typo in engine 20.10 release notes

### DIFF
--- a/content/manuals/engine/release-notes/20.10.md
+++ b/content/manuals/engine/release-notes/20.10.md
@@ -558,7 +558,7 @@ well as updated versions of the containerd.io package.
 * Suppress warnings for deprecated cgroups [docker/cli#3099](https://github.com/docker/cli/pull/3099).
 * Prevent sending `SIGURG` signals to container on Linux and macOS. The Go runtime
   (starting with Go 1.14) uses `SIGURG` signals internally as an interrupt to
-  support preemptable syscalls. In situations where the Docker CLI was attached
+  support preemptible syscalls. In situations where the Docker CLI was attached
   to a container, these interrupts were forwarded to the container. This fix
   changes the Docker CLI to ignore `SIGURG` signals [docker/cli#3107](https://github.com/docker/cli/pull/3107),
   [moby/moby#42421](https://github.com/moby/moby/pull/42421).


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `preemptable` → `preemptible` in `content/manuals/engine/release-notes/20.10.md`.
