### PR TITLE
docs: add redirect for synchronized file sharing

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -389,6 +389,7 @@
   - /go/eci/
 "/desktop/features/synchronized-file-sharing/":
   - /go/synchronized-file-sharing/
+  - /desktop/synchronized-file-sharing/
 "/reference/cli/dockerd/":
   - /go/daemon-config/
   - /engine/reference/commandline/dockerd/


### PR DESCRIPTION
## Description

Adds a redirect from the legacy `/desktop/synchronized-file-sharing/` URL to the current `/desktop/features/synchronized-file-sharing/` page, fixing the reported 404.

## Related issues or tickets

Fixes #25647

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review