### PR TITLE
Clarify volume mount wording in persist DB tutorial

### DIFF
--- a/content/get-started/workshop/05_persisting_data.md
+++ b/content/get-started/workshop/05_persisting_data.md
@@ -98,7 +98,7 @@ You can create the volume and start the container using the CLI or Docker Deskto
    as it is still running without using the persistent volume.
 
 3. Start the todo app container, but add the `--mount` option to specify a
-   volume mount. Give the volume a name, and mount it to `/etc/todos` in the
+   volume mount. Use the volume named `todo-db`, and mount it to `/etc/todos` in the
    container, which captures all files created at the path.
 
    ```console


### PR DESCRIPTION
## Description

Clarifies the wording in the "Persist the DB" workshop tutorial.

The volume is already created and named (`todo-db`) in step 1 using `docker volume create`. The previous wording in step 3 suggested that the volume was being named there, while the command actually uses the existing volume as the mount source.

This change updates the wording to make the workflow clearer and more technically accurate.

## Related issues or tickets

Fixes #25404

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
