### PR TITLE
docs: clarify default installation mode for Docker Desktop on Windows

### DIFF
--- a/content/manuals/desktop/setup/install/windows-install.md
+++ b/content/manuals/desktop/setup/install/windows-install.md
@@ -32,7 +32,7 @@ _For checksums, see [Release notes](/manuals/desktop/release-notes.md)_
 
 ## Installation modes
  
-Docker Desktop supports two installation modes. Per-user installation (Beta) is recommended for most users. It does not require administrator privileges to install or update, and the WSL 2 backend it uses covers the needs of the vast majority of Docker Desktop users.
+Docker Desktop supports two installation modes. Per-user installation is recommended for most users and is selected by default in the installer. It does not require administrator privileges to install or update, and the WSL 2 backend it uses covers the needs of the vast majority of Docker Desktop users.
  
 | | Per-user (recommended) | All users |
 |---|---|---|

--- a/content/manuals/desktop/setup/install/windows-permission-requirements.md
+++ b/content/manuals/desktop/setup/install/windows-permission-requirements.md
@@ -16,7 +16,7 @@ Docker Desktop on Windows is designed with security in mind. Administrative righ
 
 The permissions required to install and run Docker Desktop depend on which [installation mode](/manuals/desktop/setup/install/windows-install.md#installation-modes) you use.
  
-### Per-user installation (Beta)
+### Per-user installation
  
 In per-user mode, Docker Desktop installs to `%LOCALAPPDATA%\Programs\DockerDesktop` and writes only to current-user registry keys (`HKCU`). This means:
  


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Update the description of the per-user install mode on Windows to remove the 'Beta' label and confirm it is now the default in the installer UI.

## Related issues or tickets

https://docker.atlassian.net/browse/DKP-2137

## Reviews

The Docker Desktop changes related to this are going live in 4.83.0

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review