### PR TITLE
docs: flag Dynamic MCP as experimental on MCP Catalog and Toolkit index

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/_index.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/_index.md
@@ -32,7 +32,7 @@ grid:
     icon: cpu-chip
     link: /ai/mcp-catalog-and-toolkit/mcp-gateway/
   - title: Dynamic MCP
-    description: Discover and add MCP servers on-demand using natural language
+    description: Discover and add MCP servers on-demand using natural language. This feature is experimental.
     icon: magnifying-glass
     link: /ai/mcp-catalog-and-toolkit/dynamic-mcp/
   - title: Security FAQs


### PR DESCRIPTION
## Description

The [Dynamic MCP](https://docs.docker.com/ai/mcp-catalog-and-toolkit/dynamic-mcp/) page marks the feature as experimental:

> Dynamic MCP is an experimental feature in early development. While you're welcome to try it out and explore its capabilities, you may encounter unexpected behavior or limitations.

But the MCP Catalog and Toolkit overview (`_index.md`) listed Dynamic MCP alongside stable features with no such caveat, so readers arriving from the overview could assume it is production-ready.

This adds the experimental note to the overview card description so both pages agree.

## Related issue

Fixes #25259

## Reviewer notes

Single-line docs-only change to one card description in `content/manuals/ai/mcp-catalog-and-toolkit/_index.md`. No behavior or structural changes.