### PR TITLE
ai-audit-logs: add siem catalog

### DIFF
--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -87,6 +87,7 @@ Dockerized
 Dockerizing
 Dependabot
 DuckDuckGo
+Dynatrace
 Entra
 EPERM
 ESXi

--- a/content/manuals/ai/sandboxes/governance/audit/_index.md
+++ b/content/manuals/ai/sandboxes/governance/audit/_index.md
@@ -75,4 +75,5 @@ Policy](https://www.docker.com/legal/privacy/).
 - [Local audit logs](local.md)
 - [Configure audit delivery](configure.md)
 - [View and export audit events](view-export.md)
+- [SIEM forwarding](siem.md)
 - [Audit record reference](record-reference.md)

--- a/content/manuals/ai/sandboxes/governance/audit/_index.md
+++ b/content/manuals/ai/sandboxes/governance/audit/_index.md
@@ -58,6 +58,8 @@ Docker supports two delivery modes for audit records:
 
 Organization owners and users with a [custom role](/manuals/enterprise/security/roles-and-permissions/custom-roles.md) that includes AI Governance audit permissions can configure local disk, Docker Cloud, or both.
 
+The hosted audit log view, CSV export, and SIEM forwarding all require Docker Cloud delivery to be enabled. Local delivery alone does not power these features.
+
 Organizations that used local audit logging before hosted audit logs were
 available start with cloud delivery off until an owner opts in from
 [audit delivery settings](configure.md).

--- a/content/manuals/ai/sandboxes/governance/audit/_index.md
+++ b/content/manuals/ai/sandboxes/governance/audit/_index.md
@@ -6,6 +6,8 @@ description: Capture, view, export, and collect structured audit records for Doc
 keywords: docker sandboxes, audit log, audit logging, AI Governance, policy decision, SIEM, compliance, jsonl
 ---
 
+{{< summary-bar feature_name="AI Governance Audit Logs" >}}
+
 AI Governance Audit Logs record Docker AI Governance activity for your
 organization. Each record captures the principal, action, target, decision, and
 time for a governance event. Records contain metadata only. They don't contain

--- a/content/manuals/ai/sandboxes/governance/audit/siem.md
+++ b/content/manuals/ai/sandboxes/governance/audit/siem.md
@@ -23,6 +23,11 @@ saving.
 
 ## Before you begin
 
+SIEM forwarding requires Docker Cloud delivery to be enabled for your
+organization. If you haven't already, enable it under **AI Platform** >
+**Audit logs** > **Audit delivery** before configuring a SIEM destination. See
+[Configure audit delivery](configure.md).
+
 Gather credentials from your SIEM before configuring forwarding:
 
 - **Splunk Cloud**: HEC ingest URL and an HEC token. Optionally, a Splunk index

--- a/content/manuals/ai/sandboxes/governance/audit/siem.md
+++ b/content/manuals/ai/sandboxes/governance/audit/siem.md
@@ -21,7 +21,7 @@ saving.
 | Dynatrace                        | Dynatrace Log Management using the Log Ingest API               |
 | Custom HTTPS endpoint (advanced) | Any SIEM that accepts HTTPS with a custom authentication header |
 
-## What you'll need
+## Before you begin
 
 Gather credentials from your SIEM before configuring forwarding:
 

--- a/content/manuals/ai/sandboxes/governance/audit/siem.md
+++ b/content/manuals/ai/sandboxes/governance/audit/siem.md
@@ -59,6 +59,3 @@ From the **SIEM forwarding** list, select the menu next to a destination to
 edit or delete it. The edit form lets you update credentials and toggle
 forwarding on or off for that destination. Deleting a destination permanently
 removes the endpoint and its stored credential and cannot be undone.
-
-To collect host-local files with your own log shipper instead, see
-[Local audit logs](local.md).

--- a/content/manuals/ai/sandboxes/governance/audit/siem.md
+++ b/content/manuals/ai/sandboxes/governance/audit/siem.md
@@ -1,0 +1,59 @@
+---
+title: SIEM forwarding
+linkTitle: SIEM forwarding
+weight: 35
+description: Forward Docker AI Governance audit events to Splunk, Dynatrace, or a custom HTTPS endpoint.
+keywords: docker sandboxes, SIEM, audit logs, Splunk, Dynatrace, AI Governance, forwarding, NDJSON
+---
+
+Docker can forward audit events to your security information and event
+management (SIEM) system, letting you centralize Docker governance data
+alongside other security signals. Events are forwarded in NDJSON format.
+Docker verifies the endpoint is reachable with the supplied credential before
+saving.
+
+## Supported destinations
+
+| Destination                      | Description                                                     |
+| -------------------------------- | --------------------------------------------------------------- |
+| Splunk Cloud (HEC)               | Hosted Splunk using the HTTP Event Collector                    |
+| Splunk Enterprise (self-hosted)  | Self-hosted Splunk using the HTTP Event Collector               |
+| Dynatrace                        | Dynatrace Log Management using the Log Ingest API               |
+| Custom HTTPS endpoint (advanced) | Any SIEM that accepts HTTPS with a custom authentication header |
+
+## What you'll need
+
+Gather credentials from your SIEM before configuring forwarding:
+
+- **Splunk Cloud**: HEC ingest URL and an HEC token. Optionally, a Splunk index
+  name. See [Splunk documentation](https://docs.splunk.com/).
+- **Splunk Enterprise**: HEC endpoint URL (typically port 8088) and an HEC
+  token. The endpoint must present a publicly-trusted TLS certificate.
+  Optionally, a Splunk index name. See [Splunk documentation](https://docs.splunk.com/).
+- **Dynatrace**: Log Ingest API URL and an API token with the `logs.ingest`
+  scope. See [Dynatrace documentation](https://docs.dynatrace.com/).
+- **Custom HTTPS endpoint**: Your endpoint URL, authentication header name, and
+  full header value including any scheme (for example, `Bearer <token>`).
+
+## Add a SIEM destination
+
+1. Sign in to [Docker Home](https://app.docker.com/).
+1. Open your organization.
+1. Go to **AI Platform** > **Audit logs**.
+1. Open **SIEM forwarding**.
+1. Select **Add destination**.
+1. Select your destination and complete the form.
+1. Select **Save**.
+
+If verification fails, check that the URL and credential are correct and that
+the endpoint is accessible from the internet.
+
+## Manage destinations
+
+From the **SIEM forwarding** list, select the menu next to a destination to
+edit or delete it. The edit form lets you update credentials and toggle
+forwarding on or off for that destination. Deleting a destination permanently
+removes the endpoint and its stored credential and cannot be undone.
+
+To collect host-local files with your own log shipper instead, see
+[Local audit logs](local.md).

--- a/content/manuals/ai/sandboxes/governance/audit/siem.md
+++ b/content/manuals/ai/sandboxes/governance/audit/siem.md
@@ -45,7 +45,7 @@ Gather credentials from your SIEM before configuring forwarding:
 1. Sign in to [Docker Home](https://app.docker.com/).
 1. Open your organization.
 1. Go to **AI Platform** > **Audit logs**.
-1. Open **SIEM forwarding**.
+1. Open **Export & Connectors**.
 1. Select **Add destination**.
 1. Select your destination and complete the form.
 1. Select **Save**.

--- a/content/manuals/ai/sandboxes/governance/audit/view-export.md
+++ b/content/manuals/ai/sandboxes/governance/audit/view-export.md
@@ -2,13 +2,13 @@
 title: View and export audit events
 linkTitle: View and export
 weight: 30
-description: Search, filter, export, and stream Docker AI Governance audit events from the hosted audit log UI.
-keywords: docker sandboxes, audit events, audit logs, AI Governance, CSV export, SIEM, Splunk, NDJSON
+description: Search, filter, and export Docker AI Governance audit events from the hosted audit log UI.
+keywords: docker sandboxes, audit events, audit logs, AI Governance, CSV export
 ---
 
 Cloud delivery stores AI Governance audit records in Docker Cloud and makes
 them available in the hosted audit log UI. Use the hosted view to investigate
-policy decisions, export events to CSV, or stream events to your SIEM.
+policy decisions or export events to CSV.
 
 ## View audit events
 
@@ -48,20 +48,3 @@ Use CSV export when you need an offline copy of filtered audit events:
 1. Download the generated CSV file from the link Docker provides.
 
 CSV exports include up to 1 000 000 rows. Download links expire after 24 hours.
-
-## SIEM forwarding
-
-Docker can forward audit events to your security information and event
-management (SIEM) system, letting you centralize Docker governance data
-alongside other security signals in tools such as Datadog or Splunk.
-
-To set up forwarding, you provide an HTTPS endpoint that will receive the audit
-events, choose an output format, and supply the credentials Docker will use to
-authenticate against your SIEM. Docker verifies the endpoint is reachable before
-saving the configuration.
-
-Once configured, forwarding can be enabled or disabled without losing your saved
-settings.
-
-To collect host-local files with your own log shipper instead, see
-[Local audit logs](local.md).

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -1,3 +1,6 @@
+AI Governance Audit Logs:
+  subscription: [AI Governance]
+  requires: Docker Sandboxes [0.35.0](/manuals/ai/sandboxes/release-notes.md) or later
 Activity logs:
   subscription: [Team, Business]
   for: Administrators

--- a/layouts/_shortcodes/summary-bar.html
+++ b/layouts/_shortcodes/summary-bar.html
@@ -13,6 +13,7 @@
     "Docker Hardened Images Enterprise" "/icons/dhi.svg"
     "Docker Hardened Images Select or Enterprise" "/icons/dhi.svg"
     "Docker Offload" "cloud"
+    "AI Governance" "shield-check"
   }}
   {{ $availabilityIcons := dict
     "Experimental" "beaker"


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

There's a new SIEM catalog in addition to the Custom HTTPS endpoint.

- Created dedicated SIEM connector topic with more info
- Removed SIEM info from view and export topic
- Updated index with new topic

Preview: https://deploy-preview-25687--docsdocker.netlify.app/ai/sandboxes/governance/audit/siem/

Added summary bar with min version.
Preview:  https://deploy-preview-25687--docsdocker.netlify.app/ai/sandboxes/governance/audit/

## Related issues or tickets


## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review