### PR TITLE
Fix broken convert account link in organization FAQs

### DIFF
--- a/content/manuals/admin/organization/organization-faqs.md
+++ b/content/manuals/admin/organization/organization-faqs.md
@@ -43,7 +43,7 @@ convert a user account into an organization, it's not possible to
 revert it to a personal user account.
 
 For prerequisites and instructions, see
-[Convert an account into an organization](convert-account.md).
+[Convert an account into an organization](setup/convert-account.md).
 
 ### Do organization invitees take up seats?
 


### PR DESCRIPTION
## Description

Fixes a broken relative link in `content/manuals/admin/organization/organization-faqs.md`.

The FAQ linked to `convert-account.md` in the current directory, but the file is located in the `setup/` subdirectory. Updated the link to point to the correct path.

## Related issues or tickets

Fixes #25366

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
