### PR TITLE
fix: add missing useState import and remove duplicate ddClient in backend extension tutorial

### DIFF
--- a/content/manuals/extensions/extensions-sdk/build/backend-extension-tutorial.md
+++ b/content/manuals/extensions/extensions-sdk/build/backend-extension-tutorial.md
@@ -275,14 +275,13 @@ Replace the `ui/src/App.tsx` file with the following code:
 ```tsx
 
 // ui/src/App.tsx
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 //obtain docker desktop extension client
 const ddClient = createDockerDesktopClient();
 
 export function App() {
-  const ddClient = createDockerDesktopClient();
   const [hello, setHello] = useState<string>();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Add `useState` to the React import in the backend extension tutorial code example — it was used but missing from the import, causing a compilation error
- Remove the duplicate `createDockerDesktopClient()` call inside `App()` — `ddClient` is already declared at module scope

## Issue

Fixes #25192