### PR TITLE
docs(sandboxes): post-v0.32.0 doc updates

### DIFF
--- a/content/manuals/ai/sandboxes/agents/claude-code.md
+++ b/content/manuals/ai/sandboxes/agents/claude-code.md
@@ -62,12 +62,16 @@ Without extra args, the sandbox runs:
 claude --dangerously-skip-permissions
 ```
 
-Args after `--` replace these defaults rather than being appended. To keep
-`--dangerously-skip-permissions`, include it yourself:
+Arguments after `--` are added after the default flags when the first one is
+itself a flag (begins with `-`), so `--dangerously-skip-permissions` is
+preserved:
 
 ```console
-$ sbx run claude -- --dangerously-skip-permissions -c
+$ sbx run claude -- -c   # runs claude --dangerously-skip-permissions -c
 ```
+
+When the first argument is a bare word, such as the `agents` subcommand, it
+replaces the defaults instead.
 
 See the [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference)
 for available options.

--- a/content/manuals/ai/sandboxes/agents/codex.md
+++ b/content/manuals/ai/sandboxes/agents/codex.md
@@ -73,8 +73,9 @@ Without extra args, the sandbox runs:
 codex --dangerously-bypass-approvals-and-sandbox
 ```
 
-Args after `--` replace these defaults rather than being appended. To keep
-the flag, include it yourself:
+Arguments after `--` are added after the default flags when the first one is
+itself a flag (begins with `-`). A bare word — such as a prompt — replaces the
+defaults instead, so lead with the flag to keep bypass mode:
 
 ```console
 $ sbx run codex -- --dangerously-bypass-approvals-and-sandbox "fix the build"

--- a/content/manuals/ai/sandboxes/agents/copilot.md
+++ b/content/manuals/ai/sandboxes/agents/copilot.md
@@ -59,12 +59,15 @@ Without extra args, the sandbox runs:
 copilot --yolo
 ```
 
-Args after `--` replace these defaults rather than being appended. To keep
-`--yolo`, include it yourself:
+Arguments after `--` are added after the default flags when the first one is
+itself a flag (begins with `-`), so `--yolo` is preserved:
 
 ```console
-$ sbx run copilot -- --yolo -p "review this PR"
+$ sbx run copilot -- -p "review this PR"   # runs copilot --yolo -p "review this PR"
 ```
+
+When the first argument is a bare word — a subcommand or prompt — it replaces
+the defaults instead.
 
 ## Base image
 

--- a/content/manuals/ai/sandboxes/agents/cursor.md
+++ b/content/manuals/ai/sandboxes/agents/cursor.md
@@ -65,12 +65,15 @@ Without extra args, the sandbox runs:
 cursor-agent --yolo
 ```
 
-Args after `--` replace these defaults rather than being appended. To keep
-`--yolo`, include it yourself:
+Arguments after `--` are added after the default flags when the first one is
+itself a flag (begins with `-`), so `--yolo` is preserved:
 
 ```console
-$ sbx run cursor -- --yolo -p "refactor this"
+$ sbx run cursor -- -p "refactor this"   # runs cursor-agent --yolo -p "refactor this"
 ```
+
+When the first argument is a bare word — a subcommand or prompt — it replaces
+the defaults instead.
 
 ## Base image
 

--- a/content/manuals/ai/sandboxes/agents/docker-agent.md
+++ b/content/manuals/ai/sandboxes/agents/docker-agent.md
@@ -60,8 +60,10 @@ Without extra args, the sandbox runs:
 docker-agent run --yolo
 ```
 
-Args after `--` replace these defaults rather than being appended. To keep
-`run --yolo`, include them yourself:
+Arguments after `--` are added after the default flags when the first one is
+itself a flag (begins with `-`). When the first argument is a bare word — such
+as the `run` subcommand or a config file — it replaces the defaults, so include
+`run --yolo` yourself:
 
 ```console
 $ sbx run docker-agent -- run --yolo agent.yml

--- a/content/manuals/ai/sandboxes/agents/gemini.md
+++ b/content/manuals/ai/sandboxes/agents/gemini.md
@@ -65,12 +65,15 @@ Without extra args, the sandbox runs:
 gemini --yolo
 ```
 
-Args after `--` replace these defaults rather than being appended. To keep
-`--yolo`, include it yourself:
+Arguments after `--` are added after the default flags when the first one is
+itself a flag (begins with `-`), so `--yolo` is preserved:
 
 ```console
-$ sbx run gemini -- --yolo -p "explain this"
+$ sbx run gemini -- -p "explain this"   # runs gemini --yolo -p "explain this"
 ```
