### PR TITLE
sbx: document codex auth prompt before sandbox launch

### DIFF
--- a/content/manuals/ai/sandboxes/agents/codex.md
+++ b/content/manuals/ai/sandboxes/agents/codex.md
@@ -29,7 +29,21 @@ $ sbx run codex
 
 ## Authentication
 
-Codex supports two authentication methods: an API key or OAuth.
+If you haven't stored an OpenAI credential, `sbx run codex` prompts you to
+authenticate on your host before launching the sandbox. The flow runs on the
+host, so credentials are never exposed inside the sandbox.
+
+To set up authentication ahead of time, choose one of the following methods.
+
+**OAuth**: Start the OAuth flow on your host with:
+
+```console
+$ sbx secret set -g openai --oauth
+```
+
+This opens a browser window for authentication and stores the resulting tokens
+in your OS keychain. The OAuth flow runs on the host, not inside the sandbox,
+so browser-based authentication works without any extra setup.
 
 **API key**: Store your OpenAI API key using
 [stored secrets](../security/credentials.md#stored-secrets):
@@ -40,17 +54,6 @@ $ sbx secret set -g openai
 
 Alternatively, export the `OPENAI_API_KEY` environment variable in your shell
 before running the sandbox.
-
-**OAuth**: If you prefer not to use an API key, start the OAuth flow on your
-host with:
-
-```console
-$ sbx secret set -g openai --oauth
-```
-
-This opens a browser window for authentication and stores the resulting tokens
-in your OS keychain. The OAuth flow runs on the host, not inside the sandbox,
-so browser-based authentication works without any extra setup.
 
 See [Credentials](../security/credentials.md) for more details.
 

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -339,8 +339,12 @@ The proxy reads the variable from your terminal session. See individual
 - Don't set API keys manually inside the sandbox. Sandbox agents are
   pre-configured to use proxy-managed credentials.
 - For Claude Code and Codex, OAuth is another secure option: the flow runs on
-  the host, so the token is never exposed inside the sandbox. For Claude Code,
-  use `/login` inside the agent. For Codex, run `sbx secret set -g openai --oauth`.
+  the host, so the token is never exposed inside the sandbox. If you haven't
+  stored a credential, both agents prompt you to authenticate before the
+  sandbox launches — Codex prompts on the host from `sbx run codex`, and Claude
+  Code prompts inside the agent. To authenticate ahead of time, run
+  `sbx secret set -g openai --oauth` for Codex, or use `/login` inside Claude
+  Code.
 - If you store credentials in 1Password, see
   [Sourcing credentials from 1Password](../workflows.md#sourcing-credentials-from-1password)
   for how to use `op read` and `op run` with `sbx`.


### PR DESCRIPTION
## Summary

`sbx` now prompts you to authenticate to Codex on the host before launching the sandbox when no OpenAI credential is stored. Updated the Codex agent page and the credentials best practices to describe this flow, and reordered the Codex auth methods so OAuth (the host-side prompted flow) leads.

Generated by Claude Code