### PR TITLE
docs(gordon): explain YOLO mode in permissions.md

### DIFF
--- a/content/manuals/ai/gordon/how-to/configure-tools.md
+++ b/content/manuals/ai/gordon/how-to/configure-tools.md
@@ -63,8 +63,9 @@ To configure:
 
 ![Advanced tool configuration](../images/gordon_advanced_tool_config.avif)
 
-Gordon still requests approval before running allow-listed tools, unless YOLO
-mode (auto-approve mode that bypasses permission checks) is enabled.
+Gordon still requests approval before running allow-listed tools, unless
+[YOLO mode](/manuals/ai/gordon/how-to/permissions.md#yolo-mode) (auto-approve
+mode that bypasses permission checks) is enabled.
 
 ## Organizational controls
 

--- a/content/manuals/ai/gordon/how-to/permissions.md
+++ b/content/manuals/ai/gordon/how-to/permissions.md
@@ -39,6 +39,46 @@ before using a tool.
 
 You can also enable YOLO mode to bypass permission checking altogether.
 
+## YOLO mode
+
+YOLO mode (“You Only Live Once”) is a setting that lets Gordon skip permission
+checks entirely and auto-approve every tool call instead of asking you to
+confirm each action.
+
+### What it does
+
+With YOLO mode on, Gordon runs allow-listed and non-allow-listed tools
+immediately — including shell commands, file writes, and other actions that
+would normally require your approval.
+
+### How to enable it
+
+1. Open Docker Desktop.
+2. Select **Gordon** in the sidebar.
+3. Select the settings icon at the bottom of text input.
+4. In the **Basic** tab, toggle **YOLO mode** on.
+
+The setting applies immediately to all sessions.
+
+### Security implications
+
+Enabling YOLO mode removes your ability to review or stop individual actions
+before they run. Gordon can execute destructive commands (such as deleting
+containers, volumes, or files) without prompting you first. Only enable it in
+environments where you're comfortable with Gordon acting without oversight,
+such as an isolated container or VM.
+
+### When you might use it
+
+- Trusted, sandboxed, or disposable environments
+- Demos and quick experimentation
+- Automated workflows where the tool list is already trusted
+
+### How to disable it
+
+Go back to the Basic tab in settings and toggle YOLO mode off. Gordon will
+resume asking for approval before running tools.
+
 The new permission settings apply immediately to all sessions.
 
 ## Session-level permissions


### PR DESCRIPTION
<!--Delete sections as needed -->
## Description
Adds a dedicated "YOLO mode" section to `permissions.md` explaining what it
is, how to enable/disable it, when to use it, and its security implications.
Also updates `configure-tools.md` to link its existing YOLO mode mention to
this new section instead of leaving it unexplained.

## Related issues or tickets
Closes #25628

## Reviews
<!-- Notes for reviewers here -->
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review