### PR TITLE
dhi: add hsp package index

### DIFF
--- a/content/manuals/dhi/how-to/hardened-packages.md
+++ b/content/manuals/dhi/how-to/hardened-packages.md
@@ -24,8 +24,8 @@ Access to hardened packages varies by subscription:
 To browse the packages currently available in Docker's public hardened package
 repositories, see the following package indexes:
 
-- [Debian (`dhi-deb`) package index](https://dhi.io/deb/debian/main/index.html)
-- [Alpine (`dhi-apk`) package index](https://dhi.io/apk/alpine/v3.24/main/index.html)
+- [Debian package index](https://dhi.io/deb/debian/main/index.html)
+- [Alpine package index](https://dhi.io/apk/alpine/v3.24/main/index.html)
 
 Docker is constantly adding new hardened packages. If a package you need isn't
 available yet, you can [request it in the DHI catalog

--- a/content/manuals/dhi/how-to/hardened-packages.md
+++ b/content/manuals/dhi/how-to/hardened-packages.md
@@ -22,7 +22,7 @@ Access to hardened packages varies by subscription:
   to compliance and security-patched packages.
 
 To browse the packages currently available in Docker's public hardened package
-repositories, see the following package indexes:
+repositories, see the following indexes:
 
 - [Debian package index](https://dhi.io/deb/debian/main/index.html)
 - [Alpine package index](https://dhi.io/apk/alpine/v3.24/main/index.html)

--- a/content/manuals/dhi/how-to/hardened-packages.md
+++ b/content/manuals/dhi/how-to/hardened-packages.md
@@ -21,6 +21,16 @@ Access to hardened packages varies by subscription:
   the enterprise package repository directly in your own images for full access
   to compliance and security-patched packages.
 
+To browse the packages currently available in Docker's public hardened package
+repositories, see the following package indexes:
+
+- [Debian (`dhi-deb`) package index](https://dhi.io/deb/debian/main/index.html)
+- [Alpine (`dhi-apk`) package index](https://dhi.io/apk/alpine/v3.24/main/index.html)
+
+Docker is constantly adding new hardened packages. If a package you need isn't
+available yet, you can [request it in the DHI catalog
+repository](https://github.com/docker-hardened-images/catalog/issues).
+
 ## Built-in packages
 
 Supported distributions of Docker Hardened Images (DHI) automatically include

--- a/content/manuals/dhi/resources.md
+++ b/content/manuals/dhi/resources.md
@@ -61,6 +61,10 @@ organization:
   personalized demo and information about DHI Select and Enterprise subscriptions
 - [Request an image](https://github.com/docker-hardened-images/catalog/issues):
   Submit a request for a specific Docker Hardened Image
+- [Debian (`dhi-deb`) package index](https://dhi.io/deb/debian/main/index.html):
+  Browse hardened Debian packages in Docker's public repository
+- [Alpine (`dhi-apk`) package index](https://dhi.io/apk/alpine/v3.24/main/index.html):
+  Browse hardened Alpine packages in Docker's public repository
 - <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_cs_dhi_resources" class="link" rel="noopener">Contact Sales</a>: Connect with
   Docker sales team for enterprise inquiries
 - [Docker Support](https://www.docker.com/support/): Access support resources

--- a/content/manuals/dhi/resources.md
+++ b/content/manuals/dhi/resources.md
@@ -61,9 +61,9 @@ organization:
   personalized demo and information about DHI Select and Enterprise subscriptions
 - [Request an image](https://github.com/docker-hardened-images/catalog/issues):
   Submit a request for a specific Docker Hardened Image
-- [Debian (`dhi-deb`) package index](https://dhi.io/deb/debian/main/index.html):
+- [Debian package index](https://dhi.io/deb/debian/main/index.html):
   Browse hardened Debian packages in Docker's public repository
-- [Alpine (`dhi-apk`) package index](https://dhi.io/apk/alpine/v3.24/main/index.html):
+- [Alpine package index](https://dhi.io/apk/alpine/v3.24/main/index.html):
   Browse hardened Alpine packages in Docker's public repository
 - <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_cs_dhi_resources" class="link" rel="noopener">Contact Sales</a>: Connect with
   Docker sales team for enterprise inquiries


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added links to the public Docker Hardened Images (DHI) package indexes on the **Use Hardened System Packages** page and the **Additional resources** page.

## Related issues or tickets

ENGDOCS-3342

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
- [ ] Product review