### PR TITLE
docs(desktop): document macos docker desktop backend helper

### DIFF
--- a/content/manuals/desktop/setup/install/mac-permission-requirements.md
+++ b/content/manuals/desktop/setup/install/mac-permission-requirements.md
@@ -98,8 +98,8 @@ Desktop backend process (`com.docker.backend`) uses an internal helper socket
 helper processes as part of running Docker Desktop.
 
 Unlike the privileged helper, this socket does not run as `root` and grants no
-elevated privileges: it is owned by, and accessible only to, the same macOS user
-running Docker Desktop, and it is contained in Docker Desktop's application container.
+elevated privileges. It is owned by, and accessible only to, the same macOS user
+running Docker Desktop, and is contained in Docker Desktop's application container.
 
 ## Containers running as root within the Linux VM
 

--- a/content/manuals/desktop/setup/install/mac-permission-requirements.md
+++ b/content/manuals/desktop/setup/install/mac-permission-requirements.md
@@ -90,6 +90,17 @@ $ rm /Library/LaunchDaemons/com.docker.vmnetd.plist
 $ rm /Library/PrivilegedHelperTools/com.docker.vmnetd
 ```
 
+## Backend helper socket
+
+Aside from the optional [privileged helper](#privileged-helper), the Docker
+Desktop backend process (`com.docker.backend`) uses an internal helper socket
+(`~/Library/Containers/com.docker.docker/Data/forkexecd.sock`) to fork and execute
+helper processes as part of running Docker Desktop.
+
+Unlike the privileged helper, this socket does not run as `root` and grants no
+elevated privileges: it is owned by, and accessible only to, the same macOS user
+running Docker Desktop, and it is contained in Docker Desktop's application container.
+
 ## Containers running as root within the Linux VM
 
 With Docker Desktop, the Docker daemon and containers run in a lightweight Linux


### PR DESCRIPTION
## Description

Adds a section related to the forkexecd backend helper socket

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review