### PR TITLE
docs: remove conflicting Buildx packages before install

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -61,6 +61,7 @@ The unofficial packages to uninstall are:
 - `docker.io`
 - `docker-compose`
 - `docker-doc`
+- `docker-buildx`
 - `podman-docker`
 
 Moreover, Docker Engine depends on `containerd` and `runc`. Docker Engine
@@ -71,7 +72,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ sudo apt remove $(dpkg --get-selections docker.io docker-compose docker-doc podman-docker containerd runc | cut -f1)
+$ sudo apt remove $(dpkg --get-selections docker.io docker-compose docker-doc docker-buildx podman-docker containerd runc | cut -f1)
 ```
 
 `apt` might report that you have none of these packages installed.

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -78,6 +78,7 @@ The unofficial packages to uninstall are:
 - `docker-compose`
 - `docker-compose-v2`
 - `docker-doc`
+- `docker-buildx`
 - `podman-docker`
 
 Moreover, Docker Engine depends on `containerd` and `runc`. Docker Engine
@@ -88,7 +89,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ sudo apt remove $(dpkg --get-selections docker.io docker-compose docker-compose-v2 docker-doc podman-docker containerd runc | cut -f1)
+$ sudo apt remove $(dpkg --get-selections docker.io docker-compose docker-compose-v2 docker-doc docker-buildx podman-docker containerd runc | cut -f1)
 ```
 
 `apt` might report that you have none of these packages installed.


### PR DESCRIPTION
## Summary

Keep Docker’s official `docker-buildx-plugin` package name and add the distribution-provided `docker-buildx` package to the conflicting-package removal steps for Debian and Ubuntu. Both packages install the same CLI plugin binary, which causes Docker Engine installation to fail when `docker-buildx` is already installed.

Alternative to #25506.

@netlify /engine/install/debian/

- [Debian preview](https://deploy-preview-25650--docsdocker.netlify.app/engine/install/debian/)
- [Ubuntu preview](https://deploy-preview-25650--docsdocker.netlify.app/engine/install/ubuntu/)

Generated by Codex