### PR TITLE
Adds --name to Redis container in restart example

### DIFF
--- a/content/manuals/engine/containers/start-containers-automatically.md
+++ b/content/manuals/engine/containers/start-containers-automatically.md
@@ -37,7 +37,7 @@ The following command starts a Redis container and configures it to always
 restart, unless the container is explicitly stopped, or the daemon restarts.
 
 ```console
-$ docker run -d --restart unless-stopped redis
+$ docker run -d --name redis --restart unless-stopped redis
 ```
 
 The following command changes the restart policy for an already running


### PR DESCRIPTION
## Description

This PR fixes a bug in the sequential code examples for Docker restart policies. 

### The Problem
The current documentation lists the following two steps sequentially:
1. `docker run -d --restart unless-stopped redis`
2. `docker update --restart unless-stopped redis`

Step 2 assumes the container name is `redis`. However, because Step 1 does not explicitly define a `--name`, Docker assigns a randomly generated name, causing Step 2 to fail with the following error:

```
Error response from daemon: No such container: redis
```

### The Solution
Added the `--name redis` flag to the initial `docker run` command so that the subsequent `docker update` command works seamlessly as written.

```bash
docker run -d --name redis --restart unless-stopped redis
```