### PR TITLE
Fix truncated DOCKER_ACCOUNT variable in Circle CI example

### DIFF
--- a/content/manuals/build-cloud/ci.md
+++ b/content/manuals/build-cloud/ci.md
@@ -201,7 +201,7 @@ jobs:
           curl --silent -L --output ~/.docker/cli-plugins/docker-buildx $BUILDX_URL
           chmod a+x ~/.docker/cli-plugins/docker-buildx
 
-      - run: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_ --password-stdin
+      - run: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_ACCOUNT --password-stdin
       - run: docker buildx create --use --driver cloud "${DOCKER_ACCOUNT}/${CLOUD_BUILDER_NAME}"
 
       - run: |
@@ -224,7 +224,7 @@ jobs:
           curl --silent -L --output ~/.docker/cli-plugins/docker-buildx $BUILDX_URL
           chmod a+x ~/.docker/cli-plugins/docker-buildx
 
-      - run: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_ --password-stdin
+      - run: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_ACCOUNT --password-stdin
       - run: docker buildx create --use --driver cloud "${DOCKER_ACCOUNT}/${CLOUD_BUILDER_NAME}"
 
       - run: |


### PR DESCRIPTION
## Description

The Circle CI example in the Build Cloud CI docs used a truncated `$DOCKER_` variable in the `docker login` command in both the `build_push` and `build_cache` jobs. As written, `$DOCKER_` expands to an empty string, so the login fails. This changes both occurrences to `$DOCKER_ACCOUNT`, matching the very next line in each job (`${DOCKER_ACCOUNT}`) and every other CI example in the file.

## Related issues

Closes #25214

🤖 Generated with [Claude Code](https://claude.com/claude-code)