### PR TITLE
docs: restore tasks.<service-name> container discovery documentation

### DIFF
--- a/content/manuals/engine/swarm/networking.md
+++ b/content/manuals/engine/swarm/networking.md
@@ -314,6 +314,14 @@ round robin (DNSRR). You can configure this per service.
   `--endpoint-mode dnsrr` when creating a new service or updating an existing
   one.
 
+### Container discovery
+
+For most situations, connect to the service name. Docker load-balances
+requests across all running tasks ("containers") backing the service. To
+resolve the IP addresses of all individual tasks backing a service directly,
+perform a DNS lookup for `tasks.<service-name>`. Docker returns a list of
+all task IP addresses for that service, one per running replica.
+
 ## Customize the ingress network {#customize-ingress}
 
 Most users never need to configure the `ingress` network, but Docker allows you


### PR DESCRIPTION
## Summary

Restores the "Container discovery" section that was accidentally dropped in #18998 when swarm networking content was deduplicated from `network/drivers/overlay.md` into `engine/swarm/networking.md`.

The removed content documented that `tasks.<service-name>` DNS lookups return individual task IP addresses for a service — a useful swarm-specific feature for service-to-service discovery without going through the VIP.

The new section is placed directly after the VIP/DNSRR service discovery descriptions, within the "Configure service discovery" section, which is the right location for this content.

## Issue

Fixes #24940