### PR TITLE
Fix broken prerequisite in account deactivation docs

### DIFF
--- a/content/manuals/accounts/deactivate-user-account.md
+++ b/content/manuals/accounts/deactivate-user-account.md
@@ -35,7 +35,9 @@ Before deactivating your Docker account, ensure you meet the following requireme
 - If you have an active Docker subscription, [downgrade it to a Docker Personal subscription](../subscription/change.md).
 - Download any images and tags you want to keep. Use `docker pull -a <image>`
   to pull all tags, or `docker pull <image>:<tag>` to pull a specific tag.
-- Unlink your [GitHub and account](../docker-hub/repos/manage/builds/link-source.md#unlink-a-github-user-account).
+- If you linked a GitHub or Bitbucket account for automated builds, unlink it.
+  See [Unlink a GitHub user account](../docker-hub/repos/manage/builds/link-source.md#unlink-a-github-user-account)
+  or [Unlink a Bitbucket user account](../docker-hub/repos/manage/builds/link-source.md#unlink-a-bitbucket-user-account).
 
 ## Deactivate
 


### PR DESCRIPTION
## Description

The prerequisites section for deactivating a Docker account contained a broken bullet:

> Unlink your [GitHub and account](...)

\"GitHub and account\" is not grammatical. The linked page covers unlinking both GitHub and Bitbucket accounts (for the deprecated automated builds feature), but only GitHub was mentioned.

This fix:
- Rewrites the bullet to be grammatically correct
- Clarifies it only applies to users who linked accounts for automated builds
- Adds a link for Bitbucket alongside GitHub

## Related issues or tickets

Fixes #25128

## Reviews

- [ ] Technical review
- [ ] Editorial review