### PR TITLE
Fix broken Windows permission requirements link

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -3456,7 +3456,7 @@ This can be resolved by adding the user to the **docker-users** group. Before st
 - Fixed a bug where `docker run --gpus=all` hangs. Fixes [docker/for-win#13324](https://github.com/docker/for-win/issues/13324).
 - Fixed a bug where Registry Access Management policy updates were not downloaded.
 - Docker Desktop now allows Windows containers to work when BitLocker is enabled on `C:`.
-- Docker Desktop with the WSL backend no longer requires the `com.docker.service` privileged service to run permanently. For more information see [Permission requirements for Windows](https://docs.docker.com/desktop/windows/permission-requirements/).
+- Docker Desktop with the WSL backend no longer requires the `com.docker.service` privileged service to run permanently. For more information see [Permission requirements for Windows](/manuals/desktop/setup/install/windows-permission-requirements.md).
 
 ### For Mac
 


### PR DESCRIPTION
Fixes a broken link in Docker Desktop release notes.

The release notes referenced `/desktop/windows/permission-requirements/`, which returns a 404 page. This change updates the link to the current Windows permission requirements documentation page.

## Related issues or tickets

Fixes #25401

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
