### PR TITLE
docs: rename sbx policy set-default to sbx policy init

### DIFF
--- a/content/manuals/ai/sandboxes/governance/local.md
+++ b/content/manuals/ai/sandboxes/governance/local.md
@@ -64,11 +64,11 @@ workflows. Run `sbx policy ls` to see exactly which rules it includes.
 ### Non-interactive environments
 
 In non-interactive environments such as CI pipelines or headless servers, the
-interactive prompt can't be displayed. Use `sbx policy set-default` to set the
+interactive prompt can't be displayed. Use `sbx policy init` to set the
 preset before running any other `sbx` commands:
 
 ```console
-$ sbx policy set-default balanced
+$ sbx policy init balanced
 ```
 
 Available values are `allow-all`, `balanced`, and `deny-all`.


### PR DESCRIPTION
The `sbx policy set-default` command was renamed to `sbx policy init` in the latest `sbx` release. This updates the prose reference in the local network policy docs.

The CLI reference data (`data/sbx_cli/`) is updated in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)