### PR TITLE
bump compose to version v5.40

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/moby/moby/api v1.55.0
-# github.com/moby/buildkit v0.32.0
+# github.com/moby/buildkit v0.32.1
 # github.com/docker/buildx v0.36.0
 # github.com/docker/cli v29.7.1+incompatible
-# github.com/docker/compose/v5 v5.3.1
+# github.com/docker/compose/v5 v5.4.0
 # github.com/docker/model-runner v1.1.36
 # github.com/docker/docker-agent v1.110.0

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ go 1.26.5
 require (
 	github.com/docker/buildx v0.36.0
 	github.com/docker/cli v29.7.1+incompatible
-	github.com/docker/compose/v5 v5.3.1
+	github.com/docker/compose/v5 v5.4.0
 	github.com/docker/docker-agent v1.110.0
 	github.com/docker/model-runner v1.1.36
-	github.com/moby/buildkit v0.32.0
+	github.com/moby/buildkit v0.32.1
 	github.com/moby/moby/api v1.55.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/docker/compose/v5 v5.3.0 h1:JdcwUbJi2al3vOi+PZmjqPzHBIYyezZ9OaCXLO5I6
 github.com/docker/compose/v5 v5.3.0/go.mod h1:iZngpxvhuLn2VYsKS5cIa/5bTPKIdLGi5ZyjcdHBaZQ=
 github.com/docker/compose/v5 v5.3.1 h1:rZiPwrtg1dBmVGcHiioLtzCS+TcvZq81zl0zs2BwtbE=
 github.com/docker/compose/v5 v5.3.1/go.mod h1:qTcMBinqXyp2CQT6OJfBqtG8UPfYgOk1rwqIGYKLpGk=
+github.com/docker/compose/v5 v5.4.0 h1:i0xFmVvWv9QILfRE2PD07GmQqJYjpYAGutafIrJLURE=
+github.com/docker/compose/v5 v5.4.0/go.mod h1:bNeEncwZhG0F4MN+0zgln4EA2ILqGZC7knRI8QYJz9U=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
@@ -278,6 +280,8 @@ github.com/moby/buildkit v0.31.0 h1:hMUAbQGgjtzJDDOZ6o7MQk5XBZkBTyzLWEvnjguHHQI=
 github.com/moby/buildkit v0.31.0/go.mod h1:YM5iNEbNCc6L1Zt3YWFB/aXNLufvf4Rcu0DPlc9HwQg=
 github.com/moby/buildkit v0.32.0 h1:slXarYQoMo4cp2d9x30M9t0L4R+c0CVMov+5P1hhiHY=
 github.com/moby/buildkit v0.32.0/go.mod h1:Y10FBWvqxl/Wmhdzjee1Y2wQfjifTiwxENIUdaVNdME=
+github.com/moby/buildkit v0.32.1 h1:gIygb6hNTKrSh3PRIOmXJGNZJQf7n7mmVxzo1omKjAM=
+github.com/moby/buildkit v0.32.1/go.mod h1:0GB/EJ1d+4VIVqIAgy3asaoGkVXy7IrDfVy7mPhOvg8=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -170,7 +170,7 @@ params:
   # (Used to show e.g., "latest" and "latest"-1 in engine install examples
   docker_ce_version_prev: "29.7.0"
   # Latest Docker Compose version
-  compose_version: "v5.3.1"
+  compose_version: "v5.4.0"
   # Latest BuildKit version
   buildkit_version: "0.32.0"
   # Latest actions version


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Bump Compose version to latest release `v5.4.0`

## Related issues or tickets
N/A

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review