### PR TITLE
Update footer link to Docker Terms of Use

### DIFF
--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -65,10 +65,10 @@
     </button>
     <span class="mx-1 text-gray-400">|</span>
     <a
-      title="Docker Terms of Service"
-      href="https://www.docker.com/legal/docker-terms-service"
+      title="Docker Terms of Use"
+      href="https://www.docker.com/legal/docker-terms-use/"
       class="whitespace-normal md:truncate"
-      >Terms of Service</a
+      >Terms of Use</a
     >
     <span class="mx-1 text-gray-400">|</span>
     <a


### PR DESCRIPTION
## Summary

Renames the site footer "Terms of Service" link to "Terms of Use" and updates the URL to https://www.docker.com/legal/docker-terms-use/.

Generated by Claude Code