### PR TITLE
docs: fix Swarm secrets Compose reference link

### DIFF
--- a/content/manuals/engine/swarm/secrets.md
+++ b/content/manuals/engine/swarm/secrets.md
@@ -143,7 +143,7 @@ a similar way, see
 
 Both the `docker-compose` and `docker stack` commands support defining secrets
 in a compose file. See
-[the Compose file reference](/reference/compose-file/legacy-versions.md) for details.
+[the Compose file reference](/reference/compose-file/secrets.md) for details.
 
 ### Simple example: Get started with secrets
 


### PR DESCRIPTION
## Summary

Updates the Swarm secrets page to link to the Compose secrets reference instead of the legacy Compose file versions page.

Addresses the broken-link portion of #25491.

## Validation

- Ran `git diff --check`
