### PR TITLE
deps: bump @docker/marlin-sdk-web-public to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@alpinejs/collapse": "3.15.8",
         "@alpinejs/focus": "3.15.8",
         "@alpinejs/persist": "3.15.8",
-        "@docker/marlin-sdk-web-public": "0.2.0",
+        "@docker/marlin-sdk-web-public": "0.3.0",
         "@floating-ui/dom": "1.7.6",
         "@tailwindcss/cli": "4.2.1",
         "@tailwindcss/typography": "0.5.19",
@@ -110,9 +110,9 @@
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="
     },
     "node_modules/@docker/marlin-sdk-web-public": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@docker/marlin-sdk-web-public/-/marlin-sdk-web-public-0.2.0.tgz",
-      "integrity": "sha512-muk4faf3+aE9HbzGWpZCCkOmsve0BgEktQrQmWyoE05JZR8LvPEoarsiAeIMqwk9tPWMJ+0tyIlARd+41Ybw4g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@docker/marlin-sdk-web-public/-/marlin-sdk-web-public-0.3.0.tgz",
+      "integrity": "sha512-MzolUogdFKPeBw66dNR2k3I1wPZVgYk6/BRYKKnextfg9IQY1A65WvQPyGF6dXfl2STsrhcmu5QFCxNnwjBOHQ==",
       "dependencies": {
         "@bufbuild/protobuf": "2.11.0",
         "@bufbuild/protovalidate": "1.1.1",
@@ -736,6 +736,64 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@alpinejs/collapse": "3.15.8",
     "@alpinejs/focus": "3.15.8",
     "@alpinejs/persist": "3.15.8",
-    "@docker/marlin-sdk-web-public": "0.2.0",
+    "@docker/marlin-sdk-web-public": "0.3.0",
     "@floating-ui/dom": "1.7.6",
     "@tailwindcss/cli": "4.2.1",
     "@tailwindcss/typography": "0.5.19",


### PR DESCRIPTION
Bumps `@docker/marlin-sdk-web-public` from 0.2.0 to 0.3.0.