### PR TITLE
Avoid using the `newgrp` command-line tool in the doc

### DIFF
--- a/content/manuals/engine/install/linux-postinstall.md
+++ b/content/manuals/engine/install/linux-postinstall.md
@@ -63,7 +63,7 @@ To create the `docker` group and add your user:
    You can also run the following command to activate the changes to groups:
 
    ```console
-   $ newgrp docker
+   $ sudo -u $USER bash
    ```
 
 4. Verify that you can run `docker` commands without `sudo`.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

- Fixes https://github.com/docker/roadmap/issues/910 .
- Avoid using the `newgrp` command-line tool in the doc. I don't think requiring users to install an additional apt package is a good option.
- Also see https://github.com/ddev/ddev/issues/8350 .
## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

- https://github.com/docker/roadmap/issues/910

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review