### PR TITLE
Clarify uninstall-runner images and models behavior

### DIFF
--- a/content/manuals/ai/model-runner/get-started.md
+++ b/content/manuals/ai/model-runner/get-started.md
@@ -70,11 +70,9 @@ then reinstall it:
 ```bash
 docker model uninstall-runner --images && docker model install-runner
 ```
-
 > [!NOTE]
-> With the above command, local models are preserved.
-> To delete the models during the upgrade, add the `--models` option to the
-> `uninstall-runner` command.
+> With the above command, local models are preserved and only the Docker Model Runner images are removed.
+> To also delete the local models during the upgrade, add the `--models` option to the `uninstall-runner` command.
 
 ## Pull a model
 


### PR DESCRIPTION
## Description

Clarify the behavior of the `--images` and `--models` flags in the Docker Model Runner upgrade documentation.

The upgrade example uses the `--images` flag, while the accompanying note refers to the `--models` flag without explaining the difference between them. This could be confusing for users during upgrades.

This change updates the note to explicitly state that the example command removes Docker Model Runner images while preserving local models, and that the `--models` flag can be used to remove local models if desired.

## Related issues or tickets

Fixes #25346 
Closes #25351

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review