### PR TITLE
docs: add configuration files to local workspace files

### DIFF
--- a/content/manuals/ai/sandboxes/security/_index.md
+++ b/content/manuals/ai/sandboxes/security/_index.md
@@ -74,10 +74,10 @@ can still affect you through the shared workspace and allowed network channels.
 In direct mode, workspace changes are live on your host. With the default
 direct mount, the agent edits the same files you see on your host. This
 includes files that execute implicitly during normal development: Git hooks,
-CI configuration, IDE task configs, `Makefile`, `package.json` scripts, and
-similar build files. Review changes before running any modified code. Note
-that Git hooks live inside `.git/` and do not appear in `git diff` output —
-check them separately. See
+CI configuration, IDE task configs, AI project configuration and settings,
+`Makefile`, `package.json` scripts, and similar build files. Review changes
+before running any modified code. Note that Git hooks live inside `.git/`
+and do not appear in `git diff` output — check them separately. See
 [Workspace isolation](isolation/#workspace-isolation) for the full list and
 for the alternative clone-mode boundary.
 

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -115,6 +115,7 @@ including:
 - Git hooks (`.git/hooks/`)
 - CI configuration (`.github/workflows/`, `.gitlab-ci.yml`)
 - IDE configuration (`.vscode/tasks.json`, `.idea/` run configurations)
+- AI project configuration and settings (`.claude/`, `.codex/`, `.gemini/`)
 - Hidden files, shell scripts, and executables
 
 Some of these files execute code when you trigger normal development
@@ -130,6 +131,9 @@ Review them after any agent session before performing those actions:
   during build or install steps.
 - IDE configuration (`.vscode/tasks.json`, `.idea/`) can run tasks
   when you open the project.
+- AI project configuration and settings (`.claude/settings.json`, `.codex/config.toml`,
+  `.gemini/settings.json`) can define hooks and startup commands that
+  execute automatically.
 
 > [!WARNING]
 > Treat sandbox-modified workspace files the same way you would treat a pull


### PR DESCRIPTION
## Description

The warnings are quite clear, and project-level AI tool configuration could conceivably be part of the IDE settings, but we could list them explicitly here

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review