### PR TITLE
docs: redirect retired MSI installer URL

### DIFF
--- a/content/manuals/enterprise/enterprise-deployment/msi-install-and-configure.md
+++ b/content/manuals/enterprise/enterprise-deployment/msi-install-and-configure.md
@@ -5,6 +5,7 @@ keywords: msi, windows, docker desktop, install, deploy, configure, admin, mdm
 tags: [admin]
 weight: 10
 aliases:
+  - /desktop/setup/install/msi/
   - /desktop/setup/install/enterprise-deployment/msi-install-and-configure/
 ---
 


### PR DESCRIPTION
## Description

Add the retired `/desktop/setup/install/msi/` path as an alias for the current MSI installer guide so existing links no longer return a 404.

Fixes #25595

## Testing

- `git diff --check`
- Local Go redirect tests were not run because Go is unavailable in this environment; the PR checks will validate the redirect.