### PR TITLE
docs: clarify that company creation migrates the selected organization

### DIFF
--- a/content/manuals/admin/company/new-company.md
+++ b/content/manuals/admin/company/new-company.md
@@ -24,8 +24,8 @@ Before you begin, you must:
 
 To create a new company:
 
-1. Sign in to [Docker Home](https://app.docker.com/) and select your
-   organization.
+1. Sign in to [Docker Home](https://app.docker.com/) and select the
+   organization you want to add to your company.
 1. Select **Admin Console**, then **Company management**.
 1. Select **Create a company**.
 1. Enter a unique name for your company, then select **Continue**.
@@ -37,7 +37,10 @@ To create a new company:
 
 1. Review the migration details and then select **Create company**.
 
-For more information on how you can add organizations to your company,
+When you create the company, the organization you selected is automatically
+migrated to the new company.
+
+For more information on how you can add more organizations to your company,
 see [Add organizations to a company](./manage/organizations.md#add-organizations-to-a-company).
 
 ## Next steps


### PR DESCRIPTION
## Summary

Fixes #25494.

The issue flags the organization-ownership prerequisite in the create-company guide as misleading, on the premise that the steps only create an empty company. Checking this page's history shows the premise isn't quite right: before the admin IA restructures, the guide read "navigate to the organization you want to place under a company" and "review the company migration details" — creating a company migrates the selected organization under it, which is why step 5 still says "Review the migration details."

What actually got lost in the restructures is the sentence saying so. This PR restores that clarification instead of removing the (correct) prerequisite:

- Step 1 now says to select the organization you want to add to your company, instead of the generic "select your organization".
- Added one sentence after the steps stating that the selected organization is automatically migrated to the new company.
- Adjusted the follow-up link sentence to "add more organizations", since the first one is added during creation.

## Validation

- `scripts/lint.sh content/manuals/admin/company/new-company.md` — markdownlint clean.
- Cross-checked against `manage/organizations.md` (adding further organizations) and the pre-restructure wording from #18940.