### PR TITLE
Fix Docker Offload idle-state link

### DIFF
--- a/content/manuals/desktop/settings-and-maintenance/settings.md
+++ b/content/manuals/desktop/settings-and-maintenance/settings.md
@@ -345,5 +345,5 @@ Enable Docker Offload and configure idle timeout and GPU support for cloud-based
 | Setting             | Description                               | Notes                                 |
 | ------------------- | ----------------------------------------- | ------------------------------------- |
 | **Enable Docker Offload** | Run your containers in the cloud.  | Requires sign-in and an Offload subscription |
-| **Idle timeout** | Set the duration of time between no activity and Docker Offload entering idle mode. For details about idle timeout, see [Active and idle states](../../offload/configuration.md#understand-active-and-idle-states). | |
+| **Idle timeout** | Set the duration of time between no activity and Docker Offload entering idle mode. For details about idle timeout, see [Session management and idle state](/manuals/offload/about.md#session-management-and-idle-state). | |
 | **Enable GPU support** | Let your workloads use cloud GPU if available. | |


### PR DESCRIPTION
## Description

Updates the Docker Offload idle timeout link to point to the existing session management and idle state section.

## Related issues or tickets

Closes #25591
