### PR TITLE
Fix broken SSO removal anchor link

### DIFF
--- a/content/manuals/admin/organization/deactivate-account.md
+++ b/content/manuals/admin/organization/deactivate-account.md
@@ -29,7 +29,7 @@ organization:
 - If you have an active Docker subscription, [downgrade it to a free subscription](../../subscription/change.md).
 - Remove all other members within the organization.
 - Unlink your [GitHub and Bitbucket accounts](../../docker-hub/repos/manage/builds/link-source.md#unlink-a-github-user-account).
-- For Business organizations, [remove your SSO connection](/manuals/enterprise/security/single-sign-on/manage.md#remove-an-organization).
+- For Business organizations, [remove your SSO connection](/manuals/enterprise/security/single-sign-on/manage.md#delete-a-connection).
 
 ## Deactivate
 


### PR DESCRIPTION
Fixes a broken anchor link in `content/manuals/admin/organization/deactivate-account.md`.

The existing link pointed to `#remove-an-organization`, which does not exist in the target document. Updated it to `#delete-a-connection`, which points to the correct section for removing an SSO connection.

## Related issues or tickets

Fixes #25367

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
