### PR TITLE
sbx: sync cli ref for 0.35.0

### DIFF
--- a/data/sbx_cli/sbx.yaml
+++ b/data/sbx_cli/sbx.yaml
@@ -18,6 +18,7 @@ see_also:
     - sbx completion - Generate the autocompletion script for the specified shell
     - sbx cp - Copy files or directories between a sandbox and the host
     - sbx create - Create a sandbox for an agent
+    - sbx daemon - Manage sandboxd daemon
     - sbx diagnose - Diagnose common issues with your sbx installation
     - sbx exec - Execute a command inside a sandbox
     - sbx kit - (Experimental) Manage kit artifacts

--- a/data/sbx_cli/sbx_daemon.yaml
+++ b/data/sbx_cli/sbx_daemon.yaml
@@ -1,0 +1,18 @@
+name: sbx daemon
+synopsis: Manage sandboxd daemon
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for daemon
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx - Manage AI coding agent sandboxes.
+    - sbx daemon log-level - Inspect or change sandboxd's per-category log levels
+    - sbx daemon start - Start the sandboxd daemon
+    - sbx daemon status - Check sandboxd daemon status
+    - sbx daemon stop - Stop the sandboxd daemon

--- a/data/sbx_cli/sbx_daemon_log-level.yaml
+++ b/data/sbx_cli/sbx_daemon_log-level.yaml
@@ -1,0 +1,16 @@
+name: sbx daemon log-level
+synopsis: Inspect or change sandboxd's per-category log levels
+usage: sbx daemon log-level [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for log-level
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx daemon - Manage sandboxd daemon
+    - 'sbx daemon log-level set - Set a category''s log level (target: proxy, general, or all)'

--- a/data/sbx_cli/sbx_daemon_log-level_set.yaml
+++ b/data/sbx_cli/sbx_daemon_log-level_set.yaml
@@ -1,0 +1,15 @@
+name: sbx daemon log-level set
+synopsis: 'Set a category''s log level (target: proxy, general, or all)'
+usage: sbx daemon log-level set <target> <level> [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for set
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx daemon log-level - Inspect or change sandboxd's per-category log levels

--- a/data/sbx_cli/sbx_daemon_start.yaml
+++ b/data/sbx_cli/sbx_daemon_start.yaml
@@ -1,0 +1,22 @@
+name: sbx daemon start
+synopsis: Start the sandboxd daemon
+usage: sbx daemon start [flags]
+options:
+    - name: detach
+      shorthand: d
+      default_value: "false"
+      usage: Run daemon in background
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for start
+    - name: policy
+      usage: |
+        Initialize the global network policy: "allow-all", "balanced", or "deny-all"
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx daemon - Manage sandboxd daemon

--- a/data/sbx_cli/sbx_daemon_status.yaml
+++ b/data/sbx_cli/sbx_daemon_status.yaml
@@ -1,0 +1,18 @@
+name: sbx daemon status
+synopsis: Check sandboxd daemon status
+usage: sbx daemon status [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for status
+    - name: json
+      default_value: "false"
+      usage: Output as JSON
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx daemon - Manage sandboxd daemon

--- a/data/sbx_cli/sbx_daemon_stop.yaml
+++ b/data/sbx_cli/sbx_daemon_stop.yaml
@@ -1,0 +1,15 @@
+name: sbx daemon stop
+synopsis: Stop the sandboxd daemon
+usage: sbx daemon stop [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for stop
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx daemon - Manage sandboxd daemon

--- a/data/sbx_cli/sbx_kit.yaml
+++ b/data/sbx_cli/sbx_kit.yaml
@@ -19,7 +19,7 @@ inherited_options:
       usage: Enable debug logging
 see_also:
     - sbx - Manage AI coding agent sandboxes.
-    - sbx kit add - Add a kit to a running sandbox
+    - sbx kit add - Add a kit to a sandbox
     - sbx kit inspect - Display details about a kit artifact
     - sbx kit pack - Package a directory as a kit artifact
     - sbx kit pull - Pull a kit artifact from an OCI registry

--- a/data/sbx_cli/sbx_kit_add.yaml
+++ b/data/sbx_cli/sbx_kit_add.yaml
@@ -1,14 +1,21 @@
 name: sbx kit add
-synopsis: Add a kit to a running sandbox
+synopsis: Add a kit to a sandbox
 experimental: true
 description: |-
-    Inject a kit artifact into an already-running sandbox.
+    Add a kit artifact to an existing sandbox.
 
-    The kit's files, init files, and startup commands are applied to the
-    running container. This allows extending a sandbox without recreating it.
+    The sandbox's container is recreated with the new kit appended to its
+    original kit list, preserving kit-owned volumes (e.g. agent session
+    state) across the swap. Workspace data is unaffected: bind-mounted
+    sandboxes keep their host-side mount; --clone sandboxes keep their
+    in-container working tree via a named workspace volume that
+    reattaches to the swap container.
 
-    The sandbox must already exist (created or running). The reference can be a local directory,
-    ZIP file path, OCI registry reference, or git repository.
+    The sandbox must already exist and must have been created with the
+    recreate-aware label set (sandboxes created before the kit-add recreate
+    feature shipped will be refused with a clear error). The reference can be
+    a local directory, ZIP file path, OCI registry reference, or git
+    repository.
 usage: sbx kit add SANDBOX REFERENCE [flags]
 options:
     - name: help

--- a/data/sbx_cli/sbx_policy.yaml
+++ b/data/sbx_cli/sbx_policy.yaml
@@ -20,9 +20,11 @@ inherited_options:
 see_also:
     - sbx - Manage AI coding agent sandboxes.
     - sbx policy allow - Add an allow rule for sandboxes
+    - sbx policy check - Check whether policy allows an access request
     - sbx policy deny - Add a deny rule for sandboxes
     - sbx policy init - Initialize the global network policy
+    - sbx policy inspect - Inspect policy or rule details
     - sbx policy log - Show sandbox policy logs
-    - sbx policy ls - List sandbox policy rules
+    - sbx policy ls - List sandbox policies
     - sbx policy reset - Reset policies to defaults
     - sbx policy rm - Remove a policy rule

--- a/data/sbx_cli/sbx_policy_check.yaml
+++ b/data/sbx_cli/sbx_policy_check.yaml
@@ -1,0 +1,21 @@
+name: sbx policy check
+synopsis: Check whether policy allows an access request
+description: |-
+    Check whether the current sandbox policy would authorize an access request.
+
+    The check is read-only and evaluates the same daemon-side policy authorizer
+    used by sandbox network enforcement.
+usage: sbx policy check COMMAND
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for check
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+see_also:
+    - sbx policy - Manage sandbox policies
+    - sbx policy check network - Check network access to a host

--- a/data/sbx_cli/sbx_policy_check_network.yaml
+++ b/data/sbx_cli/sbx_policy_check_network.yaml
@@ -1,0 +1,38 @@
+name: sbx policy check network
+synopsis: Check network access to a host
+description: |-
+    Check whether current policy allows network access to TARGET.
+
+    TARGET may be a hostname, host:port, IP literal, or URL. Bare hosts and IP
+    literals are evaluated with port 443. HTTP(S) URLs use their default ports;
+    other URL schemes must include an explicit port.
+usage: sbx policy check network [--sandbox SANDBOX] TARGET [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for network
+    - name: json
+      default_value: "false"
+      usage: Output in JSON format
+    - name: sandbox
+      usage: Evaluate in a specific sandbox policy context
+    - name: verbose
+      default_value: "false"
+      usage: Show the exact policy request fields
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+example: |4-
+      # Check global network policy
+      sbx policy check network api.example.com
+
+      # Check policy in a sandbox context
+      sbx policy check network --sandbox my-sandbox api.example.com:443
+
+      # Check a pasted URL and output JSON
+      sbx policy check network --json https://api.example.com/v1
+see_also:
+    - sbx policy check - Check whether policy allows an access request

--- a/data/sbx_cli/sbx_policy_inspect.yaml
+++ b/data/sbx_cli/sbx_policy_inspect.yaml
@@ -1,0 +1,28 @@
+name: sbx policy inspect
+synopsis: Inspect policy or rule details
+description: |-
+    Inspect full detail for a selected policy or rule.
+
+    The selector may be a policy ID, policy name, rule ID, or rule name.
+    Selecting a policy lists every resource with its decision, rule, and status;
+    selecting a rule shows just that rule. Use "sbx policy ls" to find policy
+    names and "sbx policy ls --wide" to find rule IDs and resource values.
+usage: sbx policy inspect <policy-or-rule> [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for inspect
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+example: |4-
+      # Inspect a policy by name
+      sbx policy inspect "Developer access"
+
+      # Inspect a rule by ID
+      sbx policy inspect 2d3c1f0e-4a73-4e05-bc9d-f2f9a4b50d67
+see_also:
+    - sbx policy - Manage sandbox policies

--- a/data/sbx_cli/sbx_policy_ls.yaml
+++ b/data/sbx_cli/sbx_policy_ls.yaml
@@ -1,18 +1,23 @@
 name: sbx policy ls
-synopsis: List sandbox policy rules
+synopsis: List sandbox policies
 description: |-
-    List active policy rules.
+    List active sandbox policies.
 
-    Displays the provenance, scope, rule name (or ID if no name is set), type,
-    decision (allow/deny), and the associated resources for each rule.
+    Without SANDBOX, the command shows one overview row per policy with its source,
+    where it applies, and a summary of decisions by resource type. With SANDBOX, it
+    summarizes active rules that apply to that sandbox.
+
+    Use --wide to show the detailed rule-level table with rule IDs, resources, status,
+    and rule metadata. Use --json for the filtered daemon response.
 
     When remote governance is active, inactive policy rules are hidden by default.
     Use --include-inactive to show inactive rules for troubleshooting.
-
-    When SANDBOX is specified, only policies that apply to that sandbox are shown
-    (global rules plus rules scoped to that sandbox).
+    Use "sbx policy inspect <policy-or-rule>" for full detail on a selected policy or
+    rule.
 usage: sbx policy ls [SANDBOX] [flags]
 options:
+    - name: decision
+      usage: 'Filter policies by decision: "allow" or "deny"'
     - name: help
       shorthand: h
       default_value: "false"
@@ -20,10 +25,18 @@ options:
     - name: include-inactive
       default_value: "false"
       usage: Show inactive policy rules hidden by remote governance
+    - name: json
+      default_value: "false"
+      usage: Output filtered policy rules as JSON
+    - name: source
+      usage: 'Filter policies by source: "local", "org", or "kit"'
     - name: type
       default_value: all
       usage: |
         Filter policies by type: "all", "network", or "filesystem" (default "all")
+    - name: wide
+      default_value: "false"
+      usage: Show detailed rule-level output with rule IDs and resources
 inherited_options:
     - name: debug
       shorthand: D
@@ -33,14 +46,20 @@ example: |4-
       # List all policies
       sbx policy ls
 
+      # List the policies that apply to one sandbox
+      sbx policy ls my-sandbox
+
+      # Show detailed rule-level rows with rule IDs and resources
+      sbx policy ls --wide
+
+      # Output filtered rules as JSON
+      sbx policy ls --json
+
       # List only network policies
       sbx policy ls --type network
 
-      # List only filesystem policies
-      sbx policy ls --type filesystem
-
-      # List policies that apply to a specific sandbox
-      sbx policy ls my-sandbox
+      # List organization policies that deny access
+      sbx policy ls --source org --decision deny
 
       # Include inactive rules hidden by remote governance
       sbx policy ls --include-inactive

--- a/data/sbx_cli/sbx_policy_rm_network.yaml
+++ b/data/sbx_cli/sbx_policy_rm_network.yaml
@@ -6,7 +6,8 @@ description: |-
     The rule is removed from the global policy by default. Use --sandbox to
     remove from policy "local" scoped to a single sandbox instead.
 
-    Use "sbx policy ls" to see active policies and their IDs/resources.
+    Use "sbx policy ls --wide" to see active rule IDs and resources, or
+    "sbx policy ls --json" for the raw filtered daemon response.
 usage: sbx policy rm network [--sandbox SANDBOX] [flags]
 options:
     - name: help
@@ -26,8 +27,8 @@ inherited_options:
       default_value: "false"
       usage: Enable debug logging
 example: |4-
-      # List policies to find the ID or resource to remove
-      sbx policy ls
+      # List rules to find the ID or resource to remove
+      sbx policy ls --wide
 
       # Remove a global rule by resource
       sbx policy rm network --resource api.example.com

--- a/data/sbx_cli/sbx_reset.yaml
+++ b/data/sbx_cli/sbx_reset.yaml
@@ -9,6 +9,7 @@ description: |-
     - Clear all internal registries
     - Delete all sandbox state
     - Remove all policies
+    - Clear the Gordon assistant's sessions and history
     - Delete all stored secrets
     - Sign out of Docker Sandboxes
     - Stop the daemon

--- a/data/sbx_cli/sbx_rm.yaml
+++ b/data/sbx_cli/sbx_rm.yaml
@@ -7,7 +7,8 @@ description: |-
     worktrees, and deletes sandbox state. This action cannot be undone.
 
     Removal requires confirmation; use --force to skip confirmation prompts
-    (for non-interactive scripts). Use --all to remove every sandbox.
+    (for non-interactive scripts) and to delete a sandbox that is in use
+    (e.g. an open SSH connection). Use --all to remove every sandbox.
 usage: sbx rm [SANDBOX...] [flags]
 options:
     - name: all
@@ -16,7 +17,8 @@ options:
     - name: force
       shorthand: f
       default_value: "false"
-      usage: Skip confirmation prompts
+      usage: |
+        Skip confirmation prompts and delete even if in use (e.g. an open SSH connection)
     - name: help
       shorthand: h
       default_value: "false"

--- a/data/sbx_cli/sbx_secret.yaml
+++ b/data/sbx_cli/sbx_secret.yaml
@@ -11,7 +11,8 @@ description: |-
     REGISTRY SECRETS (e.g. "ghcr.io", "myregistry.azurecr.io")
       Used to pull private template images and kit artifacts before sandbox
       creation. Host-only secrets (no -g) are not injected into sandboxes;
-      global secrets (-g) are written as ~/.docker/config.json in every new sandbox.
+      global secrets (-g) are injected by the proxy into the registry login of
+      every new sandbox (the credential never enters the sandbox filesystem).
       Use "sbx secret set --registry <host> --password-stdin" to store them.
 options:
     - name: help
@@ -25,6 +26,7 @@ inherited_options:
       usage: Enable debug logging
 see_also:
     - sbx - Manage AI coding agent sandboxes.
+    - sbx secret import - Import secrets detected in host environment variables
     - sbx secret ls - List stored secrets
     - sbx secret rm - Remove a secret
     - sbx secret set - Create or update a secret

--- a/data/sbx_cli/sbx_secret_import.yaml
+++ b/data/sbx_cli/sbx_secret_import.yaml
@@ -1,0 +1,62 @@
+name: sbx secret import
+synopsis: Import secrets detected in host environment variables
+description: |-
+    Import secrets that sbx detects in your host environment
+    variables (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, GH_TOKEN) into the
+    global keychain. Once imported, the secret is available to every
+    sandbox without needing the env var on each shell.
+
+    Each detected env var is offered interactively with a Y/n prompt and a
+    last-4-char preview of the value. Existing stored entries are never
+    overwritten silently:
+
+      - Interactive mode prompts for confirmation before overwriting.
+      - --all imports new entries without prompting but SKIPS overwrites
+        (use --force when you actually want to replace stored values).
+      - --force imports unconditionally, including overwriting.
+
+    Services that already have an OAuth token configured (e.g. anthropic
+    after `sbx run claude … -- auth login`) are skipped: the OAuth token
+    takes precedence at runtime so any api-key import would never be used.
+    Run `sbx secret rm -g <service>` first if you want to switch from
+    OAuth to api-key auth.
+
+    Available services: anthropic, cursor, droid, github, google, groq, mistral, nebius, openai, openrouter, xai
+usage: sbx secret import [SERVICE] [flags]
+options:
+    - name: all
+      default_value: "false"
+      usage: Import every detected env var without prompting
+    - name: dry-run
+      default_value: "false"
+      usage: Show what would be imported without writing
+    - name: force
+      shorthand: f
+      default_value: "false"
+      usage: Overwrite an existing stored entry without confirmation
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for import
+inherited_options:
+    - name: debug
+      shorthand: D
+      default_value: "false"
+      usage: Enable debug logging
+example: |4-
+      # Walk every detected env var, prompting before each import
+      sbx secret import
+
+      # Import only the openai service (uses OPENAI_API_KEY)
+      sbx secret import openai
+
+      # Non-interactive: import everything detected without prompting
+      sbx secret import --all
+
+      # Overwrite an existing stored entry without confirmation
+      sbx secret import openai --force
+
+      # Preview what would be imported without writing
+      sbx secret import --dry-run
+see_also:
+    - sbx secret - Manage stored secrets

--- a/data/sbx_cli/sbx_secret_set.yaml
+++ b/data/sbx_cli/sbx_secret_set.yaml
@@ -3,15 +3,19 @@ synopsis: Create or update a secret
 description: |-
     Create or update a secret for a service or registry.
 
-    Available services: anthropic, aws, cursor, droid, github, google, groq, mistral, nebius, openai, openrouter, xai
+    Available services: anthropic, cursor, droid, github, google, groq, mistral, nebius, openai, openrouter, xai
 
     When no arguments are provided, an interactive prompt guides you through
     scope and service selection.
 
-    Use --registry to store pull credentials for a container registry:
-      Without -g: host-only — used for template/kit pulls, not injected into sandboxes.
-      With -g:    global   — host pulls AND written as ~/.docker/config.json in every new sandbox.
-      With SANDBOX as the first argument: scoped to that specific sandbox only.
+    Use --registry to store pull credentials for a container registry. Where the
+    credential applies depends on the scope:
+      - Default (no -g): host-only. Used for template and kit pulls on the host;
+        never injected into a sandbox.
+      - With -g: global. Used for host pulls, and injected by the proxy into the
+        registry login of every new sandbox. The credential itself never enters
+        the sandbox.
+      - With a SANDBOX argument: injected into that one sandbox only.
 usage: sbx secret set [-g | SANDBOX] [SERVICE] [flags]
 options:
     - name: force

--- a/data/sbx_cli/sbx_setup.yaml
+++ b/data/sbx_cli/sbx_setup.yaml
@@ -9,6 +9,7 @@ description: |-
     env vars set on this host, and accepted secrets are imported into the global
     secrets store (the same store as "sbx secret set -g").
 
+      [g]      Get help with Gordon using the detected setup context
       [T]      toggle the detailed review table on/off
       ↑/↓      move between rows
       TAB      toggle import / skip for the selected row


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Syncs all CLI reference YAML files in `data/sbx_cli/` from
`docker/sandboxes` at the v0.35.0 tag.

### New commands

| Command | Notes |
|---------|-------|
| `sbx daemon start/stop/status/log-level` | Manage the sandbox daemon directly |
| `sbx policy check network` | Test whether the current policy would allow a request |
| `sbx policy inspect` | Inspect a single policy or rule (replaces `sbx policy show`) |
| `sbx secret import` | Import credential env vars into the keychain |

### Updated commands

| Command | What changed |
|---------|--------------|
| `sbx rm` | New `--force` flag for active sessions |
| `sbx policy ls` | New `--wide`, `--source`, `--decision` filters; updated output format |
| `sbx policy` | Updated `see_also` to list new subcommands |
| `sbx secret` | Updated `see_also` to list `import` subcommand |
| `sbx kit add` | Synopsis and description reflect swap-recreate behavior |

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review