### PR TITLE
Document DSR overlay networks

### DIFF
--- a/content/manuals/engine/network/drivers/overlay.md
+++ b/content/manuals/engine/network/drivers/overlay.md
@@ -7,6 +7,7 @@ aliases:
   - /engine/userguide/networking/overlay-security-model/
   - /network/overlay/
   - /network/drivers/overlay/
+  - /network/network-tutorial-overlay/
   - /engine/network/tutorials/overlay/
   - /engine/userguide/networking/get-started-overlay/
 ---

--- a/content/manuals/engine/swarm/networking.md
+++ b/content/manuals/engine/swarm/networking.md
@@ -243,6 +243,26 @@ If you need more than 256 IP addresses, do not increase the IP block size. You c
 endpoint mode with an external load balancer, or use multiple smaller overlay networks. See 
 [Configure service discovery](#configure-service-discovery) for more information about different endpoint modes.
 
+#### Use direct server return
+
+Direct server return (DSR) changes east-west overlay load balancing so that
+IPVS routes packets by changing the destination MAC address. The source IP and
+destination virtual IP (VIP) remain unchanged.
+
+Create an overlay network that uses DSR:
+
+```console
+$ docker network create \
+  --driver overlay \
+  --opt dsr \
+  dsr-net
+```
+
+> [!NOTE]
+>
+> DSR is supported only for traffic between services on Linux nodes. The
+> ingress routing mesh does not use DSR.
+
 #### Configure encryption of application data {#encryption}
 
 Management and control plane data related to a swarm is always encrypted.


### PR DESCRIPTION
## Summary

Document the DSR option for Linux east-west overlay traffic and restore the legacy overlay tutorial redirect.

Closes #9652

Generated by Codex