### PR TITLE
dhi: fix broken link

### DIFF
--- a/content/manuals/dhi/tools/cli.md
+++ b/content/manuals/dhi/tools/cli.md
@@ -265,7 +265,7 @@ The `docker dhi` CLI can be configured with a YAML file located at:
 - `$HOME/.config/dhictl/config.yaml` on _Linux_ and _macOS_
 - `%USERPROFILE%\.config\dhictl\config.yaml` on _Windows_
 
-If `$XDG_CONFIG_HOME` is set, the configuration file is located at `$XDG_CONFIG_HOME/dhictl/config.yaml` (see the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/spec/latest/)).
+If `$XDG_CONFIG_HOME` is set, the configuration file is located at `$XDG_CONFIG_HOME/dhictl/config.yaml`.
 
 Available configuration options:
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Removed a broken link to the XDG Base Directory Specification. The link doesn't resolve and users don't need to know the spec. They're just setting/checking an environment variable.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
