### PR TITLE
Subscription overview updates

### DIFF
--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -40,19 +40,19 @@ aliases:
   - /docker-hub/billing/faq/
 ---
 
-Docker offers several plans ranging from free to paid tiers, including add-on usage top-ups. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products.
+Docker offers several plans ranging from free to paid plans, including add-on usage top-ups. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products.
 
 ## Docker plans
 
 You can subscribe to plans for individual or organization accounts, or plans for specific products. The following table summarizes the available plans.
 
-| Plans                                          | Billing model                                          | Types                                     |
-| ---------------------------------------------- | ------------------------------------------------------ | ----------------------------------------- |
-| [Docker Individual](/accounts/)                | Flat-rate tiers for personal accounts                  | Docker Personal, Docker Pro               |
-| [Docker Organization](/admin/)                 | Flat-rate tiers for organization accounts              | Docker Team, Docker Business              |
-| [Docker Hardened Images (DHI)](/dhi/)          | Tiered access to hardened container image repositories | DHI Community, DHI Select, DHI Enterprise |
-| [Gordon](/ai/gordon/)                          | Prepaid usage tiers added to a base plan               | Gordon Plus, Gordon Max, Gordon Ultra     |
-| [AI Governance](/ai/sandboxes/governance/org/) | Purchase set amount of licenses                        | AI Governance                             |
+| Plans                                          | Billing model                                             | Types                                     |
+| ---------------------------------------------- | --------------------------------------------------------- | ----------------------------------------- |
+| [Docker Individual](/accounts/)                | Flat-rate plans for personal accounts                     | Docker Personal, Docker Pro               |
+| [Docker Organization](/admin/)                 | Flat-rate plans for organization accounts                 | Docker Team, Docker Business              |
+| [Docker Hardened Images (DHI)](/dhi/)          | Graduated security features for hardened container images | DHI Community, DHI Select, DHI Enterprise |
+| [Gordon](/ai/gordon/)                          | Prepaid usage for the Gordon AI agent                     | Gordon Plus, Gordon Max, Gordon Ultra     |
+| [AI Governance](/ai/sandboxes/governance/org/) | Purchase set amount of licenses                           | AI Governance                             |
 
 Docker plans for accounts (like individual or organizations) provide a foundation for most users. Some product plans may require a Docker plan for accounts while some products may not need an upgraded Docker plan at all.
 
@@ -73,7 +73,7 @@ Depending on the plan, you can top up your account through self-service or by co
 
 ## Support add-ons
 
