### PR TITLE
Clarify seccomp profile path resolution

### DIFF
--- a/content/manuals/engine/security/seccomp.md
+++ b/content/manuals/engine/security/seccomp.md
@@ -48,6 +48,11 @@ $ docker run --rm \
              hello-world
 ```
 
+The Docker CLI resolves a relative profile path from the working directory
+where you invoke `docker`. The CLI reads the profile and sends its contents to
+the daemon, so the profile must be available on the client host when the client
+and daemon run on separate hosts.
+
 ### Significant syscalls blocked by the default profile
 
 Docker's default seccomp profile is an allowlist which specifies the calls that


### PR DESCRIPTION
## Summary

Clarify that Docker CLI resolves relative seccomp profile paths from its working directory and sends the profile contents to the daemon. This also explains which host must contain the profile in remote-daemon setups.

Closes #8749

Generated by Codex