### PR TITLE
docs: document sbx daemon restart

### DIFF
--- a/content/manuals/ai/sandboxes/architecture.md
+++ b/content/manuals/ai/sandboxes/architecture.md
@@ -94,7 +94,7 @@ semantics. This only affects traffic routed through `DOCKER_SANDBOXES_PROXY`
 Set these variables in the environment where the sandbox daemon starts. The
 daemon starts automatically the first time a command needs it, so set the
 variables before you run a `sbx` command. If the daemon is already running,
-restart it for a change to take effect.
+run `sbx daemon restart` for a change to take effect.
 
 One limitation applies:
 

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -28,8 +28,7 @@ If sandbox commands hang, fail to connect to the daemon, or keep returning
 daemon errors, restart the sandbox daemon before resetting sandbox state:
 
 ```console
-$ sbx daemon stop
-$ sbx daemon start --detach
+$ sbx daemon restart
 ```
 
 Then retry the command that failed. Restarting the daemon doesn't delete


### PR DESCRIPTION
## Summary

Use the upcoming `sbx daemon restart` command in daemon troubleshooting and proxy configuration guidance. This replaces the separate stop and detached-start sequence.

@netlify /ai/sandboxes/troubleshooting/

## Preview

- [Troubleshooting](https://deploy-preview-25705--docsdocker.netlify.app/ai/sandboxes/troubleshooting/)
- [Architecture](https://deploy-preview-25705--docsdocker.netlify.app/ai/sandboxes/architecture/)

Generated by Codex