### PR TITLE
docs: add redirect for Windows installation modes

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -434,6 +434,8 @@
   - /go/desktop-mac-requirements/
 "/desktop/setup/install/windows-install/#system-requirements":
   - /go/desktop-windows-requirements/
+"/desktop/setup/install/windows-install/#installation-modes":
+  - /go/desktop-windows-install-modes/
 "/support/#diagnostic-data-and-privacy":
   - /go/diagnostic-data/
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Adds a permanent redirect to our 'windows installation modes' docs, so that we can link to it from Docker Desktop.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review