### PR TITLE
sbx: add governance API sync script and re-vendor spec

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -42,6 +42,7 @@ jobs:
         - Any YAML file in `data/*/*.yaml` subdirectories (CLI reference data generated from upstream)
           - Examples: `data/engine-cli/*.yaml`, `data/buildx/*.yaml`, `data/scout-cli/*.yaml`
           - Exception: root-level data/ files are manually maintained (allow edits)
+        - `content/reference/api/ai-governance/api.yaml` (verbatim copy of the upstream OpenAPI spec, vendored from the private docker/governor-services repo via `hack/sync-governance-api.sh`)
 
         ### 2. Missing Redirects When Removing/Moving Pages (HIGH)
         When a PR removes or moves a page:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,15 @@ must go to the source repository:
 | Model Runner reference | docker/model-runner |
 | Dockerfile reference | moby/buildkit |
 | Engine API reference | moby/moby |
+| AI Governance API (`content/reference/api/ai-governance/api.yaml`) | docker/governor-services (private) |
 
 If a validation failure or broken link traces back to vendored content, note
 the upstream repo that needs fixing. Do not attempt to fix it locally.
+
+`content/reference/api/ai-governance/api.yaml` is a verbatim copy of the
+upstream `openapi.yaml` — do not edit it by hand. Re-vendor it with
+`hack/sync-governance-api.sh`, which fetches the latest spec from the private
+`docker/governor-services` repo (using your own `gh` auth).
 
 ## Writing guidelines
 

--- a/content/reference/api/ai-governance/api.yaml
+++ b/content/reference/api/ai-governance/api.yaml
@@ -130,7 +130,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "403":
-          $ref: "#/components/responses/PermissionDenied"
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
@@ -259,7 +259,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "403":
-          $ref: "#/components/responses/PermissionDenied"
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
@@ -383,7 +383,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "403":
-          $ref: "#/components/responses/PermissionDenied"
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
@@ -851,7 +851,9 @@ components:
                 already exists. `invalid_argument`: the request body is malformed
                 or fails validation. `unauthenticated`: missing or invalid
                 credentials. `permission_denied`: the org is not entitled to use
-                governance. `unimplemented`: the endpoint or feature is not yet
+                governance. `limit_exceeded`: the org has reached its maximum
+                number of policies, or the policy has reached its maximum number
+                of rules. `unimplemented`: the endpoint or feature is not yet
                 available. `internal`: unexpected server error.
               enum:
                 - not_found
@@ -859,6 +861,7 @@ components:
                 - invalid_argument
                 - unauthenticated
                 - permission_denied
+                - limit_exceeded
                 - unimplemented
                 - internal
             message:
@@ -931,6 +934,29 @@ components:
                 error:
                   code: permission_denied
                   message: permission denied
+
+    Forbidden:
+      description: >
+        Caller lacks the required permission for this org, the org is not
+        entitled to use governance (`permission_denied`), or a creation limit
+        has been reached (`limit_exceeded`): the org already has the maximum
+        number of policies, or the policy already has the maximum number of
+        rules.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            permission_denied:
+              value:
+                error:
+                  code: permission_denied
+                  message: permission denied
+            limit_exceeded:
+              value:
+                error:
+                  code: limit_exceeded
+                  message: organization has reached the maximum of 100 policies
 
     InternalError:
       description: Internal server error

--- a/hack/sync-governance-api.sh
+++ b/hack/sync-governance-api.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Re-vendor the AI Governance OpenAPI spec from docker/governor-services.
+#
+# The spec at content/reference/api/ai-governance/api.yaml is a verbatim copy
+# of the upstream openapi.yaml — no transformation is applied. This script
+# fetches the latest version and overwrites the local copy, then prints a diff
+# summary so you can sanity-check before committing.
+#
+# Requires: gh (authenticated with access to the private docker/governor-services
+# repo). No secrets are stored in this repo — auth comes from your own gh login.
+#
+# Usage: hack/sync-governance-api.sh [ref]
+#   ref   optional git ref (branch, tag, or SHA). Defaults to the repo default branch.
+set -euo pipefail
+
+REPO="docker/governor-services"
+SRC_PATH="governor-service-api/openapi.yaml"
+DEST="content/reference/api/ai-governance/api.yaml"
+REF="${1:-}"
+
+# Resolve this repo's root so the script works from any working directory.
+ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+DEST_ABS="$ROOT/$DEST"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found. Install it and run 'gh auth login'." >&2
+  exit 1
+fi
+
+api_path="repos/$REPO/contents/$SRC_PATH"
+[ -n "$REF" ] && api_path="$api_path?ref=$REF"
+
+echo "Fetching $SRC_PATH from $REPO${REF:+@$REF}..."
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+if ! gh api "$api_path" --jq '.content' | base64 -d > "$tmp"; then
+  echo "error: failed to fetch spec. Check 'gh auth status' and repo access." >&2
+  exit 1
+fi
+
+if [ ! -s "$tmp" ]; then
+  echo "error: fetched spec is empty — aborting without overwriting $DEST." >&2
+  exit 1
+fi
+
+if diff -q "$DEST_ABS" "$tmp" >/dev/null 2>&1; then
+  echo "Already up to date — $DEST is identical to upstream."
+  exit 0
+fi
+
+cp "$tmp" "$DEST_ABS"
+echo "Updated $DEST. Review the change:"
+echo
+git -C "$ROOT" --no-pager diff --stat -- "$DEST"


### PR DESCRIPTION
## What

Make re-vendoring the AI Governance Policy API reference easier, and re-vendor it:

1. **`hack/sync-governance-api.sh`** — a script to re-vendor the spec from the private `docker/governor-services` repo. The vendored copy at `content/reference/api/ai-governance/api.yaml` is a verbatim copy of upstream's `openapi.yaml`, so the script just fetches the latest via `gh` and prints a diff summary for review. It uses the caller's own `gh` auth (no repo secrets) and follows the existing `hack/sync-cli-docs.sh` convention.

2. **Re-vendored spec** — running the script picked up the latest upstream changes:
   - Renames the shared `403` response component from `PermissionDenied` to `Forbidden` across the policy/rule endpoints.
   - Adds a `limit_exceeded` error code covering org policy and per-policy rule maximums.

3. **Marked the spec as vendored** — so neither agents nor the review bot treat it as hand-editable:
   - `AGENTS.md`: added it to the "Vendored content (do not edit)" table, with a note to re-vendor via the script.
   - `.github/workflows/pr-review.yml`: added the path to the review bot's "Vendored/Generated Content (auto-reject)" list (which previously only matched `_vendor/` and `data/*/*.yaml`).

## Why

Re-vendoring was a manual copy/paste chore each time. A GitHub Action was undesirable (private source repo + secrets), and a verbatim copy needs no transformation — so a committed script that runs against each maintainer's own `gh` auth is the lightest fit.

## Test

- Ran `hack/sync-governance-api.sh`; output is valid YAML and byte-identical to upstream.
- Re-validated `pr-review.yml` parses as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
