### PR TITLE
docs: document OpenCode Zen sandbox keys

### DIFF
--- a/content/manuals/ai/sandboxes/agents/opencode.md
+++ b/content/manuals/ai/sandboxes/agents/opencode.md
@@ -48,6 +48,34 @@ $ sbx secret set -g openrouter
 You only need to configure the providers you want to use. OpenCode detects
 available credentials and offers those providers in the TUI.
 
+### OpenCode Zen API keys
+
+OpenCode Zen API keys aren't part of the built-in OpenCode credentials that
+`sbx secret set` supports. To use an OpenCode Zen API key, store it as a
+[custom secret](../security/credentials.md#custom-secrets):
+
+Set the `OPENCODE_API_KEY` environment variable on the host, then store it:
+
+```console
+$ sbx secret set-custom -g \
+    --host opencode.ai \
+    --env OPENCODE_API_KEY \
+    --value "$OPENCODE_API_KEY"
+```
+
+Custom secrets keep the real key in the host secret store. The sandbox receives
+`OPENCODE_API_KEY` as a placeholder, and the host-side proxy replaces that
+placeholder with the real key on requests to `opencode.ai`.
+
+OpenCode Zen also requires network access to `opencode.ai`:
+
+```console
+$ sbx policy allow network opencode.ai:443
+```
+
+If you add the custom secret globally with `-g`, recreate existing OpenCode
+sandboxes so the new environment variable is available inside the sandbox.
+
 ## Configuration
 
 Sandboxes don't pick up user-level configuration from your host. Only


### PR DESCRIPTION
## Summary

Document the OpenCode Zen API key limitation for Sandboxes and show how to use a custom secret plus network policy for Zen access.

@netlify /ai/sandboxes/agents/opencode/

Preview: https://deploy-preview-25644--docsdocker.netlify.app/ai/sandboxes/agents/opencode/

Closes #25633

Generated by Codex