### PR TITLE
docs: align sponsored open source terminology

### DIFF
--- a/content/manuals/docker-hub/image-library/_index.md
+++ b/content/manuals/docker-hub/image-library/_index.md
@@ -15,8 +15,9 @@ In this section, learn about:
 
 - [Search](./search.md): Discover how to browse and search Docker Hub's extensive resources.
 - [Trusted content](./trusted-content.md): Dive into Docker Hardened Images,
-  Docker Official Images, Verified Publisher content, and Sponsored Open Source
-  images, all vetted for security and reliability to streamline your workflows.
+  Docker Official Images, Verified Publisher content, and Docker-Sponsored Open
+  Source Software images, all vetted for security and reliability to streamline
+  your workflows.
 - [Catalogs](./catalogs.md): Explore specialized collections like the generative AI catalogs.
 - [Mirroring](./mirror.md): Learn how to create a mirror of Docker Hub's
   container image library as a pull-through cache.


### PR DESCRIPTION
## Description

Align the content-library index with the trusted-content page by using the full Docker-Sponsored Open Source Software image name.

Fixes #25543.

## Validation

- `git diff --check`
- Focused markdownlint via `scripts/lint.sh content/manuals/docker-hub/image-library/_index.md`

Local Vale and the prescribed Prettier plugin are unavailable in this checkout; CI will run both.