### PR TITLE
Make docker-users workaround script idempotent

### DIFF
--- a/content/manuals/enterprise/enterprise-deployment/faq.md
+++ b/content/manuals/enterprise/enterprise-deployment/faq.md
@@ -73,8 +73,10 @@ Here's an example script that creates the `docker-users` group and adds the curr
 $Group = "docker-users"
 $CurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
 
-# Create the group
-New-LocalGroup -Name $Group
+# Create the group only if it doesn't already exist
+if (-not (Get-LocalGroup -Name $Group -ErrorAction SilentlyContinue)) {
+    New-LocalGroup -Name $Group
+}
 
 # Add the user to the group
 Add-LocalGroupMember -Group $Group -Member $CurrentUser

--- a/content/manuals/enterprise/enterprise-deployment/faq.md
+++ b/content/manuals/enterprise/enterprise-deployment/faq.md
@@ -78,8 +78,10 @@ if (-not (Get-LocalGroup -Name $Group -ErrorAction SilentlyContinue)) {
     New-LocalGroup -Name $Group
 }
 
-# Add the user to the group
-Add-LocalGroupMember -Group $Group -Member $CurrentUser
+# Add the user to the group only if they aren't already a member
+if (-not (Get-LocalGroupMember -Group $Group -Member $CurrentUser -ErrorAction SilentlyContinue)) {
+    Add-LocalGroupMember -Group $Group -Member $CurrentUser
+}
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Description

Updates the workaround script in the Enterprise Deployment FAQ to avoid recreating the `docker-users` group when it already exists.

The current script unconditionally calls `New-LocalGroup`, which can fail if the group is already present. This change makes the script idempotent by checking for the group's existence before creating it.

## Related issues or tickets

Fixes #25420

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
