### PR TITLE
dhi: update migration examples

### DIFF
--- a/content/manuals/dhi/migration/migrate-from-doi.md
+++ b/content/manuals/dhi/migration/migrate-from-doi.md
@@ -58,7 +58,7 @@ replaced by the new hardened image.
 - FROM golang:1.25
 
 + ## Updated to use hardened base image
-+ FROM dhi.io/golang:1.25-debian12-dev
++ FROM dhi.io/golang:1.25-debian13-dev
 ```
 
 Note that DHI does not have a `latest` tag in order to promote best practices
@@ -89,13 +89,13 @@ The following example shows a multi-stage Dockerfile with a build stage and runt
 
 ```dockerfile
 # Build stage
-FROM dhi.io/golang:1.25-debian12-dev AS builder
+FROM dhi.io/golang:1.25-debian13-dev AS builder
 WORKDIR /app
 COPY . .
 RUN go build -o myapp
 
 # Runtime stage
-FROM dhi.io/golang:1.25-debian12
+FROM dhi.io/golang:1.25-debian13
 WORKDIR /app
 COPY --from=builder /app/myapp .
 ENTRYPOINT ["/app/myapp"]

--- a/content/manuals/dhi/migration/migrate-from-ubuntu.md
+++ b/content/manuals/dhi/migration/migrate-from-ubuntu.md
@@ -53,7 +53,7 @@ replaced by the new DHI Debian image.
 - FROM ubuntu/go:1.22-24.04
 
 + ## Updated to use hardened Debian-based image
-+ FROM dhi.io/golang:1-debian13-dev
++ FROM dhi.io/golang:1.25-debian13-dev
 ```
 
 To find the right tag, explore the available tags in the [DHI
@@ -74,7 +74,7 @@ contain package managers.
 -     && rm -rf /var/lib/apt/lists/*
 
 + ## DHI: Use a language-specific dev image with package manager
-+ FROM dhi.io/golang:1-debian13-dev
++ FROM dhi.io/golang:1.25-debian13-dev
 + RUN apt-get update && apt-get install -y \
 +     git \
 +     && rm -rf /var/lib/apt/lists/*
@@ -105,7 +105,7 @@ The following example shows a multi-stage Dockerfile migrating from Ubuntu to DH
 
 ```dockerfile
 # Build stage
-FROM dhi.io/golang:1-debian13-dev AS builder
+FROM dhi.io/golang:1.25-debian13-dev AS builder
 WORKDIR /app
 
 # Install system dependencies (only available in dev images)
@@ -121,7 +121,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o main .
 
 # Runtime stage
-FROM dhi.io/golang:1-debian13
+FROM dhi.io/golang:1.25-debian13
 WORKDIR /app
 
 # Copy compiled binary from builder

--- a/content/manuals/dhi/migration/migrate-from-wolfi.md
+++ b/content/manuals/dhi/migration/migrate-from-wolfi.md
@@ -43,7 +43,7 @@ replaced by the new hardened image.
 - FROM cgr.dev/chainguard/go:latest-dev
 
 + ## Updated to use hardened base image
-+ FROM dhi.io/golang:1.25-alpine3.22-dev
++ FROM dhi.io/golang:1.25-alpine3.24-dev
 ```
 
 Note that DHI does not have a `latest` tag in order to promote best practices
@@ -70,13 +70,13 @@ The following example shows a multi-stage Dockerfile with a build stage and runt
 
 ```dockerfile
 # Build stage
-FROM dhi.io/golang:1.25-alpine3.22-dev AS builder
+FROM dhi.io/golang:1.25-alpine3.24-dev AS builder
 WORKDIR /app
 COPY . .
 RUN go build -o myapp
 
 # Runtime stage
-FROM dhi.io/golang:1.25-alpine3.22
+FROM dhi.io/golang:1.25-alpine3.24
 WORKDIR /app
 COPY --from=builder /app/myapp .
 ENTRYPOINT ["/app/myapp"]


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Updated image tags across the three DHI migration guides to use valid, consistent versions verified against the DHI catalog:

- `migrate-from-doi.md`: debian12 → debian13 (debian12 is old)
- `migrate-from-wolfi.md`: alpine3.22 → alpine3.24 (alpine3.22 is old)
- `migrate-from-ubuntu.md`: golang:1 → golang:1.25 (consistent minor version across all guides)

## Related issues or tickets

Closes #25509

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
