### PR TITLE
Add cursor and droid to sandboxes built-in services table

### DIFF
--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -96,6 +96,8 @@ checks and the API domains it authenticates requests to:
 | ----------- | ---------------------------------- | ----------------------------------- |
 | `anthropic` | `ANTHROPIC_API_KEY`                | `api.anthropic.com`                 |
 | `aws`       | `AWS_ACCESS_KEY_ID`                | AWS Bedrock endpoints               |
+| `cursor`    | `CURSOR_API_KEY`                   | `api2.cursor.sh`                    |
+| `droid`     | `FACTORY_API_KEY`                  | `factory.ai`                        |
 | `github`    | `GH_TOKEN`, `GITHUB_TOKEN`         | `api.github.com`, `github.com`      |
 | `google`    | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `generativelanguage.googleapis.com` |
 | `groq`      | `GROQ_API_KEY`                     | `api.groq.com`                      |


### PR DESCRIPTION
## Description

The built-in services table in `credentials.md` was missing entries for `cursor` and `droid`, both of which are documented agent pages that use `sbx secret set -g <service>`.

Added both rows in alphabetical order:

| Service | Environment variable | API domain |
|---------|---------------------|------------|
| `cursor` | `CURSOR_API_KEY` | `api2.cursor.sh` |
| `droid` | `FACTORY_API_KEY` | `factory.ai` |

These match the env var names and domains referenced in the respective agent pages (`agents/cursor.md` and `agents/droid.md`).

## Related issues or tickets

Fixes #25272

## Reviews

- [ ] Technical review
- [ ] Editorial review