### PR TITLE
vendor: docker/cli v29.7.1, docker/compose v5.3.1, and add engine v29.6 and v29.7 to API version matrix

### DIFF
--- a/_vendor/github.com/docker/cli/docs/extend/plugins_authorization.md
+++ b/_vendor/github.com/docker/cli/docs/extend/plugins_authorization.md
@@ -95,6 +95,18 @@ The Engine's authorization middleware fails closed: when a plugin returns an err
 the request is denied and the error is surfaced to the client. Plugins should also fail closed: if the plugin
 cannot confidently evaluate a request, it should return an error or `Allow: false`.
 
+> [!WARNING]
+> Because the plugin receives the [**raw** request body](#authzpluginauthzreq) from the daemon, it must
+> apply the same decoding semantics as the daemon to be sure it evaluates the request the daemon will
+> act on. The daemon decodes JSON with Go's [`encoding/json.Unmarshal`](https://pkg.go.dev/encoding/json#Unmarshal).
+>
+> The same requirement applies to the response body. Plugins that depend on `ResponseBody`
+> inspection for redaction or content-filtering should restrict their policies to endpoints
+> whose response is produced as a single write (typical of REST-style API responses). For
+> commands whose responses are streamed or are likely to exceed the [buffer](#response-body-size-and-partial-buffering) through multiple
+> writes, do not rely on `ResponseBody` for security-relevant decisions; perform the filtering
+> in a separate layer in front of the daemon.
+
 ### Response body size and partial buffering
 
 The internal buffer that holds the response body between the daemon's HTTP
@@ -110,15 +122,6 @@ is the practical effect of this 64 KiB threshold combined with the
 `io.WriteFlusher` write pattern used by streaming handlers, where each write
 is immediately drained to the client and is therefore no longer available
 for plugin inspection by the time the handler returns.
-
-> [!NOTE]
-> Plugins that depend on `ResponseBody` inspection for redaction or
-> content-filtering should restrict their policies to endpoints whose
-> response is produced as a single write (typical of REST-style API
-> responses). For commands whose responses are streamed or are likely to
-> exceed the buffer through multiple writes, do not rely on `ResponseBody`
-> for security-relevant decisions; perform the filtering in a separate
-> layer in front of the daemon.
 
 During request/response processing, some authorization flows might
 need to do additional queries to the Docker daemon. To complete such flows,

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -2,6 +2,6 @@
 # github.com/moby/buildkit v0.32.0
 # github.com/docker/buildx v0.36.0
 # github.com/docker/cli v29.7.1+incompatible
-# github.com/docker/compose/v5 v5.3.0
+# github.com/docker/compose/v5 v5.3.1
 # github.com/docker/model-runner v1.1.36
 # github.com/docker/docker-agent v1.110.0

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/moby/moby/api v1.55.0
 # github.com/moby/buildkit v0.32.0
 # github.com/docker/buildx v0.36.0
-# github.com/docker/cli v29.6.2+incompatible
+# github.com/docker/cli v29.7.1+incompatible
 # github.com/docker/compose/v5 v5.3.0
 # github.com/docker/model-runner v1.1.36
 # github.com/docker/docker-agent v1.110.0

--- a/content/reference/api/engine/_index.md
+++ b/content/reference/api/engine/_index.md
@@ -140,6 +140,8 @@ to provide full compatibility, some functionality may not be available.
 
 | Docker version | Maximum API version                          | Minimum API version                          | Change log                                                         |
 |:---------------|:---------------------------------------------|:---------------------------------------------|:-------------------------------------------------------------------|
+| 29.7           | [1.55](/reference/api/engine/version/v1.55/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v155-api-changes) |
+| 29.6           | [1.55](/reference/api/engine/version/v1.55/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v155-api-changes) |
 | 29.5           | [1.54](/reference/api/engine/version/v1.54/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v154-api-changes) |
 | 29.4           | [1.54](/reference/api/engine/version/v1.54/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v154-api-changes) |
 | 29.3           | [1.54](/reference/api/engine/version/v1.54/) | [1.40](/reference/api/engine/version/v1.40/) | [changes](/reference/api/engine/version-history/#v154-api-changes) |

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ go 1.26.5
 // Make sure to add an entry in the "tools" section when adding a new repository.
 require (
 	github.com/docker/buildx v0.36.0
-	github.com/docker/cli v29.6.2+incompatible
+	github.com/docker/cli v29.7.1+incompatible
 	github.com/docker/compose/v5 v5.3.0
 	github.com/docker/docker-agent v1.110.0
 	github.com/docker/model-runner v1.1.36

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ go 1.26.5
 require (
 	github.com/docker/buildx v0.36.0
 	github.com/docker/cli v29.7.1+incompatible
-	github.com/docker/compose/v5 v5.3.0
+	github.com/docker/compose/v5 v5.3.1
 	github.com/docker/docker-agent v1.110.0
 	github.com/docker/model-runner v1.1.36
 	github.com/moby/buildkit v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/docker/cli v29.6.1+incompatible h1:oO7F4nn3Ovr/5TlfTUWFbMwBSS/B7Xs6Ep
 github.com/docker/cli v29.6.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v29.6.2+incompatible h1:/bjePvcbbFTnRrMfWJBY7AjfICdsiLVgHn6LwTVOcqw=
 github.com/docker/cli v29.6.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v29.7.1+incompatible h1:ILZpP6B7fedIr6ANy824QkDp1WMJuouIq0O2SrBkB2w=
+github.com/docker/cli v29.7.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose/v5 v5.0.0 h1:J2uMCzJ/5xLcoIVVXvMmPe6HBzVQpmJThKa7Qk7Xldc=
 github.com/docker/compose/v5 v5.0.0/go.mod h1:BurapGv8zmYnsbSmlpCz5EU2Pi3YFV/PjeUnoFpcw64=
 github.com/docker/compose/v5 v5.0.1 h1:5yCjDJbwUqcuI+6WNFHNWz2/3vyBDsNnfe8LlFjyxEc=

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/docker/compose/v5 v5.2.0 h1:WuZgtAM91BjFWy7xMKcM2Huq9OksVqRgkgBKFiEXs
 github.com/docker/compose/v5 v5.2.0/go.mod h1:tjYsBMooQQZ8XGtVoUnc+/T9peXtkMmTdmMakW8/ZXE=
 github.com/docker/compose/v5 v5.3.0 h1:JdcwUbJi2al3vOi+PZmjqPzHBIYyezZ9OaCXLO5I6f0=
 github.com/docker/compose/v5 v5.3.0/go.mod h1:iZngpxvhuLn2VYsKS5cIa/5bTPKIdLGi5ZyjcdHBaZQ=
+github.com/docker/compose/v5 v5.3.1 h1:rZiPwrtg1dBmVGcHiioLtzCS+TcvZq81zl0zs2BwtbE=
+github.com/docker/compose/v5 v5.3.1/go.mod h1:qTcMBinqXyp2CQT6OJfBqtG8UPfYgOk1rwqIGYKLpGk=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -168,11 +168,11 @@ params:
   docker_ce_version: "29.7.1"
   # Previous version of the Docker Engine
   # (Used to show e.g., "latest" and "latest"-1 in engine install examples
-  docker_ce_version_prev: "29.6.2"
+  docker_ce_version_prev: "29.7.0"
   # Latest Docker Compose version
-  compose_version: "v5.1.2"
+  compose_version: "v5.3.1"
   # Latest BuildKit version
-  buildkit_version: "0.28.0"
+  buildkit_version: "0.32.0"
   # Latest actions version
   bake_action_version: "v7"
   build_push_action_version: "v7"
@@ -188,7 +188,7 @@ params:
   cache_action_version: "v5"
 
   # Example runtime/library/os versions
-  example_go_version: "1.25"
+  example_go_version: "1.26"
   example_alpine_version: "3.23"
   example_node_version: "24"
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review