### PR TITLE
docs(sandboxes): credentials

### DIFF
--- a/content/manuals/ai/sandboxes/agents/claude-code.md
+++ b/content/manuals/ai/sandboxes/agents/claude-code.md
@@ -38,10 +38,6 @@ Claude Code requires either an Anthropic API key or a Claude subscription.
 $ sbx secret set -g anthropic
 ```
 
-Alternatively, export the `ANTHROPIC_API_KEY` environment variable in your
-shell before running the sandbox. See
-[Credentials](../security/credentials.md) for details on both methods.
-
 **Claude subscription**: If no API key is set, use the `/login` command inside 
 Claude Code to authenticate via OAuth.
 

--- a/content/manuals/ai/sandboxes/agents/codex.md
+++ b/content/manuals/ai/sandboxes/agents/codex.md
@@ -52,9 +52,6 @@ so browser-based authentication works without any extra setup.
 $ sbx secret set -g openai
 ```
 
-Alternatively, export the `OPENAI_API_KEY` environment variable in your shell
-before running the sandbox.
-
 See [Credentials](../security/credentials.md) for more details.
 
 ## Configuration

--- a/content/manuals/ai/sandboxes/agents/copilot.md
+++ b/content/manuals/ai/sandboxes/agents/copilot.md
@@ -36,10 +36,6 @@ Copilot requires a GitHub token with Copilot access. Store your token using
 $ echo "$(gh auth token)" | sbx secret set -g github
 ```
 
-Alternatively, export the `GH_TOKEN` or `GITHUB_TOKEN` environment variable in
-your shell before running the sandbox. See
-[Credentials](../security/credentials.md) for details on both methods.
-
 ## Configuration
 
 Sandboxes don't pick up user-level configuration from your host. Only

--- a/content/manuals/ai/sandboxes/agents/cursor.md
+++ b/content/manuals/ai/sandboxes/agents/cursor.md
@@ -38,10 +38,6 @@ Cursor supports two authentication methods: an API key or OAuth.
 $ sbx secret set -g cursor
 ```
 
-Alternatively, export the `CURSOR_API_KEY` environment variable in your shell
-before running the sandbox. See
-[Credentials](../security/credentials.md) for details on both methods.
-
 **OAuth**: If no API key is set, Cursor prompts you to sign in interactively
 on first run. The proxy intercepts the token exchange with
 `api2.cursor.sh/auth/poll`, so credentials are managed by the host and aren't

--- a/content/manuals/ai/sandboxes/agents/docker-agent.md
+++ b/content/manuals/ai/sandboxes/agents/docker-agent.md
@@ -38,12 +38,6 @@ $ sbx secret set -g openrouter
 You only need to configure the providers you want to use. Docker Agent detects
 available credentials and routes requests to the appropriate provider.
 
-Alternatively, export the environment variables (`OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `NEBIUS_API_KEY`,
-`MISTRAL_API_KEY`, `OPENROUTER_API_KEY`) in your shell before running the
-sandbox. See
-[Credentials](../security/credentials.md) for details on both methods.
-
 ## Configuration
 
 Sandboxes don't pick up user-level configuration from your host. Only

--- a/content/manuals/ai/sandboxes/agents/droid.md
+++ b/content/manuals/ai/sandboxes/agents/droid.md
@@ -40,10 +40,6 @@ your Factory account.
 $ sbx secret set -g droid
 ```
 
-Alternatively, export the `FACTORY_API_KEY` environment variable in your shell
-before running the sandbox. See
-[Credentials](../security/credentials.md) for details on both methods.
-
 **OAuth**: If no API key is set, Droid prompts you to authenticate
 interactively on first run. The proxy handles the OAuth flow, so credentials
 aren't stored inside the sandbox.

--- a/content/manuals/ai/sandboxes/agents/gemini.md
+++ b/content/manuals/ai/sandboxes/agents/gemini.md
@@ -38,10 +38,6 @@ Gemini requires either a Google API key or a Google account with Gemini access.
 $ sbx secret set -g google
 ```
 
-Alternatively, export the `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment
-variable in your shell before running the sandbox. See
-[Credentials](../security/credentials.md) for details on both methods.
-
 **Google account**: If no API key is set, Gemini prompts you to sign in
 interactively when it starts. Interactive authentication is scoped to the
 sandbox and doesn't persist if you remove and recreate it.

--- a/content/manuals/ai/sandboxes/agents/opencode.md
+++ b/content/manuals/ai/sandboxes/agents/opencode.md
@@ -48,11 +48,6 @@ $ sbx secret set -g openrouter
 You only need to configure the providers you want to use. OpenCode detects
 available credentials and offers those providers in the TUI.
 
-You can also use environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
-`GOOGLE_GENERATIVE_AI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`,
-`AWS_ACCESS_KEY_ID`, `OPENROUTER_API_KEY`). See
-[Credentials](../security/credentials.md) for details on both methods.
-
 ## Configuration
 
 Sandboxes don't pick up user-level configuration from your host. Only

