### PR TITLE
scout: document curated cve list

### DIFF
--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -424,12 +424,14 @@ bootloader
 Buildkite
 crypto
 Graylog
+Heartbleed
 Kubuntu
 Libnetwork
 lockfile
 Lubuntu
 multimodal
 multithreading
+Log4Shell
 NLP
 Nodemon
 oldoldstable
@@ -437,6 +439,8 @@ parallelizable
 PHPUnit
 pnpm
 PyTorch
+Shellshock
+Spring4Shell
 superset
 tokenization
 WebGL

--- a/content/manuals/scout/policy/_index.md
+++ b/content/manuals/scout/policy/_index.md
@@ -69,9 +69,10 @@ successfully. For more information, see [No base image data](#no-base-image-data
 ### High-Profile Vulnerabilities
 
 The **High-Profile Vulnerabilities** policy type checks whether your images
-contain vulnerabilities from Docker Scout's curated list of widely recognized,
-high-impact CVEs. The list includes Log4Shell, Spring4Shell, XZ backdoor, and
-others, and is updated as new high-profile vulnerabilities are disclosed.
+contain vulnerabilities from a [curated list of widely recognized, high-impact
+CVEs](./local.md#default-high-profile-cves), including Log4Shell, Spring4Shell,
+and XZ backdoor. The list is updated as new high-profile vulnerabilities are
+disclosed.
 
 You can configure which CVEs are considered high-profile and enable tracking
 of CISA's Known Exploited Vulnerabilities catalog.

--- a/content/manuals/scout/policy/local.md
+++ b/content/manuals/scout/policy/local.md
@@ -169,7 +169,7 @@ The following table lists the configurable keys for each built-in policy.
 | `fixable-vulnerabilities` | `fixable_only` | `true` | When `true`, only vulnerabilities with a known fix count |
 | `fixable-vulnerabilities` | `package_types` | `[]` | Allowlist of PURL package types to consider; empty means all |
 | `fixable-vulnerabilities` | `grace_period_days` | `0` | Days a newly disclosed CVE is exempt |
-| `high-profile-vulnerabilities` | `cves` | [see below](#default-high-profile-cves) | CVE IDs considered high-profile |
+| `high-profile-vulnerabilities` | `cves` | [Default high-profile CVEs](#default-high-profile-cves) | CVE IDs considered high-profile |
 | `high-profile-vulnerabilities` | `ignored_cves` | `[]` | CVE IDs excluded from causing a failure |
 | `high-profile-vulnerabilities` | `include_cisa_kev` | `true` | Also flag vulnerabilities in the CISA KEV catalog |
 | `copyleft-license` | `licenses` | AGPL/GPL/LGPL/MPL/… | SPDX license IDs treated as copyleft |

--- a/content/manuals/scout/policy/local.md
+++ b/content/manuals/scout/policy/local.md
@@ -169,7 +169,7 @@ The following table lists the configurable keys for each built-in policy.
 | `fixable-vulnerabilities` | `fixable_only` | `true` | When `true`, only vulnerabilities with a known fix count |
 | `fixable-vulnerabilities` | `package_types` | `[]` | Allowlist of PURL package types to consider; empty means all |
 | `fixable-vulnerabilities` | `grace_period_days` | `0` | Days a newly disclosed CVE is exempt |
-| `high-profile-vulnerabilities` | `cves` | curated list | CVE IDs considered high-profile |
+| `high-profile-vulnerabilities` | `cves` | [see below](#default-high-profile-cves) | CVE IDs considered high-profile |
 | `high-profile-vulnerabilities` | `ignored_cves` | `[]` | CVE IDs excluded from causing a failure |
 | `high-profile-vulnerabilities` | `include_cisa_kev` | `true` | Also flag vulnerabilities in the CISA KEV catalog |
 | `copyleft-license` | `licenses` | AGPL/GPL/LGPL/MPL/… | SPDX license IDs treated as copyleft |
@@ -178,6 +178,37 @@ The following table lists the configurable keys for each built-in policy.
 | `approved-base-images` | `allowed_distros_only` | `true` | When enabled, base image must use an allowed OS distribution |
 | `approved-base-images` | `allowed_distros` | curated list | OS distributions considered allowed |
 | `supply-chain-attestations` | `required_attestations` | provenance and SBOM predicate types | Attestation predicate types that must be present |
+
+#### Default high-profile CVEs {#default-high-profile-cves}
+
+The built-in `cves` list includes the following CVEs. Docker updates this list
+as new high-profile vulnerabilities are disclosed.
+
+| CVE ID | Common name |
+| --- | --- |
+| CVE-2014-0160 | Heartbleed |
+| CVE-2014-6271 | Shellshock |
+| CVE-2021-44228 | Log4Shell |
+| CVE-2021-45046 | Log4j follow-up |
+| CVE-2022-22965 | Spring4Shell |
+| CVE-2023-38545 | curl SOCKS5 heap overflow |
+| CVE-2023-44487 | HTTP/2 Rapid Reset |
+| CVE-2024-3094 | XZ Utils backdoor |
+
+To override the list, set `cves` in your policy-config file:
+
+```json
+{
+  "policies": [
+    {
+      "name": "high-profile-vulnerabilities",
+      "config": {
+        "cves": ["CVE-2021-44228", "CVE-2024-3094"]
+      }
+    }
+  ]
+}
+```
 
 ## Write custom policies
 

--- a/content/manuals/scout/policy/local.md
+++ b/content/manuals/scout/policy/local.md
@@ -179,7 +179,7 @@ The following table lists the configurable keys for each built-in policy.
 | `approved-base-images` | `allowed_distros` | curated list | OS distributions considered allowed |
 | `supply-chain-attestations` | `required_attestations` | provenance and SBOM predicate types | Attestation predicate types that must be present |
 
-#### Default high-profile CVEs {#default-high-profile-cves}
+#### Default high-profile CVEs
 
 The built-in `cves` list includes the following CVEs. Docker updates this list
 as new high-profile vulnerabilities are disclosed.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added list of curated cves for high-profile-vulnerabilities policy.

https://deploy-preview-25521--docsdocker.netlify.app/scout/policy/local/#default-high-profile-cves

## Related issues or tickets

https://docker.slack.com/archives/C04C69EM70C/p1783522070330899

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review