### PR TITLE
gordon: update data privacy — plan tiers, provider zero-data-retention, sensitive-data redaction

### DIFF
--- a/content/manuals/ai/gordon/concepts/data-privacy.md
+++ b/content/manuals/ai/gordon/concepts/data-privacy.md
@@ -43,21 +43,41 @@ Gordon has access to your Docker daemon's state, including:
 
 Gordon's data retention differs based on your subscription tier:
 
-### Paid subscriptions (Pro, Team, Business)
+### Paid subscriptions
 
 Docker and its AI providers do not retain any inputs or outputs from your
 Gordon sessions. Your queries, Gordon's responses, and any code or files
-processed are not stored.
+processed are not stored. This applies to all paid subscriptions: Docker
+Desktop plans (Pro, Team, Business) and Gordon plans (Plus, Max, Ultra).
 
 ### Personal (free) subscription
 
-Anonymized conversation threads are stored for 30 days to improve the service.
-Individual queries and responses are retained as part of your conversation history.
+Anonymized conversation threads are stored for 5 days to help guarantee
+quality of service and fight abuse. Individual queries and responses are
+retained as part of your conversation history.
 
 ### All subscriptions
 
 Data is never used for training AI models or shared with third parties. All
-data transferred to Gordon's backend is encrypted in transit.
+data transferred to Gordon's backend is encrypted in transit. Docker's
+third-party AI providers process requests under zero-data-retention
+agreements: they don't store your prompts or Gordon's responses.
+
+## Sensitive data protection
+
+Gordon automatically detects and redacts secrets and other sensitive material
+from your requests using [portcullis](https://github.com/docker/portcullis),
+Docker's open source redaction library. Around 240 patterns are covered,
+including:
+
+- Cloud provider credentials (AWS, GCP, Azure, and others)
+- API tokens (GitHub, GitLab, Docker Hub, Slack, OpenAI, Stripe, and more)
+- PEM private keys and JWTs
+- Database connection-string passwords
+- Payment card numbers, IBANs, and US Social Security numbers
+
+Detected values are replaced with `[REDACTED]` before your request is
+processed.
 
 ## Data security
 


### PR DESCRIPTION
Updates the Gordon data privacy page:

- **Paid subscriptions**: zero retention now explicitly covers all paid subscriptions — Docker Desktop plans (Pro, Team, Business) and Gordon plans (Plus, Max, Ultra).
- **Personal (free) subscription**: retention of anonymized conversation threads reduced from 30 days to 5 days; purpose clarified (quality of service and abuse prevention).
- **All subscriptions**: documents that Docker's third-party AI providers operate under zero-data-retention agreements.
- **New section — Sensitive data protection**: documents Gordon's automatic secret/PII redaction based on [docker/portcullis](https://github.com/docker/portcullis).
