### PR TITLE
chore: add Dependabot for @docker/marlin-sdk-web-public (daily)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: daily
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: '@docker/marlin-sdk-web-public'
+    open-pull-requests-limit: 1
+
   - package-ecosystem: gomod
     directory: /
     cooldown:


### PR DESCRIPTION
Tracks daily updates to the public Marlin web SDK on npmjs.com. No registry auth required — the public package is on npmjs.