### PR TITLE
docs: rename What's next to Next steps in Platform and Enterprise

### DIFF
--- a/content/manuals/accounts/_index.md
+++ b/content/manuals/accounts/_index.md
@@ -59,6 +59,6 @@ Docker also ties a verified email to the account.
   [single sign-on (SSO)](/manuals/enterprise/security/single-sign-on/_index.md),
   Google, or GitHub.
 
-## What's next
+## Next steps
 
 {{< grid >}}

--- a/content/manuals/accounts/create-account.md
+++ b/content/manuals/accounts/create-account.md
@@ -83,7 +83,7 @@ basis:
 - [Docker Community Forums](https://forums.docker.com/)
 - [Docker Community Slack](https://dockr.ly/comm-slack)
 
-## What's next
+## Next steps
 
 - [Manage a Docker account](/manuals/accounts/manage-account.md)
 - [Enable two-factor authentication](/manuals/security/2fa/_index.md)

--- a/content/manuals/accounts/general-faqs.md
+++ b/content/manuals/accounts/general-faqs.md
@@ -55,7 +55,7 @@ organization name can't be the same as an existing Docker ID.
 For more information, see
 [Docker organization overview](/manuals/admin/organization/_index.md).
 
-## What's next
+## Next steps
 
 - [Create a Docker account](/manuals/accounts/create-account.md)
 - [Manage a Docker account](/manuals/accounts/manage-account.md)

--- a/content/manuals/accounts/manage-account.md
+++ b/content/manuals/accounts/manage-account.md
@@ -123,7 +123,7 @@ organization](/manuals/admin/organization/setup/convert-account.md).
 For information on deactivating your account, see
 [Deactivate a Docker account](/manuals/accounts/deactivate-user-account.md).
 
-## What's next
+## Next steps
 
 - [Docker accounts overview](/manuals/accounts/_index.md)
 - [Create a Docker account](/manuals/accounts/create-account.md)

--- a/content/manuals/admin/_index.md
+++ b/content/manuals/admin/_index.md
@@ -81,7 +81,7 @@ or functions.
 A member is any Docker user added to an organization. Organization and company
 owners can assign roles to members to define their level of access.
 
-## What's next
+## Next steps
 
 Learn how to manage companies and organizations in the following sections.
 

--- a/content/manuals/admin/company/_index.md
+++ b/content/manuals/admin/company/_index.md
@@ -64,7 +64,7 @@ organization owners.
 To add or remove company owners, see
 [Manage your company](/manuals/admin/company/manage.md#company-owners).
 
-## What's next
+## Next steps
 
 Learn how to create and manage a company in the following sections.
 

--- a/content/manuals/admin/organization/_index.md
+++ b/content/manuals/admin/organization/_index.md
@@ -69,7 +69,7 @@ For details about each role and its permissions, see
 [Roles and
 permissions](/manuals/enterprise/security/roles-and-permissions/_index.md).
 
-## What's next
+## Next steps
 
 Learn how to create and manage your organization in the following sections.
 

--- a/content/manuals/admin/organization/manage/_index.md
+++ b/content/manuals/admin/organization/manage/_index.md
@@ -46,7 +46,7 @@ plans. The following table summarizes the difference.
 For details, see [Seats](/manuals/admin/organization/manage/manage-seats.md)
 and [License assignment](/manuals/admin/organization/manage/manage-licenses.md).
 
-## What's next
+## Next steps
 
 Explore the following sections to manage your organization.
 

--- a/content/manuals/admin/organization/manage/manage-licenses.md
+++ b/content/manuals/admin/organization/manage/manage-licenses.md
@@ -38,7 +38,7 @@ Automatic license assignment gives members a product license when they use a sup
 
 AI Governance licenses include single sign-on (SSO) and provisioning features regardless of your Docker Core subscription. Automatic license assignment requires [setting up SSO](/manuals/enterprise/security/single-sign-on/connect.md), then [provisioning](/manuals/enterprise/security/provisioning/_index.md) with System for Cross-domain Identity Management (SCIM) or Just-in-Time (JIT).
 
-## What's next
+## Next steps
 
 See these docs to explore Docker Core add-ons, or products that need licenses:
 

--- a/content/manuals/admin/organization/manage/manage-products.md
+++ b/content/manuals/admin/organization/manage/manage-products.md
@@ -13,7 +13,7 @@ aliases:
 Use this page to learn how to control and monitor product access and usage
 for your organization's members. If you're looking for setup and
 configuration instructions, see each product's manual under
-[What's next](#whats-next).
+[Next steps](#next-steps).
 
 ## Control access for your organization
 
@@ -142,7 +142,7 @@ following table to learn where you can monitor organization usage:
 To learn about the included usage across Docker plans, see
 [Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminManageProducts).
 
-## What's next
+## Next steps
 
 For more detailed information about each product, including how to set up
 and configure them, see the following manuals:

--- a/content/manuals/admin/organization/setup/_index.md
+++ b/content/manuals/admin/organization/setup/_index.md
@@ -50,7 +50,7 @@ Setting up an organization happens in broad phases:
    other, so follow them in order.
 1. You can update your organization's general information whenever it changes.
 
-## What's next
+## Next steps
 
 Explore the following sections to set up your organization.
 

--- a/content/manuals/admin/organization/setup/onboard.md
+++ b/content/manuals/admin/organization/setup/onboard.md
@@ -168,7 +168,7 @@ security posture:
 - [Registry Access Management](/manuals/enterprise/security/hardened-desktop/registry-access-management.md): Define which registries your developers can access.
 - [Settings management](/manuals/enterprise/security/hardened-desktop/settings-management.md): Set and control Docker Desktop settings for your users.
 
-## What's next
+## Next steps
 
 - [Manage Docker products](../manage/manage-products.md) to configure access and view usage.
 - Configure [Hardened Docker Desktop](/manuals/enterprise/security/hardened-desktop/_index.md) to improve your organization’s security posture for containerized development.

--- a/content/manuals/billing/_index.md
+++ b/content/manuals/billing/_index.md
@@ -39,6 +39,6 @@ payment methods, reviewing billing details, and tracking invoice history.
 
 Your invoice history is a reference to the Docker plans you subscribe to. For information about your billing cycle and renewal dates, see [plan details](/manuals/subscription/plans/_index.md). To upgrade or add a new plan, see [Subscription](/manuals/subscription/_index.md).
 
-## What's next
+## Next steps
 
 {{< grid items="grid_core" >}}

--- a/content/manuals/enterprise/security/oidc-connections/_index.md
+++ b/content/manuals/enterprise/security/oidc-connections/_index.md
@@ -46,7 +46,7 @@ While OATs govern access to your Docker resources through organization
 membership, OIDC connections authenticate GitHub Actions workflows when
 they request a change to your Docker resources.
 
-## What's next
+## Next steps
 
 - [Create an OIDC connection](/manuals/enterprise/security/oidc-connections/create-manage.md)
 - [OIDC rulesets and subject claims](/manuals/enterprise/security/oidc-connections/rulesets-claims.md)

--- a/content/manuals/enterprise/security/oidc-connections/create-manage.md
+++ b/content/manuals/enterprise/security/oidc-connections/create-manage.md
@@ -127,6 +127,6 @@ whose `docker/oidc-action` step still references the deleted
 replacement connection's ID in every affected workflow before it runs
 again.
 
-## What's next
+## Next steps
 
 - [OIDC connections rulesets and subject claims](/manuals/enterprise/security/oidc-connections/rulesets-claims.md)

--- a/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
+++ b/content/manuals/enterprise/security/oidc-connections/rulesets-claims.md
@@ -89,7 +89,7 @@ determine the level of access granted.
 
 Docker Hub repositories and Docker Build Cloud are supported resources.
 
-## What's next
+## Next steps
 
 - [OIDC connections overview](/manuals/enterprise/security/oidc-connections/_index.md)
 - [Create or manage OIDC connections](/manuals/enterprise/security/oidc-connections/create-manage.md)

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -68,6 +68,6 @@ To subscribe to a new plan, you can self-serve through **Billing** in [Docker Ho
 
 To learn more about adding a new plan or upgrading an active plan, see [Manage plans](/manuals/subscription/manage.md).
 
-## What's next
+## Next steps
 
 {{< grid items="grid_subscriptions" >}}

--- a/content/manuals/subscription/manage.md
+++ b/content/manuals/subscription/manage.md
@@ -62,7 +62,7 @@ You can upgrade active plans from the billing Overview page.
 Some products are sales-led. You must
 <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_cs_plans_manage" class="link" rel="noopener">contact sales</a> to opt in.
 
-## What's next
+## Next steps
 
 - [Learn about available plans](/manuals/subscription/plans/_index.md)
 - [Set up payment information](/manuals/billing/payment-method.md)


### PR DESCRIPTION
Noticed the freshness agents seem to prefer ## Next steps over ## What's next. I like this standard in any case, so updated my docs area to reflect it. May follow up with team to standardize on the rule