### PR TITLE
docs: clarify GitHub immutable identifier behavior

### DIFF
--- a/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
+++ b/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
@@ -67,7 +67,8 @@ The exact format varies and depends on what triggered the workflow.
   for the full list of formats.
 
 > [!NOTE]
-> GitHub now includes immutable identifiers in the default subject claim
+> repositories created after July 15, 2026 use immutable
+> identifiers for default subject claims
 > for repositories created after July 15, 2026. For example:
 > `repo:octocat@123456/my-repo@456789:ref:refs/heads/main`. See the
 > [GitHub changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)

--- a/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
+++ b/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
@@ -67,8 +67,8 @@ The exact format varies and depends on what triggered the workflow.
   for the full list of formats.
 
 > [!NOTE]
-> GitHub repositories created after July 15, 2026 have immutable
-> identifiers in the default subject claim. For example:
+> GitHub now includes immutable identifiers in the default subject claim
+> for repositories created after July 15, 2026. For example:
 > `repo:octocat@123456/my-repo@456789:ref:refs/heads/main`. See the
 > [GitHub changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)
 > for more details.

--- a/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
+++ b/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
@@ -67,9 +67,8 @@ The exact format varies and depends on what triggered the workflow.
   for the full list of formats.
 
 > [!NOTE]
-> repositories created after July 15, 2026 use immutable
-> identifiers for default subject claims
-> for repositories created after July 15, 2026. For example:
+> GitHub repositories created after July 15, 2026 use immutable
+> identifiers for default subject claims. For example:
 > `repo:octocat@123456/my-repo@456789:ref:refs/heads/main`. See the
 > [GitHub changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)
 > for more details.


### PR DESCRIPTION
## Description

Clarifies that GitHub's immutable identifiers in the default subject claim are now described as the current behavior for repositories created after July 15, 2026.

## Related issues or tickets

Fixes #25621

## Reviews

- [x] Technical review
- [x] Editorial review
- [ ] Product review