### PR TITLE
docs: clarify Docker Model Runner upgrade flags

### DIFF
--- a/content/manuals/ai/model-runner/get-started.md
+++ b/content/manuals/ai/model-runner/get-started.md
@@ -72,9 +72,10 @@ docker model uninstall-runner --images && docker model install-runner
 ```
 
 > [!NOTE]
-> With the above command, local models are preserved.
-> To delete the models during the upgrade, add the `--models` option to the
-> `uninstall-runner` command.
+> With the above command, local models are preserved because `--images`
+> removes only the Docker Model Runner images.
+> To also delete the local models during the upgrade, add the `--models`
+> option to the `uninstall-runner` command.
 
 ## Pull a model
 


### PR DESCRIPTION
## Summary
- clarify that `docker model uninstall-runner --images` removes runner images but preserves local models
- explain that `--models` must be added when users also want to remove the local model volume during upgrade

Closes #25346