### PR TITLE
docs: fix admin settings filename

### DIFF
--- a/content/manuals/extensions/private-marketplace.md
+++ b/content/manuals/extensions/private-marketplace.md
@@ -65,7 +65,7 @@ This creates 2 files:
 
 > [!IMPORTANT]
 >
-> If your org is using [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md) via [Docker Home](manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console/_index.md), you will not need the `admins-settings.json` file. Delete the generated file and keep only the `extensions.txt` file.
+> If your org is using [Settings Management](/manuals/enterprise/security/hardened-desktop/settings-management/_index.md) via [Docker Home](manuals/enterprise/security/hardened-desktop/settings-management/configure-admin-console/_index.md), you will not need the `admin-settings.json` file. Delete the generated file and keep only the `extensions.txt` file.
 
 ## Step two: Set the behaviour
 


### PR DESCRIPTION
## Description

Correct the private marketplace guide's single `admins-settings.json` reference to `admin-settings.json`, matching the generated filename used throughout the page.

Fixes #25577.

## Validation

- `scripts/lint.sh content/manuals/extensions/private-marketplace.md` — Markdown lint passed; Vale was unavailable locally
- `git diff --check`