### PR TITLE
cloud plan

### DIFF
--- a/content/manuals/subscription/plans/_index.md
+++ b/content/manuals/subscription/plans/_index.md
@@ -20,6 +20,10 @@ grid:
     description: Personal and organization plans, including build and runtime minutes.
     link: /subscription/plans/docker/
     icon: credit-card
+  - title: AI Cloud
+    description: Pay-as-you-go plans for Cloud Sandboxes and the Agentic Platform.
+    link: /subscription/plans/ai-cloud/
+    icon: cloud
   - title: Gordon plans
     description: Usage plans that increase your Gordon allowance.
     link: /subscription/plans/gordon/

--- a/content/manuals/subscription/plans/ai-cloud.md
+++ b/content/manuals/subscription/plans/ai-cloud.md
@@ -1,0 +1,61 @@
+---
+title: Docker AI Cloud plans
+linkTitle: AI Cloud
+description:
+  Learn about Docker AI Cloud plans for individual developers, including usage
+  entitlements, pay-as-you-go billing behaviors, and cancellation
+keywords:
+  ai cloud, cloud sandboxes, mcp gateway, agentic platform, pay-as-you-go,
+  paygo, metered billing, personal subscription, promotional credit
+weight: 20
+---
+
+> [!TIP]
+> AI Cloud Personal sign-ups receive a one-time
+> promotional credit toward cloud compute usage.
+
+Docker AI Cloud plans are a Docker Personal and Docker Pro exclusive. Docker AI
+Cloud combines the Agentic Platform,
+[MCP Gateway](/manuals/ai/mcp-catalog-and-toolkit/mcp-gateway.md), and
+[Cloud Sandboxes](/manuals/ai/sandboxes/_index.md) together in a single
+product for individual developers.
+
+- AI Cloud Basic is the free default for every new signup. It doesn't require
+  a payment method.
+- AI Cloud Personal is a pay-as-you-go plan for developers who need Cloud
+  Sandboxes. It has no recurring subscription fee, so you pay only for the
+  usage you accrue.
+
+To add an AI Cloud Personal plan to your Docker Personal or Docker Pro
+account, see [Manage plans](/manuals/subscription/manage.md).
+
+## Usage
+
+AI Cloud Basic includes MCP Gateway access with a monthly tool-call
+allowance. When you upgrade from AI Cloud Basic to AI Cloud Personal, you
+receive:
+
+- Cloud Sandboxes
+- Higher MCP Gateway limits
+- Concurrent sandboxes and snapshot storage
+- Private Docker Hub repositories
+
+When you subscribe to an AI Cloud plan, your invoice reflects metered,
+pay-as-you-go usage. Docker meters compute usage based on the vCPU and memory
+that your sandboxes consume over time, along with outbound data transfer.
+When you use AI Cloud Basic or Personal, you bring your own API keys for
+inference. Those costs are handled by your inference provider.
+
+## Billing behaviors
+
+AI Cloud Basic requires no payment method and incurs no charges. When you
+upgrade from AI Cloud Basic to AI Cloud Personal, you add a payment method to
+enable Cloud Sandboxes with higher limits. AI Cloud Personal bills your
+accrued usage monthly on the first of the month.
+
+## Cancel a plan
+
+When you cancel AI Cloud Personal, access ends immediately and Docker charges
+your accrued pay-as-you-go usage right away rather than waiting for your next
+billing date. Canceling also terminates any running background processes,
+including active sandboxes. Your account returns to AI Cloud Basic.

--- a/content/manuals/subscription/plans/ai-cloud.md
+++ b/content/manuals/subscription/plans/ai-cloud.md
@@ -15,12 +15,10 @@ weight: 20
 > promotional credit toward cloud compute usage.
 
 Docker AI Cloud plans are a Docker Personal and Docker Pro exclusive. Docker AI
-Cloud combines the Agentic Platform,
-[MCP Gateway](/manuals/ai/mcp-catalog-and-toolkit/mcp-gateway.md), and
-[Cloud Sandboxes](/manuals/ai/sandboxes/_index.md) together in a single
-product for individual developers.
+Cloud combines the Agentic Platform, MCP Gateway, and Cloud Sandboxes together
+in a single product for individual developers.
 
-- AI Cloud Basic is the free default for every new signup. It doesn't require
+- AI Cloud Basic is the free default for every new sign-up. It doesn't require
   a payment method.
 - AI Cloud Personal is a pay-as-you-go plan for developers who need Cloud
   Sandboxes. It has no recurring subscription fee, so you pay only for the

--- a/content/manuals/subscription/plans/ai-governance.md
+++ b/content/manuals/subscription/plans/ai-governance.md
@@ -7,7 +7,7 @@ description:
 keywords:
   ai governance, licenses, organization licenses, ai policy, docker sandbox,
   subscription management
-weight: 40
+weight: 50
 aliases:
   - /subscription/products/ai-governance/
   - /subscription/ai-governance/

--- a/content/manuals/subscription/plans/dhi.md
+++ b/content/manuals/subscription/plans/dhi.md
@@ -7,7 +7,7 @@ description:
   deactivating
 keywords: dhi select, dhi enterprise, docker hardened images, hardened images,
   repositories, organization subscription, secure images
-weight: 30
+weight: 40
 aliases:
   - /subscription/products/dhi-select/
   - /subscription/dhi-select/

--- a/content/manuals/subscription/plans/gordon.md
+++ b/content/manuals/subscription/plans/gordon.md
@@ -7,7 +7,7 @@ description:
 keywords:
   gordon, gordon plus, gordon max, gordon ultra, gordon usage, gordon plan,
   personal subscription, ai assistant, usage allowance
-weight: 20
+weight: 30
 aliases:
   - /subscription/products/gordon/
   - /subscription/gordon/


### PR DESCRIPTION
#### Summary

Add a new plans page including usage entitlements, pay-as-you-go billing behaviors, and cancellation. Adds plan entry to the plans grid and renumbers sibling plan pages' `weight` values to keep sidebar ordering consistent with the grid.

- Add `content/manuals/subscription/plans/ai-cloud.md`
- Add entry to the grid in `content/manuals/subscription/plans/_index.md`
- Renumber `weight` in `gordon.md` (20→30), `dhi.md` (30→40), `ai-governance.md` (40→50) to make room for AI Cloud at weight 20

#### To do

- [ ] **Confirm with SME**: `ai-cloud.md` links "Cloud Sandboxes" to `/manuals/ai/sandboxes/_index.md` ("Docker Sandboxes"), which documents a free, local `sbx` CLI tool (microVM sandboxes run on your own machine, no metered billing). 
    - This contradicts the pay-as-you-go, metered vCPU/memory/network billing model described on the AI Cloud page. 
    - Need to confirm whether "Cloud Sandboxes" is the same product (and the billing description or the linked page needs correcting) or a distinct, not-yet-documented cloud-hosted offering that needs its own page.
- [ ] Clarify what exactly Agentic Platform refers to (and unspool that)