### PR TITLE
docs(secrets): note compose build not yet supported

### DIFF
--- a/data/cli/secrets/docker_pass.yaml
+++ b/data/cli/secrets/docker_pass.yaml
@@ -86,6 +86,8 @@ long: |-
           DB_PASSWORD: se://postgres/prod/app-user
     ```
 
+    Note: `docker compose build` is not supported yet.
+
     #### Host commands
 
     `docker pass run` wraps any host process and resolves `se://`


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

Explicitly highlighting secrets from docker pass are not supported in `docker compose build` yet. See https://github.com/docker/secrets-engine/issues/584

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review