### PR TITLE
dhi: clean up wording

### DIFF
--- a/content/manuals/dhi/core-concepts/sbom.md
+++ b/content/manuals/dhi/core-concepts/sbom.md
@@ -51,7 +51,7 @@ The significance of SBOMs is underscored by several key factors:
 
 ## Docker Hardened Image SBOMs
 
-Docker Hardened Images come with built-in SBOMs, ensuring that every component
+Docker Hardened Images have SBOMs, ensuring that every component
 in the image is documented and verifiable. These SBOMs are cryptographically
 signed, providing a tamper-evident record of the image's contents. This
 integration simplifies audits and enhances trust in the software supply chain.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Removed `comes with` and `built-in` as they're misleading. The attestations are separate from the image.


## Related issues or tickets

https://docker.slack.com/archives/C0989V6TAK0/p1780606035242419

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
