### PR TITLE
Clarify docker driver support for cache backends

### DIFF
--- a/content/manuals/build/cache/backends/gha.md
+++ b/content/manuals/build/cache/backends/gha.md
@@ -15,8 +15,9 @@ recommended cache to use inside your GitHub Actions workflows, as long as your
 use case falls within the
 [size and usage limits set by GitHub](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy).
 
-This cache storage backend is not supported with the default `docker` driver.
-To use this feature, create a new builder using a different driver. See
+This cache storage backend is supported with the default `docker` driver
+when the containerd image store is enabled. Otherwise, create a new builder
+using a different driver. See
 [Build drivers](/manuals/build/builders/drivers/_index.md) for more information.
 
 ## Synopsis

--- a/content/manuals/build/cache/backends/registry.md
+++ b/content/manuals/build/cache/backends/registry.md
@@ -18,8 +18,9 @@ everything that the inline cache can do, and more:
 - It works with other exporters for more flexibility, instead of only the
   `image` exporter.
 
-This cache storage backend is not supported with the default `docker` driver.
-To use this feature, create a new builder using a different driver. See
+This cache storage backend is supported with the default `docker` driver
+when the containerd image store is enabled. Otherwise, create a new builder
+using a different driver. See
 [Build drivers](/manuals/build/builders/drivers/_index.md) for more information.
 
 ## Synopsis


### PR DESCRIPTION
Updates GitHub Actions (`gha`) and Registry cache backend docs to match the cache backend overview page.

The overview page states that the default `docker` driver supports the `registry` and `gha` cache backends when the containerd image store is enabled. The backend-specific pages stated that those backends were not supported with the default driver.

This change clarifies the containerd image store requirement on the backend-specific pages and removes conflicting guidance.

## Related Issues/Tickets

Fixes #25396

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
