### PR TITLE
docs: fix LocalStack port, Compose configs key, and a doubled link slash

### DIFF
--- a/content/guides/bun/deploy.md
+++ b/content/guides/bun/deploy.md
@@ -11,7 +11,7 @@ aliases:
 ## Prerequisites
 
 - Complete all the previous sections of this guide, starting with [Containerize a Bun application](containerize.md).
-- [Turn on Kubernetes](/manuals//desktop/use-desktop/kubernetes.md#enable-kubernetes) in Docker Desktop.
+- [Turn on Kubernetes](/manuals/desktop/use-desktop/kubernetes.md#enable-kubernetes) in Docker Desktop.
 
 ## Overview
 

--- a/content/guides/localstack.md
+++ b/content/guides/localstack.md
@@ -110,7 +110,7 @@ Now that you've familiarized yourself with LocalStack, it's time to see it in ac
 
 Now it’s time to connect your app to LocalStack. The `index.js` file, located in the backend/ directory, serves as the main entry point for the backend application.
 
-The code interacts with LocalStack’s S3 service, which is accessed via the endpoint defined by the `S3_ENDPOINT_URL` environment variable, typically set to `http://localhost:4556` for local development.
+The code interacts with LocalStack’s S3 service, which is accessed via the endpoint defined by the `S3_ENDPOINT_URL` environment variable, typically set to `http://localhost:4566` for local development.
 
 The `S3Client` from the AWS SDK is configured to use this LocalStack endpoint, along with test credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) that are also sourced from environment variables. This setup lets the application to perform operations on the locally simulated S3 service as if it were interacting with the real AWS S3, making the code flexible for different environments.
 

--- a/content/guides/pgadmin.md
+++ b/content/guides/pgadmin.md
@@ -129,7 +129,7 @@ Fortunately, there is an ability to auto-connect to the database.
     Add the following config to your `compose.yaml` file to define a pgpass file:
 
     ```yaml
-    config:
+    configs:
       pgadmin-pgpass:
         content: |
           postgres:5432:*:postgres:secret


### PR DESCRIPTION
Three small fixes in the guides.

- `guides/localstack`: the prose says `S3_ENDPOINT_URL` is `http://localhost:4556`, but LocalStack's edge port is `4566`, and the guide's own `.env` block later uses `4566`.
- `guides/pgadmin`: the top-level Compose key for the pgpass file is `configs`, not `config`. As written the compose file is invalid.
- `guides/bun/deploy`: the "Turn on Kubernetes" link has a doubled slash (`/manuals//desktop/...`).
