### PR TITLE
dhi: sync cli ref

### DIFF
--- a/content/guides/dhi-backstage.md
+++ b/content/guides/dhi-backstage.md
@@ -375,10 +375,11 @@ Then create the customization:
 dhictl customization create --org YOUR_ORG node-backstage.yaml
 ```
 
-Monitor the build progress:
+Monitor the build progress using the customization ID from the create output, or
+run `dhictl customization list --org YOUR_ORG` to look it up:
 
 ```console
-dhictl customization build list --org YOUR_ORG YOUR_ORG/dhi-node "backstage"
+dhictl customization build list <customization-id> --org YOUR_ORG
 ```
 
 Docker builds the customized image on its secure infrastructure and publishes it as `YOUR_ORG/dhi-node:24-alpine3.23_backstage`.

--- a/content/guides/dhi-backstage.md
+++ b/content/guides/dhi-backstage.md
@@ -375,8 +375,14 @@ Then create the customization:
 dhictl customization create --org YOUR_ORG node-backstage.yaml
 ```
 
-Monitor the build progress using the customization ID from the create output, or
-run `dhictl customization list --org YOUR_ORG` to look it up:
+Monitor the build progress using the customization ID from the create output.
+To look up the ID, run:
+
+```console
+dhictl customization list --org YOUR_ORG
+```
+
+Then monitor the build:
 
 ```console
 dhictl customization build list <customization-id> --org YOUR_ORG

--- a/content/manuals/dhi/release-notes/cli.md
+++ b/content/manuals/dhi/release-notes/cli.md
@@ -15,6 +15,28 @@ the full release history, including pre-releases and downloads, see the
 
 <!-- BEGIN GENERATED RELEASES -->
 
+## 0.0.7
+
+{{< release-date date="2026-07-21" >}}
+
+[GitHub release](https://github.com/docker-hardened-images/dhictl/releases/tag/v0.0.7)
+
+### Bug Fixes
+
+- Fixes JSON output incorrectly escaping ampersands as `\u0026` — values such as catalog categories containing `&` now appear as-is in output
+
+## 0.0.6
+
+{{< release-date date="2026-07-13" >}}
+
+[GitHub release](https://github.com/docker-hardened-images/dhictl/releases/tag/v0.0.6)
+
+This release fixes an issue that prevented customizations from being created via the CLI.
+
+### Bug Fixes
+
+- Fixes `dhictl customization create` failing when GraphQL rejected mutation inputs that incorrectly included the output-only `__typename` field from OCI artifact data
+
 ## 0.0.5
 
 {{< release-date date="2026-06-29" >}}

--- a/data/cli/dhi/docker_dhi_customization_build_get.yaml
+++ b/data/cli/dhi/docker_dhi_customization_build_get.yaml
@@ -2,7 +2,7 @@ command: docker dhi customization build get
 short: Get details of a build
 long: |
     Get detailed information about a Docker Hardened Images customization build
-usage: docker dhi customization build get <repository> <name> <build-id>
+usage: docker dhi customization build get <customization-id> <build-id>
 pname: docker dhi customization build
 plink: docker_dhi_customization_build.yaml
 options:

--- a/data/cli/dhi/docker_dhi_customization_build_list.yaml
+++ b/data/cli/dhi/docker_dhi_customization_build_list.yaml
@@ -1,8 +1,7 @@
 command: docker dhi customization build list
 short: List builds of a customization
-long: |
-    List all builds of a Docker Hardened Images customization by repository and name
-usage: docker dhi customization build list <repository> <name>
+long: List all builds of a Docker Hardened Images customization by its ID
+usage: docker dhi customization build list <customization-id>
 pname: docker dhi customization build
 plink: docker_dhi_customization_build.yaml
 options:

--- a/data/cli/dhi/docker_dhi_customization_build_logs.yaml
+++ b/data/cli/dhi/docker_dhi_customization_build_logs.yaml
@@ -1,7 +1,7 @@
 command: docker dhi customization build logs
 short: Get logs of a build
 long: Get the logs of a Docker Hardened Images customization build
-usage: docker dhi customization build logs <repository> <name> <build-id>
+usage: docker dhi customization build logs <customization-id> <build-id>
 pname: docker dhi customization build
 plink: docker_dhi_customization_build.yaml
 options:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Synced DHI CLI docs:
 - Release notes — Added v0.0.6 and v0.0.7 to the DHI CLI release notes page.
 - Reference YAML — Synced commands (these syncs got missed a previous release):
   - customization build get
   - customization build list
   - customization build logs

Backstage guide — Fixed a stale customization build list example in the dhictl CLI tab that still used the old two-argument format; updated to `<customization-id>` with a note on how to retrieve it.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
