### PR TITLE
docs(desktop): add legacy mac troubleshoot alias

### DIFF
--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
@@ -9,6 +9,8 @@ linkTitle: Troubleshoot and diagnose
 aliases:
   - /desktop/troubleshoot/overview/
   - /desktop/troubleshoot/
+  - /desktop/mac/troubleshoot/
+  - /desktop/mac/troubleshoot
 tags: [Troubleshooting]
 weight: 10
 ---

--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
@@ -10,7 +10,6 @@ aliases:
   - /desktop/troubleshoot/overview/
   - /desktop/troubleshoot/
   - /desktop/mac/troubleshoot/
-  - /desktop/mac/troubleshoot
 tags: [Troubleshooting]
 weight: 10
 ---


### PR DESCRIPTION
## Summary

Adds legacy aliases for the old Docker Desktop macOS troubleshoot path so links from older Docker Desktop dialogs continue to resolve.

## Related issue

Closes #25449
