### PR TITLE
Fix OpenAI-compatible provider examples in Docker Agent docs

### DIFF
--- a/content/manuals/ai/docker-agent/model-providers.md
+++ b/content/manuals/ai/docker-agent/model-providers.md
@@ -123,15 +123,20 @@ You can use the `openai` provider type to connect to any model or provider that
 implements the OpenAI API specification. This includes services like Azure
 OpenAI, local inference servers, and other compatible endpoints.
 
-Configure an OpenAI-compatible provider by specifying the base URL:
+Define a named model in the `models` section with the `openai` provider and a
+`base_url`, then reference it from your agent:
 
 ```yaml
+models:
+  my-model:
+    provider: openai
+    model: your-model-name
+    base_url: https://your-provider.example.com/v1
+
 agents:
   root:
-    model: openai/your-model-name
+    model: my-model
     instruction: You are a helpful coding assistant
-    provider:
-      base_url: https://your-provider.example.com/v1
 ```
 
 By default, Docker Agent uses the `OPENAI_API_KEY` environment variable for
@@ -139,13 +144,17 @@ authentication. If your provider uses a different variable, specify it with
 `token_key`:
 
 ```yaml
+models:
+  my-model:
+    provider: openai
+    model: your-model-name
+    base_url: https://your-provider.example.com/v1
+    token_key: YOUR_PROVIDER_API_KEY
+
 agents:
   root:
-    model: openai/your-model-name
+    model: my-model
     instruction: You are a helpful coding assistant
-    provider:
-      base_url: https://your-provider.example.com/v1
-      token_key: YOUR_PROVIDER_API_KEY
 ```
 
 ## What's next


### PR DESCRIPTION
## Description

The OpenAI-compatible provider examples on the [Model providers](https://docs.docker.com/ai/docker-agent/model-providers/#openai-compatible-providers) page nest model settings under a `provider:` key directly on the agent:

```yaml
agents:
  root:
    model: openai/your-model-name
    provider:
      base_url: https://your-provider.example.com/v1
```

That is not a valid field, so running the agent fails with:

```
parsing config file
[7:1] unknown field "provider"
```

This PR rewrites both examples to define a named model in the `models` section (with `provider: openai` and `base_url`) and reference it from the agent, which is the supported syntax. The corrected YAML was validated against Docker Agent's config loader.

Fixes docker/docker-agent#3121