### PR TITLE
docs: correct sandbox policy prompt timing

### DIFF
--- a/content/manuals/ai/sandboxes/get-started.md
+++ b/content/manuals/ai/sandboxes/get-started.md
@@ -104,24 +104,7 @@ The first command adds Docker's `apt` repository to your system.
 If you need to install `sbx` manually, download a binary directly from the
 [sbx-releases](https://github.com/docker/sbx-releases/releases) repository.
 
-`sbx login` opens a browser for Docker OAuth. On first login (and after `sbx
-policy reset`), the CLI prompts you to choose a default network policy for your
-sandboxes:
-
-```plaintext
-Choose a default network policy:
-
-     1. Open         — All network traffic allowed, no restrictions.
-     2. Balanced     — Default deny, with common dev sites allowed.
-     3. Locked Down  — All network traffic blocked unless you allow it.
-
-Use ↑/↓ to navigate, Enter to select, or press 1–3.
-```
-
-**Balanced** is a good starting point — it permits traffic to common
-development services while blocking everything else. You can adjust individual
-rules later. See [Policies](governance/local.md) for a full description of each
-option.
+`sbx login` opens a browser for Docker OAuth.
 
 > [!NOTE]
 > See the [FAQ](faq.md) for details on why sign-in is required and what
@@ -154,6 +137,28 @@ Pick a project directory and launch an agent with
 $ cd ~/my-project
 $ sbx run --name my-sandbox claude
 ```
+
+The first time you run a sandbox, the CLI prompts you to choose a default
+network preset:
+
+```plaintext
+Initialize the global network policy for your sandboxes:
+
+  Applies to all sandboxes, current and future — change it later with
+  "sbx policy allow/deny/rm". Kits, including built-in agent kits, may
+  also add per-sandbox rules.
+
+     1. Open         — All network traffic allowed, no restrictions.
+  ❯  2. Balanced     — Default deny, with common dev sites allowed.
+     3. Locked Down  — All network traffic blocked unless you allow it.
+
+  Use ↑/↓ or 1–3 to navigate, Enter to confirm, Esc to cancel.
+```
+
+**Balanced** is a good starting point — it permits traffic to common
+development services while blocking everything else. You can adjust individual
+rules later. See [Policies](governance/local.md) for a full description of each
+option.
 
 Replace `claude` with the agent you want to use — see [Agents](agents/) for the
 full list.
@@ -201,8 +206,8 @@ when running several agents on one repository — use
 ## Control what the agent can reach
 
 Isolation isn't only about the filesystem. You also control what the sandbox
-can reach on the network. You chose a default policy when you signed in, and
-you can inspect or adjust it at any time.
+can reach on the network. You chose a default policy before the sandbox
+started, and you can inspect or adjust it at any time.
 
 Check which rules are in effect:
 

--- a/content/manuals/ai/sandboxes/governance/local.md
+++ b/content/manuals/ai/sandboxes/governance/local.md
@@ -34,17 +34,22 @@ destination IP and port (for example, `sbx policy allow network "10.1.2.3:22"`).
 UDP and ICMP are blocked at the network layer and can't be unblocked with policy
 rules.
 
-On first start, and after running `sbx policy reset`, the daemon prompts you
-to choose a network preset:
+If you haven't chosen a default preset, the CLI prompts you before it runs a
+sandbox. Running `sbx policy reset` clears the preset and prompts you to choose
+again:
 
 ```plaintext
-Choose a default network policy:
+Initialize the global network policy for your sandboxes:
+
+  Applies to all sandboxes, current and future — change it later with
+  "sbx policy allow/deny/rm". Kits, including built-in agent kits, may
+  also add per-sandbox rules.
 
      1. Open         — All network traffic allowed, no restrictions.
-     2. Balanced     — Default deny, with common dev sites allowed.
+  ❯  2. Balanced     — Default deny, with common dev sites allowed.
      3. Locked Down  — All network traffic blocked unless you allow it.
 
-  Use ↑/↓ to navigate, Enter to select, or press 1–3.
+  Use ↑/↓ or 1–3 to navigate, Enter to confirm, Esc to cancel.
 ```
 
 | Preset      | Description                                                                                                                                       |
@@ -152,10 +157,9 @@ To remove all custom rules and start fresh with a new preset, use
 $ sbx policy reset
 ```
 
-This deletes the local policy store and stops the daemon. When the daemon
-restarts on the next command, you are prompted to choose a new preset. Running
-sandboxes stop when the daemon shuts down. Pass `--force` to skip the
-confirmation prompt:
+This deletes the local policy store, restarts the daemon, and prompts you to
+choose a new preset. Running sandboxes stop when the daemon shuts down. Pass
+`--force` to skip the confirmation prompt:
 
 ```console
 $ sbx policy reset --force


### PR DESCRIPTION
## Summary

Correct the Docker Sandboxes onboarding flow so the policy selector appears with the first sandbox run instead of `sbx login`. Align the local policy page and prompt example with the current CLI behavior.

@netlify /ai/sandboxes/get-started/

Preview:
- [Get started](https://deploy-preview-25724--docsdocker.netlify.app/ai/sandboxes/get-started/)
- [Local policy](https://deploy-preview-25724--docsdocker.netlify.app/ai/sandboxes/governance/local/)

Closes docker/sandboxes#4850

Generated by Codex