--- a/content/manuals/ai/sandboxes/agents/shell.md
+++ b/content/manuals/ai/sandboxes/agents/shell.md
@@ -33,13 +33,13 @@ $ sbx run shell -- -c "echo hi"   # runs bash -l -c "echo hi"
 
 When the first argument is a bare word, it replaces `-l` instead.
 
-Set your API keys as environment variables so the sandbox proxy can inject
-them into API requests automatically. Credentials are never stored inside
-the VM:
+Store credentials using [stored secrets](../security/credentials.md#stored-secrets)
+before running the sandbox. The proxy injects them into outbound API requests;
+credentials are never stored inside the VM:
 
 ```console
-$ export ANTHROPIC_API_KEY=sk-ant-xxxxx
-$ export OPENAI_API_KEY=sk-xxxxx
+$ sbx secret set -g anthropic
+$ sbx secret set -g openai
 ```
 
 Once inside the shell, you can install agents using their standard methods,

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -124,25 +124,14 @@ option.
 
 ## Authenticate your agent
 
-Agents need credentials for their model provider. How you provide them depends
-on the agent.
-
 For Claude Code with a Claude subscription (Max, Team, or Enterprise), no
 upfront setup is needed — use the `/login` command inside the sandbox to sign
-in with OAuth. The session token stays on your host and is injected by a
-proxy, not stored inside the sandbox.
+in with OAuth. The session token stays on your host and is never stored inside
+the sandbox.
 
-For agents that use API keys (or if you prefer API key authentication for
-Claude Code), store the key before starting a sandbox:
-
-```console
-$ sbx secret set -g anthropic
-```
-
-This prompts for the secret value and stores it in your OS keychain. A proxy on
-your host injects the key into outbound API requests so it's never exposed
-inside the sandbox. See [Credentials](security/credentials.md) for details on
-scoping, supported services, and alternative methods.
+If you prefer to authenticate with an API key, see
+[Credentials](security/credentials.md) for how to store one with
+`sbx secret set`.
 
 To give the agent access to GitHub for creating pull requests or interacting
 with repositories:

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -22,16 +22,14 @@ value never enters the sandbox — the agent sees only a sentinel like
 `proxy-managed`.
 
 There are several ways to provide that value. When more than one source has a
-value for the same service, the stored secret takes precedence over a host
-environment variable.
+value for the same service, the stored secret takes precedence.
 
-| Form | What it is | Use it when |
-| ---- | ---------- | ----------- |
-| [Stored secrets](#stored-secrets) (`sbx secret set`) | A value in your OS keychain, keyed by service | The default for any built-in or kit-declared service |
-| [Custom secrets](#custom-secrets) (`sbx secret set-custom`) | A value keyed to a domain and environment variable | The service model doesn't fit — the agent validates the variable's format, or the secret rides in a request body |
-| [Environment variables](#environment-variables) | Read from your shell session | One-off testing or CI, where keychain storage isn't worth it |
-| OAuth | A host-side sign-in flow; the token never enters the sandbox | The agent supports it, such as Claude Code, Codex, or Cursor |
-| [Registry credentials](#registry-credentials) (`sbx secret set --registry`) | Authentication for pulling images and kits | Pulling templates or kits from a private registry |
+| Form                                                                        | What it is                                                   | Use it when                                                                                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| [Stored secrets](#stored-secrets) (`sbx secret set`)                        | A value in your OS keychain, keyed by service                | The default for any built-in or kit-declared service                                                             |
+| [Custom secrets](#custom-secrets) (`sbx secret set-custom`)                 | A value keyed to a domain and environment variable           | The service model doesn't fit — the agent validates the variable's format, or the secret rides in a request body |
+| OAuth                                                                       | A host-side sign-in flow; the token never enters the sandbox | The agent supports it, such as Claude Code, Codex, or Cursor                                                     |
+| [Registry credentials](#registry-credentials) (`sbx secret set --registry`) | Authentication for pulling images and kits                   | Pulling templates or kits from a private registry                                                                |
 
 For multi-provider agents (OpenCode, Docker Agent), the proxy selects
 credentials based on the API endpoint being called. See individual
@@ -93,16 +91,39 @@ $ sbx secret set my-sandbox openai
 > you set or change a global secret while a sandbox is running, recreate the
 > sandbox for the new value to take effect.
 
-You can also pipe in a value for non-interactive use:
+### Import from environment variables
+
+If you already have API keys set in your shell, `sbx secret import` reads them
+and stores them in the keychain without typing each value manually:
 
 ```console
-$ echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
+$ sbx secret import
 ```
+
+This scans your current session for the environment variables in the
+[built-in services table](#built-in-services) below and prompts you to confirm
+each one before writing. To import a single service:
+
+```console
+$ sbx secret import openai
+```
+
+Pass `--all` to import everything without prompting (new entries only; existing
+entries are left unchanged), or `--force` to overwrite existing entries:
+
+```console
+$ sbx secret import --all
+$ sbx secret import openai --force
+```
+
+Pass `--dry-run` to preview what would be imported without writing anything.
+Run `sbx secret ls` afterwards to confirm what's stored. For setting up
+credentials in CI, see [CI and headless use](../workflows.md#ci-and-headless-use).
 
 ### Built-in services
 
-Each built-in service name maps to a set of environment variables the proxy
-checks and the API domains it authenticates requests to:
+Each built-in service name maps to the environment variables `sbx secret import`
+reads and the API domains the proxy injects credentials into:
 
 | Service      | Environment variables              | API domains                                                                                                                   |
 | ------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
@@ -118,9 +139,8 @@ checks and the API domains it authenticates requests to:
 | `openrouter` | `OPENROUTER_API_KEY`               | `openrouter.ai`                                                                                                               |
 | `xai`        | `XAI_API_KEY`                      | `api.x.ai`                                                                                                                    |
 
-When you store a secret with `sbx secret set -g <service>`, the proxy uses it
-the same way it would use the corresponding environment variable. You don't
-need to set both.
+When you store a secret with `sbx secret set -g <service>`, the proxy injects
+it into requests to the listed API domains.
 
 ### Services declared by kits
 
@@ -236,26 +256,6 @@ proxy replaces it with the real value. The agent never sees the real secret.
 Prefer the [service-based flow](#stored-secrets) whenever it's an option —
 the kit handles the wiring; you only provide the value.
 
-## Environment variables
-
-As an alternative to stored secrets, export the relevant environment variable
-in your shell before running a sandbox:
-
-```console
-$ export ANTHROPIC_API_KEY=sk-ant-api03-xxxxx
-$ sbx run claude
-```
-
-The proxy reads the variable from your terminal session. See individual
-[agent pages](../agents/) for the variable names each agent expects.
-
-> [!NOTE]
-> These environment variables are set on your host, not inside the sandbox.
-> Sandbox agents are pre-configured to use credentials managed by the
-> host-side proxy. For custom environment variables not tied to a
-> [built-in service](#built-in-services), see
-> [Setting custom environment variables](../faq.md#how-do-i-set-custom-environment-variables-inside-a-sandbox).
-
 ## Registry credentials
 
 Registry credentials authenticate to private OCI registries when pulling
@@ -348,10 +348,9 @@ $ sbx secret rm my-sandbox --registry ghcr.io -f
 
 ## Best practices
 
-- Use [stored secrets](#stored-secrets) over environment variables. Stored
-  secrets are encrypted at rest in the OS keychain (or an encrypted file on
-  Linux hosts without a keychain), while environment variables are plaintext in
-  your shell. See [Where secrets are stored](#where-secrets-are-stored).
+- Use [stored secrets](#stored-secrets) to provide credentials. They are
+  encrypted at rest in the OS keychain (or an encrypted file on Linux hosts
+  without a keychain). See [Where secrets are stored](#where-secrets-are-stored).
 - Don't set API keys manually inside the sandbox. Sandbox agents are
   pre-configured to use proxy-managed credentials.
 - Registry credentials you make available inside a sandbox are stored in the VM

--- a/content/manuals/ai/sandboxes/workflows.md
+++ b/content/manuals/ai/sandboxes/workflows.md
@@ -333,9 +333,18 @@ $ sbx rm ci-task
 ```
 
 Agent credentials (API keys, GitHub token) can be pre-configured as global
-secrets so they're available to any sandbox the CI runner creates:
+secrets so they're available to any sandbox the CI runner creates. If the
+relevant environment variables are already set in the CI environment (see the
+[built-in services table](security/credentials.md#built-in-services) for which
+variables each service reads), import them all at once:
 
 ```console
-$ echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
-$ echo "$GITHUB_TOKEN" | sbx secret set -g github
+$ sbx secret import --all
+```
+
+To overwrite an existing stored entry, add `--force`. To pass a value from your
+CI provider's secret store, use `-t`. For example, in a GitHub Actions step:
+
+```yaml
+- run: sbx secret set -g anthropic -t "${{ secrets.ANTHROPIC_API_KEY }}"
 ```


### PR DESCRIPTION
## Summary

Updates the credentials documentation for Docker Sandboxes:

- Removes the environment variables section. Exporting API keys in your host shell is no longer a supported authentication path; use `sbx secret set` or `sbx secret import` instead.
- Adds `sbx secret import` documentation: imports recognized API key environment variables from your shell into the keychain in one step, with flags for non-interactive use (`--all`), overwriting (`--force`), and dry-run preview.
- Lightens the get-started authentication section to lead with OAuth as the primary path for Claude Code, pointing to the credentials page for API key setup.
- Reverts agent pages that previously described a first-run credential prompt that no longer applies to built-in agents.

## What's not in this PR

The credential bindings / `credentials.yaml` / first-run approval flow for third-party kit authors lands alongside the schemaVersion 2 kit docs in companion PR #25467.

> [!NOTE]
> While this PR does not hinge on a schemaVersion 2 public release, it does assume that the built-in agents are migrated to schemaVersion 2.