### PR TITLE
docs: simplify billing nav linkTitles and reorder

### DIFF
--- a/content/manuals/billing/3d-secure.md
+++ b/content/manuals/billing/3d-secure.md
@@ -1,9 +1,9 @@
 ---
 title: Use 3D Secure authentication for Docker billing
-linkTitle: 3D Secure authentication
+linkTitle: 3D Secure
 description: Docker billing supports 3D Secure (3DS) for secure payment authentication. Learn how 3DS works with Docker subscriptions.
 keywords: billing, renewal, payments, subscriptions, 3DS, credit card verification, secure payments, Docker billing security
-weight: 40
+weight: 30
 ---
 
 Docker supports 3D Secure (3DS), an extra layer of authentication required

--- a/content/manuals/billing/cycle.md
+++ b/content/manuals/billing/cycle.md
@@ -1,5 +1,6 @@
 ---
 title: Change your billing cycle
+linkTitle: Change cycle
 weight: 50
 description: Learn to change your billing cycle for your Docker subscription
 keywords: billing, cycle, payments, subscription

--- a/content/manuals/billing/details.md
+++ b/content/manuals/billing/details.md
@@ -1,6 +1,7 @@
 ---
-title: Manage your billing information
-weight: 30
+title: Update your billing information
+linkTitle: Update information
+weight: 40
 description: Learn how to update your billing information in Docker Hub
 keywords: payments, billing, subscription, invoices, update billing email, change billing address, VAT ID, Docker billing account
 ---

--- a/content/manuals/billing/faqs.md
+++ b/content/manuals/billing/faqs.md
@@ -4,7 +4,7 @@ linkTitle: FAQs
 description: Frequently asked questions related to billing
 keywords: billing, renewal, payments, faq
 tags: [FAQ]
-weight: 60
+weight: 80
 ---
 
 ### What happens if my subscription payment fails?

--- a/content/manuals/billing/history.md
+++ b/content/manuals/billing/history.md
@@ -1,6 +1,7 @@
 ---
-title: Invoices and billing history
-weight: 40
+title: View and manage invoices and billing history
+linkTitle: Invoices
+weight: 60
 description: Learn how to view invoices and your billing history
 keywords: payments, billing, subscription, invoices, renewals, invoice management, billing administration, pay invoice
 aliases:

--- a/content/manuals/billing/payment-method.md
+++ b/content/manuals/billing/payment-method.md
@@ -1,5 +1,6 @@
 ---
 title: Add or update a payment method
+linkTitle: Payment methods
 weight: 20
 description: Learn how to add or update a payment method in Docker Hub
 keywords: payments, billing, subscription, supported payment methods, failed payments, add credit card, bank transfer, Stripe Link, payment failure

--- a/content/manuals/billing/tax-certificate.md
+++ b/content/manuals/billing/tax-certificate.md
@@ -1,8 +1,9 @@
 ---
 title: Submit a tax exemption certificate
+linkTitle: Tax exemption certificate
 description: Learn how to submit a tax exemption or VAT certificate for Docker billing.
 keywords: billing, renewal, payments, tax, exemption, VAT, billing support, Docker billing
-weight: 50
+weight: 70
 ---
 
 If you're a customer in the United States and are exempt from sales tax, you


### PR DESCRIPTION
Billing's sidebar labels were wordier than the rest of the docs. Across
`content/manuals`, 74% of linkTitles are 1–2 words and 82% are noun-based —
billing's were all 3–4 word verb phrases repeating "billing".