### PR TITLE
docs: clarify distinct purposes of --pull and --no-cache flags

### DIFF
--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -109,7 +109,7 @@ reused.
 ### Use --no-cache for clean builds
 
 The `--no-cache` flag disables the build cache, forcing Docker to
-re-execute all `RUN` instructions from scratch:
+rebuild all layers from scratch:
 
 ```console
 $ docker build --no-cache -t my-image:my-tag .

--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -103,8 +103,6 @@ $ docker build --pull -t my-image:my-tag .
 
 The `--pull` flag forces Docker to check for and download a newer
 version of the base image, even if you have a version cached locally.
-It only affects the `FROM` instruction — cached `RUN` layers are still
-reused.
 
 ### Use --no-cache for clean builds
 

--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -103,20 +103,24 @@ $ docker build --pull -t my-image:my-tag .
 
 The `--pull` flag forces Docker to check for and download a newer
 version of the base image, even if you have a version cached locally.
+It only affects the `FROM` instruction — cached `RUN` layers are still
+reused.
 
 ### Use --no-cache for clean builds
 
 The `--no-cache` flag disables the build cache, forcing Docker to
-rebuild all layers from scratch:
+re-execute all `RUN` instructions from scratch:
 
 ```console
 $ docker build --no-cache -t my-image:my-tag .
 ```
 
 This gets the latest available versions of dependencies from package
-managers like `apt-get` or `npm`. However, `--no-cache` doesn't pull a
-fresh base image - it only prevents reusing cached layers. For a
-completely fresh build with the latest base image, combine both flags:
+managers like `apt-get` or `npm`. It does not pull a fresh base image —
+for that, use `--pull`.
+
+The two flags serve distinct purposes and can be combined. Use both
+together to get a fresh base image and re-execute all build steps:
 
 ```console
 $ docker build --pull --no-cache -t my-image:my-tag .


### PR DESCRIPTION
## Summary

- In the \`--pull\` section: clarifies that the flag checks for and downloads a newer version of the base image even if one is cached locally.
- In the \`--no-cache\` section: replaces the "however... doesn't pull a fresh base image" correction with a positive cross-reference to \`--pull\`, and reframes the combined usage as two complementary flags rather than a workaround.

## Issue

Fixes #25291