### PR TITLE
docs: guard docker-users group creation

### DIFF
--- a/content/manuals/enterprise/enterprise-deployment/faq.md
+++ b/content/manuals/enterprise/enterprise-deployment/faq.md
@@ -63,18 +63,20 @@ psexec -i -s msiexec /i "DockerDesktop.msi"
 ```
 The installation should complete successfully, but the `docker-users` group won't be populated.
 
-As a workaround, you can create a script that runs in the context of the user account. 
+As a workaround, you can create a script that runs in the context of the user account.
 
-The script would be responsible for creating the `docker-users` group and populating it with the correct user.
+The script would be responsible for ensuring the `docker-users` group exists and populating it with the correct user.
 
-Here's an example script that creates the `docker-users` group and adds the current user to it (requirements may vary depending on environment):
+Here's an example script that creates the `docker-users` group if needed and adds the current user to it (requirements may vary depending on environment):
 
 ```powershell
 $Group = "docker-users"
 $CurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
 
-# Create the group
-New-LocalGroup -Name $Group
+# Create the group if it doesn't exist
+if (-not (Get-LocalGroup -Name $Group -ErrorAction SilentlyContinue)) {
+    New-LocalGroup -Name $Group
+}
 
 # Add the user to the group
 Add-LocalGroupMember -Group $Group -Member $CurrentUser


### PR DESCRIPTION
## Description

Closes #25420.

Updates the enterprise deployment FAQ PowerShell example so it only creates the `docker-users` group when the group does not already exist, then adds the current user to it.

This keeps the example usable when the MSI has already created the local group but did not populate it with the user account.

## Validation

- `git diff --check`

`docker buildx bake validate` was not run locally because Docker is not installed in this shell.