### PR TITLE
chore: migrate cagent-action to docker-agent-action (v2.0.0)

### DIFF
--- a/.github/workflows/nightly-docs-scan.yml
+++ b/.github/workflows/nightly-docs-scan.yml
@@ -66,7 +66,7 @@ jobs:
           echo "GITHUB_APP_TOKEN=$PAT" >> "$GITHUB_ENV"
 
       - name: Run documentation scan
-        uses: docker/cagent-action@f208610469d69f20983cad64c577949a132caa33 # v1.5.3
+        uses: docker/docker-agent-action@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
         env:
           GH_TOKEN: ${{ env.GITHUB_APP_TOKEN || github.token }}
         with:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,10 +11,7 @@ permissions:
 
 jobs:
   review:
-    if: |
-      github.event_name == 'issue_comment' ||
-      github.event.workflow_run.conclusion == 'success'
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@f208610469d69f20983cad64c577949a132caa33 # v1.5.3
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary

`docker/cagent-action` has moved to a new repository: `docker/docker-agent-action`.
GitHub Actions `uses:` references must be updated explicitly, so this PR migrates all references and pins them to [v2.0.0](https://github.com/docker/docker-agent-action/releases/tag/v2.0.0).

- **New repository**: `docker/docker-agent-action`
- **Pinned commit**: `3c0fa9d282c3f84d08dfd70ab0a28b151d11db70`
- **Version**: `v2.0.0`

ℹ️ The old `docker/cagent-action` repo remains functional, so there is no deadline — merge whenever convenient. New features and fixes land in the new repo, which is where you'll want to be going forward.

> Auto-generated by the [migrate-consumers](https://github.com/docker/docker-agent-action/actions/runs/28023540082) workflow.