### PR TITLE
Fix grammatical error in Scout Slack notification description

### DIFF
--- a/content/manuals/scout/integrations/team-collaboration/slack.md
+++ b/content/manuals/scout/integrations/team-collaboration/slack.md
@@ -22,10 +22,10 @@ to the Slack channels associated with the webhook.
 
 > [!NOTE]
 >
-> Notifications are only triggered for the *last pushed* image tags for each
+> Notifications are only triggered for the _last pushed_ image tags for each
 > repository. "Last pushed" refers to the image tag that was most recently
 > pushed to the registry and analyzed by Docker Scout. If the last pushed image
-> is not by a newly disclosed CVE, then no notification will be triggered.
+> is not affected by a newly disclosed CVE, then no notification will be triggered.
 
 For more information about Docker Scout notifications,
 see [Notification settings](/manuals/scout/explore/dashboard.md#notification-settings)


### PR DESCRIPTION
## Description

Fixes a grammatical error in the Scout Slack integration page. The phrase \"is not by a newly disclosed CVE\" is broken — it should read \"is not affected by a newly disclosed CVE\", which is also consistent with the same explanation in the dashboard documentation.

## Related issues or tickets

Fixes #25158

## Reviews

- [ ] Technical review
- [ ] Editorial review