### PR TITLE
dhi: alpine 3.24 updates

### DIFF
--- a/content/manuals/dhi/how-to/build.md
+++ b/content/manuals/dhi/how-to/build.md
@@ -46,6 +46,7 @@ The frontend version corresponds to the base distribution:
 |---------------------|----------------------------------------|
 | Alpine 3.22         | `# syntax=dhi.io/build:2-alpine3.22`  |
 | Alpine 3.23         | `# syntax=dhi.io/build:2-alpine3.23`  |
+| Alpine 3.24         | `# syntax=dhi.io/build:2-alpine3.24`  |
 | Debian 12 (Bookworm)| `# syntax=dhi.io/build:2-debian12`    |
 | Debian 13 (Trixie)  | `# syntax=dhi.io/build:2-debian13`    |
 

--- a/content/manuals/dhi/how-to/customize.md
+++ b/content/manuals/dhi/how-to/customize.md
@@ -66,8 +66,8 @@ You can create customizations using either the DHI CLI or the Docker Hub web int
       image.
 
       The packages available in the drop-down are OS system packages for the
-      selected image variant. For version 3.23 Alpine-based images, these are
-      hardened packages that have been built from source by Docker with
+      selected image variant. For version 3.23 and later Alpine-based images,
+      these are hardened packages that have been built from source by Docker with
       cryptographic signatures and full supply chain security. For version 3.22
       Alpine-based images and Debian-based images, these are standard system
       packages.

--- a/content/manuals/dhi/how-to/hardened-packages.md
+++ b/content/manuals/dhi/how-to/hardened-packages.md
@@ -83,6 +83,7 @@ RUN apk update && \
 ```
 
 Replace `3.23` with your Alpine version in both the base image tag and repository URL.
+Supported versions include Alpine 3.23 and 3.24.
 
 To verify the configuration, build and run the image:
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

A few small changes to account for the Alpine 3.24 updates that are rolling out.
- Added Alpine 3.24 to the yaml build spec topic
- Added Alpine 3.23 and later to the GUI customization hsp flow.
- Added Alpine 3.24 hsp repo note to packages example

## Related issues or tickets

ENGDOCS-3323

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review