### PR TITLE
Add docs for image mounts (--mount type=image)

### DIFF
--- a/content/manuals/engine/storage/_index.md
+++ b/content/manuals/engine/storage/_index.md
@@ -42,6 +42,7 @@ of the writable layer of the container:
 - [Volume mounts](#volume-mounts)
 - [Bind mounts](#bind-mounts)
 - [tmpfs mounts](#tmpfs-mounts)
+- [Image mounts](#image-mounts)
 - [Named pipes](#named-pipes)
 
 No matter which type of mount you choose to use, the data looks the same from
@@ -85,6 +86,18 @@ such as caching intermediate data, handling sensitive information like
 credentials, or reducing disk I/O. Use tmpfs mounts only when the data does not
 need to persist beyond the current container session.
 
+### Image mounts
+
+An image mount makes the contents of another image available inside a container
+at a path you choose. The mounted image is read-only and isn't part of the
+container's own image, so you can bring in tools or assets from one image
+without rebuilding another.
+
+Use image mounts when you need to consume files packaged as an image, such as
+mounting a tool-rich image to debug a minimal container, or sharing read-only
+assets across containers running different images. Image mounts require the
+[containerd image store](containerd.md).
+
 ### Named pipes
 
 [Named pipes](https://docs.microsoft.com/en-us/windows/desktop/ipc/named-pipes)
@@ -99,6 +112,7 @@ Learn more about container data persistence:
 - [Volumes](./volumes.md)
 - [Bind mounts](./bind-mounts.md)
 - [tmpfs mounts](./tmpfs.md)
+- [Image mounts](./image-mounts.md)
 
 Learn more about daemon storage backends:
 

--- a/content/manuals/engine/storage/bind-mounts.md
+++ b/content/manuals/engine/storage/bind-mounts.md
@@ -115,8 +115,8 @@ $ docker run --mount type=bind,src=<host-path>,dst=<container-path>[,<key>=<valu
 
 Valid options for `--mount type=bind` include:
 
-| Option                         | Description                                                                                                                                                          |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Option                         | Description                                                                                                                                                         |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `source`, `src`                | The location of the file or directory on the host. This can be an absolute or relative path.                                                                        |
 | `destination`, `dst`, `target` | The path where the file or directory is mounted in the container. Must be an absolute path.                                                                         |
 | `readonly`, `ro`               | If present, causes the bind mount to be [mounted into the container as read-only](#use-a-read-only-bind-mount).                                                     |
@@ -486,4 +486,5 @@ and
 
 - Learn about [volumes](./volumes.md).
 - Learn about [tmpfs mounts](./tmpfs.md).
+- Learn about [image mounts](./image-mounts.md).
 - Learn about [storage drivers](/engine/storage/drivers/).

--- a/content/manuals/engine/storage/image-mounts.md
+++ b/content/manuals/engine/storage/image-mounts.md
@@ -1,0 +1,208 @@
+---
+description: Using image mounts
+title: Image mounts
+weight: 40
+keywords: storage, mounts, image mounts, image mount
+---
+
+[Volumes](volumes.md), [bind mounts](bind-mounts.md), and [tmpfs mounts](tmpfs.md)
+all give a container a place to read and write data. An image mount is
+different: instead of mounting a directory or a memory-backed filesystem, it
+mounts the contents of another image into the container.
+
+When you use an image mount, the filesystem of a second image is mounted into
+the container at a path you choose. The container can read the files from that
+image alongside its own filesystem, without those files being part of the
+container's own image. This is useful when you want to bring the tools or assets
+from one image into a container that's running a different image.
+
+Image mounts are read-only. The mounted image is never modified, and the
+container can't write to the mount.
+
+> [!NOTE]
+> Image mounts require the [containerd image store](containerd.md).
+
+## When to use image mounts
+
+Image mounts are appropriate for the following types of use case:
+
+- Debugging a minimal or hardened image that doesn't include a shell or common
+  utilities. You can mount a tool-rich image, such as `busybox`, into the
+  running container's namespace and run those tools without changing the
+  original image. For a worked example, see
+  [Debug with Docker Hardened Images](/manuals/dhi/troubleshoot.md).
+
+- Sharing read-only assets, such as datasets, models, or static content, that
+  are distributed as an image and consumed by containers running a different
+  image.
+
+- Keeping application images small by packaging optional tooling in a separate
+  image and mounting it only when needed.
+
+## Mounting over existing data
+
+If you mount an image into a directory in the container in which files or
+directories exist, the pre-existing files are obscured by the mount. This is
+similar to if you were to save files into `/mnt` on a Linux host, and then
+mounted a USB drive into `/mnt`. The contents of `/mnt` would be obscured by the
+contents of the USB drive until the USB drive was unmounted.
+
+With containers, there's no straightforward way of removing a mount to reveal
+the obscured files again. Your best option is to recreate the container without
+the mount.
+
+## Considerations and constraints
+
+- Image mounts are always read-only. The container can't modify the mounted
+  image, and changes aren't persisted anywhere.
+
+- The source image must already exist in the daemon's image store. Docker
+  doesn't pull the source image automatically when you create the mount. If the
+  image isn't present, the command fails:
+
+  ```console
+  $ docker run --mount type=image,source=busybox:musl,destination=/dbg alpine
+  docker: Error response from daemon: No such image: busybox:musl
+  ```
+
+  Pull the image first with `docker pull`, then create the mount.
+
+- Image mounts require the [containerd image store](containerd.md). They aren't
+  available when the daemon uses the classic storage drivers.
+
+- You can only create an image mount with the `--mount` flag. There is no
+  `--volume` (`-v`) equivalent.
+
+- Running an executable from a mounted image requires a compatible runtime in
+  the container. A dynamically linked binary only runs if the container provides
+  a matching dynamic linker and shared libraries. For example, a glibc-based
+  binary fails in a musl-based image such as Alpine. Statically linked binaries,
+  or mounting only data from an image, avoid this constraint.
+
+## Syntax
+
+To mount an image with the `docker run` command, use the `--mount` flag with
+`type=image`.
+
+```console
+$ docker run --mount type=image,src=<image-reference>,dst=<container-path>
+```
+
+The `--mount` flag consists of multiple key-value pairs, separated by commas and
+each consisting of a `<key>=<value>` tuple. The order of the keys isn't
+significant.
+
+```console
+$ docker run --mount type=image,src=<image-reference>,dst=<container-path>[,<key>=<value>...]
+```
+
+### Options for --mount
+
+Valid options for `--mount type=image` include:
+
+| Option                         | Description                                                                                                                       |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `source`, `src`                | The reference of the image to mount, for example `busybox` or `busybox:musl`. The image must exist locally.                       |
+| `destination`, `dst`, `target` | The path where the image is mounted in the container. Must be an absolute path.                                                   |
+| `image-subpath`                | Path inside the source image to mount instead of the image root. See [Mount a subpath of an image](#mount-a-subpath-of-an-image). |
+
+```console {title="Example"}
+$ docker run --mount type=image,src=busybox,dst=/dbg,image-subpath=bin
+```
+
+## Use an image mount in a container
+
+The following example runs an Alpine container and mounts the `busybox:musl`
+image at `/dbg`. Pull the source image first, since Docker doesn't pull it for
+you when creating the mount. This example uses the musl-based BusyBox image so
+its binaries are compatible with the musl-based Alpine container.
+
+```console
+$ docker pull busybox:musl
+$ docker run -d \
+  -it \
+  --name imgtest \
+  --mount type=image,source=busybox:musl,destination=/dbg \
+  alpine:latest
+```
+
+The container can now read the BusyBox tools from `/dbg` while running the Alpine
+image:
+
+```console
+$ docker exec imgtest /dbg/bin/echo "hello from busybox"
+hello from busybox
+```
+
+Verify that the mount is an `image` mount by looking in the `Mounts` section of
+the `docker inspect` output:
+
+```console
+$ docker inspect imgtest --format '{{ json .Mounts }}'
+[{"Type":"image","Name":"busybox:musl","Source":"/var/lib/docker/rootfs/overlayfs/...","Destination":"/dbg","Mode":"","RW":false,"Propagation":"rprivate"}]
+```
+
+This shows that the mount is an `image` mount, that its source is the
+`busybox:musl` image, and that it's read-only (`"RW":false`).
+
+Stop and remove the container:
+
+```console
+$ docker container rm -fv imgtest
+```
+
+## Mount a subpath of an image
+
+Use the `image-subpath` option to mount a specific directory from the source
+image instead of its root. For example, to mount only the `bin` directory of the
+`busybox` image at `/tools`:
+
+```console
+$ docker run -d \
+  -it \
+  --name imgtest \
+  --mount type=image,source=busybox,destination=/tools,image-subpath=bin \
+  alpine:latest
+```
+
+The container sees the contents of the image's `bin` directory at `/tools`.
+
+## Use an image mount with Docker Compose
+
+A single Docker Compose service with an image mount looks like this:
+
+```yaml
+services:
+  app:
+    image: alpine:latest
+    volumes:
+      - type: image
+        source: busybox
+        target: /dbg
+```
+
+To mount a subpath of the image, use the `subpath` option under `image`:
+
+```yaml
+services:
+  app:
+    image: alpine:latest
+    volumes:
+      - type: image
+        source: busybox
+        target: /tools
+        image:
+          subpath: bin
+```
+
+The `image.subpath` option is available in Docker Compose version 2.35.0 and
+later. For more information about using mounts of the `image` type with Compose,
+see the
+[Compose reference on the volume attribute](/reference/compose-file/services.md#volumes).
+
+## Next steps
+
+- Learn about [volumes](./volumes.md).
+- Learn about [bind mounts](./bind-mounts.md).
+- Learn about [tmpfs mounts](./tmpfs.md).
+- Learn about [storage drivers](/engine/storage/drivers/).

--- a/content/manuals/engine/storage/tmpfs.md
+++ b/content/manuals/engine/storage/tmpfs.md
@@ -203,4 +203,5 @@ $ docker rm tmptest
 
 - Learn about [volumes](volumes.md)
 - Learn about [bind mounts](bind-mounts.md)
+- Learn about [image mounts](image-mounts.md)
 - Learn about [storage drivers](/engine/storage/drivers/)

--- a/content/manuals/engine/storage/volumes.md
+++ b/content/manuals/engine/storage/volumes.md
@@ -809,5 +809,6 @@ $ docker volume prune
 
 - Learn about [bind mounts](bind-mounts.md).
 - Learn about [tmpfs mounts](tmpfs.md).
+- Learn about [image mounts](image-mounts.md).
 - Learn about [storage drivers](/engine/storage/drivers/).
 - Learn about [third-party volume driver plugins](/engine/extend/legacy_plugins/).


### PR DESCRIPTION
## Summary

Adds documentation for the image mount storage type (`--mount type=image`),
which had no dedicated page. New `content/manuals/engine/storage/image-mounts.md`
follows the same template and depth as the volumes/bind/tmpfs pages, and the
storage overview plus sibling "Next steps" lists are updated to link it.

Written in anticipation of image mounts being unflagged as experimental
(moby/moby#52998), so no experimental callouts are included. Every command and
output on the page was verified against a live Docker Engine 29.6.1 daemon
(containerd image store).

## Learnings

- Image mounts are read-only unconditionally (`readonly=false` has no effect;
  `docker inspect` always reports `"RW":false`), the source image is not
  auto-pulled, there is no `-v` shorthand, and executables from the mounted
  image only run if the container's libc/dynamic linker matches (a glibc binary
  fails in musl-based Alpine). These are easy to get wrong from the CLI help
  alone — worth verifying against a daemon.

Generated by Claude Code