### PR TITLE
Clarify that Docker Sandboxes is free and OK for commercial use

### DIFF
--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -13,6 +13,10 @@ sandbox gets its own Docker daemon, filesystem, and network — the agent can
 build containers, install packages, and modify files without touching your host
 system.
 
+> [!NOTE]
+> The `sbx` CLI is free to use, including for commercial work. Only
+> [organization governance](governance/) requires a separate paid subscription.
+
 Organization admins can
 [centrally manage sandbox network and filesystem policies](governance/org.md)
 from the Docker Admin Console, so the same rules apply uniformly across every

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -2,8 +2,23 @@
 title: FAQ
 weight: 70
 description: Frequently asked questions about Docker Sandboxes.
-keywords: docker sandboxes, sbx, faq, sign in, telemetry, clipboard, image paste
+keywords: docker sandboxes, sbx, faq, sign in, telemetry, clipboard, image paste, pricing, commercial use
 ---
+
+## Is Docker Sandboxes free? Can I use it commercially?
+
+Yes to both. The `sbx` CLI is free to use, including for commercial and
+professional work, with no per-seat fee. Install it, sign in with a free
+Docker account, and run sandboxes at no cost.
+
+The only paid component is organization governance: centrally managed network
+and filesystem policies, [sign-in enforcement](governance/sign-in-enforcement.md),
+and [audit logs](governance/audit.md). These
+[organization governance features](governance/) require a separate paid
+subscription —
+[contact Docker Sales](https://www.docker.com/products/ai-governance/#contact-sales)
+to get started. Everything else, including running agents in isolated
+sandboxes, is free.
 
 ## Why do I need to sign in?
 


### PR DESCRIPTION
## Description

The "Ask AI" assistant on docs.docker.com can't answer whether `sbx` may be used commercially because the Sandboxes docs never state the licensing terms (see internal thread — a user asked "Czy docker sbx można używać komercyjnie?" and got "my knowledge base doesn't contain this information").

This adds the missing information in two places:

- **FAQ:** a new top entry, "Is Docker Sandboxes free? Can I use it commercially?", stating the `sbx` CLI is free to use including for commercial work, with no per-seat fee, and that only organization governance features require a paid subscription.
- **Sandboxes front page:** a short `[!NOTE]` callout making the same point near the top, where the existing governance paragraph already mentions the paid subscription.

## Related

- Surfaced by an "Ask AI" feedback thread (👎) on https://docs.docker.com/ai/sandboxes/faq/

🤖 Generated with [Claude Code](https://claude.com/claude-code)