### PR TITLE
Fixes Dockerfile build failing due to comments on same line as instructions

### DIFF
--- a/content/manuals/compose/gettingstarted.md
+++ b/content/manuals/compose/gettingstarted.md
@@ -64,16 +64,33 @@ Make sure you have:
 
    ```dockerfile
    # syntax=docker/dockerfile:1
-   FROM python:3.12-alpine  # Builds an image with the Python 3.12 image
-   WORKDIR /code  # Sets the working directory to `/code`
-   ENV FLASK_APP=app.py  # Sets environment variables used by the `flask` command
+   
+   # Builds an image with the Python 3.12 image
+   FROM python:3.12-alpine
+   
+   # Sets the working directory to `/code`
+   WORKDIR /code
+   
+   # Sets environment variables used by the `flask` command
+   ENV FLASK_APP=app.py
    ENV FLASK_RUN_HOST=0.0.0.0
-   RUN apk add --no-cache gcc musl-dev linux-headers  # Installs `gcc` and other dependencies
-   COPY requirements.txt .  # Copies `requirements.txt`
-   RUN pip install -r requirements.txt  # Installs the Python dependencies
-   COPY . .  # Copies the current directory `.` in the project to the workdir `.` in the image
+   
+   # Installs `gcc` and other dependencies
+   RUN apk add --no-cache gcc musl-dev linux-headers
+   
+   # Copies `requirements.txt`
+   COPY requirements.txt .
+   
+   # Installs the Python dependencies
+   RUN pip install -r requirements.txt
+   
+   # Copies the current directory `.` in the project to the workdir `.` in the image
+   COPY . .
+   
    EXPOSE 5000
-   CMD ["flask", "run", "--debug"]  # Sets the default command for the container to `flask run --debug`
+   
+   # Sets the default command for the container to `flask run --debug`
+   CMD ["flask", "run", "--debug"]
    ```
 
    > [!IMPORTANT]

--- a/content/manuals/compose/gettingstarted.md
+++ b/content/manuals/compose/gettingstarted.md
@@ -65,31 +65,31 @@ Make sure you have:
    ```dockerfile
    # syntax=docker/dockerfile:1
    
-   # Builds an image with the Python 3.12 image
+   # Build an image with the Python 3.12 image
    FROM python:3.12-alpine
    
-   # Sets the working directory to `/code`
+   # Set the working directory to `/code`
    WORKDIR /code
    
-   # Sets environment variables used by the `flask` command
+   # Set environment variables used by the `flask` command
    ENV FLASK_APP=app.py
    ENV FLASK_RUN_HOST=0.0.0.0
    
-   # Installs `gcc` and other dependencies
+   # Install `gcc` and other dependencies
    RUN apk add --no-cache gcc musl-dev linux-headers
    
-   # Copies `requirements.txt`
+   # Copy `requirements.txt`
    COPY requirements.txt .
    
-   # Installs the Python dependencies
+   # Install the Python dependencies
    RUN pip install -r requirements.txt
    
-   # Copies the current directory `.` in the project to the workdir `.` in the image
+   # Copy the current directory `.` in the project to the workdir `.` in the image
    COPY . .
    
    EXPOSE 5000
    
-   # Sets the default command for the container to `flask run --debug`
+   # Set the default command for the container to `flask run --debug`
    CMD ["flask", "run", "--debug"]
    ```
 


### PR DESCRIPTION
Dockerfile has comments appended at the end of instructions in the same line, causing the build to fail

## Description

Separated out the comments on their own lines before each instruction.
Changed comment language from passive to active voice since each comment is now explaining the instruction following it instead of explaining the instruction preceding it.

This is in compliance with the format of Dockerfile as mentioned [here](https://docs.docker.com/reference/dockerfile/#format:~:text=BuildKit%20treats%20lines%20that%20begin%20with%20%23%20as%20a%20comment%2C%20unless%20the%20line%20is%20a%20valid%20parser%20directive.%20A%20%23%20marker%20anywhere%20else%20in%20a%20line%20is%20treated%20as%20an%20argument.)

The build is supposed to fail if a comment is placed on the same line as the instruction unless it is a valid syntactic `#` symbol.

## Reviews

- Tested by running the docs website locally as instructed in [CONTRIBUTING.md](https://github.com/docker/docs/blob/ab6453ef1184543d563ecb051293a1b25e678441/CONTRIBUTING.md)
- Tested the build by following instructions as mentioned on the page [Docker Compose Quickstart](https://docs.docker.com/compose/gettingstarted/)
- Verified everything using human intelligence (no vibe-coding / AI-fluff used)

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review