### PR TITLE
Clarify sandbox Docker registry credentials use case

### DIFF
--- a/content/manuals/ai/sandboxes/workflows.md
+++ b/content/manuals/ai/sandboxes/workflows.md
@@ -241,9 +241,10 @@ The token is never stored in plaintext inside the sandbox. See
 
 ### Docker registry
 
-To let the agent push images it builds to a private registry, store registry
-credentials on your host. The agent can then run `docker build` and
-`docker push` without any extra authentication:
+To push or pull private images, including [templates](customize/templates.md),
+configure registry credentials for `sbx` to use. The agent can then run `docker
+build` and `docker push`, and `sbx` can resolve private image references,
+without any extra authentication:
 
 ```console
 $ gh auth token | sbx secret set --registry ghcr.io \
@@ -254,8 +255,11 @@ $ echo "$ACR_PASSWORD" | sbx secret set --registry myregistry.azurecr.io \
 
 Images and containers built inside the sandbox run on the sandbox's private
 Docker daemon, not your host's. They're deleted when the sandbox is removed.
-See [Registry credentials](security/credentials.md#registry-credentials) for
-the full reference.
+
+Docker Hub needs no registry credentials; `sbx` reuses your `sbx login`
+session. For information on how registry credentials differ from other secrets,
+per-registry username requirements, and global versus per-sandbox scoping, see
+[Registry credentials](security/credentials.md#registry-credentials).
 
 ### Sourcing credentials from 1Password
 


### PR DESCRIPTION
## Summary

The "Docker registry" section in the sandbox workflows page described only pushing built images and used "store credentials on your host," which conflicts with how we describe credentials saved for `sbx` elsewhere. This reframes the section around its use cases — pulling private images (including templates referenced by OCI URL) and pushing built images — rewords it to "configure registry credentials for `sbx` to use," and cross-references credentials.md for the secret-type details (Docker Hub `sbx login` reuse, per-registry usernames, global vs per-sandbox scoping) instead of duplicating them. credentials.md stays the single source of truth for distinguishing secret types.

Generated by Claude Code