### PR TITLE
build: Buildx OCI artifact opt-out

### DIFF
--- a/content/manuals/build/building/variables.md
+++ b/content/manuals/build/building/variables.md
@@ -326,6 +326,7 @@ They're used to configure the Buildx client, or the BuildKit daemon.
 | [BUILDX_METADATA_PROVENANCE](#buildx_metadata_provenance)                   | String \| Boolean | Customize provenance information included in the metadata file.  |
 | [BUILDX_METADATA_WARNINGS](#buildx_metadata_warnings)                       | String            | Include build warnings in the metadata file.                     |
 | [BUILDX_NO_DEFAULT_ATTESTATIONS](#buildx_no_default_attestations)           | Boolean           | Turn off default provenance attestations.                        |
+| [BUILDX_NO_DEFAULT_OCI_ARTIFACT](#buildx_no_default_oci_artifact)           | Boolean           | Turn off OCI artifact storage for attestations by default.       |
 | [BUILDX_NO_DEFAULT_LOAD](#buildx_no_default_load)                           | Boolean           | Turn off loading images to image store by default.               |
 | [EXPERIMENTAL_BUILDKIT_SOURCE_POLICY](#experimental_buildkit_source_policy) | String            | Specify a BuildKit source policy file.                           |
 
@@ -684,6 +685,22 @@ Usage:
 
 ```console
 $ export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+```
+
+### BUILDX_NO_DEFAULT_OCI_ARTIFACT
+
+{{< summary-bar feature_name="Buildx no default OCI artifact" >}}
+
+Starting with BuildKit v0.32.0, BuildKit stores attestations as OCI artifacts
+when OCI media types are enabled. Set `BUILDX_NO_DEFAULT_OCI_ARTIFACT=1` to
+make Buildx set `oci-artifact=false` when the build uses an exporter that
+supports attestations and you haven't explicitly set the `oci-artifact`
+exporter attribute.
+
+Usage:
+
+```console
+$ export BUILDX_NO_DEFAULT_OCI_ARTIFACT=1
 ```
 
 ### BUILDX_NO_DEFAULT_LOAD

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -70,6 +70,8 @@ Buildx metadata warnings:
   requires: Docker Buildx [0.16.0](https://github.com/docker/buildx/releases/tag/v0.16.0) and later
 Buildx no default:
   requires: Docker Buildx [0.10.4](https://github.com/docker/buildx/releases/tag/v0.10.4) and later
+Buildx no default OCI artifact:
+  requires: Docker Buildx [0.36.1](https://github.com/docker/buildx/releases/tag/v0.36.1) and later
 Cache backend API:
   availability: Experimental
 Company:


### PR DESCRIPTION
## Description

Document BUILDX_NO_DEFAULT_OCI_ARTIFACT as a compatibility escape hatch for registries that reject OCI artifact attestations.

Add the corresponding Buildx version requirement to the summary bar metadata.

## Related issues or tickets

* https://github.com/docker/buildx/pull/3991

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review