+
+When the first argument is a bare word — a subcommand or prompt — it replaces
+the defaults instead.
 
 ## Base image
 

--- a/content/manuals/ai/sandboxes/agents/kiro.md
+++ b/content/manuals/ai/sandboxes/agents/kiro.md
@@ -85,10 +85,12 @@ Without extra args, the sandbox runs:
 kiro chat --trust-all-tools
 ```
 
-Args after `--` replace these defaults rather than being appended. This is
-why `sbx run kiro -- login --use-device-flow` works for the login subcommand.
-To keep `chat --trust-all-tools` alongside your own args, include them
-yourself:
+When the first argument after `--` is a flag (begins with `-`), it's added
+after the defaults — for example, `sbx run kiro -- --resume` runs
+`kiro chat --trust-all-tools --resume`. When the first argument is a bare word,
+it replaces the defaults, which is why `sbx run kiro -- login --use-device-flow`
+runs the login subcommand on its own. To run `chat` with extra arguments of
+your own, include the subcommand:
 
 ```console
 $ sbx run kiro -- chat --trust-all-tools --resume

--- a/content/manuals/ai/sandboxes/agents/shell.md
+++ b/content/manuals/ai/sandboxes/agents/shell.md
@@ -23,13 +23,15 @@ $ sbx run shell -- -c "echo 'Hello from sandbox'"
 
 ## Default startup command
 
-Without extra args, the sandbox runs `bash -l`. Args after `--` replace `-l`
-rather than being appended. To preserve login-shell behavior, include `-l`
-yourself:
+Without extra args, the sandbox runs `bash -l`. When the first argument after
+`--` is a flag (begins with `-`), it's added after `-l`, so login-shell
+behavior is preserved:
 
 ```console
-$ sbx run shell -- -l -c "echo hi"
+$ sbx run shell -- -c "echo hi"   # runs bash -l -c "echo hi"
 ```
+
+When the first argument is a bare word, it replaces `-l` instead.
 
 Set your API keys as environment variables so the sandbox proxy can inject
 them into API requests automatically. Credentials are never stored inside

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -2,7 +2,7 @@
 title: FAQ
 weight: 70
 description: Frequently asked questions about Docker Sandboxes.
-keywords: docker sandboxes, sbx, faq, sign in, telemetry
+keywords: docker sandboxes, sbx, faq, sign in, telemetry, clipboard, image paste
 ---
 
 ## Why do I need to sign in?
@@ -158,6 +158,35 @@ the sandbox.
 Collocating skills and other agent configuration with the project itself is a
 good practice regardless of sandboxes. It's versioned alongside the code and
 evolves with the project as it changes.
+
+## Can I paste images into an agent?
+
+Yes, but it's off by default. Text paste already works, because the terminal
+sends it directly. Pasting an image or screenshot with `Ctrl+V` is different:
+the agent reads it from your host clipboard, and the sandbox blocks that access
+unless you opt in.
+
+Turn it on with a local setting:
+
+```console
+$ sbx settings set clipboard.imagePaste true
+```
+
+`Ctrl+V` then pastes host images into agents that read the clipboard, including
+Claude Code and Codex. The setting takes effect within a few seconds, even for
+running sandboxes.
+
+This is opt-in because it relaxes the sandbox's isolation: when enabled, a process
+inside the sandbox can read your host clipboard through the host-side proxy. The
+exposure is narrow — reads happen only on a paste, return image data only
+(`image/png`), and clipboard content is never cached or logged — but it's still
+host data crossing into the sandbox, so it stays off until you turn it on.
+
+To turn it back off:
+
+```console
+$ sbx settings set clipboard.imagePaste false
+```
 
 ## Can I use Docker Sandboxes on headless Linux?
 

--- a/content/manuals/ai/sandboxes/governance/audit.md
+++ b/content/manuals/ai/sandboxes/governance/audit.md
@@ -63,7 +63,8 @@ A network evaluation record looks like this:
     "no applicable policies for op(action=net:connect:tcp, resource=net:domain:example.com:443)"
   ],
   "action_type": "network_egress",
