### PR TITLE
docs: update HyperKit FAQ for current Mac hypervisor

### DIFF
--- a/content/manuals/desktop/troubleshoot-and-support/faqs/macfaqs.md
+++ b/content/manuals/desktop/troubleshoot-and-support/faqs/macfaqs.md
@@ -12,14 +12,18 @@ weight: 20
 
 ### What is HyperKit?
 
-HyperKit is a hypervisor built on top of the Hypervisor.framework in macOS. It runs entirely in userspace and has no other dependencies.
+HyperKit is a legacy hypervisor built on top of Hypervisor.framework in macOS.
+Previous versions of Docker Desktop for Mac used HyperKit to run the Linux VM.
 
-Docker uses HyperKit to eliminate the need for other VM products, such as Oracle
-VirtualBox or VMware Fusion.
+Current versions of Docker Desktop use the Apple Virtualization framework by
+default. HyperKit is retained here as historical context for older
+configurations.
 
 ### What is the benefit of HyperKit?
 
-HyperKit is thinner than VirtualBox and VMware fusion, and the version included is customized for Docker workloads on Mac.
+When HyperKit was the default hypervisor, it provided a lightweight
+virtualization layer customized for Docker workloads and eliminated the need
+for third-party VM products such as Oracle VirtualBox or VMware Fusion.
 
 ### Where does Docker Desktop store Linux containers and images? 
 


### PR DESCRIPTION
## Description

Updates the macOS FAQ to clarify that HyperKit is a legacy hypervisor and that
current versions of Docker Desktop use the Apple Virtualization framework by
default. Keeps the HyperKit information as historical context for older
configurations.

## Related issues or tickets

Fixes #25718

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review