### PR TITLE
dhi: clarify dev variant naming

### DIFF
--- a/content/manuals/dhi/explore/available.md
+++ b/content/manuals/dhi/explore/available.md
@@ -62,10 +62,11 @@ with. Debian tends to offer the broadest compatibility.
 To accommodate different stages of the application lifecycle, DHI offers all
 language framework images and select application images in two variants:
 
-- Development (dev) images: Equipped with necessary development tools and
+- Development images: Equipped with necessary development tools and
 libraries, these images facilitate the building and testing of applications in a
 secure environment. They include a shell, package manager, a root user, and
-other tools needed for development.
+other tools needed for development. Depending on the image, the development
+variant may use a `-dev` or `-sdk` tag suffix.
 
 - Runtime images: Stripped of development tools, these images contain only the
 essential components needed to run applications, ensuring a minimal attack


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Address customer feedback that aspnetcore appeared to be missing a dev variant. aspnetcore is a runtime image, not a language framework, so the "all language framework images" claim is accurate. Added a note that development variants may use a `-dev` or `-sdk` tag suffix to cover the dotnet naming difference.

## Related issues or tickets

https://docker.slack.com/archives/C04M34MRQS1/p1783609888996949

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
