### PR TITLE
Add note about temporary credential refresh behavior for awslogs

### DIFF
--- a/content/manuals/engine/logging/drivers/awslogs.md
+++ b/content/manuals/engine/logging/drivers/awslogs.md
@@ -338,6 +338,14 @@ default AWS shared credentials file (`~/.aws/credentials` of the root user), or
 if you are running the Docker daemon on an Amazon EC2 instance, the Amazon EC2
 instance profile.
 
+> [!NOTE]
+> Docker reads AWS credentials when the `awslogs` logging driver starts.
+> If you use a shared AWS credentials file with temporary credentials,
+> updating the file later does not automatically update the credentials
+> used by the running container. When the temporary credentials expire,
+> log delivery to Amazon CloudWatch Logs can fail. Restart the container
+> after refreshing the credentials so Docker can load the updated values.
+
 Credentials must have a policy applied that allows the `logs:CreateLogStream`
 and `logs:PutLogEvents` actions, as shown in the following example.
 

--- a/content/manuals/engine/logging/drivers/awslogs.md
+++ b/content/manuals/engine/logging/drivers/awslogs.md
@@ -339,7 +339,7 @@ if you are running the Docker daemon on an Amazon EC2 instance, the Amazon EC2
 instance profile.
 
 > [!NOTE]
-> Docker reads AWS credentials when the `awslogs` logging driver starts.
+> Docker reads AWS credentials when the container starts.
 > If you use a shared AWS credentials file with temporary credentials,
 > updating the file later does not automatically update the credentials
 > used by the running container. When the temporary credentials expire,


### PR DESCRIPTION
## Description

Adds a note to the `awslogs` credentials documentation explaining that credentials loaded from a shared AWS credentials file are read when the logging driver starts and are not automatically reloaded while the container is running.

This helps users understand that log delivery to Amazon CloudWatch Logs may stop when temporary credentials expire, even if the credentials file has been updated.

## Related issues or tickets

Closes #25327 

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
