### PR TITLE
sbx: add OpenRouter provider to agent authentication docs

### DIFF
--- a/content/manuals/ai/sandboxes/agents/docker-agent.md
+++ b/content/manuals/ai/sandboxes/agents/docker-agent.md
@@ -32,6 +32,7 @@ $ sbx secret set -g google
 $ sbx secret set -g xai
 $ sbx secret set -g nebius
 $ sbx secret set -g mistral
+$ sbx secret set -g openrouter
 ```
 
 You only need to configure the providers you want to use. Docker Agent detects
@@ -39,7 +40,8 @@ available credentials and routes requests to the appropriate provider.
 
 Alternatively, export the environment variables (`OPENAI_API_KEY`,
 `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `NEBIUS_API_KEY`,
-`MISTRAL_API_KEY`) in your shell before running the sandbox. See
+`MISTRAL_API_KEY`, `OPENROUTER_API_KEY`) in your shell before running the
+sandbox. See
 [Credentials](../security/credentials.md) for details on both methods.
 
 ## Configuration

--- a/content/manuals/ai/sandboxes/agents/opencode.md
+++ b/content/manuals/ai/sandboxes/agents/opencode.md
@@ -42,13 +42,15 @@ $ sbx secret set -g google
 $ sbx secret set -g xai
 $ sbx secret set -g groq
 $ sbx secret set -g aws
+$ sbx secret set -g openrouter
 ```
 
 You only need to configure the providers you want to use. OpenCode detects
 available credentials and offers those providers in the TUI.
 
 You can also use environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
-`GOOGLE_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `AWS_ACCESS_KEY_ID`). See
+`GOOGLE_GENERATIVE_AI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`,
+`AWS_ACCESS_KEY_ID`, `OPENROUTER_API_KEY`). See
 [Credentials](../security/credentials.md) for details on both methods.
 
 ## Configuration


### PR DESCRIPTION
## Summary

Adds `sbx secret set -g openrouter` and `OPENROUTER_API_KEY` to the Authentication sections of `docker-agent.md` and `opencode.md`, matching the OpenRouter support added in docker/sandboxes#3244. Also corrects the Google env var in `opencode.md` from `GOOGLE_API_KEY` to `GOOGLE_GENERATIVE_AI_API_KEY`, which is the name OpenCode actually uses.

Closes #25273

Generated by Claude Code