### PR TITLE
docs: fix wording in Docker Scout pages

### DIFF
--- a/content/manuals/scout/integrations/_index.md
+++ b/content/manuals/scout/integrations/_index.md
@@ -1,5 +1,5 @@
 ---
-description: How to setup Docker Scout with other systems.
+description: How to set up Docker Scout with other systems.
 keywords: supply chain, security, integrations, registries, ci, environments
 title: Integrating Docker Scout with other systems
 linkTitle: Integrations

--- a/content/manuals/scout/integrations/ci/_index.md
+++ b/content/manuals/scout/integrations/ci/_index.md
@@ -1,5 +1,5 @@
 ---
-description: How to setup Docker Scout in continuous integration pipelines
+description: How to set up Docker Scout in continuous integration pipelines
 keywords: scanning, vulnerabilities, Hub, supply chain, security, ci, continuous integration,
   github actions, gitlab
 title: Using Docker Scout in continuous integration

--- a/content/manuals/scout/policy/view.md
+++ b/content/manuals/scout/policy/view.md
@@ -52,7 +52,7 @@ for all policy violations for the current image.
 
 ![Detailed Policy Evaluation results](../images/policy-detailed-results.webp)
 
-This view also provides recommendations on how to improve improve policy status
+This view also provides recommendations on how to improve policy status
 for violated policies.
 
 ![Policy details in the tag view](../images/policy-tag-view.webp)


### PR DESCRIPTION
  ## Description

  Minor editorial fixes in the Docker Scout docs:

  - Correct "setup" used as a verb to "set up" in the Integrations and CI integration page descriptions
  - Remove a duplicated word ("improve improve") in the policy view page

  ## Reviews

  - [ ] Technical review
  - [ ] Editorial review
  - [ ] Product review