-  "network_egress": { "protocol": "tcp" }
+  "network_egress": { "protocol": "tcp" },
+  "agent": "claude"
 }
 ```
 
@@ -83,6 +84,7 @@ Common fields include:
 | `resource_id`      | The target of the evaluation, such as a host and port.                                                       |
 | `decision`         | `AUDIT_DECISION_ALLOW` or `AUDIT_DECISION_DENY`.                                                             |
 | `deny_reason`      | Why a denied request was blocked. Present on deny decisions.                                                 |
+| `agent`            | The AI agent driving the sandbox (for example, `claude`, `codex`). Omitted when the agent is unknown.       |
 
 Each record is attributed to the signed-in Docker user and the organization
 whose governance policy is in effect.

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -14,46 +14,28 @@ the security model behind this, see
 
 ## How credential injection works
 
-The proxy needs three things to inject a credential: which outbound traffic to
-match, what header to write, and what value to use. The kit (or built-in agent
-definition) declares the first two. You provide the value on the host.
+When a sandbox makes an outbound request, the host-side proxy decides three
+things: whether the request **matches** a service the kit (or built-in agent)
+declares, what **header** to write, and what **value** to inject. The kit
+declares the match and the header; you provide the value on the host. The real
+value never enters the sandbox — the agent sees only a sentinel like
+`proxy-managed`.
 
-There are two host-side stores, plus a host shell fallback:
+There are several ways to provide that value. When more than one source has a
+value for the same service, the stored secret takes precedence over a host
+environment variable.
 
-- Stored secrets, keyed on a service identifier: built-in agents declare
-  service identifiers (`anthropic`, `openai`, `github`, etc.) in their kit
-  specs; custom kits can declare their own. `sbx secret set` stores a value
-  keyed on that identifier. When a sandboxed request matches a service's
-  domain, the proxy reads the stored value and writes the configured header.
-  Inside the sandbox, the environment variable holds a sentinel like
-  `proxy-managed`, so SDKs that read the variable see something non-empty
-  without seeing the real secret. See [Stored secrets](#stored-secrets).
+| Form | What it is | Use it when |
+| ---- | ---------- | ----------- |
+| [Stored secrets](#stored-secrets) (`sbx secret set`) | A value in your OS keychain, keyed by service | The default for any built-in or kit-declared service |
+| [Custom secrets](#custom-secrets) (`sbx secret set-custom`) | A value keyed to a domain and environment variable | The service model doesn't fit — the agent validates the variable's format, or the secret rides in a request body |
+| [Environment variables](#environment-variables) | Read from your shell session | One-off testing or CI, where keychain storage isn't worth it |
+| OAuth | A host-side sign-in flow; the token never enters the sandbox | The agent supports it, such as Claude Code, Codex, or Cursor |
+| [Registry credentials](#registry-credentials) (`sbx secret set --registry`) | Authentication for pulling images and kits | Pulling templates or kits from a private registry |
 
-- Stored secrets, keyed on a target domain and environment variable name:
-  `sbx secret set-custom` stores a value alongside a target domain, an
-  environment variable name, and an optional placeholder. The sandbox sees
-  the placeholder; the proxy substitutes it with the real value anywhere it
-  appears in outbound traffic to that domain. Use this when the
-  service-identifier model doesn't fit — for example, when the agent
-  validates the variable format at boot, or when the credential lands in a
-  request body. See [Custom secrets](#custom-secrets).
-
-- Host shell environment variables: as a fallback, the proxy reads from your
-  shell environment. Useful for one-off testing or development; stored
-  secrets are preferred because shell environment variables are plaintext
-  and visible to other processes running as your user. See
-  [Environment variables](#environment-variables).
-
-Registry credentials are a separate store with a different purpose. They
-authenticate the `sbx` CLI (and optionally the sandbox itself) to private
-OCI registries for template and kit pulls, and are not used by the
-credential-injection proxy. See [Registry credentials](#registry-credentials).
-
-If both a stored secret and a host environment variable are set for the same
-service, the stored secret takes precedence. For multi-provider agents
-(OpenCode, Docker Agent), the proxy selects credentials based on the API
-endpoint being called. See individual [agent pages](../agents/) for
-provider-specific details.
+For multi-provider agents (OpenCode, Docker Agent), the proxy selects
+credentials based on the API endpoint being called. See individual
+[agent pages](../agents/) for provider-specific details.
 
 ## Stored secrets
 
@@ -252,81 +234,6 @@ proxy replaces it with the real value. The agent never sees the real secret.
 Prefer the [service-based flow](#stored-secrets) whenever it's an option —
 the kit handles the wiring; you only provide the value.
 
-## Registry credentials
-
-Registry credentials authenticate to private OCI registries when pulling
-[templates](../customize/templates.md) or [kits](../customize/kits.md). Use
-`sbx secret set --registry <host>` to store them. They are independent from
-service secrets: the proxy doesn't touch them, and they're used directly by
-the `sbx` CLI when resolving image references.
-
-For Docker Hub, `sbx` reuses your `sbx login` session — no registry secret
-needed. For other registries (GitHub Container Registry, ECR, ACR,
-self-hosted Nexus, and so on), store credentials with `sbx secret set
---registry`.
-
-### Store registry credentials
-
-Pipe a token from stdin and target the registry hostname:
-
-```console
-$ gh auth token | sbx secret set --registry ghcr.io --password-stdin
-```
-
-For registries that require a username (for example, ACR with an admin
-account), add `--username`:
-
-```console
-$ echo "$ACR_PASSWORD" | sbx secret set \
-    --registry myregistry.azurecr.io \
-    --username myuser \
-    --password-stdin
-```
-
-Three scopes control where the credential is used:
-
-- Host-only (no `-g`, no sandbox name): the `sbx` CLI uses it to pull
-  templates and kits when creating a sandbox. The credential is not
-  injected into the sandbox itself, so processes inside the sandbox can't
-  use it.
-- Global (`-g`): same as host-only, plus written into `~/.docker/config.json`
-  in every new sandbox. Use this when agents need to pull or push from
-  inside the sandbox — for example, when an agent builds and publishes
-  container images.
-- Sandbox-scoped (positional `SANDBOX` argument): credential applies only
-  to that named sandbox. Useful when only one sandbox needs access to a
-  private registry.
-
-```console
-$ gh auth token | sbx secret set -g --registry ghcr.io --password-stdin
-$ gh auth token | sbx secret set my-sandbox --registry ghcr.io --password-stdin
-```
-
-`sbx kit pull` also uses these credentials, with the Docker credential
-store as a fallback. `sbx kit push` uses only the Docker credential store —
-push targets still require a prior `docker login`.
-
-### Remove registry credentials
-
-Remove both the host-only and global entries for a registry:
-
-```console
-$ sbx secret rm --registry ghcr.io -f
-```
-
-To remove only the global (sandbox-injected) entry and leave the
-host-only credential in place, pass `-g`:
-
-```console
-$ sbx secret rm -g --registry ghcr.io -f
-```
-
-To remove a sandbox-scoped credential, pass the sandbox name:
-
-```console
-$ sbx secret rm my-sandbox --registry ghcr.io -f
-```
-
 ## Environment variables
 
 As an alternative to stored secrets, export the relevant environment variable
@@ -347,6 +254,96 @@ The proxy reads the variable from your terminal session. See individual
 > [built-in service](#built-in-services), see
 > [Setting custom environment variables](../faq.md#how-do-i-set-custom-environment-variables-inside-a-sandbox).
 
+## Registry credentials
+
+Registry credentials authenticate to private OCI registries when pulling
+[templates](../customize/templates.md) or [kits](../customize/kits.md), and can
+also let the agent pull and push images from inside the sandbox. Use
+`sbx secret set --registry <host>` to store them. For Docker Hub, `sbx` reuses
+your `sbx login` session — no registry secret needed. For other registries
+(GitHub Container Registry, ECR, ACR, self-hosted Nexus, and so on), store
+credentials with `sbx secret set --registry`.
+
+The scope you store a credential at controls where it's used — and whether its
+value enters the sandbox. The scope comes from how you target `sbx secret set`:
+
+```text
+sbx secret set [-g | SANDBOX] --registry HOST
+```
+
+- **Host-only** (no `-g`, no `SANDBOX`): the `sbx` CLI uses it to pull templates
+  and kits when creating a sandbox. The credential stays on the host and is
+  never available inside the sandbox.
+- **Global** (`-g`): same as host-only, plus written into
+  `~/.docker/config.json` in every new sandbox so the agent can pull and push
+  images. The value lives inside the VM, where the agent can read it, so it's
+  less isolated than the proxy-injected service credentials above. Use it when
+  agents build and publish container images.
+- **Sandbox-scoped** (`SANDBOX`): same in-sandbox behavior as global, but only
+  for the named sandbox. Use it when only one sandbox needs registry access.
+
+> [!NOTE]
+> Registry credentials are written into a sandbox at creation time. Recreate an
+> existing sandbox to pick up credentials added after it was created.
+
+### Store registry credentials
+
+Pipe a token from stdin and target the registry hostname:
+
+```console
+$ gh auth token | sbx secret set --registry ghcr.io --password-stdin
+```
+
+For registries that require a username (for example, ACR with an admin
+account), add `--username`:
+
+```console
+$ echo "$ACR_PASSWORD" | sbx secret set \
+    --registry myregistry.azurecr.io \
+    --username myuser \
+    --password-stdin
+```
+
+Add `-g` to store the credential globally, before you create the sandbox:
+
+```console
+$ gh auth token | sbx secret set -g --registry ghcr.io --password-stdin
+$ sbx run claude                      # created with the credential in place
+```
+
+To scope the credential to a single sandbox, store it under that sandbox's name
+and create the sandbox with the same name:
+
+```console
+$ gh auth token | sbx secret set my-app --registry ghcr.io --password-stdin
+$ sbx run claude --name my-app
+```
+
+`sbx kit pull` also uses these credentials, with the Docker credential
+store as a fallback. `sbx kit push` uses only the Docker credential store —
+push targets still require a prior `docker login`.
+
+### Remove registry credentials
+
+Remove both the host-only and global entries for a registry:
+
+```console
+$ sbx secret rm --registry ghcr.io -f
+```
+
+To remove only the global (in-sandbox) entry and leave the
+host-only credential in place, pass `-g`:
+
+```console
+$ sbx secret rm -g --registry ghcr.io -f
+```
+
+To remove a sandbox-scoped credential, pass the sandbox name:
+
+```console
+$ sbx secret rm my-sandbox --registry ghcr.io -f
+```
+
 ## Best practices
 
 - Use [stored secrets](#stored-secrets) over environment variables. Stored
@@ -355,6 +352,11 @@ The proxy reads the variable from your terminal session. See individual
   your shell. See [Where secrets are stored](#where-secrets-are-stored).
 - Don't set API keys manually inside the sandbox. Sandbox agents are
   pre-configured to use proxy-managed credentials.
+- Registry credentials you make available inside a sandbox are stored in the VM
+  (`~/.docker/config.json`), where the agent can read them — unlike
+  proxy-injected service credentials, which never enter the sandbox. Reserve
+  them for sandboxes that need registry access, and prefer sandbox scope over
+  global (`-g`) to limit exposure.
 - For Claude Code and Codex, OAuth is another secure option: the flow runs on
   the host, so the token is never exposed inside the sandbox. If you haven't
   stored a credential, both agents prompt you to authenticate before the

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -209,13 +209,25 @@ network policy. For details, see
 For credentials that don't fit the service-identifier model — for example,
 when an agent validates the environment variable format at boot, or when the
 credential lands in a request body rather than a header — use
-`sbx secret set-custom`. The secret is keyed on a target domain, an
+`sbx secret set-custom`. The secret is keyed on one or more target domains, an
 environment variable name, and an optional placeholder string, instead of a
 service identifier.
 
 ```console
 $ sbx secret set-custom -g \
     --host api.example.com \
