### PR TITLE
Fix 404 on /develop/ by redirecting to /guides/

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -8,6 +8,8 @@
 # provide a short, permanent link to refer to a topic in the documentation.
 # For example, the docker CLI can output https://docs.docker.com/go/some-topic
 # in its help output, which can be redirected to elsewhere in the documentation.
+"/guides/":
+  - /develop/
 "/security/access-tokens/":
   - /go/access-tokens/
 "/reference/api/engine/#deprecated-api-versions":


### PR DESCRIPTION
## Summary

- `docs.docker.com/develop/` returns a 404 — the old "Develop with Docker" section root was removed during a content restructure but no redirect was added
- Adds a pageless redirect from `/develop/` to `/guides/`, which is the current equivalent section

## Related

Fixes #25289