### PR TITLE
stale workflow: update permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -154,6 +154,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write  # required for actions/stale to delete its state cache between runs
 
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Fix stale action not closing PRs due to missing `actions: write` permission

The stale action uses GitHub Actions cache to persist state between runs. Without `actions: write`, it can't delete its `_state` cache entry (fails with 403), so the old state accumulates and PRs in that cached state are permanently skipped with `processed during the previous run`, meaning they never get evaluated for closing.

Confirmed via Actions logs: PR #23598 was marked stale on April 24 but has never been evaluated for closing because it appears in the stuck cache state every run.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review