### PR TITLE
Clarify dual .env file precedence behavior

### DIFF
--- a/content/manuals/compose/how-tos/environment-variables/envvars-precedence.md
+++ b/content/manuals/compose/how-tos/environment-variables/envvars-precedence.md
@@ -21,6 +21,13 @@ The order of precedence (highest to lowest) is as follows:
 5. Set in a container image in the [ENV directive](/reference/dockerfile.md#env).
    Having any `ARG` or `ENV` setting in a `Dockerfile` evaluates only if there is no Docker Compose entry for `environment`, `env_file` or `run --env`.
 
+> [!NOTE]
+>
+> Compose can load both a local `.env` file and a project-directory `.env` file.
+> When both files are present, the local `.env` file takes precedence over the
+> project-directory `.env` file. For more information, see
+> [local `.env` file versus <project directory> `.env` file](variable-interpolation.md#local-env-file-versus-project-directory-env-file).
+
 ## Simple example
 
 In the following example, a different value for the same environment variable in an `.env` file and with the `environment` attribute in the Compose file:


### PR DESCRIPTION
Adds a note to the environment variable precedence documentation clarifying that Docker Compose can load both a local .env file and a project-directory .env file.

The note explains which file takes precedence and links to the existing detailed explanation in variable-interpolation.md, helping readers understand the dual .env file scenario without duplicating content.

Related issues or tickets

Fixes #25320

Reviews

Technical review

Editorial review

Product review