### PR TITLE
docs(sandboxes): document kit install-source allowlist (v0.34)

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -443,6 +443,43 @@ For Docker Hub, include the full `docker.io` prefix. See
 > Without stored credentials, pulls from non-Docker Hub registries are
 > anonymous and private kits fail to pull.
 
+### Restrict kit sources
+
+`sbx` restricts which sources a kit can install from. A kit's install
+commands run with root privileges inside the sandbox, so limiting where kits
+come from reduces supply-chain risk. By default, only kits hosted on Docker
+Hub (`docker.io/`) are allowed. Loading a kit from any other source — a Git
+repository or a different registry — fails:
+
+```console
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale"
+ERROR: resolve kits: kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale" cannot be installed — its source is not in your allowlist.
+```
+
+To allow another publisher, add its host or host/path prefix to the
+`kit.allowedSources` setting. The setting replaces the whole list, so include
+the entries you want to keep:
+
+```console
+$ sbx settings set kit.allowedSources '["docker.io/","github.com/docker/"]'
+```
+
+Entries match as prefixes on a path-segment boundary, so `github.com/docker/`
+allows `github.com/docker/sbx-kits-contrib` but not `github.com/docker-evil/kit`.
+To remove the restriction and allow any remote source, set the list to
+`["*"]`. This isn't recommended.
+
+Installing from a local directory or ZIP file is governed separately by the
+`kit.allowLocalKits` setting, which defaults to `true`. Set it to `false` to
+require a remote source:
+
+```console
+$ sbx settings set kit.allowLocalKits false
+```
+
+For non-interactive use, both settings have environment-variable equivalents:
+`DOCKER_SANDBOXES_KIT_ALLOWED_SOURCES` and `DOCKER_SANDBOXES_KIT_ALLOW_LOCAL`.
+
 ## Packaging and distribution
 
 The `sbx kit` subcommands validate, inspect, and publish kits:

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -448,8 +448,7 @@ For Docker Hub, include the full `docker.io` prefix. See
 `sbx` restricts which sources a kit can install from. A kit's install
 commands run with root privileges inside the sandbox, so limiting where kits
 come from reduces supply-chain risk. By default, only kits hosted on Docker
-Hub (`docker.io/`) are allowed. Loading a kit from any other source — a Git
-repository or a different registry — fails:
+Hub (`docker.io/`) are allowed. Loading a kit from any other source fails:
 
 ```console
 $ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale"

--- a/content/manuals/ai/sandboxes/security/_index.md
+++ b/content/manuals/ai/sandboxes/security/_index.md
@@ -86,6 +86,11 @@ The default allowed domains include broad wildcards. Some defaults like
 see the full list of active rules, and remove entries you don't need. See
 [Default security posture](defaults/).
 
+Kits run install commands with root privileges inside the sandbox. To limit
+supply-chain risk, `sbx` restricts kit installs to an allowlist of sources
+that defaults to Docker Hub only. See
+[Restrict kit sources](../customize/kits.md#restrict-kit-sources).
+
 ## Organization-wide control
 
 On a single developer's machine, security and policy are configured locally —

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -54,6 +54,27 @@ If `sbx policy allow` doesn't unblock the request, your organization may
 manage sandbox policies centrally and take precedence over local rules. See
 [Organization governance](governance/org.md).
 
+## Kit fails to install: source not in allowlist
+
+If loading a kit fails with a message like its source is not in your
+allowlist:
+
+```console
+$ sbx run claude --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale"
+ERROR: resolve kits: kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=vale" cannot be installed — its source is not in your allowlist.
+```
+
+`sbx` restricts kit installs to an allowlist of sources, which defaults to
+Docker Hub (`docker.io/`) only. Add the kit's publisher to the
+`kit.allowedSources` setting, keeping the entries you want to retain:
+
+```console
+$ sbx settings set kit.allowedSources '["docker.io/","github.com/docker/"]'
+```
+
+Then run the command again. For details, including how to allow local kits or
+any remote source, see [Restrict kit sources](customize/kits.md#restrict-kit-sources).
+
 ## SSH and other non-HTTP connections fail
 
 Non-HTTP TCP connections like SSH can be allowed by adding a policy rule for


### PR DESCRIPTION
## Summary

Document the kit install-source allowlist that shipped in **sbx v0.34**
(docker/sandboxes#3566) and is currently undocumented on the docs site.

The allowlist is **secure by default** and a **breaking change** for anyone
installing kits from non-Docker Hub sources (for example
`git+https://github.com/docker/sbx-kits-contrib.git`). Two new settings:

| Setting | Default | Env var |
|---|---|---|
| `kit.allowedSources` | `["docker.io/"]` | `DOCKER_SANDBOXES_KIT_ALLOWED_SOURCES` |
| `kit.allowLocalKits` | `true` | `DOCKER_SANDBOXES_KIT_ALLOW_LOCAL` |

## Changes

- **`customize/kits.md`** — new "Restrict kit sources" section under *Using
  kits*: default allowlist, how to add a publisher, path-segment prefix
  matching, the `["*"]` escape hatch, `kit.allowLocalKits`, and env vars.
- **`troubleshooting.md`** — new entry for the "source is not in your
  allowlist" failure with the fix command.
- **`security/_index.md`** — short note framing the allowlist as a
  supply-chain control (kit install commands run as root in the VM), linking
  to the kits section.

## Scope

- Independent of #25369 (credential bindings / kit schema v2) — that's a
  different axis (*what a kit does* vs. *where a kit installs from*) and is
  held on a separate gate. This PR can land on its own.
- admin/MDM org enforcement is deferred

## Follow-up (not in this PR)

The v0.34.0 GitHub release notes omit this allowlist from the *Kits* section,
so the auto-generated `release-notes.md` won't pick it up when regenerated.
The upstream release note should be amended at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)