+    --env API_KEY \
+    --value <secret>
+```
+
+Repeat `--host` to cover multiple domains with the same secret — useful when
+an API is split across related hostnames or when two unrelated endpoints share
+a credential:
+
+```console
+$ sbx secret set-custom -g \
+    --host api.example.com \
+    --host uploads.example.com \
     --env API_KEY \
     --value <secret>
 ```
@@ -228,8 +240,8 @@ $ sbx secret set-custom -g \
 > on the command line.
 
 Inside the sandbox, `API_KEY` is set to a generated placeholder (for example,
-`sbx-cs-<rand>`). When a sandboxed process sends a request to
-`api.example.com` and the placeholder appears anywhere in the request, the
+`sbx-cs-<rand>`). When a sandboxed process sends a request to any of the
+configured hosts and the placeholder appears anywhere in the request, the
 proxy replaces it with the real value. The agent never sees the real secret.
 
 Prefer the [service-based flow](#stored-secrets) whenever it's an option —

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -232,6 +232,11 @@ $ sbx secret set-custom -g \
     --value <secret>
 ```
 
+A `--host` value can also use wildcards, with the same syntax as
+[network rules](../governance/concepts.md#network-rules): `*` matches a
+single label (`*.example.com` covers `api.example.com`) and `**` matches any
+number (`**.example.com` covers `api.example.com` and `v2.api.example.com`).
+
 > [!WARNING]
 > Passing the secret as `--value <secret>` records it in your shell history
 > and exposes it to other processes running as your user. Avoid pasting

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -43,9 +43,11 @@ client's configuration. Both enforce the network policy; only the forward proxy
 [injects credentials](credentials.md) for AI services.
 
 Raw TCP connections, UDP, and ICMP are blocked at the network layer. DNS
-resolution is handled by the proxy; the sandbox cannot make raw DNS queries.
-Traffic to private IP ranges, loopback, and link-local addresses is also
-blocked. Only domains explicitly listed in the policy are reachable.
+resolution goes through the proxy and is subject to the same network policy —
+domains that policy denies are refused at the resolver; loopback names such as
+`localhost` are always resolved regardless of policy. Traffic to private IP
+ranges, loopback, and link-local addresses is also blocked. Only domains
+explicitly listed in the policy are reachable.
 
 For the default set of allowed domains, see
 [Default security posture](defaults.md).

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -183,20 +183,24 @@ Extracting the tar archive as the current user avoids the `chown` call.
 
 Filesystem operations such as `git status`, `git log`, or directory scans can
 be noticeably slow when the sandbox workspace is mounted in direct mode (the
-default for workspaces without `--clone`). In direct mode, virtiofs caching is
-disabled by default to prevent data corruption. Clone-mode sandboxes enable
-virtiofs caching automatically, so this tuning applies only to direct mode.
+default for workspaces without `--clone`). Virtiofs caching speeds up these
+workloads. Clone-mode sandboxes always enable it, so this tuning applies only
+to direct mode.
 
