### PR TITLE
docs: fix R guide prerequisite link

### DIFF
--- a/content/guides/r.md
+++ b/content/guides/r.md
@@ -110,7 +110,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a R application](./).
+Complete [Containerize a R application](#containerize-a-r-application).
 
 ### Overview
 


### PR DESCRIPTION
## Description

Link the R development prerequisites to the earlier containerization section on the same page instead of the general guides index.

Fixes #25606

## Testing

- `scripts/lint.sh content/guides/r.md` (markdownlint passed; Vale unavailable locally)
- `git diff --check`
- Verified the live page currently renders the old `./` target as `/guides/` and the intended `#containerize-a-r-application` anchor exists.