### PR TITLE
docs: add explicit single-page guide structure callout

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -305,6 +305,19 @@ don't front-load complexity.
 - Don't use "**Bold:** format" for subsection labels (use plain text
   with colon)
 
+### Guide structure
+
+Guides are single-page - don't split a guide into multiple sub-pages
+(for example, separate "overview", "configure", and "deploy" pages for
+one guide). Cover the full task on one page and use headings to
+organize sections.
+
+Store each guide as a single Markdown file directly under
+`content/guides/` (for example, `content/guides/django.md`), not
+wrapped in its own directory with an `index.md`. Guide images belong in
+the shared `content/guides/images/` folder, prefixed with the guide's
+slug, not in a per-guide directory - see [Images](#images).
+
 ### Lists
 
 - Limit bulleted lists to five items when possible
@@ -395,6 +408,13 @@ For code block syntax, language hints, variables, and advanced features
 - Keep images small and focused
 - Compress images before adding to repository
 - Remove unused images from repository
+
+**File organization:**
+
+- Store guide images in the shared `content/guides/images/` folder,
+  not in a per-guide directory
+- Prefix filenames with the guide's slug to avoid collisions (for
+  example, `kafka-architecture.webp`)
 
 For image syntax and parameters (sizing, borders), see
 [COMPONENTS.md](COMPONENTS.md#images).

--- a/STYLE.md
+++ b/STYLE.md
@@ -316,7 +316,7 @@ Store each guide as a single Markdown file directly under
 `content/guides/` (for example, `content/guides/django.md`), not
 wrapped in its own directory with an `index.md`. Guide images belong in
 the shared `content/guides/images/` folder, prefixed with the guide's
-slug, not in a per-guide directory - see [Images](#images).
+slug, not in a per-guide directory - see [Images](STYLE.md#images).
 
 ### Lists
 


### PR DESCRIPTION
## Description

Follow-up to #25338 (the guides revamp). That PR moved guides to a single-page structure, but STYLE.md never documented the convention, so it's easy for new guides to drift back into multi-page/directory-wrapped structures.

Adds:
- A "Guide structure" section stating guides are single-page and should live as flat `.md` files directly under `content/guides/` (not `<name>/index.md`).
- A "File organization" note under the existing "Images" section establishing the shared `content/guides/images/` folder with slug-prefixed filenames as the convention (already the dominant pattern used by most guides).

Companion PR that applies this convention to the remaining guides still using the old directory-wrapped structure: #25504

## Related issues or tickets

Discussed in the team's docs Slack channel following #25338.

## Reviews

- [ ] Editorial review