### PR TITLE
compose: add another field to trust model table

### DIFF
--- a/content/manuals/compose/trust-model.md
+++ b/content/manuals/compose/trust-model.md
@@ -86,6 +86,7 @@ implications when set by an untrusted author:
 | `devices` | Exposes host devices to the container |
 | `image` | Pulls and runs an arbitrary container image |
 | `env_file`, `label_file`, `secrets`/`configs` (`file:`), `include`, `extends` | Read files from the host, directly or through symlinks resolved from a remote checkout, and can surface their contents during configuration loading |
+| `provider` | Runs the binary named by `provider.type` on the host, outside any container, when you run `up`, `down`, or `stop` |
 
 When in doubt, look up the effect of any unfamiliar field before running the configuration.
 


### PR DESCRIPTION
## Description

Follow-up to #25414 - While the list is non-exhaustive, provide another field in the table