### PR TITLE
docs(sandboxes): document DOCKER_SANDBOXES_ROOT_SIZE for root filesystem sizing

### DIFF
--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -184,6 +184,23 @@ the egress path in the **PROXY** column:
   internal CA applies. The only difference between them is whether the client
   knows it's talking to a proxy.
 
+## Sandbox runs out of disk space
+
+The sandbox root (`/`) filesystem defaults to 20 GB. Workloads that write large amounts of data
+to the root filesystem — such as Nix (which installs packages under `/nix/store`), large package
+installations, or build artifacts — can exhaust this limit even when
+`DOCKER_SANDBOXES_DOCKER_SIZE` has been increased. That variable only sizes the Docker data disk
+(`/var/lib/docker`), not the root filesystem.
+
+To increase the root filesystem size, set `DOCKER_SANDBOXES_ROOT_SIZE` before creating the sandbox:
+
+```console
+$ DOCKER_SANDBOXES_ROOT_SIZE=40g sbx run claude
+```
+
+`DOCKER_SANDBOXES_ROOT_SIZE` and `DOCKER_SANDBOXES_DOCKER_SIZE` are independent — set both if your
+workload needs more space on both the root filesystem and the Docker data disk.
+
 ## Filesystem operations are slow in large repositories
 
 Filesystem operations such as `git status`, `git log`, or directory scans can

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -186,20 +186,16 @@ the egress path in the **PROXY** column:
 
 ## Sandbox runs out of disk space
 
-The sandbox root (`/`) filesystem defaults to 20 GB. Workloads that write large amounts of data
-to the root filesystem — such as Nix (which installs packages under `/nix/store`), large package
-installations, or build artifacts — can exhaust this limit even when
-`DOCKER_SANDBOXES_DOCKER_SIZE` has been increased. That variable only sizes the Docker data disk
-(`/var/lib/docker`), not the root filesystem.
+The sandbox root (`/`) filesystem defaults to 20 GB. `DOCKER_SANDBOXES_DOCKER_SIZE` only sizes the
+Docker data disk (`/var/lib/docker`) — it does not affect this limit.
 
-To increase the root filesystem size, set `DOCKER_SANDBOXES_ROOT_SIZE` before creating the sandbox:
+To configure the root filesystem size, set `DOCKER_SANDBOXES_ROOT_SIZE` before creating the sandbox:
 
 ```console
 $ DOCKER_SANDBOXES_ROOT_SIZE=40g sbx run claude
 ```
 
-`DOCKER_SANDBOXES_ROOT_SIZE` and `DOCKER_SANDBOXES_DOCKER_SIZE` are independent — set both if your
-workload needs more space on both the root filesystem and the Docker data disk.
+The two variables are independent — set both if you need extra space on `/` and `/var/lib/docker`.
 
 ## Filesystem operations are slow in large repositories
 

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -186,16 +186,15 @@ the egress path in the **PROXY** column:
 
 ## Sandbox runs out of disk space
 
-The sandbox root (`/`) filesystem defaults to 20 GB. `DOCKER_SANDBOXES_DOCKER_SIZE` only sizes the
-Docker data disk (`/var/lib/docker`) — it does not affect this limit.
-
-To configure the root filesystem size, set `DOCKER_SANDBOXES_ROOT_SIZE` before creating the sandbox:
+The sandbox root (`/`) filesystem defaults to 20 GB. To increase it, set `DOCKER_SANDBOXES_ROOT_SIZE`
+before creating the sandbox:
 
 ```console
 $ DOCKER_SANDBOXES_ROOT_SIZE=40g sbx run claude
 ```
 
-The two variables are independent — set both if you need extra space on `/` and `/var/lib/docker`.
+`DOCKER_SANDBOXES_ROOT_SIZE` controls the root filesystem size. `DOCKER_SANDBOXES_DOCKER_SIZE`
+controls the Docker data disk (`/var/lib/docker`) size. The two are independent — set both if needed.
 
 ## Filesystem operations are slow in large repositories
 


### PR DESCRIPTION
## Summary

Documents the new `DOCKER_SANDBOXES_ROOT_SIZE` environment variable, which lets users increase the sandbox root (`/`) filesystem size beyond the 20 GB default. Adds a new "Sandbox runs out of disk space" section to the troubleshooting page, clarifying the distinction between this variable and the existing `DOCKER_SANDBOXES_DOCKER_SIZE` (Docker data disk only).

Generated by Claude Code