### PR TITLE
docs(build): clarify WORKDIR tilde path behavior

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/rules/workdir-relative-path.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/rules/workdir-relative-path.md
@@ -28,6 +28,12 @@ image built externally is prone to breaking, since working directory may change
 upstream without warning, resulting in a completely different directory
 hierarchy for your build.
 
+> [!NOTE]
+>
+> `WORKDIR` does not perform shell expansion. Paths beginning with `~` or
+> `~username` are treated as literal directory names and are not resolved to a
+> user's home directory.
+
 ## Examples
 
 ❌ Bad: this assumes that `WORKDIR` in the base image is `/`


### PR DESCRIPTION
## Description

Adds a note clarifying that `WORKDIR` does not perform shell expansion.

Paths beginning with `~` or `~username` are treated as literal directory names and are not resolved to a user's home directory.

## Related issues or tickets

Closes #25512

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review