### PR TITLE
docs: remove empty Azure DevOps Docker task

### DIFF
--- a/content/manuals/scout/integrations/environment/cli.md
+++ b/content/manuals/scout/integrations/environment/cli.md
@@ -98,7 +98,6 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
-          - task: Docker@2
           - script: docker run -it \
               -e DOCKER_SCOUT_HUB_USER=$DOCKER_SCOUT_HUB_USER \
               -e DOCKER_SCOUT_HUB_PASSWORD=$DOCKER_SCOUT_HUB_PASSWORD \


### PR DESCRIPTION
### Description

Removes the empty `Docker@2` step from the Azure DevOps example in the Docker Scout generic CLI integration guide. The following script already passes the documented Docker Scout credentials into the Scout CLI container, so the standalone task line has no inputs and would fail if copied as-is.

Fixes #25084.

### Validation

- `git diff --check`
- `npx markdownlint-cli content/manuals/scout/integrations/environment/cli.md`

`./scripts/lint.sh content/manuals/scout/integrations/environment/cli.md` also ran markdownlint clean, then stopped because `vale` is not installed in this local environment.