### PR TITLE
sbx: clarify clone behavior

### DIFF
--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -189,11 +189,11 @@ The practical guarantees:
   writable state.
 - Credentials, signing keys, and any settings in your repository's
   `.git/config` stay on the host. The agent's clone has its own
-  independent configuration. Credential files in your working directory that aren't tracked by Git,
-  including those excluded by `.gitignore`, such as `.envrc.private`, are
-  readable inside the sandbox.
-  Store secrets outside your working directory or use
-  [credential isolation](credentials.md) instead.
+  independent configuration.
+- Credential files in your working directory that aren't tracked by Git,
+  including those excluded by `.gitignore` such as `.envrc.private`, are
+  readable inside the sandbox. Store secrets outside your working
+  directory or use [credential isolation](credentials.md) instead.
 
 Use clone mode whenever you want a strong boundary between the agent's
 Git activity and your host repository — for example when running an

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -169,7 +169,7 @@ How the boundary is enforced:
   untracked files and files excluded by `.gitignore`. Nothing the agent
   does inside the VM can write back through that mount, but all files
   under the Git root are readable inside the sandbox. This includes
-  credential files not tracked by Git, such as `.envrc.private`. Store
+  credential files not tracked by Git, such as `.env`. Store
   secrets outside your working directory or use
   [credential isolation](credentials.md) instead.
 - The agent works on a private clone that lives inside the sandbox. The

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -165,8 +165,10 @@ flowchart LR
 How the boundary is enforced:
 
 - Your repository's Git root is mounted at `/run/sandbox/source` as
-  read-only. Nothing the agent does inside the VM can write back through
-  that mount.
+  read-only. The mount covers your entire working directory, including
+  untracked files and files excluded by `.gitignore`. Nothing the agent
+  does inside the VM can write back through that mount, but all files
+  under the Git root are readable inside the sandbox.
 - The agent works on a private clone that lives inside the sandbox. The
   clone has its own index, its own refs, and its own working tree. Writes
   to the clone never reach your host.
@@ -187,7 +189,11 @@ The practical guarantees:
   writable state.
 - Credentials, signing keys, and any settings in your repository's
   `.git/config` stay on the host. The agent's clone has its own
-  independent configuration.
+  independent configuration. Credential files in your working directory that aren't tracked by Git,
+  including those excluded by `.gitignore`, such as `.envrc.private`, are
+  readable inside the sandbox.
+  Store secrets outside your working directory or use
+  [credential isolation](credentials.md) instead.
 
 Use clone mode whenever you want a strong boundary between the agent's
 Git activity and your host repository — for example when running an

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -168,7 +168,10 @@ How the boundary is enforced:
   read-only. The mount covers your entire working directory, including
   untracked files and files excluded by `.gitignore`. Nothing the agent
   does inside the VM can write back through that mount, but all files
-  under the Git root are readable inside the sandbox.
+  under the Git root are readable inside the sandbox. This includes
+  credential files not tracked by Git, such as `.envrc.private`. Store
+  secrets outside your working directory or use
+  [credential isolation](credentials.md) instead.
 - The agent works on a private clone that lives inside the sandbox. The
   clone has its own index, its own refs, and its own working tree. Writes
   to the clone never reach your host.
@@ -190,10 +193,6 @@ The practical guarantees:
 - Credentials, signing keys, and any settings in your repository's
   `.git/config` stay on the host. The agent's clone has its own
   independent configuration.
-- Credential files in your working directory that aren't tracked by Git,
-  including those excluded by `.gitignore` such as `.envrc.private`, are
-  readable inside the sandbox. Store secrets outside your working
-  directory or use [credential isolation](credentials.md) instead.
 
 Use clone mode whenever you want a strong boundary between the agent's
 Git activity and your host repository — for example when running an

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -99,9 +99,10 @@ same time, they may step on each other's changes — use
 
 ### Clone mode
 
-In clone mode, the sandbox becomes a Git remote on your host. The agent
-commits inside the sandbox; you pull its work back out by fetching from
-that remote.
+In clone mode, the sandbox becomes a Git remote on your host. Your entire
+working directory, including untracked files and files excluded by `.gitignore`, is mounted
+read-only inside the sandbox. The agent commits inside the sandbox; you pull its work back
+out by fetching from that remote.
 
 > [!NOTE]
 > Clone mode was introduced in `sbx` v0.31.0 and replaces the `--branch`


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Clarified that with clone mode, agent can still read untracked & .gitignored files.

## Related issues or tickets

docker/sbx-releases#260
https://docker.slack.com/archives/C0B1XV3FQMU/p1782148268612729

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
