### PR TITLE
docs: note that sandboxes manage proxy env vars for kits

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -125,6 +125,17 @@ For credentials, see
 Don't put secret values directly in `environment.variables` — they'd
 be visible inside the sandbox VM.
 
+> [!IMPORTANT]
+> The sandbox manages proxy settings for you. It sets `HTTP_PROXY`,
+> `HTTPS_PROXY`, `NO_PROXY`, and their lowercase equivalents automatically so
+> that traffic flows through its built-in forward proxy, which enforces
+> network policy and injects credentials. Leave these variables to the
+> sandbox — setting them in a kit points traffic away from the forward proxy,
+> so it can no longer apply network policy or inject credentials, and those
+> requests typically fail to connect. To send sandbox traffic through an
+> upstream corporate proxy, configure it on the host. See
+> [Upstream proxy](../architecture.md#upstream-proxy).
+
 ### Control network access
 
 Network rules define which domains the sandbox can reach or block. Kit


### PR DESCRIPTION
## Description

Adds a note to the sandbox kit docs explaining that the sandbox manages proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and lowercase equivalents) for the agent, and that kits shouldn't set them.

Setting these in a kit routes traffic around the sandbox's built-in forward proxy, which silently disables network policy enforcement and credential injection. The note points to the [Upstream proxy](https://docs.docker.com/ai/sandboxes/architecture/#upstream-proxy) section for configuring an upstream corporate proxy on the host, keeping the env-var details in one place.

Surfaced as a documentation suggestion in [docker/sbx-releases#240](https://github.com/docker/sbx-releases/issues/240).

## Reviews

- [ ] Technical review
- [ ] Editorial review

🤖 Generated with [Claude Code](https://claude.com/claude-code)