### PR TITLE
docs: redirect bare Learn path

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -8,6 +8,8 @@
 # provide a short, permanent link to refer to a topic in the documentation.
 # For example, the docker CLI can output https://docs.docker.com/go/some-topic
 # in its help output, which can be redirected to elsewhere in the documentation.
+"/learn/":
+  - /learn
 "/security/access-tokens/":
   - /go/access-tokens/
 "/reference/api/engine/#deprecated-api-versions":

--- a/hack/releaser/cloudfront-lambda-redirects.js
+++ b/hack/releaser/cloudfront-lambda-redirects.js
@@ -22,7 +22,12 @@ exports.handler = (event, context, callback) => {
   const redirects = JSON.parse(`{{.RedirectsJSON}}`);
   for (let key in redirects) {
     const redirectTarget = key.replace(/\/$/, "");
-    if (redirectTarget !== requestUrl) {
+    const exactMatch = key === request.uri;
+    // Preserve slash-insensitive matching without redirecting a canonical
+    // slash-terminated destination back to itself.
+    const normalizedMatch =
+      redirectTarget === requestUrl && redirects[key] !== request.uri;
+    if (!exactMatch && !normalizedMatch) {
       continue;
     }
     //console.log(`redirect: ${requestUrl} to ${redirects[key]}`);

--- a/hack/releaser/cloudfront-lambda-redirects.test.js
+++ b/hack/releaser/cloudfront-lambda-redirects.test.js
@@ -17,6 +17,7 @@ const Module = require("node:module");
 const SRC = path.join(__dirname, "cloudfront-lambda-redirects.js");
 
 const REDIRECTS = {
+  "/learn": "/learn/",
   "/old/page/": "/new/page/",
   "/target-with-query/": "/dest/?ref=docs",
   "/target-with-fragment/": "/dest/?ref=docs#install",
@@ -83,6 +84,16 @@ test("exact redirect without a query string is unchanged", async () => {
   const { result } = await invoke({ uri: "/old/page/" });
   assert.equal(result.status, "301");
   assert.equal(locationOf(result), "/new/page/");
+});
+
+test("bare path redirects without redirecting the canonical target to itself", async () => {
+  const { result: bareResult } = await invoke({ uri: "/learn" });
+  assert.equal(bareResult.status, "301");
+  assert.equal(locationOf(bareResult), "/learn/");
+
+  const { result: canonicalResult, request } = await invoke({ uri: "/learn/" });
+  assert.equal(canonicalResult, request);
+  assert.equal(request.uri, "/learn/index.html");
 });
 
 test("exact redirect appends with & when target already has a query string", async () => {


### PR DESCRIPTION
## Summary

Adds the docs-owned `/learn` to `/learn/` redirect needed before the Learn subsite is attached to the shared CloudFront distribution. The redirect matcher now preserves slash-insensitive legacy aliases without redirecting the canonical `/learn/` destination back to itself.

Related infrastructure PRs: docker/infra-terraform-modules#3060, docker/infra-terraform#13307, and docker/infra-terraform#13308.

Generated by Codex
