### PR TITLE
docs(sandboxes): note Cursor and Droid support OAuth login

### DIFF
--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -363,8 +363,10 @@ $ sbx secret rm my-sandbox --registry ghcr.io -f
   a credential, the agent prompts you to authenticate — Codex prompts on the
   host from `sbx run codex`, while Claude Code, Cursor, and Droid prompt
   interactively inside the sandbox. To authenticate ahead of time, run
-  `sbx secret set -g openai --oauth` for Codex, or use `/login` inside Claude
-  Code. See the individual [agent pages](../agents/) for each agent's flow.
+  `sbx secret set -g openai --oauth` for Codex or use `/login` inside Claude
+  Code; Cursor and Droid have no ahead-of-time option, so their sign-in prompt
+  appears when the agent starts. See the individual [agent pages](../agents/)
+  for each agent's flow.
 - If you store credentials in 1Password, see
   [Sourcing credentials from 1Password](../workflows.md#sourcing-credentials-from-1password)
   for how to use `op read` and `op run` with `sbx`.

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -28,7 +28,7 @@ value for the same service, the stored secret takes precedence.
 | --------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | [Stored secrets](#stored-secrets) (`sbx secret set`)                        | A value in your OS keychain, keyed by service                | The default for any built-in or kit-declared service                                                             |
 | [Custom secrets](#custom-secrets) (`sbx secret set-custom`)                 | A value keyed to a domain and environment variable           | The service model doesn't fit — the agent validates the variable's format, or the secret rides in a request body |
-| OAuth                                                                       | A host-side sign-in flow; the token never enters the sandbox | The agent supports it, such as Claude Code, Codex, or Cursor                                                     |
+| OAuth                                                                       | A host-side sign-in flow; the token never enters the sandbox | The agent supports it, such as Claude Code, Codex, Cursor, or Droid                                              |
 | [Registry credentials](#registry-credentials) (`sbx secret set --registry`) | Authentication for pulling images and kits                   | Pulling templates or kits from a private registry                                                                |
 
 For multi-provider agents (OpenCode, Docker Agent), the proxy selects
@@ -358,13 +358,13 @@ $ sbx secret rm my-sandbox --registry ghcr.io -f
   proxy-injected service credentials, which never enter the sandbox. Reserve
   them for sandboxes that need registry access, and prefer sandbox scope over
   global (`-g`) to limit exposure.
-- For Claude Code and Codex, OAuth is another secure option: the flow runs on
-  the host, so the token is never exposed inside the sandbox. If you haven't
-  stored a credential, both agents prompt you to authenticate before the
-  sandbox launches — Codex prompts on the host from `sbx run codex`, and Claude
-  Code prompts inside the agent. To authenticate ahead of time, run
+- Several agents support OAuth as another secure option: the flow runs on the
+  host, so the token is never exposed inside the sandbox. If you haven't stored
+  a credential, the agent prompts you to authenticate — Codex prompts on the
+  host from `sbx run codex`, while Claude Code, Cursor, and Droid prompt
+  interactively inside the sandbox. To authenticate ahead of time, run
   `sbx secret set -g openai --oauth` for Codex, or use `/login` inside Claude
-  Code.
+  Code. See the individual [agent pages](../agents/) for each agent's flow.
 - If you store credentials in 1Password, see
   [Sourcing credentials from 1Password](../workflows.md#sourcing-credentials-from-1password)
   for how to use `op read` and `op run` with `sbx`.


### PR DESCRIPTION
## What

The Docker Sandboxes credentials page framed agent OAuth login as exclusive to Claude Code, Codex, and Cursor. Cursor and Droid also support the host-side OAuth flow (Droid via [docker/sandboxes#4046](https://github.com/docker/sandboxes/pull/4046), Cursor earlier), so two enumerations were stale:

- The credential-forms table listed only "Claude Code, Codex, or Cursor" — Droid missing.
- The best-practices note framed OAuth as "For Claude Code and Codex" — both Cursor and Droid missing.

## Changes

`content/manuals/ai/sandboxes/security/credentials.md`:

- Add Droid to the OAuth row of the credential-forms table.
- Rewrite the best-practices OAuth bullet to cover all four agents, distinguish the host-prompt (Codex) from the in-sandbox prompt (Claude Code, Cursor, Droid), and point to the individual agent pages for each flow.

No change to the individual agent pages — each already documents its own OAuth behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)