### PR TITLE
docs: correct read-only volume wording

### DIFF
--- a/content/manuals/engine/storage/volumes.md
+++ b/content/manuals/engine/storage/volumes.md
@@ -403,9 +403,8 @@ $ docker volume rm nginx-vol
 
 ## Use a read-only volume
 
-For some development applications, the container needs to write into the bind
-mount so that changes are propagated back to the Docker host. At other times,
-the container only needs read access to the data. Multiple
+For some applications, the container needs to write to the volume. At other
+times, the container only needs read access to the data. Multiple
 containers can mount the same volume. You can simultaneously mount a
 single volume as `read-write` for some containers and as `read-only` for others.
 


### PR DESCRIPTION
## Summary

Correct the read-only volume section so it refers to writing to a volume rather than a bind mount. Remove the unrelated claim that changes propagate to the Docker host.

@netlify /engine/storage/volumes/

[Preview the updated Volumes page](https://deploy-preview-25614--docsdocker.netlify.app/engine/storage/volumes/)

Closes #11159

Generated by Codex