### PR TITLE
docs: fix links after single-page guide migration

### DIFF
--- a/content/guides/angular.md
+++ b/content/guides/angular.md
@@ -538,7 +538,7 @@ $ docker compose down
 
 ### Prerequisites
 
-Complete [Containerize Angular application](./).
+Complete [Containerize Angular application](#containerize-an-angular-application).
 
 ---
 
@@ -683,7 +683,7 @@ You should see the updated text appear instantly, without needing to rebuild the
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize Angular application](./).
+Complete all the previous sections of this guide, starting with [Containerize Angular application](#containerize-an-angular-application).
 
 ### Overview
 

--- a/content/guides/bun.md
+++ b/content/guides/bun.md
@@ -189,7 +189,7 @@ $ docker compose down
 
 ### Prerequisites
 
-Complete [Containerize a Bun application](./).
+Complete [Containerize a Bun application](#containerize-a-bun-application).
 
 ### Overview
 

--- a/content/guides/cpp.md
+++ b/content/guides/cpp.md
@@ -214,7 +214,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a C++ application](./).
+Complete [Containerize a C++ application](#containerize-a-c-application).
 
 ### Overview
 

--- a/content/guides/deno.md
+++ b/content/guides/deno.md
@@ -211,7 +211,7 @@ $ docker compose down
 
 ### Prerequisites
 
-Complete [Containerize a Deno application](./).
+Complete [Containerize a Deno application](#containerize-a-deno-application).
 
 ### Overview
 

--- a/content/guides/dotnet.md
+++ b/content/guides/dotnet.md
@@ -379,7 +379,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a .NET application](./).
+Complete [Containerize a .NET application](#containerize-a-net-application).
 
 ### Overview
 
@@ -394,9 +394,9 @@ In this section, you'll learn how to set up a development environment for your c
 This section uses a different branch of the `docker-dotnet-sample` repository
 that contains an updated .NET application. The updated application is on the
 `add-db` branch of the repository you cloned in [Containerize a .NET
-application](./).
+application](#containerize-a-net-application).
 
-To get the updated code, you need to checkout the `add-db` branch. For the changes you made in [Containerize a .NET application](./), for this section, you can stash them. In a terminal, run the following commands in the `docker-dotnet-sample` directory.
+To get the updated code, you need to checkout the `add-db` branch. For the changes you made in [Containerize a .NET application](#containerize-a-net-application), for this section, you can stash them. In a terminal, run the following commands in the `docker-dotnet-sample` directory.
 
 1. Stash any previous changes.
 
@@ -781,7 +781,7 @@ Your containerized application will now use the SDK image (either `dhi.io/dotnet
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize a .NET application](./).
+Complete all the previous sections of this guide, starting with [Containerize a .NET application](#containerize-a-net-application).
 
 ### Overview
 

--- a/content/guides/genai-pdf-bot.md
+++ b/content/guides/genai-pdf-bot.md
@@ -283,7 +283,7 @@ In the next section, you'll learn how you can run your application, database, an
 
 ### Prerequisites
 
-Complete [Containerize a generative AI application](./).
+Complete [Containerize a generative AI application](#containerize-a-generative-ai-application).
 
 ### Overview
 

--- a/content/guides/golang.md
+++ b/content/guides/golang.md
@@ -542,7 +542,7 @@ so feel free to check out [multi-stage builds](/manuals/build/building/multi-sta
 
 ### Prerequisites
 
-Work through the steps to containerize a Go application in [Build your Go image](./).
+Work through the steps to containerize a Go application in [Build your Go image](#build-your-go-image).
 
 ### Overview
 
@@ -739,7 +739,7 @@ Now, you can easily identify your container based on the name.
 
 ### Prerequisites
 
-Work through the steps of the [run your image as a container](./) module to learn how to manage the lifecycle of your containers.
+Work through the steps of the [run your image as a container](#run-your-go-image-as-a-container) module to learn how to manage the lifecycle of your containers.
 
 ### Introduction
 
@@ -1457,7 +1457,7 @@ Since you didn't run a cluster of CockroachDB instances, you might be wondering 
 
 ### Prerequisites
 
-Complete the [Build your Go image](./) section of this guide.
+Complete the [Build your Go image](#build-your-go-image) section of this guide.
 
 ### Overview
 
@@ -1467,7 +1467,7 @@ tests and end-to-end testing. In this guide you take a look at running your unit
 tests in Docker when building.
 
 For this section, use the `docker-gs-ping` project that you cloned in [Build
-your Go image](./).
+your Go image](#build-your-go-image).
 
 ### Run tests when building
 

--- a/content/guides/java.md
+++ b/content/guides/java.md
@@ -306,7 +306,7 @@ For more information about Compose commands, see the
 
 ### Prerequisites
 
-Work through the steps to containerize your application in [Containerize your app](./).
+Work through the steps to containerize your application in [Containerize your app](#containerize-a-java-application).
 
 ### Overview
 
@@ -687,7 +687,7 @@ Press `ctrl+c` in the terminal to stop Compose Watch.
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize a Java application](./).
+Complete all the previous sections of this guide, starting with [Containerize a Java application](#containerize-a-java-application).
 
 ### Overview
 

--- a/content/guides/nextjs.md
+++ b/content/guides/nextjs.md
@@ -978,7 +978,7 @@ $ docker stop nextjs-app
 
 ### Prerequisites
 
-Complete [Containerize Next.js application](./).
+Complete [Containerize Next.js application](#containerize-a-nextjs-application).
 
 ---
 
@@ -1152,7 +1152,7 @@ You should see the updated text appear instantly, without needing to rebuild the
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize Next.js application](./).
+Complete all the previous sections of this guide, starting with [Containerize Next.js application](#containerize-a-nextjs-application).
 
 ### Overview
 

--- a/content/guides/nodejs.md
+++ b/content/guides/nodejs.md
@@ -467,7 +467,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a Node.js application](./).
+Complete [Containerize a Node.js application](#containerize-a-nodejs-application).
 
 ### Overview
 
@@ -1095,7 +1095,7 @@ For more details about Node.js debugging, see the [Node.js debugging guide](http
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize a Node.js application](./).
+Complete all the previous sections of this guide, starting with [Containerize a Node.js application](#containerize-a-nodejs-application).
 
 ### Overview
 

--- a/content/guides/php.md
+++ b/content/guides/php.md
@@ -302,7 +302,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a PHP application](./).
+Complete [Containerize a PHP application](#containerize-a-php-application).
 
 ### Overview
 
@@ -736,7 +736,7 @@ While the application appears the same, you can now make use of the dev dependen
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize a PHP application](./).
+Complete all the previous sections of this guide, starting with [Containerize a PHP application](#containerize-a-php-application).
 
 ### Overview
 

--- a/content/guides/python.md
+++ b/content/guides/python.md
@@ -475,7 +475,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a Python application](./).
+Complete [Containerize a Python application](#containerize-a-python-application).
 
 ### Overview
 
@@ -2073,8 +2073,8 @@ Press `ctrl+c` in the terminal to stop your application.
 
 Complete [Develop your app](#use-containers-for-python-development). This topic requires a local Python
 installation because the tools and Git hooks introduced here run on your
-host. If you don't want to install Python locally, skip this topic. The same
-checks run in CI in the [next topic](./).
+host. If you don't want to install Python locally, skip this topic. You can
+also run the same checks in CI.
 
 ### Overview
 

--- a/content/guides/r.md
+++ b/content/guides/r.md
@@ -110,7 +110,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a R application](./).
+Complete [Containerize a R application](#containerize-a-r-application).
 
 ### Overview
 

--- a/content/guides/rag-ollama.md
+++ b/content/guides/rag-ollama.md
@@ -127,7 +127,7 @@ In the next section, you'll learn how to properly configure the application with
 
 ### Prerequisites
 
-Complete [Containerize a RAG application](./).
+Complete [Containerize a RAG application](#containerize-a-rag-application).
 
 ### Overview
 

--- a/content/guides/reactjs.md
+++ b/content/guides/reactjs.md
@@ -517,7 +517,7 @@ $ docker compose down
 
 ### Prerequisites
 
-Complete [Containerize React.js application](./).
+Complete [Containerize React.js application](#containerize-a-reactjs-application).
 
 ---
 
@@ -688,7 +688,7 @@ You should see the updated text appear instantly, without needing to rebuild the
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize React.js application](./).
+Complete all the previous sections of this guide, starting with [Containerize React.js application](#containerize-a-reactjs-application).
 
 ### Overview
 

--- a/content/guides/ruby.md
+++ b/content/guides/ruby.md
@@ -402,7 +402,7 @@ reference](/reference/cli/docker/compose/).
 
 ### Prerequisites
 
-Complete [Containerize a Ruby on Rails application](./).
+Complete [Containerize a Ruby on Rails application](#containerize-a-ruby-on-rails-application).
 
 ### Overview
 

--- a/content/guides/rust.md
+++ b/content/guides/rust.md
@@ -325,7 +325,7 @@ Docker removed the image tagged with `:v1.0.0`, but the `docker-rust-image-dhi:l
 
 ### Prerequisite
 
-You have completed [Build your Rust image](./) and you have built an image.
+You have completed [Build your Rust image](#build-your-rust-image) and you have built an image.
 
 ### Overview
 
@@ -335,7 +335,7 @@ To run an image inside of a container, you use the `docker run` command. The `do
 
 ### Run an image
 
-Use `docker run` to run the image you built in [Build your Rust image](./).
+Use `docker run` to run the image you built in [Build your Rust image](#build-your-rust-image).
 
 ```console
 $ docker run docker-rust-image-dhi

--- a/content/guides/vuejs.md
+++ b/content/guides/vuejs.md
@@ -541,7 +541,7 @@ $ docker compose down
 
 ### Prerequisites
 
-Complete [Containerize Vue.js application](./).
+Complete [Containerize Vue.js application](#containerize-an-vuejs-application).
 
 ---
 
@@ -698,7 +698,7 @@ You should see the updated text appear instantly, without needing to rebuild the
 
 ### Prerequisites
 
-Complete all the previous sections of this guide, starting with [Containerize Vue.js application](./).
+Complete all the previous sections of this guide, starting with [Containerize Vue.js application](#containerize-an-vuejs-application).
 
 ### Overview
 


### PR DESCRIPTION
## Summary

Replace 33 stale relative links across 18 collapsed guides with same-page section anchors. The linked #25608 fixes only the reported R occurrence; this PR applies the full `content/guides/` audit and removes one Python link to a deleted topic.

Closes #25606
Closes #25608

Generated by Codex