### PR TITLE
docs: document Governance permissions for custom roles

### DIFF
--- a/content/manuals/ai/sandboxes/governance/org.md
+++ b/content/manuals/ai/sandboxes/governance/org.md
@@ -18,6 +18,13 @@ supplement or override the organization policy.
 Admins can manage organization policies through the Admin Console UI or
 programmatically using the [Governance API](/reference/api/ai-governance/).
 
+By default, only organization
+[owners](/manuals/enterprise/security/roles-and-permissions/core-roles.md) can
+view and manage AI Governance policies. To let someone other than an owner
+manage policies, create a
+[custom role](/manuals/enterprise/security/roles-and-permissions/custom-roles.md)
+with the **Governance** permissions and assign it to a user or team.
+
 > [!NOTE]
 > Sandbox organization governance is available on a separate paid
 > subscription.

--- a/content/manuals/enterprise/security/roles-and-permissions/custom-roles.md
+++ b/content/manuals/enterprise/security/roles-and-permissions/custom-roles.md
@@ -196,3 +196,10 @@ Custom roles are built by selecting specific permissions across different catego
 | :------------- | :----------------------------------------------- |
 | View billing   | View organization billing information            |
 | Manage billing | Complete access to managing organization billing |
+
+### Governance
+
+| Permission      | Description                                          |
+| :-------------- | :--------------------------------------------------- |
+| View policies   | View existing AI Governance policies and their rules |
+| Manage policies | Full access to AI Governance policy management       |


### PR DESCRIPTION
## Summary

Policy Governance permissions are now available for Custom Roles, but the docs didn't cover them. This adds the new **Governance** permission category (View policies, Manage policies) to the custom roles permissions reference, and documents on the organization policy page that only organization owners can manage AI Governance policies by default — with custom roles as the way to delegate to non-owners.

Generated by Claude Code