### PR TITLE
Clarify proxy configuration setting for Docker Desktop

### DIFF
--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/_index.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/_index.md
@@ -48,17 +48,6 @@ Settings Management supports a wide range of Docker Desktop features, including:
 
 For a complete list of settings you can enforce, see the [Settings reference](/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md).
 
-> [!NOTE]
->
-> Proxy configuration is a special case because it must be configured in two places:
->
-> 1. In the Admin Console for your organization.
-> 2. On the user's system where Docker Desktop is installed.
->
-> On the user's machine, configure the proxy either through the admin-settings.json file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
->
-> This additional configuration is required because Docker Desktop must know which proxy server to use before it can complete user sign-in and retrieve organization settings from the Admin Console.
-
 ## Policy precedence
 
 When multiple policies exist, Docker Desktop applies them in this order:

--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/_index.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/_index.md
@@ -47,6 +47,16 @@ Settings Management supports a wide range of Docker Desktop features, including:
 - Cloud policies
 
 For a complete list of settings you can enforce, see the [Settings reference](/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md).
+> [!NOTE]
+>
+> Proxy configuration is a special case because it must be configured in two places:
+>
+> 1. In the Admin Console for your organization.
+> 2. On the user's system where Docker Desktop is installed.
+>
+> On the user's machine, configure the proxy either through the admin-settings.json file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
+>
+> This additional configuration is required because Docker Desktop must know which proxy server to use before it can complete user sign-in and retrieve organization settings from the Admin Console.
 
 ## Policy precedence
 

--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/_index.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/_index.md
@@ -47,6 +47,7 @@ Settings Management supports a wide range of Docker Desktop features, including:
 - Cloud policies
 
 For a complete list of settings you can enforce, see the [Settings reference](/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md).
+
 > [!NOTE]
 >
 > Proxy configuration is a special case because it must be configured in two places:

--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
@@ -324,7 +324,7 @@ The following tables describe all available settings in the `admin-settings.json
 > 1. In the Admin Console for your organization.
 > 2. On the user's system where Docker Desktop is installed.
 >
-> On the user's machine, configure the proxy either through the admin-settings.json file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
+> On the user's machine, configure the proxy either through the `admin-settings.json` file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
 > 
 > This additional configuration is required because Docker Desktop must know which proxy server to use before it can complete user sign-in and retrieve organization settings from the Admin Console.
 

--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/configure-json-file.md
@@ -317,6 +317,17 @@ The following tables describe all available settings in the `admin-settings.json
 | `pac`                |              | Specifies a PAC file URL. For example, `"pac": "http://proxy/proxy.pac"`.                                                                                                                                                                                                                                                                                                                                                                                               |                                        |
 | `embeddedPac`        |              | Specifies an embedded PAC (Proxy Auto-config) script. For example, `"embeddedPac": "function FindProxyForURL(url, host) { return \"DIRECT\"; }"`. This setting takes precedence over HTTP, HTTPS, Proxy bypass and PAC server URL.                                                                                                                                                                                                                                      |  |
 
+> [!NOTE]
+>
+> Proxy configuration is a special case because it must be configured in two places:
+>
+> 1. In the Admin Console for your organization.
+> 2. On the user's system where Docker Desktop is installed.
+>
+> On the user's machine, configure the proxy either through the admin-settings.json file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
+> 
+> This additional configuration is required because Docker Desktop must know which proxy server to use before it can complete user sign-in and retrieve organization settings from the Admin Console.
+
 ### Container proxy
 
 | Parameter         | OS  | Description                                                                                                                                                                                                                                         | Version                                |

--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
@@ -324,6 +324,17 @@ Keeps image metadata current by indexing during idle time or after image operati
 
 ## Proxy
 
+> [!NOTE]
+>
+> Proxy configuration is a special case because it must be configured in two places:
+>
+> 1. In the Admin Console for your organization.
+> 2. On the user's system where Docker Desktop is installed.
+>
+> On the user's machine, configure the proxy either through the admin-settings.json file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
+> 
+> This additional configuration is required because Docker Desktop must know which proxy server to use before it can complete user sign-in and retrieve organization settings from the Admin Console.
+
 ### Embedded PAC script 
 
 Specifies an embedded Proxy Auto-Config (PAC) script. For example: `"embeddedPac": "function FindProxyForURL(url, host) { return \"DIRECT\"; }"`.

--- a/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
+++ b/content/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md
@@ -331,7 +331,7 @@ Keeps image metadata current by indexing during idle time or after image operati
 > 1. In the Admin Console for your organization.
 > 2. On the user's system where Docker Desktop is installed.
 >
-> On the user's machine, configure the proxy either through the admin-settings.json file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
+> On the user's machine, configure the proxy either through the `admin-settings.json` file or by using installer flags during Docker Desktop installation. For detailed instructions, refer to the [installation guide](/manuals/desktop/setup/install/windows-install.md#proxy-configuration).
 > 
 > This additional configuration is required because Docker Desktop must know which proxy server to use before it can complete user sign-in and retrieve organization settings from the Admin Console.
 


### PR DESCRIPTION
Added note about proxy configuration requirements for Docker Desktop.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
Proxy configuration is a special case that needs configuration in Admin Console as well as in admin-settings.json/install-settings.json. Most customers miss the proxy configuration in admin-settings/install-settings.json resulting in sign-in issues with DD. Hopefully this will reduce the cases or at least we can point them to this updated manual.
## Related issues or tickets
https://docker.atlassian.net/browse/SEG-1703
<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review