### PR TITLE
docs: document router-assigned (SLAAC) IPv6 on macvlan/ipvlan

### DIFF
--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -17,6 +17,7 @@ Artifactory
 armhf
 [Aa]uditability
 auditable
+[Aa]utoconfiguration
 autolock
 [Aa]llowlist(ing)?
 Azure

--- a/content/manuals/engine/network/drivers/ipvlan.md
+++ b/content/manuals/engine/network/drivers/ipvlan.md
@@ -3,7 +3,7 @@ title: IPvlan network driver
 description:
   All about using IPvlan to make your containers appear like physical machines
   on the network
-keywords: network, ipvlan, l2, l3, standalone
+keywords: network, ipvlan, l2, l3, standalone, ipv6, slaac
 aliases:
   - /network/ipvlan/
   - /network/drivers/ipvlan/
@@ -511,6 +511,30 @@ $ docker run --net=ipvlan140 --ip=192.168.140.10 -it --rm alpine /bin/sh
 > one another. That requires a router to proxy-arp the requests with a secondary
 > subnet. However, IPvlan `L3` will route the unicast traffic between disparate
 > subnets as long as they share the same `-o parent` parent link.
+
+### Use router-assigned IPv6 addresses
+
+The previous examples assign IPv6 addresses from a subnet managed by Docker's
+IPAM. On an `ipvlan` network, you can instead let containers receive IPv6
+addresses directly from a router on the parent network, using stateless
+address autoconfiguration (SLAAC).
+
+When an `ipvlan` network has no IPv6 subnet, Docker disables IPv6 on the
+container's interface, so it can't accept the router advertisements that SLAAC
+relies on. To re-enable IPv6 on the interface, set its `disable_ipv6` sysctl
+to `0` when you connect the container to the network:
+
+```console
+$ docker network connect \
+    --driver-opt="com.docker.network.endpoint.sysctls=net.ipv6.conf.IFNAME.disable_ipv6=0" \
+    my-ipvlan-net my-container
+```
+
+Use the literal string `IFNAME` in the sysctl name. Docker replaces it with
+the name of the container's interface on this network. `disable_ipv6` is a
+per-interface sysctl, so it must be set with the `endpoint.sysctls`
+driver option rather than `docker run --sysctl`. For more details, see
+[`docker network connect`](/reference/cli/docker/network/connect/#sysctl).
 
 ### Dual stack IPv4 IPv6 IPvlan L3 mode
 

--- a/content/manuals/engine/network/drivers/macvlan.md
+++ b/content/manuals/engine/network/drivers/macvlan.md
@@ -3,7 +3,7 @@ title: Macvlan network driver
 description:
   All about using Macvlan to make your containers appear like physical
   machines on the network
-keywords: network, macvlan, standalone
+keywords: network, macvlan, standalone, ipv6, slaac
 aliases:
   - /config/containers/macvlan/
   - /engine/userguide/networking/get-started-macvlan/
@@ -146,6 +146,30 @@ $ docker network create -d macvlan \
      -o parent=eth0.218 \
      -o macvlan_mode=bridge macvlan216
 ```
+
+### Use router-assigned IPv6 addresses
+
+The previous example assigns IPv6 addresses from a subnet managed by Docker's
+IPAM. On a `macvlan` network, you can instead let containers receive IPv6
+addresses directly from a router on the parent network, using stateless
+address autoconfiguration (SLAAC).
+
+When a `macvlan` network has no IPv6 subnet, Docker disables IPv6 on the
+container's interface, so it can't accept the router advertisements that SLAAC
+relies on. To re-enable IPv6 on the interface, set its `disable_ipv6` sysctl
+to `0` when you connect the container to the network:
+
+```console
+$ docker network connect \
+    --driver-opt="com.docker.network.endpoint.sysctls=net.ipv6.conf.IFNAME.disable_ipv6=0" \
+    my-macvlan-net my-container
+```
+
+Use the literal string `IFNAME` in the sysctl name. Docker replaces it with
+the name of the container's interface on this network. `disable_ipv6` is a
+per-interface sysctl, so it must be set with the `endpoint.sysctls`
+driver option rather than `docker run --sysctl`. For more details, see
+[`docker network connect`](/reference/cli/docker/network/connect/#sysctl).
 
 ## Usage examples
 


### PR DESCRIPTION
Adds a "Use router-assigned IPv6 addresses" subsection to the macvlan and ipvlan driver pages, covering how to receive IPv6 via SLAAC from a router on the parent network instead of Docker IPAM.

When the network has no IPv6 subnet, Docker disables IPv6 on the endpoint; setting the per-interface `net.ipv6.conf.IFNAME.disable_ipv6` sysctl to `0` via the `endpoint.sysctls` driver option re-enables it so the interface accepts router advertisements. The section links to the `docker network connect` sysctl reference for the full mechanism. Also adds `ipv6`/`slaac` keywords to both pages for discoverability.

Motivated by [moby/moby#52815](https://github.com/moby/moby/issues/52815), where the per-endpoint sysctl mechanism was hard to discover from the driver docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
