### PR TITLE
docs: clarify Sandbox VDI requirement

### DIFF
--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -66,6 +66,9 @@ network, and clean up.
 {{< /tab >}}
 {{< /tabs >}}
 
+If you run `sbx` in a virtual desktop infrastructure (VDI) environment, the
+environment must support nested virtualization.
+
 Docker Desktop is not required to use `sbx`.
 
 ## Install and sign in


### PR DESCRIPTION
## Summary

Clarify that virtual desktop infrastructure environments running `sbx` must support nested virtualization. The note sits after the platform prerequisites so it is discoverable without interrupting the standard setup flow.

@netlify /ai/sandboxes/get-started/

[Preview the updated get-started page](https://deploy-preview-25723--docsdocker.netlify.app/ai/sandboxes/get-started/)

Generated by Codex