### PR TITLE
docs: sync built-in credential services with sbx secret set

### DIFF
--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -122,17 +122,20 @@ $ echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
 Each built-in service name maps to a set of environment variables the proxy
 checks and the API domains it authenticates requests to:
 
-| Service     | Environment variables              | API domains                         |
-| ----------- | ---------------------------------- | ----------------------------------- |
-| `anthropic` | `ANTHROPIC_API_KEY`                | `api.anthropic.com`                 |
-| `aws`       | `AWS_ACCESS_KEY_ID`                | AWS Bedrock endpoints               |
-| `github`    | `GH_TOKEN`, `GITHUB_TOKEN`         | `api.github.com`, `github.com`      |
-| `google`    | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `generativelanguage.googleapis.com` |
-| `groq`      | `GROQ_API_KEY`                     | `api.groq.com`                      |
-| `mistral`   | `MISTRAL_API_KEY`                  | `api.mistral.ai`                    |
-| `nebius`    | `NEBIUS_API_KEY`                   | `api.studio.nebius.ai`              |
-| `openai`    | `OPENAI_API_KEY`                   | `api.openai.com`                    |
-| `xai`       | `XAI_API_KEY`                      | `api.x.ai`                          |
+| Service      | Environment variables              | API domains                                                                                                                   |
+| ------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `anthropic`  | `ANTHROPIC_API_KEY`                | `api.anthropic.com`, `console.anthropic.com`, `claude.ai`, `mcp-proxy.anthropic.com`                                          |
+| `aws`        | `AWS_ACCESS_KEY_ID`                | `bedrock-runtime.*.amazonaws.com`, `bedrock.*.amazonaws.com`                                                                  |
+| `cursor`     | `CURSOR_API_KEY`                   | `api2.cursor.sh`, `api3.cursor.sh`, `repo42.cursor.sh`, `cursor.com`                                                          |
+| `droid`      | `FACTORY_API_KEY`                  | `api.factory.ai`, `app.factory.ai`, `relay.factory.ai`                                                                        |
+| `github`     | `GH_TOKEN`, `GITHUB_TOKEN`         | `api.github.com`, `github.com`, `raw.githubusercontent.com`, `gist.github.com`, `copilot.github.com`, `api.githubcopilot.com` |
+| `google`     | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `generativelanguage.googleapis.com`, `oauth2.googleapis.com`, `aiplatform.googleapis.com`, `vertexai.googleapis.com`          |
+| `groq`       | `GROQ_API_KEY`                     | `api.groq.com`                                                                                                                |
+| `mistral`    | `MISTRAL_API_KEY`                  | `api.mistral.ai`                                                                                                              |
+| `nebius`     | `NEBIUS_API_KEY`                   | `api.studio.nebius.com`, `api.tokenfactory.nebius.com`                                                                        |
+| `openai`     | `OPENAI_API_KEY`                   | `api.openai.com`, `openai.com`, `chatgpt.com`, `www.chatgpt.com`                                                              |
+| `openrouter` | `OPENROUTER_API_KEY`               | `openrouter.ai`                                                                                                               |
+| `xai`        | `XAI_API_KEY`                      | `api.x.ai`                                                                                                                    |
 
 When you store a secret with `sbx secret set -g <service>`, the proxy uses it
 the same way it would use the corresponding environment variable. You don't

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -125,7 +125,6 @@ checks and the API domains it authenticates requests to:
 | Service      | Environment variables              | API domains                                                                                                                   |
 | ------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `anthropic`  | `ANTHROPIC_API_KEY`                | `api.anthropic.com`, `console.anthropic.com`, `claude.ai`, `mcp-proxy.anthropic.com`                                          |
-| `aws`        | `AWS_ACCESS_KEY_ID`                | `bedrock-runtime.*.amazonaws.com`, `bedrock.*.amazonaws.com`                                                                  |
 | `cursor`     | `CURSOR_API_KEY`                   | `api2.cursor.sh`, `api3.cursor.sh`, `repo42.cursor.sh`, `cursor.com`                                                          |
 | `droid`      | `FACTORY_API_KEY`                  | `api.factory.ai`, `app.factory.ai`, `relay.factory.ai`                                                                        |
 | `github`     | `GH_TOKEN`, `GITHUB_TOKEN`         | `api.github.com`, `github.com`, `raw.githubusercontent.com`, `gist.github.com`, `copilot.github.com`, `api.githubcopilot.com` |


### PR DESCRIPTION
## What

Updates the built-in services table on the [Credentials](https://docs.docker.com/ai/sandboxes/security/credentials/#built-in-services) page so it matches what `sbx secret set` recognizes and the domains the proxy actually injects credentials for.

- Add `cursor`, `droid`, and `openrouter` services
- Fix the `nebius` API domain (`api.studio.nebius.ai` → `api.studio.nebius.com`)
- Expand the **API domains** column to the full set each service authenticates for, instead of a single representative host (for example, `anthropic` also covers `console.anthropic.com`, `claude.ai`, and `mcp-proxy.anthropic.com`)
- Remove the `aws` row — that service can't authenticate a Bedrock request and is being removed at the source