-To speed up filesystem-intensive workloads, opt into virtiofs caching when
-creating the sandbox:
+On macOS and Linux, virtiofs caching is enabled by default. On Windows it's
+still opt-in — enable it when creating the sandbox:
 
 ```console
 $ DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=1 sbx run <template>
 ```
 
 The setting is persisted in the sandbox spec and applies for the lifetime of
-that sandbox. If you experience Git index corruption or unexpected file content
-after enabling the cache, remove the sandbox and recreate it without the flag.
+that sandbox. If you experience Git index corruption or unexpected file content,
+disable caching with the kill switch and recreate the sandbox:
+
+```console
+$ DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0 sbx run <template>
+```
 
 ## Clone mode reports "not in a Git repository" on WSL
 

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -116,7 +116,7 @@ You can also create the sandbox in the background and attach later:
 
 ```console
 $ sbx create --clone --name my-sandbox claude .
-$ sbx run my-sandbox
+$ sbx run --name my-sandbox
 ```
 
 The clone follows whichever ref your host repository has checked out at
@@ -177,11 +177,33 @@ $ sbx run claude ~/my-project  # creates sandbox
 $ sbx run claude ~/my-project  # reconnects to same sandbox
 ```
 
-Use `--name` to make this explicit and avoid ambiguity:
+Use `--name` to give a sandbox an explicit identity:
 
 ```console
 $ sbx run claude --name my-project
 ```
+
+Once a named sandbox exists, `--name` is how you re-attach to it — from any
+working directory, with or without the agent positional:
+
+```console
+$ sbx run --name my-project        # re-attaches from anywhere
+$ sbx run claude --name my-project # same, with agent confirmed
+```
+
+Re-running a command that previously created a sandbox reconnects to it rather
+than returning an error, so you can up-arrow and re-enter a session without
+first looking up the sandbox name.
+
+To run multiple sandboxes against the same workspace — for example, one for a
+feature branch and one for exploratory changes — give each a distinct name:
+
+```console
+$ sbx run claude --name feature ~/my-project
+$ sbx run claude --name spike ~/my-project
+```
+
+Both sandboxes share the same workspace but are otherwise independent.
 
 ## Creating without attaching
 
@@ -189,15 +211,15 @@ $ sbx run claude --name my-project
 the agent. To create a sandbox in the background without attaching:
 
 ```console
