### PR TITLE
docs: fix concurrent Rust cache mounts

### DIFF
--- a/content/guides/rust.md
+++ b/content/guides/rust.md
@@ -107,9 +107,8 @@ RUN --mount=type=bind,source=src,target=src \
     --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=cache,target=/app/target/ \
-    --mount=type=cache,target=/usr/local/cargo/git/db \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
-    cargo build --locked --release && \
+    --mount=type=cache,target=/var/cache/cargo \
+    CARGO_HOME=/var/cache/cargo cargo build --locked --release && \
     cp ./target/release/$APP_NAME /bin/server
 
 ################################################################################
@@ -164,9 +163,8 @@ RUN --mount=type=bind,source=src,target=src \
     --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=cache,target=/app/target/ \
-    --mount=type=cache,target=/usr/local/cargo/git/db \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
-    cargo build --locked --release && \
+    --mount=type=cache,target=/var/cache/cargo \
+    CARGO_HOME=/var/cache/cargo cargo build --locked --release && \
     cp ./target/release/$APP_NAME /bin/server
 
 ################################################################################
@@ -205,6 +203,11 @@ CMD ["/bin/server"]
 
 {{< /tab >}}
 {{< /tabs >}}
+
+The cache mount uses an alternate `CARGO_HOME` so concurrent builds share
+Cargo's cache lock. Setting `CARGO_HOME` also changes where Cargo looks for
+global configuration and credentials. Project-level `.cargo/config.toml` files
+are unaffected.
 
 For building an image, only the Dockerfile is necessary. Open the Dockerfile
 in your favorite IDE or text editor and see what it contains. To learn more
@@ -591,9 +594,9 @@ For the sample application, you'll use a variation of the backend from the react
    WORKDIR /app
 
    # Build the application.
-   # Leverage a cache mount to /usr/local/cargo/registry/
-   # for downloaded dependencies and a cache mount to /app/target/ for
-   # compiled dependencies which will speed up subsequent builds.
+   # Leverage a cache mount to /var/cache/cargo for downloaded dependencies
+   # and a cache mount to /app/target/ for compiled dependencies which will
+   # speed up subsequent builds.
    # Leverage a bind mount to the src directory to avoid having to copy the
    # source code into the container. Once built, copy the executable to an
    # output directory before the cache mounted /app/target is unmounted.
@@ -601,11 +604,11 @@ For the sample application, you'll use a variation of the backend from the react
        --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
        --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
        --mount=type=cache,target=/app/target/ \
-       --mount=type=cache,target=/usr/local/cargo/registry/ \
+       --mount=type=cache,target=/var/cache/cargo \
        --mount=type=bind,source=migrations,target=migrations \
        <<EOF
    set -e
-   cargo build --locked --release
+   CARGO_HOME=/var/cache/cargo cargo build --locked --release
    cp ./target/release/$APP_NAME /bin/server
    EOF
 

--- a/content/guides/rust.md
+++ b/content/guides/rust.md
@@ -207,8 +207,7 @@ CMD ["/bin/server"]
 The cache mount uses a single `CARGO_HOME` so concurrent builds coordinate
 access through Cargo's cache lock. Setting `CARGO_HOME` also changes where
 Cargo looks for global configuration and credentials. Project-level
-`.cargo/config.toml` files are unaffected. If your build needs credentials for
-a private registry, pass them as [build secrets](/manuals/build/building/secrets.md).
+`.cargo/config.toml` files are unaffected.
 
 For building an image, only the Dockerfile is necessary. Open the Dockerfile
 in your favorite IDE or text editor and see what it contains. To learn more

--- a/content/guides/rust.md
+++ b/content/guides/rust.md
@@ -204,10 +204,11 @@ CMD ["/bin/server"]
 {{< /tab >}}
 {{< /tabs >}}
 
-The cache mount uses an alternate `CARGO_HOME` so concurrent builds share
-Cargo's cache lock. Setting `CARGO_HOME` also changes where Cargo looks for
-global configuration and credentials. Project-level `.cargo/config.toml` files
-are unaffected.
+The cache mount uses a single `CARGO_HOME` so concurrent builds coordinate
+access through Cargo's cache lock. Setting `CARGO_HOME` also changes where
+Cargo looks for global configuration and credentials. Project-level
+`.cargo/config.toml` files are unaffected. If your build needs credentials for
+a private registry, pass them as [build secrets](/manuals/build/building/secrets.md).
 
 For building an image, only the Dockerfile is necessary. Open the Dockerfile
 in your favorite IDE or text editor and see what it contains. To learn more

--- a/content/manuals/build/cache/optimize.md
+++ b/content/manuals/build/cache/optimize.md
@@ -262,10 +262,14 @@ RUN --mount=type=cache,target=/root/.gem \
 
 ```dockerfile
 RUN --mount=type=cache,target=/app/target/ \
-    --mount=type=cache,target=/usr/local/cargo/git/db \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
-    cargo build
+    --mount=type=cache,target=/var/cache/cargo \
+    CARGO_HOME=/var/cache/cargo cargo build
 ```
+
+The cache mount uses an alternate `CARGO_HOME` so concurrent builds share
+Cargo's cache lock. Setting `CARGO_HOME` also changes where Cargo looks for
+global configuration and credentials. Project-level `.cargo/config.toml` files
+are unaffected.
 
 {{< /tab >}}
 {{< tab name=".NET" >}}

--- a/content/manuals/build/cache/optimize.md
+++ b/content/manuals/build/cache/optimize.md
@@ -266,10 +266,11 @@ RUN --mount=type=cache,target=/app/target/ \
     CARGO_HOME=/var/cache/cargo cargo build
 ```
 
-The cache mount uses an alternate `CARGO_HOME` so concurrent builds share
-Cargo's cache lock. Setting `CARGO_HOME` also changes where Cargo looks for
-global configuration and credentials. Project-level `.cargo/config.toml` files
-are unaffected.
+The cache mount uses a single `CARGO_HOME` so concurrent builds coordinate
+access through Cargo's cache lock. Setting `CARGO_HOME` also changes where
+Cargo looks for global configuration and credentials. Project-level
+`.cargo/config.toml` files are unaffected. If your build needs credentials for
+a private registry, pass them as [build secrets](/manuals/build/building/secrets.md).
 
 {{< /tab >}}
 {{< tab name=".NET" >}}

--- a/content/manuals/build/cache/optimize.md
+++ b/content/manuals/build/cache/optimize.md
@@ -269,8 +269,7 @@ RUN --mount=type=cache,target=/app/target/ \
 The cache mount uses a single `CARGO_HOME` so concurrent builds coordinate
 access through Cargo's cache lock. Setting `CARGO_HOME` also changes where
 Cargo looks for global configuration and credentials. Project-level
-`.cargo/config.toml` files are unaffected. If your build needs credentials for
-a private registry, pass them as [build secrets](/manuals/build/building/secrets.md).
+`.cargo/config.toml` files are unaffected.
 
 {{< /tab >}}
 {{< tab name=".NET" >}}


### PR DESCRIPTION
## Summary

Use one alternate Cargo home cache so concurrent builds share Cargo's package-cache lock. Document how `CARGO_HOME` affects global configuration and credentials.

@netlify /build/cache/optimize/

Preview the updated [cache optimization page](https://deploy-preview-25616--docsdocker.netlify.app/build/cache/optimize/) and [Rust guide](https://deploy-preview-25616--docsdocker.netlify.app/guides/rust/).

Closes #25597

Generated by Codex