### PR TITLE
hub: dct updates

### DIFF
--- a/content/manuals/docker-hub/image-library/trusted-content.md
+++ b/content/manuals/docker-hub/image-library/trusted-content.md
@@ -162,7 +162,7 @@ If you're experiencing failed pulls of Docker Official Images, check whether
 the `DOCKER_CONTENT_TRUST` environment variable is set to `1`. Docker Content
 Trust is being retired and the service is no longer reliable for pulls. To
 resolve pull failures, unset `DOCKER_CONTENT_TRUST`. For details, see
-[Docker Content Trust (DCT)](/manuals/retired/#docker-content-trust-dct).
+[Docker Content Trust (DCT)](/manuals/retired.md#docker-content-trust-dct).
 
 ## Docker Hardened Images
 

--- a/content/manuals/docker-hub/image-library/trusted-content.md
+++ b/content/manuals/docker-hub/image-library/trusted-content.md
@@ -159,11 +159,10 @@ variants.
 ### Troubleshooting failed pulls
 
 If you're experiencing failed pulls of Docker Official Images, check whether
-the `DOCKER_CONTENT_TRUST` environment variable is set to `1`. Starting in
-August 2025, Docker Content Trust signing certificates for Docker Official
-Images began expiring. To resolve pull failures, unset the `DOCKER_CONTENT_TRUST`
-environment variable. For more details, see the
-[DCT retirement blog post](https://www.docker.com/blog/retiring-docker-content-trust/).
+the `DOCKER_CONTENT_TRUST` environment variable is set to `1`. Docker Content
+Trust is being retired and the service is no longer reliable for pulls. To
+resolve pull failures, unset `DOCKER_CONTENT_TRUST`. For details, see
+[Docker Content Trust (DCT)](/manuals/retired/#docker-content-trust-dct).
 
 ## Docker Hardened Images
 

--- a/content/manuals/docker-hub/image-library/trusted-content.md
+++ b/content/manuals/docker-hub/image-library/trusted-content.md
@@ -161,7 +161,7 @@ variants.
 If you're experiencing failed pulls of Docker Official Images, check whether
 the `DOCKER_CONTENT_TRUST` environment variable is set to `1`. Docker Content
 Trust is being retired and the service is no longer reliable for pulls. To
-resolve pull failures, unset `DOCKER_CONTENT_TRUST`. For details, see
+resolve pull failures, unset `DOCKER_CONTENT_TRUST`. For more information, see
 [Docker Content Trust (DCT)](/manuals/retired.md#docker-content-trust-dct).
 
 ## Docker Hardened Images

--- a/content/manuals/engine/security/trust/_index.md
+++ b/content/manuals/engine/security/trust/_index.md
@@ -35,15 +35,12 @@ ensure that the images they pull are signed. Publishers could be individuals
 or organizations manually signing their content or automated software supply
 chains signing content as part of their release process.
 
-> [!NOTE]
+> [!WARNING]
 >
-> Docker is retiring DCT for Docker Official Images
-> (DOI). You should start planning to transition to a different image signing
-> and verification solution (like [Sigstore](https://www.sigstore.dev/) or
-> [Notation](https://github.com/notaryproject/notation#readme)). Timelines for the
-> complete deprecation of DCT are being finalized and will be published soon.
->
-> For more information, see [Retiring Docker Content Trust](https://www.docker.com/blog/retiring-docker-content-trust/).
+> Docker Content Trust (DCT) is being retired. The Notary v1 service at
+> `notary.docker.io` will shut down on December 8, 2026. For the retirement
+> timeline, migration guidance, and alternatives, see
+> [Docker Content Trust (DCT)](/manuals/retired/#docker-content-trust-dct).
 
 ### Image tags and DCT
 

--- a/content/manuals/engine/security/trust/_index.md
+++ b/content/manuals/engine/security/trust/_index.md
@@ -38,8 +38,7 @@ chains signing content as part of their release process.
 > [!WARNING]
 >
 > Docker Content Trust (DCT) is being retired. The Notary v1 service at
-> `notary.docker.io` will shut down on December 8, 2026. For the retirement
-> timeline, migration guidance, and alternatives, see
+> `notary.docker.io` will shut down on December 8, 2026. For more information, see
 > [Docker Content Trust (DCT)](/manuals/retired.md#docker-content-trust-dct).
 
 ### Image tags and DCT

--- a/content/manuals/engine/security/trust/_index.md
+++ b/content/manuals/engine/security/trust/_index.md
@@ -40,7 +40,7 @@ chains signing content as part of their release process.
 > Docker Content Trust (DCT) is being retired. The Notary v1 service at
 > `notary.docker.io` will shut down on December 8, 2026. For the retirement
 > timeline, migration guidance, and alternatives, see
-> [Docker Content Trust (DCT)](/manuals/retired/#docker-content-trust-dct).
+> [Docker Content Trust (DCT)](/manuals/retired.md#docker-content-trust-dct).
 
 ### Image tags and DCT
 

--- a/content/manuals/retired.md
+++ b/content/manuals/retired.md
@@ -180,6 +180,16 @@ Docker images from source code in an external repository and automatically pushi
 the built image to your Docker repositories. This feature has been deprecated and
 will be removed on April 1, 2027.
 
+### Docker Content Trust (DCT)
+
+Docker Content Trust (DCT) and the Notary v1 service at `notary.docker.io` are
+being fully retired. If you've never set `DOCKER_CONTENT_TRUST=1` or used
+`docker trust` commands, this change doesn't affect you. The service shuts down
+completely on December 8, 2026, following brownout windows in July and August.
+For the timeline, migration guidance, and modern alternatives such as
+Sigstore/Cosign and Notation, see the [Docker Content Trust retirement and
+migration blog post](https://www.docker.com/blog/docker-content-trust-retirement-and-migration-guidance/).
+
 
 ## Open source projects
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

DCT retirement updates:
- Updated callout based on latest announcement
- Updated troubleshooting section based on latest announcement
- Added to the deprecated-retired page

Previews:
- https://deploy-preview-25382--docsdocker.netlify.app/retired/#docker-content-trust-dct
- https://deploy-preview-25382--docsdocker.netlify.app/docker-hub/image-library/trusted-content/#troubleshooting-failed-pulls
- https://deploy-preview-25382--docsdocker.netlify.app/engine/security/trust/

## Related issues or tickets

ENGDOCS-3321

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
- [ ] Product review