### PR TITLE
sbx: local mcp gateway and mcp governance

### DIFF
--- a/content/manuals/admin/organization/manage/manage-licenses.md
+++ b/content/manuals/admin/organization/manage/manage-licenses.md
@@ -44,5 +44,5 @@ See these docs to explore Docker Core add-ons, or products that need licenses:
 
 - [Docker plans](/manuals/subscription/plans/_index.md) to learn about different add-ons
 - [Manage seats](/manuals/admin/organization/manage/manage-seats.md) to add more seats to your Docker Core subscription
-- [AI Governance](/manuals/ai/sandboxes/governance/access-controls/organization.md) to set up organization policies for your organization members
+- [AI Governance plan](/manuals/subscription/plans/ai-governance.md) to learn about AI Governance license usage and billing
 - [Docker Offload](/manuals/offload/about.md) to let your developers offload building and running containers to the cloud

--- a/content/manuals/admin/organization/manage/manage-licenses.md
+++ b/content/manuals/admin/organization/manage/manage-licenses.md
@@ -44,5 +44,5 @@ See these docs to explore Docker Core add-ons, or products that need licenses:
 
 - [Docker plans](/manuals/subscription/plans/_index.md) to learn about different add-ons
 - [Manage seats](/manuals/admin/organization/manage/manage-seats.md) to add more seats to your Docker Core subscription
-- [AI Governance](/manuals/ai/sandboxes/governance/org.md) to set up organization policies for your organization members
+- [AI Governance](/manuals/ai/sandboxes/governance/access-controls/organization.md) to set up organization policies for your organization members
 - [Docker Offload](/manuals/offload/about.md) to let your developers offload building and running containers to the cloud

--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -18,9 +18,9 @@ system.
 > [organization governance](governance/) requires a separate paid subscription.
 
 Organization admins can
-[centrally manage sandbox network and filesystem policies](governance/org.md),
-so the same rules apply uniformly across every developer's machine. Available
-on a separate paid subscription.
+[centrally manage sandbox network and filesystem policies](governance/access-controls/organization.md)
+from the Docker Admin Console, so the same rules apply uniformly across every
+developer's machine. Available on a separate paid subscription.
 
 ## Get started
 

--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -18,9 +18,9 @@ system.
 > [organization governance](governance/) requires a separate paid subscription.
 
 Organization admins can
-[centrally manage sandbox network, filesystem, and MCP policies](governance/access-controls/organization.md)
-from the Docker Admin Console, so the same rules apply uniformly across every
-developer's machine. Available on a separate paid subscription.
+[centrally manage sandbox network, filesystem, and MCP policies](governance/access-controls/organization.md),
+so the same controls apply uniformly across every developer's machine.
+Available on a separate paid subscription.
 
 ## Get started
 

--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -18,7 +18,7 @@ system.
 > [organization governance](governance/) requires a separate paid subscription.
 
 Organization admins can
-[centrally manage sandbox network and filesystem policies](governance/access-controls/organization.md)
+[centrally manage sandbox network, filesystem, and MCP policies](governance/access-controls/organization.md)
 from the Docker Admin Console, so the same rules apply uniformly across every
 developer's machine. Available on a separate paid subscription.
 
@@ -75,6 +75,8 @@ the [usage guide](usage.md) for basic commands.
 - [Agents](agents/) — supported agents and per-agent configuration
 - [Integrations](integrations/) — connect editors and apps like VS Code and
   Cursor to a sandbox over SSH
+- [MCP gateway](mcp-gateway.md) — register MCP servers and connect them to
+  sandboxed agents
 - [Customize](customize/) — reusable templates and declarative kits for
   extending or tailoring sandboxes
 - [Architecture](architecture.md) — microVM isolation, workspace mounting,

--- a/content/manuals/ai/sandboxes/agents/_index.md
+++ b/content/manuals/ai/sandboxes/agents/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Supported agents
 linkTitle: Agents
-weight: 30
+weight: 50
 description: AI coding agents supported by Docker Sandboxes.
 keywords: docker sandboxes, ai agents, claude code, codex, cursor, gemini
 ---

--- a/content/manuals/ai/sandboxes/agents/_index.md
+++ b/content/manuals/ai/sandboxes/agents/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Supported agents
 linkTitle: Agents
-weight: 50
+weight: 40
 description: AI coding agents supported by Docker Sandboxes.
 keywords: docker sandboxes, ai agents, claude code, codex, cursor, gemini
 ---

--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-weight: 40
+weight: 70
 description: Technical architecture of Docker Sandboxes; workspace mounting, storage, networking, and sandbox lifecycle.
 keywords: docker sandboxes, architecture, microVM, workspace mounting, sandbox lifecycle
 ---

--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -102,6 +102,22 @@ One limitation applies:
   `HTTP_PROXY`, `HTTPS_PROXY`, or `DOCKER_SANDBOXES_PROXY` environment variables
   explicitly.
 
+## MCP gateway
+
+Supported agents connect to a single MCP gateway endpoint for the sandbox. The
+gateway runs on the host side of the sandbox boundary and brokers access to
+registered MCP servers.
+
+Registered MCP servers can be remote endpoints, or they can be local stdio
+servers launched on the host. Local stdio servers don't run inside the sandbox
+VM. If a local stdio server is packaged as an OCI image, or if you register an
+explicit `docker` command, it uses Docker on the host.
+
+When MCP policies apply, enforcement happens on the MCP gateway path, separate
+from the HTTP/HTTPS network proxy. Server registration is checked before the
+server is stored, and governed MCP requests are checked by the gateway before
+tool calls, resource reads, prompt retrieval, or gateway meta-tool execution.
+
 ## Lifecycle
 
 `sbx run` initializes a VM with a workspace for a specified agent and starts

--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -54,7 +54,7 @@ $ DOCKER_SANDBOXES_ENABLE_VIRTIOFS_CACHE=0 sbx run <template>
 
 All outbound traffic from the sandbox routes through an HTTP/HTTPS proxy on
 your host. Agents are configured to use the proxy automatically. The proxy
