### PR TITLE
sbx: add brew trust for macos install

### DIFF
--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -33,6 +33,7 @@ Install the `sbx` CLI and sign in:
 {{< tab name="macOS" >}}
 
 ```console
+$ brew trust docker/tap
 $ brew install docker/tap/sbx
 $ sbx login
 ```

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -69,6 +69,7 @@ Docker Desktop is not required to use `sbx`.
 {{< tab name="macOS" >}}
 
 ```console
+$ brew trust docker/tap
 $ brew install docker/tap/sbx
 $ sbx login
 ```


### PR DESCRIPTION
Homebrew 6.0.0 introduces tap trust which requires users to explicitly trust third-party taps. https://brew.sh/2026/06/11/homebrew-6.0.0/