-$ sbx create claude .
+$ sbx create --name my-project claude .
 ```
 
 Unlike `run`, `create` requires an explicit workspace path. It uses direct
 mode by default, or pass `--clone` for [clone mode](#clone-mode). Attach
-later with `sbx run`:
+later with `sbx run --name`:
 
 ```console
-$ sbx run claude-my-project
+$ sbx run --name my-project
 ```
 
 ## Multiple workspaces

--- a/content/manuals/ai/sandboxes/workflows.md
+++ b/content/manuals/ai/sandboxes/workflows.md
@@ -327,7 +327,7 @@ Create the sandbox in the background with `sbx create`, run agent tasks with
 
 ```console
 $ sbx create --name ci-task --clone claude
-$ sbx run ci-task  # attach and give instructions, or use sbx exec for one-off commands
+$ sbx run --name ci-task  # attach and give instructions, or use sbx exec for one-off commands
 $ git fetch sandbox-ci-task
 $ sbx rm ci-task
 ```

--- a/data/sbx_cli/sbx.yaml
+++ b/data/sbx_cli/sbx.yaml
@@ -32,4 +32,5 @@ see_also:
     - sbx secret - Manage stored secrets
     - sbx stop - Stop one or more sandboxes without removing them
     - sbx template - Manage sandbox templates
+    - sbx tui - Open the interactive TUI dashboard
     - sbx version - Show Docker Sandboxes version information

--- a/data/sbx_cli/sbx_cp.yaml
+++ b/data/sbx_cli/sbx_cp.yaml
@@ -12,8 +12,7 @@ options:
     - name: follow-link
       shorthand: L
       default_value: "false"
-      usage: |
-        Follow symbolic links in the source path when copying from host to sandbox
+      usage: Follow symbolic links in the source path
     - name: help
       shorthand: h
       default_value: "false"

--- a/data/sbx_cli/sbx_create.yaml
+++ b/data/sbx_cli/sbx_create.yaml
@@ -3,7 +3,7 @@ synopsis: Create a sandbox for an agent
 description: |-
     Create a sandbox with access to a host workspace for an agent.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create [flags] AGENT PATH [PATH...]
 options:
     - name: clone

--- a/data/sbx_cli/sbx_create_claude.yaml
+++ b/data/sbx_cli/sbx_create_claude.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create claude PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_codex.yaml
+++ b/data/sbx_cli/sbx_create_codex.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create codex PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_copilot.yaml
+++ b/data/sbx_cli/sbx_create_copilot.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create copilot PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_cursor.yaml
+++ b/data/sbx_cli/sbx_create_cursor.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create cursor PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_docker-agent.yaml
+++ b/data/sbx_cli/sbx_create_docker-agent.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create docker-agent PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_droid.yaml
+++ b/data/sbx_cli/sbx_create_droid.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create droid PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_gemini.yaml
+++ b/data/sbx_cli/sbx_create_gemini.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create gemini PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_kiro.yaml
+++ b/data/sbx_cli/sbx_create_kiro.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create kiro PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_opencode.yaml
+++ b/data/sbx_cli/sbx_create_opencode.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create opencode PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_create_shell.yaml
+++ b/data/sbx_cli/sbx_create_shell.yaml
@@ -7,7 +7,7 @@ description: |-
     same path as on the host. Additional workspaces can be provided as extra
     arguments. Append ":ro" to mount them read-only.
 
-    Use "sbx run SANDBOX" to attach to the agent after creation.
+    Use "sbx run --name SANDBOX" to attach to the agent after creation.
 usage: sbx create shell PATH [PATH...] [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_run.yaml
+++ b/data/sbx_cli/sbx_run.yaml
@@ -3,13 +3,17 @@ synopsis: Run an agent in a sandbox
 description: |-
     Run an agent in a sandbox, creating the sandbox if it does not already exist.
 
+    The first positional argument is the agent to run. To re-attach to an existing
+    sandbox by name, use --name; the agent positional is optional when the named
+    sandbox already exists and is read from its spec.
+
     Pass agent arguments after the "--" separator. Additional workspaces can be
     provided as extra arguments. Append ":ro" to mount them read-only.
 
     To create a sandbox without attaching, use "sbx create" instead.
 
     Available agents: claude, codex, copilot, cursor, docker-agent, droid, gemini, kiro, opencode, shell
-usage: sbx run [flags] SANDBOX | AGENT [PATH...] [-- AGENT_ARGS...]
+usage: sbx run [flags] [AGENT] [PATH...] [-- AGENT_ARGS...]
 options:
     - name: clone
       default_value: "false"
@@ -50,8 +54,11 @@ example: |4-
       # Create and run with additional workspaces (read-only)
       sbx run claude . /path/to/docs:ro
 
-      # Run an existing sandbox
-      sbx run existing-sandbox
+      # Re-attach to an existing sandbox by name (agent read from its spec)
+      sbx run --name existing-sandbox
+
+      # Re-attach to an existing sandbox by name and verify the expected agent
+      sbx run claude --name existing-sandbox
 
       # Run a sandbox with agent arguments
       sbx run claude -- --continue

--- a/data/sbx_cli/sbx_secret_set-custom.yaml
+++ b/data/sbx_cli/sbx_secret_set-custom.yaml
@@ -9,6 +9,11 @@ description: |-
     target host, the proxy replaces the placeholder with the real secret in the
     request headers — the secret never enters the sandbox directly.
 
+    --host accepts an exact host, IP address, or wildcard pattern. Repeat --host
+    to cover multiple unrelated domains with one secret. "*" matches a single label
+    and "**" matches any number of labels. For example "*.example.com" covers
+    "cli.example.com" and "ide.example.com" with one entry.
+
     Secrets can be scoped globally (shared across all sandboxes) or to a specific sandbox.
 usage: sbx secret set-custom [-g | sandbox] [flags]
 options:
@@ -23,7 +28,9 @@ options:
       default_value: "false"
       usage: help for set-custom
     - name: host
-      usage: Host or IP address
+      default_value: '[]'
+      usage: |
+        Host, IP, or wildcard pattern (e.g. *.example.com); repeatable
     - name: placeholder
       usage: |
         Placeholder value; use {rand} for a random suffix (e.g. sk-{rand})
@@ -42,6 +49,12 @@ example: |4-
       # The sandbox env var API_KEY is set to the placeholder value; outbound requests
       # to the host have the placeholder replaced with the real secret.
       sbx secret set-custom -g --host api.example.com --env API_KEY --value secret123
+
+      # Use a wildcard host to cover multiple subdomains that share one key.
+      sbx secret set-custom -g --host '*.coderabbit.ai' --env CODERABBIT_API_KEY --value secret123
+
+      # Use multiple --host flags to cover unrelated domains with the same key.
+      sbx secret set-custom -g --host api.example.com --host api.other.io --env API_KEY --value secret123
 
       # Scope to a specific sandbox instead of globally.
       sbx secret set-custom my-sandbox --host api.example.com --env API_KEY --value secret123

--- a/data/sbx_cli/sbx_tui.yaml
+++ b/data/sbx_cli/sbx_tui.yaml
@@ -1,0 +1,15 @@
+name: sbx tui
+synopsis: Open the interactive TUI dashboard
+usage: sbx tui [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for tui
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx - Manage AI coding agent sandboxes.


### PR DESCRIPTION
## Summary

Documentation updates based on changes merged into docker/sandboxes after the v0.32.0 release cut (through v0.33.0-rc1):

- **Network isolation** (`security/isolation.md`): clarifies that DNS resolution is subject to the same network policy as outbound connections — domains that policy denies are refused at the resolver, not just blocked at the connection level. Loopback names such as `localhost` are always resolved regardless of policy.
- **Audit log schema** (`governance/audit.md`): documents the new `agent` field on audit records, which identifies the AI agent driving the sandbox.
- **Custom secrets** (`security/credentials.md`): documents that `--host` on `sbx secret set-custom` is now repeatable and accepts wildcard patterns (`*` for a single label, `**` for any number), so one secret can cover multiple domains.
- **`--name` as primary sandbox identity** (`usage.md`, `workflows.md`): documents that `--name` identifies a sandbox independently of the working directory — re-attach from anywhere, run multiple named sandboxes per workspace, and re-run a create command to reconnect. Updates existing examples that used the positional sandbox-name form to use `--name` for consistency.
- **virtiofs cache default** (`troubleshooting.md`): corrects the slow-filesystem guidance — virtiofs caching is now enabled by default on macOS and Linux (Windows remains opt-in), and `DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0` is the kill switch.
- **Post-`--` argument behavior** (`agents/*.md`): corrects the "Default startup command" guidance across the agent pages — arguments after `--` keep the agent's default flags when the first argument is itself a flag, and replace them only when it's a bare word (subcommand or prompt).
- **Image paste** (`faq.md`): documents the opt-in `clipboard.imagePaste` setting for pasting host images into agents with `Ctrl+V`, including the host-clipboard isolation tradeoff.
- **Credentials page restructure** (`security/credentials.md`): [not really v0.33-specific but this needed clarification] leads with the injection model + an orientation table (which form to use, when), groups the value sources, and reframes registry credentials by purpose and isolation posture — scopes explained upfront, the in-sandbox/create-time behavior of `~/.docker/config.json`, and the isolation tradeoff vs proxy injection.

Generated by Claude Code
