### PR TITLE
docs(engine): add systemd service file for binary Docker installs

### DIFF
--- a/content/manuals/engine/install/linux-postinstall.md
+++ b/content/manuals/engine/install/linux-postinstall.md
@@ -115,6 +115,30 @@ $ sudo systemctl disable docker.service
 $ sudo systemctl disable containerd.service
 ```
 
+If you installed Docker from [binaries](binaries.md), the systemd service files
+aren't included. It is recommended to create the Docker service file manually so
+Docker starts automatically on boot. The `dockerd` daemon manages containerd
+directly, so a separate containerd service is not required.
+
+```console
+$ sudo tee /etc/systemd/system/docker.service > /dev/null <<'EOF'
+[Unit]
+Description=Docker Application Container Engine
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/bin/dockerd
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+$ sudo systemctl daemon-reload
+$ sudo systemctl enable --now docker.service
+```
+
 You can use systemd unit files to configure the Docker service on startup,
 for example to add an HTTP proxy, set a different directory or partition for the
 Docker runtime files, or other customizations. For an example, see


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

Binary installs don't include systemd unit files, so systemctl enable fails without them. 
Adds the service file creation step under the existing "Configure Docker to start on boot with systemd" section.
Clarifies that dockerd manages containerd directly, so a separate containerd.service is not needed.

Tested locally on Linux with docker-29.6.1 installed from binaries. The systemd service file structure is standard across systemd-based distributions.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
Fixes #25149 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review