### PR TITLE
dhi: remove outdated xrefs

### DIFF
--- a/content/manuals/dhi/how-to/policies.md
+++ b/content/manuals/dhi/how-to/policies.md
@@ -13,9 +13,9 @@ policies for your images without additional setup. Using Docker Scout policies,
 you can define and apply rules that ensure only approved and secure images, such
 as those based on DHIs, are used across your environments.
 
-Docker Scout includes a dedicated [**Valid Docker Hardened Image (DHI) or DHI
+Docker Scout includes a dedicated **Valid Docker Hardened Image (DHI) or DHI
 base
-image**](../../scout/policy/_index.md#valid-docker-hardened-image-dhi-or-dhi-base-image)
+image**
 policy type that validates whether your images are Docker Hardened Images or are
 built using a DHI as the base image. This policy checks for valid Docker signed
 verification summary attestations.
@@ -42,8 +42,8 @@ images and layers.
 ## Evaluate DHI policy compliance for your images
 
 When you enable Docker Scout for your repositories, you can configure the
-[**Valid Docker Hardened Image (DHI) or DHI base
-image**](../../scout/policy/_index.md#valid-docker-hardened-image-dhi-or-dhi-base-image)
+**Valid Docker Hardened Image (DHI) or DHI base
+image**
 policy. This optional policy validates whether your images are DHIs or built with DHI
 base images by checking for Docker signed verification summary attestations.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Removed broken anchor xref link. The linked topic now focuses on local policies as the dashboard policies are deprecated.

The workflow itself is still applicable until the scout policy dashboard is fully retired. This topic will be updated soon with a local policy workflow, once it's released.

## Related issues or tickets

https://docker.slack.com/archives/C0989V6TAK0/p1783443339779409
#25515

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
