### PR TITLE
sbx: virtiofs caching is now enabled by default on all platforms

### DIFF
--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -38,6 +38,12 @@ share images or layers.
 Each sandbox consumes disk space for its VM image, Docker images, container
 layers, and volumes, and this grows as you build images and install packages.
 
+Virtiofs caching is enabled by default on all operating systems. File reads
+from the sandbox VM are cached on the host side, reducing round-trips through
+the filesystem passthrough and improving performance for read-heavy workloads
+such as `git status` or directory scans. To opt out, set
+`DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0` before the daemon starts.
+
 ## Networking
 
 All outbound traffic from the sandbox routes through an HTTP/HTTPS proxy on

--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -42,7 +42,11 @@ Virtiofs caching is enabled by default on all operating systems. File reads
 from the sandbox VM are cached on the host side, reducing round-trips through
 the filesystem passthrough and improving performance for read-heavy workloads
 such as `git status` or directory scans. To opt out, set
-`DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0` before the daemon starts.
+`DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0` when creating the sandbox:
+
+```console
+$ DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0 sbx run <template>
+```
 
 ## Networking
 

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -192,16 +192,9 @@ default for workspaces without `--clone`). Virtiofs caching speeds up these
 workloads. Clone-mode sandboxes always enable it, so this tuning applies only
 to direct mode.
 
-On macOS and Linux, virtiofs caching is enabled by default. On Windows it's
-still opt-in — enable it when creating the sandbox:
-
-```console
-$ DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=1 sbx run <template>
-```
-
-The setting is persisted in the sandbox spec and applies for the lifetime of
-that sandbox. If you experience Git index corruption or unexpected file content,
-disable caching with the kill switch and recreate the sandbox:
+Virtiofs caching is enabled by default on all operating systems. If you
+experience Git index corruption or unexpected file content, disable caching
+with the kill switch and recreate the sandbox:
 
 ```console
 $ DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0 sbx run <template>


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

As of v0.35.0, virtiofs caching is enabled by default on all operating systems.
Previously it was opt-in on Windows.

Release notes: https://github.com/docker/sandboxes/releases/tag/v0.35.0
> Enable virtiofs caching by default on all operating systems for faster
> filesystem performance (`DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0` to opt out).

Upstream change: docker/sandboxes#3882

### `architecture.md`

Adds a note in the "Storage and persistence" section that virtiofs caching
is on by default everywhere, with a brief description of what it does and
the `=0` opt-out.

### `troubleshooting.md`

Removes the platform distinction and the Windows `=1` opt-in example from the
"Filesystem operations are slow" section. Keeps the `=0` kill switch and the
Git index corruption note.
## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review