### PR TITLE
﻿Restructure manage-products.md to drop tabs and product usage list

### DIFF
--- a/content/manuals/admin/organization/manage/manage-products.md
+++ b/content/manuals/admin/organization/manage/manage-products.md
@@ -3,38 +3,40 @@ title: Manage usage and access for Docker products
 linkTitle: Product usage and access
 weight: 50
 description: Learn how to manage access and usage for Docker products for your organization
-keywords: organization, tools, products, product access, organization management
+keywords: organization, product access, product usage, access control, docker desktop, docker hub, docker scout, docker build cloud, docker offload, testcontainers cloud
 aliases:
   - /admin/organization/manage-products/
 ---
 
 {{< summary-bar feature_name="Admin orgs" >}}
 
-Use this page to learn how to control and monitor product access and usage for your organization's members. 
-If you're looking for setup and
-configuration instructions, see each product's manual under [What's
-next](#whats-next).
+Use this page to learn how to control and monitor product access and usage
+for your organization's members. If you're looking for setup and
+configuration instructions, see each product's manual under
+[What's next](#whats-next).
 
 ## Monitor product usage for your organization
 
-You can monitor usage for Docker products across your organization. Use the table below to learn where you can monitor organization usage:
+You can monitor usage for Docker products across your organization. Use the
+following table to learn where you can monitor organization usage:
 
-| Product              | Monitor usage                                                                                                                                                                    |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Docker Desktop       | From [Docker Home](https://app.docker.com/), view the **Insights** page. See [Insights](../../insights.md)  for more details.                                                       |
-| Docker Hub           | From Docker Hub, view the [**Usage** page](https://hub.docker.com/usage).                                                                                                           |
-| Docker Build Cloud   | From [Docker Build Cloud](http://app.docker.com/build), view the **Build minutes** page.                                                                                            |
-| Docker Scout         | From [Docker Home](https://app.docker.com/), select **Go to Scout** to view the [**Repository settings** page](https://scout.docker.com/settings/repos).                                                                                |
-| Testcontainers Cloud | From [Docker Home](https://app.docker.com/), select **Go to Testcontainers Cloud**, then select the menu icon. Go to the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing).                                                                         |
-| Docker Offload       | From [Docker Home](https://app.docker.com/), select **Offload**, then **Offload activity**. See [Docker Offload usage and billing](/manuals/offload/usage.md) for more details. |
-
+| Product              | Monitor usage                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Docker Desktop       | From [Docker Home](https://app.docker.com/), view the [**Insights**](../../insights.md) page.                                                                                                    |
+| Docker Hub           | From Docker Hub, view the [**Usage** page](https://hub.docker.com/usage).                                                                                                                        |
+| Docker Build Cloud   | From [Docker Build Cloud](http://app.docker.com/build), view the **Build minutes** page.                                                                                                         |
+| Docker Scout         | From [Docker Home](https://app.docker.com/), select **Go to Scout** to view the [**Repository settings** page](https://scout.docker.com/settings/repos).                                         |
+| Testcontainers Cloud | From [Docker Home](https://app.docker.com/), select **Go to Testcontainers Cloud**, then select the menu icon. Go to the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing). |
+| Docker Offload       | From [Docker Home](https://app.docker.com/), select **Offload**, then **Offload activity**. See [Docker Offload usage and billing](/manuals/offload/usage.md) for more details.                  |
 
 To learn about the included usage across Docker plans, see
 [Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminManageProducts).
 
 ## Control access for your organization
 
-Organization members can access Docker products that your organization is subscribed to by default. When signed in as an organization owner, you can use the procedures to control access for all members.
+Organization members can access Docker products that your organization is
+subscribed to by default. When signed in as an organization owner, you can
+use the following procedures to control access for all members.
 
 ### Docker Desktop access
 
@@ -51,10 +53,12 @@ use Docker Desktop after signing in.
 
 To manage Docker Hub access:
 
-1. Sign in to
-[Docker Home](https://app.docker.com/), then select **Docker Desktop**.
-1. Select **Registry Access** to configure [Registry Access Management](/manuals/enterprise/security/hardened-desktop/registry-access-management.md).
-1. Select **Image Access** to control [Image Access Management](/manuals/enterprise/security/hardened-desktop/image-access-management.md).
+1. Sign in to [Docker Home](https://app.docker.com/), then select **Docker
+   Desktop**.
+1. Select **Registry Access** to configure
+   [Registry Access Management](/manuals/enterprise/security/hardened-desktop/registry-access-management.md).
+1. Select **Image Access** to control
+   [Image Access Management](/manuals/enterprise/security/hardened-desktop/image-access-management.md).
 
 ### Docker Build Cloud access
 
@@ -64,26 +68,28 @@ on-screen instructions.
 
 To manage Docker Build Cloud access:
 
-1. Sign in to
-[Docker Home](https://app.docker.com/), then select [Docker Build Cloud](http://app.docker.com/build).
+1. Sign in to [Docker Home](https://app.docker.com/), then select
+   [Docker Build Cloud](http://app.docker.com/build).
 1. Select **Account settings**.
 1. Select **Lock access to Docker Build Account**.
 
 ### Docker Scout access
 
 To initially set up and configure Docker Scout, sign in to
-[Docker Scout](https://scout.docker.com/) and follow the on-screen instructions.
+[Docker Scout](https://scout.docker.com/) and follow the on-screen
+instructions.
 
 To manage Docker Scout access:
 
-1. Sign in to
-[Docker Home](https://app.docker.com/), then select [Docker Scout](https://scout.docker.com/).
+1. Sign in to [Docker Home](https://app.docker.com/), then select
+   [Docker Scout](https://scout.docker.com/).
 1. Select your organization, then **Settings**.
 1. To manage what repositories are enabled for Docker Scout analysis, select
-   **Repository settings**. For more information on,
-   see [repository settings](../../../scout/explore/dashboard.md#repository-settings).
-1. To manage access to Docker Scout for use on local images with Docker Desktop,
-   use [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md)
+   **Repository settings**. For more information, see
+   [repository settings](../../../scout/explore/dashboard.md#repository-settings).
+1. To manage access to Docker Scout for use on local images with Docker
+   Desktop, use
+   [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md)
    and set `sbomIndexing` to `false` to disable, or to `true` to enable.
 
 ### Testcontainers Cloud access
@@ -94,7 +100,8 @@ on-screen instructions.
 
 To manage access to Testcontainers Cloud:
 
-1. Sign in to the [Testcontainers Cloud](https://app.testcontainers.cloud/), then select the menu icon.
+1. Sign in to the [Testcontainers Cloud](https://app.testcontainers.cloud/),
+   then select the menu icon.
 1. Select **Account**, then **Settings**.
 1. Choose **Lock access to Testcontainers Cloud**.
 
@@ -102,26 +109,34 @@ To manage access to Testcontainers Cloud:
 
 > [!NOTE]
 >
-> Docker Offload isn't included in the core Docker subscription plans. To make Docker Offload available, you must [contact sales](https://www.docker.com/products/docker-offload/) and subscribe.
+> Docker Offload isn't included in the core Docker subscription plans. To
+> make Docker Offload available, you must
+> [contact sales](https://www.docker.com/products/docker-offload/) and
+> subscribe.
 
 To manage Docker Offload access for your organization, use [Settings
 Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md):
 
-1. Sign in to [Docker Home](https://app.docker.com/), then select **Docker Desktop**.
+1. Sign in to [Docker Home](https://app.docker.com/), then select **Docker
+   Desktop**.
 1. Select **Settings Management**.
-1. Configure the **Enable Docker Offload** setting to control whether Docker Offload features are available in Docker
-   Desktop. You can configure this setting in five states:
-   - **Always enabled**: Docker Offload is always enabled and users cannot disable it. The Offload
-     toggle is always visible in Docker Desktop header. Recommended for VDI environments where local Docker execution is
-     not possible.
-   - **Enabled**: Docker Offload is enabled by default but users can disable it in Docker Desktop
-     settings. Suitable for hybrid environments.
-   - **Disabled**: Docker Offload is disabled by default but users can enable it in Docker Desktop
-     settings.
-   - **Always disabled**: Docker Offload is disabled and users cannot enable it. The option is
-     visible but locked. Use when Docker Offload is not approved for organizational use.
-   - **User defined**: No enforced default. Users choose whether to enable or disable Docker Offload in their
-     Docker Desktop settings.
+1. Configure the **Enable Docker Offload** setting to control whether
+   Docker Offload features are available in Docker Desktop. You can
+   configure this setting in five states:
+   - **Always enabled**: Docker Offload is always enabled and users cannot
+     disable it. The Offload toggle is always visible in the Docker Desktop
+     header. Recommended for VDI environments where local Docker execution
+     is not possible.
+   - **Enabled**: Docker Offload is enabled by default but users can
+     disable it in Docker Desktop settings. Suitable for hybrid
+     environments.
+   - **Disabled**: Docker Offload is disabled by default but users can
+     enable it in Docker Desktop settings.
+   - **Always disabled**: Docker Offload is disabled and users cannot
+     enable it. The option is visible but locked. Use when Docker Offload
+     is not approved for organizational use.
+   - **User defined**: No enforced default. Users choose whether to enable
+     or disable Docker Offload in their Docker Desktop settings.
 1. Select **Save**.
 
 For more details on Settings Management, see the [Settings
@@ -129,8 +144,8 @@ reference](/manuals/enterprise/security/hardened-desktop/settings-management/set
 
 ## What's next
 
-For more detailed information about each
-product, including how to set up and configure them, see the following manuals:
+For more detailed information about each product, including how to set up
+and configure them, see the following manuals:
 
 - [Docker Desktop](../../../desktop/_index.md)
 - [Docker Hub](../../../docker-hub/_index.md)

--- a/content/manuals/admin/organization/manage/manage-products.md
+++ b/content/manuals/admin/organization/manage/manage-products.md
@@ -17,24 +17,24 @@ next](#whats-next).
 
 ## Monitor product usage for your organization
 
+You can monitor usage for Docker products across your organization. Use the table below to learn where you can monitor organization usage:
+
 | Product              | Monitor usage                                                                                                                                                                    |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Docker Desktop       | View the **Insights** page in [Docker Home](https://app.docker.com/). For more details, see [Insights](../../insights.md).                                                       |
-| Docker Hub           | View the [**Usage** page](https://hub.docker.com/usage) in Docker Hub.                                                                                                           |
-| Docker Build Cloud   | View the **Build minutes** page in [Docker Build Cloud](http://app.docker.com/build).                                                                                            |
-| Docker Scout         | View the [**Repository settings** page](https://scout.docker.com/settings/repos) in Docker Scout.                                                                                |
-| Testcontainers Cloud | View the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing) in Testcontainers Cloud.                                                                         |
-| Docker Offload       | View the **Offload** > **Offload overview** page in [Docker Home](https://app.docker.com/). For more details, see [Docker Offload usage and billing](/manuals/offload/usage.md). |
+| Docker Desktop       | From [Docker Home](https://app.docker.com/), view the **Insights** page. See [Insights](../../insights.md)  for more details.                                                       |
+| Docker Hub           | From Docker Hub, view the [**Usage** page](https://hub.docker.com/usage).                                                                                                           |
+| Docker Build Cloud   | From [Docker Build Cloud](http://app.docker.com/build), view the **Build minutes** page.                                                                                            |
+| Docker Scout         | From [Docker Home](https://app.docker.com/), select **Go to Scout** to view the [**Repository settings** page](https://scout.docker.com/settings/repos).                                                                                |
+| Testcontainers Cloud | From [Docker Home](https://app.docker.com/), select **Go to Testcontainers Cloud**, then select the menu icon. Go to the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing).                                                                         |
+| Docker Offload       | From [Docker Home](https://app.docker.com/), select **Offload**, then **Offload activity**. See [Docker Offload usage and billing](/manuals/offload/usage.md) for more details. |
 
-If your usage or seat count exceeds your subscription amount, you can
-[add seats](./manage-seats.md) or [view available Docker plans](../../../subscription/plans/_index.md) to meet your needs.
+
+To learn about the included usage across Docker plans, see
+[Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminManageProducts).
 
 ## Control access for your organization
 
-Access to the Docker products included in your plan is turned on by
-default for all users. For an overview of products included in your
-plans, see
-[Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminManageProducts).
+Organization members can access Docker products that your organization is subscribed to by default. When signed in as an organization owner, you can use the procedures to control access for all members.
 
 ### Docker Desktop access
 
@@ -49,9 +49,12 @@ use Docker Desktop after signing in.
 
 ### Docker Hub access
 
-To manage Docker Hub access, sign in to
-[Docker Home](https://app.docker.com/) and configure [Registry Access Management](/manuals/enterprise/security/hardened-desktop/registry-access-management.md)
-or [Image Access Management](/manuals/enterprise/security/hardened-desktop/image-access-management.md).
+To manage Docker Hub access:
+
+1. Sign in to
+[Docker Home](https://app.docker.com/), then select **Docker Desktop**.
+1. Select **Registry Access** to configure [Registry Access Management](/manuals/enterprise/security/hardened-desktop/registry-access-management.md).
+1. Select **Image Access** to control [Image Access Management](/manuals/enterprise/security/hardened-desktop/image-access-management.md).
 
 ### Docker Build Cloud access
 
@@ -61,8 +64,8 @@ on-screen instructions.
 
 To manage Docker Build Cloud access:
 
-1. Sign in to [Docker Build Cloud](http://app.docker.com/build) as an
-   organization owner.
+1. Sign in to
+[Docker Home](https://app.docker.com/), then select [Docker Build Cloud](http://app.docker.com/build).
 1. Select **Account settings**.
 1. Select **Lock access to Docker Build Account**.
 
@@ -73,8 +76,8 @@ To initially set up and configure Docker Scout, sign in to
 
 To manage Docker Scout access:
 
-1. Sign in to [Docker Scout](https://scout.docker.com/) as an organization
-   owner.
+1. Sign in to
+[Docker Home](https://app.docker.com/), then select [Docker Scout](https://scout.docker.com/).
 1. Select your organization, then **Settings**.
 1. To manage what repositories are enabled for Docker Scout analysis, select
    **Repository settings**. For more information on,
@@ -91,9 +94,9 @@ on-screen instructions.
 
 To manage access to Testcontainers Cloud:
 
-1. Sign in to the [Testcontainers Cloud](https://app.testcontainers.cloud/) and
-   select **Account**.
-1. Select **Settings**, then **Lock access to Testcontainers Cloud**.
+1. Sign in to the [Testcontainers Cloud](https://app.testcontainers.cloud/), then select the menu icon.
+1. Select **Account**, then **Settings**.
+1. Choose **Lock access to Testcontainers Cloud**.
 
 ### Docker Offload access
 
@@ -104,8 +107,8 @@ To manage access to Testcontainers Cloud:
 To manage Docker Offload access for your organization, use [Settings
 Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md):
 
-1. Sign in to [Docker Home](https://app.docker.com/) as an organization owner.
-1. Select **Docker Desktop**, then **Settings Management**.
+1. Sign in to [Docker Home](https://app.docker.com/), then select **Docker Desktop**.
+1. Select **Settings Management**.
 1. Configure the **Enable Docker Offload** setting to control whether Docker Offload features are available in Docker
    Desktop. You can configure this setting in five states:
    - **Always enabled**: Docker Offload is always enabled and users cannot disable it. The Offload

--- a/content/manuals/admin/organization/manage/manage-products.md
+++ b/content/manuals/admin/organization/manage/manage-products.md
@@ -1,5 +1,6 @@
 ---
-title: Docker products
+title: Manage usage and access for Docker products
+linkTitle: Product usage and access
 weight: 50
 description: Learn how to manage access and usage for Docker products for your organization
 keywords: organization, tools, products, product access, organization management
@@ -9,28 +10,33 @@ aliases:
 
 {{< summary-bar feature_name="Admin orgs" >}}
 
-In this section, learn how to manage access and view usage of the Docker
-products for your organization. For more detailed information about each
-product, including how to set up and configure them, see the following manuals:
+Use this page to learn how to control and monitor product access and usage for your organization's members. 
+If you're looking for setup and
+configuration instructions, see each product's manual under [What's
+next](#whats-next).
 
-- [Docker Desktop](../../../desktop/_index.md)
-- [Docker Hub](../../../docker-hub/_index.md)
-- [Docker Build Cloud](../../../build-cloud/_index.md)
-- [Docker Scout](../../../scout/_index.md)
-- [Testcontainers Cloud](https://testcontainers.com/cloud/docs/#getting-started)
-- [Docker Offload](../../../offload/_index.md)
+## Monitor product usage for your organization
 
-## Manage product access for your organization
+| Product              | Monitor usage                                                                                                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Docker Desktop       | View the **Insights** page in [Docker Home](https://app.docker.com/). For more details, see [Insights](../../insights.md).                                                       |
+| Docker Hub           | View the [**Usage** page](https://hub.docker.com/usage) in Docker Hub.                                                                                                           |
+| Docker Build Cloud   | View the **Build minutes** page in [Docker Build Cloud](http://app.docker.com/build).                                                                                            |
+| Docker Scout         | View the [**Repository settings** page](https://scout.docker.com/settings/repos) in Docker Scout.                                                                                |
+| Testcontainers Cloud | View the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing) in Testcontainers Cloud.                                                                         |
+| Docker Offload       | View the **Offload** > **Offload overview** page in [Docker Home](https://app.docker.com/). For more details, see [Docker Offload usage and billing](/manuals/offload/usage.md). |
 
-Access to the Docker products included in your subscription is turned on by
+If your usage or seat count exceeds your subscription amount, you can
+[add seats](./manage-seats.md) or [view available Docker plans](../../../subscription/plans/_index.md) to meet your needs.
+
+## Control access for your organization
+
+Access to the Docker products included in your plan is turned on by
 default for all users. For an overview of products included in your
-subscription, see
+plans, see
 [Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminManageProducts).
 
-{{< tabs >}}
-{{< tab name="Docker Desktop" >}}
-
-### Manage Docker Desktop access
+### Docker Desktop access
 
 To manage Docker Desktop access:
 
@@ -41,19 +47,13 @@ To manage Docker Desktop access:
 With sign-in enforced, only users who are a member of your organization can
 use Docker Desktop after signing in.
 
-{{< /tab >}}
-{{< tab name="Docker Hub" >}}
-
-### Manage Docker Hub access
+### Docker Hub access
 
 To manage Docker Hub access, sign in to
 [Docker Home](https://app.docker.com/) and configure [Registry Access Management](/manuals/enterprise/security/hardened-desktop/registry-access-management.md)
 or [Image Access Management](/manuals/enterprise/security/hardened-desktop/image-access-management.md).
 
-{{< /tab >}}
-{{< tab name="Docker Build Cloud" >}}
-
-### Manage Docker Build Cloud access
+### Docker Build Cloud access
 
 To initially set up and configure Docker Build Cloud, sign in to
 [Docker Build Cloud](https://app.docker.com/build) and follow the
@@ -66,10 +66,7 @@ To manage Docker Build Cloud access:
 1. Select **Account settings**.
 1. Select **Lock access to Docker Build Account**.
 
-{{< /tab >}}
-{{< tab name="Docker Scout" >}}
-
-### Manage Docker Scout access
+### Docker Scout access
 
 To initially set up and configure Docker Scout, sign in to
 [Docker Scout](https://scout.docker.com/) and follow the on-screen instructions.
@@ -86,10 +83,7 @@ To manage Docker Scout access:
    use [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md)
    and set `sbomIndexing` to `false` to disable, or to `true` to enable.
 
-{{< /tab >}}
-{{< tab name="Testcontainers Cloud" >}}
-
-### Manage Testcontainers Cloud access
+### Testcontainers Cloud access
 
 To initially set up and configure Testcontainers Cloud, sign in to
 [Testcontainers Cloud](https://app.testcontainers.cloud/) and follow the
@@ -101,10 +95,7 @@ To manage access to Testcontainers Cloud:
    select **Account**.
 1. Select **Settings**, then **Lock access to Testcontainers Cloud**.
 
-{{< /tab >}}
-{{< tab name="Docker Offload" >}}
-
-### Manage Docker Offload access
+### Docker Offload access
 
 > [!NOTE]
 >
@@ -133,20 +124,14 @@ Management](/manuals/enterprise/security/hardened-desktop/settings-management/_i
 For more details on Settings Management, see the [Settings
 reference](/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md#enable-docker-offload).
 
-{{< /tab >}}
-{{< /tabs >}}
+## What's next
 
-## Monitor product usage for your organization
+For more detailed information about each
+product, including how to set up and configure them, see the following manuals:
 
-To view usage for Docker products:
-
-- Docker Desktop: View the **Insights** page in [Docker Home](https://app.docker.com/). For more details, see [Insights](../../insights.md).
-- Docker Hub: View the [**Usage** page](https://hub.docker.com/usage) in Docker Hub.
-- Docker Build Cloud: View the **Build minutes** page in [Docker Build Cloud](http://app.docker.com/build).
-- Docker Scout: View the [**Repository settings** page](https://scout.docker.com/settings/repos) in Docker Scout.
-- Testcontainers Cloud: View the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing) in Testcontainers Cloud.
-- Docker Offload: View the **Offload** > **Offload overview** page in [Docker Home](https://app.docker.com/). For more details, see
-  [Docker Offload usage and billing](/manuals/offload/usage.md).
-
-If your usage or seat count exceeds your subscription amount, you can
-[add seats](./manage-seats.md) or [view available Docker plans](../../../subscription/plans/_index.md) to meet your needs.
+- [Docker Desktop](../../../desktop/_index.md)
+- [Docker Hub](../../../docker-hub/_index.md)
+- [Docker Build Cloud](../../../build-cloud/_index.md)
+- [Docker Scout](../../../scout/_index.md)
+- [Testcontainers Cloud](https://testcontainers.com/cloud/docs/#getting-started)
+- [Docker Offload](../../../offload/_index.md)

--- a/content/manuals/admin/organization/manage/manage-products.md
+++ b/content/manuals/admin/organization/manage/manage-products.md
@@ -15,23 +15,6 @@ for your organization's members. If you're looking for setup and
 configuration instructions, see each product's manual under
 [What's next](#whats-next).
 
-## Monitor product usage for your organization
-
-You can monitor usage for Docker products across your organization. Use the
-following table to learn where you can monitor organization usage:
-
-| Product              | Monitor usage                                                                                                                                                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Docker Desktop       | From [Docker Home](https://app.docker.com/), view the [**Insights**](../../insights.md) page.                                                                                                    |
-| Docker Hub           | From Docker Hub, view the [**Usage** page](https://hub.docker.com/usage).                                                                                                                        |
-| Docker Build Cloud   | From [Docker Build Cloud](http://app.docker.com/build), view the **Build minutes** page.                                                                                                         |
-| Docker Scout         | From [Docker Home](https://app.docker.com/), select **Go to Scout** to view the [**Repository settings** page](https://scout.docker.com/settings/repos).                                         |
-| Testcontainers Cloud | From [Docker Home](https://app.docker.com/), select **Go to Testcontainers Cloud**, then select the menu icon. Go to the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing). |
-| Docker Offload       | From [Docker Home](https://app.docker.com/), select **Offload**, then **Offload activity**. See [Docker Offload usage and billing](/manuals/offload/usage.md) for more details.                  |
-
-To learn about the included usage across Docker plans, see
-[Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminManageProducts).
-
 ## Control access for your organization
 
 Organization members can access Docker products that your organization is
@@ -42,9 +25,9 @@ use the following procedures to control access for all members.
 
 To manage Docker Desktop access:
 
-1. [Enforce sign-in](/manuals/enterprise/security/enforce-sign-in/_index.md).
+1. [Enforce sign-in](../../../enterprise/security/enforce-sign-in/_index.md).
 1. Manage members [manually](./members.md) or use
-   [provisioning](/manuals/enterprise/security/provisioning/_index.md).
+   [provisioning](../../../enterprise/security/provisioning/_index.md).
 
 With sign-in enforced, only users who are a member of your organization can
 use Docker Desktop after signing in.
@@ -53,12 +36,12 @@ use Docker Desktop after signing in.
 
 To manage Docker Hub access:
 
-1. Sign in to [Docker Home](https://app.docker.com/), then select **Docker
-   Desktop**.
+1. Sign in to [Docker Home](https://app.docker.com/) and select your
+   organization, then select **Docker Desktop**.
 1. Select **Registry Access** to configure
-   [Registry Access Management](/manuals/enterprise/security/hardened-desktop/registry-access-management.md).
+   [Registry Access Management](../../../enterprise/security/hardened-desktop/registry-access-management.md).
 1. Select **Image Access** to control
-   [Image Access Management](/manuals/enterprise/security/hardened-desktop/image-access-management.md).
+   [Image Access Management](../../../enterprise/security/hardened-desktop/image-access-management.md).
 
 ### Docker Build Cloud access
 
@@ -89,7 +72,7 @@ To manage Docker Scout access:
    [repository settings](../../../scout/explore/dashboard.md#repository-settings).
 1. To manage access to Docker Scout for use on local images with Docker
    Desktop, use
-   [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md)
+   [Settings Management](../../../enterprise/security/hardened-desktop/settings-management/_index.md)
    and set `sbomIndexing` to `false` to disable, or to `true` to enable.
 
 ### Testcontainers Cloud access
@@ -115,7 +98,7 @@ To manage access to Testcontainers Cloud:
 > subscribe.
 
 To manage Docker Offload access for your organization, use [Settings
-Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md):
+Management](../../../enterprise/security/hardened-desktop/settings-management/_index.md):
 
 1. Sign in to [Docker Home](https://app.docker.com/), then select **Docker
    Desktop**.
@@ -140,7 +123,24 @@ Management](/manuals/enterprise/security/hardened-desktop/settings-management/_i
 1. Select **Save**.
 
 For more details on Settings Management, see the [Settings
-reference](/manuals/enterprise/security/hardened-desktop/settings-management/settings-reference.md#enable-docker-offload).
+reference](../../../enterprise/security/hardened-desktop/settings-management/settings-reference.md#enable-docker-offload).
+
+## Monitor product usage for your organization
+
+You can monitor usage for Docker products across your organization. Use the
+following table to learn where you can monitor organization usage:
+
+| Product              | Monitor usage                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Docker Desktop       | From [Docker Home](https://app.docker.com/), view the [**Insights**](../../insights.md) page.                                                                                                    |
+| Docker Hub           | From Docker Hub, view the [**Usage** page](https://hub.docker.com/usage).                                                                                                                        |
+| Docker Build Cloud   | From [Docker Build Cloud](http://app.docker.com/build), view the **Build minutes** page.                                                                                                         |
+| Docker Scout         | From [Docker Home](https://app.docker.com/), select **Go to Scout** to view the [**Repository settings** page](https://scout.docker.com/settings/repos).                                         |
+| Testcontainers Cloud | From [Docker Home](https://app.docker.com/), select **Go to Testcontainers Cloud**, then select the menu icon. Go to the [**Billing** page](https://app.testcontainers.cloud/dashboard/billing). |
+| Docker Offload       | From [Docker Home](https://app.docker.com/), select **Offload**, then **Offload activity**. See [Docker Offload usage and billing](../../../offload/usage.md) for more details.                  |
+
+To learn about the included usage across Docker plans, see
+[Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminManageProducts).
 
 ## What's next
 


### PR DESCRIPTION
## Summary

- **Duplication audit** — Confirmed the six product-access procedures (Desktop, Hub, Build Cloud, Scout, Testcontainers Cloud, Offload) are unique to this page; not duplicated in `enterprise/security/`, `offload/`, or `scout/` docs.
- **Restructuring** — Removed the `{{< tabs >}}` widget (wrong pattern since admins need all six products, not one-of-many) in favor of flat H3s per product. Dropped redundant "Manage" from each H3 title. Converted the "Monitor product usage" bullet list into a table. Moved the top-of-page manual links into a new "What's next" section at the bottom. Rewrote the intro to state the page's actual job (access control + usage monitoring) in 2 sentences.
- **Validation performed** — Formatted with prettier, and linted clean with markdownlint and Vale (`docker buildx bake vale`). No content/link accuracy check against live product UIs was done — that would need separate manual verification.
- **Validated UI steps** — Followed procedures to confirm steps were still fresh

## Notes on editorial changes

- **"As an organization owner" wasn't dropped, it was consolidated.** Each
  product's access-management subsection previously repeated the phrase. It
  now appears once in the "Control access for your organization" intro,
  since it applies to every procedure that follows. This cuts redundancy
  without losing the permission requirement, and the page's placement in
  the `admin/organization/` IA already implies owner-level context.
- **Docker Home routing for Build Cloud and Scout is intentional, not a
  regression.** Most users land on Docker Home first and navigate to these
  dashboards from there. The direct links to `app.docker.com/build` and
  `scout.docker.com` are preserved, but calling out the Docker Home path
  adds discoverability for the common case. It's called out explicitly
  here because these two flows leave `app.docker.com` entirely, unlike the
  other products where the context switch is implied.
- **The "select the menu icon" step for Testcontainers Cloud reflects real
  usability friction.** During testing, this menu icon was hard to locate.
  Naming it explicitly orients users who'd otherwise miss it.