### PR TITLE
docs: clarify NVIDIA GPU access scope

### DIFF
--- a/content/manuals/engine/containers/gpu.md
+++ b/content/manuals/engine/containers/gpu.md
@@ -88,9 +88,11 @@ This exposes the GPUs at index `0` and `2` — the first and third GPUs listed i
 
 > [!NOTE]
 >
-> GPU access with the `--gpus` flag is documented here for standalone Docker
-> Engine containers on a single host. This page doesn't cover GPU scheduling
-> across multiple Docker Engine hosts or orchestrators.
+> The `--gpus` flag provides GPU access to containers created with
+> `docker run`. To make GPUs available to services in a swarm, advertise them
+> as [node generic resources](/reference/cli/dockerd/#node-generic-resources)
+> and request them with
+> [`--generic-resource`](/reference/cli/docker/service/create/#generic-resources).
 
 ### Set NVIDIA capabilities
 

--- a/content/manuals/engine/containers/gpu.md
+++ b/content/manuals/engine/containers/gpu.md
@@ -88,7 +88,9 @@ This exposes the GPUs at index `0` and `2` — the first and third GPUs listed i
 
 > [!NOTE]
 >
-> NVIDIA GPUs can only be accessed by systems running a single engine.
+> GPU access with the `--gpus` flag is documented here for standalone Docker
+> Engine containers on a single host. This page doesn't cover GPU scheduling
+> across multiple Docker Engine hosts or orchestrators.
 
 ### Set NVIDIA capabilities
 


### PR DESCRIPTION
## Description

Clarify the note about NVIDIA GPU access in the Docker Engine container documentation.

The previous wording said that NVIDIA GPUs can only be accessed by systems running a "single engine", but did not define what "single engine" means. This update reframes the note around the documented scope of the page: standalone Docker Engine containers on a single host.

## Related issues or tickets

Closes #25685

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review