### PR TITLE
docs: fix Docker Offload idle-state anchor link

### DIFF
--- a/content/manuals/desktop/settings-and-maintenance/settings.md
+++ b/content/manuals/desktop/settings-and-maintenance/settings.md
@@ -345,5 +345,5 @@ Enable Docker Offload and configure idle timeout and GPU support for cloud-based
 | Setting             | Description                               | Notes                                 |
 | ------------------- | ----------------------------------------- | ------------------------------------- |
 | **Enable Docker Offload** | Run your containers in the cloud.  | Requires sign-in and an Offload subscription |
-| **Idle timeout** | Set the duration of time between no activity and Docker Offload entering idle mode. For details about idle timeout, see [Active and idle states](../../offload/configuration.md#understand-active-and-idle-states). | |
+| **Idle timeout** | Set the duration of time between no activity and Docker Offload entering idle mode. For details about idle timeout, see [Active and idle states](/manuals/offload/about.md#session-management-and-idle-state). | |
 | **Enable GPU support** | Let your workloads use cloud GPU if available. | |


### PR DESCRIPTION
## Description

Updates the broken anchor link for the Docker Offload idle timeout documentation.

This change preserves the existing link text ("Active and idle states") while updating the destination to the correct documentation page and anchor.

Fixes #25591

## Related issues or tickets

- Fixes #25591

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review