### PR TITLE
Add 'sudo apt update' before Docker installation

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -148,8 +148,9 @@ Docker from the repository.
 
    To install the latest version, run:
 
-   ```console
-   $ sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   ```bash
+   sudo apt update
+   sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
 
    {{< /tab >}}


### PR DESCRIPTION
Updated installation instructions for Docker on Debian to include 'sudo apt update' command.

This was necessary in my installation (Debian 13 XFCE), and won't hurt the installation process.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review