### PR TITLE
sbx: document SOCKS5 upstream proxy and DOCKER_SANDBOXES_NO_PROXY

### DIFF
--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -68,15 +68,24 @@ and sets the upstream proxy for both HTTP and HTTPS to that URL. Unlike
 `HTTP_PROXY` and `HTTPS_PROXY`, it doesn't affect image pulls or the daemon's
 own requests.
 
+`DOCKER_SANDBOXES_PROXY` accepts `http://`, `https://`, `socks5://`, and
+`socks5h://` URLs. With `socks5://`, DNS is resolved locally before the
+connection is handed to the proxy. With `socks5h://`, DNS resolution is
+delegated to the proxy. Both schemes support credentials in the URL:
+`socks5://user:pass@host:port`.
+
+Set `DOCKER_SANDBOXES_NO_PROXY` to exclude specific destinations from
+`DOCKER_SANDBOXES_PROXY`, using standard comma-separated `NO_PROXY` matching
+semantics. This only affects traffic routed through `DOCKER_SANDBOXES_PROXY`
+— use `NO_PROXY` to exclude destinations from `HTTP_PROXY`/`HTTPS_PROXY`.
+
 Set these variables in the environment where the sandbox daemon starts. The
 daemon starts automatically the first time a command needs it, so set the
 variables before you run a `sbx` command. If the daemon is already running,
 restart it for a change to take effect.
 
-Two limitations apply:
+One limitation applies:
 
-- Only HTTP and HTTPS traffic can be forwarded to an upstream proxy. Other TCP
-  traffic can't be redirected to a proxy.
 - Proxy auto-configuration files, such as `proxy.pac`, aren't supported. Set the
   `HTTP_PROXY`, `HTTPS_PROXY`, or `DOCKER_SANDBOXES_PROXY` environment variables
   explicitly.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

v0.35.0 adds SOCKS5 upstream proxy support and a companion exclusion variable.

Release notes: https://github.com/docker/sandboxes/releases/tag/v0.35.0
> The sandbox proxy can chain upstream egress through a SOCKS5 proxy
> (`socks5://` / `socks5h://`, with optional auth) via `DOCKER_SANDBOXES_PROXY`.
> Add `DOCKER_SANDBOXES_NO_PROXY` to exclude destinations from
> `DOCKER_SANDBOXES_PROXY`.

Upstream changes: docker/sandboxes#4041 (SOCKS5 transport),
docker/sandboxes#4056 (DOCKER_SANDBOXES_NO_PROXY)

Updates the "Upstream proxy" section of `architecture.md`:

- Documents `socks5://` and `socks5h://` scheme support, including the
  DNS resolution distinction between the two
- Documents credential embedding in the URL (`socks5://user:pass@host:port`)
- Adds `DOCKER_SANDBOXES_NO_PROXY` with a note clarifying it applies only
  to `DOCKER_SANDBOXES_PROXY` traffic, not `HTTP_PROXY`/`HTTPS_PROXY`
- Removes the "only HTTP and HTTPS traffic can be forwarded" limitation
  bullet, which is no longer accurate with SOCKS5

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review