### PR TITLE
sbx: mark set-custom as experimental (no longer hidden)

### DIFF
--- a/content/manuals/ai/sandboxes/customize/build-an-agent.md
+++ b/content/manuals/ai/sandboxes/customize/build-an-agent.md
@@ -328,6 +328,4 @@ the host to `sbx secret rm`:
 $ sbx secret rm -g --host ampcode.com
 ```
 
-The `--host` flag on `sbx secret rm` isn't listed in
-`sbx secret rm --help`, but it's the only way to remove entries
-created with `set-custom`. It's experimental and may change.
+The `--host` flag is part of the experimental `set-custom` surface and doesn't appear in `sbx secret rm --help`.

--- a/content/manuals/ai/sandboxes/customize/build-an-agent.md
+++ b/content/manuals/ai/sandboxes/customize/build-an-agent.md
@@ -249,8 +249,7 @@ outbound requests to `ampcode.com`.
 > rejected.
 
 > [!NOTE]
-> `sbx secret set-custom` is an experimental command and isn't listed
-> in `sbx secret --help`. It works today but may change in future
+> `sbx secret set-custom` is experimental and may change in future
 > releases. This tutorial surfaces it because there's no other path to
 > register a custom-format placeholder.
 
@@ -331,5 +330,4 @@ $ sbx secret rm -g --host ampcode.com
 
 The `--host` flag on `sbx secret rm` isn't listed in
 `sbx secret rm --help`, but it's the only way to remove entries
-created with `set-custom`. Like `set-custom` itself, it's experimental
-and may change.
+created with `set-custom`. It's experimental and may change.

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -173,9 +173,8 @@ network policy. For details, see
 ## Custom secrets
 
 > [!IMPORTANT]
-> Custom secrets are experimental. The `set-custom` command is hidden
-> from `sbx --help`, and behavior, flags, and the placeholder format may
-> change.
+> Custom secrets are experimental. Behavior, flags, and the placeholder format may
+> change without notice.
 
 For credentials that don't fit the service-identifier model — for example,
 when an agent validates the environment variable format at boot, or when the


### PR DESCRIPTION
## Summary

- Removes the statement that `sbx secret set-custom` is hidden from `sbx --help` — the command is now visible following the v0.32.0 release.
- Keeps the experimental callout since behavior, flags, and placeholder format may still change.

Part of milestone sbx/v0.32.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)