-Standard support is included with paid plans and scales with plan tier. Docker also offers Premium Support and a technical advisory manager (TAM) service as an add-on for Docker Business and DHI customers. The add-on includes 24×7 response, priority SLAs, and expert guidance.
+Standard support is included with paid plans and scales with your plan. Docker also offers Premium Support and a technical advisory manager (TAM) service as an add-on for Docker Business and DHI customers. The add-on includes 24×7 response, priority SLAs, and expert guidance.
 
 To learn more, see [Docker pricing](https://www.docker.com/pricing/).
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -56,7 +56,7 @@ You can subscribe to plans for individual or organization accounts, or plans for
 
 Docker plans that upgrade your account (Docker Pro or Docker Team and Business) can provide a foundation for most use cases. Some product plans may require an upgraded Docker account while other product plans let you subscribe without an upgraded account. To learn more, see [Scale your subscription](/manuals/subscription/scale.md). 
 
-To subscribe to a plan, you can self-serve through **Billing** in [Docker Home](https://app.docker.com), or contact sales. See [Scale your subscription](/subscription/scale/) to find out which applies to the plan you want.
+To subscribe to a plan, you can self-serve through **Billing** in [Docker Home](https://app.docker.com), or contact sales.
 
 ## Top up your plan
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -15,16 +15,16 @@ grid_subscriptions:
     description: Visit the pricing page to see what's included in different Docker subscriptions.
     link: "https://www.docker.com/pricing?ref=Docs&refAction=DocsSubscription"
     icon: magnifying-glass
-  - title: Set up your subscription
+  - title: Set up your plan
     description: Get started setting up a personal or organization subscription.
     link: /subscription/setup/
     icon: shopping-cart
   - title: Scale your subscription
-    description: Scale your subscription to fit your needs.
+    description: Add plans to your Docker account that fit your needs.
     link: /subscription/scale/
     icon: chart-bar
-  - title: Change your subscription
-    description: Learn how to upgrade or downgrade your subscription.
+  - title: Upgrade your Docker individual or organization plan
+    description: Learn how to upgrade or downgrade your Docker plan.
     link: /subscription/change/
     icon: arrow-up-circle
   - title: Docker Desktop license agreement
@@ -43,33 +43,36 @@ aliases:
   - /docker-hub/billing/faq/
 ---
 
-After creating a Docker account, you can subscribe to a number of Docker plans. Docker plans may include different tier levels, ranging from basic tiers to a selection of paid tiers. Each tier within a plan upgrades your usage entitlements and feature sets.
+Docker offers several Docker plans that range from base, free plans to a variety of paid tiers. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products. This page breaks down the different Docker plans you can subscribe to and how to top up certain plans.
 
-This page breaks down the kinds of Docker plans you can subscribe to, with explanations about usage within each tier.
+## Docker plans
 
-## Docker plan types
+You can subscribe to plans that upgrade your individual and organization accounts, or subscribe to plans for specific products. The table below summarizes the current available plans.
 
-There are two types of Docker plans. Docker Core upgrades your basic personal or organization accounts to higher tiers with additional feature sets. Product-based plans are subscription types tied to discrete products in Docker's product catalog.
+| Plans                                      | Billing model                                          | Types                                     |
+| ------------------------------------------ | ------------------------------------------------------ | ----------------------------------------- |
+| [Docker Individual](/accounts/)            | Flat-rate tiers for personal accounts                  | Docker Personal, Docker Pro               |
+| [Docker Organization](/admin/)             | Flat-rate tiers for organization accounts              | Docker Team, Docker Business              |
+| [Docker Hardened Images (DHI)](/dhi/)      | Tiered access to hardened container image repositories | DHI Community, DHI Select, DHI Enterprise |
+| [Gordon](/ai/gordon/)                      | Prepaid usage tiers added to a base plan               | Gordon Plus, Gordon Max, Gordon Ultra     |
+| [AI Governance](/ai/sandboxes/governance/) | Purchase set amount of licenses                        | AI Governance                             |
 
-| Subscription type | Billing model                                    | Examples                                                                        |
-| ----------------- | ------------------------------------------------ | ------------------------------------------------------------------------------- |
-| Docker Core       | Flat-rate tiers tied to account type             | Docker Pro (Personal)<br>Docker Team and Docker Business (Organization)         |
-| Product-based     | Prepaid entitlements added on top of a base plan | Gordon (Extends monthly usage limits)<br>DHI (Security and compliance features) |
+Docker plans for accounts (like individual or organizations) provide a foundation for most users. Some product plans may require a Docker plan for accounts while some products may not need an upgraded Docker plan at all.
 
-Subscription types can be combined. A Docker Core plan provides the foundation for
-most accounts, with prepaid or per-unit subscriptions added on top as needed. Depending on the product, you may not need a Docker Core plan at all.
+To subscribe to a plan, you can self-serve through **Billing** in [Docker Home](https://app.docker.com), or contact sales. See [Scale your subscription](/subscription/scale/) to find out which applies to the plan you want.
 
 ## Top up your plan
 
-Most subscriptions include a fixed amount of usage. You can purchase additional
-units to extend usage without changing your plan tier.
+Plans come with usage entitlements that can be granularly extended without upgrading to a different plan.
 
-| Unit         | Description                                                                             | Examples           |
-| ------------ | --------------------------------------------------------------------------------------- | ------------------ |
-| Seats        | Each seat extends the subscription entitlements to one more member.                     | Docker Core        |
-| Licenses     | Access to specific products or product tiers, purchased separately from your core plan. | AI Governance      |
-| Minutes      | Cloud build capacity, sold in blocks and consumed within the billing period.            | Docker Build Cloud |
-| Repositories | Additional container repositories covered by security scanning and analysis features.   | DHI                |
+| Unit         | Description                                                                           | Examples                      |
+| ------------ | ------------------------------------------------------------------------------------- | ----------------------------- |
+| Seats        | Each seat extends entitlements to one more member.                                    | Docker Team, Docker Business  |
+| Licenses     | Access to specific products or features.                                              | AI Governance, Docker Offload |
+| Minutes      | Cloud build capacity, sold in blocks and consumed within the billing period.          | Docker Build Cloud            |
+| Repositories | Additional container repositories covered by security scanning and analysis features. | DHI                           |
+
+Depending on the plan, you can self-serve topping up your account or you may need to contact sales.
 
 ## Support add-ons
 
@@ -77,6 +80,8 @@ Standard support is included with paid plans and scales with plan tier.
 
 - Docker also offers premium support as an optional add-on for Docker Business and DHI customers.
 - Premium support provides 24/7 response, priority SLAs, and a dedicated technical advisory manager.
+
+To learn more about support add-ons, see [Get support for Docker products](/support/).
 
 ## What's next
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Subscription overview
 linkTitle: Subscription
-description: Learn how Docker subscriptions work, including the types of plans available and how they apply to personal and organization accounts.
+description: Learn about Docker plans, like how to subscribe to product-based plans and how they apply to personal and organization accounts.
 keywords:
   docker subscription, pricing, billing, subscription types, subscription
   plans, docker hardened images, gordon, cloud sandboxes, subscription
@@ -23,7 +23,7 @@ grid_subscriptions:
     description: Add plans to your Docker account that fit your needs.
     link: /subscription/scale/
     icon: chart-bar
-  - title: Upgrade your Docker individual or organization plan
+  - title: Upgrade Docker plans for accounts
     description: Learn how to upgrade or downgrade your Docker plan.
     link: /subscription/change/
     icon: arrow-up-circle

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -36,9 +36,6 @@ grid_subscriptions:
     link: /subscription/faq/
     icon: question-mark-circle
 aliases:
-  - /subscription/scale/
-  - /subscription/change/
-  - /subscription/details/
   - /docker-hub/billing/
   - /docker-hub/billing/faq/
 ---
@@ -76,12 +73,9 @@ Depending on the plan, you can self-serve topping up your account or you may nee
 
 ## Support add-ons
 
-Standard support is included with paid plans and scales with plan tier.
+Standard support is included with paid plans and scales with plan tier. Docker also offers Premium Support and TAM (technical advisory manager) service as an add-on for Docker Business and DHI customers, which provides 24×7 response, priority SLAs, and expert guidance.
 
-- Docker also offers premium support as an optional add-on for Docker Business and DHI customers.
-- Premium support provides 24/7 response, priority SLAs, and a dedicated technical advisory manager.
-
-To learn more about support add-ons, see [Get support for Docker products](/support/).
+To learn more, see [Docker pricing](https://www.docker.com/pricing/).
 
 ## What's next
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -40,7 +40,7 @@ aliases:
   - /docker-hub/billing/faq/
 ---
 
-Docker offers several plans ranging from free to paid plans, including add-on usage top-ups. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products.
+You can subscribe to several Docker plans that range from free to paid plans. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products. Docker plans also let you top up some plans, extending usage to a particular capability without an upgrade. 
 
 ## Docker plans
 
@@ -54,13 +54,13 @@ You can subscribe to plans for individual or organization accounts, or plans for
 | [Gordon](/ai/gordon/)                          | Prepaid usage for the Gordon AI agent                     | Gordon Plus, Gordon Max, Gordon Ultra     |
 | [AI Governance](/ai/sandboxes/governance/org/) | Purchase set amount of licenses                           | AI Governance                             |
 
-Docker plans for accounts (like individual or organizations) provide a foundation for most users. Some product plans may require a Docker plan for accounts while some products may not need an upgraded Docker plan at all.
+Docker plans that upgrade your account (Docker Pro or Docker Team and Business) can provide a foundation for most use cases. Some product plans may require an upgraded Docker account while other product plans let you subscribe without an upgraded account. To learn more, see [Scale your subscription](/manuals/subscription/scale.md). 
 
 To subscribe to a plan, you can self-serve through **Billing** in [Docker Home](https://app.docker.com), or contact sales. See [Scale your subscription](/subscription/scale/) to find out which applies to the plan you want.
 
 ## Top up your plan
 
-Plans come with usage entitlements that can be granularly extended without upgrading to a different plan.
+Plans come with usage entitlements that can be extended without upgrading to a different plan.
 
 | Unit         | Description                                                                           | Examples                      |
 | ------------ | ------------------------------------------------------------------------------------- | ----------------------------- |
@@ -73,7 +73,7 @@ Depending on the plan, you can top up your account through self-service or by co
 
 ## Support add-ons
 
-Standard support is included with paid plans and scales with your plan. Docker also offers Premium Support and a technical advisory manager (TAM) service as an add-on for Docker Business and DHI customers. The add-on includes 24×7 response, priority SLAs, and expert guidance.
+Standard support is included with paid plans and scales with upgrades. Docker also offers Premium Support and a technical advisory manager (TAM) service as an add-on for Docker Business and DHI customers. The add-on includes 24×7 response, priority SLAs, and expert guidance.
 
 To learn more, see [Docker pricing](https://www.docker.com/pricing/).
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -40,7 +40,7 @@ aliases:
   - /docker-hub/billing/faq/
 ---
 
-You can subscribe to several Docker plans that range from free to paid plans. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products. Docker plans also let you top up some plans, extending usage to a particular capability without an upgrade. 
+You can subscribe to several Docker plans that range from free to paid plans. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products. You can also top up some plans, extending usage to more users without needing a full upgrade.
 
 ## Docker plans
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -1,8 +1,12 @@
 ---
-title: Subscription
-description: Learn about Docker subscription features and how to manage your subscription
-keywords: docker subscription, pricing, billing, pro, team, business, subscription management
-weight: 50
+title: Subscription overview
+linkTitle: Subscription
+description: Learn how Docker subscriptions work, including the types of plans available and how they apply to personal and organization accounts.
+keywords:
+  docker subscription, pricing, billing, subscription types, subscription
+  plans, docker hardened images, gordon, cloud sandboxes, subscription
+  management
+weight: 30
 params:
   sidebar:
     group: Platform
@@ -32,12 +36,48 @@ grid_subscriptions:
     link: /subscription/faq/
     icon: question-mark-circle
 aliases:
+  - /subscription/scale/
+  - /subscription/change/
+  - /subscription/details/
   - /docker-hub/billing/
   - /docker-hub/billing/faq/
 ---
 
-Docker subscriptions provide licensing for commercial use of Docker products including Docker Desktop, Docker Hub, Docker Build Cloud, Docker Scout, and Testcontainers Cloud.
+After creating a Docker account, you can subscribe to a number of Docker plans. Docker plans may include different tier levels, ranging from basic tiers to a selection of paid tiers. Each tier within a plan upgrades your usage entitlements and feature sets.
 
-Use these resources to choose the right subscription for your needs or manage your existing subscription.
+This page breaks down the kinds of Docker plans you can subscribe to, with explanations about usage within each tier.
+
+## Docker plan types
+
+There are two types of Docker plans. Docker Core upgrades your basic personal or organization accounts to higher tiers with additional feature sets. Product-based plans are subscription types tied to discrete products in Docker's product catalog.
+
+| Subscription type | Billing model                                    | Examples                                                                        |
+| ----------------- | ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| Docker Core       | Flat-rate tiers tied to account type             | Docker Pro (Personal)<br>Docker Team and Docker Business (Organization)         |
+| Product-based     | Prepaid entitlements added on top of a base plan | Gordon (Extends monthly usage limits)<br>DHI (Security and compliance features) |
+
+Subscription types can be combined. A Docker Core plan provides the foundation for
+most accounts, with prepaid or per-unit subscriptions added on top as needed. Depending on the product, you may not need a Docker Core plan at all.
+
+## Top up your plan
+
+Most subscriptions include a fixed amount of usage. You can purchase additional
+units to extend usage without changing your plan tier.
+
+| Unit         | Description                                                                             | Examples           |
+| ------------ | --------------------------------------------------------------------------------------- | ------------------ |
+| Seats        | Each seat extends the subscription entitlements to one more member.                     | Docker Core        |
+| Licenses     | Access to specific products or product tiers, purchased separately from your core plan. | AI Governance      |
+| Minutes      | Cloud build capacity, sold in blocks and consumed within the billing period.            | Docker Build Cloud |
+| Repositories | Additional container repositories covered by security scanning and analysis features.   | DHI                |
+
+## Support add-ons
+
+Standard support is included with paid plans and scales with plan tier.
+
+- Docker also offers premium support as an optional add-on for Docker Business and DHI customers.
+- Premium support provides 24/7 response, priority SLAs, and a dedicated technical advisory manager.
+
+## What's next
 
 {{< grid items="grid_subscriptions" >}}

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -40,7 +40,7 @@ aliases:
   - /docker-hub/billing/faq/
 ---
 
-Docker offers several Docker plans that range from base, free plans to a variety of paid tiers. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products. This page breaks down the different Docker plans you can subscribe to and how to top up certain plans.
+Docker offers several plans ranging from free to paid tiers, including add-on usage top-ups. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products.
 
 ## Docker plans
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -44,15 +44,15 @@ Docker offers several Docker plans that range from base, free plans to a variety
 
 ## Docker plans
 
-You can subscribe to plans that upgrade your individual and organization accounts, or subscribe to plans for specific products. The table below summarizes the current available plans.
+You can subscribe to plans that upgrade your individual and organization accounts, or subscribe to plans for specific products. The table below summarizes the available plans.
 
-| Plans                                      | Billing model                                          | Types                                     |
-| ------------------------------------------ | ------------------------------------------------------ | ----------------------------------------- |
-| [Docker Individual](/accounts/)            | Flat-rate tiers for personal accounts                  | Docker Personal, Docker Pro               |
-| [Docker Organization](/admin/)             | Flat-rate tiers for organization accounts              | Docker Team, Docker Business              |
-| [Docker Hardened Images (DHI)](/dhi/)      | Tiered access to hardened container image repositories | DHI Community, DHI Select, DHI Enterprise |
-| [Gordon](/ai/gordon/)                      | Prepaid usage tiers added to a base plan               | Gordon Plus, Gordon Max, Gordon Ultra     |
-| [AI Governance](/ai/sandboxes/governance/) | Purchase set amount of licenses                        | AI Governance                             |
+| Plans                                          | Billing model                                          | Types                                     |
+| ---------------------------------------------- | ------------------------------------------------------ | ----------------------------------------- |
+| [Docker Individual](/accounts/)                | Flat-rate tiers for personal accounts                  | Docker Personal, Docker Pro               |
+| [Docker Organization](/admin/)                 | Flat-rate tiers for organization accounts              | Docker Team, Docker Business              |
+| [Docker Hardened Images (DHI)](/dhi/)          | Tiered access to hardened container image repositories | DHI Community, DHI Select, DHI Enterprise |
+| [Gordon](/ai/gordon/)                          | Prepaid usage tiers added to a base plan               | Gordon Plus, Gordon Max, Gordon Ultra     |
+| [AI Governance](/ai/sandboxes/governance/org/) | Purchase set amount of licenses                        | AI Governance                             |
 
 Docker plans for accounts (like individual or organizations) provide a foundation for most users. Some product plans may require a Docker plan for accounts while some products may not need an upgraded Docker plan at all.
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -44,7 +44,7 @@ Docker offers several Docker plans that range from base, free plans to a variety
 
 ## Docker plans
 
-You can subscribe to plans that upgrade your individual and organization accounts, or subscribe to plans for specific products. The table below summarizes the available plans.
+You can subscribe to plans for individual or organization accounts, or plans for specific products. The following table summarizes the available plans.
 
 | Plans                                          | Billing model                                          | Types                                     |
 | ---------------------------------------------- | ------------------------------------------------------ | ----------------------------------------- |
@@ -69,11 +69,11 @@ Plans come with usage entitlements that can be granularly extended without upgra
 | Minutes      | Cloud build capacity, sold in blocks and consumed within the billing period.          | Docker Build Cloud            |
 | Repositories | Additional container repositories covered by security scanning and analysis features. | DHI                           |
 
-Depending on the plan, you can self-serve topping up your account or you may need to contact sales.
+Depending on the plan, you can top up your account through self-service or by contacting sales.
 
 ## Support add-ons
 
-Standard support is included with paid plans and scales with plan tier. Docker also offers Premium Support and TAM (technical advisory manager) service as an add-on for Docker Business and DHI customers, which provides 24×7 response, priority SLAs, and expert guidance.
+Standard support is included with paid plans and scales with plan tier. Docker also offers Premium Support and a technical advisory manager (TAM) service as an add-on for Docker Business and DHI customers. The add-on includes 24×7 response, priority SLAs, and expert guidance.
 
 To learn more, see [Docker pricing](https://www.docker.com/pricing/).
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -71,12 +71,6 @@ Plans come with usage entitlements that can be extended without upgrading to a d
 
 Depending on the plan, you can top up your account through self-service or by contacting sales.
 
-## Support add-ons
-
-Standard support is included with paid plans and scales with upgrades. Docker also offers Premium Support and a technical advisory manager (TAM) service as an add-on for Docker Business and DHI customers. The add-on includes 24×7 response, priority SLAs, and expert guidance.
-
-To learn more, see [Docker pricing](https://www.docker.com/pricing/).
-
 ## What's next
 
 {{< grid items="grid_subscriptions" >}}


### PR DESCRIPTION
This PR captures changes made to the subscription/_index page.   It doesn't include future work for breaking /scale into individual product subscription types. 