### PR TITLE
docs: update MCP integration keyword to Docker Agent

### DIFF
--- a/content/manuals/ai/docker-agent/integrations/mcp.md
+++ b/content/manuals/ai/docker-agent/integrations/mcp.md
@@ -4,7 +4,7 @@ linkTitle: MCP
 description: Expose agents as tools to MCP clients like Claude Desktop and Claude Code
 keywords:
   [
-    cagent,
+    docker agent,
     mcp,
     model context protocol,
     claude desktop,


### PR DESCRIPTION
## Summary
- replace the outdated `cagent` keyword with `docker agent` in the MCP integration page frontmatter
- align the keyword with the current product name used throughout the page and adjacent Docker Agent docs

## Testing
- git diff --check

Closes #25356