### PR TITLE
docs: fix Windows backend process name

### DIFF
--- a/content/manuals/desktop/features/networking/networking-how-tos.md
+++ b/content/manuals/desktop/features/networking/networking-how-tos.md
@@ -69,7 +69,7 @@ to give the container direct access to the network stack of the host.
 See the [run command](/reference/cli/docker/container/run/) for more details on
 publish options used with `docker run`.
 
-All inbound connections pass through the Docker Desktop backend process (`com.docker.backend` (Mac), `com.docker.backend` (Windows), or `qemu` (Linux), which handles port forwarding into the VM.
+All inbound connections pass through the Docker Desktop backend process (`com.docker.backend` (Mac), `com.docker.backend.exe` (Windows), or `qemu` (Linux)), which handles port forwarding into the VM.
 For more details, see [How exposed ports work](/manuals/desktop/features/networking/_index.md#how-exposed-ports-work)
 
 ### Working with VPNs


### PR DESCRIPTION
## Description

Fixes #25406.

Updates the Docker Desktop networking how-to so the Windows backend process name matches the overview page: `com.docker.backend.exe`. The same sentence also now closes the parenthetical process list before the explanatory clause.

## Validation

- `git diff --check`

Not run: `docker buildx bake validate`, because Docker is not installed in this environment.