### PR TITLE
offload: update activity log

### DIFF
--- a/content/manuals/admin/activity-logs.md
+++ b/content/manuals/admin/activity-logs.md
@@ -148,6 +148,10 @@ Refer to the following section for a list of events and their descriptions:
 
 ### Offload events
 
+> [!NOTE]
+>
+> Event descriptions show the Docker username of the actor and details about the lease.
+
 | Event                                                          | Description                                   |
 |:------------------------------------------------------------------|:------------------------------------------------|
 | Offload Lease Start | Occurs when an Offload lease is started in your organization. |

--- a/content/reference/api/hub/latest.yaml
+++ b/content/reference/api/hub/latest.yaml
@@ -729,6 +729,19 @@ paths:
                         timestamp: "2021-02-19T01:34:35Z"
                         action_description: |
                           pushed the tag latest with the digest sha256:c1ae9c435032a to the repository docker/example
+                      - account: docker
+                        action: offload.lease.end
+                        name: docker
+                        actor: docker
+                        data:
+                          lease_id: l_3EgPuRCjtUqT279CFPOQWcO8zOf
+                          resource_type: run_4cpu_8mem
+                          started_at: "2026-06-04T18:24:21Z"
+                          updated_at: "2026-06-04T18:36:43Z"
+                          org_id: b908ca6e-b9a9-4a53-a9a5-6bec96f72432
+                          user_id: ecae6747-e42c-43cb-925d-cfce1ab32b02
+                        timestamp: "2026-06-04T18:36:43Z"
+                        action_description: "offload lease 'l_3EgPuRCjtUqT279CFPOQWcO8zOf' ended, ran for '12m22s'"
         "429":
           description: ""
           content:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- Added note to Offload Activity logs page about the username and details being displayed. Note that `user_id` and `org_id` is not currently displayed in the event description/details.
- Added example to API docs showing what data is returned for Offload. We don't currently document the data for all the event types, so I avoided doing it inconsistently for Offload and instead opted to add it as an example.

Previews:
- https://deploy-preview-25268--docsdocker.netlify.app/admin/activity-logs/#offload-events
- https://deploy-preview-25268--docsdocker.netlify.app/reference/api/hub/latest/#tag/audit-logs/operation/AuditLogs_ListAuditLogs

UI reference:
<img width="1617" height="678" alt="image" src="https://github.com/user-attachments/assets/30a7cb6c-c6ea-43fc-981c-2856080ab9d2" />


## Related issues or tickets

ENGDOCS-3312

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
- [ ] Product review