### PR TITLE
docs: clarify ChatGPT Codex requirement

### DIFF
--- a/content/manuals/ai/sandboxes/integrations/chatgpt.md
+++ b/content/manuals/ai/sandboxes/integrations/chatgpt.md
@@ -20,8 +20,6 @@ isolated environment instead of on your host.
 
 - SSH access set up. See [Editor and app integrations](_index.md#enable-ssh-access).
 - The ChatGPT desktop app installed.
-- An existing sandbox created from the Codex template. The template includes
-  the `codex` command required by the app's remote server.
 
 ## Connect
 

--- a/content/manuals/ai/sandboxes/integrations/chatgpt.md
+++ b/content/manuals/ai/sandboxes/integrations/chatgpt.md
@@ -21,6 +21,9 @@ isolated environment instead of on your host.
 - SSH access set up. See [Editor and app integrations](_index.md#enable-ssh-access).
 - The ChatGPT desktop app installed.
 
+ChatGPT's remote server requires the `codex` command in the sandbox. The Codex
+sandbox template used in the following section includes this command.
+
 ## Connect
 
 Create a named Codex sandbox for the current directory if you don't already


### PR DESCRIPTION
## Summary

Clarify that ChatGPT's remote server requires the `codex` command in the sandbox and that the Codex sandbox template used by the Connect steps includes it. This preserves the app-specific requirement without implying that readers must create the sandbox before following the connection instructions.

@netlify /ai/sandboxes/integrations/chatgpt/

Preview: https://deploy-preview-25649--docsdocker.netlify.app/ai/sandboxes/integrations/chatgpt/

Closes #25648

Generated by Codex