-enforces [network access policies](governance/) and handles
+enforces [network access policies](governance/access-controls/network.md) and handles
 [credential injection](security/credentials.md). See
 [Network isolation](security/isolation.md#network-isolation) for how this
 works and [Default security posture](security/defaults.md) for what is

--- a/content/manuals/ai/sandboxes/customize/_index.md
+++ b/content/manuals/ai/sandboxes/customize/_index.md
@@ -3,7 +3,7 @@ title: Customizing sandboxes
 linkTitle: Customize
 description: Build reusable sandbox images, extend agents with tools and credentials, and define custom agents using templates and kits.
 keywords: sandboxes, sbx, customize, templates, kits, mixins, custom agents
-weight: 35
+weight: 60
 aliases:
   - /ai/sandboxes/agents/custom-environments/
 params:

--- a/content/manuals/ai/sandboxes/customize/kit-examples.md
+++ b/content/manuals/ai/sandboxes/customize/kit-examples.md
@@ -77,7 +77,7 @@ Install steps run under `sh`, not bash, so bash-only builtins such as
 (`curl … | bash`) or wrap the step in `bash -c '…'` when you need them.
 
 Downloads are subject to the sandbox's
-[deny-by-default network policy](../governance/access-controls/local.md). A domain that
+[network access rules](../governance/access-controls/network.md). A domain that
 resolves from your host can still be blocked inside the sandbox — for
 example, `get.sdkman.io` returns a 403 until you allow it with
 `sbx policy allow network get.sdkman.io`. A tool may also need base

--- a/content/manuals/ai/sandboxes/customize/kit-examples.md
+++ b/content/manuals/ai/sandboxes/customize/kit-examples.md
@@ -77,7 +77,7 @@ Install steps run under `sh`, not bash, so bash-only builtins such as
 (`curl … | bash`) or wrap the step in `bash -c '…'` when you need them.
 
 Downloads are subject to the sandbox's
-[deny-by-default network policy](../governance/local.md). A domain that
+[deny-by-default network policy](../governance/access-controls/local.md). A domain that
 resolves from your host can still be blocked inside the sandbox — for
 example, `get.sdkman.io` returns a 403 until you allow it with
 `sbx policy allow network get.sdkman.io`. A tool may also need base

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -40,10 +40,10 @@ Your Docker account email is only used for authentication, not marketing.
 
 ## Can I enforce sandbox policies across my organization?
 
-Yes. Admins can centrally manage network, filesystem, and MCP policies from
-the Docker Admin Console. Rules defined there apply to every sandbox in the
-organization. When organization governance is active, it replaces local rules
-set with `sbx policy` — local rules are no longer evaluated.
+Yes. Admins can centrally manage network, filesystem, and MCP policies. These
+controls apply to every sandbox in the organization. When organization
+governance is active, it replaces local rules set with `sbx policy` — local
+rules are no longer evaluated.
 
 See [Organization policies](governance/access-controls/organization.md). This
 feature requires a separate paid subscription —

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-weight: 70
+weight: 110
 description: Frequently asked questions about Docker Sandboxes.
 keywords: docker sandboxes, sbx, faq, sign in, telemetry, clipboard, image paste, pricing, commercial use, allowlist, firewall, domains, proxy
 ---

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -12,7 +12,8 @@ professional work, with no per-seat fee. Install it, sign in with a free
 Docker account, and run sandboxes at no cost.
 
 The only paid component is organization governance: centrally managed network
-and filesystem policies, [sign-in enforcement](governance/sign-in-enforcement.md),
+and filesystem policies,
+[sign-in enforcement](governance/monitor-and-enforce/sign-in-enforcement.md),
 and [audit logs](governance/audit/). These
 [organization governance features](governance/) require a separate paid
 subscription —
@@ -29,7 +30,7 @@ Signing in gives each sandbox a verified identity, which lets Docker:
   containers, install packages, and push code. Your Docker identity is the
   anchor.
 - **Enable team features.** Team-scale features like
-  [organization governance](governance/org.md), shared environments, and
+  [organization governance](governance/access-controls/organization.md), shared environments, and
   audit logs need a concept of "who," and adding that later would be worse for
   everyone.
 - **Authenticate against Docker infrastructure.** Sandboxes pull images, run
@@ -45,7 +46,7 @@ rules apply to every sandbox in the
 organization. When organization governance is active, it replaces local rules
 set with `sbx policy` — local rules are no longer evaluated.
 
-See [Organization governance](governance/org.md). This feature requires
+See [Organization governance](governance/access-controls/organization.md). This feature requires
 a separate paid subscription —
 [contact Docker Sales](https://www.docker.com/products/ai-governance/#contact-sales)
 to get started.

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -11,8 +11,8 @@ Yes to both. The `sbx` CLI is free to use, including for commercial and
 professional work, with no per-seat fee. Install it, sign in with a free
 Docker account, and run sandboxes at no cost.
 
-The only paid component is organization governance: centrally managed network
-and filesystem policies,
+The only paid component is organization governance: centrally managed network,
+filesystem, and MCP policies,
 [sign-in enforcement](governance/monitor-and-enforce/sign-in-enforcement.md),
 and [audit logs](governance/audit/). These
 [organization governance features](governance/) require a separate paid
@@ -40,13 +40,13 @@ Your Docker account email is only used for authentication, not marketing.
 
 ## Can I enforce sandbox policies across my organization?
 
-Yes. Admins can centrally manage network and filesystem policies. These
-rules apply to every sandbox in the
+Yes. Admins can centrally manage network, filesystem, and MCP policies from
+the Docker Admin Console. Rules defined there apply to every sandbox in the
 organization. When organization governance is active, it replaces local rules
 set with `sbx policy` — local rules are no longer evaluated.
 
-See [Organization policies](governance/access-controls/organization.md). This feature requires
-a separate paid subscription —
+See [Organization policies](governance/access-controls/organization.md). This
+feature requires a separate paid subscription —
 [contact Docker Sales](https://www.docker.com/products/ai-governance/#contact-sales)
 to get started.
 
@@ -132,7 +132,7 @@ $ echo $BRAVE_API_KEY
 ## Why do agents run without approval prompts?
 
 The sandbox itself is the safety boundary. Because agents run inside an
-isolated microVM with [network policies](governance/),
+isolated microVM with [network policies](governance/access-controls/network.md),
 [credential isolation](security/credentials.md), and no access to your host
 system outside explicitly shared paths, the usual reasons for approval prompts
 (preventing destructive commands, network access, file modifications) are

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -30,9 +30,8 @@ Signing in gives each sandbox a verified identity, which lets Docker:
   containers, install packages, and push code. Your Docker identity is the
   anchor.
 - **Enable team features.** Team-scale features like
-  [organization governance](governance/access-controls/organization.md), shared environments, and
-  audit logs need a concept of "who," and adding that later would be worse for
-  everyone.
+  [organization governance](governance/), shared environments, and audit logs
+  need a concept of "who," and adding that later would be worse for everyone.
 - **Authenticate against Docker infrastructure.** Sandboxes pull images, run
   daemons, and talk to Docker services. A Docker account authenticates those
   requests.
@@ -46,7 +45,7 @@ rules apply to every sandbox in the
 organization. When organization governance is active, it replaces local rules
 set with `sbx policy` — local rules are no longer evaluated.
 
-See [Organization governance](governance/access-controls/organization.md). This feature requires
+See [Organization policies](governance/access-controls/organization.md). This feature requires
 a separate paid subscription —
 [contact Docker Sales](https://www.docker.com/products/ai-governance/#contact-sales)
 to get started.

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -227,7 +227,7 @@ $ sbx policy allow network registry.npmjs.org
 With **Locked Down**, even your model provider API is blocked unless you
 explicitly allow it. With **Balanced**, common development services are
 permitted by default. See
-[local access rules](governance/access-controls/local.md) for the full rule set
+[local policy](governance/access-controls/local.md) for the full rule set
 and how to customize it.
 
 ## Clean up

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -227,8 +227,9 @@ $ sbx policy allow network registry.npmjs.org
 With **Balanced**, common development services are allowed by default. With
 **Locked Down**, everything is blocked until you allow it — including your
 model provider's API. If the agent can't reach a service it needs, the network
-policy is the first place to look. See [Policies](governance/local.md) for the
-full rule set and how to customize it.
+policy is the first place to look. See
+[Policies](governance/access-controls/local.md) for the full rule set and how
+to customize it.
 
 ## Clean up
 

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -224,12 +224,11 @@ To allow a specific host:
 $ sbx policy allow network registry.npmjs.org
 ```
 
-With **Balanced**, common development services are allowed by default. With
-**Locked Down**, everything is blocked until you allow it — including your
-model provider's API. If the agent can't reach a service it needs, the network
-policy is the first place to look. See
-[Policies](governance/access-controls/local.md) for the full rule set and how
-to customize it.
+With **Locked Down**, even your model provider API is blocked unless you
+explicitly allow it. With **Balanced**, common development services are
+permitted by default. See
+[local access rules](governance/access-controls/local.md) for the full rule set
+and how to customize it.
 
 ## Clean up
 

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -160,8 +160,8 @@ Initialize the global network policy for your sandboxes:
 
 **Balanced** is a good starting point — it permits traffic to common
 development services while blocking everything else. You can adjust individual
-rules later. See [Policies](governance/local.md) for a full description of each
-option.
+rules later. See [Local policy](governance/access-controls/local.md) for a full
+description of each option.
 
 Replace `claude` with the agent you want to use — see [Agents](agents/) for the
 full list.

--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -272,5 +272,5 @@ Then explore:
   network rules into a reusable definition you launch with a single flag.
 - [Agents](agents/) — the full list of supported agents and how to configure
   each one.
-- [Governance](governance/) — centrally manage network and filesystem policies
-  across a team.
+- [Governance](governance/) — centrally manage network, filesystem, and MCP
+  policies across a team.

--- a/content/manuals/ai/sandboxes/governance/_index.md
+++ b/content/manuals/ai/sandboxes/governance/_index.md
@@ -14,10 +14,10 @@ at two layers, and only one applies at a time:
 lets individual developers customize which domains their sandboxes can reach.
 See [Local policy](access-controls/local.md).
 
-**Organization policy** is configured centrally in the Docker Admin Console.
-Network and filesystem policies can also be managed via the
-[Governance API](/reference/api/ai-governance/). Rules defined at the org level
-apply uniformly across every sandbox in the organization. Organization
+**Organization policy** is configured centrally in Docker Home. Network and
+filesystem policies can also be managed via the
+[Governance API](/reference/api/ai-governance/). Controls defined at the org
+level apply uniformly across every sandbox in the organization. Organization
 governance can also include MCP policies for sandbox MCP activity. When
 organization governance is active, it replaces local policy entirely: local
 `sbx policy` rules are no longer evaluated. See
@@ -44,7 +44,7 @@ MCP policy basics, evaluation, and precedence.
 - [Local policy](access-controls/local.md): configure network rules on your
   machine with the `sbx policy` CLI.
 - [Organization policies](access-controls/organization.md): centrally manage
-  sandbox policies across your organization from the Admin Console.
+  sandbox policies across your organization.
 - [Network access policies](access-controls/network.md): control outbound network
   access from sandboxes.
 - [Filesystem access policies](access-controls/filesystem.md): control which

--- a/content/manuals/ai/sandboxes/governance/_index.md
+++ b/content/manuals/ai/sandboxes/governance/_index.md
@@ -44,10 +44,10 @@ MCP policy basics, evaluation, and precedence.
   machine with the `sbx policy` CLI.
 - [Organization policies](access-controls/organization.md): centrally manage
   sandbox policies across your organization from the Admin Console.
-- [Network access rules](access-controls/network.md): control outbound network
+- [Network access policies](access-controls/network.md): control outbound network
   access from sandboxes.
-- [Filesystem access rules](access-controls/filesystem.md): control which host
-  paths sandboxes can mount as workspaces.
+- [Filesystem access policies](access-controls/filesystem.md): control which
+  host paths sandboxes can mount as workspaces.
 - [MCP access policies](access-controls/mcp.md): control MCP server registration,
   tool calls, resources, prompts, and approval gates.
 

--- a/content/manuals/ai/sandboxes/governance/_index.md
+++ b/content/manuals/ai/sandboxes/governance/_index.md
@@ -66,3 +66,5 @@ MCP policy basics, evaluation, and precedence.
 
 - [AI Governance API](/reference/api/ai-governance/): manage network and
   filesystem org policies programmatically.
+- [MCP policy reference](reference/mcp-policy.md): look up Docker MCP policy
+  actions, resources, attributes, context fields, and approval behavior.

--- a/content/manuals/ai/sandboxes/governance/_index.md
+++ b/content/manuals/ai/sandboxes/governance/_index.md
@@ -1,13 +1,14 @@
 ---
 title: Governance
-weight: 55
+weight: 90
 description: Control what sandboxes can access, from local developer rules to org-wide enforcement.
 keywords: docker sandboxes, governance, policy, network access, filesystem access, mcp policy, organization policy
 ---
 
 Sandbox governance covers the policy system that controls what sandboxes can
-access over the network, on the filesystem, and through MCP. It operates at two
-layers, and only one applies at a time:
+access over the network, on the filesystem, and through MCP. For MCP setup and
+server registration, see [MCP gateway](../mcp-gateway.md). Governance operates
+at two layers, and only one applies at a time:
 
 **Local policy** is configured per machine using the `sbx policy` CLI. It
 lets individual developers customize which domains their sandboxes can reach.

--- a/content/manuals/ai/sandboxes/governance/_index.md
+++ b/content/manuals/ai/sandboxes/governance/_index.md
@@ -11,7 +11,7 @@ layers, and only one applies at a time:
 
 **Local policy** is configured per machine using the `sbx policy` CLI. It
 lets individual developers customize which domains their sandboxes can reach.
-See [Local access rules](access-controls/local.md).
+See [Local policy](access-controls/local.md).
 
 **Organization policy** is configured centrally in the Docker Admin Console.
 Network and filesystem policies can also be managed via the
@@ -40,15 +40,15 @@ MCP policy basics, evaluation, and precedence.
 
 ### Access controls
 
-- [Local access rules](access-controls/local.md): configure network rules on
-  your machine with the `sbx policy` CLI.
+- [Local policy](access-controls/local.md): configure network rules on your
+  machine with the `sbx policy` CLI.
 - [Organization policies](access-controls/organization.md): centrally manage
   sandbox policies across your organization from the Admin Console.
 - [Network access rules](access-controls/network.md): control outbound network
   access from sandboxes.
 - [Filesystem access rules](access-controls/filesystem.md): control which host
   paths sandboxes can mount as workspaces.
-- [MCP tool access](access-controls/mcp.md): control MCP server registration,
+- [MCP access policies](access-controls/mcp.md): control MCP server registration,
   tool calls, resources, prompts, and approval gates.
 
 ### Monitor and enforce

--- a/content/manuals/ai/sandboxes/governance/_index.md
+++ b/content/manuals/ai/sandboxes/governance/_index.md
@@ -2,23 +2,24 @@
 title: Governance
 weight: 55
 description: Control what sandboxes can access, from local developer rules to org-wide enforcement.
-keywords: docker sandboxes, governance, policy, network access, filesystem access, organization policy
+keywords: docker sandboxes, governance, policy, network access, filesystem access, mcp policy, organization policy
 ---
 
 Sandbox governance covers the policy system that controls what sandboxes can
-access over the network and on the filesystem. It operates at two layers, and
-only one applies at a time:
+access over the network, on the filesystem, and through MCP. It operates at two
+layers, and only one applies at a time:
 
 **Local policy** is configured per machine using the `sbx policy` CLI. It lets
 individual developers customize which domains their sandboxes can reach. See
 [Local policy](local.md).
 
-**Organization policy** is configured centrally in the Docker Admin Console or
-via the [Governance API](/reference/api/ai-governance/). Rules defined at the
-org level apply uniformly across every sandbox in the organization. When
+**Organization policy** is configured centrally in the Docker Admin Console.
+Network and filesystem policies can also be managed via the
+[Governance API](/reference/api/ai-governance/). Rules defined at the org level
+apply uniformly across every sandbox in the organization. Organization
+governance can also include MCP policies for sandbox MCP activity. When
 organization governance is active, it replaces local policy entirely: local
-`sbx policy` rules are no longer evaluated. See
-[Organization policy](org.md).
+`sbx policy` rules are no longer evaluated. See [Organization policy](org.md).
 
 Alongside this access-control policy, admins can require developers to sign in
 as members of their organization before using sandboxes at all.
@@ -33,8 +34,8 @@ personal account.
 
 ## Learn more
 
-- [Policy concepts](concepts.md): resource model, rule syntax, evaluation, and
-  precedence
+- [Policy concepts](concepts.md): resource model, rule syntax, MCP policy,
+  evaluation, and precedence
 - [Local policy](local.md): configure network and filesystem rules on your
   machine with the `sbx policy` CLI
 - [Organization policy](org.md): centrally manage sandbox policies across your

--- a/content/manuals/ai/sandboxes/governance/_index.md
+++ b/content/manuals/ai/sandboxes/governance/_index.md
@@ -9,9 +9,9 @@ Sandbox governance covers the policy system that controls what sandboxes can
 access over the network, on the filesystem, and through MCP. It operates at two
 layers, and only one applies at a time:
 
-**Local policy** is configured per machine using the `sbx policy` CLI. It lets
-individual developers customize which domains their sandboxes can reach. See
-[Local policy](local.md).
+**Local policy** is configured per machine using the `sbx policy` CLI. It
+lets individual developers customize which domains their sandboxes can reach.
+See [Local access rules](access-controls/local.md).
 
 **Organization policy** is configured centrally in the Docker Admin Console.
 Network and filesystem policies can also be managed via the
@@ -19,13 +19,14 @@ Network and filesystem policies can also be managed via the
 apply uniformly across every sandbox in the organization. Organization
 governance can also include MCP policies for sandbox MCP activity. When
 organization governance is active, it replaces local policy entirely: local
-`sbx policy` rules are no longer evaluated. See [Organization policy](org.md).
+`sbx policy` rules are no longer evaluated. See
+[Organization policies](access-controls/organization.md).
 
 Alongside this access-control policy, admins can require developers to sign in
 as members of their organization before using sandboxes at all.
-[Sign-in enforcement](sign-in-enforcement.md) is deployed through endpoint
-management and ensures developers can't bypass organization policy by using a
-personal account.
+[Sign-in enforcement](monitor-and-enforce/sign-in-enforcement.md) is deployed
+through endpoint management and ensures developers can't bypass organization
+policy by using a personal account.
 
 > [!NOTE]
 > Organization governance is available on a separate paid subscription.
@@ -34,17 +35,34 @@ personal account.
 
 ## Learn more
 
-- [Policy concepts](concepts.md): resource model, rule syntax, MCP policy,
-  evaluation, and precedence
-- [Local policy](local.md): configure network and filesystem rules on your
-  machine with the `sbx policy` CLI
-- [Organization policy](org.md): centrally manage sandbox policies across your
-  organization from the Admin Console
-- [Sign-in enforcement](sign-in-enforcement.md): require developers to sign in
-  as organization members, enforced through endpoint management
-- [Monitoring](monitoring.md): inspect active rules and monitor sandbox network
-  traffic with `sbx policy ls` and `sbx policy log`
+Start with [Policy concepts](concepts.md) for the resource model, rule syntax,
+MCP policy basics, evaluation, and precedence.
+
+### Access controls
+
+- [Local access rules](access-controls/local.md): configure network rules on
+  your machine with the `sbx policy` CLI.
+- [Organization policies](access-controls/organization.md): centrally manage
+  sandbox policies across your organization from the Admin Console.
+- [Network access rules](access-controls/network.md): control outbound network
+  access from sandboxes.
+- [Filesystem access rules](access-controls/filesystem.md): control which host
+  paths sandboxes can mount as workspaces.
+- [MCP tool access](access-controls/mcp.md): control MCP server registration,
+  tool calls, resources, prompts, and approval gates.
+
+### Monitor and enforce
+
+- [Monitoring policies](monitor-and-enforce/monitoring.md): inspect active
+  rules and monitor sandbox network traffic with `sbx policy ls` and
+  `sbx policy log`.
 - [Audit logs](audit/): view, configure, export, and collect governance audit
-  records
-- [API reference](/reference/api/ai-governance/): manage org policies
-  programmatically via the Governance API
+  records.
+- [Sign-in enforcement](monitor-and-enforce/sign-in-enforcement.md): require
+  developers to sign in as organization members, enforced through endpoint
+  management.
+
+### Reference
+
+- [AI Governance API](/reference/api/ai-governance/): manage network and
+  filesystem org policies programmatically.

--- a/content/manuals/ai/sandboxes/governance/access-controls/_index.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/_index.md
@@ -19,9 +19,9 @@ and filesystem rule format.
 
 ## Access surfaces
 
-- [Network access rules](network.md): control outbound network access from
+- [Network access policies](network.md): control outbound network access from
   sandboxes.
-- [Filesystem access rules](filesystem.md): control which host paths sandboxes
-  can mount as workspaces.
+- [Filesystem access policies](filesystem.md): control which host paths
+  sandboxes can mount as workspaces.
 - [MCP access policies](mcp.md): control MCP server registration, tool calls,
   resources, prompts, and approval gates with Cedar policy.

--- a/content/manuals/ai/sandboxes/governance/access-controls/_index.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/_index.md
@@ -1,13 +1,12 @@
 ---
 title: Access controls
-weight: 10
+weight: 20
 description: Configure local and organization controls for sandbox network, filesystem, and MCP access.
 keywords: docker sandboxes, access controls, governance, network access, filesystem access, MCP access
 ---
 
-Access controls define what sandboxes can reach or use. Use these pages to
-configure policies by scope, then drill into the access surface you want to
-govern.
+Access controls define what sandboxes can reach or use. Choose a policy scope,
+then choose the access surface you want to govern.
 
 ## Policy scope
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/_index.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/_index.md
@@ -1,0 +1,26 @@
+---
+title: Access controls
+weight: 10
+description: Configure local and organization controls for sandbox network, filesystem, and MCP access.
+keywords: docker sandboxes, access controls, governance, network access, filesystem access, MCP access
+---
+
+Access controls define what sandboxes can reach or use. Use these pages to
+configure policies by scope, then drill into the access surface you want to
+govern.
+
+## Policy scope
+
+- [Local access rules](local.md): configure network rules on a developer
+  machine with the `sbx policy` CLI.
+- [Organization policies](organization.md): manage centralized policies for an
+  organization or team in the Docker Admin Console.
+
+## Access surfaces
+
+- [Network access rules](network.md): control outbound network access from
+  sandboxes.
+- [Filesystem access rules](filesystem.md): control which host paths sandboxes
+  can mount as workspaces.
+- [MCP tool access](mcp.md): control MCP server registration, tool calls,
+  resources, prompts, and approval gates with Cedar policy.

--- a/content/manuals/ai/sandboxes/governance/access-controls/_index.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/_index.md
@@ -15,7 +15,7 @@ and filesystem rule format.
 - [Local policy](local.md): configure network rules on a developer machine with
   the `sbx policy` CLI.
 - [Organization policies](organization.md): manage centralized policies for an
-  organization or team in the Docker Admin Console.
+  organization or team.
 
 ## Access surfaces
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/_index.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/_index.md
@@ -5,13 +5,15 @@ description: Configure local and organization controls for sandbox network, file
 keywords: docker sandboxes, access controls, governance, network access, filesystem access, MCP access
 ---
 
-Access controls define what sandboxes can reach or use. Choose a policy scope,
-then choose the access surface you want to govern.
+Access controls are expressed as policies. Local and organization pages
+describe where policies apply. Network and filesystem pages describe the rules
+inside those policies. MCP policies use Cedar statements instead of the network
+and filesystem rule format.
 
 ## Policy scope
 
-- [Local access rules](local.md): configure network rules on a developer
-  machine with the `sbx policy` CLI.
+- [Local policy](local.md): configure network rules on a developer machine with
+  the `sbx policy` CLI.
 - [Organization policies](organization.md): manage centralized policies for an
   organization or team in the Docker Admin Console.
 
@@ -21,5 +23,5 @@ then choose the access surface you want to govern.
   sandboxes.
 - [Filesystem access rules](filesystem.md): control which host paths sandboxes
   can mount as workspaces.
-- [MCP tool access](mcp.md): control MCP server registration, tool calls,
+- [MCP access policies](mcp.md): control MCP server registration, tool calls,
   resources, prompts, and approval gates with Cedar policy.

--- a/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
@@ -35,9 +35,9 @@ and WSL, see [Filesystem rules](../concepts.md#filesystem-rules).
 
 ## Organization filesystem rules
 
-Admins manage filesystem policies in the Docker Admin Console. A policy can
-apply to the whole organization or to selected teams. For setup steps and team
-scoping, see [Organization policies](organization.md).
+Organization filesystem rules belong to policies that can apply to the whole
+organization or to selected teams. For setup steps and team scoping, see
+[Organization policies](organization.md).
 
 Filesystem policy is checked when a workspace is mounted, which happens when a
 sandbox is created. To apply a filesystem policy change to a running workflow,
@@ -48,5 +48,5 @@ remove the sandbox and create a new one.
 ### Sandbox cannot mount workspace
 
 If a sandbox fails to mount with a `mount policy denied` error, verify that the
-filesystem allow rule in the Admin Console uses `**` rather than `*`. A single
-`*` doesn't match across directory separators.
+filesystem allow rule uses `**` rather than `*`. A single `*` doesn't match
+across directory separators.

--- a/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
@@ -1,0 +1,44 @@
+---
+title: Filesystem access rules
+linkTitle: Filesystem access
+weight: 40
+description: Control which host paths Docker Sandboxes can mount as workspaces with organization filesystem policies.
+keywords: docker sandboxes, filesystem access, filesystem rules, workspace mount, organization policy, governance
+---
+
+Filesystem access rules control which host paths a sandbox can mount as a
+workspace. They help admins restrict sandbox workspaces to approved directories
+across an organization.
+
+Filesystem access is managed with [organization policies](organization.md). When
+organization governance is active, filesystem rules replace local behavior for
+workspace mounts.
+
+## Rule syntax
+
+Filesystem rules use the actions `read` and `write`. Resources are host path
+patterns.
+
+A writable workspace mount must be allowed by both a `read` rule and a `write`
+rule. A read-only workspace needs only `read`.
+
+Examples:
+
+- `~/**`
+- `/data/project/**`
+- `C:\data\project\**`
+- `\\wsl.localhost\<distro>\data\project\**`
+
+Use `**` to match a directory tree recursively. A single `*` matches only one
+path segment. For exact path matching behavior across macOS, Linux, Windows,
+and WSL, see [Filesystem rules](../concepts.md#filesystem-rules).
+
+## Organization filesystem rules
+
+Admins manage filesystem policies in the Docker Admin Console. A policy can
+apply to the whole organization or to selected teams. For setup steps and team
+scoping, see [Organization policies](organization.md).
+
+Filesystem policy is checked when a workspace is mounted, which happens when a
+sandbox is created. To apply a filesystem policy change to a running workflow,
+remove the sandbox and create a new one.

--- a/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
@@ -42,3 +42,11 @@ scoping, see [Organization policies](organization.md).
 Filesystem policy is checked when a workspace is mounted, which happens when a
 sandbox is created. To apply a filesystem policy change to a running workflow,
 remove the sandbox and create a new one.
+
+## Troubleshooting
+
+### Sandbox cannot mount workspace
+
+If a sandbox fails to mount with a `mount policy denied` error, verify that the
+filesystem allow rule in the Admin Console uses `**` rather than `*`. A single
+`*` doesn't match across directory separators.

--- a/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
@@ -1,14 +1,14 @@
 ---
-title: Filesystem access rules
+title: Filesystem access policies
 linkTitle: Filesystem access
 weight: 40
 description: Control which host paths Docker Sandboxes can mount as workspaces with organization filesystem policies.
 keywords: docker sandboxes, filesystem access, filesystem rules, workspace mount, organization policy, governance
 ---
 
-Filesystem access rules control which host paths a sandbox can mount as a
-workspace. Organization filesystem policies contain one or more rules that
-restrict sandbox workspaces to approved directories.
+Filesystem access policies control which host paths a sandbox can mount as a
+workspace. Each policy contains one or more rules that restrict sandbox
+workspaces to approved directories.
 
 Filesystem access is managed with [organization policies](organization.md). When
 organization governance is active, filesystem rules replace local behavior for

--- a/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/filesystem.md
@@ -7,8 +7,8 @@ keywords: docker sandboxes, filesystem access, filesystem rules, workspace mount
 ---
 
 Filesystem access rules control which host paths a sandbox can mount as a
-workspace. They help admins restrict sandbox workspaces to approved directories
-across an organization.
+workspace. Organization filesystem policies contain one or more rules that
+restrict sandbox workspaces to approved directories.
 
 Filesystem access is managed with [organization policies](organization.md). When
 organization governance is active, filesystem rules replace local behavior for

--- a/content/manuals/ai/sandboxes/governance/access-controls/local.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/local.md
@@ -1,22 +1,22 @@
 ---
-title: Local access rules
-linkTitle: Local rules
+title: Local policy
 weight: 10
-description: Configure network access rules for sandboxes on your local machine.
+description: Configure local network access rules for sandboxes on your machine.
 keywords: docker sandboxes, local policy, network access, allow rules, deny rules, sbx policy
 aliases:
   - /ai/sandboxes/security/policy/
   - /ai/sandboxes/governance/local/
 ---
 
-The `sbx policy` command manages network access rules on your local machine.
-Rules apply to all sandboxes on the machine when you use the global scope, or
-to a single sandbox when scoped by name.
+The `sbx policy` command manages the local policy on your machine. The local
+policy contains network access rules. Rules apply to all sandboxes on the
+machine when you use the global scope, or to a single sandbox when scoped by
+name.
 
-Local rules apply only when your organization doesn't enforce governance:
+Local policy applies only when your organization doesn't enforce governance:
 
-- **No org governance**: local rules fully control what sandboxes can access.
-- **Org governance active**: the organization policy replaces local policy.
+- **No org governance**: the local policy controls what sandboxes can access.
+- **Org governance active**: organization policies replace local policy.
   Local rules are inactive, and `sbx policy allow` and `sbx policy deny` have
   no effect. To list the inactive local rules, run
   `sbx policy ls --include-inactive`. See

--- a/content/manuals/ai/sandboxes/governance/access-controls/local.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/local.md
@@ -1,10 +1,12 @@
 ---
-title: Local policy
+title: Local access rules
+linkTitle: Local rules
 weight: 10
 description: Configure network access rules for sandboxes on your local machine.
 keywords: docker sandboxes, local policy, network access, allow rules, deny rules, sbx policy
 aliases:
   - /ai/sandboxes/security/policy/
+  - /ai/sandboxes/governance/local/
 ---
 
 The `sbx policy` command manages network access rules on your local machine.
@@ -18,12 +20,13 @@ Local rules apply only when your organization doesn't enforce governance:
   Local rules are inactive, and `sbx policy allow` and `sbx policy deny` have
   no effect. To list the inactive local rules, run
   `sbx policy ls --include-inactive`. See
-  [Monitoring](monitoring.md#showing-inactive-rules).
+  [Monitoring](../monitor-and-enforce/monitoring.md#showing-inactive-rules).
 
-See [Organization policy](org.md) for how organization governance works.
+See [Organization policies](organization.md) for how organization governance
+works.
 
 For domain patterns, wildcards, CIDR ranges, and filesystem path syntax, see
-[Policy concepts](concepts.md#rule-syntax).
+[Policy concepts](../concepts.md#rule-syntax).
 
 ## Default preset
 
@@ -66,7 +69,7 @@ v0.35.0, the Balanced preset also allows VS Code domains, Azure Blob Storage
 > [!NOTE]
 > If your organization manages sandbox policies centrally, organization rules
 > take precedence over the preset you select here. See
-> [Organization policy](org.md).
+> [Organization policies](organization.md).
 
 ### Non-interactive environments
 
@@ -122,7 +125,8 @@ To inspect which policies are active and where they come from, use
 `sbx policy ls`. Use `--source` to filter by origin (`local`, `org`, `kit`),
 `--decision` to filter by outcome (`allow`, `deny`), and `--wide` for
 rule-level detail including rule IDs. To inspect a single policy or rule in
-full, use `sbx policy inspect`. See [Monitoring](monitoring.md).
+full, use `sbx policy inspect`. See
+[Monitoring](../monitor-and-enforce/monitoring.md).
 
 ## Testing policy
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -104,10 +104,17 @@ It prevents a developer from registering another endpoint under the approved
 name or registering the approved endpoint under another name. Remove the
 resource or prompt permit if users don't need that capability.
 
-## Require approval for non-read-only tools
+## Require confirmation with MCP elicitation
 
-Add an approval-gated permit to the previous policy when users should be able to
-run other tools after confirmation:
+Despite its name, `@requireApproval` doesn't send a request to an organization
+administrator. It turns a matching `permit` into a per-request confirmation
+through MCP. The gateway sends an `elicitation/create` request to the same MCP
+client session that made the governed request. In a human-driven client, the
+person operating the agent sees the prompt and decides whether to proceed.
+
+Add an approval-gated permit to the previous policy to require this
+confirmation for non-read-only tools. The annotation string becomes the reason
+shown in the elicitation:
 
 ```plaintext
 @requireApproval("non-read-only tool call")
@@ -120,13 +127,39 @@ when {
 
 Tool annotations are supplied by the server and are advisory. `readOnly`
 defaults to `false` for tools that don't declare it, so this pattern requires
-approval for unannotated tools. If the client session can't ask the user for
-approval, the request is denied. A matching `forbid` also denies the request
-without showing an approval prompt.
+confirmation for unannotated tools.
 
-Use approval for in-session gateway requests. `sbx mcp add` can't present an
-approval request, so a registration permit with `@requireApproval` results in a
-denial.
+The gateway handles a matching request as follows:
+
+```mermaid
+flowchart TD
+  request["Agent sends a governed MCP request"] --> evaluate["Gateway evaluates MCP policy"]
+  evaluate -->|"Normal permit"| forward["Forward request"]
+  evaluate -->|"No permit or matching forbid"| deny["Deny request"]
+  evaluate -->|"Permit with @requireApproval"| elicit["Send MCP elicitation to connected client"]
+  elicit --> confirm{"Client returns explicit confirmation?"}
+  confirm -->|"No, unsupported, or error"| deny
+  confirm -->|"Yes"| reevaluate["Re-evaluate with approval digest"]
+  reevaluate -->|"Allowed"| forward
+  reevaluate -->|"Denied or changed"| deny
+```
+
+The prompt identifies the server or gateway tool and includes the annotation
+reason. It doesn't include raw tool arguments. Each matching request requires a
+new confirmation. After confirmation, the gateway re-evaluates the request with
+a digest that binds the response to the evaluated authorization request.
+
+Use this mechanism as a confirmation guardrail for human-driven clients. It
+doesn't create administrator approval or separation of duties. An autonomous
+MCP client can respond to an in-protocol elicitation programmatically. Use
+`forbid` for operations that must never run.
+
+The request is denied if the originating client session can't handle MCP
+elicitation, the user declines, the elicitation fails, or re-evaluation doesn't
+allow the request. `sbx mcp add` can't present an elicitation, so a registration
+permit with `@requireApproval` results in a denial. Tool calls made from an
+execution context that can't relay an elicitation, including calls from inside
+`code-mode`, are also denied.
 
 ## Withdraw server access
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -10,8 +10,8 @@ MCP policies control Model Context Protocol activity made available to a
 sandbox through Docker's MCP gateway. Use them to govern server registration,
 tool calls, gateway meta-tools, resources, prompts, and approval requirements.
 
-Unlike [network access rules](network.md) and
-[filesystem access rules](filesystem.md), MCP policies are organization
+Unlike [network access policies](network.md) and
+[filesystem access policies](filesystem.md), MCP policies are organization
 policies written in Cedar. Docker defines the `MCP` namespace, including the
 actions, resource types, attributes, and approval behavior that policies can
 match. For Docker's MCP policy actions, resources, attributes, and context

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -37,6 +37,16 @@ For Docker MCP policies:
 - A matching `forbid` overrides any `permit`, including a permit with
   `@requireApproval`.
 
+MCP policies are enforced on the MCP gateway path, not by the sandbox network
+proxy. During `sbx mcp add`, Docker Sandboxes evaluates the resolved server
+definition against `MCP::Action::"register"` before storing the registration.
+When a sandbox uses MCP, the gateway evaluates governed MCP requests before
+tool calls, resource reads, prompt retrieval, and gateway meta-tool execution.
+
+Tool and resource listings can include entries that policy later denies at use
+time. Use the [MCP policy reference](../reference/mcp-policy.md) for the exact
+actions and limitations.
+
 ## Start with a baseline
 
 To allow all MCP activity while you build a narrower policy, use an actionless

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -6,151 +6,140 @@ description: Use Cedar-based MCP policies to control sandbox MCP server registra
 keywords: docker sandboxes, MCP policy, MCP access, Cedar policy, requireApproval, AI Governance
 ---
 
-MCP policies control Model Context Protocol activity made available to a
-sandbox through Docker's MCP gateway. Use them to govern server registration,
-tool calls, gateway meta-tools, resources, prompts, and approval requirements.
-To register MCP servers and connect them to sandboxes, see
+MCP access policies let organization administrators control which Model
+Context Protocol (MCP) servers developers can register and what agents can do
+through Docker's MCP gateway. Use these policies to approve trusted servers,
+withdraw access to a server, require approval for tool calls, and restrict
+host-run servers. To register MCP servers and connect them to sandboxes, see
 [MCP gateway](../../mcp-gateway.md).
 
 Unlike [network access policies](network.md) and
 [filesystem access policies](filesystem.md), MCP policies are organization
 policies written in Cedar. Docker defines the `MCP` namespace, including the
 actions, resource types, attributes, and approval behavior that policies can
-match. For Docker's MCP policy actions, resources, attributes, and context
-fields, see the [MCP policy reference](../reference/mcp-policy.md). For Cedar
-syntax and language semantics, see the
+match. This page focuses on representative access patterns. For Docker's exact
+policy surface, see the [MCP policy reference](../reference/mcp-policy.md). For
+Cedar syntax and language semantics, see the
 [Cedar documentation](https://docs.cedarpolicy.com/).
 
-## How MCP policy works
+## Govern the server lifecycle
 
-Cedar evaluates each request against a principal, action, resource, and context.
-For Docker MCP policies:
+MCP policy applies at two points in a server's lifecycle. A rule for one point
+doesn't automatically govern the other.
 
-- Policy scope supplies the principal. Use organization or team scope instead
-  of matching users, teams, tenants, or roles in the policy.
-- Actions use the `MCP::Action` namespace, such as
-  `MCP::Action::"invokeTool"`.
-- Resources use MCP entity types, such as `MCP::Server`, `MCP::Tool`,
-  `MCP::Resource`, `MCP::Prompt`, and `MCP::Primordial`.
-- A matching `forbid` overrides any `permit`, including a permit with
-  `@requireApproval`.
-- When MCP policy enforcement is active, evaluation is fail closed: server
-  registration and governed MCP requests are denied unless a matching `permit`
-  allows them.
+| Admin decision                             | Evaluation point                            | Match with                                                                 |
+| ------------------------------------------ | ------------------------------------------- | -------------------------------------------------------------------------- |
+| Whether a server can be registered         | When a developer runs `sbx mcp add`         | The registered name and resolved server attributes, such as `identityURL`  |
+| What agents can do through the MCP gateway | When the gateway handles a governed request | The registered server name, tool annotations, resource URI, or prompt name |
 
-If MCP policy enforcement isn't active for a user, the MCP gateway doesn't
-evaluate Cedar policy and MCP activity is allowed by the gateway. MCP doesn't
-have a local preset equivalent to network policy.
+Registration rules affect future registrations. They don't remove a saved
+registration or prevent an existing registration from being loaded with
+`sbx mcp load`. Use-time rules govern tool calls, resource reads, and prompt
+retrieval from servers that are already registered or loaded.
 
-MCP policies are enforced on the MCP gateway path, not by the sandbox network
-proxy. During `sbx mcp add`, Docker Sandboxes evaluates the resolved server
-definition against `MCP::Action::"register"` before storing the registration.
-When a sandbox uses MCP, the gateway evaluates governed MCP requests before
-tool calls, resource reads, prompt retrieval, and gateway meta-tool execution.
+Server names are chosen during registration. Registration rules can match the
+chosen name and resolved server identity together. At use time, tools,
+resources, and prompts are associated with the registered name, so rules for an
+existing server must match every name under which it was registered.
 
-Tool and resource listings can include entries that policy later denies at use
-time. Use the [MCP policy reference](../reference/mcp-policy.md) for the exact
-actions and limitations.
+Built-in gateway tools, such as `code-mode` and OAuth authorization helpers,
+are also governed at use time. They are `MCP::Primordial` resources rather than
+tools associated with a registered server. For details, see
+[Built-in gateway tools](../../mcp-gateway.md#built-in-gateway-tools).
 
-## Start with a baseline
+Use-time policy doesn't hide or remove existing registrations. Tool and
+resource listings can also include entries that policy denies when an agent
+tries to use them.
 
-To allow all MCP activity while you build a narrower policy, use an actionless
-`permit`:
+## Choose an access posture
+
+When MCP policy enforcement is active for a user, registration and governed MCP
+requests are denied unless a matching `permit` allows them. A matching `forbid`
+overrides any `permit`, including a permit with `@requireApproval`.
+
+Use permits for an allowlist policy. For a blocklist policy that grants MCP
+activity except for explicit restrictions, start with an actionless permit:
 
 ```plaintext
 permit (principal, action, resource);
 ```
 
-This is useful as a temporary baseline. For production policies, prefer
-patterns that limit access to approved servers, read-only tools, or
-approval-gated tool calls.
+This statement permits every MCP action that reaches Cedar evaluation. Add
+`forbid` statements for the restrictions the policy must enforce.
 
-## Allow read-only tools
+Policy scope supplies the principal. Use organization or team scope instead of
+matching users, teams, tenants, or roles in Cedar. If MCP policy enforcement
+isn't active for a user, the gateway doesn't evaluate Cedar policy and permits
+MCP activity. MCP doesn't have a local preset equivalent to network policy.
 
-Servers can declare tool annotations such as `readOnly` and `destructive`. To
-allow tools that a server marks read-only:
+## Approve a server
 
-```plaintext
-permit (principal, action == MCP::Action::"invokeTool", resource)
-when { resource.readOnly == true };
-```
-
-`readOnly` defaults to `false` for tools that don't declare it, so this pattern
-fails closed for unannotated tools.
-
-## Require approval for writes
-
-Use `@requireApproval` on a `permit` statement to require user approval before
-a matching request runs:
+For an allowlist, approve both the server registration and its use-time
+capabilities. The following policy approves a remote server only when it is
+registered as `example` with the expected identity URL. It permits read-only
+tool calls, resource reads, and prompt retrieval from that registered server:
 
 ```plaintext
-permit (principal, action == MCP::Action::"invokeTool", resource)
-when { resource.readOnly == true };
+permit (principal, action == MCP::Action::"register", resource)
+when {
+  resource in MCP::Server::"example" &&
+  resource.identityURL == "https://mcp.example.com/mcp"
+};
 
-@requireApproval("write tool call")
-permit (principal, action == MCP::Action::"invokeTool", resource)
-when { resource.readOnly == false };
-```
-
-If the sandbox can't ask a user for approval, the request is denied. A matching
-`forbid` still denies the request without showing an approval prompt.
-
-## Limit tools to approved servers
-
-Use `MCP::Server` to match the registered server that exposes a tool:
-
-```plaintext
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when {
-  resource.readOnly == true &&
-  (resource in MCP::Server::"github" || resource in MCP::Server::"notion")
+  resource in MCP::Server::"example" &&
+  resource.readOnly == true
+};
+
+permit (principal, action == MCP::Action::"readResource", resource)
+when { resource in MCP::Server::"example" };
+
+permit (principal, action == MCP::Action::"getPrompt", resource)
+when { resource in MCP::Server::"example" };
+```
+
+Matching both the name and identity URL establishes a canonical registration.
+It prevents a developer from registering another endpoint under the approved
+name or registering the approved endpoint under another name. Remove the
+resource or prompt permit if users don't need that capability.
+
+## Require approval for non-read-only tools
+
+Add an approval-gated permit to the previous policy when users should be able to
+run other tools after confirmation:
+
+```plaintext
+@requireApproval("non-read-only tool call")
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when {
+  resource in MCP::Server::"example" &&
+  resource.readOnly == false
 };
 ```
 
-Server names must match the registered MCP server names.
+Tool annotations are supplied by the server and are advisory. `readOnly`
+defaults to `false` for tools that don't declare it, so this pattern requires
+approval for unannotated tools. If the client session can't ask the user for
+approval, the request is denied. A matching `forbid` also denies the request
+without showing an approval prompt.
 
-## Block destructive tools
+Use approval for in-session gateway requests. `sbx mcp add` can't present an
+approval request, so a registration permit with `@requireApproval` results in a
+denial.
 
-Use `forbid` for controls that must always win over permits:
+## Withdraw server access
 
-```plaintext
-permit (principal, action == MCP::Action::"invokeTool", resource);
-
-forbid (principal, action == MCP::Action::"invokeTool", resource)
-when { resource.destructive == true };
-```
-
-`destructive` defaults to `true` for tools that don't declare it, so this
-pattern also blocks unannotated tools.
-
-## Control server registration
-
-Use the `register` action to control which MCP servers can be registered:
+To withdraw access from a server that broader rules permit, address both
+enforcement points. First, prevent future registrations of the server by
+matching its identity URL:
 
 ```plaintext
-permit (principal, action == MCP::Action::"register", resource)
-when { resource in MCP::Server::"github" };
-
-permit (principal, action == MCP::Action::"register", resource)
-when { resource in MCP::Server::"notion" };
-```
-
-Server names are chosen at registration time. To block a remote server
-regardless of the name a developer chooses, match the server's
-`resource.identityURL`:
-
-```plaintext
-permit (principal, action == MCP::Action::"register", resource);
-
 forbid (principal, action == MCP::Action::"register", resource)
 when { resource.identityURL == "https://mcp.example.com/mcp" };
 ```
 
-This pattern prevents future `sbx mcp add` registrations for that identity URL.
-It doesn't remove registrations that already exist or stop an already-loaded
-server by itself. To govern existing registrations, add use-time rules for the
-registered server name. Replace `example` with the name used in the existing
-registration:
+Then deny use-time requests for each registered name that refers to the server:
 
 ```plaintext
 forbid (principal, action == MCP::Action::"invokeTool", resource)
@@ -163,15 +152,43 @@ forbid (principal, action == MCP::Action::"getPrompt", resource)
 when { resource in MCP::Server::"example" };
 ```
 
-For remote server registration, match attributes the gateway provides, such as
-server type, identity URL, OAuth requirement, or network requirement. Local
-server command and argument attributes don't apply to remote servers.
+The registration remains saved and can still be listed or loaded. These rules
+prevent another registration for the identity URL and deny governed use under
+the registered name. If the server was registered under other names, add
+use-time rules for those names as well.
 
-For local stdio servers, `resource.type == "local-stdio"` matches host-side
-local servers. Use `resource.command` and `resource.args` only when the
-resolved registration includes command details.
+An OAuth authorization helper is a built-in gateway tool, not a child of the
+registered server. To prevent agents from starting authorization for the
+server, govern the helper separately:
 
-## Next steps
+```plaintext
+forbid (principal, action == MCP::Action::"invokePrimordial", resource)
+when { resource in MCP::Primordial::"example-authorize" };
+```
+
+## Restrict host-run servers
+
+Local stdio servers run on the host, outside the sandbox VM. This includes
+explicit host commands and OCI-packaged stdio servers started with host Docker.
+For details about this boundary, see
+[Docker Engine isolation](../../security/isolation.md#docker-engine-isolation).
+
+In a blocklist policy that otherwise permits registration, deny both host-run
+server types:
+
+```plaintext
+forbid (principal, action == MCP::Action::"register", resource)
+when {
+  resource.type == "local-stdio" ||
+  resource.type == "container-stdio"
+};
+```
+
+`local-stdio` covers explicit commands, including commands that start a Docker
+container. `container-stdio` covers OCI-packaged stdio servers resolved from
+registry or manifest metadata.
+
+## Related information
 
 - Use [Policy concepts](../concepts.md#mcp-policies) for the MCP policy model.
 - Use the [MCP policy reference](../reference/mcp-policy.md) for exact action,

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -57,7 +57,7 @@ actions and limitations.
 To allow all MCP activity while you build a narrower policy, use an actionless
 `permit`:
 
-```cedar
+```plaintext
 permit (principal, action, resource);
 ```
 
@@ -70,7 +70,7 @@ approval-gated tool calls.
 Servers can declare tool annotations such as `readOnly` and `destructive`. To
 allow tools that a server marks read-only:
 
-```cedar
+```plaintext
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when { resource.readOnly == true };
 ```
@@ -83,7 +83,7 @@ fails closed for unannotated tools.
 Use `@requireApproval` on a `permit` statement to require user approval before
 a matching request runs:
 
-```cedar
+```plaintext
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when { resource.readOnly == true };
 
@@ -99,7 +99,7 @@ If the sandbox can't ask a user for approval, the request is denied. A matching
 
 Use `MCP::Server` to match the registered server that exposes a tool:
 
-```cedar
+```plaintext
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when {
   resource.readOnly == true &&
@@ -113,7 +113,7 @@ Server names must match the registered MCP server names.
 
 Use `forbid` for controls that must always win over permits:
 
-```cedar
+```plaintext
 permit (principal, action == MCP::Action::"invokeTool", resource);
 
 forbid (principal, action == MCP::Action::"invokeTool", resource)
@@ -127,7 +127,7 @@ pattern also blocks unannotated tools.
 
 Use the `register` action to control which MCP servers can be registered:
 
-```cedar
+```plaintext
 permit (principal, action == MCP::Action::"register", resource)
 when { resource in MCP::Server::"github" };
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -1,17 +1,17 @@
 ---
-title: Control MCP tool access
-linkTitle: MCP tool access
+title: MCP access policies
+linkTitle: MCP access
 weight: 50
 description: Use Cedar-based MCP policies to control sandbox MCP server registration, tool calls, prompts, resources, and approval gates.
-keywords: docker sandboxes, MCP policy, MCP tool access, Cedar policy, requireApproval, AI Governance
+keywords: docker sandboxes, MCP policy, MCP access, Cedar policy, requireApproval, AI Governance
 ---
 
-MCP access rules control Model Context Protocol activity made available to a
+MCP policies control Model Context Protocol activity made available to a
 sandbox through Docker's MCP gateway. Use them to govern server registration,
 tool calls, gateway meta-tools, resources, prompts, and approval requirements.
 
 Unlike [network access rules](network.md) and
-[filesystem access rules](filesystem.md), MCP access rules are organization
+[filesystem access rules](filesystem.md), MCP policies are organization
 policies written in Cedar. Docker defines the `MCP` namespace, including the
 actions, resource types, attributes, and approval behavior that policies can
 match. For Docker's MCP policy actions, resources, attributes, and context

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -14,10 +14,10 @@ Unlike [network access rules](network.md) and
 [filesystem access rules](filesystem.md), MCP access rules are organization
 policies written in Cedar. Docker defines the `MCP` namespace, including the
 actions, resource types, attributes, and approval behavior that policies can
-match. For Docker's MCP policy actions, resources, attributes, context fields,
-and approval behavior, see the
-[MCP policy reference](../reference/mcp-policy.md). For Cedar syntax and
-language semantics, see the [Cedar documentation](https://docs.cedarpolicy.com/).
+match. For Docker's MCP policy actions, resources, attributes, and context
+fields, see the [MCP policy reference](../reference/mcp-policy.md). For Cedar
+syntax and language semantics, see the
+[Cedar documentation](https://docs.cedarpolicy.com/).
 
 ## How MCP policy works
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -106,15 +106,15 @@ resource or prompt permit if users don't need that capability.
 
 ## Require confirmation with MCP elicitation
 
-Despite its name, `@requireApproval` doesn't send a request to an organization
-administrator. It turns a matching `permit` into a per-request confirmation
-through MCP. The gateway sends an `elicitation/create` request to the same MCP
-client session that made the governed request. In a human-driven client, the
-person operating the agent sees the prompt and decides whether to proceed.
+Use `@requireApproval` to require per-request confirmation through MCP. When a
+request matches the annotated `permit`, the gateway sends an
+`elicitation/create` request to the same MCP client session that made the
+governed request. In a human-driven client, the person operating the agent sees
+the prompt and decides whether to proceed.
 
-Add an approval-gated permit to the previous policy to require this
-confirmation for non-read-only tools. The annotation string becomes the reason
-shown in the elicitation:
+The following policy adds this confirmation to the previous policy for
+non-read-only tools. The annotation string becomes the reason shown in the
+elicitation:
 
 ```plaintext
 @requireApproval("non-read-only tool call")

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -32,16 +32,15 @@ For Docker MCP policies:
   `MCP::Action::"invokeTool"`.
 - Resources use MCP entity types, such as `MCP::Server`, `MCP::Tool`,
   `MCP::Resource`, `MCP::Prompt`, and `MCP::Primordial`.
-- Governed MCP activity is default deny. A request is blocked unless a
-  matching `permit` allows it.
 - A matching `forbid` overrides any `permit`, including a permit with
   `@requireApproval`.
+- When MCP policy enforcement is active, evaluation is fail closed: server
+  registration and governed MCP requests are denied unless a matching `permit`
+  allows them.
 
 If MCP policy enforcement isn't active for a user, the MCP gateway doesn't
-evaluate Cedar policy and MCP activity is allowed by the gateway. When
-enforcement is active, evaluation is fail closed: server registration and
-governed MCP requests are denied unless a matching `permit` allows them. MCP
-doesn't have a local preset equivalent to network policy.
+evaluate Cedar policy and MCP activity is allowed by the gateway. MCP doesn't
+have a local preset equivalent to network policy.
 
 MCP policies are enforced on the MCP gateway path, not by the sandbox network
 proxy. During `sbx mcp add`, Docker Sandboxes evaluates the resolved server

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -134,6 +134,10 @@ For remote server registration, match attributes the gateway provides, such as
 server type, identity URL, OAuth requirement, or network requirement. Local
 server command and argument attributes don't apply to remote servers.
 
+For local stdio servers, `resource.type == "local-stdio"` matches host-side
+local servers. Use `resource.command` and `resource.args` only when the
+resolved registration includes command details.
+
 ## Next steps
 
 - Use [Policy concepts](../concepts.md#mcp-policies) for the MCP policy model.

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -37,6 +37,12 @@ For Docker MCP policies:
 - A matching `forbid` overrides any `permit`, including a permit with
   `@requireApproval`.
 
+If MCP policy enforcement isn't active for a user, the MCP gateway doesn't
+evaluate Cedar policy and MCP activity is allowed by the gateway. When
+enforcement is active, evaluation is fail closed: server registration and
+governed MCP requests are denied unless a matching `permit` allows them. MCP
+doesn't have a local preset equivalent to network policy.
+
 MCP policies are enforced on the MCP gateway path, not by the sandbox network
 proxy. During `sbx mcp add`, Docker Sandboxes evaluates the resolved server
 definition against `MCP::Action::"register"` before storing the registration.

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -112,9 +112,10 @@ request matches the annotated `permit`, the gateway sends an
 governed request. In a human-driven client, the person operating the agent sees
 the prompt and decides whether to proceed.
 
-The following policy adds this confirmation to the previous policy for
-non-read-only tools. The annotation string becomes the reason shown in the
-elicitation:
+The following policy requires confirmation for non-read-only tools on a server
+registered as `example`. Use it alongside any permits needed to register the
+server or use its other capabilities. The annotation string becomes the reason
+shown in the elicitation:
 
 ```plaintext
 @requireApproval("non-read-only tool call")
@@ -163,16 +164,19 @@ execution context that can't relay an elicitation, including calls from inside
 
 ## Withdraw server access
 
-To withdraw access from a server that broader rules permit, address both
-enforcement points. First, prevent future registrations of the server by
-matching its identity URL:
+To withdraw access from a server that broader rules permit, block it at
+registration and at use time. Registration policy controls future `sbx mcp add`
+operations, while use-time policy controls requests from servers that are
+already registered or loaded.
+
+Prevent future registrations of the server by matching its identity URL:
 
 ```plaintext
 forbid (principal, action == MCP::Action::"register", resource)
 when { resource.identityURL == "https://mcp.example.com/mcp" };
 ```
 
-Then deny use-time requests for each registered name that refers to the server:
+Deny use-time requests for each registered name that refers to the server:
 
 ```plaintext
 forbid (principal, action == MCP::Action::"invokeTool", resource)

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -9,6 +9,8 @@ keywords: docker sandboxes, MCP policy, MCP access, Cedar policy, requireApprova
 MCP policies control Model Context Protocol activity made available to a
 sandbox through Docker's MCP gateway. Use them to govern server registration,
 tool calls, gateway meta-tools, resources, prompts, and approval requirements.
+To register MCP servers and connect them to sandboxes, see
+[MCP gateway](../../mcp-gateway.md).
 
 Unlike [network access policies](network.md) and
 [filesystem access policies](filesystem.md), MCP policies are organization

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -135,6 +135,34 @@ permit (principal, action == MCP::Action::"register", resource)
 when { resource in MCP::Server::"notion" };
 ```
 
+Server names are chosen at registration time. To block a remote server
+regardless of the name a developer chooses, match the server's
+`resource.identityURL`:
+
+```plaintext
+permit (principal, action == MCP::Action::"register", resource);
+
+forbid (principal, action == MCP::Action::"register", resource)
+when { resource.identityURL == "https://mcp.example.com/mcp" };
+```
+
+This pattern prevents future `sbx mcp add` registrations for that identity URL.
+It doesn't remove registrations that already exist or stop an already-loaded
+server by itself. To govern existing registrations, add use-time rules for the
+registered server name. Replace `example` with the name used in the existing
+registration:
+
+```plaintext
+forbid (principal, action == MCP::Action::"invokeTool", resource)
+when { resource in MCP::Server::"example" };
+
+forbid (principal, action == MCP::Action::"readResource", resource)
+when { resource in MCP::Server::"example" };
+
+forbid (principal, action == MCP::Action::"getPrompt", resource)
+when { resource in MCP::Server::"example" };
+```
+
 For remote server registration, match attributes the gateway provides, such as
 server type, identity URL, OAuth requirement, or network requirement. Local
 server command and argument attributes don't apply to remote servers.

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -80,21 +80,25 @@ registered as `example` with the expected identity URL. It permits read-only
 tool calls, resource reads, and prompt retrieval from that registered server:
 
 ```plaintext
+// Permit registration with the expected name and identity URL.
 permit (principal, action == MCP::Action::"register", resource)
 when {
   resource in MCP::Server::"example" &&
   resource.identityURL == "https://mcp.example.com/mcp"
 };
 
+// Permit read-only tool calls.
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when {
   resource in MCP::Server::"example" &&
   resource.readOnly == true
 };
 
+// Permit resource reads.
 permit (principal, action == MCP::Action::"readResource", resource)
 when { resource in MCP::Server::"example" };
 
+// Permit prompt retrieval.
 permit (principal, action == MCP::Action::"getPrompt", resource)
 when { resource in MCP::Server::"example" };
 ```
@@ -210,26 +214,24 @@ explicit host commands and OCI-packaged stdio servers started with host Docker.
 For details about this boundary, see
 [Docker Engine isolation](../../security/isolation.md#docker-engine-isolation).
 
-In a blocklist policy that otherwise permits registration, deny both host-run
-server types:
+In a blocklist policy that otherwise permits registration, deny the host-run
+server type:
 
 ```plaintext
 forbid (principal, action == MCP::Action::"register", resource)
-when {
-  resource.type == "local-stdio" ||
-  resource.type == "container-stdio"
-};
+when { resource.type == "local-stdio" };
 ```
 
 `local-stdio` covers explicit commands, including commands that start a Docker
-container. `container-stdio` covers OCI-packaged stdio servers resolved from
-registry or manifest metadata.
+container, and OCI-packaged stdio servers resolved from registry or manifest
+metadata with `--local`.
 
 ## Related information
 
-- Use [Policy concepts](../concepts.md#mcp-policies) for the MCP policy model.
-- Use the [MCP policy reference](../reference/mcp-policy.md) for exact action,
-  resource, attribute, context, and approval behavior.
-- Use [Organization policies](organization.md) to manage policy scope.
-- Use [Audit logs](../audit/) to collect policy decision
+- [MCP policy concepts](../concepts.md#mcp-policies): policy model and rule
+  evaluation.
+- [MCP policy reference](../reference/mcp-policy.md): exact action, resource,
+  attribute, context, and approval behavior.
+- [Organization policies](organization.md): policy creation and scope.
+- [MCP policy audit logs](../audit/): policy decision
   records.

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -42,9 +42,9 @@ chosen name and resolved server identity together. At use time, tools,
 resources, and prompts are associated with the registered name, so rules for an
 existing server must match every name under which it was registered.
 
-Built-in gateway tools, such as `code-mode` and OAuth authorization helpers,
-are also governed at use time. They are `MCP::Primordial` resources rather than
-tools associated with a registered server. For details, see
+Built-in gateway tools, such as `mcp-add`, `code-mode`, and OAuth authorization
+helpers, are also governed at use time. They are `MCP::Primordial` resources
+rather than tools associated with a registered server. For details, see
 [Built-in gateway tools](../../mcp-gateway.md#built-in-gateway-tools).
 
 Use-time policy doesn't hide or remove existing registrations. Tool and

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -14,8 +14,10 @@ Unlike [network access rules](network.md) and
 [filesystem access rules](filesystem.md), MCP access rules are organization
 policies written in Cedar. Docker defines the `MCP` namespace, including the
 actions, resource types, attributes, and approval behavior that policies can
-match. For the full Cedar language, see the
-[Cedar documentation](https://docs.cedarpolicy.com/).
+match. For Docker's MCP policy actions, resources, attributes, context fields,
+and approval behavior, see the
+[MCP policy reference](../reference/mcp-policy.md). For Cedar syntax and
+language semantics, see the [Cedar documentation](https://docs.cedarpolicy.com/).
 
 ## How MCP policy works
 
@@ -123,6 +125,8 @@ server command and argument attributes don't apply to remote servers.
 ## Next steps
 
 - Use [Policy concepts](../concepts.md#mcp-policies) for the MCP policy model.
+- Use the [MCP policy reference](../reference/mcp-policy.md) for exact action,
+  resource, attribute, context, and approval behavior.
 - Use [Organization policies](organization.md) to manage policy scope.
 - Use [Audit logs](../audit/) to collect policy decision
   records.

--- a/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/mcp.md
@@ -1,0 +1,128 @@
+---
+title: Control MCP tool access
+linkTitle: MCP tool access
+weight: 50
+description: Use Cedar-based MCP policies to control sandbox MCP server registration, tool calls, prompts, resources, and approval gates.
+keywords: docker sandboxes, MCP policy, MCP tool access, Cedar policy, requireApproval, AI Governance
+---
+
+MCP access rules control Model Context Protocol activity made available to a
+sandbox through Docker's MCP gateway. Use them to govern server registration,
+tool calls, gateway meta-tools, resources, prompts, and approval requirements.
+
+Unlike [network access rules](network.md) and
+[filesystem access rules](filesystem.md), MCP access rules are organization
+policies written in Cedar. Docker defines the `MCP` namespace, including the
+actions, resource types, attributes, and approval behavior that policies can
+match. For the full Cedar language, see the
+[Cedar documentation](https://docs.cedarpolicy.com/).
+
+## How MCP policy works
+
+Cedar evaluates each request against a principal, action, resource, and context.
+For Docker MCP policies:
+
+- Policy scope supplies the principal. Use organization or team scope instead
+  of matching users, teams, tenants, or roles in the policy.
+- Actions use the `MCP::Action` namespace, such as
+  `MCP::Action::"invokeTool"`.
+- Resources use MCP entity types, such as `MCP::Server`, `MCP::Tool`,
+  `MCP::Resource`, `MCP::Prompt`, and `MCP::Primordial`.
+- Governed MCP activity is default deny. A request is blocked unless a
+  matching `permit` allows it.
+- A matching `forbid` overrides any `permit`, including a permit with
+  `@requireApproval`.
+
+## Start with a baseline
+
+To allow all MCP activity while you build a narrower policy, use an actionless
+`permit`:
+
+```cedar
+permit (principal, action, resource);
+```
+
+This is useful as a temporary baseline. For production policies, prefer
+patterns that limit access to approved servers, read-only tools, or
+approval-gated tool calls.
+
+## Allow read-only tools
+
+Servers can declare tool annotations such as `readOnly` and `destructive`. To
+allow tools that a server marks read-only:
+
+```cedar
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when { resource.readOnly == true };
+```
+
+`readOnly` defaults to `false` for tools that don't declare it, so this pattern
+fails closed for unannotated tools.
+
+## Require approval for writes
+
+Use `@requireApproval` on a `permit` statement to require user approval before
+a matching request runs:
+
+```cedar
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when { resource.readOnly == true };
+
+@requireApproval("write tool call")
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when { resource.readOnly == false };
+```
+
+If the sandbox can't ask a user for approval, the request is denied. A matching
+`forbid` still denies the request without showing an approval prompt.
+
+## Limit tools to approved servers
+
+Use `MCP::Server` to match the registered server that exposes a tool:
+
+```cedar
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when {
+  resource.readOnly == true &&
+  (resource in MCP::Server::"github" || resource in MCP::Server::"notion")
+};
+```
+
+Server names must match the registered MCP server names.
+
+## Block destructive tools
+
+Use `forbid` for controls that must always win over permits:
+
+```cedar
+permit (principal, action == MCP::Action::"invokeTool", resource);
+
+forbid (principal, action == MCP::Action::"invokeTool", resource)
+when { resource.destructive == true };
+```
+
+`destructive` defaults to `true` for tools that don't declare it, so this
+pattern also blocks unannotated tools.
+
+## Control server registration
+
+Use the `register` action to control which MCP servers can be registered:
+
+```cedar
+permit (principal, action == MCP::Action::"register", resource)
+when { resource in MCP::Server::"github" };
+
+permit (principal, action == MCP::Action::"register", resource)
+when { resource in MCP::Server::"notion" };
+```
+
+For remote server registration, match attributes the gateway provides, such as
+server type, identity URL, OAuth requirement, or network requirement. Local
+server command and argument attributes don't apply to remote servers.
+
+## Next steps
+
+- Use [Policy concepts](../concepts.md#mcp-policies) for the MCP policy model.
+- Use [Organization policies](organization.md) to manage policy scope.
+- Use [Audit logs](../audit/) to collect policy decision
+  records.

--- a/content/manuals/ai/sandboxes/governance/access-controls/network.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/network.md
@@ -52,9 +52,9 @@ For presets, sandbox-scoped rules, testing, and troubleshooting, see
 
 ## Organization network rules
 
-Admins manage organization network rules in the Docker Admin Console. A policy
-can apply to the whole organization or to selected teams. For setup steps and
-team scoping, see [Organization policies](organization.md).
+Organization network rules belong to policies that can apply to the whole
+organization or to selected teams. For setup steps and team scoping, see
+[Organization policies](organization.md).
 
 Use [Monitoring policies](../monitor-and-enforce/monitoring.md) to inspect
 which network rules are active on a developer machine.

--- a/content/manuals/ai/sandboxes/governance/access-controls/network.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/network.md
@@ -1,0 +1,60 @@
+---
+title: Network access rules
+linkTitle: Network access
+weight: 30
+description: Control outbound network access from Docker Sandboxes with local and organization policy rules.
+keywords: docker sandboxes, network access, network rules, governance, local policy, organization policy
+---
+
+Network access rules control outbound connections from sandboxes. Use them to
+allow the domains, IP ranges, and ports a workflow needs, and to block
+destinations that should stay unavailable.
+
+You can configure network access in two places:
+
+- [Local access rules](local.md), which apply to sandboxes on one developer
+  machine when organization governance is not active.
+- [Organization policies](organization.md), which apply centrally across an
+  organization or to selected teams.
+
+When organization governance is active, organization network rules replace
+local rules. Local rules are inactive until organization governance no longer
+applies.
+
+## Rule syntax
+
+Network rules use the actions `connect:tcp` and `connect:udp`. Resources are
+hostnames, CIDR ranges, ports, or hostnames with ports.
+
+Examples:
+
+- `api.example.com`
+- `*.example.com`
+- `**.example.com`
+- `example.com:443`
+- `10.0.0.0/8`
+
+For exact wildcard behavior and CIDR support, see
+[Network rules](../concepts.md#network-rules).
+
+## Local network rules
+
+Use `sbx policy allow network` and `sbx policy deny network` to manage local
+network rules:
+
+```console
+$ sbx policy allow network api.example.com
+$ sbx policy deny network ads.example.com
+```
+
+For presets, sandbox-scoped rules, testing, and troubleshooting, see
+[Local access rules](local.md).
+
+## Organization network rules
+
+Admins manage organization network rules in the Docker Admin Console. A policy
+can apply to the whole organization or to selected teams. For setup steps and
+team scoping, see [Organization policies](organization.md).
+
+Use [Monitoring policies](../monitor-and-enforce/monitoring.md) to inspect
+which network rules are active on a developer machine.

--- a/content/manuals/ai/sandboxes/governance/access-controls/network.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/network.md
@@ -1,14 +1,14 @@
 ---
-title: Network access rules
+title: Network access policies
 linkTitle: Network access
 weight: 30
 description: Control outbound network access from Docker Sandboxes with local and organization policy rules.
 keywords: docker sandboxes, network access, network rules, governance, local policy, organization policy
 ---
 
-Network access rules control outbound connections from sandboxes. Network
-policies contain one or more rules that allow the domains, IP ranges, and ports
-a workflow needs, or block destinations that should stay unavailable.
+Network access policies control outbound connections from sandboxes. Each
+policy contains one or more rules that allow the domains, IP ranges, and ports a
+workflow needs, or block destinations that should stay unavailable.
 
 You can configure network access in two places:
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/network.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/network.md
@@ -6,14 +6,14 @@ description: Control outbound network access from Docker Sandboxes with local an
 keywords: docker sandboxes, network access, network rules, governance, local policy, organization policy
 ---
 
-Network access rules control outbound connections from sandboxes. Use them to
-allow the domains, IP ranges, and ports a workflow needs, and to block
-destinations that should stay unavailable.
+Network access rules control outbound connections from sandboxes. Network
+policies contain one or more rules that allow the domains, IP ranges, and ports
+a workflow needs, or block destinations that should stay unavailable.
 
 You can configure network access in two places:
 
-- [Local access rules](local.md), which apply to sandboxes on one developer
-  machine when organization governance is not active.
+- [Local policy](local.md), which applies to sandboxes on one developer machine
+  when organization governance is not active.
 - [Organization policies](organization.md), which apply centrally across an
   organization or to selected teams.
 
@@ -48,7 +48,7 @@ $ sbx policy deny network ads.example.com
 ```
 
 For presets, sandbox-scoped rules, testing, and troubleshooting, see
-[Local access rules](local.md).
+[Local policy](local.md).
 
 ## Organization network rules
 

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -36,26 +36,23 @@ with the **Governance** permissions and assign it to a user or team.
 ## Create a policy
 
 Manage policies from the **AI Platform** section in the left-hand navigation
-of [Docker Home](https://app.docker.com). Network and filesystem policies are
-managed separately, under **Network access** and **Filesystem access**.
-
-The steps in this section cover network and filesystem policies. MCP policies
-use Cedar rather than the network and filesystem rule form. For MCP examples, see
-[MCP access policies](mcp.md).
+of [Docker Home](https://app.docker.com).
 
 To create a policy:
 
 1. Sign in to [Docker Home](https://app.docker.com) and select your
    organization.
 1. In the left-hand navigation, expand **AI Platform** and select
-   **Network access** or **Filesystem access**.
+   **Network access**, **Filesystem access**, or **MCP access**.
 1. Select **Create policy**.
 1. Enter a **Policy name**.
 1. Set the **Scope** to **Organization** or **Teams**. If you select **Teams**,
    choose the teams the policy applies to. See
    [Scope policies to teams](#scope-policies-to-teams).
-1. Select **Add rule** to add each rule. For rule syntax, use the relevant
-   access-control page in [Choose a policy type](#choose-a-policy-type).
+1. Define the policy rules. For network and filesystem policies, select
+   **Add rule** for each rule. For MCP policies, enter Cedar statements in the
+   policy editor. For syntax and examples, use the relevant access-control page
+   in [Choose a policy type](#choose-a-policy-type).
 
 Existing policies are listed with their name, scope, rule count, and last
 update. Use the action menu (⋮) to edit or delete a policy.

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -11,7 +11,7 @@ aliases:
 
 [Local policies](local.md) give individual developers control over what their
 sandboxes can access. Organization policy moves that control to the admin level:
-rules defined in **Admin Console** apply to sandboxes across the organization,
+rules defined in the Admin Console apply to sandboxes across the organization,
 either to every member or to specific teams. When organization governance is
 active, it replaces local `sbx policy` rules entirely — local rules are no
 longer evaluated and can't be used to supplement or override the organization
@@ -41,7 +41,7 @@ of [Docker Home](https://app.docker.com). Network and filesystem policies are
 managed separately, under **Network access** and **Filesystem access**.
 
 The steps in this section cover network and filesystem policies. MCP policies
-use Cedar rather than rule rows. For MCP examples, see
+use Cedar rather than the network and filesystem rule form. For MCP examples, see
 [MCP tool access](mcp.md).
 
 To create a policy:

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -145,7 +145,7 @@ organization policies on the next `sbx` command.
 > `sbx policy reset` deletes all locally configured policy rules. The command
 > prompts for confirmation before proceeding.
 
-#### Enforcement timing by policy type {#network-versus-filesystem-enforcement-timing}
+#### Enforcement timing by policy type
 
 Policy types differ in when a change takes effect after it reaches the
 developer machine:

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -170,6 +170,6 @@ developer machine:
   rules apply to subsequent governed MCP requests through the gateway.
 
 To apply a filesystem policy change immediately, remove the running sandbox
-and create a new one. To block an existing MCP registration after it has been
-loaded into a sandbox, add use-time rules for the registered server name. For
-examples, see [MCP access policies](mcp.md#control-server-registration).
+and create a new one. To prevent use of an MCP server that is already registered
+or loaded, add use-time rules for the registered server name. For examples, see
+[Withdraw server access](mcp.md#withdraw-server-access).

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -1,11 +1,12 @@
 ---
-title: Organization policy
-linkTitle: Org policy
+title: Organization policies
+linkTitle: Org policies
 weight: 20
 description: Centrally manage sandbox network, filesystem, and MCP policies for your organization.
 keywords: docker sandboxes, governance, organization policy, AI governance, admin console, network access, filesystem access, mcp policy
 aliases:
   - /ai/sandboxes/security/governance/
+  - /ai/sandboxes/governance/org/
 ---
 
 [Local policies](local.md) give individual developers control over what their
@@ -40,7 +41,8 @@ of [Docker Home](https://app.docker.com). Network and filesystem policies are
 managed separately, under **Network access** and **Filesystem access**.
 
 The steps in this section cover network and filesystem policies. MCP policies
-use Cedar rather than rule rows; see [MCP policies](#mcp-policies).
+use Cedar rather than rule rows. For MCP examples, see
+[MCP tool access](mcp.md).
 
 To create a policy:
 
@@ -53,7 +55,7 @@ To create a policy:
    choose the teams the policy applies to. See
    [Scope policies to teams](#scope-policies-to-teams).
 1. Select **Add rule** to add each rule. For rule syntax, see
-   [Policy concepts](concepts.md#rule-syntax).
+   [Policy concepts](../concepts.md#rule-syntax).
 
 Existing policies are listed with their name, scope, rule count, and last
 update. Use the action menu (⋮) to edit or delete a policy.
@@ -84,13 +86,13 @@ A network rule takes a network target and an action (allow or deny). You can
 add multiple entries at once, one per line.
 
 For the full syntax reference (exact hostnames, wildcard subdomains, port
-suffixes, and CIDR ranges), see [Policy concepts](concepts.md#network-rules).
+suffixes, and CIDR ranges), see [Network access rules](network.md).
 
 When organization governance is active, local network rules are not evaluated.
 The organization policy is the only policy in effect. `sbx policy ls` hides
 these inactive local rules by default. See
-[Monitoring](monitoring.md#showing-inactive-rules) for how to list them and read
-the rule view.
+[Monitoring](../monitor-and-enforce/monitoring.md#showing-inactive-rules) for
+how to list them and read the rule view.
 
 ## Filesystem policies
 
@@ -102,26 +104,15 @@ Admins can restrict which paths are mountable with filesystem allow and deny
 rules. Each rule takes a path pattern and an action (allow or deny).
 
 For path pattern syntax and how read and write access combine to allow a
-mount, see [Policy concepts](concepts.md#filesystem-rules).
+mount, see [Filesystem access rules](filesystem.md).
 
 ## MCP policies
 
 MCP policies control sandbox activity that goes through MCP servers, such as
 server registration, tool calls, resource reads, prompts, and gateway
 meta-tools. Unlike network and filesystem policies, MCP policies are written in
-Cedar using the `MCP` namespace.
-
-MCP policy is default deny: an MCP request is blocked unless a matching
-`permit` allows it. Use `forbid` for rules that must always deny a matching
-request. A matching `forbid` overrides a `permit`, including one that requires
-approval.
-
-Use `@requireApproval` on a `permit` statement to require user approval before a
-matching request runs. If the sandbox can't ask a user for approval, the request
-is denied.
-
-For the MCP policy model and a starter example, see
-[MCP policies](concepts.md#mcp-policies).
+Cedar using the `MCP` namespace. For policy patterns and examples, see
+[MCP tool access](mcp.md).
 
 ## Scope policies to teams
 
@@ -153,12 +144,12 @@ team membership changes, including changes synced from your IdP.
 ### How org-wide and team-scoped policies combine
 
 A user is governed by all of their
-[effective policies](concepts.md#policy-scope) at once — every org-wide policy,
-plus the team-scoped policies for the teams they belong to. The rules combine
-into a single evaluation in which deny always wins, so a team-scoped policy can
-grant access on top of the org-wide policies but can't loosen a restriction they
-impose. For the full evaluation model, see
-[Rule evaluation](concepts.md#rule-evaluation).
+[effective policies](../concepts.md#policy-scope) at once — every org-wide
+policy, plus the team-scoped policies for the teams they belong to. The rules
+combine into a single evaluation in which deny always wins, so a team-scoped
+policy can grant access on top of the org-wide policies but can't loosen a
+restriction they impose. For the full evaluation model, see
+[Rule evaluation](../concepts.md#rule-evaluation).
 
 This makes org-wide policies the natural home for guardrails that must hold
 everywhere. For example, an org-wide policy can deny a category of domains for
@@ -176,7 +167,7 @@ The examples that follow show each pattern.
 
 ### Grant one team access to a blocked domain
 
-Because access is [denied by default](concepts.md#rule-evaluation), you don't
+Because access is [denied by default](../concepts.md#rule-evaluation), you don't
 need an explicit deny to keep a domain off-limits. Leaving it out of every allow
 rule is enough. To give a single team access to a domain no one else can reach:
 
@@ -207,7 +198,7 @@ team allow apply to different hostnames, so they never conflict.
 
 To block a domain and all its subdomains, deny `**.example.com` instead. With
 that pattern, deny wins over any team-scoped allow on a subdomain. See
-[Hostname patterns](concepts.md#network-rules) for how exact hostnames and
+[Hostname patterns](../concepts.md#network-rules) for how exact hostnames and
 wildcards match.
 
 ## Precedence
@@ -217,7 +208,7 @@ organization rules set in the Admin Console determine what is allowed or denied,
 and they can't be supplemented or overridden from a developer's machine. The
 same applies to filesystem policies: organization rules replace local behavior
 entirely. For how a user's organization policies are evaluated together, see
-[Policy concepts](concepts.md#rule-evaluation).
+[Policy concepts](../concepts.md#rule-evaluation).
 
 To unblock a domain when organization governance is active, update the rule in
 the Admin Console or via the [API](/reference/api/ai-governance/). Without

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -145,9 +145,10 @@ organization policies on the next `sbx` command.
 > `sbx policy reset` deletes all locally configured policy rules. The command
 > prompts for confirmation before proceeding.
 
-#### Network versus filesystem enforcement timing
+#### Enforcement timing by policy type {#network-versus-filesystem-enforcement-timing}
 
-Network policy and filesystem policy differ in when a change takes effect:
+Policy types differ in when a change takes effect after it reaches the
+developer machine:
 
 - Network policy is evaluated on every outbound request. Once a policy
   change has synced to the developer's machine (up to 5 minutes), it applies
@@ -159,5 +160,16 @@ Network policy and filesystem policy differ in when a change takes effect:
   access the previously allowed path until it is removed and a new one is
   created.
 
+- MCP registration policy is evaluated when a server is registered with
+  `sbx mcp add`. Changing registration rules doesn't remove existing
+  registrations or stop an already-loaded server by itself.
+
+- MCP use-time policy is evaluated by the MCP gateway when a sandbox makes a
+  governed MCP request, such as a tool call, resource read, prompt retrieval,
+  or built-in gateway tool call. Once a policy change has synced, use-time
+  rules apply to subsequent governed MCP requests through the gateway.
+
 To apply a filesystem policy change immediately, remove the running sandbox
-and create a new one.
+and create a new one. To block an existing MCP registration after it has been
+loaded into a sandbox, add use-time rules for the registered server name. For
+examples, see [MCP access policies](mcp.md#control-server-registration).

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -3,7 +3,7 @@ title: Organization policies
 linkTitle: Org policies
 weight: 20
 description: Centrally manage sandbox network, filesystem, and MCP policies for your organization.
-keywords: docker sandboxes, governance, organization policy, AI governance, admin console, network access, filesystem access, mcp policy
+keywords: docker sandboxes, governance, organization policy, AI governance, Docker Home, network access, filesystem access, mcp policy
 aliases:
   - /ai/sandboxes/security/governance/
   - /ai/sandboxes/governance/org/
@@ -11,13 +11,12 @@ aliases:
 
 [Local policies](local.md) give individual developers control over what their
 sandboxes can access. Organization policy moves that control to the admin level:
-rules defined in the Admin Console apply to sandboxes across the organization,
-either to every member or to specific teams. When organization governance is
-active, it replaces local `sbx policy` rules entirely — local rules are no
-longer evaluated and can't be used to supplement or override the organization
-policy.
+organization policies apply to sandboxes across the organization, either to
+every member or to specific teams. When organization governance is active, it
+replaces local `sbx policy` rules entirely — local rules are no longer
+evaluated and can't be used to supplement or override the organization policy.
 
-Admins can manage organization policies through the Admin Console UI. For
+Admins can manage organization policies through the Docker Home UI. For
 programmatic management of network and filesystem policies, use the
 [Governance API](/reference/api/ai-governance/).
 
@@ -36,7 +35,7 @@ with the **Governance** permissions and assign it to a user or team.
 
 ## Create a policy
 
-Manage policies under **Admin Console**, a section in the left-hand navigation
+Manage policies from the **AI Platform** section in the left-hand navigation
 of [Docker Home](https://app.docker.com). Network and filesystem policies are
 managed separately, under **Network access** and **Filesystem access**.
 
@@ -48,8 +47,9 @@ To create a policy:
 
 1. Sign in to [Docker Home](https://app.docker.com) and select your
    organization.
-1. Select **AI Platform**, then the governance section you want.
-1. Select **Network access** or **Filesystem access**, then **Create policy**.
+1. In the left-hand navigation, expand **AI Platform** and select
+   **Network access** or **Filesystem access**.
+1. Select **Create policy**.
 1. Enter a **Policy name**.
 1. Set the **Scope** to **Organization** or **Teams**. If you select **Teams**,
    choose the teams the policy applies to. See
@@ -111,7 +111,7 @@ Team scoping targets your organization's existing
 exist before you can scope a policy to it. Create teams and manage their members
 in one of two ways:
 
-- Manually, in the Admin Console.
+- Manually, in Docker Home.
 - Automatically, by using
   [group mapping](/manuals/enterprise/security/provisioning/scim/group-mapping.md)
   to synchronize your identity provider's groups with the teams in your
@@ -136,11 +136,10 @@ deny rules combine, see [Policy concepts](../concepts.md).
 
 ### Policy changes not taking effect
 
-After updating organization policies in the Admin Console, changes take up
-to 5 minutes to propagate to developer machines. To apply changes
-immediately, users can run `sbx policy reset`, which stops the daemon and
-forces it to pull the latest organization policies on the next `sbx`
-command.
+After updating organization policies, changes take up to 5 minutes to
+propagate to developer machines. To apply changes immediately, users can run
+`sbx policy reset`, which stops the daemon and forces it to pull the latest
+organization policies on the next `sbx` command.
 
 > [!WARNING]
 > `sbx policy reset` deletes all locally configured policy rules. The command

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -42,7 +42,7 @@ managed separately, under **Network access** and **Filesystem access**.
 
 The steps in this section cover network and filesystem policies. MCP policies
 use Cedar rather than the network and filesystem rule form. For MCP examples, see
-[MCP tool access](mcp.md).
+[MCP access policies](mcp.md).
 
 To create a policy:
 
@@ -87,7 +87,7 @@ pages for syntax, examples, and enforcement details:
   sandboxes.
 - [Filesystem access rules](filesystem.md): control which host paths sandboxes
   can mount as workspaces.
-- [MCP tool access](mcp.md): control MCP server registration, tool calls,
+- [MCP access policies](mcp.md): control MCP server registration, tool calls,
   resources, prompts, and approval gates with Cedar policy.
 
 When organization governance is active, local and kit-defined rules are not

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -54,8 +54,8 @@ To create a policy:
 1. Set the **Scope** to **Organization** or **Teams**. If you select **Teams**,
    choose the teams the policy applies to. See
    [Scope policies to teams](#scope-policies-to-teams).
-1. Select **Add rule** to add each rule. For rule syntax, see
-   [Policy concepts](../concepts.md#rule-syntax).
+1. Select **Add rule** to add each rule. For rule syntax, use the relevant
+   access-control page in [Choose a policy type](#choose-a-policy-type).
 
 Existing policies are listed with their name, scope, rule count, and last
 update. Use the action menu (⋮) to edit or delete a policy.
@@ -78,41 +78,21 @@ Docker shows the message only for denials caused by organization governance
 policy. If you leave it blank, Docker shows the policy denial without additional
 contact text.
 
-## Network policies
+## Choose a policy type
 
-### Configuring org-level network rules
+Organization policies are managed by access surface. Use the access-control
+pages for syntax, examples, and enforcement details:
 
-A network rule takes a network target and an action (allow or deny). You can
-add multiple entries at once, one per line.
+- [Network access rules](network.md): control outbound network access from
+  sandboxes.
+- [Filesystem access rules](filesystem.md): control which host paths sandboxes
+  can mount as workspaces.
+- [MCP tool access](mcp.md): control MCP server registration, tool calls,
+  resources, prompts, and approval gates with Cedar policy.
 
-For the full syntax reference (exact hostnames, wildcard subdomains, port
-suffixes, and CIDR ranges), see [Network access rules](network.md).
-
-When organization governance is active, local network rules are not evaluated.
-The organization policy is the only policy in effect. `sbx policy ls` hides
-these inactive local rules by default. See
-[Monitoring](../monitor-and-enforce/monitoring.md#showing-inactive-rules) for
-how to list them and read the rule view.
-
-## Filesystem policies
-
-Filesystem policies control which host paths a sandbox can mount as
-workspaces. By default, sandboxes can mount any directory the user has
-access to.
-
-Admins can restrict which paths are mountable with filesystem allow and deny
-rules. Each rule takes a path pattern and an action (allow or deny).
-
-For path pattern syntax and how read and write access combine to allow a
-mount, see [Filesystem access rules](filesystem.md).
-
-## MCP policies
-
-MCP policies control sandbox activity that goes through MCP servers, such as
-server registration, tool calls, resource reads, prompts, and gateway
-meta-tools. Unlike network and filesystem policies, MCP policies are written in
-Cedar using the `MCP` namespace. For policy patterns and examples, see
-[MCP tool access](mcp.md).
+When organization governance is active, local and kit-defined rules are not
+evaluated. To see which rules are active on a developer machine, use
+[Monitoring policies](../monitor-and-enforce/monitoring.md).
 
 ## Scope policies to teams
 
@@ -141,78 +121,16 @@ in one of two ways:
 Because policies apply by team, a user's policies update automatically as their
 team membership changes, including changes synced from your IdP.
 
-### How org-wide and team-scoped policies combine
+### How scoped policies combine
 
 A user is governed by all of their
-[effective policies](../concepts.md#policy-scope) at once — every org-wide
-policy, plus the team-scoped policies for the teams they belong to. The rules
-combine into a single evaluation in which deny always wins, so a team-scoped
-policy can grant access on top of the org-wide policies but can't loosen a
-restriction they impose. For the full evaluation model, see
-[Rule evaluation](../concepts.md#rule-evaluation).
+[effective policies](../concepts.md#policy-scope): every org-wide policy, plus
+the team-scoped policies for the teams they belong to. Use org-wide policies
+for guardrails that must apply everywhere, and team-scoped policies for access
+that only some teams need.
 
-This makes org-wide policies the natural home for guardrails that must hold
-everywhere. For example, an org-wide policy can deny a category of domains for
-all members, while a team-scoped policy grants a research team access to extra
-package mirrors. Research-team members get the extra access, but the org-wide
-deny still applies.
-
-In practice, three patterns cover most layering:
-
-- Deny by default: leave a domain out of every allow rule to keep it blocked.
-- Allow when needed: add a team-scoped allow to grant an exception.
-- Explicit deny: deny a domain outright when no team should ever reach it.
-
-The examples that follow show each pattern.
-
-### Grant one team access to a blocked domain
-
-Because access is [denied by default](../concepts.md#rule-evaluation), you don't
-need an explicit deny to keep a domain off-limits. Leaving it out of every allow
-rule is enough. To give a single team access to a domain no one else can reach:
-
-1. Don't add an allow rule for the domain at the organization level. Default
-   deny keeps it blocked for everyone.
-1. Create a team-scoped policy that allows the domain, and scope it to that team.
-
-Only members of that team can reach the domain. Everyone else is still blocked
-by default.
-
-### Block a domain everywhere as a guardrail
-
-Use an explicit org-wide deny when a domain must be off-limits to everyone,
-including teams that have broad allow rules. Because deny wins, an org-wide deny
-on `**.example.com` blocks `example.com` and every subdomain for all members,
-and no team-scoped allow can grant access to it.
-
-Reserve explicit deny rules for domains you want to block outright. For
-everything else, rely on default deny and add allow rules only where access is
-needed.
-
-### An exact deny doesn't cover subdomains
-
-A deny rule matches only the hostnames its pattern matches. A deny on the exact
-hostname `example.com` doesn't match `api.example.com`, so a team-scoped allow
-on `api.example.com` still grants that team access. The org-wide deny and the
-team allow apply to different hostnames, so they never conflict.
-
-To block a domain and all its subdomains, deny `**.example.com` instead. With
-that pattern, deny wins over any team-scoped allow on a subdomain. See
-[Hostname patterns](../concepts.md#network-rules) for how exact hostnames and
-wildcards match.
-
-## Precedence
-
-When organization governance is active, local rules are not evaluated. Only
-organization rules set in the Admin Console determine what is allowed or denied,
-and they can't be supplemented or overridden from a developer's machine. The
-same applies to filesystem policies: organization rules replace local behavior
-entirely. For how a user's organization policies are evaluated together, see
-[Policy concepts](../concepts.md#rule-evaluation).
-
-To unblock a domain when organization governance is active, update the rule in
-the Admin Console or via the [API](/reference/api/ai-governance/). Without
-organization governance, remove the local rule with `sbx policy rm`.
+For precedence between local and organization policies, and for how allow and
+deny rules combine, see [Policy concepts](../concepts.md).
 
 ## Troubleshooting
 
@@ -244,9 +162,3 @@ Network policy and filesystem policy differ in when a change takes effect:
 
 To apply a filesystem policy change immediately, remove the running sandbox
 and create a new one.
-
-### Sandbox cannot mount workspace
-
-If a sandbox fails to mount with a `mount policy denied` error, verify that
-the filesystem allow rule in the Admin Console uses `**` rather than `*`. A
-single `*` doesn't match across directory separators.

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -83,10 +83,10 @@ contact text.
 Organization policies are managed by access surface. Use the access-control
 pages for syntax, examples, and enforcement details:
 
-- [Network access rules](network.md): control outbound network access from
+- [Network access policies](network.md): control outbound network access from
   sandboxes.
-- [Filesystem access rules](filesystem.md): control which host paths sandboxes
-  can mount as workspaces.
+- [Filesystem access policies](filesystem.md): control which host paths
+  sandboxes can mount as workspaces.
 - [MCP access policies](mcp.md): control MCP server registration, tool calls,
   resources, prompts, and approval gates with Cedar policy.
 

--- a/content/manuals/ai/sandboxes/governance/audit/_index.md
+++ b/content/manuals/ai/sandboxes/governance/audit/_index.md
@@ -16,8 +16,8 @@ prompt content, agent output, or parameter values.
 Audit logs are exposed when AI Governance is enabled for your organization.
 Docker Sandboxes send audit records only for signed-in users who have an AI
 Governance license and are governed by an enforced centralized [organization
-policy](../org.md). Docker Sandboxes users without both don't send audit data to
-audit logs.
+policy](../access-controls/organization.md). Docker Sandboxes users without both
+don't send audit data to audit logs.
 
 > [!NOTE]
 > AI Governance Audit Logs are part of Docker AI Governance and require a

--- a/content/manuals/ai/sandboxes/governance/audit/local.md
+++ b/content/manuals/ai/sandboxes/governance/audit/local.md
@@ -14,10 +14,10 @@ on or off.
 
 The sandbox daemon writes local audit records only for signed-in users who have
 an AI Governance license and are governed by an enforced centralized
-[organization policy](../org.md). Docker Sandboxes users without both do not
-send audit data to audit logs. To confirm governance is active, run
-`sbx policy ls`. The output includes a `Governance: Managed by <org>` line
-when an organization policy is in effect.
+[organization policy](../access-controls/organization.md). Docker Sandboxes
+users without both do not send audit data to audit logs. To confirm governance
+is active, run `sbx policy ls`. The output includes a `Governance: Managed by
+<org>` line when an organization policy is in effect.
 
 ## What gets recorded
 

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -2,7 +2,7 @@
 title: Policy concepts
 weight: 5
 description: The resource model, rule syntax, and evaluation logic behind Docker sandbox governance.
-keywords: docker sandboxes, policy concepts, rule syntax, network rules, filesystem rules, precedence, rule evaluation
+keywords: docker sandboxes, policy concepts, rule syntax, network rules, filesystem rules, mcp policy, cedar policy, precedence, rule evaluation
 ---
 
 ## Resource model
@@ -15,7 +15,8 @@ Policies exist at two levels:
 
 - **Local**: configured per machine using the `sbx policy` CLI. Applies to
   sandboxes on that machine only.
-- **Organization**: configured in Docker Home or via the
+- **Organization**: configured in the Docker Admin Console. Network and
+  filesystem policies can also be managed via the
   [Governance API](/reference/api/ai-governance/). Applies to sandboxes across
   the organization. An organization can have several policies, each applying
   either org-wide or to specific teams. See [Policy scope](#policy-scope).
@@ -30,8 +31,10 @@ A **rule** is the unit of access control within a policy. Each rule has:
 - **Resources**: the targets the rule matches against
 - **Decision**: `allow` or `deny`
 
-Rules are grouped by domain: all rules in a policy must share the same domain,
-either `network` or `filesystem`.
+Rules are grouped by domain. Network and filesystem rules in a policy must
+share the same domain, either `network` or `filesystem`. MCP policies use Cedar
+statements written in the `MCP` namespace instead of the network and filesystem
+rule format.
 
 ## Policy scope
 
@@ -115,6 +118,52 @@ Use `**` to match a directory tree recursively. A single `*` matches within one
 path segment and won't cross a path separator. For example, `~/**` matches all
 paths under the home directory, while `~/*` matches only its direct children.
 
+### MCP policies
+
+MCP policies control Model Context Protocol activity made available to a
+sandbox through Docker's MCP gateway. They are organization policies written in
+Cedar using the `MCP` namespace, rather than the network and filesystem rule
+format.
+
+Cedar evaluates each MCP request against a principal, action, resource, and
+context. Admins write rules for the action, resource, and context. Policy scope
+supplies the principal, so a rule that tries to match a specific user, team,
+tenant, or role in the principal doesn't match.
+
+Governed MCP actions are default deny: an MCP request is blocked unless a
+matching `permit` allows it. A matching `forbid` overrides any `permit`,
+including a permit that requires approval.
+
+MCP policies can match actions such as:
+
+- `register`: Register an MCP server
+- `invokeTool`: Call an MCP tool
+- `invokePrimordial`: Call a gateway meta-tool
+- `readResource`: Read an MCP resource
+- `getPrompt`: Retrieve an MCP prompt
+
+Resources are referenced with `MCP` entity types, such as `MCP::Server`,
+`MCP::Tool`, `MCP::Resource`, `MCP::Prompt`, and `MCP::Primordial`. For example,
+a tool policy can match the server that exposes the tool, the tool's bare name,
+and server-declared tool annotations such as `readOnly` or `destructive`.
+
+The following policy allows tools that the server declares read-only, and
+requires approval before a non-read-only tool can run:
+
+```cedar
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when { resource.readOnly == true };
+
+@requireApproval("write tool call")
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when { resource.readOnly == false };
+```
+
+The `@requireApproval` annotation applies to `permit` statements. When a request
+matches that permit and no matching `forbid` overrides it, the sandbox asks the
+user to approve before the request runs. If the request can't be presented to a
+user for approval, it is denied.
+
 ## Rule evaluation
 
 When organization governance is active, the rules from all of a user's
@@ -125,7 +174,8 @@ each request, following two principles:
   regardless of any matching allow rules.
 - Default deny: anything an allow rule doesn't match is blocked. Outbound
   network traffic is blocked unless a network rule allows the destination, and a
-  host path can't be mounted unless a filesystem rule allows it.
+  host path can't be mounted unless a filesystem rule allows it. MCP activity is
+  blocked unless an MCP `permit` allows it.
 
 Because every effective policy feeds the same evaluation, allows are additive (a
 request is allowed if any effective policy allows it) and denies are absolute (a

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Policy concepts
-weight: 5
+weight: 10
 description: The resource model, rule syntax, and evaluation logic behind Docker sandbox governance.
 keywords: docker sandboxes, policy concepts, rule syntax, network rules, filesystem rules, mcp policy, cedar policy, precedence, rule evaluation
 ---
@@ -126,9 +126,9 @@ Cedar using the `MCP` namespace, rather than the network and filesystem rule
 format.
 
 Cedar evaluates each MCP request against a principal, action, resource, and
-context. Admins write rules for the action, resource, and context. Policy scope
-supplies the principal, so a rule that tries to match a specific user, team,
-tenant, or role in the principal doesn't match.
+context. Admins write policy statements for the action, resource, and context.
+Policy scope supplies the principal, so a statement that tries to match a
+specific user, team, tenant, or role in the principal doesn't match.
 
 Governed MCP actions are default deny: an MCP request is blocked unless a
 matching `permit` allows it. A matching `forbid` overrides any `permit`,

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -78,6 +78,9 @@ need to match the root domain and its subdomains.
 Both IPv4 and IPv6 notation are supported: `10.0.0.0/8`, `192.168.1.0/24`,
 `2001:db8::/32`.
 
+For local and organization policy configuration, see
+[Network access policies](access-controls/network.md).
+
 ### Filesystem rules
 
 Filesystem rules use the actions `read` and `write`. Resources are host paths
@@ -117,6 +120,9 @@ Wildcards behave the same way in every path format:
 Use `**` to match a directory tree recursively. A single `*` matches within one
 path segment and won't cross a path separator. For example, `~/**` matches all
 paths under the home directory, while `~/*` matches only its direct children.
+
+For organization policy configuration and enforcement details, see
+[Filesystem access policies](access-controls/filesystem.md).
 
 ### MCP policies
 

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -125,47 +125,20 @@ sandbox through Docker's [MCP gateway](../mcp-gateway.md). They are
 organization policies written in Cedar using the `MCP` namespace, rather than
 the network and filesystem rule format.
 
-Cedar evaluates each MCP request against a principal, action, resource, and
-context. Admins write policy statements for the action, resource, and context.
-Policy scope supplies the principal, so a statement that tries to match a
-specific user, team, tenant, or role in the principal doesn't match.
+MCP policy applies when a developer registers a server and when an agent uses
+the MCP gateway. Registration rules control future `sbx mcp add` operations.
+Use-time rules control tool calls, gateway meta-tools, resource reads, and
+prompt retrieval from servers that are already registered or loaded.
 
-Governed MCP actions are default deny: an MCP request is blocked unless a
-matching `permit` allows it. A matching `forbid` overrides any `permit`,
-including a permit that requires approval.
+Governed MCP activity is default deny: a request is blocked unless a matching
+`permit` allows it. A matching `forbid` overrides any `permit`, including a
+permit that requires approval. Policy scope supplies the principal, so use
+organization or team scope instead of matching users, teams, tenants, or roles
+in Cedar.
 
-MCP policies can match actions such as:
-
-- `register`: Register an MCP server
-- `invokeTool`: Call an MCP tool
-- `invokePrimordial`: Call a gateway meta-tool
-- `readResource`: Read an MCP resource
-- `getPrompt`: Retrieve an MCP prompt
-
-Resources are referenced with `MCP` entity types, such as `MCP::Server`,
-`MCP::Tool`, `MCP::Resource`, `MCP::Prompt`, and `MCP::Primordial`. For example,
-a tool policy can match the server that exposes the tool, the tool's bare name,
-and server-declared tool annotations such as `readOnly` or `destructive`.
-
+For representative policies, see [MCP access policies](access-controls/mcp.md).
 For exact action, resource, context, and approval behavior, see the
 [MCP policy reference](reference/mcp-policy.md).
-
-The following policy allows tools that the server declares read-only, and
-requires approval before a non-read-only tool can run:
-
-```plaintext
-permit (principal, action == MCP::Action::"invokeTool", resource)
-when { resource.readOnly == true };
-
-@requireApproval("write tool call")
-permit (principal, action == MCP::Action::"invokeTool", resource)
-when { resource.readOnly == false };
-```
-
-The `@requireApproval` annotation applies to `permit` statements. When a request
-matches that permit and no matching `forbid` overrides it, the sandbox asks the
-user to approve before the request runs. If the request can't be presented to a
-user for approval, it is denied.
 
 ## Rule evaluation
 

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -15,8 +15,8 @@ Policies exist at two levels:
 
 - **Local**: configured per machine using the `sbx policy` CLI. Applies to
   sandboxes on that machine only.
-- **Organization**: configured in the Docker Admin Console. Network and
-  filesystem policies can also be managed via the
+- **Organization**: configured in Docker Home. Network and filesystem policies
+  can also be managed via the
   [Governance API](/reference/api/ai-governance/). Applies to sandboxes across
   the organization. An organization can have several policies, each applying
   either org-wide or to specific teams. See [Policy scope](#policy-scope).

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -153,7 +153,7 @@ For exact action, resource, context, and approval behavior, see the
 The following policy allows tools that the server declares read-only, and
 requires approval before a non-read-only tool can run:
 
-```cedar
+```plaintext
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when { resource.readOnly == true };
 

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -196,7 +196,8 @@ whether your organization has governance enabled:
 - Organization governance active: organization rules apply across all developer
   machines, and local and kit-defined rules are not evaluated. `sbx policy ls`
   hides these inactive rules by default; see
-  [Monitoring](monitoring.md#showing-inactive-rules) for how to list them.
+  [Monitoring](monitor-and-enforce/monitoring.md#showing-inactive-rules) for how
+  to list them.
 
 When organization governance is active, a user's organization policies are
 evaluated together, as described in [Rule evaluation](#rule-evaluation).

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -121,9 +121,9 @@ paths under the home directory, while `~/*` matches only its direct children.
 ### MCP policies
 
 MCP policies control Model Context Protocol activity made available to a
-sandbox through Docker's MCP gateway. They are organization policies written in
-Cedar using the `MCP` namespace, rather than the network and filesystem rule
-format.
+sandbox through Docker's [MCP gateway](../mcp-gateway.md). They are
+organization policies written in Cedar using the `MCP` namespace, rather than
+the network and filesystem rule format.
 
 Cedar evaluates each MCP request against a principal, action, resource, and
 context. Admins write policy statements for the action, resource, and context.

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -147,6 +147,9 @@ Resources are referenced with `MCP` entity types, such as `MCP::Server`,
 a tool policy can match the server that exposes the tool, the tool's bare name,
 and server-declared tool annotations such as `readOnly` or `destructive`.
 
+For exact action, resource, context, and approval behavior, see the
+[MCP policy reference](reference/mcp-policy.md).
+
 The following policy allows tools that the server declares read-only, and
 requires approval before a non-read-only tool can run:
 

--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/_index.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Monitor and enforce
-weight: 20
+weight: 30
 description: Inspect active sandbox governance rules, collect audit records, and enforce organization sign-in.
 keywords: docker sandboxes, governance monitoring, audit logs, sign-in enforcement, policy enforcement
 ---

--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/_index.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/_index.md
@@ -1,0 +1,16 @@
+---
+title: Monitor and enforce
+weight: 20
+description: Inspect active sandbox governance rules, collect audit records, and enforce organization sign-in.
+keywords: docker sandboxes, governance monitoring, audit logs, sign-in enforcement, policy enforcement
+---
+
+After policies are configured, use monitoring, audit records, and sign-in
+enforcement to verify how governance behaves across developer machines.
+
+- [Monitoring policies](monitoring.md): inspect active policy rules and monitor
+  sandbox network traffic.
+- [Audit logs](../audit/): view, configure, export, and collect governance audit
+  records.
+- [Sign-in enforcement](sign-in-enforcement.md): require users to sign in as
+  members of approved Docker organizations.

--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
@@ -1,8 +1,10 @@
 ---
 title: Monitoring policies
-weight: 25
+weight: 10
 description: Inspect active policy rules and monitor sandbox network traffic with sbx policy ls and sbx policy log.
 keywords: docker sandboxes, policy monitoring, sbx policy ls, sbx policy log, network traffic, policy debugging
+aliases:
+  - /ai/sandboxes/governance/monitoring/
 ---
 
 `sbx policy ls` and `sbx policy log` give you a combined view of all active
@@ -27,7 +29,7 @@ The columns are:
 - `POLICY`: the policy name.
 - `SOURCE`: where the policy came from. `local` means your local configuration
   — a preset or rules you added with `sbx policy`. `kit` means a
-  [kit](../customize/kits.md#control-network-access). `org` means your
+  [kit](../../customize/kits.md#control-network-access). `org` means your
   organization.
 - `APPLIES TO`: which sandboxes the policy applies to. `all` means the policy
   is global. `sandbox:<name>` scopes it to a single sandbox; a profile name
@@ -113,7 +115,7 @@ A writable workspace mount must be allowed by both a `filesystem:read` and a
 `filesystem:write` rule; a read-only mount needs only `filesystem:read`. The
 default local policy allows read and write access to all paths, shown as the
 two `default-fs-*` rules above. For the rule syntax and path patterns, see
-[Policy concepts](concepts.md#filesystem-rules).
+[Policy concepts](../concepts.md#filesystem-rules).
 
 ## Monitoring traffic
 
@@ -135,13 +137,13 @@ my-sandbox   network  app.example.com        browser-open                       
 
 The `PROXY` column shows how the request left the sandbox:
 
-| Value | Description |
-| ----- | ----------- |
-| `forward` | Routed through the forward proxy. Supports [credential injection](../security/credentials.md). |
-| `forward-bypass` | Routed through the forward proxy without credential injection. |
-| `transparent` | Intercepted by the transparent proxy. Policy is enforced but credential injection is not available. |
-| `network` | Non-HTTP traffic (raw TCP, UDP, ICMP). TCP can be allowed with a policy rule; UDP and ICMP are always blocked. |
-| `browser-open` | A sandbox process requested opening a URL in the host browser. Policy is enforced before opening the URL. |
+| Value            | Description                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- |
+| `forward`        | Routed through the forward proxy. Supports [credential injection](../../security/credentials.md).              |
+| `forward-bypass` | Routed through the forward proxy without credential injection.                                                 |
+| `transparent`    | Intercepted by the transparent proxy. Policy is enforced but credential injection is not available.            |
+| `network`        | Non-HTTP traffic (raw TCP, UDP, ICMP). TCP can be allowed with a policy rule; UDP and ICMP are always blocked. |
+| `browser-open`   | A sandbox process requested opening a URL in the host browser. Policy is enforced before opening the URL.      |
 
 The `RULE` column identifies the policy rule that matched the request. The
 `REASON` column includes extra context when the daemon records one.

--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
@@ -142,7 +142,7 @@ The `PROXY` column shows how the request left the sandbox:
 | `forward`        | Routed through the forward proxy. Supports [credential injection](../../security/credentials.md).              |
 | `forward-bypass` | Routed through the forward proxy without credential injection.                                                 |
 | `transparent`    | Intercepted by the transparent proxy. Policy is enforced but credential injection is not available.            |
-| `network`        | Non-HTTP traffic (raw TCP, UDP, ICMP). TCP can be allowed with a policy rule; UDP and ICMP are always blocked. |
+| `network`        | Non-HTTP traffic (raw TCP, UDP, ICMP). TCP can be allowed with a policy rule. UDP and ICMP are always blocked. |
 | `browser-open`   | A sandbox process requested opening a URL in the host browser. Policy is enforced before opening the URL.      |
 
 The `RULE` column identifies the policy rule that matched the request. The

--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/sign-in-enforcement.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/sign-in-enforcement.md
@@ -265,7 +265,8 @@ For access, contact ACME IT Security:
 ## Related pages
 
 - [Organization policies](../access-controls/organization.md): centrally manage
-  sandbox network and filesystem rules from the Docker Admin Console
+  sandbox network, filesystem, and MCP access controls from the Docker Admin
+  Console
 - [Governance overview](../_index.md): how local and organization governance fit
   together
 - [Enforce sign-in for Docker Desktop](/manuals/enterprise/security/enforce-sign-in/_index.md):

--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/sign-in-enforcement.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/sign-in-enforcement.md
@@ -1,9 +1,11 @@
 ---
 title: Sign-in enforcement
 linkTitle: Sign-in enforcement
-weight: 22
+weight: 30
 description: Require Docker Sandboxes users to sign in as members of your organization, enforced through endpoint management.
 keywords: docker sandboxes, sign-in enforcement, organization enforcement, sbx login, MDM, configuration profile, registry key, allowedOrgs
+aliases:
+  - /ai/sandboxes/governance/sign-in-enforcement/
 ---
 
 Sign-in enforcement restricts Docker Sandboxes to users who are members of
@@ -13,8 +15,9 @@ membership after the user authenticates. If the check fails, credentials are
 immediately revoked and the user can't run sandboxes.
 
 Without this enforcement, a developer can sign in with a personal account and
-bypass organization [governance policies](org.md). Sign-in enforcement closes
-that gap at the endpoint, where users can't override it.
+bypass organization [governance policies](../access-controls/organization.md).
+Sign-in enforcement closes that gap at the endpoint, where users can't override
+it.
 
 > [!NOTE]
 > Sign-in enforcement is part of Docker's AI Governance offering.
@@ -261,9 +264,9 @@ For access, contact ACME IT Security:
 
 ## Related pages
 
-- [Organization policy](org.md): centrally manage sandbox network and
-  filesystem rules
-- [Governance overview](_index.md): how local and organization governance fit
+- [Organization policies](../access-controls/organization.md): centrally manage
+  sandbox network and filesystem rules from the Docker Admin Console
+- [Governance overview](../_index.md): how local and organization governance fit
   together
 - [Enforce sign-in for Docker Desktop](/manuals/enterprise/security/enforce-sign-in/_index.md):
   the equivalent control for Docker Desktop

--- a/content/manuals/ai/sandboxes/governance/org.md
+++ b/content/manuals/ai/sandboxes/governance/org.md
@@ -2,21 +2,23 @@
 title: Organization policy
 linkTitle: Org policy
 weight: 20
-description: Centrally manage sandbox network and filesystem policies for your organization.
-keywords: docker sandboxes, governance, organization policy, AI governance, Docker Home, network access, filesystem access
+description: Centrally manage sandbox network, filesystem, and MCP policies for your organization.
+keywords: docker sandboxes, governance, organization policy, AI governance, admin console, network access, filesystem access, mcp policy
 aliases:
   - /ai/sandboxes/security/governance/
 ---
 
 [Local policies](local.md) give individual developers control over what their
 sandboxes can access. Organization policy moves that control to the admin level:
-rules apply to sandboxes across the organization,
-either to every member or to specific teams. When organization governance is active, it replaces local `sbx policy`
-rules entirely — local rules are no longer evaluated and can't be used to
-supplement or override the organization policy.
+rules defined in **Admin Console** apply to sandboxes across the organization,
+either to every member or to specific teams. When organization governance is
+active, it replaces local `sbx policy` rules entirely — local rules are no
+longer evaluated and can't be used to supplement or override the organization
+policy.
 
-Admins can manage organization policies through the Docker Home UI or
-programmatically using the [Governance API](/reference/api/ai-governance/).
+Admins can manage organization policies through the Admin Console UI. For
+programmatic management of network and filesystem policies, use the
+[Governance API](/reference/api/ai-governance/).
 
 By default, only organization
 [owners](/manuals/enterprise/security/roles-and-permissions/core-roles.md) can
@@ -33,17 +35,19 @@ with the **Governance** permissions and assign it to a user or team.
 
 ## Create a policy
 
-Manage policies from the **AI Platform** section in the left-hand navigation
+Manage policies under **Admin Console**, a section in the left-hand navigation
 of [Docker Home](https://app.docker.com). Network and filesystem policies are
 managed separately, under **Network access** and **Filesystem access**.
+
+The steps in this section cover network and filesystem policies. MCP policies
+use Cedar rather than rule rows; see [MCP policies](#mcp-policies).
 
 To create a policy:
 
 1. Sign in to [Docker Home](https://app.docker.com) and select your
    organization.
-1. In the left-hand navigation, expand **AI Platform** and select
-   **Network access** or **Filesystem access**.
-1. Select **Create policy**.
+1. Select **AI Platform**, then the governance section you want.
+1. Select **Network access** or **Filesystem access**, then **Create policy**.
 1. Enter a **Policy name**.
 1. Set the **Scope** to **Organization** or **Teams**. If you select **Teams**,
    choose the teams the policy applies to. See
@@ -100,6 +104,25 @@ rules. Each rule takes a path pattern and an action (allow or deny).
 For path pattern syntax and how read and write access combine to allow a
 mount, see [Policy concepts](concepts.md#filesystem-rules).
 
+## MCP policies
+
+MCP policies control sandbox activity that goes through MCP servers, such as
+server registration, tool calls, resource reads, prompts, and gateway
+meta-tools. Unlike network and filesystem policies, MCP policies are written in
+Cedar using the `MCP` namespace.
+
+MCP policy is default deny: an MCP request is blocked unless a matching
+`permit` allows it. Use `forbid` for rules that must always deny a matching
+request. A matching `forbid` overrides a `permit`, including one that requires
+approval.
+
+Use `@requireApproval` on a `permit` statement to require user approval before a
+matching request runs. If the sandbox can't ask a user for approval, the request
+is denied.
+
+For the MCP policy model and a starter example, see
+[MCP policies](concepts.md#mcp-policies).
+
 ## Scope policies to teams
 
 An organization can have more than one policy, and each policy applies either
@@ -117,7 +140,7 @@ Team scoping targets your organization's existing
 exist before you can scope a policy to it. Create teams and manage their members
 in one of two ways:
 
-- Manually, in Docker Home.
+- Manually, in the Admin Console.
 - Automatically, by using
   [group mapping](/manuals/enterprise/security/provisioning/scim/group-mapping.md)
   to synchronize your identity provider's groups with the teams in your
@@ -190,21 +213,21 @@ wildcards match.
 ## Precedence
 
 When organization governance is active, local rules are not evaluated. Only
-organization rules determine what is allowed or denied,
+organization rules set in the Admin Console determine what is allowed or denied,
 and they can't be supplemented or overridden from a developer's machine. The
 same applies to filesystem policies: organization rules replace local behavior
 entirely. For how a user's organization policies are evaluated together, see
 [Policy concepts](concepts.md#rule-evaluation).
 
 To unblock a domain when organization governance is active, update the rule in
-Docker Home or via the [API](/reference/api/ai-governance/). Without
+the Admin Console or via the [API](/reference/api/ai-governance/). Without
 organization governance, remove the local rule with `sbx policy rm`.
 
 ## Troubleshooting
 
 ### Policy changes not taking effect
 
-After updating organization policies, changes take up
+After updating organization policies in the Admin Console, changes take up
 to 5 minutes to propagate to developer machines. To apply changes
 immediately, users can run `sbx policy reset`, which stops the daemon and
 forces it to pull the latest organization policies on the next `sbx`
@@ -234,5 +257,5 @@ and create a new one.
 ### Sandbox cannot mount workspace
 
 If a sandbox fails to mount with a `mount policy denied` error, verify that
-the filesystem allow rule uses `**` rather than `*`. A
+the filesystem allow rule in the Admin Console uses `**` rather than `*`. A
 single `*` doesn't match across directory separators.

--- a/content/manuals/ai/sandboxes/governance/reference/_index.md
+++ b/content/manuals/ai/sandboxes/governance/reference/_index.md
@@ -9,7 +9,7 @@ Use reference material when you need API details or exact policy syntax.
 
 - [Policy concepts](../concepts.md): resource model, rule syntax, policy
   evaluation, and precedence.
-- [AI Governance API](api.md): HTTP API reference for network and filesystem
-  organization policies.
+- [AI Governance API](/reference/api/ai-governance/): HTTP API reference for
+  network and filesystem organization policies.
 - [MCP policy reference](mcp-policy.md): Docker MCP policy actions, resources,
   attributes, context fields, and approval behavior.

--- a/content/manuals/ai/sandboxes/governance/reference/_index.md
+++ b/content/manuals/ai/sandboxes/governance/reference/_index.md
@@ -11,3 +11,5 @@ Use reference material when you need API details or exact policy syntax.
   evaluation, and precedence.
 - [AI Governance API](api.md): HTTP API reference for network and filesystem
   organization policies.
+- [MCP policy reference](mcp-policy.md): Docker MCP policy actions, resources,
+  attributes, context fields, and approval behavior.

--- a/content/manuals/ai/sandboxes/governance/reference/_index.md
+++ b/content/manuals/ai/sandboxes/governance/reference/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Reference
-weight: 30
+weight: 40
 description: Reference material for Docker AI Governance policy APIs and policy syntax.
 keywords: docker sandboxes, governance reference, governance API, policy reference
 ---

--- a/content/manuals/ai/sandboxes/governance/reference/_index.md
+++ b/content/manuals/ai/sandboxes/governance/reference/_index.md
@@ -1,0 +1,13 @@
+---
+title: Reference
+weight: 30
+description: Reference material for Docker AI Governance policy APIs and policy syntax.
+keywords: docker sandboxes, governance reference, governance API, policy reference
+---
+
+Use reference material when you need API details or exact policy syntax.
+
+- [Policy concepts](../concepts.md): resource model, rule syntax, policy
+  evaluation, and precedence.
+- [AI Governance API](api.md): HTTP API reference for network and filesystem
+  organization policies.

--- a/content/manuals/ai/sandboxes/governance/reference/api.md
+++ b/content/manuals/ai/sandboxes/governance/reference/api.md
@@ -2,7 +2,7 @@
 title: AI Governance API
 linkTitle: API reference
 description: Programmatic management of Docker AI Governance policies and rules via HTTP+JSON.
-weight: 30
+weight: 10
 build:
   render: never
 sidebar:

--- a/content/manuals/ai/sandboxes/governance/reference/api.md
+++ b/content/manuals/ai/sandboxes/governance/reference/api.md
@@ -2,6 +2,7 @@
 title: AI Governance API
 linkTitle: API reference
 description: Programmatic management of Docker AI Governance policies and rules via HTTP+JSON.
+keywords: docker sandboxes, AI Governance API, governance API, policy API, organization policies
 weight: 10
 build:
   render: never

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -9,7 +9,7 @@ keywords: docker sandboxes, MCP policy, Cedar policy, MCP actions, MCP resources
 MCP policies are organization policies written in Cedar using Docker's `MCP`
 namespace. This reference defines the Docker-specific policy surface for Model
 Context Protocol (MCP) activity made available to sandboxes through Docker's
-MCP gateway.
+[MCP gateway](../../mcp-gateway.md).
 
 Use this reference with [MCP access policies](../access-controls/mcp.md) for
 common policy patterns. For the Cedar language, see the

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -72,21 +72,21 @@ resource in MCP::Primordial::"code-mode"
 Tool annotation attributes come from MCP tool annotations or catalog metadata
 and are advisory.
 
-| Attribute                  | Applies to                | Notes                                                                                          |
-| -------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
-| `resource.name`            | Tools and prompts         | For tools, this is the bare tool name, not a display-prefixed name.                            |
-| `resource.uri`             | Resources                 | Use with string operators such as `like`.                                                      |
-| `resource.readOnly`        | Tools                     | Defaults to `false` when a tool doesn't declare it.                                            |
-| `resource.destructive`     | Tools                     | Defaults to `true` when a tool doesn't declare it.                                             |
-| `resource.idempotent`      | Tools                     | Defaults to `false` when a tool doesn't declare it.                                            |
-| `resource.openWorld`       | Tools                     | Defaults to `true` when a tool doesn't declare it.                                             |
-| `resource.category`        | Tools                     | Server or catalog category copied onto the tool resource. Tools don't self-declare categories. |
-| `resource.type`            | Servers                   | Use for server registration rules.                                                             |
-| `resource.identityURL`     | Servers                   | The server URL or source. Use for server registration rules.                                   |
-| `resource.requiresOAuth`   | Servers                   | Use for server registration rules.                                                             |
-| `resource.requiresNetwork` | Servers                   | Use for server registration rules.                                                             |
-| `resource.command`         | Local server registration | Local stdio server command. The MCP gateway sends an empty value.                              |
-| `resource.args`            | Local server registration | Local stdio server arguments. This is a set, so `.contains()` can match values.                |
+| Attribute                  | Applies to        | Notes                                                                                                                                                 |
+| -------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resource.name`            | Tools and prompts | For tools, this is the bare tool name, not a display-prefixed name.                                                                                   |
+| `resource.uri`             | Resources         | Use with string operators such as `like`.                                                                                                             |
+| `resource.readOnly`        | Tools             | Defaults to `false` when a tool doesn't declare it.                                                                                                   |
+| `resource.destructive`     | Tools             | Defaults to `true` when a tool doesn't declare it.                                                                                                    |
+| `resource.idempotent`      | Tools             | Defaults to `false` when a tool doesn't declare it.                                                                                                   |
+| `resource.openWorld`       | Tools             | Defaults to `true` when a tool doesn't declare it.                                                                                                    |
+| `resource.category`        | Tools             | Server or catalog category copied onto the tool resource. Tools don't self-declare categories.                                                        |
+| `resource.type`            | Servers           | Use for server registration rules.                                                                                                                    |
+| `resource.identityURL`     | Servers           | The server URL or source. Use for server registration rules.                                                                                          |
+| `resource.requiresOAuth`   | Servers           | Use for server registration rules.                                                                                                                    |
+| `resource.requiresNetwork` | Servers           | Use for server registration rules.                                                                                                                    |
+| `resource.command`         | Servers           | Local stdio server command, such as `npx` or `docker`, when available. Empty for remote servers and registrations that don't include command details. |
+| `resource.args`            | Servers           | Local stdio server arguments when available. This is a set, so `.contains()` can match values. Empty when no command details are available.           |
 
 Use `like` for string attributes. In Cedar, `like` uses `*` as its wildcard,
 matches the full string, treats `?` as a literal character, and treats `\*` as
@@ -151,8 +151,10 @@ don't require approval.
 - Tool and resource listing actions aren't Cedar-gated. Listings can include
   entries that a policy denies when the sandbox tries to use them.
 - Server command and argument rules using `resource.command` or `resource.args`
-  apply where local stdio server details are available. The MCP gateway sends
-  empty values for those attributes.
+  apply only when the resolved server registration includes local stdio command
+  details. Remote servers and metadata-resolved local servers can have empty
+  values for those attributes. Use `resource.type` to match all local stdio
+  servers.
 - Principal-based rules don't take effect. Use organization and team policy
   scope to target users.
 - Server groups aren't supported in MCP policy. Reference servers individually.

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -11,8 +11,8 @@ namespace. This reference defines the Docker-specific policy surface for Model
 Context Protocol (MCP) activity made available to sandboxes through Docker's
 MCP gateway.
 
-Use this reference with [Control MCP tool access](../access-controls/mcp.md)
-for common policy patterns. For the Cedar language, see the
+Use this reference with [MCP access policies](../access-controls/mcp.md) for
+common policy patterns. For the Cedar language, see the
 [Cedar documentation](https://docs.cedarpolicy.com/).
 
 ## Evaluation model

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -127,8 +127,8 @@ Unsupported, malformed, or too deeply nested arguments are omitted.
 
 ## Approval annotation
 
-Use `@requireApproval("reason")` on a `permit` statement to require user
-approval before a matching request runs:
+Use `@requireApproval("reason")` on a `permit` statement to require in-session
+confirmation through MCP elicitation before a matching request runs:
 
 ```plaintext
 @requireApproval("write tool call")
@@ -138,12 +138,18 @@ when { resource.readOnly == false };
 
 When a request matches the annotated `permit` and no `forbid` overrides it, the
 policy engine returns an approval-required outcome. The annotation string is
-shown as the approval reason.
+shown as the elicitation reason. An approval-required outcome takes precedence
+over a normal `permit`. A matching `forbid` denies the request without an
+elicitation.
+
+For the request flow and trust model, see
+[Require confirmation with MCP elicitation](../access-controls/mcp.md#require-confirmation-with-mcp-elicitation).
 
 Approval requires a client session that can present an MCP elicitation request
 to the user. If the request can't be presented for approval, the request is
 denied. Approval is an in-session confirmation, not an out-of-band approval
-workflow.
+workflow. Each confirmation applies to one authorization request. After the
+client confirms, the gateway re-evaluates the request with an approval digest.
 
 `sbx mcp add` can't present an elicitation request. A registration permit with
 `@requireApproval` therefore results in a denial.
@@ -156,6 +162,9 @@ don't require approval.
 
 - Tool and resource listing actions aren't Cedar-gated. Listings can include
   entries that a policy denies when the sandbox tries to use them.
+- Approval-gated requests are denied when the execution context can't relay an
+  MCP elicitation to the originating client. This includes tool calls made from
+  inside `code-mode`.
 - Registration policy is evaluated when a server is registered. It doesn't
   remove existing registrations or stop an already-loaded server by itself.
   Govern existing registrations with use-time rules such as `invokeTool`,

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -28,7 +28,7 @@ Governed MCP activity is default deny. A request is blocked unless a matching
 permit annotated with `@requireApproval`.
 
 For details about when Docker Sandboxes evaluates MCP policies for a user, see
-[How MCP policy works](../access-controls/mcp.md#how-mcp-policy-works).
+[Govern the server lifecycle](../access-controls/mcp.md#govern-the-server-lifecycle).
 
 An actionless `permit` matches every MCP action that reaches Cedar evaluation:
 
@@ -84,7 +84,7 @@ and are advisory.
 | `resource.idempotent`      | Tools             | Defaults to `false` when a tool doesn't declare it.                                                                                                   |
 | `resource.openWorld`       | Tools             | Defaults to `true` when a tool doesn't declare it.                                                                                                    |
 | `resource.category`        | Tools             | Server or catalog category copied onto the tool resource. Tools don't self-declare categories.                                                        |
-| `resource.type`            | Servers           | Use for server registration rules.                                                                                                                    |
+| `resource.type`            | Servers           | Use for server registration rules. `local-stdio` identifies explicit host commands, and `container-stdio` identifies OCI-packaged stdio servers.      |
 | `resource.identityURL`     | Servers           | The server URL or source. Use for server registration rules.                                                                                          |
 | `resource.requiresOAuth`   | Servers           | Use for server registration rules.                                                                                                                    |
 | `resource.requiresNetwork` | Servers           | Use for server registration rules.                                                                                                                    |
@@ -145,6 +145,9 @@ to the user. If the request can't be presented for approval, the request is
 denied. Approval is an in-session confirmation, not an out-of-band approval
 workflow.
 
+`sbx mcp add` can't present an elicitation request. A registration permit with
+`@requireApproval` therefore results in a denial.
+
 Only the exact annotation name `@requireApproval` applies approval behavior.
 Other annotation names, such as `@requireConsent` or `@requireConfirmation`,
 don't require approval.
@@ -160,8 +163,8 @@ don't require approval.
 - Server command and argument rules using `resource.command` or `resource.args`
   apply only when the resolved server registration includes local stdio command
   details. Remote servers and metadata-resolved local servers can have empty
-  values for those attributes. Use `resource.type` to match all local stdio
-  servers.
+  values for those attributes. Use `resource.type` to match the `local-stdio`
+  and `container-stdio` server classes.
 - Principal-based rules don't take effect. Use organization and team policy
   scope to target users.
 - Server groups aren't supported in MCP policy. Reference servers individually.

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -27,6 +27,11 @@ Governed MCP activity is default deny. A request is blocked unless a matching
 `permit` allows it. A matching `forbid` overrides any `permit`, including a
 permit annotated with `@requireApproval`.
 
+Default deny applies only to MCP activity that reaches Cedar evaluation. If MCP
+policy enforcement isn't active for a user, the MCP gateway doesn't evaluate
+Cedar policy and MCP activity is allowed by the gateway. If enforcement is
+active but no effective MCP policy permits a request, the request is denied.
+
 An actionless `permit` matches every MCP action that reaches Cedar evaluation:
 
 ```cedar

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -1,0 +1,157 @@
+---
+title: MCP policy reference
+linkTitle: MCP policy
+weight: 20
+description: Reference for Docker MCP policy actions, resources, attributes, context fields, and approval behavior.
+keywords: docker sandboxes, MCP policy, Cedar policy, MCP actions, MCP resources, requireApproval, AI Governance
+---
+
+MCP policies are organization policies written in Cedar using Docker's `MCP`
+namespace. This reference defines the Docker-specific policy surface for Model
+Context Protocol (MCP) activity made available to sandboxes through Docker's
+MCP gateway.
+
+Use this reference with [Control MCP tool access](../access-controls/mcp.md)
+for common policy patterns. For the Cedar language, see the
+[Cedar documentation](https://docs.cedarpolicy.com/).
+
+## Evaluation model
+
+Cedar evaluates MCP requests against a principal, action, resource, and context.
+For Docker MCP policies, policy scope supplies the principal. Write policies
+against the action, resource, and context. Clauses that reference principal
+attributes, such as `principal in ...`, `principal.role`, or
+`principal.tenant`, don't match.
+
+Governed MCP activity is default deny. A request is blocked unless a matching
+`permit` allows it. A matching `forbid` overrides any `permit`, including a
+permit annotated with `@requireApproval`.
+
+An actionless `permit` covers every MCP action:
+
+```cedar
+permit (principal, action, resource);
+```
+
+## Actions
+
+| Action              | Governs                   | Notes                                                                                                                  |
+| ------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `register`          | MCP server registration   | Remote server registration needs an explicit `permit`. Use `forbid` rules to block local server registration patterns. |
+| `invokeTool`        | MCP tool calls            | Most tool access policies target this action.                                                                          |
+| `invokePrimordial`  | Gateway meta-tool calls   | Applies to gateway-injected meta-tools such as `mcp-add` and `code-mode`.                                              |
+| `readResource`      | MCP resource reads        | Cedar policy is enforced inside the sandbox. Remote server reads aren't evaluated by Cedar policy.                     |
+| `getPrompt`         | MCP prompt retrieval      | Remote prompt access is governed by gateway config, not Cedar policy.                                                  |
+| `listTools`         | MCP tool listing          | Not Cedar-gated. Tool listings can include tools denied at invocation.                                                 |
+| `listResources`     | MCP resource listing      | Not Cedar-gated.                                                                                                       |
+| `subscribeResource` | MCP resource subscription | Not Cedar-gated.                                                                                                       |
+
+## Resources
+
+Match resources with the MCP entity type and attributes for the request.
+
+| Entity            | Match with             | Notes                                                                                                                            |
+| ----------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `MCP::Server`     | Registered server name | The server URL is the `resource.identityURL` attribute, not the entity ID.                                                       |
+| `MCP::Tool`       | Bare tool name         | Use `resource.name`. Display prefixes aren't included. A bare-name match applies to every server exposing a tool with that name. |
+| `MCP::Resource`   | Resource URI           | Use `resource.uri`.                                                                                                              |
+| `MCP::Prompt`     | Prompt name            | Use `resource.name`.                                                                                                             |
+| `MCP::Primordial` | Gateway meta-tool name | Match a specific primordial with an entity reference.                                                                            |
+
+Examples:
+
+```cedar
+resource in MCP::Server::"notion"
+resource.name == "move_file"
+resource.uri like "*/docs/*"
+resource in MCP::Primordial::"code-mode"
+```
+
+## Resource attributes
+
+Tool annotation attributes are server-declared and advisory.
+
+| Attribute                  | Applies to                | Notes                                                                           |
+| -------------------------- | ------------------------- | ------------------------------------------------------------------------------- |
+| `resource.name`            | Tools and prompts         | For tools, this is the bare tool name, not a display-prefixed name.             |
+| `resource.uri`             | Resources                 | Use with string operators such as `like`.                                       |
+| `resource.readOnly`        | Tools                     | Defaults to `false` when a tool doesn't declare it.                             |
+| `resource.destructive`     | Tools                     | Defaults to `true` when a tool doesn't declare it.                              |
+| `resource.idempotent`      | Tools                     | Server-declared tool annotation.                                                |
+| `resource.openWorld`       | Tools                     | Server-declared tool annotation.                                                |
+| `resource.type`            | Server registration       | Use for remote server registration rules.                                       |
+| `resource.identityURL`     | Server registration       | The server URL. Use for remote server registration rules.                       |
+| `resource.requiresOAuth`   | Server registration       | Use for remote server registration rules.                                       |
+| `resource.requiresNetwork` | Server registration       | Use for remote server registration rules.                                       |
+| `resource.command`         | Local server registration | Local stdio server command. Remote servers don't provide this value.            |
+| `resource.args`            | Local server registration | Local stdio server arguments. This is a set, so `.contains()` can match values. |
+
+Use `like` for string attributes. In Cedar, `like` uses `*` as its wildcard,
+matches the full string, treats `?` as a literal character, and treats `\*` as
+a literal asterisk.
+
+Use `.contains()` only on set attributes, such as `resource.args`. On string
+attributes, use `like`.
+
+## Context fields
+
+| Field                  | Notes                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| `context.request_time` | Bound at each enforcement point. Use it for time-window rules.                                 |
+| `context.args`         | Tool-call arguments. Bound inside the sandbox. Gateway enforcement doesn't receive this field. |
+
+Guard tool-call argument rules with `context has args` and a field check:
+
+```cedar
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when {
+  resource.name == "approve_expense" &&
+  context has args &&
+  context.args has amount &&
+  context.args.amount <= 500
+};
+```
+
+A `permit` gated on missing arguments doesn't match, so the request falls to
+default deny. A `forbid` gated on missing arguments doesn't match, so it
+doesn't block the request.
+
+## Approval annotation
+
+Use `@requireApproval("reason")` on a `permit` statement to require user
+approval before a matching request runs:
+
+```cedar
+@requireApproval("write tool call")
+permit (principal, action == MCP::Action::"invokeTool", resource)
+when { resource.readOnly == false };
+```
+
+When a request matches the annotated `permit` and no `forbid` overrides it, the
+policy engine returns an approval-required outcome. The annotation string is
+shown as the approval reason.
+
+Approval requires a client session that can present an MCP elicitation request
+to the user. If the request can't be presented for approval, the request is
+denied. Approval is an in-session confirmation, not an out-of-band approval
+workflow.
+
+Only the exact annotation name `@requireApproval` applies approval behavior.
+Other annotation names, such as `@requireConsent` or `@requireConfirmation`,
+don't require approval.
+
+## Limitations
+
+- Tool and resource listing actions aren't Cedar-gated. Listings can include
+  entries that a policy denies when the sandbox tries to use them.
+- `readResource` is evaluated by Cedar policy inside the sandbox, not for
+  remote server reads.
+- `getPrompt` for remote servers is governed by gateway config, not Cedar
+  policy.
+- Tool-call argument rules using `context.args` apply inside the sandbox only.
+- Server command and argument rules using `resource.command` or `resource.args`
+  apply to local stdio servers only.
+- Principal-based rules don't take effect. Use organization and team policy
+  scope to target users.
+- Server groups and tool categories aren't supported in MCP policy. Reference
+  servers and tools individually.

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -40,7 +40,7 @@ permit (principal, action, resource);
 
 | Action              | Governs                   | Notes                                                                                                |
 | ------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `register`          | MCP server registration   | Remote server registration needs an explicit `permit`. Use server attributes to scope registration.  |
+| `register`          | MCP server registration   | Server registration needs an explicit `permit`. Use server attributes to scope registration.         |
 | `invokeTool`        | MCP tool calls            | Most tool access policies target this action.                                                        |
 | `invokePrimordial`  | Gateway meta-tool calls   | Applies to built-in gateway tools such as `mcp-exec`, `code-mode`, and OAuth authorization helpers.  |
 | `readResource`      | MCP resource reads        | Rules match `MCP::Resource` and `resource.uri`.                                                      |
@@ -55,7 +55,7 @@ Match resources with the MCP entity type and attributes for the request.
 
 | Entity            | Match with             | Notes                                                                                                                            |
 | ----------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `MCP::Server`     | Registered server name | The server URL or source is the `resource.identityURL` attribute, not the entity ID.                                             |
+| `MCP::Server`     | Registered server name | The canonical server identity is the `resource.identityURL` attribute, not the entity ID.                                        |
 | `MCP::Tool`       | Bare tool name         | Use `resource.name`. Display prefixes aren't included. A bare-name match applies to every server exposing a tool with that name. |
 | `MCP::Resource`   | Resource URI           | Use `resource.uri`.                                                                                                              |
 | `MCP::Prompt`     | Prompt name            | Use `resource.name`.                                                                                                             |
@@ -83,9 +83,8 @@ and are advisory.
 | `resource.destructive`     | Tools             | Defaults to `true` when a tool doesn't declare it.                                                                                                    |
 | `resource.idempotent`      | Tools             | Defaults to `false` when a tool doesn't declare it.                                                                                                   |
 | `resource.openWorld`       | Tools             | Defaults to `true` when a tool doesn't declare it.                                                                                                    |
-| `resource.category`        | Tools             | Server or catalog category copied onto the tool resource. Tools don't self-declare categories.                                                        |
-| `resource.type`            | Servers           | Use for server registration rules. `local-stdio` identifies explicit host commands, and `container-stdio` identifies OCI-packaged stdio servers.      |
-| `resource.identityURL`     | Servers           | The server URL or source. Use for server registration rules.                                                                                          |
+| `resource.type`            | Servers           | Use for server registration rules. See [Server type values](#server-type-values).                                                                     |
+| `resource.identityURL`     | Servers           | Canonical server identity. The value depends on the registration type. See [Server identity values](#server-identity-values).                         |
 | `resource.requiresOAuth`   | Servers           | Use for server registration rules.                                                                                                                    |
 | `resource.requiresNetwork` | Servers           | Use for server registration rules.                                                                                                                    |
 | `resource.command`         | Servers           | Local stdio server command, such as `npx` or `docker`, when available. Empty for remote servers and registrations that don't include command details. |
@@ -98,13 +97,33 @@ a literal asterisk.
 Use `.contains()` only on set attributes, such as `resource.args`. On string
 attributes, use `like`.
 
+### Server type values
+
+- `local-stdio`: a host-run stdio server. This includes explicit commands and
+  OCI-packaged stdio servers resolved from metadata with `--local`.
+- `container-stdio`: reserved for containerized stdio servers provisioned
+  through hosted gateway modes. The local gateway doesn't emit this value.
+- `remote-dcr`: a remote endpoint that doesn't require OAuth or supports OAuth
+  Dynamic Client Registration.
+- `remote-no-dcr`: a remote OAuth endpoint that doesn't support Dynamic Client
+  Registration.
+
+### Server identity values
+
+For a remote server, `resource.identityURL` is the endpoint URL. For an explicit
+local command, it is the resolved executable path on the host. For a `--local`
+metadata registration, it is `local://stdio/<name>`, not the registry or
+manifest URL.
+
 ## Context fields
 
-| Field                  | Notes                                                                                             |
-| ---------------------- | ------------------------------------------------------------------------------------------------- |
-| `context.request_time` | Bound at each enforcement point. Use it for time-window rules.                                    |
-| `context.oauth_scopes` | OAuth scopes for the caller. Present as a set, even when empty.                                   |
-| `context.args`         | Tool-call arguments for `invokeTool`. Present when arguments are available as a supported object. |
+| Field                  | Notes                                                                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context.request_time` | Bound for tool calls, built-in gateway tool calls, resource reads, and prompt retrieval. Registration requests don't include it.                                           |
+| `context.args`         | Tool-call arguments for `invokeTool` requests to local stdio servers. Present when arguments are available as a supported object. Remote server requests don't include it. |
+
+A registration `permit` conditioned on `context.request_time` doesn't match,
+so the registration falls to default deny.
 
 Guard tool-call argument rules with `context has args` and a field check:
 
@@ -123,7 +142,7 @@ default deny. A `forbid` gated on missing arguments doesn't match, so it
 doesn't block the request.
 
 Only object-shaped tool arguments are represented in `context.args`.
-Unsupported, malformed, or too deeply nested arguments are omitted.
+Unsupported or malformed arguments are omitted.
 
 ## Approval annotation
 
@@ -172,11 +191,8 @@ don't require approval.
 - Server command and argument rules using `resource.command` or `resource.args`
   apply only when the resolved server registration includes local stdio command
   details. Remote servers and metadata-resolved local servers can have empty
-  values for those attributes. Use `resource.type` to match the `local-stdio`
-  and `container-stdio` server classes.
+  values for those attributes. Use `resource.type == "local-stdio"` to match
+  host-run servers independently of command details.
 - Principal-based rules don't take effect. Use organization and team policy
   scope to target users.
 - Server groups aren't supported in MCP policy. Reference servers individually.
-- Tool categories aren't self-declared by MCP tools. When available,
-  `resource.category` is server or catalog metadata copied onto the tool
-  resource.

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -27,7 +27,7 @@ Governed MCP activity is default deny. A request is blocked unless a matching
 `permit` allows it. A matching `forbid` overrides any `permit`, including a
 permit annotated with `@requireApproval`.
 
-An actionless `permit` covers every MCP action:
+An actionless `permit` matches every MCP action that reaches Cedar evaluation:
 
 ```cedar
 permit (principal, action, resource);
@@ -35,16 +35,16 @@ permit (principal, action, resource);
 
 ## Actions
 
-| Action              | Governs                   | Notes                                                                                                                  |
-| ------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `register`          | MCP server registration   | Remote server registration needs an explicit `permit`. Use `forbid` rules to block local server registration patterns. |
-| `invokeTool`        | MCP tool calls            | Most tool access policies target this action.                                                                          |
-| `invokePrimordial`  | Gateway meta-tool calls   | Applies to gateway-injected meta-tools such as `mcp-add` and `code-mode`.                                              |
-| `readResource`      | MCP resource reads        | Cedar policy is enforced inside the sandbox. Remote server reads aren't evaluated by Cedar policy.                     |
-| `getPrompt`         | MCP prompt retrieval      | Remote prompt access is governed by gateway config, not Cedar policy.                                                  |
-| `listTools`         | MCP tool listing          | Not Cedar-gated. Tool listings can include tools denied at invocation.                                                 |
-| `listResources`     | MCP resource listing      | Not Cedar-gated.                                                                                                       |
-| `subscribeResource` | MCP resource subscription | Not Cedar-gated.                                                                                                       |
+| Action              | Governs                   | Notes                                                                                                |
+| ------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `register`          | MCP server registration   | Remote server registration needs an explicit `permit`. Use server attributes to scope registration.  |
+| `invokeTool`        | MCP tool calls            | Most tool access policies target this action.                                                        |
+| `invokePrimordial`  | Gateway meta-tool calls   | Applies to gateway-injected meta-tools such as `mcp-add` and `code-mode`.                            |
+| `readResource`      | MCP resource reads        | Rules match `MCP::Resource` and `resource.uri`.                                                      |
+| `getPrompt`         | MCP prompt retrieval      | Rules match `MCP::Prompt` and `resource.name`.                                                       |
+| `listTools`         | MCP tool listing          | Defined in the schema but not Cedar-gated. Tool listings can include tools denied at invocation.     |
+| `listResources`     | MCP resource listing      | Defined in the schema but not Cedar-gated. Resource listings can include resources denied by policy. |
+| `subscribeResource` | MCP resource subscription | Defined in the schema but not Cedar-gated.                                                           |
 
 ## Resources
 
@@ -52,7 +52,7 @@ Match resources with the MCP entity type and attributes for the request.
 
 | Entity            | Match with             | Notes                                                                                                                            |
 | ----------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `MCP::Server`     | Registered server name | The server URL is the `resource.identityURL` attribute, not the entity ID.                                                       |
+| `MCP::Server`     | Registered server name | The server URL or source is the `resource.identityURL` attribute, not the entity ID.                                             |
 | `MCP::Tool`       | Bare tool name         | Use `resource.name`. Display prefixes aren't included. A bare-name match applies to every server exposing a tool with that name. |
 | `MCP::Resource`   | Resource URI           | Use `resource.uri`.                                                                                                              |
 | `MCP::Prompt`     | Prompt name            | Use `resource.name`.                                                                                                             |
@@ -69,22 +69,24 @@ resource in MCP::Primordial::"code-mode"
 
 ## Resource attributes
 
-Tool annotation attributes are server-declared and advisory.
+Tool annotation attributes come from MCP tool annotations or catalog metadata
+and are advisory.
 
-| Attribute                  | Applies to                | Notes                                                                           |
-| -------------------------- | ------------------------- | ------------------------------------------------------------------------------- |
-| `resource.name`            | Tools and prompts         | For tools, this is the bare tool name, not a display-prefixed name.             |
-| `resource.uri`             | Resources                 | Use with string operators such as `like`.                                       |
-| `resource.readOnly`        | Tools                     | Defaults to `false` when a tool doesn't declare it.                             |
-| `resource.destructive`     | Tools                     | Defaults to `true` when a tool doesn't declare it.                              |
-| `resource.idempotent`      | Tools                     | Server-declared tool annotation.                                                |
-| `resource.openWorld`       | Tools                     | Server-declared tool annotation.                                                |
-| `resource.type`            | Server registration       | Use for remote server registration rules.                                       |
-| `resource.identityURL`     | Server registration       | The server URL. Use for remote server registration rules.                       |
-| `resource.requiresOAuth`   | Server registration       | Use for remote server registration rules.                                       |
-| `resource.requiresNetwork` | Server registration       | Use for remote server registration rules.                                       |
-| `resource.command`         | Local server registration | Local stdio server command. Remote servers don't provide this value.            |
-| `resource.args`            | Local server registration | Local stdio server arguments. This is a set, so `.contains()` can match values. |
+| Attribute                  | Applies to                | Notes                                                                                          |
+| -------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `resource.name`            | Tools and prompts         | For tools, this is the bare tool name, not a display-prefixed name.                            |
+| `resource.uri`             | Resources                 | Use with string operators such as `like`.                                                      |
+| `resource.readOnly`        | Tools                     | Defaults to `false` when a tool doesn't declare it.                                            |
+| `resource.destructive`     | Tools                     | Defaults to `true` when a tool doesn't declare it.                                             |
+| `resource.idempotent`      | Tools                     | Defaults to `false` when a tool doesn't declare it.                                            |
+| `resource.openWorld`       | Tools                     | Defaults to `true` when a tool doesn't declare it.                                             |
+| `resource.category`        | Tools                     | Server or catalog category copied onto the tool resource. Tools don't self-declare categories. |
+| `resource.type`            | Servers                   | Use for server registration rules.                                                             |
+| `resource.identityURL`     | Servers                   | The server URL or source. Use for server registration rules.                                   |
+| `resource.requiresOAuth`   | Servers                   | Use for server registration rules.                                                             |
+| `resource.requiresNetwork` | Servers                   | Use for server registration rules.                                                             |
+| `resource.command`         | Local server registration | Local stdio server command. The MCP gateway sends an empty value.                              |
+| `resource.args`            | Local server registration | Local stdio server arguments. This is a set, so `.contains()` can match values.                |
 
 Use `like` for string attributes. In Cedar, `like` uses `*` as its wildcard,
 matches the full string, treats `?` as a literal character, and treats `\*` as
@@ -95,10 +97,11 @@ attributes, use `like`.
 
 ## Context fields
 
-| Field                  | Notes                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------- |
-| `context.request_time` | Bound at each enforcement point. Use it for time-window rules.                                 |
-| `context.args`         | Tool-call arguments. Bound inside the sandbox. Gateway enforcement doesn't receive this field. |
+| Field                  | Notes                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| `context.request_time` | Bound at each enforcement point. Use it for time-window rules.                                    |
+| `context.oauth_scopes` | OAuth scopes for the caller. Present as a set, even when empty.                                   |
+| `context.args`         | Tool-call arguments for `invokeTool`. Present when arguments are available as a supported object. |
 
 Guard tool-call argument rules with `context has args` and a field check:
 
@@ -115,6 +118,9 @@ when {
 A `permit` gated on missing arguments doesn't match, so the request falls to
 default deny. A `forbid` gated on missing arguments doesn't match, so it
 doesn't block the request.
+
+Only object-shaped tool arguments are represented in `context.args`.
+Unsupported, malformed, or too deeply nested arguments are omitted.
 
 ## Approval annotation
 
@@ -144,14 +150,12 @@ don't require approval.
 
 - Tool and resource listing actions aren't Cedar-gated. Listings can include
   entries that a policy denies when the sandbox tries to use them.
-- `readResource` is evaluated by Cedar policy inside the sandbox, not for
-  remote server reads.
-- `getPrompt` for remote servers is governed by gateway config, not Cedar
-  policy.
-- Tool-call argument rules using `context.args` apply inside the sandbox only.
 - Server command and argument rules using `resource.command` or `resource.args`
-  apply to local stdio servers only.
+  apply where local stdio server details are available. The MCP gateway sends
+  empty values for those attributes.
 - Principal-based rules don't take effect. Use organization and team policy
   scope to target users.
-- Server groups and tool categories aren't supported in MCP policy. Reference
-  servers and tools individually.
+- Server groups aren't supported in MCP policy. Reference servers individually.
+- Tool categories aren't self-declared by MCP tools. When available,
+  `resource.category` is server or catalog metadata copied onto the tool
+  resource.

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -32,7 +32,7 @@ For details about when Docker Sandboxes evaluates MCP policies for a user, see
 
 An actionless `permit` matches every MCP action that reaches Cedar evaluation:
 
-```cedar
+```plaintext
 permit (principal, action, resource);
 ```
 
@@ -63,7 +63,7 @@ Match resources with the MCP entity type and attributes for the request.
 
 Examples:
 
-```cedar
+```plaintext
 resource in MCP::Server::"notion"
 resource.name == "move_file"
 resource.uri like "*/docs/*"
@@ -108,7 +108,7 @@ attributes, use `like`.
 
 Guard tool-call argument rules with `context has args` and a field check:
 
-```cedar
+```plaintext
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when {
   resource.name == "approve_expense" &&
@@ -130,7 +130,7 @@ Unsupported, malformed, or too deeply nested arguments are omitted.
 Use `@requireApproval("reason")` on a `permit` statement to require user
 approval before a matching request runs:
 
-```cedar
+```plaintext
 @requireApproval("write tool call")
 permit (principal, action == MCP::Action::"invokeTool", resource)
 when { resource.readOnly == false };

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -27,10 +27,8 @@ Governed MCP activity is default deny. A request is blocked unless a matching
 `permit` allows it. A matching `forbid` overrides any `permit`, including a
 permit annotated with `@requireApproval`.
 
-Default deny applies only to MCP activity that reaches Cedar evaluation. If MCP
-policy enforcement isn't active for a user, the MCP gateway doesn't evaluate
-Cedar policy and MCP activity is allowed by the gateway. If enforcement is
-active but no effective MCP policy permits a request, the request is denied.
+For details about when Docker Sandboxes evaluates MCP policies for a user, see
+[How MCP policy works](../access-controls/mcp.md#how-mcp-policy-works).
 
 An actionless `permit` matches every MCP action that reaches Cedar evaluation:
 

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -42,7 +42,7 @@ permit (principal, action, resource);
 | ------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `register`          | MCP server registration   | Remote server registration needs an explicit `permit`. Use server attributes to scope registration.  |
 | `invokeTool`        | MCP tool calls            | Most tool access policies target this action.                                                        |
-| `invokePrimordial`  | Gateway meta-tool calls   | Applies to gateway-injected meta-tools such as `mcp-add` and `code-mode`.                            |
+| `invokePrimordial`  | Gateway meta-tool calls   | Applies to built-in gateway tools such as `mcp-exec`, `code-mode`, and OAuth authorization helpers.  |
 | `readResource`      | MCP resource reads        | Rules match `MCP::Resource` and `resource.uri`.                                                      |
 | `getPrompt`         | MCP prompt retrieval      | Rules match `MCP::Prompt` and `resource.name`.                                                       |
 | `listTools`         | MCP tool listing          | Defined in the schema but not Cedar-gated. Tool listings can include tools denied at invocation.     |

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -153,6 +153,10 @@ don't require approval.
 
 - Tool and resource listing actions aren't Cedar-gated. Listings can include
   entries that a policy denies when the sandbox tries to use them.
+- Registration policy is evaluated when a server is registered. It doesn't
+  remove existing registrations or stop an already-loaded server by itself.
+  Govern existing registrations with use-time rules such as `invokeTool`,
+  `readResource`, and `getPrompt`.
 - Server command and argument rules using `resource.command` or `resource.args`
   apply only when the resolved server registration includes local stdio command
   details. Remote servers and metadata-resolved local servers can have empty

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -99,10 +99,10 @@ attributes, use `like`.
 
 ### Server type values
 
+Local gateway registrations use these values:
+
 - `local-stdio`: a host-run stdio server. This includes explicit commands and
   OCI-packaged stdio servers resolved from metadata with `--local`.
-- `container-stdio`: reserved for containerized stdio servers provisioned
-  through hosted gateway modes. The local gateway doesn't emit this value.
 - `remote-dcr`: a remote endpoint that doesn't require OAuth or supports OAuth
   Dynamic Client Registration.
 - `remote-no-dcr`: a remote OAuth endpoint that doesn't support Dynamic Client

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -38,16 +38,16 @@ permit (principal, action, resource);
 
 ## Actions
 
-| Action              | Governs                   | Notes                                                                                                |
-| ------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `register`          | MCP server registration   | Server registration needs an explicit `permit`. Use server attributes to scope registration.         |
-| `invokeTool`        | MCP tool calls            | Most tool access policies target this action.                                                        |
-| `invokePrimordial`  | Gateway meta-tool calls   | Applies to built-in gateway tools such as `mcp-exec`, `code-mode`, and OAuth authorization helpers.  |
-| `readResource`      | MCP resource reads        | Rules match `MCP::Resource` and `resource.uri`.                                                      |
-| `getPrompt`         | MCP prompt retrieval      | Rules match `MCP::Prompt` and `resource.name`.                                                       |
-| `listTools`         | MCP tool listing          | Defined in the schema but not Cedar-gated. Tool listings can include tools denied at invocation.     |
-| `listResources`     | MCP resource listing      | Defined in the schema but not Cedar-gated. Resource listings can include resources denied by policy. |
-| `subscribeResource` | MCP resource subscription | Defined in the schema but not Cedar-gated.                                                           |
+| Action              | Governs                   | Notes                                                                                                          |
+| ------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `register`          | MCP server registration   | Server registration needs an explicit `permit`. Use server attributes to scope registration.                   |
+| `invokeTool`        | MCP tool calls            | Most tool access policies target this action.                                                                  |
+| `invokePrimordial`  | Gateway meta-tool calls   | Applies to built-in gateway tools such as `mcp-exec`, `mcp-add`, `code-mode`, and OAuth authorization helpers. |
+| `readResource`      | MCP resource reads        | Rules match `MCP::Resource` and `resource.uri`.                                                                |
+| `getPrompt`         | MCP prompt retrieval      | Rules match `MCP::Prompt` and `resource.name`.                                                                 |
+| `listTools`         | MCP tool listing          | Defined in the schema but not Cedar-gated. Tool listings can include tools denied at invocation.               |
+| `listResources`     | MCP resource listing      | Defined in the schema but not Cedar-gated. Resource listings can include resources denied by policy.           |
+| `subscribeResource` | MCP resource subscription | Defined in the schema but not Cedar-gated.                                                                     |
 
 ## Resources
 

--- a/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
+++ b/content/manuals/ai/sandboxes/governance/reference/mcp-policy.md
@@ -103,6 +103,9 @@ Local gateway registrations use these values:
 
 - `local-stdio`: a host-run stdio server. This includes explicit commands and
   OCI-packaged stdio servers resolved from metadata with `--local`.
+- `container-stdio`: an OCI-packaged server resolved from metadata without
+  `--local`. This value can appear in `register` decisions, but the local
+  gateway can't attach or run this server type.
 - `remote-dcr`: a remote endpoint that doesn't require OAuth or supports OAuth
   Dynamic Client Registration.
 - `remote-no-dcr`: a remote OAuth endpoint that doesn't support Dynamic Client
@@ -117,10 +120,10 @@ manifest URL.
 
 ## Context fields
 
-| Field                  | Notes                                                                                                                                                                      |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `context.request_time` | Bound for tool calls, built-in gateway tool calls, resource reads, and prompt retrieval. Registration requests don't include it.                                           |
-| `context.args`         | Tool-call arguments for `invokeTool` requests to local stdio servers. Present when arguments are available as a supported object. Remote server requests don't include it. |
+| Field                  | Notes                                                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context.request_time` | Bound for tool calls, built-in gateway tool calls, resource reads, and prompt retrieval. Registration requests don't include it.            |
+| `context.args`         | Arguments for `invokeTool` and `invokePrimordial` requests evaluated by the gateway. Present when arguments are available as a JSON object. |
 
 A registration `permit` conditioned on `context.request_time` doesn't match,
 so the registration falls to default deny.

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -230,7 +230,14 @@ visible without reconnecting.
 ## Built-in gateway tools
 
 The local MCP gateway exposes a small set of built-in tools. These tools belong
-to the gateway itself, not to a registered MCP server.
+to the gateway itself, not to a registered MCP server. Agents can see and call
+them on the same MCP connection as server tools, so they can appear in agent
+tool lists, logs, policy decisions, audit logs, or approval prompts.
+
+You don't need to call these tools directly for normal setup. Use `sbx mcp`
+commands to register servers and manage credentials from the host. The tools
+matter because agents can call them during a session, and admins can govern
+them separately from tools provided by registered MCP servers.
 
 | Tool                 | Description                                                                                    |
 | -------------------- | ---------------------------------------------------------------------------------------------- |
@@ -238,9 +245,9 @@ to the gateway itself, not to a registered MCP server.
 | `code-mode`          | Creates a session-scoped JavaScript tool that can call selected tools through the MCP gateway. |
 | `<server>-authorize` | Starts OAuth authorization for an exposed server that requires authorization.                  |
 
-The gateway exposes `<server>-authorize` only when an OAuth-backed server needs
-authorization. If `code-mode` creates a generated tool, that generated tool is
-available only in the current session.
+The gateway exposes `<server>-authorize` only when an OAuth-backed server is
+exposed to the sandbox and needs authorization. If `code-mode` creates a
+generated tool, that generated tool is available only in the current session.
 
 In MCP access policies, built-in gateway tools are `MCP::Primordial` resources
 and use the `invokePrimordial` action. Tools from registered MCP servers are

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -29,8 +29,9 @@ server sets, live server loading, and organization governance.
   Gemini, Kiro, or OpenCode.
 - For remote servers that require OAuth, use MCP servers that support OAuth
   Dynamic Client Registration.
-- For local containerized MCP servers, use a host with Docker installed and
-  running.
+- For `--local --url` registrations that resolve to OCI packages, use a host
+  with Docker installed and running. Docker is also required for explicit
+  `--command docker ...` registrations.
 
 ## Quick start
 
@@ -105,16 +106,20 @@ the host. You can provide a metadata URL or an explicit command.
 
 Use `--local --url` when you have an MCP community registry URL or a URL that
 returns a `server.json` or `server.yaml` document. The registry entry or
-manifest must describe an OCI package that uses stdio transport. `sbx` resolves
-the image from the metadata and starts it on the host with Docker.
+manifest must describe an OCI package that uses stdio transport. `sbx` doesn't
+launch non-OCI package types, such as `npm`, from metadata. To use those
+servers, register an explicit command.
+
+This path resolves the image from the metadata and starts it on the host with
+Docker, so Docker must be installed and running on the host.
 
 ```console
 $ sbx mcp add fetch --local \
   --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
 ```
 
-If the entry doesn't publish a stdio package, `sbx` rejects the registration
-instead of starting it locally.
+If the entry doesn't publish an OCI stdio package, `sbx` rejects the
+registration instead of starting it locally.
 
 A server manifest describes the MCP server package and how to start it. It can
 be hosted on a GitHub raw URL, internal HTTP server, or CDN.

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -56,16 +56,21 @@ $ sbx run claude --name mcp-demo
 
 The sandbox starts with an MCP gateway. In the default dynamic mode, the agent
 can discover registered MCP servers through gateway tools and use them during
-the session. The registration remains on the host and can be reused by other
-sandboxes.
+the session. Because you registered the server before starting the sandbox, it
+is part of that sandbox's initial MCP catalog. The registration remains on the
+host and can be reused by other sandboxes.
 
 ## Register an MCP server
 
 `sbx mcp add` registers an MCP server by name. The registration records the
 server definition on the host. It doesn't attach the server to a running sandbox
-by itself.
+by itself. A server registered before sandbox creation is available when that
+sandbox's gateway starts. To add a server to a sandbox that's already running,
+use [`sbx mcp load`](#add-a-server-to-a-running-sandbox).
 
 Server names can contain letters, numbers, dots, hyphens, and underscores.
+
+### Remote endpoint URL
 
 For a remote MCP endpoint, pass the server URL:
 
@@ -74,26 +79,50 @@ $ sbx mcp add notion --url https://mcp.notion.com/mcp
 $ sbx mcp add linear --url https://mcp.linear.app/mcp
 ```
 
-You can also register a server from an MCP registry URL, a `server.json` or
-`server.yaml` manifest URL, or a Docker Hardened Image reference that carries
-an MCP server manifest:
+### MCP registry URL
+
+You can register a server from the MCP community registry:
 
 ```console
 $ sbx mcp add fetch \
   --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
+```
 
+### Server manifest URL
+
+You can register a server from a URL that returns a `server.json` or
+`server.yaml` document. A server manifest describes the MCP server and how the
+gateway should connect to it. This is the same general shape used by the MCP
+community registry, and it works for manifests hosted on GitHub raw URLs,
+internal HTTP servers, or CDNs.
+
+```console
 $ sbx mcp add opine --url https://example.com/mcp/opine/server.yaml
+```
 
+### Docker Hardened Image reference
+
+You can register a Docker Hardened Image reference when the image carries an
+MCP server manifest in its attestation:
+
+```console
 $ sbx mcp add fetch --url dhi.io/fetch-mcp:latest
 ```
 
-To run a registry server locally as a container, add `--local`. This is useful
-for stdio-based servers packaged as containers:
+Generic image references, such as `docker.io/example/server:latest`, aren't
+accepted. Use a server manifest URL instead.
+
+### Registry server as a local container
+
+To run a registry server locally as a container, add `--local` to a registry or
+manifest URL. This is useful for stdio-based servers packaged as containers:
 
 ```console
 $ sbx mcp add fetch --local \
   --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
 ```
+
+### Local stdio command
 
 You can also register a local stdio command:
 

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -171,9 +171,10 @@ To register an OAuth-backed server without authorizing it, pass `--skip_auth`:
 $ sbx mcp add notion --url https://mcp.notion.com/mcp --skip_auth
 ```
 
-When an unauthorized OAuth-backed server is exposed to a sandbox, the gateway
-exposes a helper tool named `<server>-authorize`, such as `notion-authorize`.
-The agent can call that tool from inside the sandbox when it needs the server.
+For each OAuth-backed remote server exposed to a sandbox, the gateway exposes a
+helper tool named `<server>-authorize`, such as `notion-authorize`. The agent can
+call the tool to authorize or reauthorize the server. If the server isn't
+authorized, the helper is the only tool exposed for that server.
 
 You can manage OAuth credentials from the host:
 
@@ -208,9 +209,9 @@ $ sbx run claude --name my-session \
 ```
 
 Every name in the static set must already be registered with `sbx mcp add`. The
-static set is fixed at sandbox creation time. If you omit `--static-mcp`, the
-sandbox starts with an MCP gateway but no registered MCP servers. To use a
-different static set, create a new sandbox.
+static set is fixed at sandbox creation time. In local gateway mode, if you omit
+`--static-mcp`, the sandbox starts with an MCP gateway but no registered MCP
+servers. To use a different static set, create a new sandbox.
 
 ## Add a server to a running sandbox
 
@@ -238,15 +239,17 @@ commands to register servers and manage credentials from the host. The tools
 matter because agents can call them during a session, and admins can govern
 them separately from tools provided by registered MCP servers.
 
-| Tool                 | Description                                                                                    |
-| -------------------- | ---------------------------------------------------------------------------------------------- |
-| `mcp-exec`           | Executes a tool by name in the current gateway session.                                        |
-| `code-mode`          | Creates a session-scoped JavaScript tool that can call selected tools through the MCP gateway. |
-| `<server>-authorize` | Starts OAuth authorization for an exposed server that requires authorization.                  |
+| Tool                 | Description                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `mcp-exec`           | Executes a tool by name through the gateway.                                               |
+| `code-mode`          | Creates an ephemeral JavaScript tool that can call selected tools through the MCP gateway. |
+| `<server>-authorize` | Starts or restarts OAuth authorization for an exposed OAuth-backed remote server.          |
 
-The gateway exposes `<server>-authorize` only when an OAuth-backed server is
-exposed to the sandbox and needs authorization. If `code-mode` creates a
-generated tool, that generated tool is available only in the current session.
+The gateway exposes `<server>-authorize` for OAuth-backed remote servers, even
+when they already have a valid token. Local stdio servers don't expose this
+helper. If `code-mode` creates a generated tool, the tool is shared by clients
+connected to the sandbox's gateway and disappears when the gateway is replaced
+or stops.
 
 In MCP access policies, built-in gateway tools are `MCP::Primordial` resources
 and use the `invokePrimordial` action. Tools from registered MCP servers are

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -6,13 +6,21 @@ weight: 30
 ---
 
 Docker Sandboxes includes an MCP gateway for connecting agents to Model Context
-Protocol servers. The gateway runs with the sandbox and presents one MCP
-endpoint to the agent. Use `sbx mcp` on the host to register servers, manage
-OAuth credentials, and attach registered servers to running sandboxes.
+Protocol servers. The gateway gives the agent inside the sandbox one MCP
+endpoint, while `sbx` manages the registered servers, OAuth credentials, and
+sandbox lifecycle on the host.
 
-This page focuses on local gateway mode, where MCP traffic is handled by a
-gateway running on your machine. Use `sbx mcp status` to check the effective
-gateway for your account.
+This is different from configuring an MCP server directly in an agent such as
+Claude Code. Direct MCP setup configures that agent's own MCP client. With
+Docker Sandboxes, you register MCP servers once on the host, and the sandbox
+gateway exposes them to supported agents inside isolated sandboxes. That
+host-managed gateway provides a single path for credentials, dynamic or fixed
+server sets, live server loading, and organization governance.
+
+> [!NOTE]
+> The Docker Sandboxes MCP gateway is separate from the Docker Desktop MCP
+> Toolkit. You don't need the Docker Desktop MCP Toolkit to use `sbx mcp`, and
+> MCP Toolkit server settings aren't shared with Docker Sandboxes.
 
 ## Prerequisites
 
@@ -22,35 +30,42 @@ gateway for your account.
 - For remote servers that require OAuth, use MCP servers that support OAuth
   Dynamic Client Registration.
 
-The Docker Desktop MCP Toolkit isn't required for sandbox MCP support.
+## Quick start
 
-## Check the gateway mode
-
-Run `sbx mcp status` to see the effective MCP gateway:
+Start by registering one MCP server on the host:
 
 ```console
-$ sbx mcp status
-Gateway mode: local
-Gateway URL:  (none)
-Source:       mcp-saas gateway-mode API (resolved by daemon)
+$ sbx mcp add notion --url https://mcp.notion.com/mcp
 ```
 
-The output can also include `Decision` and `Reason` fields. These fields show
-the raw gateway decision and why that decision produced the effective gateway.
-
-The daemon resolves the gateway mode and caches the result for its lifetime. If
-you change sign-in state or an MCP gateway setting, restart the daemon before
-checking again:
+If the server requires OAuth, `sbx` opens an authorization flow before it stores
+the registration. After registration, verify that the server is in your local
+MCP catalog:
 
 ```console
-$ sbx daemon stop
-$ sbx mcp status
+$ sbx mcp ls
+NAME                 TYPE     URL/COMMAND
+notion               remote   https://mcp.notion.com/mcp
 ```
+
+Then start a sandbox:
+
+```console
+$ sbx run claude --name mcp-demo
+```
+
+The sandbox starts with an MCP gateway. In the default dynamic mode, the agent
+can discover registered MCP servers through gateway tools and use them during
+the session. The registration remains on the host and can be reused by other
+sandboxes.
 
 ## Register an MCP server
 
-Register servers on the host before you connect them to a sandbox. Server names
-can contain letters, numbers, dots, hyphens, and underscores.
+`sbx mcp add` registers an MCP server by name. The registration records the
+server definition on the host. It doesn't attach the server to a running sandbox
+by itself.
+
+Server names can contain letters, numbers, dots, hyphens, and underscores.
 
 For a remote MCP endpoint, pass the server URL:
 
@@ -94,10 +109,6 @@ $ sbx mcp add local-image-server --command docker \
 > credentials available to that user. Use `--command` only with executables you
 > trust.
 
-`sbx mcp add` registers the server. It doesn't attach the server to a running
-sandbox by itself. To connect registered servers to a sandbox, use dynamic mode,
-static mode, or `sbx mcp load`.
-
 ## Authorize OAuth-backed servers
 
 If a registered remote server requires OAuth, `sbx mcp add` starts the
@@ -137,7 +148,7 @@ $ sbx mcp auth rm notion
 Use `--all` to apply `auth`, `auth status`, or `auth rm` to all registered
 OAuth-backed servers. Use `--format=json` for machine-readable output.
 
-## Start a sandbox with MCP
+## Expose servers to a sandbox
 
 Every sandbox starts an MCP gateway. When the sandbox starts, supported agent
 integrations read the gateway URL and register it with the agent.
@@ -185,8 +196,8 @@ create a new sandbox.
 
 ## Add a server to a running sandbox
 
-To attach an already-registered server to a running sandbox, use `sbx mcp
-load`:
+To attach an already-registered server to a running sandbox outside the initial
+dynamic or static setup, use `sbx mcp load`:
 
 ```console
 $ sbx mcp add linear --url https://mcp.linear.app/mcp

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -14,8 +14,8 @@ This is different from configuring an MCP server directly in an agent such as
 Claude Code. Direct MCP setup configures that agent's own MCP client. With
 Docker Sandboxes, you register MCP servers once on the host, and the sandbox
 gateway exposes them to supported agents inside isolated sandboxes. That
-host-managed gateway provides a single path for credentials, dynamic or fixed
-server sets, live server loading, and organization governance.
+host-managed gateway provides a single path for credentials, explicit server
+loading, live updates, and organization governance.
 
 > [!NOTE]
 > The Docker Sandboxes MCP gateway is separate from the Docker Desktop MCP
@@ -42,8 +42,7 @@ $ sbx mcp add notion --url https://mcp.notion.com/mcp
 ```
 
 If the server requires OAuth, `sbx` opens an authorization flow before it stores
-the registration. After registration, verify that the server is in your local
-MCP catalog:
+the registration. After registration, verify that the server is registered:
 
 ```console
 $ sbx mcp ls
@@ -51,25 +50,23 @@ NAME                 TYPE     URL/COMMAND
 notion               remote   https://mcp.notion.com/mcp
 ```
 
-Then start a sandbox:
+Then start a sandbox and expose the registered server:
 
 ```console
-$ sbx run claude --name mcp-demo
+$ sbx run claude --name mcp-demo --static-mcp notion
 ```
 
-The sandbox starts with an MCP gateway. In the default dynamic mode, the agent
-can discover registered MCP servers through gateway tools and use them during
-the session. Because you registered the server before starting the sandbox, it
-is part of that sandbox's initial MCP catalog. The registration remains on the
-host and can be reused by other sandboxes.
+The sandbox starts with an MCP gateway and pre-loads the `notion` server. The
+registration remains on the host and can be reused by other sandboxes.
 
 ## Register an MCP server
 
 `sbx mcp add` registers an MCP server by name. The registration records the
-server definition on the host. It doesn't attach the server to a running sandbox
-by itself. A server registered before sandbox creation is available when that
-sandbox's gateway starts. To add a server to a sandbox that's already running,
-use [`sbx mcp load`](#add-a-server-to-a-running-sandbox).
+server definition on the host. It doesn't attach the server to a sandbox by
+itself. To expose a registered server to a sandbox, pass it with
+[`--static-mcp`](#expose-servers-at-sandbox-creation) when you create the
+sandbox, or use [`sbx mcp load`](#add-a-server-to-a-running-sandbox) for a
+sandbox that's already running.
 
 Server names can contain letters, numbers, dots, hyphens, and underscores.
 
@@ -175,10 +172,9 @@ To register an OAuth-backed server without authorizing it, pass `--skip_auth`:
 $ sbx mcp add notion --url https://mcp.notion.com/mcp --skip_auth
 ```
 
-When a server isn't authorized, the gateway exposes a helper tool named
-`<server>-authorize`, such as `notion-authorize`. The agent can call that tool
-from inside the sandbox when it needs the server. The gateway also exposes
-`<server>-revoke-auth` for OAuth-backed servers.
+When an unauthorized OAuth-backed server is exposed to a sandbox, the gateway
+exposes a helper tool named `<server>-authorize`, such as `notion-authorize`.
+The agent can call that tool from inside the sandbox when it needs the server.
 
 You can manage OAuth credentials from the host:
 
@@ -191,34 +187,13 @@ $ sbx mcp auth rm notion
 Use `--all` to apply `auth`, `auth status`, or `auth rm` to all registered
 OAuth-backed servers. Use `--format=json` for machine-readable output.
 
-## Expose servers to a sandbox
+## Expose servers at sandbox creation
 
 Every sandbox starts an MCP gateway. When the sandbox starts, supported agent
 integrations read the gateway URL and register it with the agent.
 
-A sandbox can use MCP in dynamic mode or static mode. The mode is selected when
-the sandbox is created.
-
-| Mode    | How to use it             | Behavior                                                                  |
-| ------- | ------------------------- | ------------------------------------------------------------------------- |
-| Dynamic | Omit `--static-mcp`       | The registered catalog is searchable from the agent through gateway tools |
-| Static  | Pass `--static-mcp` names | Only the named servers are pre-loaded, and discovery tools are disabled   |
-
-### Dynamic mode
-
-Dynamic mode is the default. Start a sandbox without `--static-mcp`:
-
-```console
-$ sbx run claude --name my-session
-```
-
-In dynamic mode, the agent can search the registered MCP catalog and connect
-servers during the session. The gateway exposes discovery tools such as
-`mcp-find` and `mcp-add`.
-
-### Static mode
-
-Use static mode when you want a fixed MCP server set for the sandbox:
+Use `--static-mcp` when you want to pre-load registered MCP servers into a
+sandbox:
 
 ```console
 $ sbx mcp add notion --url https://mcp.notion.com/mcp
@@ -234,13 +209,14 @@ $ sbx run claude --name my-session \
 ```
 
 Every name in the static set must already be registered with `sbx mcp add`. The
-static set is fixed at sandbox creation time. To use a different static set,
-create a new sandbox.
+static set is fixed at sandbox creation time. If you omit `--static-mcp`, the
+sandbox starts with an MCP gateway but no registered MCP servers. To use a
+different static set, create a new sandbox.
 
 ## Add a server to a running sandbox
 
-To attach an already-registered server to a running sandbox outside the initial
-dynamic or static setup, use `sbx mcp load`:
+To attach an already-registered server to a running sandbox, use
+`sbx mcp load`:
 
 ```console
 $ sbx mcp add linear --url https://mcp.linear.app/mcp
@@ -248,8 +224,28 @@ $ sbx mcp load linear --sandbox my-session
 MCP server "linear" loaded into sandbox "my-session" (live)
 ```
 
-Connected agent sessions receive a tool-list update, so the agent can discover
-the added tools without reconnecting.
+Connected agent sessions receive a tool-list update, so the added tools become
+visible without reconnecting.
+
+## Built-in gateway tools
+
+The local MCP gateway exposes a small set of built-in tools. These tools belong
+to the gateway itself, not to a registered MCP server.
+
+| Tool                 | Description                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| `mcp-exec`           | Executes a tool by name in the current gateway session.                                        |
+| `code-mode`          | Creates a session-scoped JavaScript tool that can call selected tools through the MCP gateway. |
+| `<server>-authorize` | Starts OAuth authorization for an exposed server that requires authorization.                  |
+
+The gateway exposes `<server>-authorize` only when an OAuth-backed server needs
+authorization. If `code-mode` creates a generated tool, that generated tool is
+available only in the current session.
+
+In MCP access policies, built-in gateway tools are `MCP::Primordial` resources
+and use the `invokePrimordial` action. Tools from registered MCP servers are
+`MCP::Tool` resources and use the `invokeTool` action. For details, see the
+[MCP policy reference](governance/reference/mcp-policy.md).
 
 ## Manage registrations
 

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -100,9 +100,9 @@ $ sbx mcp add fetch --local \
   --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
 ```
 
-For local gateway usage, include `--local`. Without `--local`, registry and
-manifest URLs resolve to OCI-backed server registrations for hosted gateway
-modes, which this page doesn't cover.
+The `--local` flag tells `sbx` to run the registry or manifest entry as a
+host-side stdio server. If the entry doesn't publish a stdio package, `sbx`
+rejects the registration instead of starting it locally.
 
 A server manifest describes the MCP server package and how to start it. It can
 be hosted on a GitHub raw URL, internal HTTP server, or CDN.

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -29,6 +29,8 @@ server sets, live server loading, and organization governance.
   Gemini, Kiro, or OpenCode.
 - For remote servers that require OAuth, use MCP servers that support OAuth
   Dynamic Client Registration.
+- For local containerized MCP servers, use a host with Docker installed and
+  running.
 
 ## Quick start
 
@@ -79,64 +81,59 @@ $ sbx mcp add notion --url https://mcp.notion.com/mcp
 $ sbx mcp add linear --url https://mcp.linear.app/mcp
 ```
 
-### MCP registry URL
+### Local stdio server
 
-You can register a server from the MCP community registry:
+Some MCP servers communicate over stdio instead of exposing a remote HTTP
+endpoint. Docker Sandboxes can register local stdio servers in two ways: by
+resolving a package from registry or manifest metadata, or by running an
+explicit command.
 
-```console
-$ sbx mcp add fetch \
-  --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
-```
+#### From registry or manifest metadata
 
-### Server manifest URL
-
-You can register a server from a URL that returns a `server.json` or
-`server.yaml` document. A server manifest describes the MCP server and how the
-gateway should connect to it. This is the same general shape used by the MCP
-community registry, and it works for manifests hosted on GitHub raw URLs,
-internal HTTP servers, or CDNs.
-
-```console
-$ sbx mcp add opine --url https://example.com/mcp/opine/server.yaml
-```
-
-### Docker Hardened Image reference
-
-You can register a Docker Hardened Image reference when the image carries an
-MCP server manifest in its attestation:
-
-```console
-$ sbx mcp add fetch --url dhi.io/fetch-mcp:latest
-```
-
-Generic image references, such as `docker.io/example/server:latest`, aren't
-accepted. Use a server manifest URL instead.
-
-### Registry server as a local container
-
-To run a registry server locally as a container, add `--local` to a registry or
-manifest URL. This is useful for stdio-based servers packaged as containers:
+Use `--local` with an MCP community registry URL or a URL that returns a
+`server.json` or `server.yaml` document. The registry entry or manifest must
+describe an OCI package that uses stdio transport. `sbx` resolves the image from
+the metadata and starts it on the host with Docker.
 
 ```console
 $ sbx mcp add fetch --local \
   --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
 ```
 
-### Local stdio command
+For local gateway usage, include `--local`. Without `--local`, registry and
+manifest URLs resolve to OCI-backed server registrations for hosted gateway
+modes, which this page doesn't cover.
 
-You can also register a local stdio command:
+A server manifest describes the MCP server package and how to start it. It can
+be hosted on a GitHub raw URL, internal HTTP server, or CDN.
+
+```console
+$ sbx mcp add opine --local --url https://example.com/mcp/opine/server.yaml
+```
+
+#### From an explicit command
+
+Use `--command` when you already know the executable and arguments, or when you
+need custom Docker flags. The command can be a package runner such as `npx` or
+a Docker container command:
 
 ```console
 $ sbx mcp add playwright --command npx --args @playwright/mcp@latest
 $ sbx mcp add local-image-server --command docker \
-  --args run --args -i --args your/image
+  --args run --args -i --args --rm --args your/image
 ```
 
+Use registry or manifest metadata when you have a published server definition
+and don't need to customize `docker run`. Use `--command` for local
+development, private servers, or custom container flags.
+
 > [!WARNING]
-> Local stdio commands run on the host, outside the sandbox. They run with your
-> host user's permissions and can access host files, host network resources, and
-> credentials available to that user. Use `--command` only with executables you
-> trust.
+> Local stdio servers run on the host, outside sandbox isolation. If the command
+> starts a Docker container, that container uses host Docker isolation, not
+> sandbox isolation. The process or container can access host files, host
+> network resources, and credentials made available to it. Use trusted commands
+> and images, and avoid mounting host paths or passing credentials unless the
+> server needs them.
 
 ## Authorize OAuth-backed servers
 

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -1,0 +1,264 @@
+---
+title: MCP gateway
+description: Register MCP servers, authorize OAuth-backed servers, and connect MCP tools to Docker Sandboxes.
+keywords: docker sandboxes, sbx, MCP gateway, Model Context Protocol, MCP servers, sbx mcp, static MCP, OAuth
+weight: 30
+---
+
+Docker Sandboxes includes an MCP gateway for connecting agents to Model Context
+Protocol servers. The gateway runs with the sandbox and presents one MCP
+endpoint to the agent. Use `sbx mcp` on the host to register servers, manage
+OAuth credentials, and attach registered servers to running sandboxes.
+
+This page focuses on local gateway mode, where MCP traffic is handled by a
+gateway running on your machine. Use `sbx mcp status` to check the effective
+gateway for your account.
+
+## Prerequisites
+
+- Sign in with `sbx login`.
+- Use an agent integration that configures MCP at startup: Claude Code, Codex,
+  Gemini, Kiro, or OpenCode.
+- For remote servers that require OAuth, use MCP servers that support OAuth
+  Dynamic Client Registration.
+
+The Docker Desktop MCP Toolkit isn't required for sandbox MCP support.
+
+## Check the gateway mode
+
+Run `sbx mcp status` to see the effective MCP gateway:
+
+```console
+$ sbx mcp status
+Gateway mode: local
+Gateway URL:  (none)
+Source:       mcp-saas gateway-mode API (resolved by daemon)
+```
+
+The output can also include `Decision` and `Reason` fields. These fields show
+the raw gateway decision and why that decision produced the effective gateway.
+
+The daemon resolves the gateway mode and caches the result for its lifetime. If
+you change sign-in state or an MCP gateway setting, restart the daemon before
+checking again:
+
+```console
+$ sbx daemon stop
+$ sbx mcp status
+```
+
+## Register an MCP server
+
+Register servers on the host before you connect them to a sandbox. Server names
+can contain letters, numbers, dots, hyphens, and underscores.
+
+For a remote MCP endpoint, pass the server URL:
+
+```console
+$ sbx mcp add notion --url https://mcp.notion.com/mcp
+$ sbx mcp add linear --url https://mcp.linear.app/mcp
+```
+
+You can also register a server from an MCP registry URL, a `server.json` or
+`server.yaml` manifest URL, or a Docker Hardened Image reference that carries
+an MCP server manifest:
+
+```console
+$ sbx mcp add fetch \
+  --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
+
+$ sbx mcp add opine --url https://example.com/mcp/opine/server.yaml
+
+$ sbx mcp add fetch --url dhi.io/fetch-mcp:latest
+```
+
+To run a registry server locally as a container, add `--local`. This is useful
+for stdio-based servers packaged as containers:
+
+```console
+$ sbx mcp add fetch --local \
+  --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
+```
+
+You can also register a local stdio command:
+
+```console
+$ sbx mcp add playwright --command npx --args @playwright/mcp@latest
+$ sbx mcp add local-image-server --command docker \
+  --args run --args -i --args your/image
+```
+
+> [!WARNING]
+> Local stdio commands run on the host, outside the sandbox. They run with your
+> host user's permissions and can access host files, host network resources, and
+> credentials available to that user. Use `--command` only with executables you
+> trust.
+
+`sbx mcp add` registers the server. It doesn't attach the server to a running
+sandbox by itself. To connect registered servers to a sandbox, use dynamic mode,
+static mode, or `sbx mcp load`.
+
+## Authorize OAuth-backed servers
+
+If a registered remote server requires OAuth, `sbx mcp add` starts the
+authorization flow by default:
+
+```console
+$ sbx mcp add notion --url https://mcp.notion.com/mcp
+Resolving MCP server "notion"...
+Open this URL to authorize MCP server "notion":
+https://api.notion.com/v1/oauth/authorize?...
+MCP server "notion" authorized
+MCP server "notion" registered (type: remote)
+```
+
+OAuth credentials stay on the host. In local gateway mode, `sbx` stores tokens
+in the host operating system's credential store.
+
+To register an OAuth-backed server without authorizing it, pass `--skip_auth`:
+
+```console
+$ sbx mcp add notion --url https://mcp.notion.com/mcp --skip_auth
+```
+
+When a server isn't authorized, the gateway exposes a helper tool named
+`<server>-authorize`, such as `notion-authorize`. The agent can call that tool
+from inside the sandbox when it needs the server. The gateway also exposes
+`<server>-revoke-auth` for OAuth-backed servers.
+
+You can manage OAuth credentials from the host:
+
+```console
+$ sbx mcp auth status notion
+$ sbx mcp auth notion
+$ sbx mcp auth rm notion
+```
+
+Use `--all` to apply `auth`, `auth status`, or `auth rm` to all registered
+OAuth-backed servers. Use `--format=json` for machine-readable output.
+
+## Start a sandbox with MCP
+
+Every sandbox starts an MCP gateway. When the sandbox starts, supported agent
+integrations read the gateway URL and register it with the agent.
+
+A sandbox can use MCP in dynamic mode or static mode. The mode is selected when
+the sandbox is created.
+
+| Mode    | How to use it             | Behavior                                                                  |
+| ------- | ------------------------- | ------------------------------------------------------------------------- |
+| Dynamic | Omit `--static-mcp`       | The registered catalog is searchable from the agent through gateway tools |
+| Static  | Pass `--static-mcp` names | Only the named servers are pre-loaded, and discovery tools are disabled   |
+
+### Dynamic mode
+
+Dynamic mode is the default. Start a sandbox without `--static-mcp`:
+
+```console
+$ sbx run claude --name my-session
+```
+
+In dynamic mode, the agent can search the registered MCP catalog and connect
+servers during the session. The gateway exposes discovery tools such as
+`mcp-find` and `mcp-add`.
+
+### Static mode
+
+Use static mode when you want a fixed MCP server set for the sandbox:
+
+```console
+$ sbx mcp add notion --url https://mcp.notion.com/mcp
+$ sbx mcp add linear --url https://mcp.linear.app/mcp
+$ sbx run claude --name my-session --static-mcp notion,linear
+```
+
+You can pass `--static-mcp` as a comma-separated list or repeat the flag:
+
+```console
+$ sbx run claude --name my-session \
+  --static-mcp notion --static-mcp linear
+```
+
+Every name in the static set must already be registered with `sbx mcp add`. The
+static set is fixed at sandbox creation time. To use a different static set,
+create a new sandbox.
+
+## Add a server to a running sandbox
+
+To attach an already-registered server to a running sandbox, use `sbx mcp
+load`:
+
+```console
+$ sbx mcp add linear --url https://mcp.linear.app/mcp
+$ sbx mcp load linear --sandbox my-session
+MCP server "linear" loaded into sandbox "my-session" (live)
+```
+
+Connected agent sessions receive a tool-list update, so the agent can discover
+the added tools without reconnecting.
+
+## Manage registrations
+
+List registered servers:
+
+```console
+$ sbx mcp ls
+```
+
+Inspect a registered server:
+
+```console
+$ sbx mcp inspect notion
+```
+
+Remove a registered server:
+
+```console
+$ sbx mcp rm notion
+```
+
+For OAuth-backed servers, `sbx mcp rm` removes the OAuth credential before it
+removes the server registration. To remove only the OAuth credential, use
+`sbx mcp auth rm`.
+
+## Register a bundle
+
+An MCP bundle is a JSON array of server definitions fetched from a URL. Each
+entry maps to one `sbx mcp add` registration.
+
+```json
+[
+  { "name": "notion", "url": "https://mcp.notion.com/mcp" },
+  { "name": "linear", "url": "https://mcp.linear.app/mcp" },
+  {
+    "name": "github",
+    "command": "npx",
+    "args": ["@modelcontextprotocol/server-github"]
+  }
+]
+```
+
+Fetch and register a bundle:
+
+```console
+$ sbx mcp bundle add core --url https://example.com/mcp-bundle.json
+```
+
+List registered bundles:
+
+```console
+$ sbx mcp bundle ls
+```
+
+Remove a bundle and the servers it registered:
+
+```console
+$ sbx mcp bundle rm core
+```
+
+## Governance
+
+Organizations with AI Governance can use
+[MCP access policies](governance/access-controls/mcp.md) to control MCP server
+registration, tool calls, gateway meta-tools, resources, prompts, and approval
+requirements. MCP access policies are organization policies written in Cedar.

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -72,6 +72,20 @@ use [`sbx mcp load`](#add-a-server-to-a-running-sandbox).
 
 Server names can contain letters, numbers, dots, hyphens, and underscores.
 
+The `--url` flag can point to different kinds of input. The execution location
+depends on what you register:
+
+- **Remote endpoint URL**: The URL is the running MCP server endpoint. The
+  server runs remotely, and the sandbox gateway connects to it.
+- **Metadata URL with `--local`**: The URL returns a registry entry,
+  `server.json`, or `server.yaml` that describes an OCI-packaged stdio server.
+  `sbx` resolves the image and runs it on the host with Docker.
+- **Explicit command**: `sbx` runs the command on the host as a stdio MCP
+  server.
+
+Local stdio servers run on the host, not inside the sandbox. The agent inside
+the sandbox connects only to the MCP gateway.
+
 ### Remote endpoint URL
 
 For a remote MCP endpoint, pass the server URL:
@@ -84,25 +98,23 @@ $ sbx mcp add linear --url https://mcp.linear.app/mcp
 ### Local stdio server
 
 Some MCP servers communicate over stdio instead of exposing a remote HTTP
-endpoint. Docker Sandboxes can register local stdio servers in two ways: by
-resolving a package from registry or manifest metadata, or by running an
-explicit command.
+endpoint. Use a local stdio server when `sbx` should launch the MCP server on
+the host. You can provide a metadata URL or an explicit command.
 
 #### From registry or manifest metadata
 
-Use `--local` with an MCP community registry URL or a URL that returns a
-`server.json` or `server.yaml` document. The registry entry or manifest must
-describe an OCI package that uses stdio transport. `sbx` resolves the image from
-the metadata and starts it on the host with Docker.
+Use `--local --url` when you have an MCP community registry URL or a URL that
+returns a `server.json` or `server.yaml` document. The registry entry or
+manifest must describe an OCI package that uses stdio transport. `sbx` resolves
+the image from the metadata and starts it on the host with Docker.
 
 ```console
 $ sbx mcp add fetch --local \
   --url https://registry.modelcontextprotocol.io/v0/servers/fetch-mcp/versions/latest
 ```
 
-The `--local` flag tells `sbx` to run the registry or manifest entry as a
-host-side stdio server. If the entry doesn't publish a stdio package, `sbx`
-rejects the registration instead of starting it locally.
+If the entry doesn't publish a stdio package, `sbx` rejects the registration
+instead of starting it locally.
 
 A server manifest describes the MCP server package and how to start it. It can
 be hosted on a GitHub raw URL, internal HTTP server, or CDN.

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -2,7 +2,7 @@
 title: MCP gateway
 description: Register MCP servers, authorize OAuth-backed servers, and connect MCP tools to Docker Sandboxes.
 keywords: docker sandboxes, sbx, MCP gateway, Model Context Protocol, MCP servers, sbx mcp, static MCP, OAuth
-weight: 30
+weight: 50
 ---
 
 Docker Sandboxes includes an MCP gateway for connecting agents to Model Context

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -73,13 +73,12 @@ Server names can contain letters, numbers, dots, hyphens, and underscores.
 The `--url` flag can point to different kinds of input. The execution location
 depends on what you register:
 
-- **Remote endpoint URL**: The URL is the running MCP server endpoint. The
-  server runs remotely, and the sandbox gateway connects to it.
-- **Metadata URL with `--local`**: The URL returns a registry entry,
-  `server.json`, or `server.yaml` that describes an OCI-packaged stdio server.
-  `sbx` resolves the image and runs it on the host with Docker.
-- **Explicit command**: `sbx` runs the command on the host as a stdio MCP
-  server.
+- A remote endpoint URL identifies a running MCP server. The server runs
+  remotely, and the sandbox gateway connects to it.
+- A metadata URL with `--local` returns a registry entry, `server.json`, or
+  `server.yaml` that describes an OCI-packaged stdio server. `sbx` resolves the
+  image and runs it on the host with Docker.
+- An explicit command runs on the host as a stdio MCP server.
 
 Local stdio servers run on the host, not inside the sandbox. The agent inside
 the sandbox connects only to the MCP gateway.

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -137,7 +137,7 @@ a Docker container command:
 ```console
 $ sbx mcp add playwright --command npx --args @playwright/mcp@latest
 $ sbx mcp add local-image-server --command docker \
-  --args run --args -i --args --rm --args your/image
+  --args "run,-i,--rm,your/image"
 ```
 
 Use registry or manifest metadata when you have a published server definition

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -247,13 +247,24 @@ $ sbx mcp auth rm notion
 Use `--all` to apply `auth`, `auth status`, or `auth rm` to all registered
 OAuth-backed servers. Use `--format=json` for machine-readable output.
 
-## Expose servers at sandbox creation
+## Choose an MCP mode
 
 Every sandbox starts an MCP gateway. When the sandbox starts, supported agent
 integrations read the gateway URL and register it with the agent.
 
-Use `--static-mcp` when you want to pre-load registered MCP servers into a
-sandbox:
+Whether you pass `--static-mcp` when you create the sandbox determines its MCP
+mode:
+
+- Static mode pre-loads the specified servers and doesn't expose dynamic
+  discovery tools to the agent.
+- Dynamic mode pre-loads no servers and lets the agent find and attach
+  registered servers.
+
+This choice persists across sandbox restarts.
+
+### Use static mode
+
+Pass `--static-mcp` to pre-load registered MCP servers:
 
 ```console
 $ sbx mcp add notion --url https://mcp.notion.com/mcp
@@ -269,14 +280,27 @@ $ sbx run claude --name my-session \
 ```
 
 Every name in the static set must already be registered with `sbx mcp add`. The
-static set is fixed at sandbox creation time. In local gateway mode, if you omit
-`--static-mcp`, the sandbox starts with an MCP gateway but no registered MCP
-servers. To use a different static set, create a new sandbox.
+gateway doesn't expose `mcp-find`, `mcp-add`, or `mcp-config-set` to the agent.
+
+You can't replace the initial set by passing `--static-mcp` when reconnecting to
+an existing sandbox. To attach another server from the host, use
+[`sbx mcp load`](#add-a-server-to-a-running-sandbox).
+
+### Use dynamic mode
+
+Omit `--static-mcp` to use dynamic mode. The gateway pre-loads no servers and
+exposes `mcp-find`, `mcp-add`, and `mcp-config-set` to the agent. The agent can
+search the registered server catalog and attach servers during the session.
+
+If you run `sbx mcp add` after a dynamic sandbox starts, its gateway refreshes
+the searchable catalog. The agent can then find and attach the new registration
+without restarting. The `sbx mcp add` command doesn't attach the server by
+itself.
 
 ## Add a server to a running sandbox
 
 To attach an already-registered server to a running sandbox, use
-`sbx mcp load`:
+`sbx mcp load`. This works in both static and dynamic modes:
 
 ```console
 $ sbx mcp add linear --url https://mcp.linear.app/mcp
@@ -285,7 +309,8 @@ MCP server "linear" loaded into sandbox "my-session" (live)
 ```
 
 Connected agent sessions receive a tool-list update, so the added tools become
-visible without reconnecting.
+visible without reconnecting. The loaded server remains attached across sandbox
+restarts.
 
 ## Built-in gateway tools
 
@@ -303,13 +328,16 @@ them separately from tools provided by registered MCP servers.
 | -------------------- | ------------------------------------------------------------------------------------------ |
 | `mcp-exec`           | Executes a tool by name through the gateway.                                               |
 | `code-mode`          | Creates an ephemeral JavaScript tool that can call selected tools through the MCP gateway. |
+| `mcp-find`           | Searches the registered server catalog without changing sandbox state. Dynamic mode only.  |
+| `mcp-add`            | Attaches a registered server to the sandbox. Dynamic mode only.                            |
+| `mcp-config-set`     | Sets per-session configuration overrides for an attached server. Dynamic mode only.        |
 | `<server>-authorize` | Starts or restarts OAuth authorization for an exposed OAuth-backed remote server.          |
 
-The gateway exposes `<server>-authorize` for OAuth-backed remote servers, even
-when they already have a valid token. Local stdio servers don't expose this
-helper. If `code-mode` creates a generated tool, the tool is shared by clients
-connected to the sandbox's gateway and disappears when the gateway is replaced
-or stops.
+Servers attached with `mcp-add` remain attached across sandbox restarts. The
+gateway exposes `<server>-authorize` for OAuth-backed remote servers, even when
+they already have a valid token. Local stdio servers don't expose this helper.
+If `code-mode` creates a generated tool, the tool is shared by clients connected
+to the sandbox's gateway and disappears when the gateway is replaced or stops.
 
 In MCP access policies, built-in gateway tools are `MCP::Primordial` resources
 and use the `invokePrimordial` action. Tools from registered MCP servers are
@@ -342,41 +370,6 @@ client and its identity binding remain in the host credential store so you can
 reuse them when you re-add the same client. The command prints the
 `sbx secret rm` commands for removing them. To remove only the OAuth access
 token, use `sbx mcp auth rm`.
-
-## Register a bundle
-
-An MCP bundle is a JSON array of server definitions fetched from a URL. Each
-entry maps to one `sbx mcp add` registration.
-
-```json
-[
-  { "name": "notion", "url": "https://mcp.notion.com/mcp" },
-  { "name": "linear", "url": "https://mcp.linear.app/mcp" },
-  {
-    "name": "github",
-    "command": "npx",
-    "args": ["@modelcontextprotocol/server-github"]
-  }
-]
-```
-
-Fetch and register a bundle:
-
-```console
-$ sbx mcp bundle add core --url https://example.com/mcp-bundle.json
-```
-
-List registered bundles:
-
-```console
-$ sbx mcp bundle ls
-```
-
-Remove a bundle and the servers it registered:
-
-```console
-$ sbx mcp bundle rm core
-```
 
 ## Governance
 

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -64,7 +64,7 @@ registration remains on the host and can be reused by other sandboxes.
 `sbx mcp add` registers an MCP server by name. The registration records the
 server definition on the host. It doesn't attach the server to a sandbox by
 itself. To expose a registered server to a sandbox, pass it with
-[`--static-mcp`](#expose-servers-at-sandbox-creation) when you create the
+[`--static-mcp`](#use-static-mode) when you create the
 sandbox, or use [`sbx mcp load`](#add-a-server-to-a-running-sandbox) for a
 sandbox that's already running.
 

--- a/content/manuals/ai/sandboxes/mcp-gateway.md
+++ b/content/manuals/ai/sandboxes/mcp-gateway.md
@@ -27,8 +27,8 @@ loading, live updates, and organization governance.
 - Sign in with `sbx login`.
 - Use an agent integration that configures MCP at startup: Claude Code, Codex,
   Gemini, Kiro, or OpenCode.
-- For remote servers that require OAuth, use MCP servers that support OAuth
-  Dynamic Client Registration.
+- For remote servers that require OAuth without Dynamic Client Registration,
+  register an OAuth client with the server provider.
 - For `--local --url` registrations that resolve to OCI packages, use a host
   with Docker installed and running. Docker is also required for explicit
   `--command docker ...` registrations.
@@ -136,6 +136,13 @@ $ sbx mcp add local-image-server --command docker \
   --args "run,-i,--rm,your/image"
 ```
 
+To set the working directory for the host process, pass `--dir`. This flag is
+only valid with `--command`:
+
+```console
+$ sbx mcp add local-fs --command node --args server.js --dir /srv/data
+```
+
 Use registry or manifest metadata when you have a published server definition
 and don't need to customize `docker run`. Use `--command` for local
 development, private servers, or custom container flags.
@@ -170,6 +177,59 @@ To register an OAuth-backed server without authorizing it, pass `--skip_auth`:
 ```console
 $ sbx mcp add notion --url https://mcp.notion.com/mcp --skip_auth
 ```
+
+### Use a pre-registered OAuth client
+
+In local gateway mode, you can register a remote OAuth server that doesn't
+support Dynamic Client Registration. If the server publishes OAuth metadata,
+pass the client ID that you registered with the server provider:
+
+```console
+$ sbx mcp add slack --url https://slack.example.com/mcp \
+  --client-id <CLIENT_ID>
+```
+
+If the server doesn't publish OAuth metadata, pass
+`--oauth-authorization-server` with the client ID. The flag accepts a local
+file path or an HTTP or HTTPS URL to an RFC 8414 authorization server metadata
+document. The document must define `authorization_endpoint` and
+`token_endpoint`:
+
+```console
+$ sbx mcp add serverx --url https://mcp.serverx.example/mcp \
+  --oauth-authorization-server ./serverx-authorization-server.json \
+  --client-id <CLIENT_ID>
+```
+
+These flags are only valid with `--url`.
+
+For a confidential OAuth client, store the client secret before registering
+the server. There is no `--client-secret` flag:
+
+```console
+$ sbx secret set mcp:slack.client_secret
+$ sbx mcp add slack --url https://slack.example.com/mcp \
+  --client-id <CLIENT_ID>
+```
+
+The client secret stays in the encrypted host credential store and isn't
+written to the MCP registration. If the server requires a confidential client
+and no secret is stored, registration succeeds but authorization is skipped.
+Store the secret, then run `sbx mcp auth <server>`.
+
+### Set OAuth scopes
+
+Use the repeatable `--scope` flag to record the default scopes requested during
+authorization:
+
+```console
+$ sbx mcp add serverx --url https://mcp.serverx.example/mcp \
+  --scope read --scope write
+```
+
+The `sbx mcp auth` command also accepts `--scope` to override the recorded
+defaults for one authorization. If the authorization server advertises
+supported scopes, every requested scope must be in that set.
 
 For each OAuth-backed remote server exposed to a sandbox, the gateway exposes a
 helper tool named `<server>-authorize`, such as `notion-authorize`. The agent can
@@ -276,9 +336,12 @@ Remove a registered server:
 $ sbx mcp rm notion
 ```
 
-For OAuth-backed servers, `sbx mcp rm` removes the OAuth credential before it
-removes the server registration. To remove only the OAuth credential, use
-`sbx mcp auth rm`.
+For OAuth-backed servers, `sbx mcp rm` removes the OAuth access token before it
+removes the server registration. A client secret for a pre-registered OAuth
+client and its identity binding remain in the host credential store so you can
+reuse them when you re-add the same client. The command prints the
+`sbx secret rm` commands for removing them. To remove only the OAuth access
+token, use `sbx mcp auth rm`.
 
 ## Register a bundle
 

--- a/content/manuals/ai/sandboxes/release-notes.md
+++ b/content/manuals/ai/sandboxes/release-notes.md
@@ -3,7 +3,7 @@ title: Docker Sandboxes release notes
 linkTitle: Release notes
 description: New features, bug fixes, and changes in Docker Sandboxes
 keywords: docker sandboxes, sbx, release notes, changelog
-weight: 130
+weight: 120
 toc_min: 1
 toc_max: 2
 tags:

--- a/content/manuals/ai/sandboxes/release-notes.md
+++ b/content/manuals/ai/sandboxes/release-notes.md
@@ -3,6 +3,7 @@ title: Docker Sandboxes release notes
 linkTitle: Release notes
 description: New features, bug fixes, and changes in Docker Sandboxes
 keywords: docker sandboxes, sbx, release notes, changelog
+weight: 130
 toc_min: 1
 toc_max: 2
 tags:

--- a/content/manuals/ai/sandboxes/security/_index.md
+++ b/content/manuals/ai/sandboxes/security/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Security model
 linkTitle: Security model
-weight: 50
+weight: 80
 description: Trust boundaries, isolation layers, and security properties of Docker Sandboxes.
 keywords: docker sandboxes, security model, isolation, trust boundaries, microVM
 ---

--- a/content/manuals/ai/sandboxes/security/_index.md
+++ b/content/manuals/ai/sandboxes/security/_index.md
@@ -29,6 +29,8 @@ What crosses the boundary into the VM:
 - **Shared agent skills:** a persistent host-side store is mounted read-write
   at the agent's skills directory unless you opt out when creating the
   sandbox. Supported agents in other sandboxes mount the same store.
+- **MCP gateway traffic:** supported agents connect to a host-side MCP gateway
+  endpoint. The gateway brokers access to registered MCP servers.
 
 What crosses the boundary back to the host:
 
@@ -43,6 +45,12 @@ host filesystem. It also cannot access your host Docker daemon, your host
 network or localhost, or any domain not in the allow list. Sandboxes cannot
 communicate directly over the network. Raw TCP, UDP, and ICMP are blocked at
 the network layer.
+
+MCP servers are an explicit integration point. Remote MCP servers run outside
+Docker Sandboxes, and local stdio MCP servers run on the host, not inside the
+sandbox VM. An agent can invoke the tools those servers expose through the MCP
+gateway, subject to MCP policies when organization governance is active. Treat
+local MCP servers as trusted host integrations.
 
 ![Sandbox security model showing the hypervisor boundary between the sandbox VM and the host system. The workspace directory is shared read-write. The agent process, Docker Engine, packages, and VM filesystem are inside the VM. Host filesystem, processes, Docker Engine, and network are outside the VM and not accessible. A proxy enforces allow/deny policies and injects credentials into outbound requests.](../images/sbx-security.png)
 
@@ -104,6 +112,11 @@ the host filesystem or create a direct network path between sandboxes, but it
 does put participating sandboxes in the same trust boundary. See
 [Share agent skills](../workflows.md#share-agent-skills) for details and the
 per-sandbox opt-out.
+
+Local stdio MCP servers run outside the sandbox VM. If you register a local MCP
+server that starts a host process or host Docker container, that process or
+container uses host permissions and host isolation, not sandbox isolation. See
+[MCP gateway](../mcp-gateway.md).
 
 ## Organization-wide control
 

--- a/content/manuals/ai/sandboxes/security/_index.md
+++ b/content/manuals/ai/sandboxes/security/_index.md
@@ -136,5 +136,5 @@ admins.
 - [Default security posture](defaults/): what a fresh sandbox permits and
   blocks
 - [Credentials](credentials/): how to provide and manage API keys
-- [Governance](../governance/): configure network and filesystem access rules,
-  locally or across your organization
+- [Governance](../governance/): configure network, filesystem, and MCP access
+  controls locally or across your organization

--- a/content/manuals/ai/sandboxes/security/defaults.md
+++ b/content/manuals/ai/sandboxes/security/defaults.md
@@ -18,8 +18,9 @@ addresses, and link-local addresses is also blocked.
 
 Run `sbx policy ls` to see the active network rules for your installation.
 Rules can be customized per machine with the `sbx policy` CLI, or managed
-centrally across your organization. Org-level rules take precedence over local
-rules. See [Governance](../governance/).
+centrally across your organization from the Admin Console. Org-level rules
+take precedence over local rules. See
+[Network access policies](../governance/access-controls/network.md).
 
 ## Workspace defaults
 

--- a/content/manuals/ai/sandboxes/security/defaults.md
+++ b/content/manuals/ai/sandboxes/security/defaults.md
@@ -18,8 +18,8 @@ addresses, and link-local addresses is also blocked.
 
 Run `sbx policy ls` to see the active network rules for your installation.
 Rules can be customized per machine with the `sbx policy` CLI, or managed
-centrally across your organization from the Admin Console. Org-level rules
-take precedence over local rules. See
+centrally across your organization. Org-level rules take precedence over local
+rules. See
 [Network access policies](../governance/access-controls/network.md).
 
 ## Workspace defaults

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -38,10 +38,11 @@ each other and cannot reach your host's localhost. There is no shared network
 between sandboxes or between a sandbox and your host.
 
 All HTTP and HTTPS traffic leaving a sandbox passes through a proxy on your
-host that enforces the [network policy](../governance/). The sandbox routes
-traffic through either a forward proxy or a transparent proxy depending on the
-client's configuration. Both enforce the network policy; only the forward proxy
-[injects credentials](credentials.md) for AI services.
+host that enforces the
+[network access policy](../governance/access-controls/network.md). The sandbox
+routes traffic through either a forward proxy or a transparent proxy depending
+on the client's configuration. Both enforce the network policy; only the
+forward proxy [injects credentials](credentials.md) for AI services.
 
 Raw TCP connections, UDP, and ICMP are blocked at the network layer. DNS
 resolution goes through the proxy and is subject to the same network policy —

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -65,6 +65,12 @@ your host. When the agent runs `docker build` or `docker compose up`, those
 commands execute against that engine. The agent has no path to your host Docker
 daemon.
 
+This Docker Engine boundary applies to processes running inside the sandbox VM.
+It doesn't apply to local stdio MCP servers registered through the
+[MCP gateway](../mcp-gateway.md). Those servers run on the host, outside the
+sandbox VM. If a local MCP server starts a Docker container, it uses Docker on
+the host.
+
 Each sandbox VM runs its own Docker Engine. The agent runs inside the VM,
 alongside that engine, and drives it to create containers, all within the
 VM:

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -41,7 +41,7 @@ All HTTP and HTTPS traffic leaving a sandbox passes through a proxy on your
 host that enforces the
 [network access policy](../governance/access-controls/network.md). The sandbox
 routes traffic through either a forward proxy or a transparent proxy depending
-on the client's configuration. Both enforce the network policy; only the
+on the client's configuration. Both enforce the network policy. Only the
 forward proxy [injects credentials](credentials.md) for AI services.
 
 Raw TCP connections, UDP, and ICMP are blocked at the network layer. DNS

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-weight: 60
+weight: 100
 description: Resolve common issues when using Docker Sandboxes.
 keywords: docker sandboxes, sbx, troubleshooting, diagnostics, reset, network policy, git, ssh
 ---

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -43,7 +43,8 @@ data. Create fresh sandboxes afterwards.
 
 ## Agent can't install packages or reach an API
 
-Sandboxes use a [deny-by-default network policy](governance/access-controls/local.md).
+Sandboxes use [network access rules](governance/access-controls/network.md) to
+control outbound traffic.
 If the agent fails to install packages or call an external API, the target
 domain is likely not in the allow list. Check which requests are being blocked:
 
@@ -65,7 +66,7 @@ $ sbx policy allow network "**"
 
 If `sbx policy allow` doesn't unblock the request, your organization may
 manage sandbox policies centrally and take precedence over local rules. See
-[Organization governance](governance/access-controls/organization.md).
+[Organization policies](governance/access-controls/organization.md).
 
 ## Kit fails to install: source not in allowlist
 

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -43,7 +43,7 @@ data. Create fresh sandboxes afterwards.
 
 ## Agent can't install packages or reach an API
 
-Sandboxes use a [deny-by-default network policy](governance/local.md).
+Sandboxes use a [deny-by-default network policy](governance/access-controls/local.md).
 If the agent fails to install packages or call an external API, the target
 domain is likely not in the allow list. Check which requests are being blocked:
 
@@ -65,7 +65,7 @@ $ sbx policy allow network "**"
 
 If `sbx policy allow` doesn't unblock the request, your organization may
 manage sandbox policies centrally and take precedence over local rules. See
-[Organization governance](governance/org.md).
+[Organization governance](governance/access-controls/organization.md).
 
 ## Kit fails to install: source not in allowlist
 
@@ -140,7 +140,7 @@ If credentials are configured correctly but API calls still fail, check
 the `transparent` proxy don't get credential injection. This can happen when a
 client inside the sandbox (such as a process in a Docker container) isn't
 configured to use the forward proxy. See
-[Monitoring network activity](governance/monitoring.md)
+[Monitoring network activity](governance/monitor-and-enforce/monitoring.md)
 for details.
 
 ## API calls fail with a certificate error

--- a/content/manuals/ai/sandboxes/workflows.md
+++ b/content/manuals/ai/sandboxes/workflows.md
@@ -580,10 +580,10 @@ defaults. Version kit specs and template definitions with the project, and
 publish reusable template images to your registry. This gives each developer the
 same starting environment.
 
-Use [organization governance](governance/org.md) for rules that admins need to
-apply across developers, such as network and filesystem policies. Organization
-rules are managed in the Docker Admin Console, take precedence over local
-policy, and require a separate paid subscription.
+Use [organization policies](governance/access-controls/organization.md) for
+controls that organization administrators apply across developers, such as
+network, filesystem, and MCP policies. Organization policies take precedence
+over local policy and require a separate paid subscription.
 
 You can use both. Templates and kits describe the development environment;
 governance defines the boundaries it runs within.

--- a/content/manuals/subscription/plans/ai-governance.md
+++ b/content/manuals/subscription/plans/ai-governance.md
@@ -20,7 +20,7 @@ aliases:
 
 ## Usage
 
-AI Governance lets organization owners enforce [governance policies](/manuals/ai/sandboxes/governance/org.md) to license-holding members. Organization policies override the local policies of a license-holding member.
+AI Governance lets organization owners enforce [governance policies](/manuals/ai/sandboxes/governance/access-controls/organization.md) to license-holding members. Organization policies override the local policies of a license-holding member.
 
 You can [assign AI Governance licenses](/manuals/admin/organization/manage/manage-licenses.md) to any organization member, even if they don't occupy a Docker Team or Docker Business seat. For best practice, review available licenses as you add new members since members without an AI Governance license can still use Docker AI products.
 

--- a/content/manuals/subscription/plans/ai-governance.md
+++ b/content/manuals/subscription/plans/ai-governance.md
@@ -20,7 +20,7 @@ aliases:
 
 ## Usage
 
-AI Governance lets organization owners enforce [governance policies](/manuals/ai/sandboxes/governance/access-controls/organization.md) to license-holding members. Organization policies override the local policies of a license-holding member.
+AI Governance lets organization owners enforce [organization policies](/manuals/ai/sandboxes/governance/access-controls/organization.md) for license-holding members. Organization policies override a license-holding member's local policies.
 
 You can [assign AI Governance licenses](/manuals/admin/organization/manage/manage-licenses.md) to any organization member, even if they don't occupy a Docker Team or Docker Business seat. For best practice, review available licenses as you add new members since members without an AI Governance license can still use Docker AI products.
 

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -327,6 +327,11 @@
 
 # Links in Desktop
 
+# Docker Sandboxes
+"/ai/sandboxes/governance/access-controls/mcp/":
+  - /go/mcp-policy/
+"/ai/sandboxes/mcp-gateway/":
+  - /go/sbx-mcp-gateway/
 
 # Desktop MCP Toolkit
 "/ai/mcp-catalog-and-toolkit/toolkit/":


### PR DESCRIPTION
## Summary

Add Docker Sandboxes MCP docs for the local gateway path, including `sbx mcp` usage, OAuth behavior, bundles, explicit sandbox exposure, built-in gateway tools, and MCP access-governance documentation.

Generated by Codex

## Scope note for reviewers

This PR deliberately documents the local MCP gateway path only. That is the path that ships by default for Docker Sandboxes: servers and bundles are registered on the host, exposed explicitly to sandboxes, and governed through the local gateway surface.

Remote, SaaS, and self-hosted gateway behavior is intentionally out of scope for this PR. That includes dynamic discovery tools such as `mcp-find` and `mcp-add`, remote dataplane behavior, and setup for non-local gateways. These will be documented in a follow-up PR.

The MCP policy reference is likewise limited to values available in the local gateway path. Hosted-only policy surface, including the `container-stdio` server type, `resource.category`, and `context.oauth_scopes`, is deferred to the same follow-up.

Preview links:

- [MCP gateway](https://deploy-preview-25559--docsdocker.netlify.app/ai/sandboxes/mcp-gateway/)
- [MCP policies concept](https://deploy-preview-25559--docsdocker.netlify.app/ai/sandboxes/governance/concepts/#mcp-policies)
- [MCP access policies](https://deploy-preview-25559--docsdocker.netlify.app/ai/sandboxes/governance/access-controls/mcp/)
- [MCP policy reference](https://deploy-preview-25559--docsdocker.netlify.app/ai/sandboxes/governance/reference/mcp-policy/)