### PR TITLE
sbx:  document sbx rm --force requirement for active sessions

### DIFF
--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -186,7 +186,7 @@ agents, open shells, and manage network rules from one place. See
 
 By default, the agent edits your working tree directly. To give the agent an
 isolated copy of your repository, use `--clone`. Because `--clone` is a
-create-time flag, remove the existing sandbox first:
+create-time flag, stop and remove the existing sandbox first:
 
 ```console
 $ sbx stop my-sandbox

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -189,6 +189,7 @@ isolated copy of your repository, use `--clone`. Because `--clone` is a
 create-time flag, remove the existing sandbox first:
 
 ```console
+$ sbx stop my-sandbox
 $ sbx rm my-sandbox
 $ sbx run --clone --name my-sandbox claude
 ```
@@ -262,6 +263,12 @@ space:
 
 ```console
 $ sbx rm my-sandbox
+```
+
+If the sandbox has an active session, pass `--force`:
+
+```console
+$ sbx rm --force my-sandbox
 ```
 
 Removing a sandbox deletes everything inside it — installed packages, Docker

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -19,8 +19,8 @@ $ sbx stop my-sandbox               # pause it
 $ sbx rm my-sandbox                 # delete it entirely
 ```
 
-If the sandbox has an active session (an open attach, SSH connection, or
-in-flight SFTP transfer), `sbx rm` refuses unless you pass `--force`:
+If the sandbox has an active session — an open attach, SSH connection, or
+in-flight SFTP transfer — `sbx rm` refuses unless you pass `--force`:
 
 ```console
 $ sbx rm --force my-sandbox

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -19,6 +19,13 @@ $ sbx stop my-sandbox               # pause it
 $ sbx rm my-sandbox                 # delete it entirely
 ```
 
+If the sandbox has an active session (an open attach, SSH connection, or
+in-flight SFTP transfer), `sbx rm` refuses unless you pass `--force`:
+
+```console
+$ sbx rm --force my-sandbox
+```
+
 To get a shell inside a running sandbox — useful for inspecting the environment,
 checking Docker containers, or manually installing something:
 
@@ -29,6 +36,7 @@ $ sbx exec -it <sandbox-name> bash
 If you need a clean slate, remove the sandbox and re-run:
 
 ```console
+$ sbx stop my-sandbox
 $ sbx rm my-sandbox
 $ sbx run claude
 ```


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

As of v0.35.0, `sbx rm` refuses to delete a sandbox that has an active
session (an open attach, SSH connection, or in-flight SFTP transfer) unless
`--force` is passed:

sandbox 'x' is in use (e.g. an open SSH connection); close it or re-run with --force

Updates two files:

- **`usage.md`** — adds a `--force` note after the basic workflow example;
  updates the "clean slate" snippet to `sbx stop` first so the session is
  cleanly closed before `sbx rm`
- **`get-started.md`** — updates the clone-mode setup snippet to `sbx stop`
  first; adds a `--force` note in the Clean up section

Release notes: https://github.com/docker/sandboxes/releases/tag/v0.35.0
> `sbx rm` now won't delete an active session unless `--force` is passed.

Upstream change: docker/sandboxes#4035

## Related issues or tickets

#25532: cli ref update

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review