### PR TITLE
docs(governance): clarify network vs filesystem policy enforcement timing

### DIFF
--- a/content/manuals/ai/sandboxes/governance/org.md
+++ b/content/manuals/ai/sandboxes/governance/org.md
@@ -195,6 +195,23 @@ command.
 > `sbx policy reset` deletes all locally configured policy rules. The command
 > prompts for confirmation before proceeding.
 
+#### Network versus filesystem enforcement timing
+
+Network policy and filesystem policy differ in when a change takes effect:
+
+- Network policy is evaluated on every outbound request. Once a policy
+  change has synced to the developer's machine (up to 5 minutes), it applies
+  immediately to subsequent requests.
+
+- Filesystem policy is only checked when a workspace is mounted — that
+  is, when a sandbox is created. Once a sandbox is running, changing the
+  filesystem policy has no effect on that sandbox. The sandbox continues to
+  access the previously allowed path until it is removed and a new one is
+  created.
+
+To apply a filesystem policy change immediately, remove the running sandbox
+and create a new one.
+
 ### Sandbox cannot mount workspace
 
 If a sandbox fails to mount with a `mount policy denied` error, verify that


### PR DESCRIPTION
## Summary

The "Policy changes not taking effect" troubleshooting section only described
network policy propagation. Expanded it to explain that filesystem policy is
evaluated only at mount time (sandbox creation), so a policy change does not
affect already-running sandboxes — users must remove and recreate the sandbox
for a filesystem policy change to take effect. Network policy, by contrast, is
evaluated on every request and updates within the propagation window.

Generated by Claude Code