### PR TITLE
Add overview pages for org setup and manage sections

### DIFF
--- a/content/manuals/admin/organization/manage/_index.md
+++ b/content/manuals/admin/organization/manage/_index.md
@@ -1,6 +1,51 @@
 ---
-build:
-  render: never
-title: Manage
+title: Manage your organization
+linkTitle: Manage
 weight: 20
+description: Learn how to manage your Docker organization, including members, teams, licenses, seats, and product access.
+keywords: manage organization, members, teams, licenses, seats, product access, organization management, docker home
+grid:
+  - title: Members
+    description: Invite, manage, and assign roles to your organization members.
+    icon: user-plus
+    link: /admin/organization/manage/members/
+  - title: Product access and usage
+    description: Manage access and view usage for Docker products across your organization.
+    icon: squares-2x2
+    link: /admin/organization/manage/manage-products/
+  - title: Security
+    description: Configure single sign-on, provisioning, and access management.
+    icon: shield-check
+    link: /enterprise/security/
+  - title: Billing
+    description: Manage payment methods and view billing history.
+    icon: credit-card
+    link: /billing/
 ---
+
+As an organization owner, you manage your organization's membership, access, and product usage. You can invite members, group
+them into teams, assign (or revoke) licenses and seats, and make changes to access to Docker
+products.
+
+## Managing your organization
+
+You manage your organization from [Docker Home](https://app.docker.com) and must be assigned
+the [organization owner role](/manuals/enterprise/security/roles-and-permissions/_index.md).
+
+## Seats and licenses
+
+Seats and licenses both control access, but they apply to different kinds of plans. The following table summarizes the difference.
+
+| Entitlement | What it grants                                          | Applies to                                       | Managed from |
+| ----------- | ------------------------------------------------------- | ------------------------------------------------ | ------------ |
+| Seat        | Membership in your Docker Team or Business subscription | Docker Core subscription                         | Billing      |
+| License     | Access to a specific product or add-on                  | AI Governance, Docker Offload, and other add-ons | Members      |
+
+For details, see [Seats](/manuals/admin/organization/manage/manage-seats.md)
+and [License assignment](/manuals/admin/organization/manage/manage-licenses.md).
+
+## What's next
+
+Explore the following sections to manage your organization.
+
+{{< grid >}}

--- a/content/manuals/admin/organization/manage/_index.md
+++ b/content/manuals/admin/organization/manage/_index.md
@@ -23,18 +23,20 @@ grid:
     link: /billing/
 ---
 
-As an organization owner, you manage your organization's membership, access, and product usage. You can invite members, group
-them into teams, assign (or revoke) licenses and seats, and make changes to access to Docker
-products.
+As an organization owner, you manage your organization's membership, access,
+and product usage. You can invite members, group them into teams, assign or
+revoke licenses and seats, and change access to Docker products.
 
 ## Managing your organization
 
-You manage your organization from [Docker Home](https://app.docker.com) and must be assigned
-the [organization owner role](/manuals/enterprise/security/roles-and-permissions/_index.md).
+You manage your organization from [Docker Home](https://app.docker.com) and
+must be assigned the
+[organization owner role](/manuals/enterprise/security/roles-and-permissions/_index.md).
 
 ## Seats and licenses
 
-Seats and licenses both control access, but they apply to different kinds of plans. The following table summarizes the difference.
+Seats and licenses both control access, but they apply to different kinds of
+plans. The following table summarizes the difference.
 
 | Entitlement | What it grants                                          | Applies to                                       | Managed from |
 | ----------- | ------------------------------------------------------- | ------------------------------------------------ | ------------ |

--- a/content/manuals/admin/organization/setup/_index.md
+++ b/content/manuals/admin/organization/setup/_index.md
@@ -37,15 +37,18 @@ an existing user account into an organization.
 
 ## Setting up your organization
 
-You set up your organization from [Docker Home](https://app.docker.com) and must be assigned
-the [organization owner role](/manuals/enterprise/security/roles-and-permissions/_index.md). Setting up an organization happens in broad phases:
+You set up your organization from [Docker Home](https://app.docker.com) and
+must be assigned the
+[organization owner role](/manuals/enterprise/security/roles-and-permissions/_index.md).
+Setting up an organization happens in broad phases:
 
-1. You can create a new organization, or convert an existing user account into one.
-  Choose the option that fits how you already use Docker; you don't need both.
+1. You can create a new organization, or convert an existing user account
+   into one. Choose the option that fits how you already use Docker. You
+   don't need both.
 1. After creating your organization, you must onboard it by inviting members,
-  securing authentication, and enforcing sign-in. These steps build on each
-  other, so follow them in order.
-1. You can update your organization's general information whenever it changes at any time.
+   securing authentication, and enforcing sign-in. These steps build on each
+   other, so follow them in order.
+1. You can update your organization's general information whenever it changes.
 
 ## What's next
 

--- a/content/manuals/admin/organization/setup/_index.md
+++ b/content/manuals/admin/organization/setup/_index.md
@@ -1,6 +1,54 @@
 ---
-build:
-  render: never
-title: Setup
+title: Set up your organization
+linkTitle: Setup
 weight: 10
+description: Learn how to set up your Docker organization, including creating an organization, onboarding, and configuring settings.
+keywords: set up organization, create organization, onboard, convert account, organization settings, docker home
+grid:
+  - title: Create your organization
+    description: Create an organization to group teams and members and assign access.
+    icon: building-storefront
+    link: /admin/organization/setup/orgs/
+  - title: Onboard your organization
+    description: Onboard and secure your Docker Team or Business organization.
+    icon: magnifying-glass-plus
+    link: /admin/organization/setup/onboard/
+  - title: Change information
+    description: Update your organization's general information and settings.
+    icon: pencil-square
+    link: /admin/organization/setup/general-settings/
+  - title: Convert account
+    description: Convert an existing Docker user account into an organization.
+    icon: arrows-right-left
+    link: /admin/organization/setup/convert-account/
+  - title: Manage your organization
+    description: Add members, teams, licenses, and seats after setup.
+    icon: user-group
+    link: /admin/organization/manage/
+  - title: Security
+    description: Configure single sign-on, provisioning, and access management.
+    icon: shield-check
+    link: /enterprise/security/
 ---
+
+Before you manage members and access, set up your Docker organization. You can
+create an organization, onboard and secure it, update its information, or convert
+an existing user account into an organization.
+
+## Setting up your organization
+
+You set up your organization from [Docker Home](https://app.docker.com) and must be assigned
+the [organization owner role](/manuals/enterprise/security/roles-and-permissions/_index.md). Setting up an organization happens in broad phases:
+
+1. You can create a new organization, or convert an existing user account into one.
+  Choose the option that fits how you already use Docker; you don't need both.
+1. After creating your organization, you must onboard it by inviting members,
+  securing authentication, and enforcing sign-in. These steps build on each
+  other, so follow them in order.
+1. You can update your organization's general information whenever it changes at any time.
+
+## What's next
+
+Explore the following sections to set up your organization.
+
+{{< grid >}}


### PR DESCRIPTION
## Summary

The admin > organization **Setup** and **Manage** section landing pages
(`_index.md`) were hidden stubs (`build: render: never`). Because Hugo doesn't
publish those pages, the sidebar rendered both sections as non-clickable,
expand-only entries. This PR turns them into proper overview pages that follow
the pattern used by sibling section overviews (Organization, Company, etc.).

- Add front matter (`title`, `linkTitle`, `description`, `keywords`) and a grid
  of child-page cards to both pages, so they render and become clickable in the
  sidebar.
- Add a short overview of the setup phases (create/convert, onboard, maintain)
  that clarifies which tasks are sequential and which aren't.
- Add a seats-vs-licenses comparison table to the Manage overview to distinguish
  the two entitlements.