### PR TITLE
docs(sandboxes): clarify Claude Code OAuth login in sandbox

### DIFF
--- a/content/manuals/ai/sandboxes/agents/claude-code.md
+++ b/content/manuals/ai/sandboxes/agents/claude-code.md
@@ -42,9 +42,8 @@ Alternatively, export the `ANTHROPIC_API_KEY` environment variable in your
 shell before running the sandbox. See
 [Credentials](../security/credentials.md) for details on both methods.
 
-**Claude subscription**: If no API key is set, Claude Code prompts you to
-authenticate interactively using OAuth. The proxy handles the OAuth flow, so
-credentials aren't stored inside the sandbox.
+**Claude subscription**: If no API key is set, use the `/login` command inside 
+Claude Code to authenticate via OAuth.
 
 ## Configuration
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Updated the Claude Code authentication instructions for Docker Sandbox to reflect actual behavior: when no API key is set, users should run /login inside Claude Code to authenticate via OAuth.

Verified locally by running Claude Code in a Sandbox and confirming the /login command prompts for authentication (see #25271).

`docker buildx bake validate` ran with no warnings

## Related issues or tickets

Fixes #25271

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review